### PR TITLE
Fix/pandasdataset deepcopy

### DIFF
--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -248,11 +248,12 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
            default_expectations (see :func:`add_default_expectations`)
     """
 
+    # We may want to expand or alter support for subclassing dataframes in the future:
+    # See http://pandas.pydata.org/pandas-docs/stable/extending.html#extending-subclassing-pandas
+
     @property
     def _constructor(self):
         return self.__class__
-
-# Do we need to define _constructor_sliced and/or _constructor_expanddim? See http://pandas.pydata.org/pandas-docs/stable/internals.html#subclassing-pandas-data-structures
 
     def __finalize__(self, other, method=None, **kwargs):
         if isinstance(other, PandasDataset):
@@ -261,7 +262,10 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 discard_result_format_kwargs=False,
                 discard_include_configs_kwargs=False,
                 discard_catch_exceptions_kwargs=False))
-            self.discard_subset_failing_expectations = other.discard_subset_failing_expectations
+            # If other was coerced to be a PandasDataset (e.g. via _constructor call during self.copy() operation)
+            # then it may not have discard_subset_failing_expectations set. Default to self value
+            self.discard_subset_failing_expectations = other.get("discard_subset_failing_expectations",
+                                                                 self.discard_subset_failing_expectations)
             if self.discard_subset_failing_expectations:
                 self.discard_failing_expectations()
         super(PandasDataset, self).__finalize__(other, method, **kwargs)

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -264,8 +264,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 discard_catch_exceptions_kwargs=False))
             # If other was coerced to be a PandasDataset (e.g. via _constructor call during self.copy() operation)
             # then it may not have discard_subset_failing_expectations set. Default to self value
-            self.discard_subset_failing_expectations = other.get("discard_subset_failing_expectations",
-                                                                 self.discard_subset_failing_expectations)
+            self.discard_subset_failing_expectations = getattr(other, "discard_subset_failing_expectations",
+                                                               self.discard_subset_failing_expectations)
             if self.discard_subset_failing_expectations:
                 self.discard_failing_expectations()
         super(PandasDataset, self).__finalize__(other, method, **kwargs)

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -2,7 +2,6 @@ from __future__ import division
 
 import unittest
 import json
-import numpy as np
 import datetime
 import pandas as pd
 
@@ -956,6 +955,20 @@ class TestPandasDataset(unittest.TestCase):
 
         df2 = df.sample(frac=0.5)
         self.assertTrue(type(df2) == type(df))
+
+
+def test_pandas_deepcopy():
+    import copy
+
+    df = ge.dataset.PandasDataset({"a": [1, 2, 3]})
+    df2 = copy.deepcopy(df)
+
+    df["a"] = [2, 3, 4]
+
+    # Our copied dataframe should not be affected
+    assert df2.expect_column_to_exist("a")["success"] == True
+    assert list(df["a"]) == [2, 3, 4]
+    assert list(df2["a"]) == [1, 2, 3]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The value of `other` in `__finalize__` may have been coerced to be a `PandasDataset` by `_constructor` even when it was not `__init__`-ed as one (for example in the case of `DataFrame.copy()`.

In such cases, use the current value of `discard_subset_failing_expectations` to address #342