### PR TITLE
Add new expect_column_values_to_not_match_regex_list expectation (#277)

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -38,6 +38,7 @@ String matching
 * :func:`expect_column_values_to_match_regex <great_expectations.dataset.base.Dataset.expect_column_values_to_match_regex>`
 * :func:`expect_column_values_to_not_match_regex <great_expectations.dataset.base.Dataset.expect_column_values_to_not_match_regex>`
 * :func:`expect_column_values_to_match_regex_list <great_expectations.dataset.base.Dataset.expect_column_values_to_match_regex_list>`
+* :func:`expect_column_values_to_not_match_regex_list <great_expectations.dataset.base.Dataset.expect_column_values_to_not_match_regex_list>`
 
 Datetime and JSON parsing
 --------------------------------------------------------------------------------

--- a/docs/source/roadmap_changelog.rst
+++ b/docs/source/roadmap_changelog.rst
@@ -16,7 +16,8 @@ Planned Features
 develop
 -------
 * Add new expectation expect_column_values_to_not_match_regex_list.
-  * Change behavior of expect_column_values_to_match_regex_list to use python re.findall in PandasDataset, relaxing matching of individuals expressions.
+  * Change behavior of expect_column_values_to_match_regex_list to use python re.findall in PandasDataset, relaxing \
+  matching of individuals expressions to allow matches anywhere in the string.
 
 v.0.4.1
 -------

--- a/docs/source/roadmap_changelog.rst
+++ b/docs/source/roadmap_changelog.rst
@@ -13,7 +13,12 @@ Planned Features
 * Support for non-tabular datasources (e.g. JSON, XML, AVRO)
 * Real-time/streaming and adaption of distributional expectations
 
-v 0.4.1
+develop
+-------
+* Add new expectation expect_column_values_to_not_match_regex_list.
+  * Change behavior of expect_column_values_to_match_regex_list to use python re.findall in PandasDataset, relaxing matching of individuals expressions.
+
+v.0.4.1
 -------
 * Correct inclusion of new data_context module in source distribution
 

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -1988,6 +1988,49 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         """
         raise NotImplementedError
 
+    def expect_column_values_to_not_match_regex_list(self, column, regex_list,
+                                                mostly=None,
+                                                result_format=None, include_config=False, catch_exceptions=None, meta=None):
+        """Expect the column entries to be strings that do not match any of a list of regular expressions.
+
+        expect_column_values_to_not_match_regex_list is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
+
+        Args:
+            column (str): \
+                The column name.
+            regex_list (list): \
+                The list of regular expressions which the column entries should not match
+
+        Keyword Args:
+            mostly (None or a float between 0 and 1): \
+                Return `"success": True` if the percentage of unexpected values is less than or equal to `mostly`. \
+                For more detail, see :ref:`mostly`.
+
+        Other Parameters:
+            result_format (str or None): \
+                Which output mode to use: `BOOLEAN_ONLY`, `BASIC`, `COMPLETE`, or `SUMMARY`.
+                For more detail, see :ref:`result_format <result_format>`.
+            include_config (boolean): \
+                If True, then include the expectation config as part of the result object. \
+                For more detail, see :ref:`include_config`.
+            catch_exceptions (boolean or None): \
+                If True, then catch exceptions and include them as part of the result object. \
+                For more detail, see :ref:`catch_exceptions`.
+            meta (dict or None): \
+                A JSON-serializable dictionary (nesting allowed) that will be included in the output without modification. \
+                For more detail, see :ref:`meta`.
+
+        Returns:
+            A JSON-serializable expectation result object.
+
+            Exact fields vary depending on the values passed to :ref:`result_format <result_format>` and
+            :ref:`include_config`, :ref:`catch_exceptions`, and :ref:`meta`.
+
+        See Also:
+            expect_column_values_to_match_regex_list
+        """
+        raise NotImplementedError
+
     ##### Datetime and JSON parsing #####
 
     def expect_column_values_to_match_strftime_format(self,

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -1848,7 +1848,9 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         mostly=None,
         result_format=None, include_config=False, catch_exceptions=None, meta=None
     ):
-        """Expect column entries to be strings that match against a given regular expression.
+        """Expect column entries to be strings that match a given regular expression. Valid matches can be found \
+        anywhere in the string, for example "[at]+" will identify the following strings as expected: "cat", "hat", \
+        "aa", "a", and "t", and the following strings as unexpected: "fish", "dog".
 
         expect_column_values_to_match_regex is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 
@@ -1895,7 +1897,9 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         mostly=None,
         result_format=None, include_config=False, catch_exceptions=None, meta=None
     ):
-        """Expect column entries to be strings that do NOT match against a given regular expression.
+        """Expect column entries to be strings that do NOT match a given regular expression. The regex must not match \
+        any portion of the provided string. For example, "[at]+" would identify the following strings as expected: \
+        "fish", "dog", and the following as unexpected: "cat", "hat".
 
         expect_column_values_to_not_match_regex is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 
@@ -1944,6 +1948,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         result_format=None, include_config=False, catch_exceptions=None, meta=None
     ):
         """Expect the column entries to be strings that can be matched to either any of or all of a list of regular expressions.
+        Matches can be anywhere in the string.
 
         expect_column_values_to_match_regex_list is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 
@@ -1991,7 +1996,9 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
     def expect_column_values_to_not_match_regex_list(self, column, regex_list,
                                                 mostly=None,
                                                 result_format=None, include_config=False, catch_exceptions=None, meta=None):
-        """Expect the column entries to be strings that do not match against any of a list of regular expressions.
+        """Expect the column entries to be strings that do not match any of a list of regular expressions. Matches can \
+        be anywhere in the string.
+
 
         expect_column_values_to_not_match_regex_list is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -1848,7 +1848,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         mostly=None,
         result_format=None, include_config=False, catch_exceptions=None, meta=None
     ):
