### PR TITLE
Add Redshift compatibility when creating temporary tables (#372)

### DIFF
--- a/docs/source/roadmap_changelog.rst
+++ b/docs/source/roadmap_changelog.rst
@@ -14,6 +14,8 @@ Planned Features
 
 v.0.4.4__develop
 ----------------
+* Remove `IF NOT EXISTS` check for custom sql temporary tables, for
+  Redshift compatibility (#372)
 
 v.0.4.4
 ----------------

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -86,16 +86,20 @@ class MetaSqlAlchemyDataset(Dataset):
                             sa.or_(
                                 # SA normally evaluates `== None` as `IS NONE`. However `sa.in_()`
                                 # replaces `None` as `NULL` in the list and incorrectly uses `== NULL`
-                                sa.column(column).is_(None) == False if None in ignore_values else False,
+                                sa.column(column).is_(
+                                    None) == False if None in ignore_values else False,
                                 # Ignore any other values that are in the ignore list
                                 sa.column(column).in_(ignore_values) == False))
                 ).limit(unexpected_count_limit)
             )
 
-            nonnull_count = count_results['element_count'] - count_results['null_count']
-            maybe_limited_unexpected_list = [x[column] for x in unexpected_query_results.fetchall()]
+            nonnull_count = count_results['element_count'] - \
+                count_results['null_count']
+            maybe_limited_unexpected_list = [x[column]
+                                             for x in unexpected_query_results.fetchall()]
             success_count = nonnull_count - count_results['unexpected_count']
