### PR TITLE
Create Autoinspect API -- Remove Default Expectations

### DIFF
--- a/docs/source/autoinspection.rst
+++ b/docs/source/autoinspection.rst
@@ -1,0 +1,34 @@
+.. _autoinspection:
+
+================================================================================
+Autoinspection
+================================================================================
+
+It can be very convenient to have great expectations automatically review a \
+dataset and suggest expectations that may be appropriate. Currently, there \
+a very basic, but easily extensible, autoinspection capability available.
+
+Dataset objects have an `autoinspect` method which allows you to provide a \
+function that will evaluate a dataset object and add expectations to it. \
+By default `autoinspect` will call the autoinspect function \
+:func:`columns_exist <great_expectations.dataset.autoinspect.columns_exist>` \
+which will add an `expect_column_to_exist` expectation for each column \
+currently present on the dataset.
+
+To implement additional autoinspection functions, you simply take a single \
+parameter, a Dataset, and evaluate and add expectations to that object.
+
+
+.. code-block:: python
+
+    >> import great_expectations as ge
+    >> df = ge.dataset.PandasDataset({"col": [1, 2, 3, 4, 5]})
+    >> df.autoinspect(ge.dataset.autoinspect.columns_exist)
+    >> df.get_expectations_config()
+        {'dataset_name': None,
+         'meta': {'great_expectations.__version__': '0.4.4__develop'},
+         'expectations': [
+             {'expectation_type': 'expect_column_to_exist',
+              'kwargs': {'column': 'col'}
+             }]
+        }

--- a/docs/source/dataset_module.rst
+++ b/docs/source/dataset_module.rst
@@ -59,3 +59,12 @@ great_expectations.dataset.util
     :members:
     :undoc-members:
     :show-inheritance:
+
+
+great_expectations.dataset.autoinspect
+-------------------------------
+
+.. automodule:: great_expectations.dataset.autoinspect
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ Advanced
 
    standard_arguments
    result_format
+   autoinspection
    evaluation_parameters
    custom_expectations
    conventions

--- a/great_expectations/dataset/autoinspect.py
+++ b/great_expectations/dataset/autoinspect.py
@@ -23,7 +23,9 @@ class AutoInspectError(Exception):
 def columns_exist(inspect_dataset):
     """
     This function will take a dataset and add expectations that each column present exists.
-    :param inspect_dataset:
+
+    Args:
+        inspect_dataset (great_expectations.dataset): The dataset to inspect and to which to add expectations.
     """
 
     # Attempt to get column names. For pandas, columns is just a list of strings

--- a/great_expectations/dataset/autoinspect.py
+++ b/great_expectations/dataset/autoinspect.py
@@ -1,0 +1,40 @@
+"""
+Autoinspect utilities to automatically generate expectations by evaluating a dataset.
+"""
+from __future__ import division
+
+import warnings
+from six import string_types
+
+from .util import create_multiple_expectations
+
+
+class AutoInspectError(Exception):
+    """Exception raised for errors in autoinspection.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+
+def autoinspect_columns_exist(inspect_dataset):
+    """
+    This function will take a dataset and add expectations that each column present exists.
+    :param inspect_dataset:
+    """
+
+    # Attempt to get column names. For pandas, columns is just a list of strings
+    if not hasattr(inspect_dataset, "columns"):
+        warnings.warn("No columns list found in dataset; no autoinspection performed.")
+        return
+    elif isinstance(inspect_dataset.columns[0], string_types):
+        columns = inspect_dataset.columns
+    elif isinstance(inspect_dataset.columns[0], dict) and "name" in inspect_dataset.columns[0]:
+        columns = [col['name'] for col in inspect_dataset.columns]
+    else:
+        raise AutoInspectError("Unable to determine column names for this dataset.")
+
+    create_multiple_expectations(inspect_dataset, columns, "expect_column_to_exist")

--- a/great_expectations/dataset/autoinspect.py
+++ b/great_expectations/dataset/autoinspect.py
@@ -20,7 +20,7 @@ class AutoInspectError(Exception):
         self.message = message
 
 
-def autoinspect_columns_exist(inspect_dataset):
+def columns_exist(inspect_dataset):
     """
     This function will take a dataset and add expectations that each column present exists.
     :param inspect_dataset:

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -15,13 +15,16 @@ from collections import (
 
 from ..version import __version__
 from .util import DotDict, recursively_convert_to_json_serializable, parse_result_format
+from .autoinspect import autoinspect_columns_exist
 
 
 class Dataset(object):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, autoinspect_func=autoinspect_columns_exist, **kwargs):
         super(Dataset, self).__init__(*args, **kwargs)
         self._initialize_expectations()
