### PR TITLE
Add a new classmethod to Dataset, get_datasource_names()

### DIFF
--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -13,6 +13,8 @@ from collections import (
     defaultdict
 )
 
+import numpy as np
+
 from ..version import __version__
 from .util import DotDict, recursively_convert_to_json_serializable, parse_result_format
 
@@ -1113,7 +1115,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
     ##### Table shape expectations #####
 
     def expect_column_to_exist(
-            self, column, column_index=None, result_format=None, include_config=False, 
+            self, column, column_index=None, result_format=None, include_config=False,
             catch_exceptions=None, meta=None
         ):
         """Expect the specified column to exist.
@@ -1527,6 +1529,42 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
             expect_column_values_to_be_of_type
         """
         raise NotImplementedError
+
+    _python_avro_types = {
+            "null":type(None),
+            "boolean":bool,
+            "int":int,
+            "long":int,
+            "float":float,
+            "double":float,
+            "bytes":bytes,
+            "string":str
+            }
+
+    _numpy_avro_types = {
+            "null":np.nan,
+            "boolean":np.bool_,
+            "int":np.int64,
+            "long":np.longdouble,
+            "float":np.float_,
+            "float64":np.float_,
+            "double":np.longdouble,
+            "bytes":np.bytes_,
+            "string":np.string_
+            }
+
+    datasources = {
+        "python":_python_avro_types,
+        "numpy":_numpy_avro_types,
+    }
+
+    @classmethod
+    def get_datasource_names(cls):
+        """Return a dictionary mapping target_datasource names to their type strings."""
+        names = {}
+        for source in cls.datasources:
+            names[source] = sorted(cls.datasources[source])
+        return names
 
     ##### Sets and ranges #####
 

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -62,7 +62,7 @@ class MetaPandasDataset(Dataset):
             ignore_values = [None, np.nan]
             if func.__name__ in ['expect_column_values_to_not_be_null', 'expect_column_values_to_be_null']:
                 ignore_values = []
-        
+
             series = self[column]
 
             # FIXME rename to mapped_ignore_values?
@@ -136,9 +136,9 @@ class MetaPandasDataset(Dataset):
             assert len(series_A) == len(series_B), "Series A and B must be the same length"
 
             #This next bit only works if series_A and _B are the same length
-            element_count = int(len(series_A)) 
+            element_count = int(len(series_A))
             nonnull_count = (boolean_mapped_null_values==False).sum()
-            
+
             nonnull_values_A = series_A[boolean_mapped_null_values==False]
             nonnull_values_B = series_B[boolean_mapped_null_values==False]
             nonnull_values = [value_pair for value_pair in zip(
@@ -406,31 +406,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     def expect_column_values_to_be_of_type(self, column, type_, target_datasource="numpy",
                                            mostly=None,
                                            result_format=None, include_config=False, catch_exceptions=None, meta=None):
-        python_avro_types = {
-                "null":type(None),
-                "boolean":bool,
-                "int":int,
-                "long":int,
-                "float":float,
-                "double":float,
-                "bytes":bytes,
-                "string":str
-                }
-
-        numpy_avro_types = {
-                "null":np.nan,
-                "boolean":np.bool_,
-                "int":np.int64,
-                "long":np.longdouble,
-                "float":np.float_,
-                "double":np.longdouble,
-                "bytes":np.bytes_,
-                "string":np.string_
-                }
-
-        datasource = {"python":python_avro_types, "numpy":numpy_avro_types}
-
-        target_type = datasource[target_datasource][type_]
+        target_type = self.datasources[target_datasource][type_]
         result = column.map(lambda x: type(x) == target_type)
 
         return result
@@ -440,32 +416,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     def expect_column_values_to_be_in_type_list(self, column, type_list, target_datasource="numpy",
                                                 mostly=None,
                                                 result_format=None, include_config=False, catch_exceptions=None, meta=None):
-
-        python_avro_types = {
-                "null":type(None),
-                "boolean":bool,
-                "int":int,
-                "long":int,
-                "float":float,
-                "double":float,
-                "bytes":bytes,
-                "string":str
-                }
-
-        numpy_avro_types = {
-                "null":np.nan,
-                "boolean":np.bool_,
-                "int":np.int64,
-                "long":np.longdouble,
-                "float":np.float_,
-                "double":np.longdouble,
-                "bytes":np.bytes_,
-                "string":np.string_
-                }
-
-        datasource = {"python":python_avro_types, "numpy":numpy_avro_types}
-
-        target_type_list = [datasource[target_datasource][t] for t in type_list]
+        target_type_list = [self.datasources[target_datasource][t]
+                              for t in type_list]
         result = column.map(lambda x: type(x) in target_type_list)
 
         return result
@@ -1367,7 +1319,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         #FIXME
         if allow_cross_type_comparisons==True:
             raise NotImplementedError
-        
+
         if parse_strings_as_datetimes:
             temp_column_A = column_A.map(parse)
             temp_column_B = column_B.map(parse)
@@ -1399,12 +1351,12 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 a = None
             else:
                 a = t["A"]
-                
+
             if pd.isnull(t["B"]):
                 b = None
             else:
                 b = t["B"]
-                
+
             results.append((a, b) in value_pairs_set)
 
         return pd.Series(results, temp_df.index)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1157,6 +1157,10 @@ class TestDataset(unittest.TestCase):
         with self.assertRaises(AttributeError) as context:
             result = my_df.validate(catch_exceptions=False)
 
+    def test_get_datasource_names(self):
+        ds = ge.dataset.Dataset
+        self.assertTrue("float64" in ds.get_datasource_names()["numpy"])
+        self.assertFalse("float64" in ds.get_datasource_names()["python"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -38,6 +38,7 @@ class TestPandasDataset(unittest.TestCase):
         D = ge.dataset.PandasDataset({
             'x' : [1,2,4],
             'y' : [1.0,2.2,5.3],
+            'y1' : [np.float64(f) for f in [1.0,2.2,5.3]],
             'z' : ['hello', 'jello', 'mello'],
             'n' : [None, np.nan, None],
             'b' : [False, True, False],
@@ -59,6 +60,9 @@ class TestPandasDataset(unittest.TestCase):
                 {
                     'in':{"column":"y","type_":"float","target_datasource":"numpy"},
                     'out':{'success':False, 'unexpected_list':[1.0,2.2,5.3], 'unexpected_index_list':[0,1,2]}},
+                {
+                    'in':{"column":"y1","type_":"float64","target_datasource":"numpy"},
+                    'out':{'success':True, 'unexpected_list':[], 'unexpected_index_list':[]}},
                 {
                     'in':{"column":"z","type_":"string","target_datasource":"python"},
                     'out':{'success':True, 'unexpected_list':[], 'unexpected_index_list':[]}},


### PR DESCRIPTION
This PR adds Dataset.get_datasource_names() to the public API, making it possible for users
to discover the valid values for target_datasource and corresponding type strings to the user.

Notes:

- The class attribute, datasources, is also used by expect_column_values_to_be_of_type() and
expect_column_values_to_be_in_type_list().
- This PR is related to https://github.com/great-expectations/great_expectations/issues/313 but I don't
know how to tie this PR to that issue.
- This is just me taking a stab at solving the problem I encountered. It may will not be the way the maintainers would do this (if they would do it at all). It might just provide some talking points.
- Note that I added "float64" as a type string for "numpy". Again, maybe not what you want, though I will note there are several other float* numpy types which aren't available.