-            success, percent_success = self._calc_map_expectation_success(success_count, nonnull_count, mostly)
+            success, percent_success = self._calc_map_expectation_success(
+                success_count, nonnull_count, mostly)
 
             return_obj = self._format_column_map_output(
                 result_format, success,
@@ -118,7 +122,6 @@ class MetaSqlAlchemyDataset(Dataset):
 
         return inner_wrapper
 
-
     @classmethod
     def column_aggregate_expectation(cls, func):
         """Constructs an expectation using column-aggregate semantics.
@@ -130,7 +133,7 @@ class MetaSqlAlchemyDataset(Dataset):
 
         @cls.expectation(argspec)
         @wraps(func)
-        def inner_wrapper(self, column, result_format = None, *args, **kwargs):
+        def inner_wrapper(self, column, result_format=None, *args, **kwargs):
 
             if result_format is None:
                 result_format = self.default_expectation_args["result_format"]
@@ -140,13 +143,16 @@ class MetaSqlAlchemyDataset(Dataset):
             evaluation_result = func(self, column, *args, **kwargs)
 
             if 'success' not in evaluation_result:
-                raise ValueError("Column aggregate expectation failed to return required information: success")
+                raise ValueError(
+                    "Column aggregate expectation failed to return required information: success")
 
             if 'result' not in evaluation_result:
-                raise ValueError("Column aggregate expectation failed to return required information: result")
+                raise ValueError(
+                    "Column aggregate expectation failed to return required information: result")
 
             if 'observed_value' not in evaluation_result['result']:
-                raise ValueError("Column aggregate expectation failed to return required information: result.observed_value")
+                raise ValueError(
+                    "Column aggregate expectation failed to return required information: result.observed_value")
 
             return_obj = {
                 'success': bool(evaluation_result['success'])
@@ -166,7 +172,8 @@ class MetaSqlAlchemyDataset(Dataset):
                     ).label('null_count'),
                 ]).select_from(sa.table(self.table_name))
 
-                count_results = dict(self.engine.execute(count_query).fetchone())
+                count_results = dict(
+                    self.engine.execute(count_query).fetchone())
 
                 # Handle case of empty table gracefully:
                 if "element_count" not in count_results or count_results["element_count"] is None:
@@ -197,7 +204,8 @@ class MetaSqlAlchemyDataset(Dataset):
             if result_format['result_format'] in ["SUMMARY", "COMPLETE"]:
                 return return_obj
 
-            raise ValueError("Unknown result_format %s." % (result_format['result_format'],))
+            raise ValueError("Unknown result_format %s." %
+                             (result_format['result_format'],))
 
         return inner_wrapper
 
@@ -240,17 +248,18 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         It hasn't been tested in all SQL dialects, and may change based on community feedback.
         :param custom_sql:
         """
-        stmt = "CREATE TEMPORARY TABLE IF NOT EXISTS {table_name} AS {custom_sql}".format(
+        stmt = "CREATE TEMPORARY TABLE {table_name} AS {custom_sql}".format(
             table_name=table_name, custom_sql=custom_sql)
         self.engine.execute(stmt)
 
     def _is_numeric_column(self, column):
         for col in self.columns:
             if (col['name'] == column and
-                isinstance(col['type'],
-                           (sa.types.Integer, sa.types.BigInteger, sa.types.Float, sa.types.Numeric, sa.types.SmallInteger, sa.types.Boolean)
-                           )
-            ):
+                    isinstance(col['type'],
+                               (sa.types.Integer, sa.types.BigInteger, sa.types.Float,
+                                sa.types.Numeric, sa.types.SmallInteger, sa.types.Boolean)
+                               )
+                ):
                 return True
 
         return False
@@ -268,9 +277,9 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @Dataset.expectation(['value'])
     def expect_table_row_count_to_equal(self,
-        value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        value=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         # Assert that min_value and max_value are integers
         try:
             if value is not None:
@@ -282,7 +291,8 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         if value is None:
             raise ValueError("value must be provided")
 
-        count_query = sa.select([sa.func.count()]).select_from(sa.table(self.table_name))
+        count_query = sa.select([sa.func.count()]).select_from(
+            sa.table(self.table_name))
         row_count = self.engine.execute(count_query).scalar()
 
         return {
@@ -295,10 +305,10 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @Dataset.expectation(['min_value', 'max_value'])
     def expect_table_row_count_to_be_between(self,
-        min_value=0,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                             min_value=0,
+                                             max_value=None,
+                                             result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                             ):
         # Assert that min_value and max_value are integers
         try:
             if min_value is not None:
@@ -310,7 +320,8 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         except ValueError:
             raise ValueError("min_value and max_value must be integers")
 
-        count_query = sa.select([sa.func.count()]).select_from(sa.table(self.table_name))
+        count_query = sa.select([sa.func.count()]).select_from(
+            sa.table(self.table_name))
         row_count = self.engine.execute(count_query).scalar()
 
         if min_value != None and max_value != None:
@@ -332,11 +343,11 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @Dataset.expectation(['column_list'])
     def expect_table_columns_to_match_ordered_list(self, column_list,
-                               result_format=None, include_config=False, catch_exceptions=None, meta=None):
+                                                   result_format=None, include_config=False, catch_exceptions=None, meta=None):
 
         if [col['name'] for col in self.columns] == list(column_list):
             return {
-                "success" : True
+                "success": True
             }
         else:
             return {
@@ -346,9 +357,9 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @Dataset.expectation(['column'])
     def expect_column_to_exist(self,
-            column, column_index=None, result_format=None, include_config=False,
-            catch_exceptions=None, meta=None
-        ):
+                               column, column_index=None, result_format=None, include_config=False,
+                               catch_exceptions=None, meta=None
+                               ):
 
         col_names = [col['name'] for col in self.columns]
 
@@ -378,64 +389,63 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @MetaSqlAlchemyDataset.column_map_expectation
     def expect_column_values_to_be_null(self,
-        column,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        mostly=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
 
         return sa.column(column) == None
 
     @DocInherit
     @MetaSqlAlchemyDataset.column_map_expectation
     def expect_column_values_to_not_be_null(self,
-        column,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                            column,
+                                            mostly=None,
+                                            result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                            ):
 
         return sa.column(column) != None
-
 
     @DocInherit
     @MetaSqlAlchemyDataset.column_map_expectation
     def expect_column_values_to_be_in_set(self,
-        column,
-        value_set,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
-        return sa.column(column).in_(tuple(value_set))
-
-    @DocInherit
-    @MetaSqlAlchemyDataset.column_map_expectation
-    def expect_column_values_to_not_be_in_set(self,
                                           column,
                                           value_set,
                                           mostly=None,
                                           result_format=None, include_config=False, catch_exceptions=None, meta=None
                                           ):
+        return sa.column(column).in_(tuple(value_set))
+
+    @DocInherit
+    @MetaSqlAlchemyDataset.column_map_expectation
+    def expect_column_values_to_not_be_in_set(self,
+                                              column,
+                                              value_set,
+                                              mostly=None,
+                                              result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                              ):
         return sa.column(column).notin_(tuple(value_set))
 
     @DocInherit
     @MetaSqlAlchemyDataset.column_map_expectation
     def expect_column_values_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        allow_cross_type_comparisons=None,
-        parse_strings_as_datetimes=None,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                           column,
+                                           min_value=None,
+                                           max_value=None,
+                                           allow_cross_type_comparisons=None,
+                                           parse_strings_as_datetimes=None,
+                                           mostly=None,
+                                           result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                           ):
         if parse_strings_as_datetimes is not None:
-            raise ValueError("parse_strings_as_datetimes is not currently supported in SqlAlchemy.")
+            raise ValueError(
+                "parse_strings_as_datetimes is not currently supported in SqlAlchemy.")
 
         if min_value != None and max_value != None and min_value > max_value:
             raise ValueError("min_value cannot be greater than max_value")
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
-
 
         if min_value is None:
             return sa.column(column) <= max_value
@@ -445,29 +455,29 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         else:
             return sa.and_(
-                        min_value <= sa.column(column),
-                        sa.column(column) <= max_value
-                )
+                min_value <= sa.column(column),
+                sa.column(column) <= max_value
+            )
 
     @DocInherit
     @MetaSqlAlchemyDataset.column_map_expectation
     def expect_column_value_lengths_to_equal(self,
-        column,
-        value,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                             column,
+                                             value,
+                                             mostly=None,
+                                             result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                             ):
         return sa.func.length(sa.column(column)) == value
 
     @DocInherit
     @MetaSqlAlchemyDataset.column_map_expectation
     def expect_column_value_lengths_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                  column,
+                                                  min_value=None,
+                                                  max_value=None,
+                                                  mostly=None,
+                                                  result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                  ):
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
@@ -506,22 +516,24 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @MetaSqlAlchemyDataset.column_aggregate_expectation
     def expect_column_max_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        parse_strings_as_datetimes=None,
-        output_strftime_format=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        parse_strings_as_datetimes=None,
+                                        output_strftime_format=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
 
         if parse_strings_as_datetimes:
-            raise ValueError("parse_strings_as_datetimes is not supported in SqlAlchemy")
+            raise ValueError(
+                "parse_strings_as_datetimes is not supported in SqlAlchemy")
 
         col_max = self.engine.execute(
-            sa.select([sa.func.max(sa.column(column))]).select_from(sa.table(self.table_name))
+            sa.select([sa.func.max(sa.column(column))]).select_from(
+                sa.table(self.table_name))
         ).scalar()
 
         # Handle possible missing values
@@ -549,26 +561,27 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 }
             }
 
