### PR TITLE
this version doesn't bind the name 'doc_inherit', so use DocInherit here

### DIFF
--- a/great_expectations/dataset/util.py
+++ b/great_expectations/dataset/util.py
@@ -61,7 +61,7 @@ Usage::
             pass
 
     class Bar(Foo):
-        @doc_inherit
+        @DocInherit
         def foo(self):
             pass
 
@@ -230,10 +230,10 @@ def is_valid_continuous_partition_object(partition_object):
 
 def categorical_partition_data(data):
     """Convenience method for creating weights from categorical data.
-    
+
     Args:
         data (list-like): The data from which to construct the estimate.
-    
+
     Returns:
         A new partition object::
 


### PR DESCRIPTION
Just a quick thing I noticed as I was reading up on the DocInherit decorator. The original ActiveState recipe binds the name doc_inherit to the decorator class. As this implementation doesn't do that, it seemed reasonable to use the class name in the description.