+        if autoinspect_func is not None:
+            autoinspect_func(self)
 
     @classmethod
     def expectation(cls, method_arg_names):

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -15,7 +15,8 @@ from collections import (
 
 from ..version import __version__
 from .util import DotDict, recursively_convert_to_json_serializable, parse_result_format
-from .autoinspect import autoinspect_columns_exist
+from .autoinspect import columns_exist
+
 
 class Dataset(object):
 
@@ -27,10 +28,11 @@ class Dataset(object):
             establish baseline expectations.
 
         Note: Dataset is designed to support multiple inheritance (e.g. PandasDataset inherits from both a
-        Pandas DataFrame and Dataset, so it accepts generic *args and **kwargs arguments so that they can also be
+        Pandas DataFrame and Dataset), so it accepts generic *args and **kwargs arguments so that they can also be
         passed to other parent classes. In python 2, there isn't a clean way to include all of *args, **kwargs, and a
-        named kwarg...so we use the inelegant solution of popping from kwargs, leaving the support for kwargs not
-        obvious from the signature.
+        named kwarg...so we use the inelegant solution of popping from kwargs, leaving the support for the autoinspect_func
+        parameter not obvious from the signature.
+
 
         """
         autoinspect_func = kwargs.pop("autoinspect_func", None)
@@ -40,7 +42,7 @@ class Dataset(object):
         if autoinspect_func is not None:
             autoinspect_func(self)
 
-    def autoinspect(self, autoinspect_func=autoinspect_columns_exist):
+    def autoinspect(self, autoinspect_func=columns_exist):
         autoinspect_func(self)
 
     @classmethod

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -20,7 +20,22 @@ from .autoinspect import autoinspect_columns_exist
 
 class Dataset(object):
 
-    def __init__(self, *args, autoinspect_func=autoinspect_columns_exist, **kwargs):
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the Dataset.
+
+        :param autoinspect_func (function) = None: The autoinspection function that should be run on the dataset to
+            establish baseline expectations.
+
+        Note: Dataset is designed to support multiple inheritance (e.g. PandasDataset inherits from both a
+        Pandas DataFrame and Dataset, so it accepts generic *args and **kwargs arguments so that they can also be
+        passed to other parent classes. In python 2, there isn't a clean way to include all of *args, **kwargs, and a
+        named kwarg...so we use the inelegant solution of popping from kwargs, leaving the support for kwargs not
+        obvious from the signature.
+
+        """
+        autoinspect_func = kwargs.pop("autoinspect_func", None)
+
         super(Dataset, self).__init__(*args, **kwargs)
         self._initialize_expectations()
         if autoinspect_func is not None:

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -27,10 +27,10 @@ class Dataset(object):
             establish baseline expectations.
 
         Note: Dataset is designed to support multiple inheritance (e.g. PandasDataset inherits from both a
-        Pandas DataFrame and Dataset, so it accepts generic *args and **kwargs arguments so that they can also be
+        Pandas DataFrame and Dataset), so it accepts generic *args and **kwargs arguments so that they can also be
         passed to other parent classes. In python 2, there isn't a clean way to include all of *args, **kwargs, and a
-        named kwarg...so we use the inelegant solution of popping from kwargs, leaving the support for kwargs not
-        obvious from the signature.
+        named kwarg...so we use the inelegant solution of popping from kwargs, leaving the support for the autoinspect_func
+        parameter not obvious from the signature.
 
         """
         autoinspect_func = kwargs.pop("autoinspect_func", None)

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -17,7 +17,6 @@ from ..version import __version__
 from .util import DotDict, recursively_convert_to_json_serializable, parse_result_format
 from .autoinspect import autoinspect_columns_exist
 
-
 class Dataset(object):
 
     def __init__(self, *args, **kwargs):
@@ -40,6 +39,9 @@ class Dataset(object):
         self._initialize_expectations()
         if autoinspect_func is not None:
             autoinspect_func(self)
+
+    def autoinspect(self, autoinspect_func=autoinspect_columns_exist):
+        autoinspect_func(self)
 
     @classmethod
     def expectation(cls, method_arg_names):

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -280,9 +280,9 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
     def add_default_expectations(self):
         """
-        The default behavior for PandasDataset is to explicitly include expectations that every column present upon initialization exists.
+        No expectations are added by default, so simply pass.
         """
-        create_multiple_expectations(self, self.columns, "expect_column_to_exist")
+        pass
 
     ### Expectation methods ###
     @DocInherit

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -246,8 +246,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         1. Samples and Subsets of PandaDataSet have ALL the expectations of the original \
            data frame unless the user specifies the ``discard_subset_failing_expectations = True`` \
            property on the original data frame.
-        2. Concatenations, joins, and merges of PandaDataSets ONLY contain the \
-           default_expectations (see :func:`add_default_expectations`)
+        2. Concatenations, joins, and merges of PandaDataSets contain NO expectations (since no autoinspection
+           is performed by default).
     """
 
     # We may want to expand or alter support for subclassing dataframes in the future:

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -276,13 +276,6 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     def __init__(self, *args, **kwargs):
         super(PandasDataset, self).__init__(*args, **kwargs)
         self.discard_subset_failing_expectations = kwargs.get('discard_subset_failing_expectations', False)
-        self.add_default_expectations()
-
-    def add_default_expectations(self):
-        """
-        No expectations are added by default, so simply pass.
-        """
-        pass
 
     ### Expectation methods ###
     @DocInherit

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -234,11 +234,9 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
     def add_default_expectations(self):
         """
-        The default behavior for SqlAlchemyDataset is to explicitly include expectations that every column present upon
-        initialization exists.
+        No expectations are added by default, so simply pass.
         """
-        columns = [col['name'] for col in self.columns]
-        create_multiple_expectations(self, columns, "expect_column_to_exist")
+        pass
 
     def _is_numeric_column(self, column):
         for col in self.columns:

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -194,9 +194,7 @@ class MetaSqlAlchemyDataset(Dataset):
 
 class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
-    def __init__(self, table_name=None, engine=None, connection_string=None, custom_sql=None):
-        super(SqlAlchemyDataset, self).__init__()
-
+    def __init__(self, table_name=None, engine=None, connection_string=None, custom_sql=None, *args, **kwargs):
         if table_name is None:
             raise ValueError("No table_name provided.")
 
@@ -221,6 +219,10 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         insp = reflection.Inspector.from_engine(engine)
         self.columns = insp.get_columns(self.table_name)
 
+        # Only call super once connection is established and table_name and columns known to allow autoinspection
+        super(SqlAlchemyDataset, self).__init__(*args, **kwargs)
+
+
     def create_temporary_table(self, table_name, custom_sql):
         """
         Create Temporary table based on sql query. This will be used as a basis for executing expectations.
@@ -231,12 +233,6 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         stmt = "CREATE TEMPORARY TABLE IF NOT EXISTS {table_name} AS {custom_sql}".format(
             table_name=table_name, custom_sql=custom_sql)
         self.engine.execute(stmt)
-
-    def add_default_expectations(self):
-        """
-        No expectations are added by default, so simply pass.
-        """
-        pass
 
     def _is_numeric_column(self, column):
         for col in self.columns:

--- a/great_expectations/dataset/util.py
+++ b/great_expectations/dataset/util.py
@@ -6,7 +6,6 @@ import decimal
 
 from six import string_types, integer_types
 
-import numpy as np
 from scipy import stats
 import pandas as pd
 import numpy as np
@@ -610,3 +609,4 @@ def create_multiple_expectations(df, columns, expectation_type, *args, **kwargs)
         results.append(expectation(column, *args,  **kwargs))
 
     return results
+

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -3,7 +3,7 @@ import json
 
 import great_expectations.dataset as dataset
 
-def _convert_to_dataset_class(df, dataset_class, expectations_config=None):
+def _convert_to_dataset_class(df, dataset_class, expectations_config=None, autoinspect_func=None):
     """
     Convert a (pandas) dataframe to a great_expectations dataset, with (optional) expectations_config
     """
@@ -14,7 +14,7 @@ def _convert_to_dataset_class(df, dataset_class, expectations_config=None):
     else:
         # Instantiate the new Dataset with default expectations
         try:
-            df = dataset_class(df)
+            df = dataset_class(df, autoinspect_func=autoinspect_func)
         except:
             raise NotImplementedError("read_csv requires a Dataset class that can be instantiated from a Pandas DataFrame")
 
@@ -25,10 +25,11 @@ def read_csv(
     filename,
     dataset_class=dataset.pandas_dataset.PandasDataset,
     expectations_config=None,
+    autoinspect_func=None,
     *args, **kwargs
 ):
     df = pd.read_csv(filename, *args, **kwargs)
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config)
+    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
@@ -37,6 +38,7 @@ def read_json(
     dataset_class=dataset.pandas_dataset.PandasDataset,
     expectations_config=None,
     accessor_func=None,
+    autoinspect_func=None,
     *args, **kwargs
 ):
     if accessor_func != None:
@@ -47,13 +49,14 @@ def read_json(
     else:
         df = pd.read_json(filename, *args, **kwargs)
 
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config)
+    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 def read_excel(
     filename,
     dataset_class=dataset.pandas_dataset.PandasDataset,
     expectations_config=None,
+    autoinspect_func=None,
     *args, **kwargs
 ):
     """Read a file using Pandas read_excel and return a great_expectations dataset.
@@ -70,9 +73,9 @@ def read_excel(
     df = pd.read_excel(filename, *args, **kwargs)
     if isinstance(df, dict):
         for key in df:
-            df[key] = _convert_to_dataset_class(df[key], dataset_class, expectations_config)
+            df[key] = _convert_to_dataset_class(df[key], dataset_class, expectations_config, autoinspect_func)
     else:
-        df = _convert_to_dataset_class(df, dataset_class, expectations_config)
+        df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
@@ -80,6 +83,7 @@ def read_table(
     filename,
     dataset_class=dataset.pandas_dataset.PandasDataset,
     expectations_config=None,
+    autoinspect_func=None,
     *args, **kwargs
 ):
     """Read a file using Pandas read_table and return a great_expectations dataset.
@@ -93,7 +97,7 @@ def read_table(
         great_expectations dataset
     """
     df = pd.read_table(filename, *args, **kwargs)
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config)
+    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
@@ -101,6 +105,7 @@ def read_parquet(
     filename,
     dataset_class=dataset.pandas_dataset.PandasDataset,
     expectations_config=None,
+    autoinspect_func=None,
     *args, **kwargs
 ):
     """Read a file using Pandas read_parquet and return a great_expectations dataset.
@@ -114,15 +119,16 @@ def read_parquet(
         great_expectations dataset
     """
     df = pd.read_parquet(filename, *args, **kwargs)
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config)
+    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
-def from_pandas(pandas_df, expectations_config=None):
+def from_pandas(pandas_df, expectations_config=None, autoinspect_func=None):
     return _convert_to_dataset_class(
         pandas_df,
         dataset.pandas_dataset.PandasDataset,
-        expectations_config
+        expectations_config,
+        autoinspect_func
     )
 
 

