### PR TITLE
add expectation and remove from temporary unimplemented list

### DIFF
--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -550,6 +550,62 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
     @DocInherit
     @MetaSqlAlchemyDataset.column_aggregate_expectation
+    def expect_column_median_to_be_between(self,
+                                         column,
+                                         min_value=None,
+                                         max_value=None,
+                                         result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                         ):
+
+        if min_value is None and max_value is None:
+            raise ValueError("min_value and max_value cannot both be None")
+
+
+        # Inspiration from https://stackoverflow.com/questions/942620/missing-median-aggregate-function-in-django
+        count_query = self.engine.execute(
+            sa.select([
+                sa.func.count().label("element_count"),
+                sa.func.sum(
+                    sa.case([(sa.column(column) == None, 1)], else_=0)
+                ).label('null_count')
+            ]).
+            select_from(sa.table(self.table_name))
+        )
+
+        element_values = self.engine.execute(
+            sa.select(column).order_by(column).where(
+                sa.column(column) != None
+            ).select_from(sa.table(self.table_name))
+        )
+
+        # Fetch the Element count, null count, and sorted/null dropped column values
+        elements = count_query.fetchone()
+        column_values = list(element_values.fetchall())
+
+        # The number of non-null/non-ignored values
+        nonnull_count = elements['element_count'] - elements['null_count']
+
+        if nonnull_count % 2 == 0:
+            # An even number of column values: take the average of the two center values
+            column_median = (
+                column_values[nonnull_count // 2 - 1 + elements['null_count']][0] +  # left center value
+                column_values[nonnull_count // 2][0]        # right center value
+            ) / 2.0  # Average center values
+        else:
+            # An odd number of column values, we can just take the center value
+            column_median = column_values[nonnull_count // 2][0]  # True center value
+
+        return {
+            'success':
+                ((min_value is None) or (min_value <= column_median)) and
+                ((max_value is None) or (column_median <= max_value)),
+            'result': {
+                'observed_value': column_median
+                }
+            }
+
+    @DocInherit
+    @MetaSqlAlchemyDataset.column_aggregate_expectation
     def expect_column_unique_value_count_to_be_between(self, column, min_value=None, max_value=None,
                                                        result_format=None, include_config=False, catch_exceptions=None, meta=None):
 

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -588,7 +588,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         if nonnull_count % 2 == 0:
             # An even number of column values: take the average of the two center values
             column_median = (
-                column_values[nonnull_count // 2 - 1 + elements['null_count']][0] +  # left center value
+                column_values[nonnull_count // 2 - 1][0] +  # left center value
                 column_values[nonnull_count // 2][0]        # right center value
             ) / 2.0  # Average center values
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,7 +105,7 @@ def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type
             "expect_column_values_to_be_json_parseable",
             "expect_column_values_to_match_json_schema",
             #"expect_column_mean_to_be_between",
-            "expect_column_median_to_be_between",
+            #"expect_column_median_to_be_between",
             "expect_column_stdev_to_be_between",
             #"expect_column_unique_value_count_to_be_between",
             #"expect_column_proportion_of_unique_values_to_be_between",


### PR DESCRIPTION
Implemented `expect_column_median_to_be_between` and removed it from the temporary unimplemented list. 