### PR TITLE
Fix expect_*_to_[not]_be_null result percentages (#239)

### DIFF
--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -707,14 +707,13 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
 
         missing_count = element_count - nonnull_count
         unexpected_count = len(unexpected_list)
-        non_missing_unexpected_count = sum([x is not None for x in unexpected_list])
 
         if element_count > 0:
             unexpected_percent = float(unexpected_count) / element_count
             missing_percent = float(missing_count) / element_count
 
             if nonnull_count > 0:
-                unexpected_percent_nonmissing = float(non_missing_unexpected_count) / nonnull_count
+                unexpected_percent_nonmissing = float(unexpected_count) / nonnull_count
             else:
                 unexpected_percent_nonmissing = None
 

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -707,13 +707,14 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
 
         missing_count = element_count - nonnull_count
         unexpected_count = len(unexpected_list)
+        non_missing_unexpected_count = sum([x is not None for x in unexpected_list])
 
         if element_count > 0:
             unexpected_percent = float(unexpected_count) / element_count
             missing_percent = float(missing_count) / element_count
 
             if nonnull_count > 0:
-                unexpected_percent_nonmissing = float(unexpected_count) / nonnull_count
+                unexpected_percent_nonmissing = float(non_missing_unexpected_count) / nonnull_count
             else:
                 unexpected_percent_nonmissing = None
 

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -301,27 +301,31 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         series = self[column]
         boolean_mapped_null_values = series.isnull()
 
-        element_count = int(len(series))
-        nonnull_values = series[boolean_mapped_null_values==False]
-        nonnull_count = int((boolean_mapped_null_values==False).sum())
+        element_count = len(series)
+        success_count = sum(~boolean_mapped_null_values)
+        unexpected_count = element_count - success_count
 
-        boolean_mapped_success_values = boolean_mapped_null_values==False
-        success_count = boolean_mapped_success_values.sum()
-
-        unexpected_list = [None for i in list(series[(boolean_mapped_success_values==False)])]
-        unexpected_index_list = list(series[(boolean_mapped_success_values==False)].index)
-        unexpected_count = len(unexpected_list)
+        unexpected_list = [None for i in range(unexpected_count)]
+        unexpected_index_list = boolean_mapped_null_values[boolean_mapped_null_values].index
 
         # Pass element_count instead of nonnull_count, because that's the right denominator for this expectation
         success, percent_success = self._calc_map_expectation_success(success_count, element_count, mostly)
 
-        return_obj = self._format_column_map_output(
-            result_format, success,
-            element_count, nonnull_count,
-            unexpected_list, unexpected_index_list
-        )
+        return {
+            "success": success,
+            "result": {
+                "element_count": element_count,
+                "missing_count": unexpected_count,
+                "missing_percent": float(unexpected_count) / element_count,
+                "unexpected_count": unexpected_count,
+                "unexpected_percent": float(unexpected_count) / element_count,
+                "partial_unexpected_list": unexpected_list[:min(5, len(unexpected_list))],
+                "partial_unexpected_index_list": unexpected_index_list[:min(5, len(unexpected_index_list))],
+                "unexpected_list": unexpected_list,
+                "unexpected_index_list": unexpected_index_list
+            }
+        }
 
-        return return_obj
 
     @DocInherit
     @Dataset.expectation(['column', 'mostly', 'result_format'])
@@ -334,27 +338,30 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         series = self[column]
         boolean_mapped_null_values = series.isnull()
 
-        element_count = int(len(series))
-        nonnull_values = series[boolean_mapped_null_values==False]
-        nonnull_count = (boolean_mapped_null_values==False).sum()
+        element_count = len(series)
+        success_count = sum(boolean_mapped_null_values)
+        unexpected_count = element_count - success_count
 
-        boolean_mapped_success_values = boolean_mapped_null_values
-        success_count = boolean_mapped_success_values.sum()
-
-        unexpected_list = list(series[(boolean_mapped_success_values==False)])
-        unexpected_index_list = list(series[(boolean_mapped_success_values==False)].index)
-        unexpected_count = len(unexpected_list)
+        unexpected_list = list(series[~boolean_mapped_null_values])
+        unexpected_index_list = boolean_mapped_null_values[~boolean_mapped_null_values].index
 
         # Pass element_count instead of nonnull_count, because that's the right denominator for this expectation
         success, percent_success = self._calc_map_expectation_success(success_count, element_count, mostly)
 
-        return_obj = self._format_column_map_output(
-            result_format, success,
-            element_count, nonnull_count,
-            unexpected_list, unexpected_index_list
-        )
-
-        return return_obj
+        return {
+            "success": success,
+            "result": {
+                "element_count": element_count,
+                "missing_count": unexpected_count,
+                "missing_percent": float(unexpected_count) / element_count,
+                "unexpected_count": unexpected_count,
+                "unexpected_percent": float(unexpected_count) / element_count,
+                "partial_unexpected_list": unexpected_list[:min(5, len(unexpected_list))],
+                "partial_unexpected_index_list": unexpected_index_list[:min(5, len(unexpected_index_list))],
+                "unexpected_list": unexpected_list,
+                "unexpected_index_list": unexpected_index_list
+            }
+        }
 
     @DocInherit
     @MetaPandasDataset.column_map_expectation

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -297,6 +297,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                                             result_format=None, include_config=False, catch_exceptions=None, meta=None):
         if result_format is None:
             result_format = self.default_expectation_args["result_format"]