--- a/tests/test_autoinspect.py
+++ b/tests/test_autoinspect.py
@@ -1,0 +1,33 @@
+"""
+Tests for autoinspection framework.
+"""
+
+import pytest
+from .test_utils import get_dataset
+
+import great_expectations as ge
+import great_expectations.dataset.autoinspect as autoinspect
+
+
+def test_no_autoinspection():
+    df = ge.dataset.PandasDataset({"a": [1, 2, 3]}, autoinspect_func=None)
+    config = df.get_expectations_config()
+
+    assert len(config["expectations"]) == 0
+
+
+def test_default_column_autoinspection():
+    df = ge.dataset.PandasDataset({"a": [1, 2, 3]})
+    config = df.get_expectations_config()
+
+    assert len(config["expectations"]) == 1
+
+
+@pytest.mark.parametrize("dataset_type", ["PandasDataset", "SqlAlchemyDataset"])
+def test_autoinspect_columns_exist(dataset_type):
+    df = get_dataset(dataset_type, {"a": [1, 2, 3]}, autoinspect_func=autoinspect.autoinspect_columns_exist)
+    config = df.get_expectations_config()
+
+    assert len(config["expectations"]) == 1
+    assert config["expectations"] == \
+        [{'expectation_type': 'expect_column_to_exist', 'kwargs': {'column': 'a'}}]