-
     @DocInherit
     @MetaSqlAlchemyDataset.column_aggregate_expectation
     def expect_column_min_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        parse_strings_as_datetimes=None,
-        output_strftime_format=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        parse_strings_as_datetimes=None,
+                                        output_strftime_format=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
 
         if parse_strings_as_datetimes:
-            raise ValueError("parse_strings_as_datetimes is not supported in SqlAlchemy")
+            raise ValueError(
+                "parse_strings_as_datetimes is not supported in SqlAlchemy")
 
         col_min = self.engine.execute(
-            sa.select([sa.func.min(sa.column(column))]).select_from(sa.table(self.table_name))
+            sa.select([sa.func.min(sa.column(column))]).select_from(
+                sa.table(self.table_name))
         ).scalar()
 
         # Handle possible missing values
@@ -599,17 +612,18 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @MetaSqlAlchemyDataset.column_aggregate_expectation
     def expect_column_sum_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
 
         col_sum = self.engine.execute(
-            sa.select([sa.func.sum(sa.column(column))]).select_from(sa.table(self.table_name))
+            sa.select([sa.func.sum(sa.column(column))]).select_from(
+                sa.table(self.table_name))
         ).scalar()
 
         # Handle possible missing values
@@ -640,11 +654,11 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @MetaSqlAlchemyDataset.column_aggregate_expectation
     def expect_column_mean_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                         column,