-        """Expect column entries to be strings that match a given regular expression.
+        """Expect column entries to be strings that match against a given regular expression.
 
         expect_column_values_to_match_regex is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 
@@ -1895,7 +1895,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         mostly=None,
         result_format=None, include_config=False, catch_exceptions=None, meta=None
     ):
-        """Expect column entries to be strings that do NOT match a given regular expression.
+        """Expect column entries to be strings that do NOT match against a given regular expression.
 
         expect_column_values_to_not_match_regex is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 
@@ -1943,7 +1943,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         mostly=None,
         result_format=None, include_config=False, catch_exceptions=None, meta=None
     ):
-        """Expect the column entries to be strings that match either any of or all of a list of regular expressions.
+        """Expect the column entries to be strings that can be matched to either any of or all of a list of regular expressions.
 
         expect_column_values_to_match_regex_list is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 
@@ -1991,7 +1991,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
     def expect_column_values_to_not_match_regex_list(self, column, regex_list,
                                                 mostly=None,
                                                 result_format=None, include_config=False, catch_exceptions=None, meta=None):
-        """Expect the column entries to be strings that do not match any of a list of regular expressions.
+        """Expect the column entries to be strings that do not match against any of a list of regular expressions.
 
         expect_column_values_to_not_match_regex_list is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
 

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -745,6 +745,16 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
     @DocInherit
     @MetaPandasDataset.column_map_expectation
+    def expect_column_values_to_not_match_regex_list(self, column, regex_list,
+                                                 mostly=None,
+                                                 result_format=None, include_config=False, catch_exceptions=None, meta=None):
+        return column.map(
+            lambda x: not any([re.match(regex, str(x)) for regex in regex_list])
+        )
+
+
+    @DocInherit
+    @MetaPandasDataset.column_map_expectation
     def expect_column_values_to_match_strftime_format(self, column, strftime_format,
                                                       mostly=None,
                                                       result_format=None, include_config=False, catch_exceptions=None,

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -728,7 +728,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         if match_on=="any":
 
             def match_in_list(val):
-                if any(re.match(regex, str(val)) for regex in regex_list):
+                if any(re.findall(regex, str(val)) for regex in regex_list):
                     return True
                 else:
                     return False
@@ -736,7 +736,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         elif match_on=="all":
 
             def match_in_list(val):
-                if all(re.match(regex, str(val)) for regex in regex_list):
+                if all(re.findall(regex, str(val)) for regex in regex_list):
                     return True
                 else:
                     return False
@@ -749,7 +749,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                                                  mostly=None,
                                                  result_format=None, include_config=False, catch_exceptions=None, meta=None):
         return column.map(
-            lambda x: not any([re.match(regex, str(x)) for regex in regex_list])
+            lambda x: not any([re.findall(regex, str(x)) for regex in regex_list])
         )
 
 