--- a/tests/test_autoinspect.py
+++ b/tests/test_autoinspect.py
@@ -16,11 +16,27 @@ def test_no_autoinspection():
     assert len(config["expectations"]) == 0
 
 
-def test_default_column_autoinspection():
+def test_default_no_autoinspection():
     df = ge.dataset.PandasDataset({"a": [1, 2, 3]})
     config = df.get_expectations_config()
 
-    assert len(config["expectations"]) == 1
+    assert len(config["expectations"]) == 0
+
+
+@pytest.mark.parametrize("dataset_type", ["PandasDataset", "SqlAlchemyDataset"])
+def test_autoinspect_existing_dataset(dataset_type):
+    # Get a basic dataset with no expectations
+    df = get_dataset(dataset_type, {"a": [1, 2, 3]}, autoinspect_func=None)
+    config = df.get_expectations_config()
+    assert len(config["expectations"]) == 0
+
+    # Run autoinspect
+    df.autoinspect(autoinspect.autoinspect_columns_exist)
+    config = df.get_expectations_config()
+
+    # Ensure that autoinspect worked
+    assert config["expectations"] == \
+        [{'expectation_type': 'expect_column_to_exist', 'kwargs': {'column': 'a'}}]
 
 
 @pytest.mark.parametrize("dataset_type", ["PandasDataset", "SqlAlchemyDataset"])

--- a/tests/test_autoinspect.py
+++ b/tests/test_autoinspect.py
@@ -31,7 +31,7 @@ def test_autoinspect_existing_dataset(dataset_type):
     assert len(config["expectations"]) == 0
 
     # Run autoinspect
-    df.autoinspect(autoinspect.autoinspect_columns_exist)
+    df.autoinspect(autoinspect.columns_exist)
     config = df.get_expectations_config()
 
     # Ensure that autoinspect worked
@@ -41,7 +41,7 @@ def test_autoinspect_existing_dataset(dataset_type):
 
 @pytest.mark.parametrize("dataset_type", ["PandasDataset", "SqlAlchemyDataset"])
 def test_autoinspect_columns_exist(dataset_type):
-    df = get_dataset(dataset_type, {"a": [1, 2, 3]}, autoinspect_func=autoinspect.autoinspect_columns_exist)
+    df = get_dataset(dataset_type, {"a": [1, 2, 3]}, autoinspect_func=autoinspect.columns_exist)
     config = df.get_expectations_config()
 
     assert len(config["expectations"]) == 1
@@ -51,12 +51,12 @@ def test_autoinspect_columns_exist(dataset_type):
 
 def test_autoinspect_warning():
     with pytest.warns(UserWarning, match="No columns list found in dataset; no autoinspection performed."):
-        df = ge.dataset.Dataset(autoinspect_func=autoinspect.autoinspect_columns_exist)
+        df = ge.dataset.Dataset(autoinspect_func=autoinspect.columns_exist)
 
 
 def test_autoinspect_error():
     df = ge.dataset.Dataset()
     df.columns = [{"title": "nonstandard_columns"}]
     with pytest.raises(autoinspect.AutoInspectError) as autoinspect_error:
-        df.autoinspect(autoinspect.autoinspect_columns_exist)
+        df.autoinspect(autoinspect.columns_exist)
         assert autoinspect_error.message == "Unable to determine column names for this dataset."

--- a/tests/test_autoinspect.py
+++ b/tests/test_autoinspect.py
@@ -47,3 +47,16 @@ def test_autoinspect_columns_exist(dataset_type):
     assert len(config["expectations"]) == 1
     assert config["expectations"] == \
         [{'expectation_type': 'expect_column_to_exist', 'kwargs': {'column': 'a'}}]
+
+
+def test_autoinspect_warning():
+    with pytest.warns(UserWarning, match="No columns list found in dataset; no autoinspection performed."):
+        df = ge.dataset.Dataset(autoinspect_func=autoinspect.autoinspect_columns_exist)
+
+
+def test_autoinspect_error():
+    df = ge.dataset.Dataset()
+    df.columns = [{"title": "nonstandard_columns"}]
+    with pytest.raises(autoinspect.AutoInspectError) as autoinspect_error:
+        df.autoinspect(autoinspect.autoinspect_columns_exist)
+        assert autoinspect_error.message == "Unable to determine column names for this dataset."

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,6 +7,7 @@ import warnings
 import pandas as pd
 import numpy as np
 import great_expectations as ge
+from great_expectations.dataset.autoinspect import autoinspect_columns_exist
 
 import unittest
 
@@ -31,19 +32,21 @@ class TestDataset(unittest.TestCase):
                 "meta": {
                     "great_expectations.__version__": ge.__version__
                 },
