### PR TITLE
Add success field and stats to validation report

### DIFF
--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -4,7 +4,7 @@
 Validation
 ================================================================================
 
-Once you've constructed Expectations, you can use them to validate new data.
+Once you've constructed and stored Expectations, you can use them to validate new data.
 
 .. code-block:: bash
 
@@ -76,10 +76,22 @@ Once you've constructed Expectations, you can use them to validate new data.
             ]
           }
         }
-      ]
+      ],
+      "success", False,
+      "statistics": {
+          "evaluated_expectations": 10,
+          "successful_expectations": 9,
+          "unsuccessful_expectations": 1,
+          "success_percent": 90.0,
+      }
     }
 
-Calling great_expectations's validation method generates a JSON-formatted report describing the outcome of all expectations.
+Calling great_expectations's ``validate`` method generates a JSON-formatted report.
+The report contains infos about
+- the overall sucess (the `success` field),
+- summary statistics of the expectations (the `statistics` field), and
+- the detailed results of each expectation (the `results` field).
+
 
 Command-line validation
 ------------------------------------------------------------------------------
@@ -150,6 +162,13 @@ This is especially powerful when combined with great_expectations's command line
           }
         }
       ]
+      "success", False,
+      "statistics": {
+          "evaluated_expectations": 10,
+          "successful_expectations": 9,
+          "unsuccessful_expectations": 1,
+          "success_percent": 90.0
+      }
     }
 
 Deployment patterns

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -206,6 +206,7 @@ class TestValidation(unittest.TestCase):
                             )
 
         # Finally, confirm that only_return_failures works
+        # and does not affect the "statistics" field.
         validation_results = my_df.validate(only_return_failures=True)
         #print json.dumps(validation_results)
         assertDeepAlmostEqual(
@@ -225,8 +226,11 @@ class TestValidation(unittest.TestCase):
                                 "missing_percent": 0.0, "partial_unexpected_counts": [{"count": 1, "value": "*"}],
                                 "partial_unexpected_list": ["*"],
                                 "unexpected_percent_nonmissing": 0.0007616146230007616, "missing_count": 0,
-                                "unexpected_index_list": [456]}}]}
-
+                                "unexpected_index_list": [456]}}
+            ],
+            "success": expected_results["success"],  # unaffected
+            "statistics": expected_results["statistics"],  # unaffected
+            }
         )
 
     def test_validate_catch_non_existent_expectation(self):
@@ -344,7 +348,14 @@ class TestValidation(unittest.TestCase):
                                  "unexpected_count": 2
                     }
                 }
-              ]
+              ],
+              "success": False,
+              "statistics": {
+                  "evaluated_expectations": 2,
+                  "successful_expectations": 1,
+                  "unsuccessful_expectations": 1,
+                  "success_percent": 50,
+              }
             }
         )
 

--- a/tests/test_sets/expected_cli_results_custom.json
+++ b/tests/test_sets/expected_cli_results_custom.json
@@ -64,5 +64,12 @@
         "missing_count": 0
       }
     }
-  ]
+  ],
+  "success": false,
+  "statistics": {
+    "evaluated_expectations": 1,
+    "successful_expectations": 0,
+    "unsuccessful_expectations": 1,
+    "success_percent": 0
+  }
 }

--- a/tests/test_sets/expected_cli_results_default.json
+++ b/tests/test_sets/expected_cli_results_default.json
@@ -213,5 +213,12 @@
         "missing_count": 0
       }
     }
-  ]
+  ],
+  "success": false,
+  "statistics": {
+    "evaluated_expectations": 10,
+    "successful_expectations": 9,
+    "unsuccessful_expectations": 1,
+    "success_percent": 90
+  }
 }

--- a/tests/test_sets/expected_results_20180303.json
+++ b/tests/test_sets/expected_results_20180303.json
@@ -188,5 +188,12 @@
         ]
       }
     }
-  ]
+  ],
+  "success": false,
+  "statistics": {
+    "evaluated_expectations": 10,
+    "successful_expectations": 9,
+    "unsuccessful_expectations": 1,
+    "success_percent": 90
+  }
 }


### PR DESCRIPTION
Hey,

I quickly drafted a first version of the overall success field and summary statistics for the validation report.
I'll write test and update the docs as soon as we settle on the exact scope of this PR.

In summary: the validation report now contains some infos about the overall success as well as stats about the results:
```python
{
  "results": [...],  # unchanged
   "success": True,
   "stats": {
     "n_total": 10,
     "n_success": 10,
     "n_failed": 0,
   }
```

What do you think? Do we need the stats? Should the names me different?


TODO:
- [X] intial implementation
- [X] fix old failing tests
- [X] write tests
- [X] update docs
- [x] rebase/clean up commits
- [x] decide on name "details/statistics" field

This PR closes #305.