### PR TITLE
implement expect_column_values_to_be_unique for SQLAlchemy

### DIFF
--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -272,6 +272,20 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         }
 
     @DocInherit
+    @Dataset.expectation(['column'])
+    def expect_column_values_to_be_unique(self, column,
+                                          mostly=None,
+                                          result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                          ):
+        has_duplicates = self.engine.execute(
+            sa.select([sa.sql.expression.true()]).select_from(sa.table(self.table_name)).group_by(
+                sa.column(column)).having(sa.func.count() > 1)).scalar()
+
+        return {
+            'success': False if has_duplicates else True
+        }
+
+    @DocInherit
     @Dataset.expectation(['min_value', 'max_value'])
     def expect_table_row_count_to_be_between(self,
         min_value=0,


### PR DESCRIPTION
Hi,

Implementing the expectation that all column values are unique for SQLAlchemy.

In SQL terms I'm attempting `SELECT true FROM table GROUP BY column HAVING COUNT(*) > 1 LIMIT 1` here. If there are duplicates the query returns `True`. If there aren't any duplicates the query returns no records, that is, `None`.

A couple of doubts:
* Not sure of the decorator `column_map_expectation` that was there for Pandas implementation. I've left it out because it broke the code and didn't seem necessary
* Not sure how to write the tests

Let me know if you need anything, happy to answer any questions or help out,
Ilmari