### PR TITLE
Fix docstring of `get_expectations_config`

### DIFF
--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -588,11 +588,16 @@ class Dataset(object):
         suppress_warnings=False
     ):
         """Returns _expectation_config as a JSON object, and perform some cleaning along the way.
+
         Args:
-            discard_failed_expectations=True     : Only include expectations with success_on_last_run=True in the exported config.
-            discard_result_format_kwargs=True    : In returned expectation objects, suppress the `result_format` parameter.
-            discard_include_configs_kwargs=True  : In returned expectation objects, suppress the `include_configs` parameter.
-            discard_catch_exceptions_kwargs=True : In returned expectation objects, suppress the `catch_exceptions` parameter.
+            discard_failed_expectations (boolean): \
+                Only include expectations with success_on_last_run=True in the exported config.  Defaults to `True`.
+            discard_result_format_kwargs (boolean): \
+                In returned expectation objects, suppress the `result_format` parameter. Defaults to `True`.
+            discard_include_configs_kwargs (boolean): \
+                In returned expectation objects, suppress the `include_configs` parameter. Defaults to `True`.
+            discard_catch_exceptions_kwargs (boolean): \
+                In returned expectation objects, suppress the `catch_exceptions` parameter.  Defaults to `True`.
 
         Returns:
             An expectation config.


### PR DESCRIPTION
Docstring format of get_expectations_config was wrong.

![image](https://user-images.githubusercontent.com/79138/45594921-4bf5ae00-b9a3-11e8-9436-341a91ba2b98.png)

Fixed now.