-                "expectations" : [{
-                    "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "x", 'result_format': 'BASIC'},
-                    'success_on_last_run': True
-                },{
-                    "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "y", 'result_format': 'BASIC'},
-                    'success_on_last_run': True
-                },{
-                    "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "z", 'result_format': 'BASIC'},
-                    'success_on_last_run': True
-                }]
+                "expectations" : []
+                # No longer expect autoinspection 20180920
+                # {
+                #     "expectation_type" : "expect_column_to_exist",
+                #     "kwargs" : { "column" : "x", 'result_format': 'BASIC'},
+                #     'success_on_last_run': True
+                # },{
+                #     "expectation_type" : "expect_column_to_exist",
+                #     "kwargs" : { "column" : "y", 'result_format': 'BASIC'},
+                #     'success_on_last_run': True
+                # },{
+                #     "expectation_type" : "expect_column_to_exist",
+                #     "kwargs" : { "column" : "z", 'result_format': 'BASIC'},
+                #     'success_on_last_run': True
+                # }]
             }
         )
 
@@ -55,16 +58,18 @@ class TestDataset(unittest.TestCase):
                 "meta": {
                     "great_expectations.__version__": ge.__version__
                 },
-                "expectations" : [{
-                    "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "x"}
-                },{
-                    "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "y"}
-                },{
-                    "expectation_type" : "expect_column_to_exist",
-                    "kwargs" : { "column" : "z"}
-                }]
+                "expectations" : []
+                # No longer expect autoinspection 20180920
+                # {
+                #     "expectation_type" : "expect_column_to_exist",
+                #     "kwargs" : { "column" : "x"}
+                # },{
+                #     "expectation_type" : "expect_column_to_exist",
+                #     "kwargs" : { "column" : "y"}
+                # },{
+                #     "expectation_type" : "expect_column_to_exist",
+                #     "kwargs" : { "column" : "z"}
+                # }]
             }
         )
 
@@ -141,24 +146,25 @@ class TestDataset(unittest.TestCase):
 
         output_config = {
           "expectations": [
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
-            },
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y"
-              }
-            },
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "z"
-              }
-            },
+            # No longer expect autoinspection 20180920
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "x"
+            #   }
+            # },
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "y"
+            #   }
+            # },
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "z"
+            #   }
+            # },
             {
               "expectation_type": "expect_column_values_to_be_in_set",
               "kwargs": {
@@ -201,24 +207,25 @@ class TestDataset(unittest.TestCase):
 
         output_config = {
           "expectations": [
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
-            },
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y"
-              }
-            },
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "z"
-              }
-            },
+            # No longer expect autoinspection 20180920
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "x"
+            #   }
+            # },
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "y"
+            #   }
+            # },
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "z"
+            #   }
+            # },
             {
               "expectation_type": "expect_column_values_to_be_in_set",
               "kwargs": {
@@ -277,27 +284,28 @@ class TestDataset(unittest.TestCase):
 
         output_config = {
           "expectations": [
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x",
-                "result_format": "BASIC"
-              }
-            },
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y",
-                "result_format": "BASIC"
-              }
-            },
-            {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "z",
-                "result_format": "BASIC"
-              }
-            },
+            # No longer expect autoinspection 20180920
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "x",
+            #     "result_format": "BASIC"
+            #   }
+            # },
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "y",
+            #     "result_format": "BASIC"
+            #   }
+            # },
+            # {
+            #   "expectation_type": "expect_column_to_exist",
+            #   "kwargs": {
+            #     "column": "z",
+            #     "result_format": "BASIC"
+            #   }
+            # },
             {
               "expectation_type": "expect_column_values_to_be_in_set",
               "kwargs": {
@@ -734,7 +742,7 @@ class TestDataset(unittest.TestCase):
             'x' : [1,2,3,4,5,6,7,8,9,10],
             'y' : [1,2,None,4,None,6,7,8,9,None],
             'z' : ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
-        })
+        }, autoinspect_func=autoinspect_columns_exist)
         my_df.expect_column_values_to_be_of_type('x', 'int')
         my_df.expect_column_values_to_be_of_type('y', 'int')
         my_df.expect_column_values_to_be_of_type('z', 'int')
@@ -821,7 +829,7 @@ class TestDataset(unittest.TestCase):
             'x' : [1,2,3,4,5,6,7,8,9,10],
             'y' : [1,2,None,4,None,6,7,8,9,None],
             'z' : ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
-        })
+        }, autoinspect_func=autoinspect_columns_exist)
         my_df.expect_column_values_to_be_of_type('x', 'int')
         my_df.expect_column_values_to_be_of_type('y', 'int')
         my_df.expect_column_values_to_be_of_type('z', 'int', include_config=True, catch_exceptions=True)
@@ -974,7 +982,7 @@ class TestDataset(unittest.TestCase):
             'B':[5,6,7,8],
             'C':['a','b','c','d'],
             'D':['e','f','g','h']
-        })
+        }, autoinspect_func=autoinspect_columns_exist)
 
         # Put some simple expectations on the data frame
         df.expect_column_values_to_be_in_set("A", [1, 2, 3, 4])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,7 +7,7 @@ import warnings
 import pandas as pd
 import numpy as np
 import great_expectations as ge
-from great_expectations.dataset.autoinspect import autoinspect_columns_exist
+import great_expectations.dataset.autoinspect as autoinspect
 
 import unittest
 
@@ -742,7 +742,7 @@ class TestDataset(unittest.TestCase):
             'x' : [1,2,3,4,5,6,7,8,9,10],
             'y' : [1,2,None,4,None,6,7,8,9,None],
             'z' : ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
-        }, autoinspect_func=autoinspect_columns_exist)
+        }, autoinspect_func=autoinspect.columns_exist)
         my_df.expect_column_values_to_be_of_type('x', 'int')
         my_df.expect_column_values_to_be_of_type('y', 'int')
         my_df.expect_column_values_to_be_of_type('z', 'int')
