### PR TITLE
Feature/fix timestamp expectations applied to timestamps

### DIFF
--- a/examples/notebooks/test_broken_timestamp_example.ipynb
+++ b/examples/notebooks/test_broken_timestamp_example.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pandas as pd\n",
+    "import great_expectations as ge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print df.to_json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Here's the \n",
+    "df_as_json = {\n",
+    "    \"other_var\":[13,14,10,13,14],\n",
+    "    \"date_var\":[\"2014-09-01\",\"2014-10-30\",\"2014-07-31\",\"2014-09-01\",\"2014-10-30\"]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df = ge.read_csv(\"data/broken_timestamp_example.csv\")\n",
+    "df = pd.DataFrame(df_as_json)\n",
+    "df = ge.dataset.pandas_dataset.PandasDataSet(df)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.expect_column_values_to_be_dateutil_parseable('date_var')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.date_var[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"date_var_dt\"] = pd.to_datetime(df.date_var)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.expect_column_values_to_be_dateutil_parseable('date_var_dt')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "?df.expect_column_value_lengths_to_be_between"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.expect_column_values_to_be_between(min_)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/notebooks/test_broken_timestamp_example.ipynb
+++ b/examples/notebooks/test_broken_timestamp_example.ipynb
@@ -17,29 +17,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print df.to_json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Here's the \n",
+    "# df = ge.read_csv(\"data/broken_timestamp_example.csv\")\n",
+    "\n",
+    "#Here's the dataframe\n",
     "df_as_json = {\n",
     "    \"other_var\":[13,14,10,13,14],\n",
     "    \"date_var\":[\"2014-09-01\",\"2014-10-30\",\"2014-07-31\",\"2014-09-01\",\"2014-10-30\"]\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# df = ge.read_csv(\"data/broken_timestamp_example.csv\")\n",
+    "}\n",
+    "\n",
     "df = pd.DataFrame(df_as_json)\n",
     "df = ge.dataset.pandas_dataset.PandasDataSet(df)\n",
     "df.head()"

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -530,15 +530,18 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
         try:
             datetime.strptime(datetime.strftime(datetime.now(), strftime_format), strftime_format)
         except ValueError as e:
-            raise ValueError("Unable to use provided format. " + e.message)
+            raise ValueError("Unable to use provided strftime_format. " + e.message)
 
         def is_parseable_by_format(val):
             try:
-                # Note explicit cast of val to str type
-                datetime.strptime(str(val), strftime_format)
+                datetime.strptime(val, strftime_format)
                 return True
+            except TypeError as e:
+                raise TypeError("Values must be of type string")
+
             except ValueError as e:
                 return False
+
 
         return column.map(is_parseable_by_format)
 

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -537,7 +537,7 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
                 datetime.strptime(val, strftime_format)
                 return True
             except TypeError as e:
-                raise TypeError("Values must be of type string")
+                raise TypeError("Values passed to expect_column_values_to_match_strftime_format must be of type string.\nIf you want to validate a column of dates or timestamps, please call the expectation before converting from string format.")
 
             except ValueError as e:
                 return False
@@ -550,9 +550,13 @@ class PandasDataSet(MetaPandasDataSet, pd.DataFrame):
     def expect_column_values_to_be_dateutil_parseable(self, column, mostly=None, output_format=None, include_config=False, catch_exceptions=None):
         def is_parseable(val):
             try:
+                if type(val) != str:
+                    raise TypeError("Values passed to expect_column_values_to_be_dateutil_parseable must be of type string.\nIf you want to validate a column of dates or timestamps, please call the expectation before converting from string format.")
+
                 parse(val)
                 return True
-            except:
+
+            except ValueError:
                 return False
 
         return column.map(is_parseable)

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -880,9 +880,7 @@ class TestPandasDataset(unittest.TestCase):
         ]
 
         for t in T:
-            print t
             out = D.expect_column_values_to_be_dateutil_parseable(**t['in'])
-            print out
             if 'out' in t:
                 self.assertEqual(out, t['out'])
             elif 'error' in t:


### PR DESCRIPTION
Implements #136 

Note: This changes the behavior of `expect_column_values_to_be_dateutil_parseable` and `expect_column_values_to_match_strftime_format`.

They used to return False when passed non-string values. Now they raise an error.