### PR TITLE
Allow non-default schemas when using SqlAlchemyDataset (#370)

### DIFF
--- a/docs/source/custom_expectations.rst
+++ b/docs/source/custom_expectations.rst
@@ -74,7 +74,7 @@ For SqlAlchemyDataset, the decorators work slightly differently. See the MetaSql
             mode_query = sa.select([
                 sa.column(column).label('value'),
                 sa.func.count(sa.column(column)).label('frequency')
-            ]).select_from(sa.table(self.table_name)).group_by(sa.column(column)).order_by(sa.desc(sa.column('frequency')))
+            ]).select_from(self._table).group_by(sa.column(column)).order_by(sa.desc(sa.column('frequency')))
 
             mode = self.engine.execute(mode_query).scalar()
             return {

--- a/docs/source/roadmap_changelog.rst
+++ b/docs/source/roadmap_changelog.rst
@@ -14,6 +14,7 @@ Planned Features
 
 v.0.4.4__develop
 ----------------
+* Add support for custom schema in SqlAlchemyDataset (#370)
 
 v.0.4.4
 ----------------

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -209,9 +209,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         if table_name is None:
             raise ValueError("No table_name provided.")
 
-        self.table_name = table_name
-        self.schema = schema
-        self._table = sa.Table(self.table_name, sa.MetaData(), schema=schema)
+        self._table = sa.Table(table_name, sa.MetaData(), schema=schema)
 
         if engine is None and connection_string is None:
             raise ValueError("Engine or connection_string must be provided.")
@@ -233,10 +231,10 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
 
         if custom_sql:
-            self.create_temporary_table(self.table_name, custom_sql)
+            self.create_temporary_table(table_name, custom_sql)
 
         insp = reflection.Inspector.from_engine(engine)
-        self.columns = insp.get_columns(self.table_name, schema=self.schema)
+        self.columns = insp.get_columns(table_name, schema=schema)
 
         # Only call super once connection is established and table_name and columns known to allow autoinspection
         super(SqlAlchemyDataset, self).__init__(*args, **kwargs)

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -5,7 +5,6 @@ from great_expectations.dataset import Dataset
 from functools import wraps
 import inspect
 from six import PY3
-import warnings
 
 from .util import DocInherit, parse_result_format, create_multiple_expectations
 

--- a/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
+++ b/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
@@ -18,7 +18,7 @@ def custom_dataset():
             mode_query = sa.select([
                 sa.column(column).label('value'),
                 sa.func.count(sa.column(column)).label('frequency')
-            ]).select_from(sa.table(self.table_name)).group_by(sa.column(column)).order_by(
+            ]).select_from(self._table).group_by(sa.column(column)).order_by(
                 sa.desc(sa.column('frequency')))
 
             mode = self.engine.execute(mode_query).scalar()

--- a/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
+++ b/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
@@ -85,6 +85,21 @@ def test_broken_decorator_errors(custom_dataset):
         assert "Column aggregate expectation failed to return required information: observed_value" in str(err)
 
 
+def test_missing_engine_error():
+    with pytest.raises(ValueError) as err:
+        SqlAlchemyDataset('test_engine', schema='example')
+        assert "Engine or connection_string must be provided." in str(err)
+
+
+def test_schema_custom_sql_error():
+    engine = sa.create_engine('sqlite://')
+
+    with pytest.raises(ValueError) as err:
+        SqlAlchemyDataset('test_schema_custom', schema='example', engine=engine,
+                          custom_sql='SELECT * FROM example.fake')
+        assert "Cannot specify both schema and custom_sql." in str(err)
+
+
 def test_sqlalchemydataset_with_custom_sql():
     engine = sa.create_engine('sqlite://')
 


### PR DESCRIPTION
This PR adds a parameter for instantiating a `SqlAlchemyDataset` with a non-default schema for databases that support them. `sa.table()` is very lightweight and does not support custom schemas, so I chose to create a `Table()` object and store it as an attribute for creating queries.

I didn't add any tests for this, because all of the tests are currently on sqlite, which does not support multiple schemas. I'd rather check in unit tested code, but I'm not sure the best approach to test this feature. I did test it myself on postgres and redshift (using sqlalchemy-redshift to create the engine). I'm happy to take any suggestions to keep the code coverage high.

Closes #370.