@@ -829,7 +829,7 @@ class TestDataset(unittest.TestCase):
             'x' : [1,2,3,4,5,6,7,8,9,10],
             'y' : [1,2,None,4,None,6,7,8,9,None],
             'z' : ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
-        }, autoinspect_func=autoinspect_columns_exist)
+        }, autoinspect_func=autoinspect.columns_exist)
         my_df.expect_column_values_to_be_of_type('x', 'int')
         my_df.expect_column_values_to_be_of_type('y', 'int')
         my_df.expect_column_values_to_be_of_type('z', 'int', include_config=True, catch_exceptions=True)
@@ -982,7 +982,7 @@ class TestDataset(unittest.TestCase):
             'B':[5,6,7,8],
             'C':['a','b','c','d'],
             'D':['e','f','g','h']
-        }, autoinspect_func=autoinspect_columns_exist)
+        }, autoinspect_func=autoinspect.columns_exist)
 
         # Put some simple expectations on the data frame
         df.expect_column_values_to_be_in_set("A", [1, 2, 3, 4])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1174,11 +1174,16 @@ class TestDataset(unittest.TestCase):
         my_df._append_expectation({'expectation_type':'foobar', 'kwargs':{}})
         result = my_df.validate(catch_exceptions=True)
 
-        self.assertEqual(result["results"][1]["success"], False)
-        self.assertEqual(result["results"][1]["expectation_config"]["expectation_type"], "foobar")
-        self.assertEqual(result["results"][1]["expectation_config"]["kwargs"], {})
-        self.assertEqual(result["results"][1]["exception_info"]["raised_exception"], True)
-        assert "AttributeError: \'PandasDataset\' object has no attribute \'foobar\'" in result["results"][1]["exception_info"]["exception_traceback"]
+        # Find the foobar result
+        for idx, val_result in enumerate(result["results"]):
+            if val_result["expectation_config"]["expectation_type"] == "foobar":
+                break
+
+        self.assertEqual(result["results"][idx]["success"], False)
+        self.assertEqual(result["results"][idx]["expectation_config"]["expectation_type"], "foobar")
+        self.assertEqual(result["results"][idx]["expectation_config"]["kwargs"], {})
+        self.assertEqual(result["results"][idx]["exception_info"]["raised_exception"], True)
+        assert "AttributeError: \'PandasDataset\' object has no attribute \'foobar\'" in result["results"][idx]["exception_info"]["exception_traceback"]
 
         with self.assertRaises(AttributeError) as context:
             result = my_df.validate(catch_exceptions=False)

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -8,7 +8,7 @@ import pandas as pd
 import re
 
 import great_expectations as ge