--- a/tests/column_map_expectations/expect_column_values_to_not_match_regex_list.json
+++ b/tests/column_map_expectations/expect_column_values_to_not_match_regex_list.json
@@ -1,0 +1,58 @@
+{
+  "expectation_type" : "expect_column_values_to_not_match_regex_list",
+  "datasets" : [{
+    "data" : {
+      "w" : ["111", "222", "333", "123", "321", "444", "456", "654", "555", null],
+      "x" : ["man", "plan", "canal", "panama", "hat", "bat", "bit", "bot", "but", "bet"]
+    },
+    "tests" : [{
+      "title" : "Basic positive test",
+      "exact_match_out" : false,
+      "in": {
+        "column": "w",
+        "regex_list": ["\\s+"]
+      },
+      "out": {
+        "unexpected_list": [],
+        "unexpected_index_list": [],
+        "success": true
+      }
+    },{
+      "title" : "Positive test with multiple regexes",
+      "exact_match_out" : false,
+      "in": {
+        "column": "w",
+        "regex_list": ["\\s+", "[a-zA-Z]"]
+      },
+      "out": {
+        "unexpected_list": [],
+        "unexpected_index_list": [],
+        "success": true
+      }
+    },{
+      "title" : "Basic negative test",
+      "exact_match_out" : false,
+      "in": {
+        "column": "w",
+        "regex_list": ["[12]+", "[45]+"]
+      },
+      "out": {
+        "unexpected_list": ["111", "222", "123", "444", "456", "555"],
+        "unexpected_index_list": [0,1,3,5,6,8],
+        "success": false
+      }
+    },{
+      "title" : "Negative test with more string-ish strings",
+      "exact_match_out" : false,
+      "in": {
+        "column": "x",
+        "regex_list": ["opatomus", "ovat", "^h.*t$"]
+      },
+      "out": {
+        "unexpected_list": ["hat"],
+        "unexpected_index_list": [4],
+        "success": false
+      }
+    }]
+  }]
+}

--- a/tests/column_map_expectations/expect_column_values_to_not_match_regex_list.json
+++ b/tests/column_map_expectations/expect_column_values_to_not_match_regex_list.json
@@ -37,8 +37,8 @@
         "regex_list": ["[12]+", "[45]+"]
       },
       "out": {
-        "unexpected_list": ["111", "222", "123", "444", "456", "555"],
-        "unexpected_index_list": [0,1,3,5,6,8],
+        "unexpected_list": ["111", "222", "123", "321", "444", "456", "654", "555"],
+        "unexpected_index_list": [0,1,3,4,5,6,7,8],
         "success": false
       }
     },{
@@ -46,7 +46,7 @@
       "exact_match_out" : false,
       "in": {
         "column": "x",
-        "regex_list": ["opatomus", "ovat", "^h.*t$"]
+        "regex_list": ["opatomus", "ovat", "h.*t"]
       },
       "out": {
         "unexpected_list": ["hat"],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,6 +99,7 @@ def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type
             "expect_column_values_to_match_regex",
             "expect_column_values_to_not_match_regex",
             "expect_column_values_to_match_regex_list",
+            "expect_column_values_to_not_match_regex_list",
             "expect_column_values_to_match_strftime_format",
             "expect_column_values_to_be_dateutil_parseable",
             "expect_column_values_to_be_json_parseable",


### PR DESCRIPTION
Create new expectation `expect_column_values_to_not_match_regex_list`

Note that currently the regex expectations are not consistent in use of match vs. findall. I chose match (it seems clearer and more in line with the wording of the expectation), but the non list variants both use `findall` Should that be a separate issue?