### PR TITLE
Now using `create_multiple_expectations` in add_default_expectations

### DIFF
--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -19,7 +19,7 @@ from .base import Dataset
 from .util import DocInherit, recursively_convert_to_json_serializable, \
         is_valid_partition_object, is_valid_categorical_partition_object, is_valid_continuous_partition_object, \
         infer_distribution_parameters, _scipy_distribution_positional_args_from_dict, validate_distribution_parameters,\
-        parse_result_format
+        parse_result_format, create_multiple_expectations
 
 
 class MetaPandasDataset(Dataset):
@@ -255,14 +255,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         """
         The default behavior for PandasDataset is to explicitly include expectations that every column present upon initialization exists.
         """
-
-        for col in self.columns:
-            self._append_expectation({
-                "expectation_type": "expect_column_to_exist",
-                "kwargs": {
-                    "column": col
-                }
-            })
+        create_multiple_expectations(self, self.columns, "expect_column_to_exist")
 
     ### Expectation methods ###
     @DocInherit

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -191,7 +191,8 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         The default behavior for SqlAlchemyDataset is to explicitly include expectations that every column present upon
         initialization exists.
         """
-        create_multiple_expectations(self, self.columns, "expect_column_to_exist")
+        columns = [col['name'] for col in self.columns]
+        create_multiple_expectations(self, columns, "expect_column_to_exist")
 
     def _is_numeric_column(self, column):
         for col in self.columns:

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -5,7 +5,7 @@ from great_expectations.dataset import Dataset
 from functools import wraps
 import inspect
 
-from .util import DocInherit, parse_result_format
+from .util import DocInherit, parse_result_format, create_multiple_expectations
 
 import sqlalchemy as sa
 from sqlalchemy.engine import reflection
@@ -191,13 +191,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         The default behavior for SqlAlchemyDataset is to explicitly include expectations that every column present upon
         initialization exists.
         """
-        for col in self.columns:
-            self._append_expectation({
-                "expectation_type": "expect_column_to_exist",
-                "kwargs": {
-                    "column": col["name"]
-                }
-            })
+        create_multiple_expectations(self, self.columns, "expect_column_to_exist")
 
     def _is_numeric_column(self, column):
         for col in self.columns:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -33,13 +33,16 @@ class TestDataset(unittest.TestCase):
                 },
                 "expectations" : [{
                     "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "x" }
+                    "kwargs" : { "column" : "x", 'result_format': 'BASIC'},
+                    'success_on_last_run': True
                 },{
                     "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "y" }
+                    "kwargs" : { "column" : "y", 'result_format': 'BASIC'},
+                    'success_on_last_run': True
                 },{
                     "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "z" }
+                    "kwargs" : { "column" : "z", 'result_format': 'BASIC'},
+                    'success_on_last_run': True
                 }]
             }
         )
@@ -54,13 +57,13 @@ class TestDataset(unittest.TestCase):
                 },
                 "expectations" : [{
                     "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "x" }
+                    "kwargs" : { "column" : "x"}
                 },{
                     "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "y" }
+                    "kwargs" : { "column" : "y"}
                 },{
                     "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "z" }
+                    "kwargs" : { "column" : "z"}
                 }]
             }
         )
@@ -277,19 +280,22 @@ class TestDataset(unittest.TestCase):
             {
               "expectation_type": "expect_column_to_exist",
               "kwargs": {
-                "column": "x"
+                "column": "x",
+                "result_format": "BASIC"
               }
             },
             {
               "expectation_type": "expect_column_to_exist",
               "kwargs": {
-                "column": "y"
+                "column": "y",
+                "result_format": "BASIC"
               }
             },
             {
               "expectation_type": "expect_column_to_exist",
               "kwargs": {
-                "column": "z"
+                "column": "z",
+                "result_format": "BASIC"
               }
             },
             {
@@ -325,7 +331,8 @@ class TestDataset(unittest.TestCase):
                 discard_include_configs_kwargs=False,
                 discard_catch_exceptions_kwargs=False,
             ),
-            output_config
+            output_config,
+            msg="Second Test Set"
         )
 
         df.save_expectations_config(


### PR DESCRIPTION
Per Abe's suggestion, when adding all the `expect_columns_to_exist` expectations when creating a great expectations object, does so with the new dataset.util function.