+                                         min_value=None,
+                                         max_value=None,
+                                         result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                         ):
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
@@ -659,7 +673,8 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             raise ValueError("column is not numeric")
 
         col_avg = self.engine.execute(
-            sa.select([sa.func.avg(sa.column(column))]).select_from(sa.table(self.table_name))
+            sa.select([sa.func.avg(sa.column(column))]).select_from(
+                sa.table(self.table_name))
         ).scalar()
 
         # Handle possible missing values
@@ -690,15 +705,14 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     @DocInherit
     @MetaSqlAlchemyDataset.column_aggregate_expectation
     def expect_column_median_to_be_between(self,
-                                         column,
-                                         min_value=None,
-                                         max_value=None,
-                                         result_format=None, include_config=False, catch_exceptions=None, meta=None
-                                         ):
+                                           column,
+                                           min_value=None,
+                                           max_value=None,
+                                           result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                           ):
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
-
 
         # Inspiration from https://stackoverflow.com/questions/942620/missing-median-aggregate-function-in-django
         count_query = self.engine.execute(
@@ -734,7 +748,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 'success': False,
                 'result': {
                     'observed_value': None
-                    }
+                }
             }
         else:
             if nonnull_count % 2 == 0:
@@ -754,7 +768,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 'result': {
                     'observed_value': column_median
                     }
-                }
+            }
 
     @MetaSqlAlchemyDataset.column_map_expectation
     def expect_column_values_to_be_unique(self, column, mostly=None,
@@ -777,7 +791,8 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             raise ValueError("min_value and max_value cannot both be None")
 
         unique_value_count = self.engine.execute(
-            sa.select([sa.func.count(sa.func.distinct(sa.column(column)))]).select_from(sa.table(self.table_name))
+            sa.select([sa.func.count(sa.func.distinct(sa.column(column)))]).select_from(
+                sa.table(self.table_name))
         ).scalar()
 
         # Handle possible missing values
@@ -790,7 +805,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             }
         else:
             return {
-                "success" : (
+                "success": (
                     ((min_value is None) or (min_value <= unique_value_count)) and
                     ((max_value is None) or (unique_value_count <= max_value))
                 ),
@@ -813,14 +828,16 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 sa.func.sum(
                     sa.case([(sa.column(column) == None, 1)], else_=0)
                 ).label('null_count'),
-                sa.func.count(sa.func.distinct(sa.column(column))).label('unique_value_count')
+                sa.func.count(sa.func.distinct(sa.column(column))
+                              ).label('unique_value_count')
             ]).select_from(sa.table(self.table_name))
         )
 
         counts = count_query.fetchone()
 
         if counts['element_count'] - counts['null_count'] > 0:
-            proportion_unique = counts['unique_value_count'] / (counts['element_count'] - counts['null_count'])
+            proportion_unique = counts['unique_value_count'] / \
+                (counts['element_count'] - counts['null_count'])
         else:
             proportion_unique = None
 


### PR DESCRIPTION
Remove `IF NOT EXISTS` check when creating temporary tables from custom sql, to allow Redshift compatibility for this feature. Redshift allows `IF NOT EXISTS`, but not for temporary tables. Closes #372.

This is my first contribution to this library, so I'm happy to sign the CLA, but I couldn't find a link to it in the repository.