+        result_format = parse_result_format(result_format)
 
         series = self[column]
         boolean_mapped_null_values = series.isnull()
@@ -306,7 +307,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         unexpected_count = element_count - success_count
 
         unexpected_list = [None for i in range(unexpected_count)]
-        unexpected_index_list = boolean_mapped_null_values[boolean_mapped_null_values].index
+        unexpected_index_list = series[boolean_mapped_null_values].index
 
         # Pass element_count instead of nonnull_count, because that's the right denominator for this expectation
         success, percent_success = self._calc_map_expectation_success(success_count, element_count, mostly)
@@ -319,8 +320,10 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 "missing_percent": float(unexpected_count) / element_count,
                 "unexpected_count": unexpected_count,
                 "unexpected_percent": float(unexpected_count) / element_count,
-                "partial_unexpected_list": unexpected_list[:min(5, len(unexpected_list))],
-                "partial_unexpected_index_list": unexpected_index_list[:min(5, len(unexpected_index_list))],
+                "partial_unexpected_list":
+                    unexpected_list[:result_format['partial_unexpected_count']],
+                "partial_unexpected_index_list":
+                    unexpected_index_list[:result_format['partial_unexpected_count']],
                 "unexpected_list": unexpected_list,
                 "unexpected_index_list": unexpected_index_list
             }
@@ -334,6 +337,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                                         result_format=None, include_config=False, catch_exceptions=None, meta=None):
         if result_format is None:
             result_format = self.default_expectation_args["result_format"]
+        result_format = parse_result_format(result_format)
 
         series = self[column]
         boolean_mapped_null_values = series.isnull()
@@ -342,8 +346,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         success_count = sum(boolean_mapped_null_values)
         unexpected_count = element_count - success_count
 
-        unexpected_list = list(series[~boolean_mapped_null_values])
-        unexpected_index_list = boolean_mapped_null_values[~boolean_mapped_null_values].index
+        unexpected_list = [x for x in series[~boolean_mapped_null_values]]
+        unexpected_index_list = series[~boolean_mapped_null_values].index
 
         # Pass element_count instead of nonnull_count, because that's the right denominator for this expectation
         success, percent_success = self._calc_map_expectation_success(success_count, element_count, mostly)
@@ -356,8 +360,10 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 "missing_percent": float(unexpected_count) / element_count,
                 "unexpected_count": unexpected_count,
                 "unexpected_percent": float(unexpected_count) / element_count,
-                "partial_unexpected_list": unexpected_list[:min(5, len(unexpected_list))],
-                "partial_unexpected_index_list": unexpected_index_list[:min(5, len(unexpected_index_list))],
+                "partial_unexpected_list":
+                    unexpected_list[:result_format['partial_unexpected_count']],
+                "partial_unexpected_index_list":
+                    unexpected_index_list[:result_format['partial_unexpected_count']],
                 "unexpected_list": unexpected_list,
                 "unexpected_index_list": unexpected_index_list
             }


### PR DESCRIPTION
two-liner to ensure `None`s are not counted as non-missing data