### PR TITLE
Fix/warnings

### DIFF
--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -1078,7 +1078,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         # Convert to Series object to allow joining on index values
         expected_column = pd.Series(partition_object['weights'], index=partition_object['values'], name='expected') * len(column)
         # Join along the indices to allow proper comparison of both types of possible missing values
-        test_df = pd.concat([expected_column, observed_frequencies], axis = 1)
+        test_df = pd.concat([expected_column, observed_frequencies], axis=1, sort=True)
 
         na_counts = test_df.isnull().sum()
 
@@ -1218,7 +1218,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             # Data are expected to be discrete, use value_counts
             observed_weights = column.value_counts() / len(column)
             expected_weights = pd.Series(partition_object['weights'], index=partition_object['values'], name='expected')
-            test_df = pd.concat([expected_weights, observed_weights], axis=1)
+            test_df = pd.concat([expected_weights, observed_weights], axis=1, sort=True)
 
             na_counts = test_df.isnull().sum()
 

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -653,12 +653,11 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 sa.func.sum(
                     sa.case([(sa.column(column) == None, 1)], else_=0)
                 ).label('null_count')
-            ]).
-            select_from(sa.table(self.table_name))
+            ]).select_from(sa.table(self.table_name))
         )
 
         element_values = self.engine.execute(
-            sa.select(column).order_by(column).where(
+            sa.select([sa.column(column)]).order_by(sa.column(column)).where(
                 sa.column(column) != None
             ).select_from(sa.table(self.table_name))
         )

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -656,28 +656,27 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             ]).select_from(sa.table(self.table_name))
         )
 
+        elements = count_query.fetchone()
+        # The number of non-null/non-ignored values
+        nonnull_count = elements['element_count'] - elements['null_count']
+
         element_values = self.engine.execute(
             sa.select([sa.column(column)]).order_by(sa.column(column)).where(
                 sa.column(column) != None
-            ).select_from(sa.table(self.table_name))
+            ).offset(nonnull_count // 2 - 1).limit(2).select_from(sa.table(self.table_name))
         )
 
-        # Fetch the Element count, null count, and sorted/null dropped column values
-        elements = count_query.fetchone()
         column_values = list(element_values.fetchall())
-
-        # The number of non-null/non-ignored values
-        nonnull_count = elements['element_count'] - elements['null_count']
 
         if nonnull_count % 2 == 0:
             # An even number of column values: take the average of the two center values
             column_median = (
-                column_values[nonnull_count // 2 - 1][0] +  # left center value
-                column_values[nonnull_count // 2][0]        # right center value
+                column_values[0][0] +  # left center value
+                column_values[1][0]        # right center value
             ) / 2.0  # Average center values
         else:
             # An odd number of column values, we can just take the center value
-            column_median = column_values[nonnull_count // 2][0]  # True center value
+            column_median = column_values[1][0]  # True center value
 
         return {
             'success':


### PR DESCRIPTION
This cleans up some warnings in tests that should have been caught during review. I'll flag, however, that the current implementation of expect_column_median_values... is inefficient (it is computing the median locally by pulling all values) and should be corrected. Opening separate issue.