### PR TITLE
Ensure that map expectations can be run on categorical columns

### DIFF
--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -79,7 +79,7 @@ class MetaPandasDataset(Dataset):
             nonnull_count = int((boolean_mapped_null_values==False).sum())
 
             boolean_mapped_success_values = func(self, nonnull_values, *args, **kwargs)
-            success_count = boolean_mapped_success_values.sum()
+            success_count = np.count_nonzero(boolean_mapped_success_values)
 
             unexpected_list = list(nonnull_values[boolean_mapped_success_values==False])
             unexpected_index_list = list(nonnull_values[boolean_mapped_success_values==False].index)

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -957,6 +957,21 @@ class TestPandasDataset(unittest.TestCase):
         self.assertTrue(type(df2) == type(df))
 
 
+    def test_validate_map_expectation_on_categorical_column(self):
+        """Map expectations should work on categorical columns"""
+
+        D = ge.dataset.PandasDataset({
+            'cat_column_1':['cat_one','cat_two','cat_one','cat_two', 'cat_one','cat_two', 'cat_one','cat_two'],
+        })
+
+        D['cat_column_1'] = D['cat_column_1'].astype('category')
+
+        D.set_default_expectation_argument("result_format", "COMPLETE")
+
+        out = D.expect_column_value_lengths_to_equal('cat_column_1', 7)
+
+        self.assertEqual(out['success'], True)
+
 def test_pandas_deepcopy():
     import copy
 


### PR DESCRIPTION
Converting object columns to categorical in Pandas dataframes(when possible) shrinks the dataframe's memory footprint and somewhat speeds us operations on these columns.

Without this fix validation on dataframes with categorical columns throws an exception in column_map_expectation method of pandas_dataset.py when computing success_count, since numpy refuses to perform sum on a categorical column.

This change is just one line - changing the way success_count is computed in a way that works with categorical columns.
