### PR TITLE
Allow users to pass engine connection options to SqlAlchemyDataContext (#369)

### DIFF
--- a/docs/source/roadmap_changelog.rst
+++ b/docs/source/roadmap_changelog.rst
@@ -14,6 +14,8 @@ Planned Features
 
 v.0.4.4__develop
 ----------------
+* Allow users to pass args/kwargs for engine creation in
+  SqlAlchemyDataContext (#369)
 
 v.0.4.4
 ----------------

--- a/great_expectations/data_context/__init__.py
+++ b/great_expectations/data_context/__init__.py
@@ -1,7 +1,7 @@
 from .pandas_context import PandasCSVDataContext
 from .sqlalchemy_context import SqlAlchemyDataContext
 
-def get_data_context(context_type, options):
+def get_data_context(context_type, options, *args, **kwargs):
     """Return a data_context object which exposes options to list datasets and get a dataset from
     that context. This is a new API in Great Expectations 0.4, and is subject to rapid change.
 
@@ -10,8 +10,8 @@ def get_data_context(context_type, options):
     :return: a new DataContext object
     """
     if context_type == "SqlAlchemy":
-        return SqlAlchemyDataContext(options)
+        return SqlAlchemyDataContext(options, *args, **kwargs)
     elif context_type == "PandasCSV":
-        return PandasCSVDataContext(options)
+        return PandasCSVDataContext(options, *args, **kwargs)
     else:
         raise ValueError("Unknown data context.")

--- a/great_expectations/data_context/base.py
+++ b/great_expectations/data_context/base.py
@@ -4,8 +4,8 @@ class DataContext(object):
 
     Warning: this feature is new in v0.4 and may change based on community feedback.
     """
-    def __init__(self, options):
-        self.connect(options)
+    def __init__(self, options, *args, **kwargs):
+        self.connect(options, *args, **kwargs)
 
     def connect(self, options):
         return NotImplementedError

--- a/great_expectations/data_context/sqlalchemy_context.py
+++ b/great_expectations/data_context/sqlalchemy_context.py
@@ -16,8 +16,8 @@ class SqlAlchemyDataContext(DataContext):
         super(SqlAlchemyDataContext, self).__init__(*args, **kwargs)
         self.meta = MetaData()
 
-    def connect(self, options):
-        self.engine = create_engine(options)
+    def connect(self, options, *args, **kwargs):
+        self.engine = create_engine(options, *args, **kwargs)
 
     def list_datasets(self):
         self.meta.reflect(bind=self.engine)

--- a/tests/test_data_contexts/test_data_contexts.py
+++ b/tests/test_data_contexts/test_data_contexts.py
@@ -37,7 +37,7 @@ def test_invalid_data_context():
 
 
 def test_sqlalchemy_data_context(test_db_connection_string):
-    context = get_data_context('SqlAlchemy', test_db_connection_string)
+    context = get_data_context('SqlAlchemy', test_db_connection_string, echo=False)
 
     assert context.list_datasets() == ['table_1', 'table_2']
     dataset = context.get_dataset('table_1')

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1139,9 +1139,9 @@ class TestDataset(unittest.TestCase):
         })
         def expect_second_value_to_be(self, column, value, result_format=None, include_config=False, catch_exceptions=None, meta=None):
             return {
-                "success": column.ix[1] == value,
+                "success": column.iloc[1] == value,
                 "result": {
-                    "observed_value": column.ix[1],
+                    "observed_value": column.iloc[1],
                 }
             }
 


### PR DESCRIPTION
Sometimes it's useful to pass specific connection options to `create_engine`. I added `*args` and `**kwargs` to the data contexts to allow more flexible engine creation in `SqlAlchemyDataContext`. Unrelatedly, I also changed a stray `ix` to `iloc` to quash some pandas warnings :)

I added an argument for test coverage, and also tested this with a more complex case on Redshift.

Closes #369.