-from great_expectations.dataset.autoinspect import autoinspect_columns_exist
+from great_expectations.dataset.autoinspect import columns_exist
 from great_expectations.dataset import PandasDataset, MetaPandasDataset
 from great_expectations.dataset.base import (
     _calc_validation_statistics,
@@ -423,7 +423,7 @@ class TestRepeatedAppendExpectation(unittest.TestCase):
         with open("./tests/test_sets/titanic_expectations.json") as f:
             my_expectations_config = json.load(f)
 
-        my_df = ge.read_csv("./tests/test_sets/Titanic.csv", autoinspect_func=autoinspect_columns_exist)
+        my_df = ge.read_csv("./tests/test_sets/Titanic.csv", autoinspect_func=columns_exist)
 
         self.assertEqual(
             len(my_df.get_expectations_config()['expectations']),

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -8,6 +8,7 @@ import pandas as pd
 import re
 
 import great_expectations as ge
+from great_expectations.dataset.autoinspect import autoinspect_columns_exist
 from great_expectations.dataset import PandasDataset, MetaPandasDataset
 from great_expectations.dataset.base import (
     _calc_validation_statistics,
@@ -422,7 +423,7 @@ class TestRepeatedAppendExpectation(unittest.TestCase):
         with open("./tests/test_sets/titanic_expectations.json") as f:
             my_expectations_config = json.load(f)
 
-        my_df = ge.read_csv("./tests/test_sets/Titanic.csv")
+        my_df = ge.read_csv("./tests/test_sets/Titanic.csv", autoinspect_func=autoinspect_columns_exist)
 
         self.assertEqual(
             len(my_df.get_expectations_config()['expectations']),

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -4,82 +4,11 @@ import pytest
 import json
 import datetime
 import pandas as pd
-import unittest
 import great_expectations as ge
+from great_expectations.dataset.autoinspect import autoinspect_columns_exist
 
 from .test_utils import assertDeepAlmostEqual
 
-def run_encapsulated_test(expectation_name, filename):
-    with open(filename) as f:
-        T = json.load(f)
-
-    D = ge.dataset.PandasDataset(T["dataset"])
-    D.set_default_expectation_argument("output_format", "COMPLETE")
-
-
-    for t in T["tests"]:
-
-        if "title" in t:
-            print(t["title"])
-        else:
-            print("WARNING: test set has no `title` field. In future versions of Great Expectations, this will be required.")
-
-        expectation = getattr(D, expectation_name)
-        out = expectation(**t['in'])
-        out = json.loads(json.dumps(out))
-        assert out==t['out']
-
-    # def test_expect_column_values_to_be_between(self):
-    #     """
-
-    #     """
-
-    #     with open("./tests/test_sets/expect_column_values_to_be_between_test_set.json") as f:
-    #         fixture = json.load(f)
-
-    #     dataset = fixture["dataset"]
-    #     tests = fixture["tests"]
-
-    #     D = ge.dataset.PandasDataset(dataset)
-    #     D.set_default_expectation_argument("result_format", "COMPLETE")
-
-    #     self.maxDiff = None
-
-    #     for t in tests:
-    #         out = D.expect_column_values_to_be_between(**t['in'])
-
-    #         # print '-'*80
-    #         print(t)
-    #         # print(json.dumps(out, indent=2))
-
-    #         if 'out' in t:
-    #             self.assertEqual(t['out']['success'], out['success'])
-    #             if 'unexpected_index_list' in t['out']:
-    #                 self.assertEqual(t['out']['unexpected_index_list'], out['result']['unexpected_index_list'])
-    #             if 'unexpected_list' in t['out']:
-    #                 self.assertEqual(t['out']['unexpected_list'], out['result']['unexpected_list'])
-
-    #         if 'error' in t:
-    #             self.assertEqual(out['exception_info']['raised_exception'], True)
-    #             self.assertIn(t['error']['traceback_substring'], out['exception_info']['exception_traceback'])
-
-
-    # def test_expect_column_values_to_match_regex_list(self):
-    #     with open("./tests/test_sets/expect_column_values_to_match_regex_list_test_set.json") as f:
-    #         J = json.load(f)
-    #         D = ge.dataset.PandasDataset(J["dataset"])
-    #         D.set_default_expectation_argument("result_format", "COMPLETE")
-    #         T = J["tests"]
-
-    #         self.maxDiff = None
-
-    #     for t in T:
-    #         out = D.expect_column_values_to_match_regex_list(**t['in'])
-    #         self.assertEqual(t['out']['success'], out['success'])
-    #         if 'unexpected_index_list' in t['out']:
-    #             self.assertEqual(t['out']['unexpected_index_list'], out['result']['unexpected_index_list'])
-    #         if 'unexpected_list' in t['out']:
-    #             self.assertEqual(t['out']['unexpected_list'], out['result']['unexpected_list'])
 
 def test_expect_column_values_to_match_strftime_format():
     """
@@ -422,12 +351,15 @@ def test_from_pandas_expectations_config():
 
     assertDeepAlmostEqual(results, expected_results)
 
-def test_ge_pandas_concatenating():
+
+def test_ge_pandas_concatenating_no_autoinspect():
     df1 = ge.dataset.PandasDataset({
         'A': ['A0', 'A1', 'A2'],
         'B': ['B0', 'B1', 'B2']
     })
 
+    df1.expect_column_to_exist('A')
+    df1.expect_column_to_exist('B')
     df1.expect_column_values_to_match_regex('A', '^A[0-2]$')
     df1.expect_column_values_to_match_regex('B', '^B[0-2]$')
 
@@ -436,25 +368,24 @@ def test_ge_pandas_concatenating():
         'B': ['B3', 'B4', 'B5']
     })
 
+    df2.expect_column_to_exist('A')
+    df2.expect_column_to_exist('B')
     df2.expect_column_values_to_match_regex('A', '^A[3-5]$')
     df2.expect_column_values_to_match_regex('B', '^B[3-5]$')
 
     df = pd.concat([df1, df2])
 
-    exp_c = [
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'A'}},
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'B'}}
-    ]
+    exp_c = []
 
     # The concatenated data frame will:
     #
     #   1. Be a ge.dataset.PandaDataSet
-    #   2. Only have the default expectations
+    #   2. Have no expectations (since no default expectations are created), even expectations that were common
+    #      to the concatenated dataframes and still make sense (since no autoinspection happens).
 
     assert isinstance(df, ge.dataset.PandasDataset)
     assert df.find_expectations()==exp_c
+
 
 def test_ge_pandas_joining():
     df1 = ge.dataset.PandasDataset({
@@ -476,20 +407,21 @@ def test_ge_pandas_joining():
     df = df1.join(df2)
 
     exp_j = [
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'A'}},
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'B'}},
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'C'}},
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'D'}}
+        # No autoinspection is default 20180920
+        # {'expectation_type': 'expect_column_to_exist',
+        #  'kwargs': {'column': 'A'}},
+        # {'expectation_type': 'expect_column_to_exist',
+        #  'kwargs': {'column': 'B'}},
+        # {'expectation_type': 'expect_column_to_exist',
+        #  'kwargs': {'column': 'C'}},
+        # {'expectation_type': 'expect_column_to_exist',
+        #  'kwargs': {'column': 'D'}}
     ]
 
     # The joined data frame will:
     #
     #   1. Be a ge.dataset.PandaDataSet
-    #   2. Only have the default expectations
+    #   2. Have no expectations (no autoinspection)
 
     assert isinstance(df, ge.dataset.PandasDataset)
     assert df.find_expectations()==exp_j
@@ -512,18 +444,19 @@ def test_ge_pandas_merging():
     df = df1.merge(df2, on='id')
 
     exp_m = [
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'id'}},
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'name'}},
-        {'expectation_type': 'expect_column_to_exist',
-         'kwargs': {'column': 'salary'}}
+        # No autoinspection as of 20180920
+        # {'expectation_type': 'expect_column_to_exist',
+        #  'kwargs': {'column': 'id'}},
+        # {'expectation_type': 'expect_column_to_exist',
+        #  'kwargs': {'column': 'name'}},
+        # {'expectation_type': 'expect_column_to_exist',
+        #  'kwargs': {'column': 'salary'}}
     ]
 
     # The merged data frame will:
     #
     #   1. Be a ge.dataset.PandaDataSet
-    #   2. Only have the default expectations
+    #   2. Have no expectations (no autoinspection is now default)
 
     assert isinstance(df, ge.dataset.PandasDataset)
     assert df.find_expectations()==exp_m
@@ -592,6 +525,7 @@ def test_ge_pandas_sampling():
     })
 
     # Put some simple expectations on the data frame
+    df.autoinspect(autoinspect_func=autoinspect_columns_exist)
     df.expect_column_values_to_be_in_set("A", [1, 2, 3, 4])
     df.expect_column_values_to_be_in_set("B", [5, 6, 7, 8])
     df.expect_column_values_to_be_in_set("C", ['a', 'b', 'c', 'd'])
@@ -700,6 +634,7 @@ def test_ge_pandas_automatic_failure_removal():
     })
 
     # Put some simple expectations on the data frame
+    df.autoinspect(autoinspect_columns_exist)
     df.expect_column_values_to_be_in_set("A", [1, 2, 3, 4])
     df.expect_column_values_to_be_in_set("B", [5, 6, 7, 8])
     df.expect_column_values_to_be_in_set("C", ['w', 'x', 'y', 'z'])
@@ -814,7 +749,3 @@ def test_pandas_deepcopy():
     assert df2.expect_column_to_exist("a")["success"] == True
     assert list(df["a"]) == [2, 3, 4]
     assert list(df2["a"]) == [1, 2, 3]
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -5,7 +5,7 @@ import json
 import datetime
 import pandas as pd
 import great_expectations as ge
-from great_expectations.dataset.autoinspect import autoinspect_columns_exist
+import great_expectations.dataset.autoinspect as autoinspect
 
 from .test_utils import assertDeepAlmostEqual
 
@@ -525,7 +525,7 @@ def test_ge_pandas_sampling():
     })
 
     # Put some simple expectations on the data frame
-    df.autoinspect(autoinspect_func=autoinspect_columns_exist)
+    df.autoinspect(autoinspect_func=autoinspect.columns_exist)
     df.expect_column_values_to_be_in_set("A", [1, 2, 3, 4])
     df.expect_column_values_to_be_in_set("B", [5, 6, 7, 8])
     df.expect_column_values_to_be_in_set("C", ['a', 'b', 'c', 'd'])
@@ -634,7 +634,7 @@ def test_ge_pandas_automatic_failure_removal():
     })
 
     # Put some simple expectations on the data frame
-    df.autoinspect(autoinspect_columns_exist)
+    df.autoinspect(autoinspect.columns_exist)
     df.expect_column_values_to_be_in_set("A", [1, 2, 3, 4])
     df.expect_column_values_to_be_in_set("B", [5, 6, 7, 8])
     df.expect_column_values_to_be_in_set("C", ['w', 'x', 'y', 'z'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 
 from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
-from great_expectations.dataset.autoinspect import autoinspect_columns_exist
+import great_expectations.dataset.autoinspect as autoinspect
 
 ## Taken from the following stackoverflow: https://stackoverflow.com/questions/23549419/assert-that-two-dictionaries-are-almost-equal
 def assertDeepAlmostEqual(expected, actual, *args, **kwargs):
@@ -47,7 +47,7 @@ def assertDeepAlmostEqual(expected, actual, *args, **kwargs):
         raise exc
 
 
-def get_dataset(dataset_type, data, autoinspect_func=autoinspect_columns_exist):
+def get_dataset(dataset_type, data, autoinspect_func=autoinspect.columns_exist):
     """For Pandas, data should be either a DataFrame or a dictionary that can be instantiated as a DataFrame
     For SQL, data should have the following shape:
         {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 from sqlalchemy import create_engine
 
 from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
+from great_expectations.dataset.autoinspect import autoinspect_columns_exist
 
 ## Taken from the following stackoverflow: https://stackoverflow.com/questions/23549419/assert-that-two-dictionaries-are-almost-equal
 def assertDeepAlmostEqual(test_case, expected, actual, *args, **kwargs):
@@ -50,7 +51,7 @@ def assertDeepAlmostEqual(test_case, expected, actual, *args, **kwargs):
         raise exc
 
 
-def get_dataset(dataset_type, data):
+def get_dataset(dataset_type, data, autoinspect_func=autoinspect_columns_exist):
     """For Pandas, data should be either a DataFrame or a dictionary that can be instantiated as a DataFrame
     For SQL, data should have the following shape:
         {
@@ -61,7 +62,7 @@ def get_dataset(dataset_type, data):
 
     """
     if dataset_type == 'PandasDataset':
-        return PandasDataset(data)
+        return PandasDataset(data, autoinspect_func=autoinspect_func)
     elif dataset_type == 'SqlAlchemyDataset':
         # Create a new database
 
@@ -72,7 +73,7 @@ def get_dataset(dataset_type, data):
         df.to_sql(name='test_data', con=engine, index=False)
 
         # Build a SqlAlchemyDataset using that database
-        return SqlAlchemyDataset('test_data', engine=engine)
+        return SqlAlchemyDataset('test_data', engine=engine, autoinspect_func=autoinspect_func)
     else:
         raise ValueError("Unknown dataset_type " + str(dataset_type))
 


### PR DESCRIPTION
This PR addresses #362 #366 and #338 

It creates a new "autoinspect" api which allows one to pass a function to a Dataset upon creation that will automatically generate expectations for that Dataset, and implements an example such autoinspect that replicates the current behavior of "add_default_expectations" (i.e. it creates expectations that each of the currently-present columns exists).

This PR also disables the autoinspection be default, meaning that new datasets will by default have no expectations.

Finally, it updates some documentation and tests associated with the changes, including noting that PandasDatasets created by concatenating, joining, or merging other PandasDatasets will have no expectations by default.