### PR TITLE
PEP8 linting

### DIFF
--- a/great_expectations/cli.py
+++ b/great_expectations/cli.py
@@ -9,12 +9,14 @@ from great_expectations.dataset import PandasDataset
 
 
 def dispatch(args):
-    parser = argparse.ArgumentParser(description='great_expectations command-line interface')
+    parser = argparse.ArgumentParser(
+        description='great_expectations command-line interface')
 
     subparsers = parser.add_subparsers(dest='command')
     subparsers.required = True
 
-    validate_parser = subparsers.add_parser('validate', description='Validate expectations for your dataset.')
+    validate_parser = subparsers.add_parser(
+        'validate', description='Validate expectations for your dataset.')
     validate_parser.set_defaults(func=validate)
 
     validate_parser.add_argument('dataset',
@@ -32,11 +34,12 @@ def dispatch(args):
                                  help='Specify whether to only return expectations that are not met during evaluation (defaults to False).')
     # validate_parser.add_argument('--no_catch_exceptions', '-e', default=True, action='store_false')
     # validate_parser.add_argument('--only_return_failures', '-f', default=False, action='store_true')
-    custom_dataset_group = validate_parser.add_argument_group('custom_dataset', description='Arguments defining a custom dataset to use for validation.')
+    custom_dataset_group = validate_parser.add_argument_group(
+        'custom_dataset', description='Arguments defining a custom dataset to use for validation.')
     custom_dataset_group.add_argument('--custom_dataset_module', '-m', default=None,
-                                 help='Path to a python module containing a custom dataset class.')
+                                      help='Path to a python module containing a custom dataset class.')
     custom_dataset_group.add_argument('--custom_dataset_class', '-c', default=None,
-                                 help='Name of the custom dataset class to use during evaluation.')
+                                      help='Name of the custom dataset class to use during evaluation.')
 
     version_parser = subparsers.add_parser('version')
     version_parser.set_defaults(func=version)
@@ -61,20 +64,25 @@ def validate(parsed_args):
     expectations_config = json.load(open(expectations_config_file))
 
     if parsed_args["evaluation_parameters"] is not None:
-        evaluation_parameters = json.load(open(parsed_args["evaluation_parameters"]))
+        evaluation_parameters = json.load(
+            open(parsed_args["evaluation_parameters"]))
     else:
         evaluation_parameters = None
 
     if parsed_args["custom_dataset_module"]:
-        sys.path.insert(0, os.path.dirname(parsed_args["custom_dataset_module"]))
-        module_name = os.path.basename(parsed_args["custom_dataset_module"]).split('.')[0]
+        sys.path.insert(0, os.path.dirname(
+            parsed_args["custom_dataset_module"]))
+        module_name = os.path.basename(
+            parsed_args["custom_dataset_module"]).split('.')[0]
         custom_module = __import__(module_name)
-        dataset_class = getattr(custom_module, parsed_args["custom_dataset_class"])
+        dataset_class = getattr(
+            custom_module, parsed_args["custom_dataset_class"])
 
     else:
         dataset_class = PandasDataset
 
-    df = read_csv(data_set, expectations_config=expectations_config, dataset_class=dataset_class)
+    df = read_csv(data_set, expectations_config=expectations_config,
+                  dataset_class=dataset_class)
 
     result = df.validate(
         evaluation_parameters=evaluation_parameters,

--- a/great_expectations/data_context/__init__.py
+++ b/great_expectations/data_context/__init__.py
@@ -1,6 +1,7 @@
 from .pandas_context import PandasCSVDataContext
 from .sqlalchemy_context import SqlAlchemyDataContext
 
+
 def get_data_context(context_type, options, *args, **kwargs):
     """Return a data_context object which exposes options to list datasets and get a dataset from
     that context. This is a new API in Great Expectations 0.4, and is subject to rapid change.

--- a/great_expectations/data_context/base.py
+++ b/great_expectations/data_context/base.py
@@ -4,6 +4,7 @@ class DataContext(object):
 
     Warning: this feature is new in v0.4 and may change based on community feedback.
     """
+
     def __init__(self, options, *args, **kwargs):
         self.connect(options, *args, **kwargs)
 

--- a/great_expectations/data_context/pandas_context.py
+++ b/great_expectations/data_context/pandas_context.py
@@ -4,6 +4,7 @@ import os
 from .base import DataContext
 from ..dataset.pandas_dataset import PandasDataset
 
+
 class PandasCSVDataContext(DataContext):
     """
     A PandasCSVDataContext makes it easy to get a list of files available in the list_datasets
@@ -22,5 +23,6 @@ class PandasCSVDataContext(DataContext):
         return os.listdir(self.directory)
 
     def get_dataset(self, dataset_name, *args, **kwargs):
-        df = pd.read_csv(os.path.join(self.directory, dataset_name), *args, **kwargs)
+        df = pd.read_csv(os.path.join(
+            self.directory, dataset_name), *args, **kwargs)
         return PandasDataset(df)

--- a/great_expectations/dataset/autoinspect.py
+++ b/great_expectations/dataset/autoinspect.py
@@ -30,13 +30,16 @@ def columns_exist(inspect_dataset):
 
     # Attempt to get column names. For pandas, columns is just a list of strings
     if not hasattr(inspect_dataset, "columns"):
-        warnings.warn("No columns list found in dataset; no autoinspection performed.")
+        warnings.warn(
+            "No columns list found in dataset; no autoinspection performed.")
         return
     elif isinstance(inspect_dataset.columns[0], string_types):
         columns = inspect_dataset.columns
     elif isinstance(inspect_dataset.columns[0], dict) and "name" in inspect_dataset.columns[0]:
         columns = [col['name'] for col in inspect_dataset.columns]
     else:
-        raise AutoInspectError("Unable to determine column names for this dataset.")
+        raise AutoInspectError(
+            "Unable to determine column names for this dataset.")
 
-    create_multiple_expectations(inspect_dataset, columns, "expect_column_to_exist")
+    create_multiple_expectations(
+        inspect_dataset, columns, "expect_column_to_exist")

--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -80,14 +80,14 @@ class Dataset(object):
             @wraps(func)
             def wrapper(self, *args, **kwargs):
 
-                #Get the name of the method
+                # Get the name of the method
                 method_name = func.__name__
 
                 # Combine all arguments into a single new "kwargs"
                 all_args = dict(zip(method_arg_names, args))
                 all_args.update(kwargs)
 
-                #Unpack display parameters; remove them from all_args if appropriate
+                # Unpack display parameters; remove them from all_args if appropriate
                 if "include_config" in kwargs:
                     include_config = kwargs["include_config"]
                     del all_args["include_config"]
@@ -127,15 +127,17 @@ class Dataset(object):
                 all_args = recursively_convert_to_json_serializable(all_args)
 
                 # Patch in PARAMETER args, and remove locally-supplied arguments
-                expectation_args = copy.deepcopy(all_args) # This will become the stored config
+                # This will become the stored config
+                expectation_args = copy.deepcopy(all_args)
 
                 if "evaluation_parameters" in self._expectations_config:
                     evaluation_args = self._build_evaluation_parameters(expectation_args,
-                                                                        self._expectations_config["evaluation_parameters"]) # This will be passed to the evaluation
+                                                                        self._expectations_config["evaluation_parameters"])  # This will be passed to the evaluation
                 else:
-                    evaluation_args = self._build_evaluation_parameters(expectation_args, None)
+                    evaluation_args = self._build_evaluation_parameters(
+                        expectation_args, None)
 
-                #Construct the expectation_config object
+                # Construct the expectation_config object
                 expectation_config = DotDict({
                     "expectation_type": method_name,
                     "kwargs": expectation_args
@@ -170,7 +172,8 @@ class Dataset(object):
                 self._append_expectation(expectation_config)
 
                 if include_config:
-                    return_obj["expectation_config"] = copy.deepcopy(expectation_config)
+                    return_obj["expectation_config"] = copy.deepcopy(
+                        expectation_config)
 
                 if catch_exceptions:
                     return_obj["exception_info"] = {
@@ -182,7 +185,8 @@ class Dataset(object):
                 # Add a "success" object to the config
                 expectation_config["success_on_last_run"] = return_obj["success"]
 
-                return_obj = recursively_convert_to_json_serializable(return_obj)
+                return_obj = recursively_convert_to_json_serializable(
+                    return_obj)
                 return return_obj
 
             return wrapper
@@ -262,33 +266,33 @@ class Dataset(object):
             #!!! Should validate the incoming config with jsonschema here
 
             # Copy the original so that we don't overwrite it by accident
-            ## Pandas incorrectly interprets this as an attempt to create a column and throws up a warning. Suppress it
-            ## since we are subclassing.
+            # Pandas incorrectly interprets this as an attempt to create a column and throws up a warning. Suppress it
+            # since we are subclassing.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=UserWarning)
                 self._expectations_config = DotDict(copy.deepcopy(config))
 
         else:
-            ## Pandas incorrectly interprets this as an attempt to create a column and throws up a warning. Suppress it
-            ## since we are subclassing.
+            # Pandas incorrectly interprets this as an attempt to create a column and throws up a warning. Suppress it
+            # since we are subclassing.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=UserWarning)
                 self._expectations_config = DotDict({
-                    "dataset_name" : name,
+                    "dataset_name": name,
                     "meta": {
                         "great_expectations.__version__": __version__
                     },
-                    "expectations" : []
+                    "expectations": []
                 })
 
-        ## Pandas incorrectly interprets this as an attempt to create a column and throws up a warning. Suppress it
-        ## since we are subclassing.
+        # Pandas incorrectly interprets this as an attempt to create a column and throws up a warning. Suppress it
+        # since we are subclassing.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             self.default_expectation_args = {
-                "include_config" : False,
-                "catch_exceptions" : False,
-                "result_format" : 'BASIC',
+                "include_config": False,
+                "catch_exceptions": False,
+                "result_format": 'BASIC',
             }
 
     def _append_expectation(self, expectation_config):
@@ -309,14 +313,14 @@ class Dataset(object):
         """
         expectation_type = expectation_config['expectation_type']
 
-        #Test to ensure the new expectation is serializable.
-        #FIXME: If it's not, are we sure we want to raise an error?
-        #FIXME: Should we allow users to override the error?
-        #FIXME: Should we try to convert the object using something like recursively_convert_to_json_serializable?
+        # Test to ensure the new expectation is serializable.
+        # FIXME: If it's not, are we sure we want to raise an error?
+        # FIXME: Should we allow users to override the error?
+        # FIXME: Should we try to convert the object using something like recursively_convert_to_json_serializable?
         json.dumps(expectation_config)
 
-        #Drop existing expectations with the same expectation_type.
-        #For column_expectations, _append_expectation should only replace expectations
+        # Drop existing expectations with the same expectation_type.
+        # For column_expectations, _append_expectation should only replace expectations
         # where the expectation_type AND the column match
         #!!! This is good default behavior, but
         #!!!    it needs to be documented, and
@@ -326,7 +330,8 @@ class Dataset(object):
             column = expectation_config['kwargs']['column']
 
             self._expectations_config.expectations = [f for f in filter(
-                lambda exp: (exp['expectation_type'] != expectation_type) or ('column' in exp['kwargs'] and exp['kwargs']['column'] != column),
+                lambda exp: (exp['expectation_type'] != expectation_type) or (
+                    'column' in exp['kwargs'] and exp['kwargs']['column'] != column),
                 self._expectations_config.expectations
             )]
         else:
@@ -338,11 +343,11 @@ class Dataset(object):
         self._expectations_config.expectations.append(expectation_config)
 
     def _copy_and_clean_up_expectation(self,
-        expectation,
-        discard_result_format_kwargs=True,
-        discard_include_configs_kwargs=True,
-        discard_catch_exceptions_kwargs=True,
-    ):
+                                       expectation,
+                                       discard_result_format_kwargs=True,
+                                       discard_include_configs_kwargs=True,
+                                       discard_catch_exceptions_kwargs=True,
+                                       ):
         """Returns copy of `expectation` without `success_on_last_run` and other specified key-value pairs removed
 
           Returns a copy of specified expectation will not have `success_on_last_run` key-value. The other key-value \
@@ -426,10 +431,10 @@ class Dataset(object):
         return rval
 
     def find_expectation_indexes(self,
-        expectation_type=None,
-        column=None,
-        expectation_kwargs=None
-    ):
+                                 expectation_type=None,
+                                 column=None,
+                                 expectation_kwargs=None
+                                 ):
         """Find matching expectations within _expectation_config.
         Args:
             expectation_type=None                : The name of the expectation type to be matched.
@@ -444,7 +449,8 @@ class Dataset(object):
             expectation_kwargs = {}
 
         if "column" in expectation_kwargs and column != None and column != expectation_kwargs["column"]:
-            raise ValueError("Conflicting column names in remove_expectation: %s and %s" % (column, expectation_kwargs["column"]))
+            raise ValueError("Conflicting column names in remove_expectation: %s and %s" % (
+                column, expectation_kwargs["column"]))
 
         if column != None:
             expectation_kwargs["column"] = column
@@ -455,7 +461,7 @@ class Dataset(object):
                 # if column == None or ('column' not in exp['kwargs']) or (exp['kwargs']['column'] == column) or (exp['kwargs']['column']==:
                 match = True
 
-                for k,v in expectation_kwargs.items():
+                for k, v in expectation_kwargs.items():
                     if k in exp['kwargs'] and exp['kwargs'][k] == v:
                         continue
                     else:
@@ -467,13 +473,13 @@ class Dataset(object):
         return match_indexes
 
     def find_expectations(self,
-        expectation_type=None,
-        column=None,
-        expectation_kwargs=None,
-        discard_result_format_kwargs=True,
-        discard_include_configs_kwargs=True,
-        discard_catch_exceptions_kwargs=True,
-    ):
+                          expectation_type=None,
+                          column=None,
+                          expectation_kwargs=None,
+                          discard_result_format_kwargs=True,
+                          discard_include_configs_kwargs=True,
+                          discard_catch_exceptions_kwargs=True,
+                          ):
         """Find matching expectations within _expectation_config.
         Args:
             expectation_type=None                : The name of the expectation type to be matched.
@@ -502,12 +508,12 @@ class Dataset(object):
         )
 
     def remove_expectation(self,
-        expectation_type=None,
-        column=None,
-        expectation_kwargs=None,
-        remove_multiple_matches=False,
-        dry_run=False,
-    ):
+                           expectation_type=None,
+                           column=None,
+                           expectation_kwargs=None,
+                           remove_multiple_matches=False,
+                           dry_run=False,
+                           ):
         """Remove matching expectation(s) from _expectation_config.
         Args:
             expectation_type=None                : The name of the expectation type to be matched.
@@ -538,15 +544,17 @@ class Dataset(object):
 
         elif len(match_indexes) > 1:
             if not remove_multiple_matches:
-                raise ValueError('Multiple expectations matched arguments. No expectations removed.')
+                raise ValueError(
+                    'Multiple expectations matched arguments. No expectations removed.')
             else:
 
                 if not dry_run:
-                    self._expectations_config.expectations = [i for j, i in enumerate(self._expectations_config.expectations) if j not in match_indexes]
+                    self._expectations_config.expectations = [i for j, i in enumerate(
+                        self._expectations_config.expectations) if j not in match_indexes]
                 else:
                     return self._copy_and_clean_up_expectations_from_indexes(match_indexes)
 
-        else: #Exactly one match
+        else:  # Exactly one match
             expectation = self._copy_and_clean_up_expectation(
                 self._expectations_config.expectations[match_indexes[0]]
             )
@@ -560,7 +568,6 @@ class Dataset(object):
                 else:
                     return expectation
 
-
     def discard_failing_expectations(self):
         res = self.validate(only_return_failures=True).get('results')
         if any(res):
@@ -568,7 +575,8 @@ class Dataset(object):
                 self.remove_expectation(expectation_type=item['expectation_config']['expectation_type'],
                                         expectation_kwargs=item['expectation_config']['kwargs'])
 #            print("WARNING: Removed %s expectations that were 'False'" % len(res))
-            warnings.warn("Removed %s expectations that were 'False'" % len(res))
+            warnings.warn(
+                "Removed %s expectations that were 'False'" % len(res))
 
     def get_default_expectation_arguments(self):
         """Fetch default expectation arguments for this dataset
@@ -607,12 +615,12 @@ class Dataset(object):
         self.default_expectation_args[argument] = value
 
     def get_expectations_config(self,
-        discard_failed_expectations=True,
-        discard_result_format_kwargs=True,
-        discard_include_configs_kwargs=True,
-        discard_catch_exceptions_kwargs=True,
-        suppress_warnings=False
-    ):
+                                discard_failed_expectations=True,
+                                discard_result_format_kwargs=True,
+                                discard_include_configs_kwargs=True,
+                                discard_catch_exceptions_kwargs=True,
+                                suppress_warnings=False
+                                ):
         """Returns _expectation_config as a JSON object, and perform some cleaning along the way.
 
         Args:
@@ -641,10 +649,10 @@ class Dataset(object):
             new_expectations = []
 
             for expectation in expectations:
-                #Note: This is conservative logic.
-                #Instead of retaining expectations IFF success==True, it discard expectations IFF success==False.
-                #In cases where expectation["success"] is missing or None, expectations are *retained*.
-                #Such a case could occur if expectations were loaded from a config file and never run.
+                # Note: This is conservative logic.
+                # Instead of retaining expectations IFF success==True, it discard expectations IFF success==False.
+                # In cases where expectation["success"] is missing or None, expectations are *retained*.
+                # Such a case could occur if expectations were loaded from a config file and never run.
                 if "success_on_last_run" in expectation and expectation["success_on_last_run"] == False:
                     discards["failed_expectations"] += 1
                 else:
@@ -653,7 +661,7 @@ class Dataset(object):
             expectations = new_expectations
 
         for expectation in expectations:
-            #FIXME: Factor this out into a new function. The logic is duplicated in remove_expectation, which calls _copy_and_clean_up_expectation
+            # FIXME: Factor this out into a new function. The logic is duplicated in remove_expectation, which calls _copy_and_clean_up_expectation
             if "success_on_last_run" in expectation:
                 del expectation["success_on_last_run"]
 
@@ -672,7 +680,6 @@ class Dataset(object):
                     del expectation["kwargs"]["catch_exceptions"]
                     discards["catch_exceptions"] += 1
 
-
         if not suppress_warnings:
             """
 WARNING: get_expectations_config discarded
@@ -683,16 +690,20 @@ WARNING: get_expectations_config discarded
 If you wish to change this behavior, please set discard_failed_expectations, discard_result_format_kwargs, discard_include_configs_kwargs, and discard_catch_exceptions_kwargs appropirately.
             """
             if any([discard_failed_expectations, discard_result_format_kwargs, discard_include_configs_kwargs, discard_catch_exceptions_kwargs]):
-                print ("WARNING: get_expectations_config discarded")
+                print("WARNING: get_expectations_config discarded")
                 if discard_failed_expectations:
-                    print ("\t%d failing expectations" % discards["failed_expectations"])
+                    print("\t%d failing expectations" %
+                          discards["failed_expectations"])
                 if discard_result_format_kwargs:
-                    print ("\t%d result_format kwargs" % discards["result_format"])
+                    print("\t%d result_format kwargs" %
+                          discards["result_format"])
                 if discard_include_configs_kwargs:
-                    print ("\t%d include_configs kwargs" % discards["include_configs"])
+                    print("\t%d include_configs kwargs" %
+                          discards["include_configs"])
                 if discard_catch_exceptions_kwargs:
-                    print ("\t%d catch_exceptions kwargs" % discards["catch_exceptions"])
-                print ("If you wish to change this behavior, please set discard_failed_expectations, discard_result_format_kwargs, discard_include_configs_kwargs, and discard_catch_exceptions_kwargs appropirately.")
+                    print("\t%d catch_exceptions kwargs" %
+                          discards["catch_exceptions"])
+                print("If you wish to change this behavior, please set discard_failed_expectations, discard_result_format_kwargs, discard_include_configs_kwargs, and discard_catch_exceptions_kwargs appropirately.")
 
         config["expectations"] = expectations
         return config
@@ -731,8 +742,8 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
                   suppressed.
 
         """
-        if filepath==None:
-            #FIXME: Fetch the proper filepath from the project config
+        if filepath == None:
+            # FIXME: Fetch the proper filepath from the project config
             pass
 
         expectations_config = self.get_expectations_config(
@@ -827,19 +838,24 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         # Warn if our version is different from the version in the configuration
         try:
             if expectations_config['meta']['great_expectations.__version__'] != __version__:
-                warnings.warn("WARNING: This configuration object was built using a different version of great_expectations than is currently validating it.")
+                warnings.warn(
+                    "WARNING: This configuration object was built using a different version of great_expectations than is currently validating it.")
         except KeyError:
-            warnings.warn("WARNING: No great_expectations version found in configuration object.")
+            warnings.warn(
+                "WARNING: No great_expectations version found in configuration object.")
 
         for expectation in expectations_config['expectations']:
             try:
-                expectation_method = getattr(self, expectation['expectation_type'])
+                expectation_method = getattr(
+                    self, expectation['expectation_type'])
 
                 if result_format is not None:
-                    expectation['kwargs'].update({"result_format": result_format})
+                    expectation['kwargs'].update(
+                        {"result_format": result_format})
 
                 # A missing parameter should raise a KeyError
-                evaluation_args = self._build_evaluation_parameters(expectation['kwargs'], evaluation_parameters)
+                evaluation_args = self._build_evaluation_parameters(
+                    expectation['kwargs'], evaluation_parameters)
 
                 result = expectation_method(
                     catch_exceptions=catch_exceptions,
@@ -863,7 +879,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
                 else:
                     raise(err)
 
-            #if include_config:
+            # if include_config:
             result["expectation_config"] = copy.deepcopy(expectation)
 
             # Add an empty exception_info object if no exception was caught
@@ -881,7 +897,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         if only_return_failures:
             abbrev_results = []
             for exp in results:
-                if exp["success"]==False:
+                if exp["success"] == False:
                     abbrev_results.append(exp)
             results = abbrev_results
 
@@ -929,7 +945,8 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         if 'evaluation_parameters' not in self._expectations_config:
             self._expectations_config['evaluation_parameters'] = {}
 
-        self._expectations_config['evaluation_parameters'].update({parameter_name: parameter_value})
+        self._expectations_config['evaluation_parameters'].update(
+            {parameter_name: parameter_value})
 
     def _build_evaluation_parameters(self, expectation_args, evaluation_parameters):
         """Build a dictionary of parameters to evaluate, using the provided evaluation_paramters,
@@ -946,21 +963,24 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
                 # First, check to see whether an argument was supplied at runtime
                 # If it was, use that one, but remove it from the stored config
                 if "$PARAMETER." + value["$PARAMETER"] in value:
-                    evaluation_args[key] = evaluation_args[key]["$PARAMETER." + value["$PARAMETER"]]
-                    del expectation_args[key]["$PARAMETER." + value["$PARAMETER"]]
+                    evaluation_args[key] = evaluation_args[key]["$PARAMETER." +
+                                                                value["$PARAMETER"]]
+                    del expectation_args[key]["$PARAMETER." +
+                                              value["$PARAMETER"]]
                 elif evaluation_parameters is not None and value["$PARAMETER"] in evaluation_parameters:
                     evaluation_args[key] = evaluation_parameters[value['$PARAMETER']]
                 else:
-                    raise KeyError("No value found for $PARAMETER " + value["$PARAMETER"])
+                    raise KeyError(
+                        "No value found for $PARAMETER " + value["$PARAMETER"])
 
         return evaluation_args
 
     ##### Output generation #####
     def _format_column_map_output(self,
-        result_format, success,
-        element_count, nonnull_count,
-        unexpected_list, unexpected_index_list
-    ):
+                                  result_format, success,
+                                  element_count, nonnull_count,
+                                  unexpected_list, unexpected_index_list
+                                  ):
         """Helper function to construct expectation result objects for column_map_expectations.
 
         Expectations support four result_formats: BOOLEAN_ONLY, BASIC, SUMMARY, and COMPLETE.
@@ -1017,11 +1037,13 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
                 {'value': key, 'count': value}
                 for key, value
                 in sorted(
-                    Counter(unexpected_list).most_common(result_format['partial_unexpected_count']),
+                    Counter(unexpected_list).most_common(
+                        result_format['partial_unexpected_count']),
                     key=lambda x: (-x[1], x[0]))
             ]
         except TypeError:
-            partial_unexpected_counts = ['partial_exception_counts requires a hashable type']
+            partial_unexpected_counts = [
+                'partial_exception_counts requires a hashable type']
 
         return_obj['result'].update(
             {
@@ -1043,7 +1065,8 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         if result_format['result_format'] == 'COMPLETE':
             return return_obj
 
-        raise ValueError("Unknown result_format %s." % (result_format['result_format'],))
+        raise ValueError("Unknown result_format %s." %
+                         (result_format['result_format'],))
 
     def _calc_map_expectation_success(self, success_count, nonnull_count, mostly):
         """Calculate success and percent_success for column_map_expectations
@@ -1123,7 +1146,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
             Check out :ref:`custom_expectations` for more information.
         """
 
-        new_function = self.column_map_expectation( function )
+        new_function = self.column_map_expectation(function)
         return new_function(self, *args, **kwargs)
 
     def test_column_aggregate_expectation_function(self, function, *args, **kwargs):
@@ -1144,15 +1167,15 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
             Check out :ref:`custom_expectations` for more information.
         """
 
-        new_function = self.column_aggregate_expectation( function )
+        new_function = self.column_aggregate_expectation(function)
         return new_function(self, *args, **kwargs)
 
     ##### Table shape expectations #####
 
     def expect_column_to_exist(
-            self, column, column_index=None, result_format=None, include_config=False,
-            catch_exceptions=None, meta=None
-        ):
+        self, column, column_index=None, result_format=None, include_config=False,
+        catch_exceptions=None, meta=None
+    ):
         """Expect the specified column to exist.
 
         expect_column_to_exist is a :func:`expectation <great_expectations.dataset.base.Dataset.expectation>`, not a \
@@ -1190,9 +1213,9 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_table_columns_to_match_ordered_list(self,
-            column_list,
-            result_format=None, include_config=False, catch_exceptions=None, meta=None
-        ):
+                                                   column_list,
+                                                   result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                   ):
         """Expect the columns to exactly match a specified list.
 
         expect_table_columns_to_match_ordered_list is a :func:`expectation <great_expectations.dataset.base.DataSet.expectation>`, not a \
@@ -1227,10 +1250,10 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_table_row_count_to_be_between(self,
-        min_value=0,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                             min_value=0,
+                                             max_value=None,
+                                             result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                             ):
         """Expect the number of rows to be between two values.
 
         expect_table_row_count_to_be_between is a :func:`expectation <great_expectations.dataset.base.Dataset.expectation>`, \
@@ -1273,9 +1296,9 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_table_row_count_to_equal(self,
-        value,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        value,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         """Expect the number of rows to equal a value.
 
         expect_table_row_count_to_equal is a basic :func:`expectation <great_expectations.dataset.base.Dataset.expectation>`, \
@@ -1313,10 +1336,10 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
     ##### Missing values, unique values, and types #####
 
     def expect_column_values_to_be_unique(self,
-        column,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                          column,
+                                          mostly=None,
+                                          result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                          ):
         """Expect each column value to be unique.
 
         This expectation detects duplicates. All duplicated values are counted as exceptions.
@@ -1357,10 +1380,10 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_not_be_null(self,
-        column,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                            column,
+                                            mostly=None,
+                                            result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                            ):
         """Expect column values to not be null.
 
         To be counted as an exception, values must be explicitly null or missing, such as a NULL in PostgreSQL or an np.NaN in pandas.
@@ -1404,10 +1427,10 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_be_null(self,
-        column,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        mostly=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         """Expect column values to be null.
 
         expect_column_values_to_be_null is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
@@ -1560,11 +1583,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
     ##### Sets and ranges #####
 
     def expect_column_values_to_be_in_set(self,
-        column,
-        value_set,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                          column,
+                                          value_set,
+                                          mostly=None,
+                                          result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                          ):
         """Expect each column value to be in a given set.
 
         For example:
@@ -1627,11 +1650,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_not_be_in_set(self,
-        column,
-        value_set,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                              column,
+                                              value_set,
+                                              mostly=None,
+                                              result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                              ):
         """Expect column entries to not be in the set.
 
         For example:
@@ -1693,14 +1716,14 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        allow_cross_type_comparisons=None,
-        parse_strings_as_datetimes=None,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                           column,
+                                           min_value=None,
+                                           max_value=None,
+                                           allow_cross_type_comparisons=None,
+                                           parse_strings_as_datetimes=None,
+                                           mostly=None,
+                                           result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                           ):
         """Expect column entries to be between a minimum value and a maximum value (inclusive).
 
         expect_column_values_to_be_between is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
@@ -1752,12 +1775,12 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_be_increasing(self,
-        column,
-        strictly=None,
-        parse_strings_as_datetimes=None,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                              column,
+                                              strictly=None,
+                                              parse_strings_as_datetimes=None,
+                                              mostly=None,
+                                              result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                              ):
         """Expect column values to be increasing.
 
         By default, this expectation only works for numeric or datetime data.
@@ -1807,12 +1830,12 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_be_decreasing(self,
-        column,
-        strictly=None,
-        parse_strings_as_datetimes=None,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                              column,
+                                              strictly=None,
+                                              parse_strings_as_datetimes=None,
+                                              mostly=None,
+                                              result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                              ):
         """Expect column values to be decreasing.
 
         By default, this expectation only works for numeric or datetime data.
@@ -1862,16 +1885,15 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         """
         raise NotImplementedError
 
-
     ##### String matching #####
 
     def expect_column_value_lengths_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                  column,
+                                                  min_value=None,
+                                                  max_value=None,
+                                                  mostly=None,
+                                                  result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                  ):
         """Expect column entries to be strings with length between a minimum value and a maximum value (inclusive).
 
         This expectation only works for string-type values. Invoking it on ints or floats will raise a TypeError.
@@ -1922,11 +1944,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_value_lengths_to_equal(self,
-        column,
-        value,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                             column,
+                                             value,
+                                             mostly=None,
+                                             result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                             ):
         """Expect column entries to be strings with length equal to the provided value.
 
         This expectation only works for string-type values. Invoking it on ints or floats will raise a TypeError.
@@ -1969,11 +1991,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         """
 
     def expect_column_values_to_match_regex(self,
-        column,
-        regex,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                            column,
+                                            regex,
+                                            mostly=None,
+                                            result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                            ):
         """Expect column entries to be strings that match a given regular expression. Valid matches can be found \
         anywhere in the string, for example "[at]+" will identify the following strings as expected: "cat", "hat", \
         "aa", "a", and "t", and the following strings as unexpected: "fish", "dog".
@@ -2018,11 +2040,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_not_match_regex(self,
-        column,
-        regex,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                column,
+                                                regex,
+                                                mostly=None,
+                                                result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                ):
         """Expect column entries to be strings that do NOT match a given regular expression. The regex must not match \
         any portion of the provided string. For example, "[at]+" would identify the following strings as expected: \
         "fish", "dog", and the following as unexpected: "cat", "hat".
@@ -2067,12 +2089,12 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_match_regex_list(self,
-        column,
-        regex_list,
-        match_on="any",
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                 column,
+                                                 regex_list,
+                                                 match_on="any",
+                                                 mostly=None,
+                                                 result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                 ):
         """Expect the column entries to be strings that can be matched to either any of or all of a list of regular expressions.
         Matches can be anywhere in the string.
 
@@ -2120,8 +2142,8 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_not_match_regex_list(self, column, regex_list,
-                                                mostly=None,
-                                                result_format=None, include_config=False, catch_exceptions=None, meta=None):
+                                                     mostly=None,
+                                                     result_format=None, include_config=False, catch_exceptions=None, meta=None):
         """Expect the column entries to be strings that do not match any of a list of regular expressions. Matches can \
         be anywhere in the string.
 
@@ -2167,11 +2189,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
     ##### Datetime and JSON parsing #####
 
     def expect_column_values_to_match_strftime_format(self,
-        column,
-        strftime_format,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                      column,
+                                                      strftime_format,
+                                                      mostly=None,
+                                                      result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                      ):
         """Expect column entries to be strings representing a date or time with a given format.
 
         expect_column_values_to_match_strftime_format is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
@@ -2211,10 +2233,10 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_be_dateutil_parseable(self,
-        column,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                      column,
+                                                      mostly=None,
+                                                      result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                      ):
         """Expect column entries to be parseable using dateutil.
 
         expect_column_values_to_be_dateutil_parseable is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
@@ -2251,10 +2273,10 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_be_json_parseable(self,
-        column,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                  column,
+                                                  mostly=None,
+                                                  result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                  ):
         """Expect column entries to be data written in JavaScript Object Notation.
 
         expect_column_values_to_be_json_parseable is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
@@ -2294,11 +2316,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_values_to_match_json_schema(self,
-        column,
-        json_schema,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                  column,
+                                                  json_schema,
+                                                  mostly=None,
+                                                  result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                  ):
         """Expect column entries to be JSON objects matching a given JSON schema.
 
         expect_column_values_to_match_json_schema is a :func:`column_map_expectation <great_expectations.dataset.base.Dataset.column_map_expectation>`.
@@ -2416,11 +2438,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_mean_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                         column,
+                                         min_value=None,
+                                         max_value=None,
+                                         result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                         ):
         """Expect the column mean to be between a minimum value and a maximum value (inclusive).
 
         expect_column_mean_to_be_between is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2472,11 +2494,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_median_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                           column,
+                                           min_value=None,
+                                           max_value=None,
+                                           result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                           ):
         """Expect the column median to be between a minimum value and a maximum value.
 
         expect_column_median_to_be_between is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2529,11 +2551,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_stdev_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                          column,
+                                          min_value=None,
+                                          max_value=None,
+                                          result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                          ):
         """Expect the column standard deviation to be between a minimum value and a maximum value.
 
         expect_column_stdev_to_be_between is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2585,11 +2607,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_unique_value_count_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                       column,
+                                                       min_value=None,
+                                                       max_value=None,
+                                                       result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                       ):
         """Expect the number of unique values to be between a minimum value and a maximum value.
 
         expect_column_unique_value_count_to_be_between is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2640,11 +2662,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_proportion_of_unique_values_to_be_between(self,
-        column,
-        min_value=0,
-        max_value=1,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                                column,
+                                                                min_value=0,
+                                                                max_value=1,
+                                                                result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                                ):
         """Expect the proportion of unique values to be between a minimum value and a maximum value.
 
         For example, in a column containing [1, 2, 2, 3, 3, 3, 4, 4, 4, 4], there are 4 unique values and 10 total \
@@ -2698,11 +2720,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_most_common_value_to_be_in_set(self,
-        column,
-        value_set,
-        ties_okay=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                     column,
+                                                     value_set,
+                                                     ties_okay=None,
+                                                     result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                     ):
         """Expect the most common value to be within the designated value set
 
         expect_column_most_common_value_to_be_in_set is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2753,11 +2775,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_sum_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         """Expect the column to sum to be between an min and max value
 
         expect_column_sum_to_be_between is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2807,13 +2829,13 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_min_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        parse_strings_as_datetimes=None,
-        output_strftime_format=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        parse_strings_as_datetimes=None,
+                                        output_strftime_format=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         """Expect the column to sum to be between an min and max value
 
         expect_column_min_to_be_between is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2869,13 +2891,13 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_max_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        parse_strings_as_datetimes=None,
-        output_strftime_format=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        parse_strings_as_datetimes=None,
+                                        output_strftime_format=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         """Expect the column max to be between an min and max value
 
         expect_column_max_to_be_between is a :func:`column_aggregate_expectation <great_expectations.dataset.base.Dataset.column_aggregate_expectation>`.
@@ -2930,14 +2952,14 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         """
         raise NotImplementedError
 
-    ### Distributional expectations
+    # Distributional expectations
     def expect_column_chisquare_test_p_value_to_be_greater_than(self,
-        column,
-        partition_object=None,
-        p=0.05,
-        tail_weight_holdout=0,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                                column,
+                                                                partition_object=None,
+                                                                p=0.05,
+                                                                tail_weight_holdout=0,
+                                                                result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                                ):
         """Expect column values to be distributed similarly to the provided categorical partition. \
 
         This expectation compares categorical distributions using a Chi-squared test. \
@@ -3001,13 +3023,13 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_bootstrapped_ks_test_p_value_to_be_greater_than(self,
-        column,
-        partition_object=None,
-        p=0.05,
-        bootstrap_samples=None,
-        bootstrap_sample_size=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                                      column,
+                                                                      partition_object=None,
+                                                                      p=0.05,
+                                                                      bootstrap_samples=None,
+                                                                      bootstrap_sample_size=None,
+                                                                      result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                                      ):
         """Expect column values to be distributed similarly to the provided continuous partition. This expectation \
         compares continuous distributions using a bootstrapped Kolmogorov-Smirnov test. It returns `success=True` if \
         values in the column match the distribution of the provided partition.
@@ -3086,12 +3108,12 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_kl_divergence_to_be_less_than(self,
-        column,
-        partition_object=None,
-        threshold=None,
-        tail_weight_holdout=0,
-        internal_weight_holdout=0,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None):
+                                                    column,
+                                                    partition_object=None,
+                                                    threshold=None,
+                                                    tail_weight_holdout=0,
+                                                    internal_weight_holdout=0,
+                                                    result_format=None, include_config=False, catch_exceptions=None, meta=None):
         """Expect the Kulback-Leibler (KL) divergence (relative entropy) of the specified column with respect to the \
         partition object to be lower than the provided threshold.
 
@@ -3182,7 +3204,7 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
                 with weight zero in the partition_object.
                 * If tail_weight_holdout is specified, that value will be appended to the tails of the bins \
                 ((-Infinity, min(bins)) and (max(bins), Infinity).
-                
+
           If relative entropy/kl divergence goes to infinity for any of the reasons mentioned above, the observed value\
           will be set to None. This is because inf, -inf, Nan, are not json serializable and cause some json parsers to\
           crash when encountered. The python None token will be serialized to null in json. 
@@ -3197,11 +3219,11 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
     ### Column pairs ###
 
     def expect_column_pair_values_to_be_equal(self,
-        column_A,
-        column_B,
-        ignore_row_if="both_values_are_missing",
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                              column_A,
+                                              column_B,
+                                              ignore_row_if="both_values_are_missing",
+                                              result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                              ):
         """
         Expect the values in column A to be the same as column B.
 
@@ -3236,14 +3258,14 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         raise NotImplementedError
 
     def expect_column_pair_values_A_to_be_greater_than_B(self,
-        column_A,
-        column_B,
-        or_equal=None,
-        parse_strings_as_datetimes=None,
-        allow_cross_type_comparisons=None,
-        ignore_row_if="both_values_are_missing",
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                                         column_A,
+                                                         column_B,
+                                                         or_equal=None,
+                                                         parse_strings_as_datetimes=None,
+                                                         allow_cross_type_comparisons=None,
+                                                         ignore_row_if="both_values_are_missing",
+                                                         result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                         ):
         """
         Expect values in column A to be greater than column B.
 
@@ -3282,14 +3304,13 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
         """
         raise NotImplementedError
 
-
     def expect_column_pair_values_to_be_in_set(self,
-        column_A,
-        column_B,
-        value_pairs_set,
-        ignore_row_if="both_values_are_missing",
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                               column_A,
+                                               column_B,
+                                               value_pairs_set,
+                                               ignore_row_if="both_values_are_missing",
+                                               result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                               ):
         """
         Expect paired values from columns A and B to belong to a set of valid pairs.
 

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -17,9 +17,9 @@ from six import PY3, integer_types, string_types
 
 from .base import Dataset
 from .util import DocInherit, \
-        is_valid_partition_object, is_valid_categorical_partition_object, is_valid_continuous_partition_object, \
-        _scipy_distribution_positional_args_from_dict, validate_distribution_parameters,\
-        parse_result_format, create_multiple_expectations
+    is_valid_partition_object, is_valid_categorical_partition_object, is_valid_continuous_partition_object, \
+    _scipy_distribution_positional_args_from_dict, validate_distribution_parameters,\
+    parse_result_format
 
 
 class MetaPandasDataset(Dataset):
@@ -34,7 +34,6 @@ class MetaPandasDataset(Dataset):
 
     def __init__(self, *args, **kwargs):
         super(MetaPandasDataset, self).__init__(*args, **kwargs)
-
 
     @classmethod
     def column_map_expectation(cls, func):
@@ -71,7 +70,8 @@ class MetaPandasDataset(Dataset):
 
             # FIXME rename to mapped_ignore_values?
             if len(ignore_values) == 0:
-                boolean_mapped_null_values = np.array([False for value in series])
+                boolean_mapped_null_values = np.array(
+                    [False for value in series])
             else:
                 boolean_mapped_null_values = np.array([True if (value in ignore_values) or (pd.isnull(value)) else False
                                                        for value in series])
@@ -79,16 +79,20 @@ class MetaPandasDataset(Dataset):
             element_count = int(len(series))
 
             # FIXME rename nonnull to non_ignored?
-            nonnull_values = series[boolean_mapped_null_values==False]
-            nonnull_count = int((boolean_mapped_null_values==False).sum())
+            nonnull_values = series[boolean_mapped_null_values == False]
+            nonnull_count = int((boolean_mapped_null_values == False).sum())
 
-            boolean_mapped_success_values = func(self, nonnull_values, *args, **kwargs)
+            boolean_mapped_success_values = func(
+                self, nonnull_values, *args, **kwargs)
             success_count = np.count_nonzero(boolean_mapped_success_values)
 
-            unexpected_list = list(nonnull_values[boolean_mapped_success_values==False])
-            unexpected_index_list = list(nonnull_values[boolean_mapped_success_values==False].index)
+            unexpected_list = list(
+                nonnull_values[boolean_mapped_success_values == False])
+            unexpected_index_list = list(
+                nonnull_values[boolean_mapped_success_values == False].index)
 
-            success, percent_success = self._calc_map_expectation_success(success_count, nonnull_count, mostly)
+            success, percent_success = self._calc_map_expectation_success(
+                success_count, nonnull_count, mostly)
 
             return_obj = self._format_column_map_output(
                 result_format, success,
@@ -132,38 +136,45 @@ class MetaPandasDataset(Dataset):
             series_A = self[column_A]
             series_B = self[column_B]
 
-            if ignore_row_if=="both_values_are_missing":
+            if ignore_row_if == "both_values_are_missing":
                 boolean_mapped_null_values = series_A.isnull() & series_B.isnull()
-            elif ignore_row_if=="either_value_is_missing":
+            elif ignore_row_if == "either_value_is_missing":
                 boolean_mapped_null_values = series_A.isnull() | series_B.isnull()
-            elif ignore_row_if=="never":
+            elif ignore_row_if == "never":
                 boolean_mapped_null_values = series_A.map(lambda x: False)
             else:
-                raise ValueError("Unknown value of ignore_row_if: %s", (ignore_row_if,))
+                raise ValueError(
+                    "Unknown value of ignore_row_if: %s", (ignore_row_if,))
 
-            assert len(series_A) == len(series_B), "Series A and B must be the same length"
+            assert len(series_A) == len(
+                series_B), "Series A and B must be the same length"
 
-            #This next bit only works if series_A and _B are the same length
+            # This next bit only works if series_A and _B are the same length
             element_count = int(len(series_A))
-            nonnull_count = (boolean_mapped_null_values==False).sum()
+            nonnull_count = (boolean_mapped_null_values == False).sum()
 
-            nonnull_values_A = series_A[boolean_mapped_null_values==False]
-            nonnull_values_B = series_B[boolean_mapped_null_values==False]
+            nonnull_values_A = series_A[boolean_mapped_null_values == False]
+            nonnull_values_B = series_B[boolean_mapped_null_values == False]
             nonnull_values = [value_pair for value_pair in zip(
                 list(nonnull_values_A),
                 list(nonnull_values_B)
             )]
 
-            boolean_mapped_success_values = func(self, nonnull_values_A, nonnull_values_B, *args, **kwargs)
+            boolean_mapped_success_values = func(
+                self, nonnull_values_A, nonnull_values_B, *args, **kwargs)
             success_count = boolean_mapped_success_values.sum()
 
             unexpected_list = [value_pair for value_pair in zip(
-                list(series_A[(boolean_mapped_success_values==False)&(boolean_mapped_null_values==False)]),
-                list(series_B[(boolean_mapped_success_values==False)&(boolean_mapped_null_values==False)])
+                list(series_A[(boolean_mapped_success_values == False) & (
+                    boolean_mapped_null_values == False)]),
+                list(series_B[(boolean_mapped_success_values == False) & (
+                    boolean_mapped_null_values == False)])
             )]
-            unexpected_index_list = list(series_A[(boolean_mapped_success_values==False)&(boolean_mapped_null_values==False)].index)
+            unexpected_index_list = list(series_A[(boolean_mapped_success_values == False) & (
+                boolean_mapped_null_values == False)].index)
 
-            success, percent_success = self._calc_map_expectation_success(success_count, nonnull_count, mostly)
+            success, percent_success = self._calc_map_expectation_success(
+                success_count, nonnull_count, mostly)
 
             return_obj = self._format_column_map_output(
                 result_format, success,
@@ -195,7 +206,7 @@ class MetaPandasDataset(Dataset):
 
         @cls.expectation(argspec)
         @wraps(func)
-        def inner_wrapper(self, column, result_format = None, *args, **kwargs):
+        def inner_wrapper(self, column, result_format=None, *args, **kwargs):
 
             if result_format is None:
                 result_format = self.default_expectation_args["result_format"]
@@ -213,10 +224,12 @@ class MetaPandasDataset(Dataset):
             evaluation_result = func(self, nonnull_values, *args, **kwargs)
 
             if 'success' not in evaluation_result:
-                raise ValueError("Column aggregate expectation failed to return required information: success")
+                raise ValueError(
+                    "Column aggregate expectation failed to return required information: success")
 
             if ('result' not in evaluation_result) or ('observed_value' not in evaluation_result['result']):
-                raise ValueError("Column aggregate expectation failed to return required information: observed_value")
+                raise ValueError(
+                    "Column aggregate expectation failed to return required information: observed_value")
 
             # Retain support for string-only output formats:
             result_format = parse_result_format(result_format)
@@ -244,7 +257,8 @@ class MetaPandasDataset(Dataset):
             if result_format['result_format'] in ["SUMMARY", "COMPLETE"]:
                 return return_obj
 
-            raise ValueError("Unknown result_format %s." % (result_format['result_format'],))
+            raise ValueError("Unknown result_format %s." %
+                             (result_format['result_format'],))
 
         return inner_wrapper
 
@@ -288,7 +302,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
     def __init__(self, *args, **kwargs):
         super(PandasDataset, self).__init__(*args, **kwargs)
-        self.discard_subset_failing_expectations = kwargs.get('discard_subset_failing_expectations', False)
+        self.discard_subset_failing_expectations = kwargs.get(
+            'discard_subset_failing_expectations', False)
 
     ### Expectation methods ###
     @DocInherit
@@ -311,11 +326,11 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     @DocInherit
     @Dataset.expectation(['column_list'])
     def expect_table_columns_to_match_ordered_list(self, column_list,
-                               result_format=None, include_config=False, catch_exceptions=None, meta=None):
+                                                   result_format=None, include_config=False, catch_exceptions=None, meta=None):
 
         if list(self.columns) == list(column_list):
             return {
-                "success" : True
+                "success": True
             }
         else:
             return {
@@ -325,10 +340,10 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     @DocInherit
     @Dataset.expectation(['min_value', 'max_value'])
     def expect_table_row_count_to_be_between(self,
-        min_value=0,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                             min_value=0,
+                                             max_value=None,
+                                             result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                             ):
         # Assert that min_value and max_value are integers
         try:
             if min_value is not None:
@@ -361,9 +376,9 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     @DocInherit
     @Dataset.expectation(['value'])
     def expect_table_row_count_to_equal(self,
-        value,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        value,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         try:
             if value is not None:
                 float(value).is_integer()
@@ -380,9 +395,9 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             outcome = False
 
         return {
-            'success':outcome,
+            'success': outcome,
             'result': {
-                'observed_value':self.shape[0]
+                'observed_value': self.shape[0]
             }
         }
 
@@ -394,7 +409,6 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         dupes = set(column[column.duplicated()])
         return column.map(lambda x: x not in dupes)
 
-
     # @Dataset.expectation(['column', 'mostly', 'result_format'])
     @DocInherit
     @MetaPandasDataset.column_map_expectation
@@ -403,7 +417,6 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                                             result_format=None, include_config=False, catch_exceptions=None, meta=None, include_nulls=True):
 
         return column.map(lambda x: x is not None and not pd.isnull(x))
-
 
     @DocInherit
     @MetaPandasDataset.column_map_expectation
@@ -476,13 +489,13 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     @DocInherit
     @MetaPandasDataset.column_map_expectation
     def expect_column_values_to_be_between(self,
-        column,
-        min_value=None, max_value=None,
-        parse_strings_as_datetimes=None,
-        allow_cross_type_comparisons=None,
-        mostly=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                           column,
+                                           min_value=None, max_value=None,
+                                           parse_strings_as_datetimes=None,
+                                           allow_cross_type_comparisons=None,
+                                           mostly=None,
+                                           result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                           ):
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
 
@@ -518,7 +531,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
                     else:
                         if (isinstance(val, string_types) != isinstance(min_value, string_types)) or (isinstance(val, string_types) != isinstance(max_value, string_types)):
-                            raise TypeError("Column values, min_value, and max_value must either be None or of the same type.")
+                            raise TypeError(
+                                "Column values, min_value, and max_value must either be None or of the same type.")
 
                         return (min_value <= val) and (val <= max_value)
 
@@ -531,7 +545,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
                     else:
                         if isinstance(val, string_types) != isinstance(max_value, string_types):
-                            raise TypeError("Column values, min_value, and max_value must either be None or of the same type.")
+                            raise TypeError(
+                                "Column values, min_value, and max_value must either be None or of the same type.")
 
                         return val <= max_value
 
@@ -544,13 +559,13 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
                     else:
                         if isinstance(val, string_types) != isinstance(min_value, string_types):
-                            raise TypeError("Column values, min_value, and max_value must either be None or of the same type.")
+                            raise TypeError(
+                                "Column values, min_value, and max_value must either be None or of the same type.")
 
                         return min_value <= val
 
                 else:
                     return False
-
 
         return temp_column.map(is_between)
 
@@ -564,7 +579,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
             col_diff = temp_column.diff()
 
-            #The first element is null, so it gets a bye and is always treated as True
+            # The first element is null, so it gets a bye and is always treated as True
             col_diff[0] = pd.Timedelta(1)
 
             if strictly:
@@ -574,7 +589,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
         else:
             col_diff = column.diff()
-            #The first element is null, so it gets a bye and is always treated as True
+            # The first element is null, so it gets a bye and is always treated as True
             col_diff[col_diff.isnull()] = 1
 
             if strictly:
@@ -592,7 +607,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
             col_diff = temp_column.diff()
 
-            #The first element is null, so it gets a bye and is always treated as True
+            # The first element is null, so it gets a bye and is always treated as True
             col_diff[0] = pd.Timedelta(-1)
 
             if strictly:
@@ -602,7 +617,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
         else:
             col_diff = column.diff()
-            #The first element is null, so it gets a bye and is always treated as True
+            # The first element is null, so it gets a bye and is always treated as True
             col_diff[col_diff.isnull()] = -1
 
             if strictly:
@@ -630,7 +645,6 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         except ValueError:
             raise ValueError("min_value and max_value must be integers")
 
-
         def length_is_between(val):
             if min_value != None and max_value != None:
                 return len(val) >= min_value and len(val) <= max_value
@@ -651,7 +665,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     def expect_column_value_lengths_to_equal(self, column, value,
                                              mostly=None,
                                              result_format=None, include_config=False, catch_exceptions=None, meta=None):
-        return column.map(lambda x : len(x) == value)
+        return column.map(lambda x: len(x) == value)
 
     @DocInherit
     @MetaPandasDataset.column_map_expectation
@@ -675,7 +689,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                                                  mostly=None,
                                                  result_format=None, include_config=False, catch_exceptions=None, meta=None):
 
-        if match_on=="any":
+        if match_on == "any":
 
             def match_in_list(val):
                 if any(re.findall(regex, str(val)) for regex in regex_list):
@@ -683,7 +697,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 else:
                     return False
 
-        elif match_on=="all":
+        elif match_on == "all":
 
             def match_in_list(val):
                 if all(re.findall(regex, str(val)) for regex in regex_list):
@@ -696,12 +710,12 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     @DocInherit
     @MetaPandasDataset.column_map_expectation
     def expect_column_values_to_not_match_regex_list(self, column, regex_list,
-                                                 mostly=None,
-                                                 result_format=None, include_config=False, catch_exceptions=None, meta=None):
+                                                     mostly=None,
+                                                     result_format=None, include_config=False, catch_exceptions=None, meta=None):
         return column.map(
-            lambda x: not any([re.findall(regex, str(x)) for regex in regex_list])
+            lambda x: not any([re.findall(regex, str(x))
+                               for regex in regex_list])
         )
-
 
     @DocInherit
     @MetaPandasDataset.column_map_expectation
@@ -709,12 +723,14 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                                                       mostly=None,
                                                       result_format=None, include_config=False, catch_exceptions=None,
                                                       meta=None):
-        ## Below is a simple validation that the provided format can both format and parse a datetime object.
-        ## %D is an example of a format that can format but not parse, e.g.
+        # Below is a simple validation that the provided format can both format and parse a datetime object.
+        # %D is an example of a format that can format but not parse, e.g.
         try:
-            datetime.strptime(datetime.strftime(datetime.now(), strftime_format), strftime_format)
+            datetime.strptime(datetime.strftime(
+                datetime.now(), strftime_format), strftime_format)
         except ValueError as e:
-            raise ValueError("Unable to use provided strftime_format. " + e.message)
+            raise ValueError(
+                "Unable to use provided strftime_format. " + e.message)
 
         def is_parseable_by_format(val):
             try:
@@ -726,7 +742,6 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             except ValueError as e:
                 return False
 
-
         return column.map(is_parseable_by_format)
 
     @DocInherit
@@ -737,7 +752,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         def is_parseable(val):
             try:
                 if type(val) != str:
-                    raise TypeError("Values passed to expect_column_values_to_be_dateutil_parseable must be of type string.\nIf you want to validate a column of dates or timestamps, please call the expectation before converting from string format.")
+                    raise TypeError(
+                        "Values passed to expect_column_values_to_be_dateutil_parseable must be of type string.\nIf you want to validate a column of dates or timestamps, please call the expectation before converting from string format.")
 
                 parse(val)
                 return True
@@ -770,8 +786,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             try:
                 val_json = json.loads(val)
                 jsonschema.validate(val_json, json_schema)
-                #jsonschema.validate raises an error if validation fails.
-                #So if we make it this far, we know that the validation succeeded.
+                # jsonschema.validate raises an error if validation fails.
+                # So if we make it this far, we know that the validation succeeded.
                 return True
             except:
                 return False
@@ -790,13 +806,15 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
         # Validate params
         try:
-            validate_distribution_parameters(distribution=distribution, params=params)
+            validate_distribution_parameters(
+                distribution=distribution, params=params)
         except ValueError as e:
             raise e
 
         # Format arguments for scipy.kstest
         if (isinstance(params, dict)):
-            positional_parameters = _scipy_distribution_positional_args_from_dict(distribution, params)
+            positional_parameters = _scipy_distribution_positional_args_from_dict(
+                distribution, params)
         else:
             positional_parameters = params
 
@@ -856,7 +874,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 ((min_value is None) or (min_value <= column_median)) and
                 ((max_value is None) or (column_median <= max_value))
             ),
-            "result":{
+            "result": {
                 "observed_value": column_median
             }
         }
@@ -892,7 +910,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         unique_value_count = column.value_counts().shape[0]
 
         return {
-            "success" : (
+            "success": (
                 ((min_value is None) or (min_value <= unique_value_count)) and
                 ((max_value is None) or (unique_value_count <= max_value))
             ),
@@ -910,7 +928,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             raise ValueError("min_value and max_value cannot both be None")
 
         unique_value_count = column.value_counts().shape[0]
-        total_value_count = int(len(column))#.notnull().sum()
+        total_value_count = int(len(column))  # .notnull().sum()
 
         if total_value_count > 0:
             proportion_unique = float(unique_value_count) / total_value_count
@@ -936,15 +954,15 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         intersection_count = len(set(value_set).intersection(mode_list))
 
         if ties_okay:
-            success = intersection_count>0
+            success = intersection_count > 0
         else:
             if len(mode_list) > 1:
                 success = False
             else:
-                success = intersection_count==1
+                success = intersection_count == 1
 
         return {
-            'success' : success,
+            'success': success,
             'result': {
                 'observed_value': mode_list
             }
@@ -953,11 +971,11 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     @DocInherit
     @MetaPandasDataset.column_aggregate_expectation
     def expect_column_sum_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
 
@@ -973,22 +991,22 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             success = (min_value <= col_sum)
 
         return {
-            "success" : success,
+            "success": success,
             "result": {
-                "observed_value" : col_sum
+                "observed_value": col_sum
             }
         }
 
     @DocInherit
     @MetaPandasDataset.column_aggregate_expectation
     def expect_column_min_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        parse_strings_as_datetimes=None,
-        output_strftime_format=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        parse_strings_as_datetimes=None,
+                                        output_strftime_format=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
 
@@ -1021,26 +1039,24 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             else:
                 col_min = str(col_min)
         return {
-            'success' : success,
+            'success': success,
             'result': {
-                'observed_value' : col_min
+                'observed_value': col_min
             }
         }
-
 
     @DocInherit
     @MetaPandasDataset.column_aggregate_expectation
     def expect_column_max_to_be_between(self,
-        column,
-        min_value=None,
-        max_value=None,
-        parse_strings_as_datetimes=None,
-        output_strftime_format=None,
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                        column,
+                                        min_value=None,
+                                        max_value=None,
+                                        parse_strings_as_datetimes=None,
+                                        output_strftime_format=None,
+                                        result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                        ):
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
-
 
         if parse_strings_as_datetimes:
             if min_value:
@@ -1072,12 +1088,11 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 col_max = str(col_max)
 
         return {
-            "success" : success,
+            "success": success,
             "result": {
-                "observed_value" : col_max
+                "observed_value": col_max
             }
         }
-
 
     @DocInherit
     @MetaPandasDataset.column_aggregate_expectation
@@ -1088,40 +1103,44 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
 
         observed_frequencies = column.value_counts()
         # Convert to Series object to allow joining on index values
-        expected_column = pd.Series(partition_object['weights'], index=partition_object['values'], name='expected') * len(column)
+        expected_column = pd.Series(
+            partition_object['weights'], index=partition_object['values'], name='expected') * len(column)
         # Join along the indices to allow proper comparison of both types of possible missing values
         # test_df = pd.concat([expected_column, observed_frequencies], axis=1, sort=True) # Sort parameter not available before pandas 0.23.0
         test_df = pd.concat([expected_column, observed_frequencies], axis=1)
 
         na_counts = test_df.isnull().sum()
 
-        ## Handle NaN: if we expected something that's not there, it's just not there.
+        # Handle NaN: if we expected something that's not there, it's just not there.
         test_df[column.name] = test_df[column.name].fillna(0)
-        ## Handle NaN: if something's there that was not expected, substitute the relevant value for tail_weight_holdout
+        # Handle NaN: if something's there that was not expected, substitute the relevant value for tail_weight_holdout
         if na_counts['expected'] > 0:
             # Scale existing expected values
-            test_df['expected'] = test_df['expected'] * (1 - tail_weight_holdout)
+            test_df['expected'] = test_df['expected'] * \
+                (1 - tail_weight_holdout)
             # Fill NAs with holdout.
-            test_df['expected'] = test_df['expected'].fillna(len(column) * (tail_weight_holdout / na_counts['expected']))
+            test_df['expected'] = test_df['expected'].fillna(
+                len(column) * (tail_weight_holdout / na_counts['expected']))
 
-        test_result = stats.chisquare(test_df[column.name], test_df['expected'])[1]
+        test_result = stats.chisquare(
+            test_df[column.name], test_df['expected'])[1]
 
         return_obj = {
-                "success": test_result > p,
-                "result": {
-                    "observed_value": test_result,
-                    "details": {
-                        "observed_partition": {
-                            "values": test_df.index.tolist(),
-                            "weights": test_df[column.name].tolist()
-                        },
-                        "expected_partition": {
-                            "values": test_df.index.tolist(),
-                            "weights": test_df['expected'].tolist()
-                        }
+            "success": test_result > p,
+            "result": {
+                "observed_value": test_result,
+                "details": {
+                    "observed_partition": {
+                        "values": test_df.index.tolist(),
+                        "weights": test_df[column.name].tolist()
+                    },
+                    "expected_partition": {
+                        "values": test_df.index.tolist(),
+                        "weights": test_df['expected'].tolist()
                     }
                 }
             }
+        }
 
         return return_obj
 
@@ -1135,7 +1154,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         if (partition_object['bins'][0] == -np.inf) or (partition_object['bins'][-1] == np.inf):
             raise ValueError("Partition endpoints must be finite.")
 
-        test_cdf = np.append(np.array([0]), np.cumsum(partition_object['weights']))
+        test_cdf = np.append(np.array([0]), np.cumsum(
+            partition_object['weights']))
 
         def estimated_cdf(x):
             return np.interp(x, partition_object['bins'], test_cdf)
@@ -1152,26 +1172,33 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             bootstrap_sample_size = len(partition_object['weights']) * 2
 
         results = [stats.kstest(
-                        np.random.choice(column, size=bootstrap_sample_size, replace=True),
-                        estimated_cdf)[1]
-                   for k in range(bootstrap_samples)]
+            np.random.choice(column, size=bootstrap_sample_size, replace=True),
+            estimated_cdf)[1]
+            for k in range(bootstrap_samples)]
 
-        test_result = (1 + sum(x >= p for x in results)) / (bootstrap_samples + 1)
+        test_result = (1 + sum(x >= p for x in results)) / \
+            (bootstrap_samples + 1)
 
         hist, bin_edges = np.histogram(column, partition_object['bins'])
-        below_partition = len(np.where(column < partition_object['bins'][0])[0])
-        above_partition = len(np.where(column > partition_object['bins'][-1])[0])
+        below_partition = len(
+            np.where(column < partition_object['bins'][0])[0])
+        above_partition = len(
+            np.where(column > partition_object['bins'][-1])[0])
 
         # Expand observed partition to report, if necessary
         if below_partition > 0 and above_partition > 0:
-            observed_bins = [np.min(column)] + partition_object['bins'] + [np.max(column)]
-            observed_weights = np.concatenate(([below_partition], hist, [above_partition])) / len(column)
+            observed_bins = [np.min(column)] + \
+                partition_object['bins'] + [np.max(column)]
+            observed_weights = np.concatenate(
+                ([below_partition], hist, [above_partition])) / len(column)
         elif below_partition > 0:
             observed_bins = [np.min(column)] + partition_object['bins']
-            observed_weights = np.concatenate(([below_partition], hist)) / len(column)
+            observed_weights = np.concatenate(
+                ([below_partition], hist)) / len(column)
         elif above_partition > 0:
             observed_bins = partition_object['bins'] + [np.max(column)]
-            observed_weights = np.concatenate((hist, [above_partition])) / len(column)
+            observed_weights = np.concatenate(
+                (hist, [above_partition])) / len(column)
         else:
             observed_bins = partition_object['bins']
             observed_weights = hist / len(column)
@@ -1179,31 +1206,31 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         observed_cdf_values = np.cumsum(observed_weights)
 
         return_obj = {
-                "success" : test_result > p,
-                "result": {
-                    "observed_value": test_result,
-                    "details": {
-                        "bootstrap_samples": bootstrap_samples,
-                        "bootstrap_sample_size": bootstrap_sample_size,
-                        "observed_partition": {
-                            "bins": observed_bins,
-                            "weights": observed_weights.tolist()
-                        },
-                        "expected_partition": {
-                            "bins": partition_object['bins'],
-                            "weights": partition_object['weights']
-                        },
-                        "observed_cdf": {
-                            "x": observed_bins,
-                            "cdf_values": [0] + observed_cdf_values.tolist()
-                        },
-                        "expected_cdf": {
-                            "x": partition_object['bins'],
-                            "cdf_values": test_cdf.tolist()
-                        }
+            "success": test_result > p,
+            "result": {
+                "observed_value": test_result,
+                "details": {
+                    "bootstrap_samples": bootstrap_samples,
+                    "bootstrap_sample_size": bootstrap_sample_size,
+                    "observed_partition": {
+                        "bins": observed_bins,
+                        "weights": observed_weights.tolist()
+                    },
+                    "expected_partition": {
+                        "bins": partition_object['bins'],
+                        "weights": partition_object['weights']
+                    },
+                    "observed_cdf": {
+                        "x": observed_bins,
+                        "cdf_values": [0] + observed_cdf_values.tolist()
+                    },
+                    "expected_cdf": {
+                        "x": partition_object['bins'],
+                        "cdf_values": test_cdf.tolist()
                     }
                 }
             }
+        }
 
         return return_obj
 
@@ -1216,44 +1243,50 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             raise ValueError("Invalid partition object.")
 
         if (not isinstance(threshold, (int, float))) or (threshold < 0):
-            raise ValueError("Threshold must be specified, greater than or equal to zero.")
+            raise ValueError(
+                "Threshold must be specified, greater than or equal to zero.")
 
         if (not isinstance(tail_weight_holdout, (int, float))) or (tail_weight_holdout < 0) or (tail_weight_holdout > 1):
-            raise ValueError("tail_weight_holdout must be between zero and one.")
+            raise ValueError(
+                "tail_weight_holdout must be between zero and one.")
 
         if (not isinstance(internal_weight_holdout, (int, float))) or (internal_weight_holdout < 0) or (internal_weight_holdout > 1):
-            raise ValueError("internal_weight_holdout must be between zero and one.")
+            raise ValueError(
+                "internal_weight_holdout must be between zero and one.")
 
         if is_valid_categorical_partition_object(partition_object):
             if internal_weight_holdout > 0:
-                raise ValueError("Internal weight holdout cannot be used for discrete data.")
+                raise ValueError(
+                    "Internal weight holdout cannot be used for discrete data.")
 
             # Data are expected to be discrete, use value_counts
             observed_weights = column.value_counts() / len(column)
-            expected_weights = pd.Series(partition_object['weights'], index=partition_object['values'], name='expected')
+            expected_weights = pd.Series(
+                partition_object['weights'], index=partition_object['values'], name='expected')
             # test_df = pd.concat([expected_weights, observed_weights], axis=1, sort=True) # Sort not available before pandas 0.23.0
             test_df = pd.concat([expected_weights, observed_weights], axis=1)
 
-
             na_counts = test_df.isnull().sum()
 
-            ## Handle NaN: if we expected something that's not there, it's just not there.
+            # Handle NaN: if we expected something that's not there, it's just not there.
             pk = test_df[column.name].fillna(0)
-            ## Handle NaN: if something's there that was not expected, substitute the relevant value for tail_weight_holdout
+            # Handle NaN: if something's there that was not expected, substitute the relevant value for tail_weight_holdout
             if na_counts['expected'] > 0:
                 # Scale existing expected values
-                test_df['expected'] = test_df['expected'] * (1 - tail_weight_holdout)
+                test_df['expected'] = test_df['expected'] * \
+                    (1 - tail_weight_holdout)
                 # Fill NAs with holdout.
-                qk = test_df['expected'].fillna(tail_weight_holdout / na_counts['expected'])
+                qk = test_df['expected'].fillna(
+                    tail_weight_holdout / na_counts['expected'])
             else:
                 qk = test_df['expected']
 
             kl_divergence = stats.entropy(pk, qk)
-            
+
             if(np.isinf(kl_divergence) or np.isnan(kl_divergence)):
-                observed_value=None
+                observed_value = None
             else:
-                observed_value=kl_divergence
+                observed_value = kl_divergence
 
             return_obj = {
                 "success": kl_divergence <= threshold,
@@ -1276,19 +1309,25 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             # Data are expected to be continuous; discretize first
 
             # Build the histogram first using expected bins so that the largest bin is >=
-            hist, bin_edges = np.histogram(column, partition_object['bins'], density=False)
+            hist, bin_edges = np.histogram(
+                column, partition_object['bins'], density=False)
 
             # Add in the frequencies observed above or below the provided partition
-            below_partition = len(np.where(column < partition_object['bins'][0])[0])
-            above_partition = len(np.where(column > partition_object['bins'][-1])[0])
+            below_partition = len(
+                np.where(column < partition_object['bins'][0])[0])
+            above_partition = len(
+                np.where(column > partition_object['bins'][-1])[0])
 
-            observed_weights = np.concatenate(([below_partition], hist, [above_partition])) / len(column)
+            observed_weights = np.concatenate(
+                ([below_partition], hist, [above_partition])) / len(column)
 
-            expected_weights = np.array(partition_object['weights']) * (1 - tail_weight_holdout - internal_weight_holdout)
+            expected_weights = np.array(
+                partition_object['weights']) * (1 - tail_weight_holdout - internal_weight_holdout)
 
             # Assign internal weight holdout values if applicable
             if internal_weight_holdout > 0:
-                zero_count = len(expected_weights) - np.count_nonzero(expected_weights)
+                zero_count = len(expected_weights) - \
+                    np.count_nonzero(expected_weights)
                 if zero_count > 0:
                     for index, value in enumerate(expected_weights):
                         if value == 0:
@@ -1298,7 +1337,8 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             # We need to check cases to only add tail weight holdout if it makes sense based on the provided partition.
             if (partition_object['bins'][0] == -np.inf) and (partition_object['bins'][-1]) == np.inf:
                 if tail_weight_holdout > 0:
-                    raise ValueError("tail_weight_holdout cannot be used for partitions with infinite endpoints.")
+                    raise ValueError(
+                        "tail_weight_holdout cannot be used for partitions with infinite endpoints.")
                 expected_bins = partition_object['bins']
                 # Remove the below_partition and above_partition weights we just added (they will necessarily have been zero)
                 observed_weights = observed_weights[1:-1]
@@ -1307,69 +1347,70 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
                 expected_bins = partition_object['bins'] + [np.inf]
                 # Remove the below_partition weight we just added (it will necessarily have been zero)
                 observed_weights = observed_weights[1:]
-                expected_weights = np.concatenate((expected_weights, [tail_weight_holdout]))
+                expected_weights = np.concatenate(
+                    (expected_weights, [tail_weight_holdout]))
             elif (partition_object['bins'][-1] == np.inf):
                 expected_bins = [-np.inf] + partition_object['bins']
                 # Remove the above_partition weight we just added (it will necessarily have been zero)
                 observed_weights = observed_weights[:-1]
-                expected_weights = np.concatenate(([tail_weight_holdout], expected_weights))
+                expected_weights = np.concatenate(
+                    ([tail_weight_holdout], expected_weights))
             else:
                 expected_bins = [-np.inf] + partition_object['bins'] + [np.inf]
                 # No change to observed_weights in this case
-                expected_weights = np.concatenate(([tail_weight_holdout / 2], expected_weights, [tail_weight_holdout / 2]))
+                expected_weights = np.concatenate(
+                    ([tail_weight_holdout / 2], expected_weights, [tail_weight_holdout / 2]))
 
-                
-            kl_divergence = stats.entropy(observed_weights, expected_weights) 
-            
+            kl_divergence = stats.entropy(observed_weights, expected_weights)
+
             if(np.isinf(kl_divergence) or np.isnan(kl_divergence)):
-                observed_value=None
+                observed_value = None
             else:
-                observed_value=kl_divergence
-            
+                observed_value = kl_divergence
+
             return_obj = {
-                    "success": kl_divergence <= threshold,
-                    "result": {
-                        "observed_value": observed_value,
-                        "details": {
-                            "observed_partition": {
-                                # return expected_bins, since we used those bins to compute the observed_weights
-                                "bins": expected_bins,
-                                "weights": observed_weights.tolist()
-                            },
-                            "expected_partition": {
-                                "bins": expected_bins,
-                                "weights": expected_weights.tolist()
-                            }
+                "success": kl_divergence <= threshold,
+                "result": {
+                    "observed_value": observed_value,
+                    "details": {
+                        "observed_partition": {
+                            # return expected_bins, since we used those bins to compute the observed_weights
+                            "bins": expected_bins,
+                            "weights": observed_weights.tolist()
+                        },
+                        "expected_partition": {
+                            "bins": expected_bins,
+                            "weights": expected_weights.tolist()
                         }
                     }
                 }
+            }
 
         return return_obj
-
 
     @DocInherit
     @MetaPandasDataset.column_pair_map_expectation
     def expect_column_pair_values_to_be_equal(self,
-        column_A,
-        column_B,
-        ignore_row_if="both_values_are_missing",
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                              column_A,
+                                              column_B,
+                                              ignore_row_if="both_values_are_missing",
+                                              result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                              ):
         return column_A == column_B
 
     @DocInherit
     @MetaPandasDataset.column_pair_map_expectation
     def expect_column_pair_values_A_to_be_greater_than_B(self,
-        column_A,
-        column_B,
-        or_equal=None,
-        parse_strings_as_datetimes=None,
-        allow_cross_type_comparisons=None,
-        ignore_row_if="both_values_are_missing",
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
-        #FIXME
-        if allow_cross_type_comparisons==True:
+                                                         column_A,
+                                                         column_B,
+                                                         or_equal=None,
+                                                         parse_strings_as_datetimes=None,
+                                                         allow_cross_type_comparisons=None,
+                                                         ignore_row_if="both_values_are_missing",
+                                                         result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                                         ):
+        # FIXME
+        if allow_cross_type_comparisons == True:
             raise NotImplementedError
 
         if parse_strings_as_datetimes:
@@ -1380,7 +1421,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             temp_column_A = column_A
             temp_column_B = column_B
 
-        if or_equal==True:
+        if or_equal == True:
             return temp_column_A >= temp_column_B
         else:
             return temp_column_A > temp_column_B
@@ -1388,14 +1429,14 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     @DocInherit
     @MetaPandasDataset.column_pair_map_expectation
     def expect_column_pair_values_to_be_in_set(self,
-        column_A,
-        column_B,
-        value_pairs_set,
-        ignore_row_if="both_values_are_missing",
-        result_format=None, include_config=False, catch_exceptions=None, meta=None
-    ):
+                                               column_A,
+                                               column_B,
+                                               value_pairs_set,
+                                               ignore_row_if="both_values_are_missing",
+                                               result_format=None, include_config=False, catch_exceptions=None, meta=None
+                                               ):
         temp_df = pd.DataFrame({"A": column_A, "B": column_B})
-        value_pairs_set = {(x,y) for x,y in value_pairs_set}
+        value_pairs_set = {(x, y) for x, y in value_pairs_set}
 
         results = []
         for i, t in temp_df.iterrows():

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -6,7 +6,7 @@ from functools import wraps
 import inspect
 from six import PY3
 
-from .util import DocInherit, parse_result_format, create_multiple_expectations
+from .util import DocInherit, parse_result_format
 
 import sqlalchemy as sa
 from sqlalchemy.engine import reflection
@@ -237,7 +237,6 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             # a user-defined schema
             raise ValueError("Cannot specify both schema and custom_sql.")
 
-
         if custom_sql:
             self.create_temporary_table(table_name, custom_sql)
 
@@ -246,7 +245,6 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         # Only call super once connection is established and table_name and columns known to allow autoinspection
         super(SqlAlchemyDataset, self).__init__(*args, **kwargs)
-
 
     def create_temporary_table(self, table_name, custom_sql):
         """
@@ -262,11 +260,11 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
     def _is_numeric_column(self, column):
         for col in self.columns:
             if (col['name'] == column and
-                    isinstance(col['type'],
-                               (sa.types.Integer, sa.types.BigInteger, sa.types.Float,
-                                sa.types.Numeric, sa.types.SmallInteger, sa.types.Boolean)
-                               )
-                ):
+                        isinstance(col['type'],
+                                   (sa.types.Integer, sa.types.BigInteger, sa.types.Float,
+                                    sa.types.Numeric, sa.types.SmallInteger, sa.types.Boolean)
+                                   )
+                    ):
                 return True
 
         return False
@@ -774,7 +772,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                     ((max_value is None) or (column_median <= max_value)),
                 'result': {
                     'observed_value': column_median
-                    }
+                }
             }
 
     @MetaSqlAlchemyDataset.column_map_expectation
@@ -787,7 +785,6 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             having(sa.func.count(sa.column(column)) > 1)
 
         return sa.column(column).notin_(dup_query)
-
 
     @DocInherit
     @MetaSqlAlchemyDataset.column_aggregate_expectation

--- a/great_expectations/dataset/util.py
+++ b/great_expectations/dataset/util.py
@@ -32,19 +32,20 @@ def parse_result_format(result_format):
 
     return result_format
 
+
 class DotDict(dict):
     """dot.notation access to dictionary attributes"""
 
     def __getattr__(self, attr):
         return self.get(attr)
 
-    __setattr__= dict.__setitem__
-    __delattr__= dict.__delitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
 
     def __dir__(self):
         return self.keys()
 
-    #Cargo-cultishly copied from: https://github.com/spindlelabs/pyes/commit/d2076b385c38d6d00cebfe0df7b0d1ba8df934bc
+    # Cargo-cultishly copied from: https://github.com/spindlelabs/pyes/commit/d2076b385c38d6d00cebfe0df7b0d1ba8df934bc
     def __deepcopy__(self, memo):
         return DotDict([(copy.deepcopy(k, memo), copy.deepcopy(v, memo)) for k, v in self.items()])
 
@@ -78,6 +79,8 @@ Usage::
     Our new homegrown implementation directly searches the MRO, instead
     of relying on super, and concatenates documentation together.
 """
+
+
 class DocInherit(object):
 
     def __init__(self, mthd):
@@ -118,7 +121,7 @@ def recursively_convert_to_json_serializable(test_obj):
     """
     # Validate that all aruguments are of approved types, coerce if it's easy, else exception
     # print(type(test_obj), test_obj)
-    #Note: Not 100% sure I've resolved this correctly...
+    # Note: Not 100% sure I've resolved this correctly...
     try:
         if not isinstance(test_obj, list) and np.isnan(test_obj):
             # np.isnan is functionally vectorized, but we only want to apply this to single objects
@@ -136,7 +139,8 @@ def recursively_convert_to_json_serializable(test_obj):
     elif isinstance(test_obj, dict):
         new_dict = {}
         for key in test_obj:
-            new_dict[key] = recursively_convert_to_json_serializable(test_obj[key])
+            new_dict[key] = recursively_convert_to_json_serializable(
+                test_obj[key])
 
         return new_dict
 
@@ -149,11 +153,11 @@ def recursively_convert_to_json_serializable(test_obj):
 
     elif isinstance(test_obj, (np.ndarray, pd.Index)):
         #test_obj[key] = test_obj[key].tolist()
-        ## If we have an array or index, convert it first to a list--causing coercion to float--and then round
-        ## to the number of digits for which the string representation will equal the float representation
+        # If we have an array or index, convert it first to a list--causing coercion to float--and then round
+        # to the number of digits for which the string representation will equal the float representation
         return [recursively_convert_to_json_serializable(x) for x in test_obj.tolist()]
 
-    #Note: This clause has to come after checking for np.ndarray or we get:
+    # Note: This clause has to come after checking for np.ndarray or we get:
     #      `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`
     elif test_obj == None:
         # No problem to encode json
@@ -185,7 +189,8 @@ def recursively_convert_to_json_serializable(test_obj):
         return float(test_obj)
 
     else:
-        raise TypeError('%s is of type %s which cannot be serialized.' % (str(test_obj), type(test_obj).__name__))
+        raise TypeError('%s is of type %s which cannot be serialized.' % (
+            str(test_obj), type(test_obj).__name__))
 
 
 def is_valid_partition_object(partition_object):
@@ -274,8 +279,9 @@ def kde_partition_data(data, estimate_tails=True):
     """
     kde = stats.kde.gaussian_kde(data)
     evaluation_bins = np.linspace(start=np.min(data) - (kde.covariance_factor() / 2),
-                                  stop=np.max(data) + (kde.covariance_factor() / 2),
-                                  num=np.floor(((np.max(data) - np.min(data)) / kde.covariance_factor()) + 1 ).astype(int))
+                                  stop=np.max(data) +
+                                  (kde.covariance_factor() / 2),
+                                  num=np.floor(((np.max(data) - np.min(data)) / kde.covariance_factor()) + 1).astype(int))
     cdf_vals = [kde.integrate_box_1d(-np.inf, x) for x in evaluation_bins]
     evaluation_weights = np.diff(cdf_vals)
 
@@ -286,7 +292,8 @@ def kde_partition_data(data, estimate_tails=True):
     else:
         bins = np.concatenate(([-np.inf], evaluation_bins, [np.inf]))
 
-    weights = np.concatenate(([cdf_vals[0]], evaluation_weights, [1 - cdf_vals[-1]]))
+    weights = np.concatenate(
+        ([cdf_vals[0]], evaluation_weights, [1 - cdf_vals[-1]]))
 
     return {
         "bins": bins,
@@ -317,9 +324,10 @@ def continuous_partition_data(data, bins='auto', n_bins=10):
         }
     """
     if bins == 'uniform':
-        bins = np.linspace(start=np.min(data), stop=np.max(data), num = n_bins+1)
-    elif bins =='ntile':
-        bins = np.percentile(data, np.linspace(start=0, stop=100, num = n_bins+1))
+        bins = np.linspace(start=np.min(data), stop=np.max(data), num=n_bins+1)
+    elif bins == 'ntile':
+        bins = np.percentile(data, np.linspace(
+            start=0, stop=100, num=n_bins+1))
     elif bins != 'auto':
         raise ValueError("Invalid parameter for bins argument")
 
@@ -361,7 +369,8 @@ def infer_distribution_parameters(data, distribution, params=None):
     if params is None:
         params = dict()
     elif not isinstance(params, dict):
-        raise TypeError("params must be a dictionary object, see great_expectations documentation")
+        raise TypeError(
+            "params must be a dictionary object, see great_expectations documentation")
 
     if 'mean' not in params.keys():
         params['mean'] = data.mean()
@@ -374,7 +383,7 @@ def infer_distribution_parameters(data, distribution, params=None):
         if 'alpha' not in params.keys():
             # from https://stats.stackexchange.com/questions/12232/calculating-the-parameters-of-a-beta-distribution-using-the-mean-and-variance
             params['alpha'] = (params['mean'] ** 2) * (
-                        ((1 - params['mean']) / params['std_dev'] ** 2) - (1 / params['mean']))
+                ((1 - params['mean']) / params['std_dev'] ** 2) - (1 / params['mean']))
         if 'beta' not in params.keys():
             params['beta'] = params['alpha'] * ((1 / params['mean']) - 1)
 
@@ -384,8 +393,7 @@ def infer_distribution_parameters(data, distribution, params=None):
             # Using https://en.wikipedia.org/wiki/Gamma_distribution
             params['alpha'] = (params['mean'] / params.get('scale', 1))
 
-
-    #elif distribution == 'poisson':
+    # elif distribution == 'poisson':
     #    if 'lambda' not in params.keys():
     #       params['lambda'] = params['mean']
 
@@ -409,18 +417,20 @@ def infer_distribution_parameters(data, distribution, params=None):
             params['df'] = params['mean']
 
     #  Expon only uses loc and scale, use default
-    #elif distribution == 'expon':
+    # elif distribution == 'expon':
         # scipy cdf(x, loc=0, scale=1)
     #    if 'lambda' in params.keys():
             # Lambda is optional
     #        params['scale'] = 1 / params['lambda']
     elif distribution is not 'norm':
-        raise AttributeError("Unsupported distribution type. Please refer to Great Expectations Documentation")
+        raise AttributeError(
+            "Unsupported distribution type. Please refer to Great Expectations Documentation")
 
     params['loc'] = params.get('loc', 0)
     params['scale'] = params.get('scale', 1)
 
     return params
+
 
 def _scipy_distribution_positional_args_from_dict(distribution, params):
     """Helper function that returns positional arguments for a scipy distribution using a dict of parameters.
@@ -450,7 +460,7 @@ def _scipy_distribution_positional_args_from_dict(distribution, params):
         return params['alpha'], params['beta'], params['loc'], params['scale']
     elif distribution == 'gamma':
         return params['alpha'], params['loc'], params['scale']
-    #elif distribution == 'poisson':
+    # elif distribution == 'poisson':
     #    return params['lambda'], params['loc']
     elif distribution == 'uniform':
         return params['min'], params['max']
@@ -491,7 +501,8 @@ def validate_distribution_parameters(distribution, params):
     expon_msg = "expon distributions require 0 parameters and optionally 'loc', 'scale'."
 
     if (distribution not in ['norm', 'beta', 'gamma', 'poisson', 'uniform', 'chi2', 'expon']):
-        raise AttributeError("Unsupported  distribution provided: %s" % distribution)
+        raise AttributeError(
+            "Unsupported  distribution provided: %s" % distribution)
 
     if isinstance(params, dict):
         # `params` is a dictionary
@@ -500,19 +511,19 @@ def validate_distribution_parameters(distribution, params):
 
         # alpha and beta are required and positive
         if distribution == 'beta' and (params.get('alpha', -1) <= 0 or params.get('beta', -1) <= 0):
-            raise ValueError("Invalid parameters: %s" %beta_msg)
+            raise ValueError("Invalid parameters: %s" % beta_msg)
 
         # alpha is required and positive
         elif distribution == 'gamma' and params.get('alpha', -1) <= 0:
-            raise ValueError("Invalid parameters: %s" %gamma_msg)
+            raise ValueError("Invalid parameters: %s" % gamma_msg)
 
         # lambda is a required and positive
-        #elif distribution == 'poisson' and params.get('lambda', -1) <= 0:
+        # elif distribution == 'poisson' and params.get('lambda', -1) <= 0:
         #    raise ValueError("Invalid parameters: %s" %poisson_msg)
 
         # df is necessary and required to be positve
         elif distribution == 'chi2' and params.get('df', -1) <= 0:
-            raise ValueError("Invalid parameters: %s:" %chi2_msg)
+            raise ValueError("Invalid parameters: %s:" % chi2_msg)
 
     elif isinstance(params, tuple) or isinstance(params, list):
         scale = None
@@ -520,31 +531,32 @@ def validate_distribution_parameters(distribution, params):
         # `params` is a tuple or a list
         if distribution == 'beta':
             if len(params) < 2:
-                raise ValueError("Missing required parameters: %s" %beta_msg)
+                raise ValueError("Missing required parameters: %s" % beta_msg)
             if params[0] <= 0 or params[1] <= 0:
-                raise ValueError("Invalid parameters: %s" %beta_msg)
+                raise ValueError("Invalid parameters: %s" % beta_msg)
             if len(params) == 4:
                 scale = params[3]
             elif len(params) > 4:
-                raise ValueError("Too many parameters provided: %s" %beta_msg)
+                raise ValueError("Too many parameters provided: %s" % beta_msg)
 
         elif distribution == 'norm':
             if len(params) > 2:
-                raise ValueError("Too many parameters provided: %s" %norm_msg)
+                raise ValueError("Too many parameters provided: %s" % norm_msg)
             if len(params) == 2:
                 scale = params[1]
 
         elif distribution == 'gamma':
             if len(params) < 1:
-                raise ValueError("Missing required parameters: %s" %gamma_msg)
+                raise ValueError("Missing required parameters: %s" % gamma_msg)
             if len(params) == 3:
                 scale = params[2]
             if len(params) > 3:
-                raise ValueError("Too many parameters provided: %s" % gamma_msg)
+                raise ValueError(
+                    "Too many parameters provided: %s" % gamma_msg)
             elif params[0] <= 0:
-                raise ValueError("Invalid parameters: %s" %gamma_msg)
+                raise ValueError("Invalid parameters: %s" % gamma_msg)
 
-        #elif distribution == 'poisson':
+        # elif distribution == 'poisson':
         #    if len(params) < 1:
         #        raise ValueError("Missing required parameters: %s" %poisson_msg)
         #   if len(params) > 2:
@@ -556,31 +568,32 @@ def validate_distribution_parameters(distribution, params):
             if len(params) == 2:
                 scale = params[1]
             if len(params) > 2:
-                raise ValueError("Too many arguments provided: %s" %uniform_msg)
+                raise ValueError(
+                    "Too many arguments provided: %s" % uniform_msg)
 
         elif distribution == 'chi2':
             if len(params) < 1:
-                raise ValueError("Missing required parameters: %s" %chi2_msg)
+                raise ValueError("Missing required parameters: %s" % chi2_msg)
             elif len(params) == 3:
                 scale = params[2]
             elif len(params) > 3:
-                raise ValueError("Too many arguments provided: %s" %chi2_msg)
+                raise ValueError("Too many arguments provided: %s" % chi2_msg)
             if params[0] <= 0:
-                raise ValueError("Invalid parameters: %s" %chi2_msg)
+                raise ValueError("Invalid parameters: %s" % chi2_msg)
 
         elif distribution == 'expon':
 
             if len(params) == 2:
                 scale = params[1]
             if len(params) > 2:
-                raise ValueError("Too many arguments provided: %s" %expon_msg)
+                raise ValueError("Too many arguments provided: %s" % expon_msg)
 
         if scale is not None and scale <= 0:
             raise ValueError("std_dev and scale must be positive.")
 
     else:
         raise ValueError(
-                "params must be a dict or list, or use ge.dataset.util.infer_distribution_parameters(data, distribution)")
+            "params must be a dict or list, or use ge.dataset.util.infer_distribution_parameters(data, distribution)")
 
     return
 
@@ -609,4 +622,3 @@ def create_multiple_expectations(df, columns, expectation_type, *args, **kwargs)
         results.append(expectation(column, *args,  **kwargs))
 
     return results
-

--- a/great_expectations/file_expectations.py
+++ b/great_expectations/file_expectations.py
@@ -7,6 +7,7 @@ import json
 import jsonschema
 import os.path
 
+
 def expect_file_hash_to_equal(filename, value, hash_alg='md5'):
     """
     Return True or False indicating whether the hash matches the specified value for the default (md5) or user-specified hash algorithm
@@ -49,6 +50,7 @@ def expect_file_hash_to_equal(filename, value, hash_alg='md5'):
     except ValueError:
         raise
     return success
+
 
 def expect_file_size_to_be_between(filename, minsize, maxsize):
     """
@@ -96,6 +98,7 @@ def expect_file_size_to_be_between(filename, minsize, maxsize):
     else:
         return False
 
+
 def expect_file_to_exist(filename):
     """
     Return True or False indicating whether the specified file exists
@@ -114,6 +117,7 @@ def expect_file_to_exist(filename):
         return True
     else:
         return False
+
 
 def expect_file_unique_column_names_csv(filename,
                                         skipLines=0,
@@ -144,7 +148,7 @@ def expect_file_unique_column_names_csv(filename,
         when True, whitespace immediately following the delimiter is ignored
     escapeChar : string
         one-char string which removes any special meaning from the following character
-    
+
 
     Returns
     -------
@@ -161,10 +165,11 @@ def expect_file_unique_column_names_csv(filename,
     success = False
     try:
         with open(filename, 'r') as f:
-            reader = csv.reader(f, delimiter=sep, quotechar=quoteChar, quoting=quot, doublequote=doubleQuote, skipinitialspace=skipInitialSpace, escapechar=escapeChar, strict=True)
+            reader = csv.reader(f, delimiter=sep, quotechar=quoteChar, quoting=quot, doublequote=doubleQuote,
+                                skipinitialspace=skipInitialSpace, escapechar=escapeChar, strict=True)
             if skipLines > 0:
-              for i in range(0, skipLines):
-                  next(reader)
+                for i in range(0, skipLines):
+                    next(reader)
             colnames = next(reader)
             if len(set(colnames)) == len(colnames):
                 success = True
@@ -174,7 +179,7 @@ def expect_file_unique_column_names_csv(filename,
         raise
     return success
 
-    
+
 def expect_file_valid_json(filename, schema=None):
     """
     Return True or False indicating whether the specified file is valid JSON.

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -3,6 +3,7 @@ import json
 
 import great_expectations.dataset as dataset
 
+
 def _convert_to_dataset_class(df, dataset_class, expectations_config=None, autoinspect_func=None):
     """
     Convert a (pandas) dataframe to a great_expectations dataset, with (optional) expectations_config
@@ -16,7 +17,8 @@ def _convert_to_dataset_class(df, dataset_class, expectations_config=None, autoi
         try:
             df = dataset_class(df, autoinspect_func=autoinspect_func)
         except:
-            raise NotImplementedError("read_csv requires a Dataset class that can be instantiated from a Pandas DataFrame")
+            raise NotImplementedError(
+                "read_csv requires a Dataset class that can be instantiated from a Pandas DataFrame")
 
     return df
 
@@ -29,7 +31,8 @@ def read_csv(
     *args, **kwargs
 ):
     df = pd.read_csv(filename, *args, **kwargs)
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
+    df = _convert_to_dataset_class(
+        df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
@@ -49,8 +52,10 @@ def read_json(
     else:
         df = pd.read_json(filename, *args, **kwargs)
 
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
+    df = _convert_to_dataset_class(
+        df, dataset_class, expectations_config, autoinspect_func)
     return df
+
 
 def read_excel(
     filename,
@@ -73,9 +78,11 @@ def read_excel(
     df = pd.read_excel(filename, *args, **kwargs)
     if isinstance(df, dict):
         for key in df:
-            df[key] = _convert_to_dataset_class(df[key], dataset_class, expectations_config, autoinspect_func)
+            df[key] = _convert_to_dataset_class(
+                df[key], dataset_class, expectations_config, autoinspect_func)
     else:
-        df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
+        df = _convert_to_dataset_class(
+            df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
@@ -97,7 +104,8 @@ def read_table(
         great_expectations dataset
     """
     df = pd.read_table(filename, *args, **kwargs)
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
+    df = _convert_to_dataset_class(
+        df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
@@ -119,7 +127,8 @@ def read_parquet(
         great_expectations dataset
     """
     df = pd.read_parquet(filename, *args, **kwargs)
-    df = _convert_to_dataset_class(df, dataset_class, expectations_config, autoinspect_func)
+    df = _convert_to_dataset_class(
+        df, dataset_class, expectations_config, autoinspect_func)
     return df
 
 
@@ -133,19 +142,21 @@ def from_pandas(pandas_df, expectations_config=None, autoinspect_func=None):
 
 
 def validate(df, expectations_config, *args, **kwargs):
-    #FIXME: I'm not sure that this should always default to PandasDataset
+    # FIXME: I'm not sure that this should always default to PandasDataset
     dataset_ = _convert_to_dataset_class(df,
-        dataset.pandas_dataset.PandasDataset,
-        expectations_config
-    )
+                                         dataset.pandas_dataset.PandasDataset,
+                                         expectations_config
+                                         )
     return dataset_.validate(*args, **kwargs)
 
 
 class DotDict(dict):
     """dot.notation access to dictionary attributes"""
+
     def __getattr__(self, attr):
         return self.get(attr)
-    __setattr__= dict.__setitem__
-    __delattr__= dict.__delitem__
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
     def __dir__(self):
         return self.keys()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-#Parse requirements.txt
+# Parse requirements.txt
 with open('requirements.txt') as f:
     required = f.read().splitlines()
 

--- a/tests/column_aggregate_expectations/test_column_aggregate_expectations.py
+++ b/tests/column_aggregate_expectations/test_column_aggregate_expectations.py
@@ -45,7 +45,8 @@ def pytest_generate_tests(metafunc):
                             "test": test,
                         })
 
-                        ids.append(c + ":" + test_configuration["expectation_type"] + ":" + test["title"])
+                        ids.append(
+                            c + ":" + test_configuration["expectation_type"] + ":" + test["title"])
 
     metafunc.parametrize(
         "test_case",

--- a/tests/column_aggregate_expectations_distributional/test_pandas_dataset_distributional_expectations.py
+++ b/tests/column_aggregate_expectations_distributional/test_pandas_dataset_distributional_expectations.py
@@ -8,245 +8,270 @@ import great_expectations as ge
 class TestDistributionalExpectations(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestDistributionalExpectations, self).__init__(*args, **kwargs)
-        self.D = ge.read_csv('./tests/test_sets/distributional_expectations_data_test.csv')
+        self.D = ge.read_csv(
+            './tests/test_sets/distributional_expectations_data_test.csv')
 
         with open('./tests/test_sets/test_partitions.json', 'r') as infile:
             self.test_partitions = json.loads(infile.read())
 
     def test_expect_column_chisquare_test_p_value_to_be_greater_than(self):
         T = [
-                {
-                    'args': ['categorical_fixed'],
-                    'kwargs': {
-                        'partition_object': self.test_partitions['categorical_fixed'],
-                        'p': 0.05
-                        },
-                    'out': {'success': True, 'observed_value': 1.}
+            {
+                'args': ['categorical_fixed'],
+                'kwargs': {
+                    'partition_object': self.test_partitions['categorical_fixed'],
+                    'p': 0.05
                 },
-                {
-                    'args': ['categorical_fixed'],
-                    'kwargs': {
-                        'partition_object': self.test_partitions['categorical_fixed_alternate'],
-                        'p': 0.05
-                    },
-                    'out': {'success': False, 'observed_value': 5.1397782097623862e-53}
+                'out': {'success': True, 'observed_value': 1.}
+            },
+            {
+                'args': ['categorical_fixed'],
+                'kwargs': {
+                    'partition_object': self.test_partitions['categorical_fixed_alternate'],
+                    'p': 0.05
                 },
-                {
-                    'args': ['categorical_fixed'],
-                    'kwargs': {
-                        'partition_object': self.test_partitions['categorical_fixed_alternate'],
-                        'p': 0.05, 'result_format': 'SUMMARY'
-                    },
-                    'out': {'success': False, 'observed_value': 5.1397782097623862e-53,
-                            'details': {
-                                'observed_partition': {
-                                    'values': [u'A', u'B', u'C'],
-                                    'weights': [540, 320, 140]
-                                },
-                                'expected_partition': {
-                                    'values': [u'A', u'B', u'C'],
-                                    'weights': [333.3333333333333, 333.3333333333333, 333.3333333333333]
-                                }
+                'out': {'success': False, 'observed_value': 5.1397782097623862e-53}
+            },
+            {
+                'args': ['categorical_fixed'],
+                'kwargs': {
+                    'partition_object': self.test_partitions['categorical_fixed_alternate'],
+                    'p': 0.05, 'result_format': 'SUMMARY'
+                },
+                'out': {'success': False, 'observed_value': 5.1397782097623862e-53,
+                        'details': {
+                            'observed_partition': {
+                                'values': [u'A', u'B', u'C'],
+                                'weights': [540, 320, 140]
+                            },
+                            'expected_partition': {
+                                'values': [u'A', u'B', u'C'],
+                                'weights': [333.3333333333333, 333.3333333333333, 333.3333333333333]
                             }
-                    }
-                }
+                        }
+                        }
+            }
         ]
         for t in T:
-            out = self.D.expect_column_chisquare_test_p_value_to_be_greater_than(*t['args'], **t['kwargs'])
+            out = self.D.expect_column_chisquare_test_p_value_to_be_greater_than(
+                *t['args'], **t['kwargs'])
             self.assertEqual(t['out']['success'], out['success'])
-            self.assertEqual(t['out']['observed_value'], out['result']['observed_value'])
+            self.assertEqual(t['out']['observed_value'],
+                             out['result']['observed_value'])
             if 'result_format' in t['kwargs'] and t['kwargs']['result_format'] == 'SUMMARY':
-                self.assertDictEqual(t['out']['details'], out['result']['details'])
+                self.assertDictEqual(
+                    t['out']['details'], out['result']['details'])
 
     def test_expect_column_chisquare_test_p_value_to_be_greater_than_new_categorical_val(self):
         # Note: Chisquare test with true zero expected could be treated subtly. Here, we tolerate a warning from stats.
-        categorical_list = (['A'] * 25) + (['B'] * 25) + (['C'] * 25) + (['D'] * 25)
+        categorical_list = (['A'] * 25) + (['B'] * 25) + \
+            (['C'] * 25) + (['D'] * 25)
         df = ge.dataset.PandasDataset({'categorical': categorical_list})
 
-        out = df.expect_column_chisquare_test_p_value_to_be_greater_than('categorical', self.test_partitions['categorical_fixed_alternate'])
+        out = df.expect_column_chisquare_test_p_value_to_be_greater_than(
+            'categorical', self.test_partitions['categorical_fixed_alternate'])
         self.assertEqual(out['success'], False)
 
-        out = df.expect_column_chisquare_test_p_value_to_be_greater_than('categorical', self.test_partitions['categorical_fixed_alternate'], tail_weight_holdout=0.25)
+        out = df.expect_column_chisquare_test_p_value_to_be_greater_than(
+            'categorical', self.test_partitions['categorical_fixed_alternate'], tail_weight_holdout=0.25)
         self.assertEqual(out['success'], True)
 
     def test_expect_column_chisquare_test_p_value_to_be_greater_than_missing_categorical_val(self):
         categorical_list = (['A'] * 61) + (['B'] * 39)
         df = ge.dataset.PandasDataset({'categorical': categorical_list})
-        out = df.expect_column_chisquare_test_p_value_to_be_greater_than('categorical', self.test_partitions['categorical_fixed'])
+        out = df.expect_column_chisquare_test_p_value_to_be_greater_than(
+            'categorical', self.test_partitions['categorical_fixed'])
         self.assertEqual(out['success'], False)
 
     def test_expect_column_kl_divergence_to_be_less_than_discrete(self):
         T = [
-                {
-                    'args': ['categorical_fixed'],
-                    'kwargs': {
-                        'partition_object': self.test_partitions['categorical_fixed'],
-                        'threshold': 0.1
-                        },
-                    'out': {'success': True, 'observed_value': 0.}
+            {
+                'args': ['categorical_fixed'],
+                'kwargs': {
+                    'partition_object': self.test_partitions['categorical_fixed'],
+                    'threshold': 0.1
                 },
-                {
-                    'args': ['categorical_fixed'],
-                    'kwargs': {
-                        'partition_object': self.test_partitions['categorical_fixed_alternate'],
-                        'threshold': 0.1
-                        },
-                    'out': {'success': False, 'observed_value': 0.12599700286677529}
+                'out': {'success': True, 'observed_value': 0.}
+            },
+            {
+                'args': ['categorical_fixed'],
+                'kwargs': {
+                    'partition_object': self.test_partitions['categorical_fixed_alternate'],
+                    'threshold': 0.1
                 },
-                {
-                    'args': ['categorical_fixed'],
-                    'kwargs': {
-                        'partition_object': self.test_partitions['categorical_fixed_alternate'],
-                        'threshold': 0.1, 'result_format': 'SUMMARY'
-                    },
-                    'out': {'success': False, 'observed_value': 0.12599700286677529,
-                            'details': {
-                                'observed_partition': {
-                                    'weights': [0.54, 0.32, 0.14],
-                                    'values': [u'A', u'B', u'C']},
-                                'expected_partition': {
-                                    'weights': [0.3333333333333333, 0.3333333333333333, 0.3333333333333333],
-                                    'values': [u'A', u'B', u'C']
-                                }
+                'out': {'success': False, 'observed_value': 0.12599700286677529}
+            },
+            {
+                'args': ['categorical_fixed'],
+                'kwargs': {
+                    'partition_object': self.test_partitions['categorical_fixed_alternate'],
+                    'threshold': 0.1, 'result_format': 'SUMMARY'
+                },
+                'out': {'success': False, 'observed_value': 0.12599700286677529,
+                        'details': {
+                            'observed_partition': {
+                                'weights': [0.54, 0.32, 0.14],
+                                'values': [u'A', u'B', u'C']},
+                            'expected_partition': {
+                                'weights': [0.3333333333333333, 0.3333333333333333, 0.3333333333333333],
+                                'values': [u'A', u'B', u'C']
                             }
-                    }
-                }
-            ]
+                        }
+                        }
+            }
+        ]
         for t in T:
-            out = self.D.expect_column_kl_divergence_to_be_less_than(*t['args'], **t['kwargs'])
+            out = self.D.expect_column_kl_divergence_to_be_less_than(
+                *t['args'], **t['kwargs'])
             self.assertTrue(np.allclose(out['success'], t['out']['success']))
-            self.assertTrue(np.allclose(out['result']['observed_value'], t['out']['observed_value']))
+            self.assertTrue(np.allclose(
+                out['result']['observed_value'], t['out']['observed_value']))
             if 'result_format' in t['kwargs'] and t['kwargs']['result_format'] == 'SUMMARY':
-                self.assertDictEqual(out['result']['details'], t['out']['details'])
+                self.assertDictEqual(
+                    out['result']['details'], t['out']['details'])
 
     def test_expect_column_kl_divergence_to_be_less_than_discrete_holdout(self):
         df = ge.dataset.PandasDataset({'a': ['a', 'a', 'b', 'c']})
         out = df.expect_column_kl_divergence_to_be_less_than('a',
-                                                             {'values': ['a', 'b'], 'weights': [0.6, 0.4]},
+                                                             {'values': ['a', 'b'], 'weights': [
+                                                                 0.6, 0.4]},
                                                              threshold=0.1,
                                                              tail_weight_holdout=0.1)
         self.assertEqual(out['success'], True)
-        self.assertTrue(np.allclose(out['result']['observed_value'], [0.099431384003497381]))
+        self.assertTrue(np.allclose(
+            out['result']['observed_value'], [0.099431384003497381]))
 
         out = df.expect_column_kl_divergence_to_be_less_than('a',
-                                                             {'values': ['a', 'b'], 'weights': [0.6, 0.4]},
+                                                             {'values': ['a', 'b'], 'weights': [
+                                                                 0.6, 0.4]},
                                                              threshold=0.1,
                                                              tail_weight_holdout=0.05)
         self.assertEqual(out['success'], False)
-        self.assertTrue(np.isclose(out['result']['observed_value'], [0.23216776319077681]))
+        self.assertTrue(np.isclose(
+            out['result']['observed_value'], [0.23216776319077681]))
 
         out = df.expect_column_kl_divergence_to_be_less_than('a',
-                                                             {'values': ['a', 'b'], 'weights': [0.6, 0.4]},
+                                                             {'values': ['a', 'b'], 'weights': [
+                                                                 0.6, 0.4]},
                                                              threshold=0.1)
         self.assertEqual(out['success'], False)
         self.assertEqual(out['result']['observed_value'], None)
 
     def test_expect_column_bootstrapped_ks_test_p_value_to_be_greater_than(self):
         T = [
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs': {'partition_object': self.test_partitions['norm_0_1_auto'], "p": 0.05},
-                    'out': {'success': True, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05},
-                    'out':{'success':True, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_ntile'], "p": 0.05},
-                    'out':{'success':True, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_kde'], "p": 0.05},
-                    'out':{'success':True, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_auto'], "p": 0.05},
-                    'out':{'success':False, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05},
-                    'out':{'success':False, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_ntile'], "p": 0.05},
-                    'out':{'success':False, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_kde'], "p": 0.05},
-                    'out':{'success':False, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs':{'partition_object': self.test_partitions['bimodal_auto'], "p": 0.05},
-                    'out':{'success':True, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs':{'partition_object': self.test_partitions['bimodal_kde'], "p": 0.05},
-                    'out':{'success':True, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_auto'], "p": 0.05,
-                              'include_config': True},
-                    'out':{'success':False, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs':{'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05},
-                    'out':{'success':False, 'observed_value': "RANDOMIZED"}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs': {'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05, 'result_format': 'SUMMARY'},
-                    'out': {'success': False, 'observed_value': "RANDOMIZED",
-                            'details': {
-                                'expected_cdf': {
-                                    'cdf_values': [0.0, 0.001, 0.009000000000000001, 0.056, 0.184, 0.429, 0.6779999999999999, 0.8899999999999999, 0.9689999999999999, 0.9929999999999999, 0.9999999999999999],
-                                    'x': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364]
-                                },
-                                'observed_partition': {
-                                    'weights': [0.001, 0.006, 0.022, 0.07, 0.107, 0.146, 0.098, 0.04, 0.01, 0.0, 0.5],
-                                    'bins': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, 12.8787297644972]
-                                },
-                                'bootstrap_samples': 1000,
-                                'observed_cdf': {
-                                    'cdf_values': [0, 0.001, 0.007, 0.028999999999999998, 0.099, 0.20600000000000002, 0.352, 0.44999999999999996, 0.48999999999999994, 0.49999999999999994, 0.49999999999999994, 1.0],
-                                    'x': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, 12.8787297644972]
-                                },
-                                'expected_partition': {
-                                    'weights': [0.001, 0.008, 0.047, 0.128, 0.245, 0.249, 0.212, 0.079, 0.024, 0.007],
-                                    'bins': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364]
-                                },
-                                'bootstrap_sample_size': 20
-                            }
-                    }
-                }
-            ]
+            {
+                'args': ['norm_0_1'],
+                'kwargs': {'partition_object': self.test_partitions['norm_0_1_auto'], "p": 0.05},
+                'out': {'success': True, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['norm_0_1'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05},
+                'out':{'success': True, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['norm_0_1'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_ntile'], "p": 0.05},
+                'out':{'success': True, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['norm_0_1'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_kde'], "p": 0.05},
+                'out':{'success': True, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_auto'], "p": 0.05},
+                'out':{'success': False, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05},
+                'out':{'success': False, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_ntile'], "p": 0.05},
+                'out':{'success': False, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_kde'], "p": 0.05},
+                'out':{'success': False, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs':{'partition_object': self.test_partitions['bimodal_auto'], "p": 0.05},
+                'out':{'success': True, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs':{'partition_object': self.test_partitions['bimodal_kde'], "p": 0.05},
+                'out':{'success': True, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_auto'], "p": 0.05,
+                          'include_config': True},
+                'out':{'success': False, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs':{'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05},
+                'out':{'success': False, 'observed_value': "RANDOMIZED"}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs': {'partition_object': self.test_partitions['norm_0_1_uniform'], "p": 0.05, 'result_format': 'SUMMARY'},
+                'out': {'success': False, 'observed_value': "RANDOMIZED",
+                        'details': {
+                            'expected_cdf': {
+                                'cdf_values': [0.0, 0.001, 0.009000000000000001, 0.056, 0.184, 0.429, 0.6779999999999999, 0.8899999999999999, 0.9689999999999999, 0.9929999999999999, 0.9999999999999999],
+                                'x': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364]
+                            },
+                            'observed_partition': {
+                                'weights': [0.001, 0.006, 0.022, 0.07, 0.107, 0.146, 0.098, 0.04, 0.01, 0.0, 0.5],
+                                'bins': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, 12.8787297644972]
+                            },
+                            'bootstrap_samples': 1000,
+                            'observed_cdf': {
+                                'cdf_values': [0, 0.001, 0.007, 0.028999999999999998, 0.099, 0.20600000000000002, 0.352, 0.44999999999999996, 0.48999999999999994, 0.49999999999999994, 0.49999999999999994, 1.0],
+                                'x': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, 12.8787297644972]
+                            },
+                            'expected_partition': {
+                                'weights': [0.001, 0.008, 0.047, 0.128, 0.245, 0.249, 0.212, 0.079, 0.024, 0.007],
+                                'bins': [-3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364]
+                            },
+                            'bootstrap_sample_size': 20
+                        }
+                        }
+            }
+        ]
         for t in T:
-            out = self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than(*t['args'], **t['kwargs'])
+            out = self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than(
+                *t['args'], **t['kwargs'])
             if out['success'] != t['out']['success']:
                 print("Test case error:")
                 print(t)
                 print(out)
             self.assertEqual(out['success'], t['out']['success'])
             if 'result_format' in t['kwargs'] and t['kwargs']['result_format'] == 'SUMMARY':
-                self.assertTrue(np.allclose(out['result']['details']['observed_cdf']['x'],t['out']['details']['observed_cdf']['x']))
-                self.assertTrue(np.allclose(out['result']['details']['observed_cdf']['cdf_values'],t['out']['details']['observed_cdf']['cdf_values']))
-                self.assertTrue(np.allclose(out['result']['details']['expected_cdf']['x'],t['out']['details']['expected_cdf']['x']))
-                self.assertTrue(np.allclose(out['result']['details']['expected_cdf']['cdf_values'],t['out']['details']['expected_cdf']['cdf_values']))
-                self.assertTrue(np.allclose(out['result']['details']['observed_partition']['bins'],t['out']['details']['observed_partition']['bins']))
-                self.assertTrue(np.allclose(out['result']['details']['observed_partition']['weights'],t['out']['details']['observed_partition']['weights']))
-                self.assertTrue(np.allclose(out['result']['details']['expected_partition']['bins'],t['out']['details']['expected_partition']['bins']))
-                self.assertTrue(np.allclose(out['result']['details']['expected_partition']['weights'],t['out']['details']['expected_partition']['weights']))
+                self.assertTrue(np.allclose(
+                    out['result']['details']['observed_cdf']['x'], t['out']['details']['observed_cdf']['x']))
+                self.assertTrue(np.allclose(out['result']['details']['observed_cdf']
+                                            ['cdf_values'], t['out']['details']['observed_cdf']['cdf_values']))
+                self.assertTrue(np.allclose(
+                    out['result']['details']['expected_cdf']['x'], t['out']['details']['expected_cdf']['x']))
+                self.assertTrue(np.allclose(out['result']['details']['expected_cdf']
+                                            ['cdf_values'], t['out']['details']['expected_cdf']['cdf_values']))
+                self.assertTrue(np.allclose(
+                    out['result']['details']['observed_partition']['bins'], t['out']['details']['observed_partition']['bins']))
+                self.assertTrue(np.allclose(out['result']['details']['observed_partition']
+                                            ['weights'], t['out']['details']['observed_partition']['weights']))
+                self.assertTrue(np.allclose(
+                    out['result']['details']['expected_partition']['bins'], t['out']['details']['expected_partition']['bins']))
+                self.assertTrue(np.allclose(out['result']['details']['expected_partition']
+                                            ['weights'], t['out']['details']['expected_partition']['weights']))
 
     def test_expect_column_bootstrapped_ks_test_p_value_to_be_greater_than_expanded_partitions(self):
         # Extend observed above and below expected
@@ -256,26 +281,34 @@ class TestDistributionalExpectations(unittest.TestCase):
         self.assertTrue(out['result']['details']['observed_cdf']['x'][-1] > 1)
         # Extend observed below expected
         out = self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than('norm_0_1',
-                                                                                   {'bins': np.linspace(-10, 1, 11), 'weights': [0.1] * 10},
+                                                                                   {'bins': np.linspace(-10, 1, 11), 'weights': [
+                                                                                       0.1] * 10},
                                                                                    result_format='SUMMARY')
-        self.assertTrue(out['result']['details']['observed_cdf']['x'][0] == -10)
+        self.assertTrue(out['result']['details']
+                        ['observed_cdf']['x'][0] == -10)
         self.assertTrue(out['result']['details']['observed_cdf']['x'][-1] > 1)
         # Extend observed above expected
         out = self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than('norm_0_1',
-                                                                                   {'bins': np.linspace(-1, 10, 11), 'weights': [0.1] * 10},
+                                                                                   {'bins': np.linspace(-1, 10, 11), 'weights': [
+                                                                                       0.1] * 10},
                                                                                    result_format='SUMMARY')
         self.assertTrue(out['result']['details']['observed_cdf']['x'][0] < -1)
-        self.assertTrue(out['result']['details']['observed_cdf']['x'][-1] == 10)
+        self.assertTrue(out['result']['details']
+                        ['observed_cdf']['x'][-1] == 10)
         # Extend expected above and below observed
         out = self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than('norm_0_1',
-                                                                                   {'bins': np.linspace(-10, 10, 11), 'weights': [0.1] * 10},
+                                                                                   {'bins': np.linspace(-10, 10, 11), 'weights': [
+                                                                                       0.1] * 10},
                                                                                    result_format='SUMMARY')
-        self.assertTrue(out['result']['details']['observed_cdf']['x'][0] == -10)
-        self.assertTrue(out['result']['details']['observed_cdf']['x'][-1] == 10)
+        self.assertTrue(out['result']['details']
+                        ['observed_cdf']['x'][0] == -10)
+        self.assertTrue(out['result']['details']
+                        ['observed_cdf']['x'][-1] == 10)
 
     def test_expect_column_bootstrapped_ks_test_p_value_to_be_greater_than_bad_partition(self):
         with self.assertRaises(ValueError):
-            self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than('norm_0_1', {'bins': [-np.inf, 0, 1, 2, 3], 'weights': [0.25, 0.25, 0.25, 0.25]})
+            self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than(
+                'norm_0_1', {'bins': [-np.inf, 0, 1, 2, 3], 'weights': [0.25, 0.25, 0.25, 0.25]})
 
     def test_expect_column_kl_divergence_to_be_less_than_continuous_infinite_partition(self):
         # Manually build a partition extending to -Inf and Inf
@@ -283,11 +316,13 @@ class TestDistributionalExpectations(unittest.TestCase):
         test_partition['bins'] = [-np.inf] + test_partition['bins'] + [np.inf]
         scaled_weights = np.array(test_partition['weights']) * (1-0.01)
         test_partition['weights'] = [0.005] + scaled_weights.tolist() + [0.005]
-        out = self.D.expect_column_kl_divergence_to_be_less_than('norm_0_1', test_partition, 0.5, internal_weight_holdout=0.01)
+        out = self.D.expect_column_kl_divergence_to_be_less_than(
+            'norm_0_1', test_partition, 0.5, internal_weight_holdout=0.01)
         self.assertTrue(out['success'])
 
         # This should fail: tails have internal weight zero, which is highly unlikely.
-        out = self.D.expect_column_kl_divergence_to_be_less_than('norm_0_1', test_partition, 0.5)
+        out = self.D.expect_column_kl_divergence_to_be_less_than(
+            'norm_0_1', test_partition, 0.5)
         self.assertFalse(out['success'])
 
         # Build one-sided to infinity test partitions
@@ -306,10 +341,13 @@ class TestDistributionalExpectations(unittest.TestCase):
         test_df = ge.dataset.PandasDataset(
             {'x': [-0.5, 0.5, 1.5, 2.5]})
         # This should succeed: our data match the partition
-        out = test_df.expect_column_kl_divergence_to_be_less_than('x', test_partition, 0.5, result_format='SUMMARY')
+        out = test_df.expect_column_kl_divergence_to_be_less_than(
+            'x', test_partition, 0.5, result_format='SUMMARY')
         self.assertTrue(out['success'])
-        self.assertDictEqual(out['result']['details']['observed_partition'], summary_observed_partition)
-        self.assertDictEqual(out['result']['details']['expected_partition'], summary_expected_partition)
+        self.assertDictEqual(
+            out['result']['details']['observed_partition'], summary_observed_partition)
+        self.assertDictEqual(
+            out['result']['details']['expected_partition'], summary_expected_partition)
 
         # Build one-sided to infinity test partitions
         test_partition = {
@@ -326,11 +364,14 @@ class TestDistributionalExpectations(unittest.TestCase):
         }
         test_df = ge.dataset.PandasDataset(
             {'x': [-0.5, 0.5, 1.5, 2.5, 3.5]})
-        out = test_df.expect_column_kl_divergence_to_be_less_than('x', test_partition, 0.5, result_format='SUMMARY')
+        out = test_df.expect_column_kl_divergence_to_be_less_than(
+            'x', test_partition, 0.5, result_format='SUMMARY')
         # This should fail: we expect zero weight less than 0
         self.assertFalse(out['success'])
-        self.assertDictEqual(out['result']['details']['observed_partition'], summary_observed_partition)
-        self.assertDictEqual(out['result']['details']['expected_partition'], summary_expected_partition)
+        self.assertDictEqual(
+            out['result']['details']['observed_partition'], summary_observed_partition)
+        self.assertDictEqual(
+            out['result']['details']['expected_partition'], summary_expected_partition)
 
         # Build two-sided to infinity test partition
         test_partition = {
@@ -348,14 +389,18 @@ class TestDistributionalExpectations(unittest.TestCase):
         test_df = ge.dataset.PandasDataset(
             {'x': [-0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5, 2.5, 2.5, 3.5]})
         # This should succeed: our data match the partition
-        out = test_df.expect_column_kl_divergence_to_be_less_than('x', test_partition, 0.5, result_format='SUMMARY')
+        out = test_df.expect_column_kl_divergence_to_be_less_than(
+            'x', test_partition, 0.5, result_format='SUMMARY')
         self.assertTrue(out['success'])
-        self.assertDictEqual(out['result']['details']['observed_partition'], summary_observed_partition)
-        self.assertDictEqual(out['result']['details']['expected_partition'], summary_expected_partition)
+        self.assertDictEqual(
+            out['result']['details']['observed_partition'], summary_observed_partition)
+        self.assertDictEqual(
+            out['result']['details']['expected_partition'], summary_expected_partition)
 
         # Tail weight holdout is not defined for partitions already extending to infinity:
         with self.assertRaises(ValueError):
-            test_df.expect_column_kl_divergence_to_be_less_than('x', test_partition, 0.5, tail_weight_holdout=0.01)
+            test_df.expect_column_kl_divergence_to_be_less_than(
+                'x', test_partition, 0.5, tail_weight_holdout=0.01)
 
     def test_expect_column_kl_divergence_to_be_less_than_continuous_serialized_infinite_partition(self):
         with open('./tests/test_sets/test_partition_serialized_infinity_bins.json', 'r') as infile:
@@ -372,10 +417,13 @@ class TestDistributionalExpectations(unittest.TestCase):
         test_df = ge.dataset.PandasDataset(
             {'x': [-0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 1.5, 2.5, 2.5, 3.5]})
         # This should succeed: our data match the partition
-        out = test_df.expect_column_kl_divergence_to_be_less_than('x', test_partition, 0.5, result_format='SUMMARY')
+        out = test_df.expect_column_kl_divergence_to_be_less_than(
+            'x', test_partition, 0.5, result_format='SUMMARY')
         self.assertTrue(out['success'])
-        self.assertDictEqual(out['result']['details']['observed_partition'], summary_observed_partition)
-        self.assertDictEqual(out['result']['details']['expected_partition'], summary_expected_partition)
+        self.assertDictEqual(
+            out['result']['details']['observed_partition'], summary_observed_partition)
+        self.assertDictEqual(
+            out['result']['details']['expected_partition'], summary_expected_partition)
 
         # Confirm serialization of resulting expectations config
         expectation_config = test_df.get_expectations_config()
@@ -383,7 +431,8 @@ class TestDistributionalExpectations(unittest.TestCase):
         for expectation in expectation_config['expectations']:
             if 'expectation_type' in expectation and expectation['expectation_type'] == 'expect_column_kl_divergence_to_be_less_than':
                 self.assertEqual(
-                    json.dumps(expectation['kwargs']['partition_object']['bins']),
+                    json.dumps(expectation['kwargs']
+                               ['partition_object']['bins']),
                     '[-Infinity, 0, 1, 2, 3, Infinity]'
                 )
                 found_expectation = True
@@ -391,207 +440,221 @@ class TestDistributionalExpectations(unittest.TestCase):
 
     def test_expect_column_kl_divergence_to_be_less_than_continuous(self):
         T = [
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_auto'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':True, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_uniform'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':True, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_ntile'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':True, 'observed_value': 'NOTTESTED'}
-                },
-                ## Note higher threshold example for kde
-                {
-                    'args': ['norm_0_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_kde'],
-                              "threshold": 0.3,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':True, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_auto'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':False, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_uniform'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 1e-5,
-                              "internal_weight_holdout": 1e-5},
-                    'out':{'success':False, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_ntile'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':False, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['norm_1_1'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_kde'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':False, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs':{"partition_object": self.test_partitions['bimodal_auto'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':True, 'observed_value': 'NOTTESTED'}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_auto'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':False, 'observed_value': "NOTTESTED"}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs':{"partition_object": self.test_partitions['norm_0_1_uniform'],
-                              "threshold": 0.1,
-                              "tail_weight_holdout": 0.01,
-                              "internal_weight_holdout": 0.01},
-                    'out':{'success':False, 'observed_value': "NOTTESTED"}
-                },
-                {
-                    'args': ['bimodal'],
-                    'kwargs': {"partition_object": self.test_partitions['norm_0_1_uniform'],
-                               "threshold": 0.1,
-                               "tail_weight_holdout": 0.01,
-                               "internal_weight_holdout": 0.01,
-                               "result_format": "SUMMARY"},
-                    'out': {'success': False, 'observed_value': "NOTTESTED",
-                            'details':
-                                {'observed_partition':
-                                     {'weights': [0.0, 0.001, 0.006, 0.022, 0.07, 0.107, 0.146, 0.098, 0.04, 0.01, 0.0, 0.5],
-                                      'bins': [-np.inf, -3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, np.inf]
-                                     },
-                                 'missing_percent': 0.0,
-                                 'element_count': 1000,
-                                 'missing_count': 0,
-                                 'expected_partition': {'bins': [-np.inf, -3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, np.inf],
-                                                        'weights': [0.005, 0.00098, 0.00784, 0.04606, 0.12544, 0.24009999999999998, 0.24402, 0.20776, 0.07742, 0.02352, 0.00686, 0.005]
-                                                        }
-                                 }
-                    }
-                }
+            {
+                'args': ['norm_0_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_auto'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': True, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['norm_0_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_uniform'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': True, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['norm_0_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_ntile'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': True, 'observed_value': 'NOTTESTED'}
+            },
+            # Note higher threshold example for kde
+            {
+                'args': ['norm_0_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_kde'],
+                          "threshold": 0.3,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': True, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_auto'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': False, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_uniform'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 1e-5,
+                          "internal_weight_holdout": 1e-5},
+                'out':{'success': False, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_ntile'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': False, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['norm_1_1'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_kde'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': False, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs':{"partition_object": self.test_partitions['bimodal_auto'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': True, 'observed_value': 'NOTTESTED'}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_auto'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': False, 'observed_value': "NOTTESTED"}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs':{"partition_object": self.test_partitions['norm_0_1_uniform'],
+                          "threshold": 0.1,
+                          "tail_weight_holdout": 0.01,
+                          "internal_weight_holdout": 0.01},
+                'out':{'success': False, 'observed_value': "NOTTESTED"}
+            },
+            {
+                'args': ['bimodal'],
+                'kwargs': {"partition_object": self.test_partitions['norm_0_1_uniform'],
+                           "threshold": 0.1,
+                           "tail_weight_holdout": 0.01,
+                           "internal_weight_holdout": 0.01,
+                           "result_format": "SUMMARY"},
+                'out': {'success': False, 'observed_value': "NOTTESTED",
+                        'details':
+                        {'observed_partition':
+                         {'weights': [0.0, 0.001, 0.006, 0.022, 0.07, 0.107, 0.146, 0.098, 0.04, 0.01, 0.0, 0.5],
+                          'bins': [-np.inf, -3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, np.inf]
+                          },
+                         'missing_percent': 0.0,
+                         'element_count': 1000,
+                         'missing_count': 0,
+                         'expected_partition': {'bins': [-np.inf, -3.721835843971108, -3.02304158492966, -2.324247325888213, -1.625453066846767, -0.926658807805319, -0.227864548763872, 0.470929710277574, 1.169723969319022, 1.868518228360469, 2.567312487401916, 3.266106746443364, np.inf],
+                                                'weights': [0.005, 0.00098, 0.00784, 0.04606, 0.12544, 0.24009999999999998, 0.24402, 0.20776, 0.07742, 0.02352, 0.00686, 0.005]
+                                                }
+                         }
+                        }
+            }
         ]
         for t in T:
-            out = self.D.expect_column_kl_divergence_to_be_less_than(*t['args'], **t['kwargs'])
+            out = self.D.expect_column_kl_divergence_to_be_less_than(
+                *t['args'], **t['kwargs'])
             if t['out']['observed_value'] != 'NOTTESTED':
-                if not np.allclose(out['observed_value'],t['out']['observed_value']):
+                if not np.allclose(out['observed_value'], t['out']['observed_value']):
                     print("Test case error:")
                     print(t)
                     print(out)
-                self.assertTrue(np.allclose(out['observed_value'],t['out']['observed_value']))
+                self.assertTrue(np.allclose(
+                    out['observed_value'], t['out']['observed_value']))
             if 'result_format' in t['kwargs'] and t['kwargs']['result_format'] == 'SUMMARY':
-                self.assertTrue(np.allclose(out['result']['details']['observed_partition']['bins'],t['out']['details']['observed_partition']['bins']))
-                self.assertTrue(np.allclose(out['result']['details']['observed_partition']['weights'],t['out']['details']['observed_partition']['weights']))
-                self.assertTrue(np.allclose(out['result']['details']['expected_partition']['bins'],t['out']['details']['expected_partition']['bins']))
-                self.assertTrue(np.allclose(out['result']['details']['expected_partition']['weights'],t['out']['details']['expected_partition']['weights']))
+                self.assertTrue(np.allclose(
+                    out['result']['details']['observed_partition']['bins'], t['out']['details']['observed_partition']['bins']))
+                self.assertTrue(np.allclose(out['result']['details']['observed_partition']
+                                            ['weights'], t['out']['details']['observed_partition']['weights']))
+                self.assertTrue(np.allclose(
+                    out['result']['details']['expected_partition']['bins'], t['out']['details']['expected_partition']['bins']))
+                self.assertTrue(np.allclose(out['result']['details']['expected_partition']
+                                            ['weights'], t['out']['details']['expected_partition']['weights']))
 
             if not out['success'] == t['out']['success']:
                 print("Test case error:")
                 print(t)
                 print(out)
-            self.assertEqual(out['success'],t['out']['success'])
+            self.assertEqual(out['success'], t['out']['success'])
 
     def test_expect_column_kl_divergence_to_be_less_than_bad_parameters(self):
         with self.assertRaises(ValueError):
-            self.D.expect_column_kl_divergence_to_be_less_than('norm_0_1', {}, threshold=0.1)
+            self.D.expect_column_kl_divergence_to_be_less_than(
+                'norm_0_1', {}, threshold=0.1)
         with self.assertRaises(ValueError):
-            self.D.expect_column_kl_divergence_to_be_less_than('norm_0_1', self.test_partitions['norm_0_1_auto'])
+            self.D.expect_column_kl_divergence_to_be_less_than(
+                'norm_0_1', self.test_partitions['norm_0_1_auto'])
         with self.assertRaises(ValueError):
-            self.D.expect_column_kl_divergence_to_be_less_than('norm_0_1', self.test_partitions['norm_0_1_auto'], threshold=0.1, tail_weight_holdout=2)
+            self.D.expect_column_kl_divergence_to_be_less_than(
+                'norm_0_1', self.test_partitions['norm_0_1_auto'], threshold=0.1, tail_weight_holdout=2)
         with self.assertRaises(ValueError):
-            self.D.expect_column_kl_divergence_to_be_less_than('norm_0_1', self.test_partitions['norm_0_1_auto'], threshold=0.1, internal_weight_holdout=2)
+            self.D.expect_column_kl_divergence_to_be_less_than(
+                'norm_0_1', self.test_partitions['norm_0_1_auto'], threshold=0.1, internal_weight_holdout=2)
         with self.assertRaises(ValueError):
-            self.D.expect_column_kl_divergence_to_be_less_than('categorical_fixed', self.test_partitions['categorical_fixed'], threshold=0.1, internal_weight_holdout=0.01)
-            
-            
+            self.D.expect_column_kl_divergence_to_be_less_than(
+                'categorical_fixed', self.test_partitions['categorical_fixed'], threshold=0.1, internal_weight_holdout=0.01)
+
     def test_expect_column_kl_divergence_to_be_less_than_infinite_observed_value(self):
-    
-        #Test with discrete distribution
-        discrete_df = ge.dataset.PandasDataset({"x1":['a','a','a','a','b','b','b','b','c','c']})
-        discrete_partition_object={"weights":[0.5,0.5],
-                                   "values":["a","b"]}
-        discrete_out=discrete_df.expect_column_kl_divergence_to_be_less_than("x1",
-                                                                discrete_partition_object,
-                                                                0.05)
-        discrete_out_json=json.dumps(discrete_out['result']['observed_value'])
-        self.assertEqual(discrete_out['result']['observed_value'],None)
+
+        # Test with discrete distribution
+        discrete_df = ge.dataset.PandasDataset(
+            {"x1": ['a', 'a', 'a', 'a', 'b', 'b', 'b', 'b', 'c', 'c']})
+        discrete_partition_object = {"weights": [0.5, 0.5],
+                                     "values": ["a", "b"]}
+        discrete_out = discrete_df.expect_column_kl_divergence_to_be_less_than("x1",
+                                                                               discrete_partition_object,
+                                                                               0.05)
+        discrete_out_json = json.dumps(
+            discrete_out['result']['observed_value'])
+        self.assertEqual(discrete_out['result']['observed_value'], None)
         self.assertEqual(discrete_out_json,
                          'null')
-        
-        
-        #Test with continuous distribution
-        continuous_df=ge.dataset.PandasDataset({"x2":[-1.5,-1.5,-1.35,-1.2,-1.19,-1.12,-1.04,-1,0,0,0,0.25,
-                                                     0.34,1,1.1,1.13,1.22,1.34,1.4,1.46,1.5,1.5,1.5]})
-        
-        continuous_partition_object1={"weights":[0.1,0.4,0,0,0.4,0.1],
-            "bins":[-2,-1.5,-1,0,1,1.5,2]} #Partition sets weight to zero for to a non-empty bin 
-        
-        continuous_out1=continuous_df.expect_column_kl_divergence_to_be_less_than("x2",
-                                                                continuous_partition_object1,
-                                                                0.05)
-        continuous_out_json1=json.dumps(continuous_out1['result']['observed_value'])
-        
-        self.assertEqual(continuous_out1['result']['observed_value'],None)
+
+        # Test with continuous distribution
+        continuous_df = ge.dataset.PandasDataset({"x2": [-1.5, -1.5, -1.35, -1.2, -1.19, -1.12, -1.04, -1, 0, 0, 0, 0.25,
+                                                         0.34, 1, 1.1, 1.13, 1.22, 1.34, 1.4, 1.46, 1.5, 1.5, 1.5]})
+
+        continuous_partition_object1 = {"weights": [0.1, 0.4, 0, 0, 0.4, 0.1],
+                                        "bins": [-2, -1.5, -1, 0, 1, 1.5, 2]}  # Partition sets weight to zero for to a non-empty bin
+
+        continuous_out1 = continuous_df.expect_column_kl_divergence_to_be_less_than("x2",
+                                                                                    continuous_partition_object1,
+                                                                                    0.05)
+        continuous_out_json1 = json.dumps(
+            continuous_out1['result']['observed_value'])
+
+        self.assertEqual(continuous_out1['result']['observed_value'], None)
         self.assertEqual(continuous_out_json1,
                          'null')
-        
-        
-        
-        continuous_partition_object2={"weights":[0.25,0.25,0.25,0.25],
-        "bins":[-1,0,1,1.5,2]} #Partition bins do not cover all of data set 
-        
-        continuous_out2=continuous_df.expect_column_kl_divergence_to_be_less_than("x2",
-                                                                continuous_partition_object2,
-                                                                0.05)
-        continuous_out_json2=json.dumps(continuous_out2['result']['observed_value'])
-        
-        self.assertEqual(continuous_out2['result']['observed_value'],None)
+
+        continuous_partition_object2 = {"weights": [0.25, 0.25, 0.25, 0.25],
+                                        "bins": [-1, 0, 1, 1.5, 2]}  # Partition bins do not cover all of data set
+
+        continuous_out2 = continuous_df.expect_column_kl_divergence_to_be_less_than("x2",
+                                                                                    continuous_partition_object2,
+                                                                                    0.05)
+        continuous_out_json2 = json.dumps(
+            continuous_out2['result']['observed_value'])
+
+        self.assertEqual(continuous_out2['result']['observed_value'], None)
         self.assertEqual(continuous_out_json2,
                          'null')
 
-
     def test_expect_column_bootstrapped_ks_test_p_value_to_be_greater_than_bad_parameters(self):
         with self.assertRaises(ValueError):
-            self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than('norm_0_1', self.test_partitions['categorical_fixed'])
-        test_partition = ge.dataset.util.kde_partition_data(self.D['norm_0_1'], estimate_tails=False)
+            self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than(
+                'norm_0_1', self.test_partitions['categorical_fixed'])
+        test_partition = ge.dataset.util.kde_partition_data(
+            self.D['norm_0_1'], estimate_tails=False)
         with self.assertRaises(ValueError):
-            self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than('norm_0_1', test_partition)
+            self.D.expect_column_bootstrapped_ks_test_p_value_to_be_greater_than(
+                'norm_0_1', test_partition)
 
     def test_expect_column_chisquare_test_p_value_to_be_greater_than_bad_parameters(self):
         with self.assertRaises(ValueError):
-            self.D.expect_column_chisquare_test_p_value_to_be_greater_than('categorical_fixed', self.test_partitions['norm_0_1_auto'])
+            self.D.expect_column_chisquare_test_p_value_to_be_greater_than(
+                'categorical_fixed', self.test_partitions['norm_0_1_auto'])
 
 
 if __name__ == "__main__":

--- a/tests/column_map_expectations/test_column_map_expectations.py
+++ b/tests/column_map_expectations/test_column_map_expectations.py
@@ -18,9 +18,10 @@ from tests.test_utils import get_dataset, candidate_test_is_on_temporary_notimpl
 
 contexts = ['PandasDataset', 'SqlAlchemyDataset']
 
+
 def pytest_generate_tests(metafunc):
 
-    #Load all the JSON files in the directory
+    # Load all the JSON files in the directory
     dir_path = os.path.dirname(os.path.realpath(__file__))
     test_configuration_files = glob.glob(dir_path+'/*.json')
 
@@ -45,13 +46,15 @@ def pytest_generate_tests(metafunc):
                             "test": test,
                         })
 
-                        ids.append(c+":"+test_configuration["expectation_type"]+":"+test["title"])
+                        ids.append(
+                            c+":"+test_configuration["expectation_type"]+":"+test["title"])
 
     metafunc.parametrize(
         "test_case",
         parametrized_tests,
         ids=ids
     )
+
 
 def test_case_runner(test_case):
     # Note: this should never be done in practice, but we are wiping expectations to reuse datasets during testing.

--- a/tests/column_pair_map_expectations/test_column_pair_map_expectations.py
+++ b/tests/column_pair_map_expectations/test_column_pair_map_expectations.py
@@ -7,8 +7,6 @@
 ###
 
 
-import pytest
-
 import os
 import json
 import glob
@@ -18,9 +16,10 @@ from tests.test_utils import get_dataset, candidate_test_is_on_temporary_notimpl
 
 contexts = ['PandasDataset', 'SqlAlchemyDataset']
 
+
 def pytest_generate_tests(metafunc):
 
-    #Load all the JSON files in the directory
+    # Load all the JSON files in the directory
     dir_path = os.path.dirname(os.path.realpath(__file__))
     test_configuration_files = glob.glob(dir_path+'/*.json')
 
@@ -45,13 +44,15 @@ def pytest_generate_tests(metafunc):
                             "test": test,
                         })
 
-                        ids.append(c+":"+test_configuration["expectation_type"]+":"+test["title"])
+                        ids.append(
+                            c+":"+test_configuration["expectation_type"]+":"+test["title"])
 
     metafunc.parametrize(
         "test_case",
         parametrized_tests,
         ids=ids
     )
+
 
 def test_case_runner(test_case):
     # Note: this should never be done in practice, but we are wiping expectations to reuse datasets during testing.

--- a/tests/other_expectations/test_other_expectations.py
+++ b/tests/other_expectations/test_other_expectations.py
@@ -7,8 +7,6 @@
 ###
 
 
-import pytest
-
 import os
 import json
 import glob
@@ -45,7 +43,8 @@ def pytest_generate_tests(metafunc):
                             "test": test,
                         })
 
-                        ids.append(c + ":" + test_configuration["expectation_type"] + ":" + test["title"])
+                        ids.append(
+                            c + ":" + test_configuration["expectation_type"] + ":" + test["title"])
 
     metafunc.parametrize(
         "test_case",

--- a/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
+++ b/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
@@ -61,7 +61,8 @@ def custom_dataset():
 
 def test_custom_sqlalchemydataset(custom_dataset):
     custom_dataset._initialize_expectations()
-    custom_dataset.set_default_expectation_argument("result_format", {"result_format": "COMPLETE"})
+    custom_dataset.set_default_expectation_argument(
+        "result_format", {"result_format": "COMPLETE"})
 
     result = custom_dataset.expect_column_values_to_equal_2('c1')
     assert result['success'] == False
@@ -74,15 +75,18 @@ def test_custom_sqlalchemydataset(custom_dataset):
 
 def test_broken_decorator_errors(custom_dataset):
     custom_dataset._initialize_expectations()
-    custom_dataset.set_default_expectation_argument("result_format", {"result_format": "COMPLETE"})
+    custom_dataset.set_default_expectation_argument(
+        "result_format", {"result_format": "COMPLETE"})
 
     with pytest.raises(ValueError) as err:
         custom_dataset.broken_aggregate_expectation('c1')
-        assert "Column aggregate expectation failed to return required information: success" in str(err)
+        assert "Column aggregate expectation failed to return required information: success" in str(
+            err)
 
     with pytest.raises(ValueError) as err:
         custom_dataset.another_broken_aggregate_expectation('c1')
-        assert "Column aggregate expectation failed to return required information: observed_value" in str(err)
+        assert "Column aggregate expectation failed to return required information: observed_value" in str(
+            err)
 
 
 def test_missing_engine_error():
@@ -112,12 +116,15 @@ def test_sqlalchemydataset_with_custom_sql():
     data.to_sql(name='test_sql_data', con=engine, index=False)
 
     custom_sql = "SELECT name, pet FROM test_sql_data WHERE age > 12"
-    custom_sql_dataset = SqlAlchemyDataset('test_sql_data', engine=engine, custom_sql=custom_sql)
+    custom_sql_dataset = SqlAlchemyDataset(
+        'test_sql_data', engine=engine, custom_sql=custom_sql)
 
     custom_sql_dataset._initialize_expectations()
-    custom_sql_dataset.set_default_expectation_argument("result_format", {"result_format": "COMPLETE"})
+    custom_sql_dataset.set_default_expectation_argument(
+        "result_format", {"result_format": "COMPLETE"})
 
-    result = custom_sql_dataset.expect_column_values_to_be_in_set("pet", ["fish", "cat", "python"])
+    result = custom_sql_dataset.expect_column_values_to_be_in_set(
+        "pet", ["fish", "cat", "python"])
     assert result['success'] == True
 
     result = custom_sql_dataset.expect_column_to_exist("age")

--- a/tests/test_autoinspect.py
+++ b/tests/test_autoinspect.py
@@ -41,7 +41,8 @@ def test_autoinspect_existing_dataset(dataset_type):
 
 @pytest.mark.parametrize("dataset_type", ["PandasDataset", "SqlAlchemyDataset"])
 def test_autoinspect_columns_exist(dataset_type):
-    df = get_dataset(dataset_type, {"a": [1, 2, 3]}, autoinspect_func=autoinspect.columns_exist)
+    df = get_dataset(
+        dataset_type, {"a": [1, 2, 3]}, autoinspect_func=autoinspect.columns_exist)
     config = df.get_expectations_config()
 
     assert len(config["expectations"]) == 1
@@ -51,7 +52,7 @@ def test_autoinspect_columns_exist(dataset_type):
 
 def test_autoinspect_warning():
     with pytest.warns(UserWarning, match="No columns list found in dataset; no autoinspection performed."):
-        df = ge.dataset.Dataset(autoinspect_func=autoinspect.columns_exist)
+        ge.dataset.Dataset(autoinspect_func=autoinspect.columns_exist)
 
 
 def test_autoinspect_error():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,8 @@ def test_cli_command_error(capsys):
 
     assert pytest_wrapped_e.type == SystemExit
     assert out == ''
-    assert ('error: the following arguments are required: command' in err) or ('error: too few arguments' in err)
+    assert ('error: the following arguments are required: command' in err) or (
+        'error: too few arguments' in err)
 
 
 def test_cli_validate_help(capsys):
@@ -87,8 +88,8 @@ def test_cli_version(capsys):
 def test_validate_basic_operation(capsys):
     with pytest.warns(UserWarning, match="No great_expectations version found in configuration object."):
         return_value = great_expectations.cli.dispatch(["validate",
-                                         "./tests/test_sets/Titanic.csv",
-                                         "./tests/test_sets/titanic_expectations.json"])
+                                                        "./tests/test_sets/Titanic.csv",
+                                                        "./tests/test_sets/titanic_expectations.json"])
 
     out, err = capsys.readouterr()
     json_result = json.loads(out)

--- a/tests/test_data_contexts/test_data_contexts.py
+++ b/tests/test_data_contexts/test_data_contexts.py
@@ -1,6 +1,5 @@
 import pytest
 
-import os
 import sqlalchemy as sa
 import pandas as pd
 
@@ -10,8 +9,10 @@ from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
 
 @pytest.fixture(scope="module")
 def test_db_connection_string(tmpdir_factory):
-    df1 = pd.DataFrame({'col_1': [1, 2, 3, 4, 5], 'col_2': ['a', 'b', 'c', 'd', 'e']})
-    df2 = pd.DataFrame({'col_1': [0, 1, 2, 3, 4], 'col_2': ['b', 'c', 'd', 'e', 'f']})
+    df1 = pd.DataFrame(
+        {'col_1': [1, 2, 3, 4, 5], 'col_2': ['a', 'b', 'c', 'd', 'e']})
+    df2 = pd.DataFrame(
+        {'col_1': [0, 1, 2, 3, 4], 'col_2': ['b', 'c', 'd', 'e', 'f']})
 
     path = tmpdir_factory.mktemp("db_context").join("test.db")
     engine = sa.create_engine('sqlite:///' + str(path))
@@ -21,23 +22,27 @@ def test_db_connection_string(tmpdir_factory):
     # Return a connection string to this newly-created db
     return 'sqlite:///' + str(path)
 
+
 @pytest.fixture(scope="module")
 def test_folder_connection_path(tmpdir_factory):
-    df1 = pd.DataFrame({'col_1': [1, 2, 3, 4, 5], 'col_2': ['a', 'b', 'c', 'd', 'e']})
+    df1 = pd.DataFrame(
+        {'col_1': [1, 2, 3, 4, 5], 'col_2': ['a', 'b', 'c', 'd', 'e']})
     path = tmpdir_factory.mktemp("csv_context")
     df1.to_csv(path.join("test.csv"))
 
     return str(path)
 
+
 def test_invalid_data_context():
     # Test an unknown data context name
     with pytest.raises(ValueError) as err:
-        context = get_data_context('what_a_ridiculous_name', None)
+        get_data_context('what_a_ridiculous_name', None)
         assert "Unknown data context." in str(err)
 
 
 def test_sqlalchemy_data_context(test_db_connection_string):
-    context = get_data_context('SqlAlchemy', test_db_connection_string, echo=False)
+    context = get_data_context(
+        'SqlAlchemy', test_db_connection_string, echo=False)
 
     assert context.list_datasets() == ['table_1', 'table_2']
     dataset = context.get_dataset('table_1')

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -17,9 +17,9 @@ class TestDataset(unittest.TestCase):
     def test_dataset(self):
 
         D = ge.dataset.PandasDataset({
-            'x' : [1,2,4],
-            'y' : [1,2,5],
-            'z' : ['hello', 'jello', 'mello'],
+            'x': [1, 2, 4],
+            'y': [1, 2, 5],
+            'z': ['hello', 'jello', 'mello'],
         })
 
         # print D._expectations_config.keys()
@@ -28,11 +28,11 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(
             D._expectations_config,
             {
-                "dataset_name" : None,
+                "dataset_name": None,
                 "meta": {
                     "great_expectations.__version__": ge.__version__
                 },
-                "expectations" : []
+                "expectations": []
                 # No longer expect autoinspection 20180920
                 # {
                 #     "expectation_type" : "expect_column_to_exist",
@@ -54,11 +54,11 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(
             D.get_expectations_config(),
             {
-                "dataset_name" : None,
+                "dataset_name": None,
                 "meta": {
                     "great_expectations.__version__": ge.__version__
                 },
-                "expectations" : []
+                "expectations": []
                 # No longer expect autoinspection 20180920
                 # {
                 #     "expectation_type" : "expect_column_to_exist",
@@ -75,12 +75,13 @@ class TestDataset(unittest.TestCase):
 
     def test_expectation_meta(self):
         df = ge.dataset.PandasDataset({
-            'x' : [1,2,4],
-            'y' : [1,2,5],
-            'z' : ['hello', 'jello', 'mello'],
+            'x': [1, 2, 4],
+            'y': [1, 2, 5],
+            'z': ['hello', 'jello', 'mello'],
         })
 
-        result = df.expect_column_median_to_be_between('x', 2, 2, meta={"notes": "This expectation is for lolz."})
+        result = df.expect_column_median_to_be_between(
+            'x', 2, 2, meta={"notes": "This expectation is for lolz."})
         k = 0
         self.assertEqual(result['success'], True)
         config = df.get_expectations_config()
@@ -92,30 +93,29 @@ class TestDataset(unittest.TestCase):
                     {"notes": "This expectation is for lolz."}
                 )
 
-        self.assertEqual(k,1)
+        self.assertEqual(k, 1)
 
-        #This should raise an error because meta isn't serializable.
+        # This should raise an error because meta isn't serializable.
         with self.assertRaises(Exception) as context:
-            df.expect_column_values_to_be_increasing("x", meta={"unserializable_array":np.array(range(10))})
+            df.expect_column_values_to_be_increasing(
+                "x", meta={"unserializable_array": np.array(range(10))})
 
-
-
-    #TODO: !!! Add tests for expectation and column_expectation
-    #TODO: !!! Add tests for save_expectation
+    # TODO: !!! Add tests for expectation and column_expectation
+    # TODO: !!! Add tests for save_expectation
 
     def test_set_default_expectation_argument(self):
         df = ge.dataset.PandasDataset({
-            'x' : [1,2,4],
-            'y' : [1,2,5],
-            'z' : ['hello', 'jello', 'mello'],
+            'x': [1, 2, 4],
+            'y': [1, 2, 5],
+            'z': ['hello', 'jello', 'mello'],
         })
 
         self.assertEqual(
             df.get_default_expectation_arguments(),
             {
-                "include_config" : False,
-                "catch_exceptions" : False,
-                "result_format" : 'BASIC',
+                "include_config": False,
+                "catch_exceptions": False,
+                "result_format": 'BASIC',
             }
         )
 
@@ -124,9 +124,9 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(
             df.get_default_expectation_arguments(),
             {
-                "include_config" : False,
-                "catch_exceptions" : False,
-                "result_format" : 'SUMMARY',
+                "include_config": False,
+                "catch_exceptions": False,
+                "result_format": 'SUMMARY',
             }
         )
 
@@ -134,60 +134,61 @@ class TestDataset(unittest.TestCase):
         directory_name = tempfile.mkdtemp()
 
         df = ge.dataset.PandasDataset({
-            'x' : [1,2,4],
-            'y' : [1,2,5],
-            'z' : ['hello', 'jello', 'mello'],
+            'x': [1, 2, 4],
+            'y': [1, 2, 5],
+            'z': ['hello', 'jello', 'mello'],
         })
-        df.expect_column_values_to_be_in_set('x', [1,2,4])
-        df.expect_column_values_to_be_in_set('y', [1,2,4], catch_exceptions=True, include_config=True)
+        df.expect_column_values_to_be_in_set('x', [1, 2, 4])
+        df.expect_column_values_to_be_in_set(
+            'y', [1, 2, 4], catch_exceptions=True, include_config=True)
         df.expect_column_values_to_match_regex('z', 'ello')
 
         ### First test set ###
 
         output_config = {
-          "expectations": [
-            # No longer expect autoinspection 20180920
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "x"
-            #   }
-            # },
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "y"
-            #   }
-            # },
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "z"
-            #   }
-            # },
-            {
-              "expectation_type": "expect_column_values_to_be_in_set",
-              "kwargs": {
-                "column": "x",
-                "value_set": [
-                  1,
-                  2,
-                  4
-                ]
-              }
-            },
-            {
-              "expectation_type": "expect_column_values_to_match_regex",
-              "kwargs": {
-                "column": "z",
-                "regex": "ello"
-              }
+            "expectations": [
+                # No longer expect autoinspection 20180920
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "x"
+                #   }
+                # },
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "y"
+                #   }
+                # },
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "z"
+                #   }
+                # },
+                {
+                    "expectation_type": "expect_column_values_to_be_in_set",
+                    "kwargs": {
+                        "column": "x",
+                        "value_set": [
+                            1,
+                            2,
+                            4
+                        ]
+                    }
+                },
+                {
+                    "expectation_type": "expect_column_values_to_match_regex",
+                    "kwargs": {
+                        "column": "z",
+                        "regex": "ello"
+                    }
+                }
+            ],
+            "dataset_name": None,
+            "meta": {
+                "great_expectations.__version__": ge.__version__
             }
-          ],
-          "dataset_name": None,
-          "meta": {
-            "great_expectations.__version__": ge.__version__
-          }
         }
 
         self.assertEqual(
@@ -206,60 +207,60 @@ class TestDataset(unittest.TestCase):
         ### Second test set ###
 
         output_config = {
-          "expectations": [
-            # No longer expect autoinspection 20180920
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "x"
-            #   }
-            # },
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "y"
-            #   }
-            # },
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "z"
-            #   }
-            # },
-            {
-              "expectation_type": "expect_column_values_to_be_in_set",
-              "kwargs": {
-                "column": "x",
-                "value_set": [
-                  1,
-                  2,
-                  4
-                ]
-              }
-            },
-            {
-              "expectation_type": "expect_column_values_to_be_in_set",
-              "kwargs": {
-                "column": "y",
-                "value_set": [
-                  1,
-                  2,
-                  4
-                ]
-              }
-            },
-            {
-              "expectation_type": "expect_column_values_to_match_regex",
-              "kwargs": {
-                "column": "z",
-                "regex": "ello"
-              }
+            "expectations": [
+                # No longer expect autoinspection 20180920
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "x"
+                #   }
+                # },
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "y"
+                #   }
+                # },
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "z"
+                #   }
+                # },
+                {
+                    "expectation_type": "expect_column_values_to_be_in_set",
+                    "kwargs": {
+                        "column": "x",
+                        "value_set": [
+                            1,
+                            2,
+                            4
+                        ]
+                    }
+                },
+                {
+                    "expectation_type": "expect_column_values_to_be_in_set",
+                    "kwargs": {
+                        "column": "y",
+                        "value_set": [
+                            1,
+                            2,
+                            4
+                        ]
+                    }
+                },
+                {
+                    "expectation_type": "expect_column_values_to_match_regex",
+                    "kwargs": {
+                        "column": "z",
+                        "regex": "ello"
+                    }
+                }
+            ],
+            "dataset_name": None,
+            "meta": {
+                "great_expectations.__version__": ge.__version__
             }
-          ],
-          "dataset_name": None,
-          "meta": {
-            "great_expectations.__version__": ge.__version__
-          }
         }
 
         self.assertEqual(
@@ -270,8 +271,8 @@ class TestDataset(unittest.TestCase):
         )
 
         df.save_expectations_config(
-          directory_name+'/temp2.json',
-          discard_failed_expectations=False
+            directory_name+'/temp2.json',
+            discard_failed_expectations=False
         )
         temp_file = open(directory_name+'/temp2.json')
         self.assertEqual(
@@ -283,54 +284,54 @@ class TestDataset(unittest.TestCase):
         ### Third test set ###
 
         output_config = {
-          "expectations": [
-            # No longer expect autoinspection 20180920
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "x",
-            #     "result_format": "BASIC"
-            #   }
-            # },
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "y",
-            #     "result_format": "BASIC"
-            #   }
-            # },
-            # {
-            #   "expectation_type": "expect_column_to_exist",
-            #   "kwargs": {
-            #     "column": "z",
-            #     "result_format": "BASIC"
-            #   }
-            # },
-            {
-              "expectation_type": "expect_column_values_to_be_in_set",
-              "kwargs": {
-                "column": "x",
-                "value_set": [
-                  1,
-                  2,
-                  4
-                ],
-                "result_format": "BASIC"
-              }
-            },
-            {
-              "expectation_type": "expect_column_values_to_match_regex",
-              "kwargs": {
-                "column": "z",
-                "regex": "ello",
-                "result_format": "BASIC"
-              }
+            "expectations": [
+                # No longer expect autoinspection 20180920
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "x",
+                #     "result_format": "BASIC"
+                #   }
+                # },
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "y",
+                #     "result_format": "BASIC"
+                #   }
+                # },
+                # {
+                #   "expectation_type": "expect_column_to_exist",
+                #   "kwargs": {
+                #     "column": "z",
+                #     "result_format": "BASIC"
+                #   }
+                # },
+                {
+                    "expectation_type": "expect_column_values_to_be_in_set",
+                    "kwargs": {
+                        "column": "x",
+                        "value_set": [
+                            1,
+                            2,
+                            4
+                        ],
+                        "result_format": "BASIC"
+                    }
+                },
+                {
+                    "expectation_type": "expect_column_values_to_match_regex",
+                    "kwargs": {
+                        "column": "z",
+                        "regex": "ello",
+                        "result_format": "BASIC"
+                    }
+                }
+            ],
+            "dataset_name": None,
+            "meta": {
+                "great_expectations.__version__": ge.__version__
             }
-          ],
-          "dataset_name": None,
-          "meta": {
-            "great_expectations.__version__": ge.__version__
-          }
         }
 
         self.assertEqual(
@@ -344,10 +345,10 @@ class TestDataset(unittest.TestCase):
         )
 
         df.save_expectations_config(
-          directory_name+'/temp3.json',
-          discard_result_format_kwargs=False,
-          discard_include_configs_kwargs=False,
-          discard_catch_exceptions_kwargs=False,
+            directory_name+'/temp3.json',
+            discard_result_format_kwargs=False,
+            discard_include_configs_kwargs=False,
+            discard_catch_exceptions_kwargs=False,
         )
         temp_file = open(directory_name+'/temp3.json')
         self.assertEqual(
@@ -361,7 +362,7 @@ class TestDataset(unittest.TestCase):
 
     def test_format_column_map_output(self):
         df = ge.dataset.PandasDataset({
-            "x" : list("abcdefghijklmnopqrstuvwxyz"),
+            "x": list("abcdefghijklmnopqrstuvwxyz"),
         })
         self.maxDiff = None
 
@@ -648,7 +649,7 @@ class TestDataset(unittest.TestCase):
 
     def test_calc_map_expectation_success(self):
         df = ge.dataset.PandasDataset({
-            "x" : list("abcdefghijklmnopqrstuvwxyz")
+            "x": list("abcdefghijklmnopqrstuvwxyz")
         })
         self.assertEqual(
             df._calc_map_expectation_success(
@@ -705,7 +706,8 @@ class TestDataset(unittest.TestCase):
         )
 
         self.assertEqual(
-            df._calc_map_expectation_success(success_count=decimal.Decimal(80), nonnull_count=100, mostly=.8),
+            df._calc_map_expectation_success(
+                success_count=decimal.Decimal(80), nonnull_count=100, mostly=.8),
             (False, decimal.Decimal(80) / decimal.Decimal(100))
         )
 
@@ -736,12 +738,11 @@ class TestDataset(unittest.TestCase):
             (True, 0.0)
         )
 
-
     def test_find_expectations(self):
         my_df = ge.dataset.PandasDataset({
-            'x' : [1,2,3,4,5,6,7,8,9,10],
-            'y' : [1,2,None,4,None,6,7,8,9,None],
-            'z' : ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
+            'x': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            'y': [1, 2, None, 4, None, 6, 7, 8, 9, None],
+            'z': ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
         }, autoinspect_func=autoinspect.columns_exist)
         my_df.expect_column_values_to_be_of_type('x', 'int')
         my_df.expect_column_values_to_be_of_type('y', 'int')
@@ -755,49 +756,52 @@ class TestDataset(unittest.TestCase):
         )
 
         self.assertEqual(
-            my_df.find_expectations("expect_column_to_exist", "x", expectation_kwargs={}),
+            my_df.find_expectations(
+                "expect_column_to_exist", "x", expectation_kwargs={}),
             [{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "x"
+                }
             }]
         )
 
         self.assertEqual(
-            my_df.find_expectations("expect_column_to_exist", expectation_kwargs={"column": "y"}),
+            my_df.find_expectations(
+                "expect_column_to_exist", expectation_kwargs={"column": "y"}),
             [{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "y"
+                }
             }]
         )
 
         self.assertEqual(
             my_df.find_expectations("expect_column_to_exist"),
             [{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
-            },{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y"
-              }
-            },{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "z"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "x"
+                }
+            }, {
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "y"
+                }
+            }, {
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "z"
+                }
             }]
         )
 
         with self.assertRaises(Exception) as context:
-            my_df.find_expectations("expect_column_to_exist", "x", {"column": "y"})
+            my_df.find_expectations(
+                "expect_column_to_exist", "x", {"column": "y"})
 
-        #FIXME: I don't understand why this test fails.
+        # FIXME: I don't understand why this test fails.
         # print context.exception
         # print 'Conflicting column names in remove_expectation' in context.exception
         # self.assertTrue('Conflicting column names in remove_expectation:' in context.exception)
@@ -805,125 +809,132 @@ class TestDataset(unittest.TestCase):
         self.assertEqual(
             my_df.find_expectations(column="x"),
             [{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
-            },{
-              "expectation_type": "expect_column_values_to_be_of_type",
-              "kwargs": {
-                "column": "x",
-                "type_": "int"
-              }
-            },{
-              "expectation_type": "expect_column_values_to_be_increasing",
-              "kwargs": {
-                "column": "x"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "x"
+                }
+            }, {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "x",
+                    "type_": "int"
+                }
+            }, {
+                "expectation_type": "expect_column_values_to_be_increasing",
+                "kwargs": {
+                    "column": "x"
+                }
             }]
         )
 
-
     def test_remove_expectation(self):
         my_df = ge.dataset.PandasDataset({
-            'x' : [1,2,3,4,5,6,7,8,9,10],
-            'y' : [1,2,None,4,None,6,7,8,9,None],
-            'z' : ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
+            'x': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            'y': [1, 2, None, 4, None, 6, 7, 8, 9, None],
+            'z': ['cello', 'hello', 'jello', 'bellow', 'fellow', 'mellow', 'wellow', 'xello', 'yellow', 'zello'],
         }, autoinspect_func=autoinspect.columns_exist)
         my_df.expect_column_values_to_be_of_type('x', 'int')
         my_df.expect_column_values_to_be_of_type('y', 'int')
-        my_df.expect_column_values_to_be_of_type('z', 'int', include_config=True, catch_exceptions=True)
+        my_df.expect_column_values_to_be_of_type(
+            'z', 'int', include_config=True, catch_exceptions=True)
         my_df.expect_column_values_to_be_increasing('x')
         my_df.expect_column_values_to_match_regex('z', 'ello')
 
         with self.assertRaises(Exception) as context:
-            my_df.remove_expectation("expect_column_to_exist", "w", dry_run=True),
+            my_df.remove_expectation(
+                "expect_column_to_exist", "w", dry_run=True),
 
-        #FIXME: Python 3 doesn't like this. It would be nice to use assertRaisesRegex, but that's not available in python 2.7
+        # FIXME: Python 3 doesn't like this. It would be nice to use assertRaisesRegex, but that's not available in python 2.7
         # self.assertTrue('No matching expectation found.' in context.exception)
 
         self.assertEqual(
-            my_df.remove_expectation("expect_column_to_exist", "x", expectation_kwargs={}, dry_run=True),
+            my_df.remove_expectation(
+                "expect_column_to_exist", "x", expectation_kwargs={}, dry_run=True),
             {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "x"
+                }
             }
         )
 
         self.assertEqual(
-            my_df.remove_expectation("expect_column_to_exist", expectation_kwargs={"column": "y"}, dry_run=True),
+            my_df.remove_expectation("expect_column_to_exist", expectation_kwargs={
+                                     "column": "y"}, dry_run=True),
             {
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "y"
+                }
             }
         )
 
         self.assertEqual(
-            my_df.remove_expectation("expect_column_to_exist", expectation_kwargs={"column": "y"}, remove_multiple_matches=True, dry_run=True),
+            my_df.remove_expectation("expect_column_to_exist", expectation_kwargs={
+                                     "column": "y"}, remove_multiple_matches=True, dry_run=True),
             [{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "y"
+                }
             }]
         )
 
         with self.assertRaises(ValueError) as context:
             my_df.remove_expectation("expect_column_to_exist", dry_run=True)
 
-        #FIXME: Python 3 doesn't like this. It would be nice to use assertRaisesRegex, but that's not available in python 2.7
+        # FIXME: Python 3 doesn't like this. It would be nice to use assertRaisesRegex, but that's not available in python 2.7
         # self.assertTrue('Multiple expectations matched arguments. No expectations removed.' in context.exception)
 
         self.assertEqual(
-            my_df.remove_expectation("expect_column_to_exist", remove_multiple_matches=True, dry_run=True),
+            my_df.remove_expectation(
+                "expect_column_to_exist", remove_multiple_matches=True, dry_run=True),
             [{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
-            },{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "y"
-              }
-            },{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "z"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "x"
+                }
+            }, {
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "y"
+                }
+            }, {
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "z"
+                }
             }]
         )
 
         with self.assertRaises(Exception) as context:
-            my_df.remove_expectation("expect_column_to_exist", "x", {"column": "y"}, dry_run=True)
+            my_df.remove_expectation("expect_column_to_exist", "x", {
+                                     "column": "y"}, dry_run=True)
 
-        #FIXME: I don't understand why this test fails.
+        # FIXME: I don't understand why this test fails.
         # print context.exception
         # print 'Conflicting column names in remove_expectation' in context.exception
         # self.assertTrue('Conflicting column names in remove_expectation:' in context.exception)
 
         self.assertEqual(
-            my_df.remove_expectation(column="x", remove_multiple_matches=True, dry_run=True),
+            my_df.remove_expectation(
+                column="x", remove_multiple_matches=True, dry_run=True),
             [{
-              "expectation_type": "expect_column_to_exist",
-              "kwargs": {
-                "column": "x"
-              }
-            },{
-              "expectation_type": "expect_column_values_to_be_of_type",
-              "kwargs": {
-                "column": "x",
-                "type_": "int"
-              }
-            },{
-              "expectation_type": "expect_column_values_to_be_increasing",
-              "kwargs": {
-                "column": "x"
-              }
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "x"
+                }
+            }, {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "x",
+                    "type_": "int"
+                }
+            }, {
+                "expectation_type": "expect_column_values_to_be_increasing",
+                "kwargs": {
+                    "column": "x"
+                }
             }]
         )
 
@@ -978,10 +989,10 @@ class TestDataset(unittest.TestCase):
 
     def test_discard_failing_expectations(self):
         df = ge.dataset.PandasDataset({
-            'A':[1,2,3,4],
-            'B':[5,6,7,8],
-            'C':['a','b','c','d'],
-            'D':['e','f','g','h']
+            'A': [1, 2, 3, 4],
+            'B': [5, 6, 7, 8],
+            'C': ['a', 'b', 'c', 'd'],
+            'D': ['e', 'f', 'g', 'h']
         }, autoinspect_func=autoinspect.columns_exist)
 
         # Put some simple expectations on the data frame
@@ -1084,16 +1095,17 @@ class TestDataset(unittest.TestCase):
 
     def test_test_expectation_function(self):
         D = ge.dataset.PandasDataset({
-            'x' : [1,3,5,7,9],
-            'y' : [1,2,None,7,9],
+            'x': [1, 3, 5, 7, 9],
+            'y': [1, 2, None, 7, 9],
         })
         D2 = ge.dataset.PandasDataset({
-            'x' : [1,3,5,6,9],
-            'y' : [1,2,None,6,9],
+            'x': [1, 3, 5, 6, 9],
+            'y': [1, 2, None, 6, 9],
         })
+
         def expect_dataframe_to_contain_7(self):
             return {
-                "success": bool((self==7).sum().sum() > 0)
+                "success": bool((self == 7).sum().sum() > 0)
             }
 
         self.assertEqual(
@@ -1105,38 +1117,43 @@ class TestDataset(unittest.TestCase):
             {'success': False}
         )
 
-
     def test_test_column_map_expectation_function(self):
 
         D = ge.dataset.PandasDataset({
-            'x' : [1,3,5,7,9],
-            'y' : [1,2,None,7,9],
+            'x': [1, 3, 5, 7, 9],
+            'y': [1, 2, None, 7, 9],
         })
+
         def is_odd(self, column, mostly=None, result_format=None, include_config=False, catch_exceptions=None, meta=None):
             return column % 2 == 1
 
         self.assertEqual(
             D.test_column_map_expectation_function(is_odd, column='x'),
-            {'result': {'element_count': 5, 'missing_count': 0, 'missing_percent': 0, 'unexpected_percent': 0.0, 'partial_unexpected_list': [], 'unexpected_percent_nonmissing': 0.0, 'unexpected_count': 0}, 'success': True}
+            {'result': {'element_count': 5, 'missing_count': 0, 'missing_percent': 0, 'unexpected_percent': 0.0,
+                        'partial_unexpected_list': [], 'unexpected_percent_nonmissing': 0.0, 'unexpected_count': 0}, 'success': True}
         )
         self.assertEqual(
-            D.test_column_map_expectation_function(is_odd, 'x', result_format="BOOLEAN_ONLY"),
+            D.test_column_map_expectation_function(
+                is_odd, 'x', result_format="BOOLEAN_ONLY"),
             {'success': True}
         )
         self.assertEqual(
-            D.test_column_map_expectation_function(is_odd, column='y', result_format="BOOLEAN_ONLY"),
+            D.test_column_map_expectation_function(
+                is_odd, column='y', result_format="BOOLEAN_ONLY"),
             {'success': False}
         )
         self.assertEqual(
-            D.test_column_map_expectation_function(is_odd, column='y', result_format="BOOLEAN_ONLY", mostly=.7),
+            D.test_column_map_expectation_function(
+                is_odd, column='y', result_format="BOOLEAN_ONLY", mostly=.7),
             {'success': True}
         )
 
     def test_test_column_aggregate_expectation_function(self):
         D = ge.dataset.PandasDataset({
-            'x' : [1,3,5,7,9],
-            'y' : [1,2,None,7,9],
+            'x': [1, 3, 5, 7, 9],
+            'y': [1, 2, None, 7, 9],
         })
+
         def expect_second_value_to_be(self, column, value, result_format=None, include_config=False, catch_exceptions=None, meta=None):
             return {
                 "success": column.iloc[1] == value,
@@ -1146,24 +1163,30 @@ class TestDataset(unittest.TestCase):
             }
 
         self.assertEqual(
-            D.test_column_aggregate_expectation_function(expect_second_value_to_be, 'x', 2),
-            {'result': {'observed_value': 3.0, 'element_count': 5, 'missing_count': 0, 'missing_percent': 0.0}, 'success': False}
+            D.test_column_aggregate_expectation_function(
+                expect_second_value_to_be, 'x', 2),
+            {'result': {'observed_value': 3.0, 'element_count': 5,
+                        'missing_count': 0, 'missing_percent': 0.0}, 'success': False}
         )
         self.assertEqual(
-            D.test_column_aggregate_expectation_function(expect_second_value_to_be, column='x', value=3),
-            {'result': {'observed_value': 3.0, 'element_count': 5, 'missing_count': 0, 'missing_percent': 0.0}, 'success': True}
+            D.test_column_aggregate_expectation_function(
+                expect_second_value_to_be, column='x', value=3),
+            {'result': {'observed_value': 3.0, 'element_count': 5,
+                        'missing_count': 0, 'missing_percent': 0.0}, 'success': True}
         )
         self.assertEqual(
-            D.test_column_aggregate_expectation_function(expect_second_value_to_be, 'y', value=3, result_format="BOOLEAN_ONLY"),
+            D.test_column_aggregate_expectation_function(
+                expect_second_value_to_be, 'y', value=3, result_format="BOOLEAN_ONLY"),
             {'success': False}
         )
         self.assertEqual(
-            D.test_column_aggregate_expectation_function(expect_second_value_to_be, 'y', 2, result_format="BOOLEAN_ONLY"),
+            D.test_column_aggregate_expectation_function(
+                expect_second_value_to_be, 'y', 2, result_format="BOOLEAN_ONLY"),
             {'success': True}
         )
 
     def test_meta_version_warning(self):
-        D = ge.dataset.Dataset();
+        D = ge.dataset.Dataset()
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -1173,13 +1196,14 @@ class TestDataset(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            out = D.validate(expectations_config={"meta": {"great_expectations.__version__": "0.0.0"}, "expectations": []})
+            out = D.validate(expectations_config={
+                             "meta": {"great_expectations.__version__": "0.0.0"}, "expectations": []})
             self.assertEqual(str(w[0].message),
                              "WARNING: This configuration object was built using a different version of great_expectations than is currently validating it.")
 
     def test_catch_exceptions_with_bad_expectation_type(self):
-        my_df = ge.dataset.PandasDataset({"x":range(10)})
-        my_df._append_expectation({'expectation_type':'foobar', 'kwargs':{}})
+        my_df = ge.dataset.PandasDataset({"x": range(10)})
+        my_df._append_expectation({'expectation_type': 'foobar', 'kwargs': {}})
         result = my_df.validate(catch_exceptions=True)
 
         # Find the foobar result
@@ -1188,10 +1212,14 @@ class TestDataset(unittest.TestCase):
                 break
 
         self.assertEqual(result["results"][idx]["success"], False)
-        self.assertEqual(result["results"][idx]["expectation_config"]["expectation_type"], "foobar")
-        self.assertEqual(result["results"][idx]["expectation_config"]["kwargs"], {})
-        self.assertEqual(result["results"][idx]["exception_info"]["raised_exception"], True)
-        assert "AttributeError: \'PandasDataset\' object has no attribute \'foobar\'" in result["results"][idx]["exception_info"]["exception_traceback"]
+        self.assertEqual(
+            result["results"][idx]["expectation_config"]["expectation_type"], "foobar")
+        self.assertEqual(result["results"][idx]
+                         ["expectation_config"]["kwargs"], {})
+        self.assertEqual(result["results"][idx]
+                         ["exception_info"]["raised_exception"], True)
+        assert "AttributeError: \'PandasDataset\' object has no attribute \'foobar\'" in result[
+            "results"][idx]["exception_info"]["exception_traceback"]
 
         with self.assertRaises(AttributeError) as context:
             result = my_df.validate(catch_exceptions=False)

--- a/tests/test_dataset_util.py
+++ b/tests/test_dataset_util.py
@@ -8,43 +8,49 @@ import sys
 
 import great_expectations as ge
 
+
 class TestUtilMethods(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestUtilMethods, self).__init__(*args, **kwargs)
-        self.D = ge.read_csv('./tests/test_sets/distributional_expectations_data_base.csv')
+        self.D = ge.read_csv(
+            './tests/test_sets/distributional_expectations_data_base.csv')
 
         with open('./tests/test_sets/test_partitions.json', 'r') as file:
             self.test_partitions = json.loads(file.read())
 
     def test_DotDict(self):
         D = ge.util.DotDict({
-            'x' : [1,2,4],
-            'y' : [1,2,5],
-            'z' : ['hello', 'jello', 'mello'],
+            'x': [1, 2, 4],
+            'y': [1, 2, 5],
+            'z': ['hello', 'jello', 'mello'],
         })
-        self.assertEqual(D.x[0],D.y[0])
-        self.assertNotEqual(D.x[0],D.z[0])
+        self.assertEqual(D.x[0], D.y[0])
+        self.assertNotEqual(D.x[0], D.z[0])
 
     def test_continuous_partition_data_error(self):
         with self.assertRaises(ValueError):
-            test_partition = ge.dataset.util.continuous_partition_data(self.D['norm_0_1'], bins=-1)
-            self.assertFalse(ge.dataset.util.is_valid_continuous_partition_object(test_partition))
-            test_partition = ge.dataset.util.continuous_partition_data(self.D['norm_0_1'], n_bins=-1)
-            self.assertFalse(ge.dataset.util.is_valid_continuous_partition_object(test_partition))
+            test_partition = ge.dataset.util.continuous_partition_data(
+                self.D['norm_0_1'], bins=-1)
+            self.assertFalse(
+                ge.dataset.util.is_valid_continuous_partition_object(test_partition))
+            test_partition = ge.dataset.util.continuous_partition_data(
+                self.D['norm_0_1'], n_bins=-1)
+            self.assertFalse(
+                ge.dataset.util.is_valid_continuous_partition_object(test_partition))
 
     def test_partition_data_norm_0_1(self):
-        test_partition = ge.dataset.util.continuous_partition_data(self.D.norm_0_1)
+        test_partition = ge.dataset.util.continuous_partition_data(
+            self.D.norm_0_1)
         for key, val in self.test_partitions['norm_0_1_auto'].items():
             self.assertEqual(len(val), len(test_partition[key]))
             self.assertTrue(np.allclose(test_partition[key], val))
 
-
     def test_partition_data_bimodal(self):
-        test_partition = ge.dataset.util.continuous_partition_data(self.D.bimodal)
+        test_partition = ge.dataset.util.continuous_partition_data(
+            self.D.bimodal)
         for key, val in self.test_partitions['bimodal_auto'].items():
             self.assertEqual(len(val), len(test_partition[key]))
             self.assertTrue(np.allclose(test_partition[key], val))
-
 
     def test_kde_partition_data_norm_0_1(self):
         test_partition = ge.dataset.util.kde_partition_data(self.D.norm_0_1)
@@ -52,20 +58,20 @@ class TestUtilMethods(unittest.TestCase):
             self.assertEqual(len(val), len(test_partition[key]))
             self.assertTrue(np.allclose(test_partition[key], val))
 
-
     def test_kde_partition_data_bimodal(self):
         test_partition = ge.dataset.util.kde_partition_data(self.D.bimodal)
         for key, val in self.test_partitions['bimodal_kde'].items():
             self.assertEqual(len(val), len(test_partition[key]))
             self.assertTrue(np.allclose(test_partition[key], val))
 
-
     def test_categorical_data_fixed(self):
-        test_partition = ge.dataset.util.categorical_partition_data(self.D.categorical_fixed)
+        test_partition = ge.dataset.util.categorical_partition_data(
+            self.D.categorical_fixed)
         for k in self.test_partitions['categorical_fixed']['values']:
             # Iterate over each categorical value and check that the weights equal those computed originally.
             self.assertEqual(
-                self.test_partitions['categorical_fixed']['weights'][self.test_partitions['categorical_fixed']['values'].index(k)],
+                self.test_partitions['categorical_fixed']['weights'][self.test_partitions['categorical_fixed']['values'].index(
+                    k)],
                 test_partition['weights'][test_partition['values'].index(k)])
 
     def test_categorical_data_na(self):
@@ -73,44 +79,54 @@ class TestUtilMethods(unittest.TestCase):
             'my_column': ["A", "B", "A", "B", None]
         })
         partition = ge.dataset.util.categorical_partition_data(df['my_column'])
-        self.assertTrue(ge.dataset.util.is_valid_categorical_partition_object(partition))
+        self.assertTrue(
+            ge.dataset.util.is_valid_categorical_partition_object(partition))
         self.assertTrue(len(partition['values']) == 2)
 
     def test_is_valid_partition_object_simple(self):
-        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(ge.dataset.util.continuous_partition_data(self.D['norm_0_1'])))
-        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(ge.dataset.util.continuous_partition_data(self.D['bimodal'])))
-        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(ge.dataset.util.continuous_partition_data(self.D['norm_0_1'], bins='auto')))
-        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(ge.dataset.util.continuous_partition_data(self.D['norm_0_1'], bins='uniform', n_bins=10)))
+        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(
+            ge.dataset.util.continuous_partition_data(self.D['norm_0_1'])))
+        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(
+            ge.dataset.util.continuous_partition_data(self.D['bimodal'])))
+        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(
+            ge.dataset.util.continuous_partition_data(self.D['norm_0_1'], bins='auto')))
+        self.assertTrue(ge.dataset.util.is_valid_continuous_partition_object(
+            ge.dataset.util.continuous_partition_data(self.D['norm_0_1'], bins='uniform', n_bins=10)))
 
     def test_generated_partition_objects(self):
         for partition_name, partition_object in self.test_partitions.items():
-            result = ge.dataset.util.is_valid_partition_object(partition_object)
+            result = ge.dataset.util.is_valid_partition_object(
+                partition_object)
             if not result:
                 print("Partition object " + partition_name + " is invalid.")
             self.assertTrue(result)
 
     def test_is_valid_partition_object_fails_length(self):
-        self.assertFalse(ge.dataset.util.is_valid_partition_object({'bins': [0,1], 'weights': [0,1,2]}))
+        self.assertFalse(ge.dataset.util.is_valid_partition_object(
+            {'bins': [0, 1], 'weights': [0, 1, 2]}))
 
     def test_is_valid_partition_object_fails_weights(self):
-        self.assertFalse(ge.dataset.util.is_valid_partition_object({'bins': [0,1,2], 'weights': [0.5,0.6]}))
+        self.assertFalse(ge.dataset.util.is_valid_partition_object(
+            {'bins': [0, 1, 2], 'weights': [0.5, 0.6]}))
 
     def test_is_valid_partition_object_fails_structure(self):
-        self.assertFalse(ge.dataset.util.is_valid_partition_object({'weights': [0.5,0.5]}))
-        self.assertFalse(ge.dataset.util.is_valid_partition_object({'bins': [0,1,2]}))
+        self.assertFalse(ge.dataset.util.is_valid_partition_object(
+            {'weights': [0.5, 0.5]}))
+        self.assertFalse(
+            ge.dataset.util.is_valid_partition_object({'bins': [0, 1, 2]}))
 
     def test_recursively_convert_to_json_serializable(self):
         D = ge.dataset.PandasDataset({
-            'x' : [1,2,3,4,5,6,7,8,9,10],
+            'x': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         })
-        D.expect_column_values_to_be_in_set("x", set([1,2,3,4,5,6,7,8,9]), mostly=.8)
+        D.expect_column_values_to_be_in_set(
+            "x", set([1, 2, 3, 4, 5, 6, 7, 8, 9]), mostly=.8)
 
         part = ge.dataset.util.partition_data(D.x)
         D.expect_column_kl_divergence_to_be_less_than("x", part, .6)
 
-        #Dumping this JSON object verifies that everything is serializable
+        # Dumping this JSON object verifies that everything is serializable
         json.dumps(D.get_expectations_config(), indent=2)
-
 
         x = {
             'w': [
@@ -118,26 +134,26 @@ class TestUtilMethods(unittest.TestCase):
             ],
             'x': np.array([1, 2, 3]),
             'y': {
-                'alpha' : None,
-                'beta' : np.nan,
+                'alpha': None,
+                'beta': np.nan,
                 'delta': np.inf,
-                'gamma' : -np.inf
+                'gamma': -np.inf
             },
-            'z': set([1,2,3,4,5]),
-            'zz': (1,2,3),
+            'z': set([1, 2, 3, 4, 5]),
+            'zz': (1, 2, 3),
             'zzz': [
-                datetime.datetime(2017,1,1),
-                datetime.date(2017,5,1),
+                datetime.datetime(2017, 1, 1),
+                datetime.date(2017, 5, 1),
             ],
             'np.bool': np.bool_([True, False, True]),
-            'np.int_': np.int_([5,3,2]),
-            'np.int8': np.int8([5,3,2]),
-            'np.int16': np.int16([10,6, 4]),
+            'np.int_': np.int_([5, 3, 2]),
+            'np.int8': np.int8([5, 3, 2]),
+            'np.int16': np.int16([10, 6, 4]),
             'np.int32': np.int32([20, 12, 8]),
-            'np.uint': np.uint([20,5,6]),
-            'np.uint8': np.uint8([40,10,12]),
-            'np.uint64': np.uint64([80,20,24]),
-            'np.float_': np.float_([3.2,5.6,7.8]),
+            'np.uint': np.uint([20, 5, 6]),
+            'np.uint8': np.uint8([40, 10, 12]),
+            'np.uint64': np.uint64([80, 20, 24]),
+            'np.float_': np.float_([3.2, 5.6, 7.8]),
             'np.float32': np.float32([5.999999999, 5.6]),
             'np.float64': np.float64([5.9999999999999999999, 10.2]),
             'np.float128': np.float128([5.999999999998786324399999999, 20.4]),
@@ -184,7 +200,8 @@ class TestUtilMethods(unittest.TestCase):
 
         # Make sure nothing is going wrong with precision rounding
         # self.assertAlmostEqual(x['np.complex128'][0].real, 20.999999999978335216827, places=sys.float_info.dig)
-        self.assertAlmostEqual(x['np.float128'][0], 5.999999999998786324399999999, places=sys.float_info.dig)
+        self.assertAlmostEqual(
+            x['np.float128'][0], 5.999999999998786324399999999, places=sys.float_info.dig)
 
     # TypeError when non-serializable numpy object is in dataset.
         with self.assertRaises(TypeError):
@@ -201,29 +218,34 @@ class TestUtilMethods(unittest.TestCase):
             pass
 
     def test_validate_distribution_parameters(self):
-        D = ge.read_csv('./tests/test_sets/fixed_distributional_test_dataset.csv')
+        D = ge.read_csv(
+            './tests/test_sets/fixed_distributional_test_dataset.csv')
 
         # ------ p_value ------
         with self.assertRaises(ValueError):
             # p_value is 0
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('norm', distribution='norm',
-                                                                                          params=[0, 1],
+                                                                                          params=[
+                                                                                              0, 1],
                                                                                           p_value=0)
         with self.assertRaises(ValueError):
             # p_value negative
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('norm', distribution='norm',
-                                                                                          params=[0,1],
+                                                                                          params=[
+                                                                                              0, 1],
                                                                                           p_value=-0.1)
         with self.assertRaises(ValueError):
             P_value = 1
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('norm', distribution='norm',
-                                                                                          params=[0,1],
+                                                                                          params=[
+                                                                                              0, 1],
                                                                                           p_value=1)
 
         with self.assertRaises(ValueError):
             # p_value greater than 1
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('norm', distribution='norm',
-                                                                                          params=[0,1],
+                                                                                          params=[
+                                                                                              0, 1],
                                                                                           p_value=1.1)
         with self.assertRaises(ValueError):
             # params is none
@@ -249,12 +271,12 @@ class TestUtilMethods(unittest.TestCase):
             # std_dev is 0, list
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('norm',
                                                                                           distribution='norm',
-                                                                                          params=[0,0])
+                                                                                          params=[0, 0])
         with self.assertRaises(ValueError):
             # std_dev is negative, list
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('norm',
                                                                                           distribution='norm',
-                                                                                          params=[0,-1])
+                                                                                          params=[0, -1])
 
         # ------- beta ------
         with self.assertRaises(ValueError):
@@ -262,53 +284,53 @@ class TestUtilMethods(unittest.TestCase):
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
                                                                                           params={
-                                                                                              'alpha':0,
-                                                                                              'beta':0.1
+                                                                                              'alpha': 0,
+                                                                                              'beta': 0.1
                                                                                           })
         with self.assertRaises(ValueError):
             # beta, alpha is negative, dict params
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
                                                                                           params={
-                                                                                              'alpha':-1,
-                                                                                              'beta':0.1
+                                                                                              'alpha': -1,
+                                                                                              'beta': 0.1
                                                                                           })
         with self.assertRaises(ValueError):
             # beta, beta is 0, dict params
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
                                                                                           params={
-                                                                                              'alpha':0.1,
-                                                                                              'beta':0
+                                                                                              'alpha': 0.1,
+                                                                                              'beta': 0
                                                                                           })
         with self.assertRaises(ValueError):
             # beta, beta is negative, dict params
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
                                                                                           params={
-                                                                                              'alpha':0,
-                                                                                              'beta':-1
+                                                                                              'alpha': 0,
+                                                                                              'beta': -1
                                                                                           })
         with self.assertRaises(ValueError):
             # beta, alpha is 0, list params
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
-                                                                                          params=[0,0.1])
+                                                                                          params=[0, 0.1])
         with self.assertRaises(ValueError):
             # beta, alpha is negative, list params
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
-                                                                                          params=[-1,0.1])
+                                                                                          params=[-1, 0.1])
         with self.assertRaises(ValueError):
             # beta, beta is 0, list params
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
-                                                                                          params=[0.1,0])
+                                                                                          params=[0.1, 0])
         with self.assertRaises(ValueError):
             # beta, beta is negative, list params
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
-                                                                                          params=[0.1,-1])
+                                                                                          params=[0.1, -1])
 
         with self.assertRaises(ValueError):
             # beta, missing alpha, dict
@@ -333,7 +355,7 @@ class TestUtilMethods(unittest.TestCase):
             # beta, missing beta, list
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('beta',
                                                                                           distribution='beta',
-                                                                                          params=[1,1,1,1,1])
+                                                                                          params=[1, 1, 1, 1, 1])
 
         # ------ Gamma -------
         with self.assertRaises(ValueError):
@@ -431,7 +453,6 @@ class TestUtilMethods(unittest.TestCase):
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('norm', distribution='norm',
                                                                                           params=[0, 1, 500])
 
-
         # ----- uniform -----
         with self.assertRaises(ValueError):
             # uniform, scale is 0, list
@@ -445,22 +466,21 @@ class TestUtilMethods(unittest.TestCase):
             # uniform, scale is negative, dict
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('uniform', distribution='uniform',
                                                                                           params={
-                                                                                            'loc': 0,
-                                                                                            'scale': -1
+                                                                                              'loc': 0,
+                                                                                              'scale': -1
                                                                                           })
         with self.assertRaises(ValueError):
             # uniform, scale is 0, dict
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('uniform', distribution='uniform',
                                                                                           params={
-                                                                                            'loc': 0,
-                                                                                            'scale': 0
+                                                                                              'loc': 0,
+                                                                                              'scale': 0
                                                                                           })
 
         with self.assertRaises(ValueError):
             # uniform, too many parameters, list
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('uniform', distribution='uniform',
                                                                                           params=[0, 1, 500])
-
 
         # --- expon ---
         with self.assertRaises(ValueError):
@@ -495,37 +515,42 @@ class TestUtilMethods(unittest.TestCase):
             # non-supported distribution
             D.expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than('exponential', distribution='fakedistribution',
                                                                                           params=[0, 1])
+
     def test_infer_distribution_parameters(self):
-        D = ge.read_csv('./tests/test_sets/fixed_distributional_test_dataset.csv')
+        D = ge.read_csv(
+            './tests/test_sets/fixed_distributional_test_dataset.csv')
 
         with self.assertRaises(TypeError):
             ge.dataset.util.infer_distribution_parameters(data=D.norm,
                                                           distribution='norm',
                                                           params=['wrong_param_format'])
         t = ge.dataset.util.infer_distribution_parameters(data=D.norm_std,
-                                                      distribution='norm',
-                                                      params=None)
+                                                          distribution='norm',
+                                                          params=None)
         self.assertEqual(t['mean'], D.norm_std.mean())
         self.assertEqual(t['std_dev'], D.norm_std.std())
         self.assertEqual(t['loc'], 0)
         self.assertEqual(t['scale'], 1)
 
         # beta
-        t = ge.dataset.util.infer_distribution_parameters(data=D.beta, distribution='beta')
+        t = ge.dataset.util.infer_distribution_parameters(
+            data=D.beta, distribution='beta')
         self.assertEqual(t['alpha'], (t['mean'] ** 2) * (
                         ((1 - t['mean']) / t['std_dev'] ** 2) - (1 / t['mean'])), "beta dist, alpha infer")
-        self.assertEqual(t['beta'], t['alpha'] * ((1 / t['mean']) - 1), "beta dist, beta infer")
+        self.assertEqual(t['beta'], t['alpha'] *
+                         ((1 / t['mean']) - 1), "beta dist, beta infer")
 
         # gamma
-        t = ge.dataset.util.infer_distribution_parameters(data=D.gamma, distribution='gamma')
+        t = ge.dataset.util.infer_distribution_parameters(
+            data=D.gamma, distribution='gamma')
         self.assertEqual(t['alpha'], D.gamma.mean())
 
         # uniform distributions
         t = ge.dataset.util.infer_distribution_parameters(data=D.uniform,
                                                           distribution='uniform')
         self.assertEqual(t['min'], min(D.uniform), "uniform, min infer")
-        self.assertEqual(t['max'], max(D.uniform) - min(D.uniform), "uniform, max infer")
-
+        self.assertEqual(t['max'], max(D.uniform) -
+                         min(D.uniform), "uniform, max infer")
 
         uni_loc = 5
         uni_scale = 10
@@ -538,44 +563,44 @@ class TestUtilMethods(unittest.TestCase):
         self.assertEqual(t['min'], uni_loc, "uniform, min infer")
         self.assertEqual(t['max'], uni_scale, "uniform, max infer")
 
-
         # expon distribution
         with self.assertRaises(AttributeError):
             ge.dataset.util.infer_distribution_parameters(data=D.norm,
                                                           distribution='fakedistribution')
 
         # chi2
-        t = ge.dataset.util.infer_distribution_parameters(data=D.chi2, distribution='chi2')
+        t = ge.dataset.util.infer_distribution_parameters(
+            data=D.chi2, distribution='chi2')
         self.assertEqual(t['df'], D.chi2.mean())
 
     def test_create_multiple_expectations(self):
         D = ge.dataset.PandasDataset({
-            'x' : [1,2,3,4,5,6],
-            'y' : [0,2,4,6,8,10],
-            'z' : ['hi', 'hello', 'hey', 'howdy', 'hola', 'holy smokes'],
+            'x': [1, 2, 3, 4, 5, 6],
+            'y': [0, 2, 4, 6, 8, 10],
+            'z': ['hi', 'hello', 'hey', 'howdy', 'hola', 'holy smokes'],
             'zz': ['a', 'b', 'c', 'hi', 'howdy', 'hola']
         })
 
         # Test kwarg
         results = ge.dataset.util.create_multiple_expectations(D,
-                                                     ['x', 'y'],
-                                                     'expect_column_values_to_be_in_set',
-                                                     value_set=[1, 2, 3, 4, 5, 6])
+                                                               ['x', 'y'],
+                                                               'expect_column_values_to_be_in_set',
+                                                               value_set=[1, 2, 3, 4, 5, 6])
         self.assertTrue(results[0]['success'])
         self.assertFalse(results[1]['success'])
 
         # Test positional argument
         results = ge.dataset.util.create_multiple_expectations(D,
-                                                     ['x', 'y'],
-                                                     'expect_column_values_to_be_in_set',
-                                                     [1, 2, 3, 4, 5, 6])
+                                                               ['x', 'y'],
+                                                               'expect_column_values_to_be_in_set',
+                                                               [1, 2, 3, 4, 5, 6])
         self.assertTrue(results[0]['success'])
         self.assertFalse(results[1]['success'])
 
         results = ge.dataset.util.create_multiple_expectations(D,
-                                                     ['z', 'zz'],
-                                                     'expect_column_values_to_match_regex',
-                                                     'h')
+                                                               ['z', 'zz'],
+                                                               'expect_column_values_to_match_regex',
+                                                               'h')
         self.assertTrue(results[0]['success'])
         self.assertFalse(results[1]['success'])
 
@@ -585,7 +610,6 @@ class TestUtilMethods(unittest.TestCase):
                                                                'expect_column_values_to_not_be_null')
         self.assertTrue(results[0]['success'])
         self.assertTrue(results[1]['success'])
-
 
         # Key error when non-existant column is called
         with self.assertRaises(KeyError):
@@ -603,6 +627,8 @@ class TestUtilMethods(unittest.TestCase):
 """
 The following Parent and Child classes are used for testing documentation inheritance.
 """
+
+
 class Parent(object):
     """Parent class docstring
     """
@@ -617,7 +643,6 @@ class Parent(object):
             func(*args, **kwargs)
 
         return wrapper
-
 
     def override_me(self):
         """Parent method docstring
@@ -648,15 +673,16 @@ class TestDocumentation(unittest.TestCase):
 
         self.assertEqual(
             c.__getattribute__('override_me').__doc__,
-        """Child method docstring
+            """Child method docstring
         Returns:
             Real, instantiable, abiding satisfaction.
         """ + '\n' +
-        """Parent method docstring
+            """Parent method docstring
         Returns:
             Unattainable abiding satisfaction.
         """
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_expectation_decorators.py
+++ b/tests/test_expectation_decorators.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-import json
 import unittest
 from great_expectations.dataset import Dataset, PandasDataset, MetaPandasDataset
 
@@ -18,7 +17,7 @@ class ExpectationOnlyDataset(Dataset):
 
     @Dataset.expectation([])
     def exception_expectation(self,
-                                result_format=None, include_config=False, catch_exceptions=None, meta=None):
+                              result_format=None, include_config=False, catch_exceptions=None, meta=None):
         raise ValueError("Gotcha!")
 
 
@@ -35,7 +34,6 @@ class TestExpectationDecorators(unittest.TestCase):
 
         self.assertEqual({'expectation_type': 'no_op_value_expectation', 'kwargs': {'value': 'a'}},
                          config['expectations'][1])
-
 
     def test_expectation_decorator_include_config(self):
         eds = ExpectationOnlyDataset()
@@ -65,136 +63,137 @@ class TestExpectationDecorators(unittest.TestCase):
                          out['exception_info']['exception_traceback'].split('\n')[-2])
 
     def test_pandas_column_map_decorator_partial_exception_counts(self):
-        df = PandasDataset({'a': [0,1,2,3,4]})
+        df = PandasDataset({'a': [0, 1, 2, 3, 4]})
         out = df.expect_column_values_to_be_between('a', 3, 4,
-                                              result_format={'result_format': 'COMPLETE', 'partial_unexpected_count': 1})
+                                                    result_format={'result_format': 'COMPLETE', 'partial_unexpected_count': 1})
 
         self.assertTrue(1, len(out['result']['partial_unexpected_counts']))
         self.assertTrue(3, len(out['result']['unexpected_list']))
 
     def test_column_map_expectation_decorator(self):
 
-        # Create a new CustomPandasDataset to 
+        # Create a new CustomPandasDataset to
         # (1) Prove that custom subclassing works, AND
         # (2) Test expectation business logic without dependencies on any other functions.
         class CustomPandasDataset(PandasDataset):
 
             @MetaPandasDataset.column_map_expectation
             def expect_column_values_to_be_odd(self, column):
-                return column.map(lambda x: x % 2 )
+                return column.map(lambda x: x % 2)
 
             @MetaPandasDataset.column_map_expectation
             def expectation_that_crashes_on_sixes(self, column):
                 return column.map(lambda x: (x-6)/0 != "duck")
 
         df = CustomPandasDataset({
-            'all_odd' : [1,3,5,5,5,7,9,9,9,11],
-            'mostly_odd' : [1,3,5,7,9,2,4,1,3,5],
-            'all_even' : [2,4,4,6,6,6,8,8,8,8],
-            'odd_missing' : [1,3,5,None,None,None,None,1,3,None],
-            'mixed_missing' : [1,3,5,None,None,2,4,1,3,None],
-            'all_missing' : [None,None,None,None,None,None,None,None,None,None]
+            'all_odd': [1, 3, 5, 5, 5, 7, 9, 9, 9, 11],
+            'mostly_odd': [1, 3, 5, 7, 9, 2, 4, 1, 3, 5],
+            'all_even': [2, 4, 4, 6, 6, 6, 8, 8, 8, 8],
+            'odd_missing': [1, 3, 5, None, None, None, None, 1, 3, None],
+            'mixed_missing': [1, 3, 5, None, None, 2, 4, 1, 3, None],
+            'all_missing': [None, None, None, None, None, None, None, None, None, None]
         })
         df.set_default_expectation_argument("result_format", "COMPLETE")
 
         self.assertEqual(
             df.expect_column_values_to_be_odd("all_odd"),
             {'result': {'element_count': 10,
-                            'missing_count': 0,
-                            'missing_percent': 0.0,
-                            'partial_unexpected_counts': [],
-                            'partial_unexpected_index_list': [],
-                            'partial_unexpected_list': [],
-                            'unexpected_count': 0,
-                            'unexpected_index_list': [],
-                            'unexpected_list': [],
-                            'unexpected_percent': 0.0,
-                            'unexpected_percent_nonmissing': 0.0},
+                        'missing_count': 0,
+                        'missing_percent': 0.0,
+                        'partial_unexpected_counts': [],
+                        'partial_unexpected_index_list': [],
+                        'partial_unexpected_list': [],
+                        'unexpected_count': 0,
+                        'unexpected_index_list': [],
+                        'unexpected_list': [],
+                        'unexpected_percent': 0.0,
+                        'unexpected_percent_nonmissing': 0.0},
              'success': True}
         )
 
         self.assertEqual(
             df.expect_column_values_to_be_odd("all_missing"),
             {'result': {'element_count': 10,
-                            'missing_count': 10,
-                            'missing_percent': 1,
-                            'partial_unexpected_counts': [],
-                            'partial_unexpected_index_list': [],
-                            'partial_unexpected_list': [],
-                            'unexpected_count': 0,
-                            'unexpected_index_list': [],
-                            'unexpected_list': [],
-                            'unexpected_percent': 0.0,
-                            'unexpected_percent_nonmissing': None},
+                        'missing_count': 10,
+                        'missing_percent': 1,
+                        'partial_unexpected_counts': [],
+                        'partial_unexpected_index_list': [],
+                        'partial_unexpected_list': [],
+                        'unexpected_count': 0,
+                        'unexpected_index_list': [],
+                        'unexpected_list': [],
+                        'unexpected_percent': 0.0,
+                        'unexpected_percent_nonmissing': None},
              'success': True}
         )
 
         self.assertEqual(
             df.expect_column_values_to_be_odd("odd_missing"),
             {'result': {'element_count': 10,
-                            'missing_count': 5,
-                            'missing_percent': 0.5,
-                            'partial_unexpected_counts': [],
-                            'partial_unexpected_index_list': [],
-                            'partial_unexpected_list': [],
-                            'unexpected_count': 0,
-                            'unexpected_index_list': [],
-                            'unexpected_list': [],
-                            'unexpected_percent': 0.0,
-                            'unexpected_percent_nonmissing': 0.0},
+                        'missing_count': 5,
+                        'missing_percent': 0.5,
+                        'partial_unexpected_counts': [],
+                        'partial_unexpected_index_list': [],
+                        'partial_unexpected_list': [],
+                        'unexpected_count': 0,
+                        'unexpected_index_list': [],
+                        'unexpected_list': [],
+                        'unexpected_percent': 0.0,
+                        'unexpected_percent_nonmissing': 0.0},
              'success': True}
         )
 
         self.assertEqual(
             df.expect_column_values_to_be_odd("mixed_missing"),
             {'result': {'element_count': 10,
-                            'missing_count': 3,
-                            'missing_percent': 0.3,
-                            'partial_unexpected_counts': [{'value': 2., 'count': 1}, {'value': 4., 'count': 1}],
-                            'partial_unexpected_index_list': [5, 6],
-                            'partial_unexpected_list': [2., 4.],
-                            'unexpected_count': 2,
-                            'unexpected_index_list': [5, 6],
-                            'unexpected_list': [2., 4.],
-                            'unexpected_percent': 0.2,
-                            'unexpected_percent_nonmissing': 2/7},
+                        'missing_count': 3,
+                        'missing_percent': 0.3,
+                        'partial_unexpected_counts': [{'value': 2., 'count': 1}, {'value': 4., 'count': 1}],
+                        'partial_unexpected_index_list': [5, 6],
+                        'partial_unexpected_list': [2., 4.],
+                        'unexpected_count': 2,
+                        'unexpected_index_list': [5, 6],
+                        'unexpected_list': [2., 4.],
+                        'unexpected_percent': 0.2,
+                        'unexpected_percent_nonmissing': 2/7},
              'success': False}
         )
 
         self.assertEqual(
             df.expect_column_values_to_be_odd("mostly_odd"),
             {'result': {'element_count': 10,
-                            'missing_count': 0,
-                            'missing_percent': 0,
-                            'partial_unexpected_counts': [{'value': 2., 'count': 1}, {'value': 4., 'count': 1}],
-                            'partial_unexpected_index_list': [5, 6],
-                            'partial_unexpected_list': [2., 4.],
-                            'unexpected_count': 2,
-                            'unexpected_index_list': [5, 6],
-                            'unexpected_list': [2., 4.],
-                            'unexpected_percent': 0.2,
-                            'unexpected_percent_nonmissing': 0.2},
+                        'missing_count': 0,
+                        'missing_percent': 0,
+                        'partial_unexpected_counts': [{'value': 2., 'count': 1}, {'value': 4., 'count': 1}],
+                        'partial_unexpected_index_list': [5, 6],
+                        'partial_unexpected_list': [2., 4.],
+                        'unexpected_count': 2,
+                        'unexpected_index_list': [5, 6],
+                        'unexpected_list': [2., 4.],
+                        'unexpected_percent': 0.2,
+                        'unexpected_percent_nonmissing': 0.2},
              'success': False}
         )
 
         self.assertEqual(
             df.expect_column_values_to_be_odd("mostly_odd", mostly=.6),
             {'result': {'element_count': 10,
-                            'missing_count': 0,
-                            'missing_percent': 0,
-                            'partial_unexpected_counts': [{'value': 2., 'count': 1}, {'value': 4., 'count': 1}],
-                            'partial_unexpected_index_list': [5, 6],
-                            'partial_unexpected_list': [2., 4.],
-                            'unexpected_count': 2,
-                            'unexpected_index_list': [5, 6],
-                            'unexpected_list': [2., 4.],
-                            'unexpected_percent': 0.2,
-                            'unexpected_percent_nonmissing': 0.2},
+                        'missing_count': 0,
+                        'missing_percent': 0,
+                        'partial_unexpected_counts': [{'value': 2., 'count': 1}, {'value': 4., 'count': 1}],
+                        'partial_unexpected_index_list': [5, 6],
+                        'partial_unexpected_list': [2., 4.],
+                        'unexpected_count': 2,
+                        'unexpected_index_list': [5, 6],
+                        'unexpected_list': [2., 4.],
+                        'unexpected_percent': 0.2,
+                        'unexpected_percent_nonmissing': 0.2},
              'success': True}
         )
 
         self.assertEqual(
-            df.expect_column_values_to_be_odd("mostly_odd", result_format="BOOLEAN_ONLY"),
+            df.expect_column_values_to_be_odd(
+                "mostly_odd", result_format="BOOLEAN_ONLY"),
             {'success': False}
         )
 
@@ -208,7 +207,8 @@ class TestExpectationDecorators(unittest.TestCase):
         df.default_expectation_args["result_format"] = "BASIC"
 
         self.assertEqual(
-            df.expect_column_values_to_be_odd("mostly_odd", include_config=True),
+            df.expect_column_values_to_be_odd(
+                "mostly_odd", include_config=True),
             {
                 "expectation_config": {
                     "expectation_type": "expect_column_values_to_be_odd",
@@ -218,21 +218,19 @@ class TestExpectationDecorators(unittest.TestCase):
                     }
                 },
                 'result': {'element_count': 10,
-                               'missing_count': 0,
-                               'missing_percent': 0,
-                               'partial_unexpected_list': [2., 4.],
-                               'unexpected_count': 2,
-                               'unexpected_percent': 0.2,
-                               'unexpected_percent_nonmissing': 0.2},
+                           'missing_count': 0,
+                           'missing_percent': 0,
+                           'partial_unexpected_list': [2., 4.],
+                           'unexpected_count': 2,
+                           'unexpected_percent': 0.2,
+                           'unexpected_percent_nonmissing': 0.2},
                 'success': False,
             }
         )
 
-
-
     def test_column_aggregate_expectation_decorator(self):
 
-        # Create a new CustomPandasDataset to 
+        # Create a new CustomPandasDataset to
         # (1) Prove that custom subclassing works, AND
         # (2) Test expectation business logic without dependencies on any other functions.
         class CustomPandasDataset(PandasDataset):
@@ -242,12 +240,12 @@ class TestExpectationDecorators(unittest.TestCase):
                 return {"success": column.median() % 2, "result": {"observed_value": column.median()}}
 
         df = CustomPandasDataset({
-            'all_odd' : [1,3,5,7,9],
-            'all_even' : [2,4,6,8,10],
-            'odd_missing' : [1,3,5,None,None],
-            'mixed_missing' : [1,2,None,None,6],
-            'mixed_missing_2' : [1,3,None,None,6],
-            'all_missing' : [None,None,None,None,None,],
+            'all_odd': [1, 3, 5, 7, 9],
+            'all_even': [2, 4, 6, 8, 10],
+            'odd_missing': [1, 3, 5, None, None],
+            'mixed_missing': [1, 2, None, None, 6],
+            'mixed_missing_2': [1, 3, None, None, 6],
+            'all_missing': [None, None, None, None, None, ],
         })
         df.set_default_expectation_argument("result_format", "COMPLETE")
 
@@ -268,7 +266,8 @@ class TestExpectationDecorators(unittest.TestCase):
         )
 
         self.assertEqual(
-            df.expect_column_median_to_be_odd("all_even", result_format="SUMMARY"),
+            df.expect_column_median_to_be_odd(
+                "all_even", result_format="SUMMARY"),
             {
                 'result': {'observed_value': 6, 'element_count': 5, 'missing_count': 0, 'missing_percent': 0},
                 'success': False
@@ -276,7 +275,8 @@ class TestExpectationDecorators(unittest.TestCase):
         )
 
         self.assertEqual(
-            df.expect_column_median_to_be_odd("all_even", result_format="BOOLEAN_ONLY"),
+            df.expect_column_median_to_be_odd(
+                "all_even", result_format="BOOLEAN_ONLY"),
             {'success': False}
         )
 
@@ -287,56 +287,57 @@ class TestExpectationDecorators(unittest.TestCase):
         )
 
         self.assertEqual(
-            df.expect_column_median_to_be_odd("all_even", result_format="BASIC"),
+            df.expect_column_median_to_be_odd(
+                "all_even", result_format="BASIC"),
             {
                 'result': {'observed_value': 6, 'element_count': 5, 'missing_count': 0, 'missing_percent': 0},
                 'success': False
             }
         )
 
-
     def test_column_pair_map_expectation_decorator(self):
 
-        # Create a new CustomPandasDataset to 
+        # Create a new CustomPandasDataset to
         # (1) Prove that custom subclassing works, AND
         # (2) Test expectation business logic without dependencies on any other functions.
         class CustomPandasDataset(PandasDataset):
 
             @PandasDataset.column_pair_map_expectation
             def expect_column_pair_values_to_be_different(self,
-                column_A,
-                column_B,
-                keep_missing="either",
-                output_format=None, include_config=False, catch_exceptions=None
-            ):
+                                                          column_A,
+                                                          column_B,
+                                                          keep_missing="either",
+                                                          output_format=None, include_config=False, catch_exceptions=None
+                                                          ):
                 return column_A != column_B
 
         df = CustomPandasDataset({
-            'all_odd' : [1,3,5,7,9],
-            'all_even' : [2,4,6,8,10],
-            'odd_missing' : [1,3,5,None,None],
-            'mixed_missing' : [1,2,None,None,6],
-            'mixed_missing_2' : [1,3,None,None,6],
-            'all_missing' : [None,None,None,None,None,],
+            'all_odd': [1, 3, 5, 7, 9],
+            'all_even': [2, 4, 6, 8, 10],
+            'odd_missing': [1, 3, 5, None, None],
+            'mixed_missing': [1, 2, None, None, 6],
+            'mixed_missing_2': [1, 3, None, None, 6],
+            'all_missing': [None, None, None, None, None, ],
         })
         df.set_default_expectation_argument("result_format", "COMPLETE")
 
         self.assertEqual(
-            df.expect_column_pair_values_to_be_different("all_odd", "all_even"),
+            df.expect_column_pair_values_to_be_different(
+                "all_odd", "all_even"),
             {
                 "success": True,
                 "result": {
                     "element_count": 5,
-                    "missing_count": 0, 
-                    "unexpected_count": 0, 
-                    "missing_percent": 0.0, 
-                    "unexpected_percent": 0.0, 
-                    "unexpected_percent_nonmissing": 0.0, 
-                    "unexpected_list": [], 
+                    "missing_count": 0,
+                    "unexpected_count": 0,
+                    "missing_percent": 0.0,
+                    "unexpected_percent": 0.0,
+                    "unexpected_percent_nonmissing": 0.0,
+                    "unexpected_list": [],
                     "unexpected_index_list": [],
-                    "partial_unexpected_list": [], 
-                    "partial_unexpected_index_list": [], 
-                    "partial_unexpected_counts": [], 
+                    "partial_unexpected_list": [],
+                    "partial_unexpected_index_list": [],
+                    "partial_unexpected_counts": [],
                 }
             }
         )
@@ -348,39 +349,40 @@ class TestExpectationDecorators(unittest.TestCase):
                 ignore_row_if="both_values_are_missing",
             ),
             {
-                'success' : True,
+                'success': True,
                 'result': {
                     "element_count": 5,
-                    "missing_count": 0, 
-                    "unexpected_count": 0, 
-                    "missing_percent": 0.0, 
-                    "unexpected_percent": 0.0, 
-                    "unexpected_percent_nonmissing": 0.0, 
-                    "unexpected_list": [], 
+                    "missing_count": 0,
+                    "unexpected_count": 0,
+                    "missing_percent": 0.0,
+                    "unexpected_percent": 0.0,
+                    "unexpected_percent_nonmissing": 0.0,
+                    "unexpected_list": [],
                     "unexpected_index_list": [],
-                    "partial_unexpected_list": [], 
-                    "partial_unexpected_index_list": [], 
-                    "partial_unexpected_counts": [], 
+                    "partial_unexpected_list": [],
+                    "partial_unexpected_index_list": [],
+                    "partial_unexpected_counts": [],
                 }
             }
         )
 
         self.maxDiff = None
         self.assertEqual(
-            df.expect_column_pair_values_to_be_different("all_odd", "odd_missing"),
+            df.expect_column_pair_values_to_be_different(
+                "all_odd", "odd_missing"),
             {
-                'success' : False,
+                'success': False,
                 'result': {
                     "element_count": 5,
-                    "missing_count": 0, 
-                    "unexpected_count": 3, 
-                    "missing_percent": 0.0, 
+                    "missing_count": 0,
+                    "unexpected_count": 3,
+                    "missing_percent": 0.0,
                     "unexpected_percent": 0.6,
                     "unexpected_percent_nonmissing": 0.6,
-                    "unexpected_list": [[1,1],[3,3],[5,5]],
-                    "unexpected_index_list": [0,1,2],
-                    "partial_unexpected_list": [[1,1],[3,3],[5,5]],
-                    "partial_unexpected_index_list": [0,1,2],
+                    "unexpected_list": [[1, 1], [3, 3], [5, 5]],
+                    "unexpected_index_list": [0, 1, 2],
+                    "partial_unexpected_list": [[1, 1], [3, 3], [5, 5]],
+                    "partial_unexpected_index_list": [0, 1, 2],
                     "partial_unexpected_counts": [
                         {'count': 1, 'value': [1, 1.0]},
                         {'count': 1, 'value': [3, 3.0]},
@@ -397,18 +399,18 @@ class TestExpectationDecorators(unittest.TestCase):
                 ignore_row_if="both_values_are_missing"
             ),
             {
-                'success' : False,
+                'success': False,
                 'result': {
                     "element_count": 5,
-                    "missing_count": 0, 
-                    "unexpected_count": 3, 
-                    "missing_percent": 0.0, 
+                    "missing_count": 0,
+                    "unexpected_count": 3,
+                    "missing_percent": 0.0,
                     "unexpected_percent": 0.6,
                     "unexpected_percent_nonmissing": 0.6,
-                    "unexpected_list": [[1,1],[3,3],[5,5]],
-                    "unexpected_index_list": [0,1,2],
-                    "partial_unexpected_list": [[1,1],[3,3],[5,5]],
-                    "partial_unexpected_index_list": [0,1,2],
+                    "unexpected_list": [[1, 1], [3, 3], [5, 5]],
+                    "unexpected_index_list": [0, 1, 2],
+                    "partial_unexpected_list": [[1, 1], [3, 3], [5, 5]],
+                    "partial_unexpected_index_list": [0, 1, 2],
                     "partial_unexpected_counts": [
                         {'count': 1, 'value': [1, 1.0]},
                         {'count': 1, 'value': [3, 3.0]},
@@ -425,18 +427,18 @@ class TestExpectationDecorators(unittest.TestCase):
                 ignore_row_if="either_value_is_missing"
             ),
             {
-                'success' : False,
+                'success': False,
                 'result': {
                     "element_count": 5,
                     "missing_count": 2,
-                    "unexpected_count": 3, 
+                    "unexpected_count": 3,
                     "missing_percent": 0.4,
                     "unexpected_percent": 0.6,
                     "unexpected_percent_nonmissing": 1.0,
-                    "unexpected_list": [[1,1],[3,3],[5,5]],
-                    "unexpected_index_list": [0,1,2],
-                    "partial_unexpected_list": [[1,1],[3,3],[5,5]],
-                    "partial_unexpected_index_list": [0,1,2],
+                    "unexpected_list": [[1, 1], [3, 3], [5, 5]],
+                    "unexpected_index_list": [0, 1, 2],
+                    "partial_unexpected_list": [[1, 1], [3, 3], [5, 5]],
+                    "partial_unexpected_index_list": [0, 1, 2],
                     "partial_unexpected_counts": [
                         {'count': 1, 'value': [1, 1.0]},
                         {'count': 1, 'value': [3, 3.0]},
@@ -480,7 +482,6 @@ class TestExpectationDecorators(unittest.TestCase):
         #     }
         # )
 
-
         with self.assertRaises(ValueError):
             df.expect_column_pair_values_to_be_different(
                 "all_odd",
@@ -488,7 +489,7 @@ class TestExpectationDecorators(unittest.TestCase):
                 ignore_row_if="blahblahblah"
             )
 
-        #Test SUMMARY, BASIC, and BOOLEAN_ONLY output_formats
+        # Test SUMMARY, BASIC, and BOOLEAN_ONLY output_formats
         self.assertEqual(
             df.expect_column_pair_values_to_be_different(
                 "all_odd",
@@ -499,14 +500,14 @@ class TestExpectationDecorators(unittest.TestCase):
                 "success": True,
                 "result": {
                     "element_count": 5,
-                    "missing_count": 0, 
-                    "unexpected_count": 0, 
-                    "missing_percent": 0.0, 
-                    "unexpected_percent": 0.0, 
-                    "unexpected_percent_nonmissing": 0.0, 
-                    "partial_unexpected_list": [], 
-                    "partial_unexpected_index_list": [], 
-                    "partial_unexpected_counts": [], 
+                    "missing_count": 0,
+                    "unexpected_count": 0,
+                    "missing_percent": 0.0,
+                    "unexpected_percent": 0.0,
+                    "unexpected_percent_nonmissing": 0.0,
+                    "partial_unexpected_list": [],
+                    "partial_unexpected_index_list": [],
+                    "partial_unexpected_counts": [],
                 }
             }
         )
@@ -521,12 +522,12 @@ class TestExpectationDecorators(unittest.TestCase):
                 "success": True,
                 "result": {
                     "element_count": 5,
-                    "missing_count": 0, 
-                    "unexpected_count": 0, 
-                    "missing_percent": 0.0, 
-                    "unexpected_percent": 0.0, 
-                    "unexpected_percent_nonmissing": 0.0, 
-                    "partial_unexpected_list": [], 
+                    "missing_count": 0,
+                    "unexpected_count": 0,
+                    "missing_percent": 0.0,
+                    "unexpected_percent": 0.0,
+                    "unexpected_percent_nonmissing": 0.0,
+                    "partial_unexpected_list": [],
                 }
             }
         )
@@ -541,6 +542,7 @@ class TestExpectationDecorators(unittest.TestCase):
                 "success": True,
             }
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_file_expectations.py
+++ b/tests/test_file_expectations.py
@@ -2,7 +2,6 @@ import unittest
 
 import great_expectations as ge
 
-import json
 
 class TestUtilMethods(unittest.TestCase):
     def test_expect_file_hash_to_equal(self):
@@ -63,16 +62,19 @@ class TestUtilMethods(unittest.TestCase):
         except ValueError:
             pass
         # Test file size not in range
-        self.assertFalse(ge.expect_file_size_to_be_between(test_file, 0, 10000))
+        self.assertFalse(
+            ge.expect_file_size_to_be_between(test_file, 0, 10000))
         # Test file size in range
-        self.assertTrue(ge.expect_file_size_to_be_between(test_file, 70000, 71000))
+        self.assertTrue(ge.expect_file_size_to_be_between(
+            test_file, 70000, 71000))
 
     def test_expect_file_to_exist(self):
         # Test for non-existent file
         self.assertFalse(ge.expect_file_to_exist('abc'))
         # Test for existing file
-        self.assertTrue(ge.expect_file_to_exist('./tests/test_sets/Titanic.csv'))
-                         
+        self.assertTrue(ge.expect_file_to_exist(
+            './tests/test_sets/Titanic.csv'))
+
     def test_expect_file_unique_column_names_csv(self):
         # Test for non-existent file
         try:
@@ -106,10 +108,11 @@ class TestUtilMethods(unittest.TestCase):
         # Test valid JSON file with non-matching schema
         test_file = './tests/test_sets/json_test1_against_schema.json'
         schema_file = './tests/test_sets/sample_schema.json'
-        self.assertFalse(ge.expect_file_valid_json(test_file, schema=schema_file))
+        self.assertFalse(ge.expect_file_valid_json(
+            test_file, schema=schema_file))
 
         # Test valid JSON file with valid schema
         test_file = './tests/test_sets/json_test2_against_schema.json'
         schema_file = './tests/test_sets/sample_schema.json'
-        self.assertTrue(ge.expect_file_valid_json(test_file, schema=schema_file))
-
+        self.assertTrue(ge.expect_file_valid_json(
+            test_file, schema=schema_file))

--- a/tests/test_fixtures/custom_dataset.py
+++ b/tests/test_fixtures/custom_dataset.py
@@ -1,5 +1,6 @@
 from great_expectations.dataset.pandas_dataset import PandasDataset
 
+
 class CustomPandasDataset(PandasDataset):
 
     drg_codes = [
@@ -12,9 +13,9 @@ class CustomPandasDataset(PandasDataset):
         305, 282, 39, 244, 238, 482, 684, 149, 563, 74, 491, 418,
         439, 249, 602, 870, 469, 480, 699, 254, 246, 286, 897,
         203, 301, 698, 419, 315, 917, 473, 251,
-        #885
+        # 885
     ]
-    
+
     @PandasDataset.column_map_expectation
     def expect_column_to_start_with_valid_drg(self, column):
         return column.map(lambda x: int(x[:3]) in self.drg_codes)

--- a/tests/test_fixtures/distributional_expectations_partition_fixtures.py
+++ b/tests/test_fixtures/distributional_expectations_partition_fixtures.py
@@ -15,6 +15,7 @@ The partitions should be built from distributional_expectations_data_base.csv. T
 
 """
 
+
 def generate_new_data():
     norm_0_1 = stats.norm.rvs(0, 1, 1000)
     norm_1_1 = stats.norm.rvs(1, 1, 1000)
@@ -22,14 +23,13 @@ def generate_new_data():
     bimodal = np.concatenate((norm_0_1[:500], norm_10_1[500:]))
     categorical_fixed = (['A'] * 540) + (['B'] * 320) + (['C'] * 140)
 
-    return pd.DataFrame( {
+    return pd.DataFrame({
         'norm_0_1': norm_0_1,
         'norm_1_1': norm_1_1,
         'norm_10_1': norm_10_1,
         'bimodal': bimodal,
         'categorical_fixed': categorical_fixed
     })
-
 
 
 def generate_new_partitions(df):
@@ -41,16 +41,20 @@ def generate_new_partitions(df):
         test_partitions[column + '_kde'] = partition_object
 
         for bin_type in ['uniform', 'ntile', 'auto']:
-            partition_object = ge.dataset.util.continuous_partition_data(df[column], bin_type)
+            partition_object = ge.dataset.util.continuous_partition_data(
+                df[column], bin_type)
             # Print how close sum of weights is to one for a quick visual consistency check when data are generated
             #print(column + '_' + bin_type + ': ' + str(abs(1 - np.sum(partition_object['weights']))))
             test_partitions[column + '_' + bin_type] = partition_object
 
-    partition_object = ge.dataset.util.categorical_partition_data(df['categorical_fixed'])
+    partition_object = ge.dataset.util.categorical_partition_data(
+        df['categorical_fixed'])
     test_partitions['categorical_fixed'] = partition_object
-    alt_partition = ge.dataset.util.categorical_partition_data(df['categorical_fixed'])
+    alt_partition = ge.dataset.util.categorical_partition_data(
+        df['categorical_fixed'])
     # overwrite weights with uniform weights to give a testing dataset
-    alt_partition['weights'] = [1./len(alt_partition['values'])] * len(alt_partition['values'])
+    alt_partition['weights'] = [
+        1./len(alt_partition['values'])] * len(alt_partition['values'])
     test_partitions['categorical_fixed_alternate'] = alt_partition
 
     return test_partitions
@@ -59,10 +63,12 @@ def generate_new_partitions(df):
 if __name__ == "__main__":
     # Set precision we'll use:
     precision = sys.float_info.dig
-    print("Setting pandas float_format to use " + str(precision) + " digits of precision.")
+    print("Setting pandas float_format to use " +
+          str(precision) + " digits of precision.")
 
     df = generate_new_data()
-    df.to_csv('../test_sets/distributional_expectations_data_base.csv', float_format='%.' + str(precision) + 'g')
+    df.to_csv('../test_sets/distributional_expectations_data_base.csv',
+              float_format='%.' + str(precision) + 'g')
     test_partitions = generate_new_partitions(df)
 
     ge.dataset.util.ensure_json_serializable(test_partitions)
@@ -70,5 +76,6 @@ if __name__ == "__main__":
         file.write(json.dumps(test_partitions))
 
     df = generate_new_data()
-    df.to_csv('../test_sets/distributional_expectations_data_test.csv', float_format='%.' + str(precision) + 'g')
+    df.to_csv('../test_sets/distributional_expectations_data_test.csv',
+              float_format='%.' + str(precision) + 'g')
     print("Done generating new base data, partitions, and test data.")

--- a/tests/test_fixtures/fixed_distribution_data.py
+++ b/tests/test_fixtures/fixed_distribution_data.py
@@ -8,16 +8,16 @@ e.g. kstest(data_column, "distribution name", p-value=0.05) == True
 import numpy as np
 from scipy import stats
 import pandas as pd
-import sys
+
 
 def generate_data():
-    ## Code used to create reproducible and static test data
+    # Code used to create reproducible and static test data
 
-    std_loc, std_scale = 0, 1
+    # std_loc, std_scale = 0, 1
     norm_mean, norm_std = -2, 5
     beta_a, beta_b, beta_loc, beta_scale = 0.5, 10, 5, 11
     gamma_a, gamma_loc, gamma_scale = 2, 20, 3
-    poisson_lambda, poisson_loc = 8.2, 40
+    # poisson_lambda, poisson_loc = 8.2, 40
     uniform_loc, uniform_scale = -5, 11
     chi2_df, chi2_loc, chi2_scale = 30, 3, 5
     expon_loc, expon_scale = 4.2, 10
@@ -42,7 +42,8 @@ def generate_data():
 
     # different seed for chi2
     np.random.seed(123456)
-    fixed['chi2'] = stats.chi2.rvs(df=chi2_df, loc=chi2_loc, scale=chi2_scale, size=500)
+    fixed['chi2'] = stats.chi2.rvs(
+        df=chi2_df, loc=chi2_loc, scale=chi2_scale, size=500)
 
     return fixed
 
@@ -52,9 +53,9 @@ if __name__ == "__main__":
     #precision = sys.float_info.dig
     #print("Setting pandas float_format to use " + str(precision) + " digits of precision.")
 
-
     df = generate_data()
-    df.to_csv("../test_sets/fixed_distributional_test_dataset.csv", header=True, index=None)
+    df.to_csv("../test_sets/fixed_distributional_test_dataset.csv",
+              header=True, index=None)
     with open('../test_sets/fixed_distributional_test_dataset.json', 'a') as data_file:
         for column in list(df):
             data_file.write("\"" + str(column) + "\" : [")

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -16,8 +16,9 @@ from great_expectations.dataset.base import (
 )
 from .test_utils import assertDeepAlmostEqual
 
+
 def isprime(n):
-    #https://stackoverflow.com/questions/18833759/python-prime-number-checker
+    # https://stackoverflow.com/questions/18833759/python-prime-number-checker
     '''check if integer n is a prime'''
 
     # make sure n is a positive integer
@@ -55,35 +56,36 @@ class CustomPandasDataset(PandasDataset):
         not_null = self[column].notnull()
 
         result = self[column][not_null] == 1
-        unexpected_values = list(self[column][not_null][result==False])
+        unexpected_values = list(self[column][not_null][result == False])
 
         if mostly:
-            #Prevent division-by-zero errors
+            # Prevent division-by-zero errors
             if len(not_null) == 0:
                 return {
-                    'success':True,
+                    'success': True,
                     'result': {
-                        'unexpected_list':unexpected_values,
-                        'unexpected_index_list':self.index[result],
+                        'unexpected_list': unexpected_values,
+                        'unexpected_index_list': self.index[result],
                     }
                 }
 
             percent_equaling_1 = float(sum(result))/len(not_null)
             return {
-                "success" : percent_equaling_1 >= mostly,
+                "success": percent_equaling_1 >= mostly,
                 'result': {
-                    "unexpected_list" : unexpected_values[:20],
-                    "unexpected_index_list" : list(self.index[result==False])[:20],
+                    "unexpected_list": unexpected_values[:20],
+                    "unexpected_index_list": list(self.index[result == False])[:20],
                 }
             }
         else:
             return {
-                "success" : len(unexpected_values) == 0,
+                "success": len(unexpected_values) == 0,
                 'result': {
-                    "unexpected_list" : unexpected_values[:20],
-                    "unexpected_index_list" : list(self.index[result==False])[:20],
+                    "unexpected_list": unexpected_values[:20],
+                    "unexpected_index_list": list(self.index[result == False])[:20],
                 }
             }
+
 
 class TestCustomClass(unittest.TestCase):
 
@@ -95,7 +97,8 @@ class TestCustomClass(unittest.TestCase):
         )
         df.set_default_expectation_argument("result_format", "COMPLETE")
         self.assertEqual(
-            df.expect_column_values_to_be_prime('Age')['result']['unexpected_list'],
+            df.expect_column_values_to_be_prime(
+                'Age')['result']['unexpected_list'],
             [30.0, 25.0, 0.92000000000000004, 63.0, 39.0, 58.0, 50.0, 24.0, 36.0, 26.0, 25.0, 25.0, 28.0, 45.0, 39.0,
              30.0, 58.0, 45.0, 22.0, 48.0, 44.0, 60.0, 45.0, 58.0, 36.0, 33.0, 36.0, 36.0, 14.0, 49.0, 36.0, 46.0, 27.0,
              27.0, 26.0, 64.0, 39.0, 55.0, 70.0, 69.0, 36.0, 39.0, 38.0, 27.0, 27.0, 4.0, 27.0, 50.0, 48.0, 49.0, 48.0,
@@ -133,33 +136,40 @@ class TestCustomClass(unittest.TestCase):
              27.0, 15.0, 27.0, 26.0, 22.0, 24.0]
         )
 
-        primes = [3,5,7,11,13,17,23,31]
+        primes = [3, 5, 7, 11, 13, 17, 23, 31]
         df["primes"] = df.Age.map(lambda x: random.choice(primes))
         self.assertEqual(
-            df.expect_column_values_to_be_prime("primes")['result']['unexpected_list'],
+            df.expect_column_values_to_be_prime(
+                "primes")['result']['unexpected_list'],
             []
         )
 
     def test_custom_expectation(self):
-        df = CustomPandasDataset({'x': [1,1,1,1,2]})
+        df = CustomPandasDataset({'x': [1, 1, 1, 1, 2]})
         df.set_default_expectation_argument("result_format", "COMPLETE")
 
         out = df.expect_column_values_to_be_prime('x')
-        t = {'out': {'unexpected_list':[1,1,1,1],'unexpected_index_list':[0,1,2,3], 'success':False}}
+        t = {'out': {'unexpected_list': [1, 1, 1, 1], 'unexpected_index_list': [
+            0, 1, 2, 3], 'success': False}}
         self.assertEqual(t['out']['success'], out['success'])
         if 'unexpected_index_list' in t['out']:
-            self.assertEqual(t['out']['unexpected_index_list'], out['result']['unexpected_index_list'])
+            self.assertEqual(t['out']['unexpected_index_list'],
+                             out['result']['unexpected_index_list'])
         if 'unexpected_list' in t['out']:
-            self.assertEqual(t['out']['unexpected_list'], out['result']['unexpected_list'])
+            self.assertEqual(t['out']['unexpected_list'],
+                             out['result']['unexpected_list'])
 
         out = df.expect_column_values_to_equal_1('x', mostly=.8)
         print(out)
-        t = {'out': {'unexpected_list':[2],'unexpected_index_list':[4],'success':True}}
+        t = {'out': {'unexpected_list': [
+            2], 'unexpected_index_list': [4], 'success': True}}
         self.assertEqual(t['out']['success'], out['success'])
         if 'unexpected_index_list' in t['out']:
-            self.assertEqual(t['out']['unexpected_index_list'], out['result']['unexpected_index_list'])
+            self.assertEqual(t['out']['unexpected_index_list'],
+                             out['result']['unexpected_index_list'])
         if 'unexpected_list' in t['out']:
-            self.assertEqual(t['out']['unexpected_list'], out['result']['unexpected_list'])
+            self.assertEqual(t['out']['unexpected_list'],
+                             out['result']['unexpected_list'])
 
    # Ensure that Custom Data Set classes can properly call non-overridden methods from their parent class
     def test_base_class_expectation(self):
@@ -170,7 +180,8 @@ class TestCustomClass(unittest.TestCase):
         })
 
         self.assertEqual(
-            df.expect_column_values_to_be_between("aaa", min_value=1, max_value=5)['success'],
+            df.expect_column_values_to_be_between(
+                "aaa", min_value=1, max_value=5)['success'],
             True
         )
 
@@ -192,13 +203,13 @@ class TestValidation(unittest.TestCase):
 
         with open('./tests/test_sets/expected_results_20180303.json') as f:
             expected_results = json.load(f)
-            #print json.dumps(expected_results, indent=2)
+            # print json.dumps(expected_results, indent=2)
 
         self.maxDiff = None
         assertDeepAlmostEqual(
-                              results,
-                              expected_results
-                              )
+            results,
+            expected_results
+        )
 
         # Now, change the results and ensure they are no longer equal
         results[0] = {}
@@ -209,48 +220,49 @@ class TestValidation(unittest.TestCase):
         # Finally, confirm that only_return_failures works
         # and does not affect the "statistics" field.
         validation_results = my_df.validate(only_return_failures=True)
-        #print json.dumps(validation_results)
+        # print json.dumps(validation_results)
         assertDeepAlmostEqual(
             validation_results,
             {"results": [
                 {"expectation_config": {
-                     "expectation_type": "expect_column_values_to_be_in_set",
-                     "kwargs": {"column": "PClass", "value_set": ["1st", "2nd", "3rd"], "result_format": "COMPLETE"}
-                 },
-                 "success": False,
-                 "exception_info": {"exception_message": None,
-                                    "exception_traceback": None,
-                                    "raised_exception": False},
-                 "result": {"partial_unexpected_index_list": [456], "unexpected_count": 1, "unexpected_list": ["*"],
-                                "unexpected_percent": 0.0007616146230007616, "element_count": 1313,
-                                "missing_percent": 0.0, "partial_unexpected_counts": [{"count": 1, "value": "*"}],
-                                "partial_unexpected_list": ["*"],
-                                "unexpected_percent_nonmissing": 0.0007616146230007616, "missing_count": 0,
-                                "unexpected_index_list": [456]}}
+                    "expectation_type": "expect_column_values_to_be_in_set",
+                    "kwargs": {"column": "PClass", "value_set": ["1st", "2nd", "3rd"], "result_format": "COMPLETE"}
+                },
+                    "success": False,
+                    "exception_info": {"exception_message": None,
+                                       "exception_traceback": None,
+                                       "raised_exception": False},
+                    "result": {"partial_unexpected_index_list": [456], "unexpected_count": 1, "unexpected_list": ["*"],
+                               "unexpected_percent": 0.0007616146230007616, "element_count": 1313,
+                               "missing_percent": 0.0, "partial_unexpected_counts": [{"count": 1, "value": "*"}],
+                               "partial_unexpected_list": ["*"],
+                               "unexpected_percent_nonmissing": 0.0007616146230007616, "missing_count": 0,
+                               "unexpected_index_list": [456]}}
             ],
-            "success": expected_results["success"],  # unaffected
-            "statistics": expected_results["statistics"],  # unaffected
+                "success": expected_results["success"],  # unaffected
+                "statistics": expected_results["statistics"],  # unaffected
             }
         )
 
     def test_validate_catch_non_existent_expectation(self):
         df = ge.dataset.PandasDataset({
-            "x" : [1,2,3,4,5]
+            "x": [1, 2, 3, 4, 5]
         })
 
         validation_config_non_existent_expectation = {
-            "dataset_name" : None,
+            "dataset_name": None,
             "meta": {
                 "great_expectations.__version__": ge.__version__
             },
-            "expectations" : [{
-                "expectation_type" : "non_existent_expectation",
-                "kwargs" : {
-                    "column" : "x"
+            "expectations": [{
+                "expectation_type": "non_existent_expectation",
+                "kwargs": {
+                    "column": "x"
                 }
             }]
         }
-        results = df.validate(expectations_config=validation_config_non_existent_expectation)['results']
+        results = df.validate(
+            expectations_config=validation_config_non_existent_expectation)['results']
 
         self.assertIn(
             "object has no attribute 'non_existent_expectation'",
@@ -263,21 +275,22 @@ class TestValidation(unittest.TestCase):
         })
 
         validation_config_invalid_parameter = {
-            "dataset_name" : None,
+            "dataset_name": None,
             "meta": {
                 "great_expectations.__version__": ge.__version__
             },
-            "expectations" : [{
-                "expectation_type" : "expect_column_values_to_be_between",
-                "kwargs" : {
-                    "column" : "x",
-                    "min_value" : 6,
-                    "max_value" : 5
+            "expectations": [{
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": {
+                    "column": "x",
+                    "min_value": 6,
+                    "max_value": 5
                 }
             }]
         }
 
-        results = df.validate(expectations_config=validation_config_invalid_parameter)['results']
+        results = df.validate(expectations_config=validation_config_invalid_parameter)[
+            'results']
         print(results[0]['exception_info'])
         self.assertIn(
             "min_value cannot be greater than max_value",
@@ -286,76 +299,76 @@ class TestValidation(unittest.TestCase):
 
     def test_top_level_validate(self):
         my_df = pd.DataFrame({
-            "x" : [1,2,3,4,5]
+            "x": [1, 2, 3, 4, 5]
         })
         validation_result = ge.validate(my_df, {
-            "dataset_name" : None,
+            "dataset_name": None,
             "meta": {
                 "great_expectations.__version__": ge.__version__
             },
-            "expectations" : [{
-                "expectation_type" : "expect_column_to_exist",
-                "kwargs" : {
-                    "column" : "x"
+            "expectations": [{
+                "expectation_type": "expect_column_to_exist",
+                "kwargs": {
+                    "column": "x"
                 }
-            },{
-                "expectation_type" : "expect_column_values_to_be_between",
-                "kwargs" : {
-                    "column" : "x",
-                    "min_value" : 3,
-                    "max_value" : 5
+            }, {
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": {
+                    "column": "x",
+                    "min_value": 3,
+                    "max_value": 5
                 }
             }]
         })
         self.assertEqual(
             validation_result,
             {
-              "results": [
-                {
-                  "expectation_config": {
-                      "kwargs": {
-                          "column": "x"
-                      },
-                      "expectation_type": "expect_column_to_exist",
-                  },
-                  "exception_info": {"exception_message": None,
-                                    "exception_traceback": None,
-                                    "raised_exception": False},
-                  "success": True
-                },
-                {
-                    "expectation_config": {
-                        "expectation_type": "expect_column_values_to_be_between",
-                        "kwargs": {
-                            "column": "x",
-                            "max_value": 5,
-                            "min_value": 3
-                        }
+                "results": [
+                    {
+                        "expectation_config": {
+                            "kwargs": {
+                                "column": "x"
+                            },
+                            "expectation_type": "expect_column_to_exist",
+                        },
+                        "exception_info": {"exception_message": None,
+                                           "exception_traceback": None,
+                                           "raised_exception": False},
+                        "success": True
                     },
-                    "exception_info": {"exception_message": None,
-                                        "exception_traceback": None,
-                                        "raised_exception": False},
-                    "success": False,
-                    "result": {'element_count': 5,
-                                 'missing_count': 0,
-                                 'missing_percent': 0.0,
-                                 "unexpected_percent": 0.4,
-                                 "partial_unexpected_list": [
-                                      1,
-                                      2
-                                 ],
-                                 "unexpected_percent_nonmissing": 0.4,
-                                 "unexpected_count": 2
+                    {
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_be_between",
+                            "kwargs": {
+                                "column": "x",
+                                "max_value": 5,
+                                "min_value": 3
+                            }
+                        },
+                        "exception_info": {"exception_message": None,
+                                           "exception_traceback": None,
+                                           "raised_exception": False},
+                        "success": False,
+                        "result": {'element_count': 5,
+                                   'missing_count': 0,
+                                   'missing_percent': 0.0,
+                                   "unexpected_percent": 0.4,
+                                   "partial_unexpected_list": [
+                                       1,
+                                       2
+                                   ],
+                                   "unexpected_percent_nonmissing": 0.4,
+                                   "unexpected_count": 2
+                                   }
                     }
+                ],
+                "success": False,
+                "statistics": {
+                    "evaluated_expectations": 2,
+                    "successful_expectations": 1,
+                    "unsuccessful_expectations": 1,
+                    "success_percent": 50,
                 }
-              ],
-              "success": False,
-              "statistics": {
-                  "evaluated_expectations": 2,
-                  "successful_expectations": 1,
-                  "unsuccessful_expectations": 1,
-                  "success_percent": 50,
-              }
             }
         )
 
@@ -423,19 +436,21 @@ class TestRepeatedAppendExpectation(unittest.TestCase):
         with open("./tests/test_sets/titanic_expectations.json") as f:
             my_expectations_config = json.load(f)
 
-        my_df = ge.read_csv("./tests/test_sets/Titanic.csv", autoinspect_func=columns_exist)
+        my_df = ge.read_csv("./tests/test_sets/Titanic.csv",
+                            autoinspect_func=columns_exist)
 
         self.assertEqual(
             len(my_df.get_expectations_config()['expectations']),
             7
         )
 
-        #For column_expectations, _append_expectation should only replace expectations where the expetation_type AND the column match
+        # For column_expectations, _append_expectation should only replace expectations where the expetation_type AND the column match
         my_df.expect_column_to_exist("PClass")
         self.assertEqual(
             len(my_df.get_expectations_config()['expectations']),
             7
         )
+
 
 class TestIO(unittest.TestCase):
 
@@ -453,7 +468,7 @@ class TestIO(unittest.TestCase):
 
         df = ge.read_json(
             script_path+'/test_sets/nested_test_json_data_file.json',
-            accessor_func= lambda x: x["data"]
+            accessor_func=lambda x: x["data"]
         )
 
     def test_read_excel(self):

--- a/tests/test_pandas_dataset.py
+++ b/tests/test_pandas_dataset.py
@@ -15,144 +15,147 @@ def test_expect_column_values_to_match_strftime_format():
     """
 
     D = ge.dataset.PandasDataset({
-        'x' : [1,2,4],
-        'us_dates' : ['4/30/2017','4/30/2017','7/4/1776'],
-        'us_dates_type_error' : ['4/30/2017','4/30/2017', 5],
-        'almost_iso8601' : ['1977-05-25T00:00:00', '1980-05-21T13:47:59', '2017-06-12T23:57:59'],
-        'almost_iso8601_val_error' : ['1977-05-55T00:00:00', '1980-05-21T13:47:59', '2017-06-12T23:57:59'],
-        'already_datetime' : [datetime.datetime(2015,1,1), datetime.datetime(2016,1,1), datetime.datetime(2017,1,1)]
+        'x': [1, 2, 4],
+        'us_dates': ['4/30/2017', '4/30/2017', '7/4/1776'],
+        'us_dates_type_error': ['4/30/2017', '4/30/2017', 5],
+        'almost_iso8601': ['1977-05-25T00:00:00', '1980-05-21T13:47:59', '2017-06-12T23:57:59'],
+        'almost_iso8601_val_error': ['1977-05-55T00:00:00', '1980-05-21T13:47:59', '2017-06-12T23:57:59'],
+        'already_datetime': [datetime.datetime(2015, 1, 1), datetime.datetime(2016, 1, 1), datetime.datetime(2017, 1, 1)]
     })
     D.set_default_expectation_argument("result_format", "COMPLETE")
 
     T = [
-            {
-                'in':{'column':'us_dates', 'strftime_format':'%m/%d/%Y'},
-                'out':{'success':True, 'unexpected_index_list':[], 'unexpected_list':[]}
+        {
+            'in': {'column': 'us_dates', 'strftime_format': '%m/%d/%Y'},
+            'out': {'success': True, 'unexpected_index_list': [], 'unexpected_list':[]}
+        },
+        {
+            'in': {'column': 'us_dates_type_error', 'strftime_format': '%m/%d/%Y', 'mostly': 0.5, 'catch_exceptions': True},
+            # 'out':{'success':True, 'unexpected_index_list':[2], 'unexpected_list':[5]}},
+            'error': {
+                'traceback_substring': 'TypeError'
             },
-            {
-                'in':{'column':'us_dates_type_error','strftime_format':'%m/%d/%Y', 'mostly': 0.5, 'catch_exceptions': True},
-                # 'out':{'success':True, 'unexpected_index_list':[2], 'unexpected_list':[5]}},
-                'error':{
-                    'traceback_substring' : 'TypeError'
-                },
-            },
-            {
-                'in':{'column':'us_dates_type_error','strftime_format':'%m/%d/%Y', 'catch_exceptions': True},
-                'error':{
-                    'traceback_substring' : 'TypeError'
-                }
-            },
-            {
-                'in':{'column':'almost_iso8601','strftime_format':'%Y-%m-%dT%H:%M:%S'},
-                'out':{'success':True,'unexpected_index_list':[], 'unexpected_list':[]}},
-            {
-                'in':{'column':'almost_iso8601_val_error','strftime_format':'%Y-%m-%dT%H:%M:%S'},
-                'out':{'success':False,'unexpected_index_list':[0], 'unexpected_list':['1977-05-55T00:00:00']}},
-            {
-                'in':{'column':'already_datetime','strftime_format':'%Y-%m-%d', 'catch_exceptions':True},
-                # 'out':{'success':False,'unexpected_index_list':[0], 'unexpected_list':['1977-05-55T00:00:00']},
-                'error':{
-                    'traceback_substring' : 'TypeError: Values passed to expect_column_values_to_match_strftime_format must be of type string.'
-                },
+        },
+        {
+            'in': {'column': 'us_dates_type_error', 'strftime_format': '%m/%d/%Y', 'catch_exceptions': True},
+            'error': {
+                'traceback_substring': 'TypeError'
             }
+        },
+        {
+            'in': {'column': 'almost_iso8601', 'strftime_format': '%Y-%m-%dT%H:%M:%S'},
+            'out': {'success': True, 'unexpected_index_list': [], 'unexpected_list':[]}},
+        {
+            'in': {'column': 'almost_iso8601_val_error', 'strftime_format': '%Y-%m-%dT%H:%M:%S'},
+            'out': {'success': False, 'unexpected_index_list': [0], 'unexpected_list':['1977-05-55T00:00:00']}},
+        {
+            'in': {'column': 'already_datetime', 'strftime_format': '%Y-%m-%d', 'catch_exceptions': True},
+            # 'out':{'success':False,'unexpected_index_list':[0], 'unexpected_list':['1977-05-55T00:00:00']},
+            'error': {
+                'traceback_substring': 'TypeError: Values passed to expect_column_values_to_match_strftime_format must be of type string.'
+            },
+        }
     ]
 
     for t in T:
         out = D.expect_column_values_to_match_strftime_format(**t['in'])
         if 'out' in t:
-            assert t['out']['success']==out['success']
+            assert t['out']['success'] == out['success']
             if 'unexpected_index_list' in t['out']:
-                assert t['out']['unexpected_index_list']==out['result']['unexpected_index_list']
+                assert t['out']['unexpected_index_list'] == out['result']['unexpected_index_list']
             if 'unexpected_list' in t['out']:
-                assert t['out']['unexpected_list']==out['result']['unexpected_list']
+                assert t['out']['unexpected_list'] == out['result']['unexpected_list']
         elif 'error' in t:
-            assert out['exception_info']['raised_exception']==True
+            assert out['exception_info']['raised_exception'] == True
             assert t['error']['traceback_substring'] in out['exception_info']['exception_traceback']
+
 
 def test_expect_column_values_to_be_dateutil_parseable():
 
     D = ge.dataset.PandasDataset({
-        'c1':['03/06/09','23 April 1973','January 9, 2016'],
-        'c2':['9/8/2012','covfefe',25],
-        'c3':['Jared','June 1, 2013','July 18, 1976'],
-        'c4':['1', '2', '49000004632'],
-        'already_datetime' : [datetime.datetime(2015,1,1), datetime.datetime(2016,1,1), datetime.datetime(2017,1,1)],
+        'c1': ['03/06/09', '23 April 1973', 'January 9, 2016'],
+        'c2': ['9/8/2012', 'covfefe', 25],
+        'c3': ['Jared', 'June 1, 2013', 'July 18, 1976'],
+        'c4': ['1', '2', '49000004632'],
+        'already_datetime': [datetime.datetime(2015, 1, 1), datetime.datetime(2016, 1, 1), datetime.datetime(2017, 1, 1)],
     })
     D.set_default_expectation_argument("result_format", "COMPLETE")
 
     T = [
-            {
-                'in':{'column': 'c1'},
-                'out':{'success':True, 'unexpected_list':[], 'unexpected_index_list': []}},
-            {
-                'in':{"column":'c2', "catch_exceptions":True},
-                # 'out':{'success':False, 'unexpected_list':['covfefe', 25], 'unexpected_index_list': [1, 2]}},
-                'error':{ 'traceback_substring' : 'TypeError: Values passed to expect_column_values_to_be_dateutil_parseable must be of type string' },
-            },
-            {
-                'in':{"column":'c3'},
-                'out':{'success':False, 'unexpected_list':['Jared'], 'unexpected_index_list': [0]}},
-            {
-                'in':{'column': 'c3', 'mostly':.5},
-                'out':{'success':True, 'unexpected_list':['Jared'], 'unexpected_index_list': [0]}
-            },
-            {
-                'in':{'column': 'c4'},
-                'out':{'success':False, 'unexpected_list':['49000004632'], 'unexpected_index_list': [2]}
-            },
-            {
-                'in':{'column':'already_datetime', 'catch_exceptions':True},
-                'error':{ 'traceback_substring' : 'TypeError: Values passed to expect_column_values_to_be_dateutil_parseable must be of type string' },
-            }
+        {
+            'in': {'column': 'c1'},
+            'out': {'success': True, 'unexpected_list': [], 'unexpected_index_list': []}},
+        {
+            'in': {"column": 'c2', "catch_exceptions": True},
+            # 'out':{'success':False, 'unexpected_list':['covfefe', 25], 'unexpected_index_list': [1, 2]}},
+            'error': {'traceback_substring': 'TypeError: Values passed to expect_column_values_to_be_dateutil_parseable must be of type string'},
+        },
+        {
+            'in': {"column": 'c3'},
+            'out': {'success': False, 'unexpected_list': ['Jared'], 'unexpected_index_list': [0]}},
+        {
+            'in': {'column': 'c3', 'mostly': .5},
+            'out': {'success': True, 'unexpected_list': ['Jared'], 'unexpected_index_list': [0]}
+        },
+        {
+            'in': {'column': 'c4'},
+            'out': {'success': False, 'unexpected_list': ['49000004632'], 'unexpected_index_list': [2]}
+        },
+        {
+            'in': {'column': 'already_datetime', 'catch_exceptions': True},
+            'error': {'traceback_substring': 'TypeError: Values passed to expect_column_values_to_be_dateutil_parseable must be of type string'},
+        }
     ]
 
     for t in T:
         out = D.expect_column_values_to_be_dateutil_parseable(**t['in'])
         if 'out' in t:
-            assert t['out']['success']==out['success']
-            assert t['out']['unexpected_index_list']==out['result']['unexpected_index_list']
-            assert t['out']['unexpected_list']==out['result']['unexpected_list']
+            assert t['out']['success'] == out['success']
+            assert t['out']['unexpected_index_list'] == out['result']['unexpected_index_list']
+            assert t['out']['unexpected_list'] == out['result']['unexpected_list']
         elif 'error' in t:
-            assert out['exception_info']['raised_exception']==True
+            assert out['exception_info']['raised_exception'] == True
             assert t['error']['traceback_substring'] in out['exception_info']['exception_traceback']
 
 
 def test_expect_column_values_to_be_json_parseable():
-    d1 = json.dumps({'i':[1,2,3],'j':35,'k':{'x':'five','y':5,'z':'101'}})
-    d2 = json.dumps({'i':1,'j':2,'k':[3,4,5]})
-    d3 = json.dumps({'i':'a', 'j':'b', 'k':'c'})
-    d4 = json.dumps({'i':[4,5], 'j':[6,7], 'k':[8,9], 'l':{4:'x', 5:'y', 6:'z'}})
+    d1 = json.dumps({'i': [1, 2, 3], 'j': 35, 'k': {
+                    'x': 'five', 'y': 5, 'z': '101'}})
+    d2 = json.dumps({'i': 1, 'j': 2, 'k': [3, 4, 5]})
+    d3 = json.dumps({'i': 'a', 'j': 'b', 'k': 'c'})
+    d4 = json.dumps({'i': [4, 5], 'j': [6, 7], 'k': [
+                    8, 9], 'l': {4: 'x', 5: 'y', 6: 'z'}})
     D = ge.dataset.PandasDataset({
-        'json_col':[d1,d2,d3,d4],
-        'not_json':[4,5,6,7],
-        'py_dict':[{'a':1, 'out':1},{'b':2, 'out':4},{'c':3, 'out':9},{'d':4, 'out':16}],
-        'most':[d1,d2,d3,'d4']
+        'json_col': [d1, d2, d3, d4],
+        'not_json': [4, 5, 6, 7],
+        'py_dict': [{'a': 1, 'out': 1}, {'b': 2, 'out': 4}, {'c': 3, 'out': 9}, {'d': 4, 'out': 16}],
+        'most': [d1, d2, d3, 'd4']
     })
     D.set_default_expectation_argument("result_format", "COMPLETE")
 
     T = [
-            {
-                'in':{'column':'json_col'},
-                'out':{'success':True, 'unexpected_index_list':[], 'unexpected_list':[]}},
-            {
-                'in':{'column':'not_json'},
-                'out':{'success':False, 'unexpected_index_list':[0,1,2,3], 'unexpected_list':[4,5,6,7]}},
-            {
-                'in':{'column':'py_dict'},
-                'out':{'success':False, 'unexpected_index_list':[0,1,2,3], 'unexpected_list':[{'a':1, 'out':1},{'b':2, 'out':4},{'c':3, 'out':9},{'d':4, 'out':16}]}},
-            {
-                'in':{'column':'most'},
-                'out':{'success':False, 'unexpected_index_list':[3], 'unexpected_list':['d4']}},
-            {
-                'in':{'column':'most', 'mostly':.75},
-                'out':{'success':True, 'unexpected_index_list':[3], 'unexpected_list':['d4']}}
+        {
+            'in': {'column': 'json_col'},
+            'out': {'success': True, 'unexpected_index_list': [], 'unexpected_list':[]}},
+        {
+            'in': {'column': 'not_json'},
+            'out': {'success': False, 'unexpected_index_list': [0, 1, 2, 3], 'unexpected_list':[4, 5, 6, 7]}},
+        {
+            'in': {'column': 'py_dict'},
+            'out': {'success': False, 'unexpected_index_list': [0, 1, 2, 3], 'unexpected_list':[{'a': 1, 'out': 1}, {'b': 2, 'out': 4}, {'c': 3, 'out': 9}, {'d': 4, 'out': 16}]}},
+        {
+            'in': {'column': 'most'},
+            'out': {'success': False, 'unexpected_index_list': [3], 'unexpected_list':['d4']}},
+        {
+            'in': {'column': 'most', 'mostly': .75},
+            'out': {'success': True, 'unexpected_index_list': [3], 'unexpected_list':['d4']}}
     ]
 
     for t in T:
         out = D.expect_column_values_to_be_json_parseable(**t['in'])
-        assert t['out']['success']==out['success']
-        assert t['out']['unexpected_index_list']==out['result']['unexpected_index_list']
-        assert t['out']['unexpected_list']==out['result']['unexpected_list']
+        assert t['out']['success'] == out['success']
+        assert t['out']['unexpected_index_list'] == out['result']['unexpected_index_list']
+        assert t['out']['unexpected_list'] == out['result']['unexpected_list']
 
 # def test_expect_column_values_to_match_json_schema(self):
 
@@ -176,38 +179,36 @@ def test_expect_column_values_to_be_json_parseable():
 def test_expectation_decorator_summary_mode():
 
     df = ge.dataset.PandasDataset({
-        'x' : [1,2,3,4,5,6,7,7,None,None],
+        'x': [1, 2, 3, 4, 5, 6, 7, 7, None, None],
     })
     df.set_default_expectation_argument("result_format", "COMPLETE")
 
     # print '&'*80
     # print json.dumps(df.expect_column_values_to_be_between('x', min_value=1, max_value=5, result_format="SUMMARY"), indent=2)
 
-    
-    exp_output={
-        "success" : False,
-        "result" : {
-            "element_count" : 10,
-            "missing_count" : 2,
-            "missing_percent" : .2,
-            "unexpected_count" : 3,
+    exp_output = {
+        "success": False,
+        "result": {
+            "element_count": 10,
+            "missing_count": 2,
+            "missing_percent": .2,
+            "unexpected_count": 3,
             "partial_unexpected_counts": [
                 {"value": 7.0,
                     "count": 2},
-                 {"value": 6.0,
+                {"value": 6.0,
                     "count": 1}
             ],
             "unexpected_percent": 0.3,
             "unexpected_percent_nonmissing": 0.375,
-            "partial_unexpected_list" : [6.0,7.0,7.0],
-            "partial_unexpected_index_list": [5,6,7],
+            "partial_unexpected_list": [6.0, 7.0, 7.0],
+            "partial_unexpected_index_list": [5, 6, 7],
         }
     }
     assert df.expect_column_values_to_be_between('x', min_value=1, max_value=5, result_format="SUMMARY")\
-    ==exp_output
-        
-        
-    exp_output={
+        == exp_output
+
+    exp_output = {
         'success': True,
         'result': {
             'observed_value': 4.375,
@@ -216,119 +217,122 @@ def test_expectation_decorator_summary_mode():
             'missing_percent': .2
         },
     }
-    
+
     assert df.expect_column_mean_to_be_between("x", 3, 7, result_format="SUMMARY")\
-    ==exp_output
+        == exp_output
+
 
 def test_positional_arguments():
 
     df = ge.dataset.PandasDataset({
-        'x':[1,3,5,7,9],
-        'y':[2,4,6,8,10],
-        'z':[None,'a','b','c','abc']
+        'x': [1, 3, 5, 7, 9],
+        'y': [2, 4, 6, 8, 10],
+        'z': [None, 'a', 'b', 'c', 'abc']
     })
     df.set_default_expectation_argument('result_format', 'COMPLETE')
-    
-    exp_output={'success':True, 'result': {'observed_value': 5, 'element_count': 5,
-            'missing_count': 0,
-            'missing_percent': 0.0}}
 
-    assert df.expect_column_mean_to_be_between('x',4,6)==exp_output
-        
+    exp_output = {'success': True, 'result': {'observed_value': 5, 'element_count': 5,
+                                              'missing_count': 0,
+                                              'missing_percent': 0.0}}
 
-    out = df.expect_column_values_to_be_between('y',1,6)
-    t = {'out': {'success':False, 'unexpected_list':[8,10], 'unexpected_index_list': [3,4]}}
+    assert df.expect_column_mean_to_be_between('x', 4, 6) == exp_output
+
+    out = df.expect_column_values_to_be_between('y', 1, 6)
+    t = {'out': {'success': False, 'unexpected_list': [
+        8, 10], 'unexpected_index_list': [3, 4]}}
     if 'out' in t:
-        assert t['out']['success']==out['success']
+        assert t['out']['success'] == out['success']
         if 'unexpected_index_list' in t['out']:
-            assert t['out']['unexpected_index_list']==out['result']['unexpected_index_list']
+            assert t['out']['unexpected_index_list'] == out['result']['unexpected_index_list']
         if 'unexpected_list' in t['out']:
-            assert t['out']['unexpected_list']==out['result']['unexpected_list']
+            assert t['out']['unexpected_list'] == out['result']['unexpected_list']
 
-    out = df.expect_column_values_to_be_between('y',1,6,mostly=.5)
-    t = {'out': {'success':True, 'unexpected_list':[8,10], 'unexpected_index_list':[3,4]}}
+    out = df.expect_column_values_to_be_between('y', 1, 6, mostly=.5)
+    t = {'out': {'success': True, 'unexpected_list': [
+        8, 10], 'unexpected_index_list': [3, 4]}}
     if 'out' in t:
-        assert t['out']['success']==out['success']
+        assert t['out']['success'] == out['success']
         if 'unexpected_index_list' in t['out']:
-            assert t['out']['unexpected_index_list']==out['result']['unexpected_index_list']
+            assert t['out']['unexpected_index_list'] == out['result']['unexpected_index_list']
         if 'unexpected_list' in t['out']:
-            assert t['out']['unexpected_list']==out['result']['unexpected_list']
+            assert t['out']['unexpected_list'] == out['result']['unexpected_list']
 
-    out = df.expect_column_values_to_be_in_set('z',['a','b','c'])
-    t = {'out': {'success':False, 'unexpected_list':['abc'], 'unexpected_index_list':[4]}}
+    out = df.expect_column_values_to_be_in_set('z', ['a', 'b', 'c'])
+    t = {'out': {'success': False, 'unexpected_list': [
+        'abc'], 'unexpected_index_list': [4]}}
     if 'out' in t:
-        assert t['out']['success']==out['success']
+        assert t['out']['success'] == out['success']
         if 'unexpected_index_list' in t['out']:
-            assert t['out']['unexpected_index_list']==out['result']['unexpected_index_list']
+            assert t['out']['unexpected_index_list'] == out['result']['unexpected_index_list']
         if 'unexpected_list' in t['out']:
-            assert t['out']['unexpected_list']==out['result']['unexpected_list']
+            assert t['out']['unexpected_list'] == out['result']['unexpected_list']
 
-    out = df.expect_column_values_to_be_in_set('z',['a','b','c'],mostly=.5)
-    t = {'out': {'success':True, 'unexpected_list':['abc'], 'unexpected_index_list':[4]}}
+    out = df.expect_column_values_to_be_in_set('z', ['a', 'b', 'c'], mostly=.5)
+    t = {'out': {'success': True, 'unexpected_list': [
+        'abc'], 'unexpected_index_list': [4]}}
     if 'out' in t:
-        assert t['out']['success']==out['success']
+        assert t['out']['success'] == out['success']
         if 'unexpected_index_list' in t['out']:
-            assert t['out']['unexpected_index_list']==out['result']['unexpected_index_list']
+            assert t['out']['unexpected_index_list'] == out['result']['unexpected_index_list']
         if 'unexpected_list' in t['out']:
-            assert t['out']['unexpected_list']==out['result']['unexpected_list']
-
+            assert t['out']['unexpected_list'] == out['result']['unexpected_list']
 
 
 def test_result_format_argument_in_decorators():
     df = ge.dataset.PandasDataset({
-        'x':[1,3,5,7,9],
-        'y':[2,4,6,8,10],
-        'z':[None,'a','b','c','abc']
+        'x': [1, 3, 5, 7, 9],
+        'y': [2, 4, 6, 8, 10],
+        'z': [None, 'a', 'b', 'c', 'abc']
     })
     df.set_default_expectation_argument('result_format', 'COMPLETE')
 
-    #Test explicit Nones in result_format
-    
-    exp_output={'success':True, 'result': {'observed_value': 5, 'element_count': 5,
-        'missing_count': 0,
-        'missing_percent': 0.0
-        }}
-    assert df.expect_column_mean_to_be_between('x',4,6, result_format=None)\
-    ==exp_output
-        
-    exp_output={'result': {'element_count': 5,
-                'missing_count': 0,
-                'missing_percent': 0.0,
-                'partial_unexpected_counts': [{'count': 1, 'value': 8},
-                                                      {'count': 1, 'value': 10}],
-                'partial_unexpected_index_list': [3, 4],
-                'partial_unexpected_list': [8, 10],
-                'unexpected_count': 2,
-                'unexpected_index_list': [3, 4],
-                'unexpected_list': [8, 10],
-                'unexpected_percent': 0.4,
-                'unexpected_percent_nonmissing': 0.4},
-         'success': False}
+    # Test explicit Nones in result_format
 
-    assert df.expect_column_values_to_be_between('y',1,6, result_format=None)\
-    ==exp_output
+    exp_output = {'success': True, 'result': {'observed_value': 5, 'element_count': 5,
+                                              'missing_count': 0,
+                                              'missing_percent': 0.0
+                                              }}
+    assert df.expect_column_mean_to_be_between('x', 4, 6, result_format=None)\
+        == exp_output
 
-    #Test unknown output format
+    exp_output = {'result': {'element_count': 5,
+                             'missing_count': 0,
+                             'missing_percent': 0.0,
+                             'partial_unexpected_counts': [{'count': 1, 'value': 8},
+                                                           {'count': 1, 'value': 10}],
+                             'partial_unexpected_index_list': [3, 4],
+                             'partial_unexpected_list': [8, 10],
+                             'unexpected_count': 2,
+                             'unexpected_index_list': [3, 4],
+                             'unexpected_list': [8, 10],
+                             'unexpected_percent': 0.4,
+                             'unexpected_percent_nonmissing': 0.4},
+                  'success': False}
+
+    assert df.expect_column_values_to_be_between('y', 1, 6, result_format=None)\
+        == exp_output
+
+    # Test unknown output format
     with pytest.raises(ValueError):
-        df.expect_column_values_to_be_between('y',1,6, result_format="QUACK")
+        df.expect_column_values_to_be_between('y', 1, 6, result_format="QUACK")
 
     with pytest.raises(ValueError):
-        df.expect_column_mean_to_be_between('x',4,6, result_format="QUACK")
-        
+        df.expect_column_mean_to_be_between('x', 4, 6, result_format="QUACK")
+
 
 def test_from_pandas():
     pd_df = pd.DataFrame({
-        'x':[1,3,5,7,9],
-        'y':[2,4,6,8,10],
-        'z':[None,'a','b','c','abc']
+        'x': [1, 3, 5, 7, 9],
+        'y': [2, 4, 6, 8, 10],
+        'z': [None, 'a', 'b', 'c', 'abc']
     })
 
     ge_df = ge.from_pandas(pd_df)
     assert isinstance(ge_df, ge.dataset.Dataset)
-    assert list(ge_df.columns)==['x', 'y', 'z']
-    assert list(ge_df['x'])==list(pd_df['x'])
-    assert list(ge_df['y'])==list(pd_df['y'])
-    assert list(ge_df['z'])==list(pd_df['z'])
+    assert list(ge_df.columns) == ['x', 'y', 'z']
+    assert list(ge_df['x']) == list(pd_df['x'])
+    assert list(ge_df['y']) == list(pd_df['y'])
+    assert list(ge_df['z']) == list(pd_df['z'])
 
 
 def test_from_pandas_expectations_config():
@@ -337,7 +341,8 @@ def test_from_pandas_expectations_config():
         with open(file) as f:
             return json.load(f)
 
-    my_expectations_config = load_ge_config("./tests/test_sets/titanic_expectations.json")
+    my_expectations_config = load_ge_config(
+        "./tests/test_sets/titanic_expectations.json")
 
     pd_df = pd.read_csv("./tests/test_sets/Titanic.csv")
     my_df = ge.from_pandas(pd_df, expectations_config=my_expectations_config)
@@ -346,8 +351,8 @@ def test_from_pandas_expectations_config():
 
     results = my_df.validate(catch_exceptions=False)
 
-    expected_results = load_ge_config("./tests/test_sets/expected_results_20180303.json")
-
+    expected_results = load_ge_config(
+        "./tests/test_sets/expected_results_20180303.json")
 
     assertDeepAlmostEqual(results, expected_results)
 
@@ -384,7 +389,7 @@ def test_ge_pandas_concatenating_no_autoinspect():
     #      to the concatenated dataframes and still make sense (since no autoinspection happens).
 
     assert isinstance(df, ge.dataset.PandasDataset)
-    assert df.find_expectations()==exp_c
+    assert df.find_expectations() == exp_c
 
 
 def test_ge_pandas_joining():
@@ -424,7 +429,8 @@ def test_ge_pandas_joining():
     #   2. Have no expectations (no autoinspection)
 
     assert isinstance(df, ge.dataset.PandasDataset)
-    assert df.find_expectations()==exp_j
+    assert df.find_expectations() == exp_j
+
 
 def test_ge_pandas_merging():
     df1 = ge.dataset.PandasDataset({
@@ -459,7 +465,8 @@ def test_ge_pandas_merging():
     #   2. Have no expectations (no autoinspection is now default)
 
     assert isinstance(df, ge.dataset.PandasDataset)
-    assert df.find_expectations()==exp_m
+    assert df.find_expectations() == exp_m
+
 
 def test_ge_pandas_sampling():
     df = ge.dataset.PandasDataset({
@@ -484,11 +491,11 @@ def test_ge_pandas_sampling():
 
     samp1 = df.sample(n=2)
     assert isinstance(samp1, ge.dataset.PandasDataset)
-    assert samp1.find_expectations()==exp1
+    assert samp1.find_expectations() == exp1
 
     samp1 = df.sample(frac=0.25, replace=True)
     assert isinstance(samp1, ge.dataset.PandasDataset)
-    assert samp1.find_expectations()==exp1
+    assert samp1.find_expectations() == exp1
 
     # Change expectation on column "D", sample, and check expectations.
     # The failing expectation on column "D" is automatically dropped in
@@ -511,9 +518,7 @@ def test_ge_pandas_sampling():
         {'expectation_type': 'expect_column_values_to_be_in_set',
          'kwargs': {'column': 'C', 'value_set': ['a', 'b', 'c', 'd']}}
     ]
-    assert samp1.find_expectations()==exp1
-
-
+    assert samp1.find_expectations() == exp1
 
 
 def test_ge_pandas_sampling():
@@ -540,11 +545,11 @@ def test_ge_pandas_sampling():
 
     samp1 = df.sample(n=2)
     assert isinstance(samp1, ge.dataset.PandasDataset)
-    assert samp1.find_expectations()==exp1
+    assert samp1.find_expectations() == exp1
 
     samp1 = df.sample(frac=0.25, replace=True)
     assert isinstance(samp1, ge.dataset.PandasDataset)
-    assert samp1.find_expectations()==exp1
+    assert samp1.find_expectations() == exp1
 
     # Change expectation on column "D", sample, and check expectations.
     # The failing expectation on column "D" is NOT automatically dropped
@@ -569,15 +574,15 @@ def test_ge_pandas_sampling():
         {'expectation_type': 'expect_column_values_to_be_in_set',
          'kwargs': {'column': 'D', 'value_set': ['e', 'f', 'g', 'x']}}
     ]
-    assert samp1.find_expectations()==exp1
+    assert samp1.find_expectations() == exp1
 
 
 def test_ge_pandas_subsetting():
     df = ge.dataset.PandasDataset({
-        'A':[1,2,3,4],
-        'B':[5,6,7,8],
-        'C':['a','b','c','d'],
-        'D':['e','f','g','h']
+        'A': [1, 2, 3, 4],
+        'B': [5, 6, 7, 8],
+        'C': ['a', 'b', 'c', 'd'],
+        'D': ['e', 'f', 'g', 'h']
     })
 
     # Put some simple expectations on the data frame
@@ -595,35 +600,36 @@ def test_ge_pandas_subsetting():
 
     sub1 = df[['A', 'D']]
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     sub1 = df[['A']]
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     sub1 = df[:3]
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     sub1 = df[1:2]
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     sub1 = df[:-1]
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     sub1 = df[-1:]
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     sub1 = df.iloc[:3, 1:4]
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     sub1 = df.loc[0:, 'A':'B']
     assert isinstance(sub1, ge.dataset.PandasDataset)
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
+
 
 def test_ge_pandas_automatic_failure_removal():
     df = ge.dataset.PandasDataset({
@@ -662,12 +668,12 @@ def test_ge_pandas_automatic_failure_removal():
          'kwargs': {'column': 'D', 'value_set': ['e', 'f', 'g', 'h']}}
     ]
     samp1 = df.sample(n=2)
-    assert samp1.find_expectations()==exp1
+    assert samp1.find_expectations() == exp1
 
     # Now check subsetting to verify that failing expectations are NOT
     # automatically dropped when subsetting.
     sub1 = df[['A', 'D']]
-    assert sub1.find_expectations()==exp1
+    assert sub1.find_expectations() == exp1
 
     # Set property/attribute so that failing expectations are
     # automatically removed when sampling or subsetting.
@@ -691,7 +697,7 @@ def test_ge_pandas_automatic_failure_removal():
     ]
 
     samp2 = df.sample(n=2)
-    assert samp2.find_expectations()==exp_samp
+    assert samp2.find_expectations() == exp_samp
 
     # Now check subsetting. In additional to the failure on column "C",
     # the expectations on column "B" now fail since column "B" doesn't
@@ -707,9 +713,7 @@ def test_ge_pandas_automatic_failure_removal():
         {'expectation_type': 'expect_column_values_to_be_in_set',
          'kwargs': {'column': 'D', 'value_set': ['e', 'f', 'g', 'h']}}
     ]
-    assert sub2.find_expectations()==exp_sub
-
-
+    assert sub2.find_expectations() == exp_sub
 
 
 def test_subclass_pandas_subset_retains_subclass():
@@ -718,7 +722,7 @@ def test_subclass_pandas_subset_retains_subclass():
 
         @ge.dataset.MetaPandasDataset.column_map_expectation
         def expect_column_values_to_be_odd(self, column):
-            return column.map(lambda x: x % 2 )
+            return column.map(lambda x: x % 2)
 
         @ge.dataset.MetaPandasDataset.column_map_expectation
         def expectation_that_crashes_on_sixes(self, column):
@@ -736,12 +740,11 @@ def test_subclass_pandas_subset_retains_subclass():
     df2 = df.sample(frac=0.5)
     assert type(df2) == type(df)
 
-
     def test_validate_map_expectation_on_categorical_column(self):
         """Map expectations should work on categorical columns"""
 
         D = ge.dataset.PandasDataset({
-            'cat_column_1':['cat_one','cat_two','cat_one','cat_two', 'cat_one','cat_two', 'cat_one','cat_two'],
+            'cat_column_1': ['cat_one', 'cat_two', 'cat_one', 'cat_two', 'cat_one', 'cat_two', 'cat_one', 'cat_two'],
         })
 
         D['cat_column_1'] = D['cat_column_1'].astype('category')
@@ -751,6 +754,7 @@ def test_subclass_pandas_subset_retains_subclass():
         out = D.expect_column_value_lengths_to_equal('cat_column_1', 7)
 
         self.assertEqual(out['success'], True)
+
 
 def test_pandas_deepcopy():
     import copy

--- a/tests/test_parameter_substitution.py
+++ b/tests/test_parameter_substitution.py
@@ -1,5 +1,6 @@
 """
-Test the expectation decorator's ability to substitute parameters at evaluation time, and store parameters in expectations_config
+Test the expectation decorator's ability to substitute parameters
+at evaluation time, and store parameters in expectations_config
 """
 
 import pytest
@@ -11,6 +12,7 @@ from great_expectations.dataset import Dataset
 @pytest.fixture
 def dataset():
     return Dataset()
+
 
 @pytest.fixture
 def single_expectation_custom_dataset():
@@ -33,62 +35,81 @@ def single_expectation_custom_dataset():
 
 def test_store_evaluation_parameter(dataset):
     dataset.set_evaluation_parameter("my_parameter", "value")
-    val = dataset.get_evaluation_parameter("my_parameter")
     assert dataset.get_evaluation_parameter("my_parameter") == "value"
 
-    dataset.set_evaluation_parameter("my_second_parameter", [1, 2, "value", None, np.nan])
-    assert dataset.get_evaluation_parameter("my_second_parameter") == [1, 2, "value", None, np.nan]
+    dataset.set_evaluation_parameter(
+        "my_second_parameter", [1, 2, "value", None, np.nan])
+    assert dataset.get_evaluation_parameter("my_second_parameter") == [
+        1, 2, "value", None, np.nan]
 
     with pytest.raises(TypeError):
-        dataset.set_evaluation_parameter(["a", "list", "cannot", "be", "a", "parameter"], "value")
+        dataset.set_evaluation_parameter(
+            ["a", "list", "cannot", "be", "a", "parameter"], "value")
+
 
 def test_parameter_substitution(single_expectation_custom_dataset):
     # Set our evaluation parameter from upstream
-    single_expectation_custom_dataset.set_evaluation_parameter("upstream_dag_key", "upstream_dag_value")
+    single_expectation_custom_dataset.set_evaluation_parameter(
+        "upstream_dag_key", "upstream_dag_value")
 
     # Establish our expectation using that parameter
-    result = single_expectation_custom_dataset.expect_nothing(expectation_argument={"$PARAMETER": "upstream_dag_key"})
+    result = single_expectation_custom_dataset.expect_nothing(
+        expectation_argument={"$PARAMETER": "upstream_dag_key"})
     config = single_expectation_custom_dataset.get_expectations_config()
 
     # Ensure our value has been substituted during evaluation, and set properly in the config
     assert result["result"]["details"]["expectation_argument"] == "upstream_dag_value"
-    assert config["evaluation_parameters"] == {"upstream_dag_key": "upstream_dag_value"}
-    assert config["expectations"][0]["kwargs"] == {"expectation_argument": {"$PARAMETER": "upstream_dag_key"}}
+    assert config["evaluation_parameters"] == {
+        "upstream_dag_key": "upstream_dag_value"}
+    assert config["expectations"][0]["kwargs"] == {
+        "expectation_argument": {"$PARAMETER": "upstream_dag_key"}}
+
 
 def test_exploratory_parameter_substitution(single_expectation_custom_dataset):
     # Establish our expectation using a parameter provided at runtime
 
-    result = single_expectation_custom_dataset.expect_nothing(expectation_argument={"$PARAMETER": "upstream_dag_key",
-                                                                                    "$PARAMETER.upstream_dag_key": "temporary_value"})
+    result = single_expectation_custom_dataset.expect_nothing(
+        expectation_argument={"$PARAMETER": "upstream_dag_key",
+                              "$PARAMETER.upstream_dag_key": "temporary_value"})
     config = single_expectation_custom_dataset.get_expectations_config()
     # Ensure our value has been substituted during evaluation, and NOT stored in the config
     assert result["result"]["details"]["expectation_argument"] == "temporary_value"
-    assert "evaluation_parameters" not in config or config["evaluation_parameters"] == {}
-    assert config["expectations"][0]["kwargs"] == {"expectation_argument": {"$PARAMETER": "upstream_dag_key"}}
+    assert "evaluation_parameters" not in config or config["evaluation_parameters"] == {
+    }
+    assert config["expectations"][0]["kwargs"] == {
+        "expectation_argument": {"$PARAMETER": "upstream_dag_key"}}
 
     # Evaluating the expectation without the parameter should now fail, because no parameters were set
     with pytest.raises(KeyError) as excinfo:
         single_expectation_custom_dataset.validate(catch_exceptions=False)
-        assert str(excinfo.message) == "No value found for $PARAMETER upstream_dag_key"
+        assert str(
+            excinfo.message) == "No value found for $PARAMETER upstream_dag_key"
 
     # Setting a parameter value should allow it to succeed
-    single_expectation_custom_dataset.set_evaluation_parameter("upstream_dag_key", "upstream_dag_value")
+    single_expectation_custom_dataset.set_evaluation_parameter(
+        "upstream_dag_key", "upstream_dag_value")
     validation_result = single_expectation_custom_dataset.validate()
     assert validation_result["results"][0]["result"]["details"]["expectation_argument"] == "upstream_dag_value"
 
+
 def test_validation_substitution(single_expectation_custom_dataset):
     # Set up an expectation using a parameter, providing a default value.
-    result = single_expectation_custom_dataset.expect_nothing(expectation_argument={"$PARAMETER": "upstream_dag_key",
-                                                                                    "$PARAMETER.upstream_dag_key": "temporary_value"})
+    result = single_expectation_custom_dataset.expect_nothing(
+        expectation_argument={"$PARAMETER": "upstream_dag_key",
+                              "$PARAMETER.upstream_dag_key": "temporary_value"})
     assert result["result"]["details"]["expectation_argument"] == "temporary_value"
 
     # Provide a run-time evaluation parameter
-    validation_result = single_expectation_custom_dataset.validate(evaluation_parameters={"upstream_dag_key": "upstream_dag_value"})
+    validation_result = single_expectation_custom_dataset.validate(
+        evaluation_parameters={"upstream_dag_key": "upstream_dag_value"})
     assert validation_result["results"][0]["result"]["details"]["expectation_argument"] == "upstream_dag_value"
 
 
 def test_validation_parameters_returned(single_expectation_custom_dataset):
-    result = single_expectation_custom_dataset.expect_nothing(expectation_argument={"$PARAMETER": "upstream_dag_key",
-                                                                                    "$PARAMETER.upstream_dag_key": "temporary_value"})
-    validation_result = single_expectation_custom_dataset.validate(evaluation_parameters={"upstream_dag_key": "upstream_dag_value"})
-    assert validation_result["evaluation_parameters"] == {"upstream_dag_key": "upstream_dag_value"}
+    single_expectation_custom_dataset.expect_nothing(
+        expectation_argument={"$PARAMETER": "upstream_dag_key",
+                              "$PARAMETER.upstream_dag_key": "temporary_value"})
+    validation_result = single_expectation_custom_dataset.validate(
+        evaluation_parameters={"upstream_dag_key": "upstream_dag_value"})
+    assert validation_result["evaluation_parameters"] == {
+        "upstream_dag_key": "upstream_dag_value"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,9 @@ from sqlalchemy import create_engine
 from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
 import great_expectations.dataset.autoinspect as autoinspect
 
-## Taken from the following stackoverflow: https://stackoverflow.com/questions/23549419/assert-that-two-dictionaries-are-almost-equal
+
+# Taken from the following stackoverflow:
+# https://stackoverflow.com/questions/23549419/assert-that-two-dictionaries-are-almost-equal
 def assertDeepAlmostEqual(expected, actual, *args, **kwargs):
     """
     Assert that two complex structures have almost equal contents.
@@ -25,20 +27,20 @@ def assertDeepAlmostEqual(expected, actual, *args, **kwargs):
     try:
        # if isinstance(expected, (int, float, long, complex)):
         if isinstance(expected, (int, float, complex)):
-            assert expected==pytest.approx(actual, *args, **kwargs)
+            assert expected == pytest.approx(actual, *args, **kwargs)
         elif isinstance(expected, (list, tuple, np.ndarray)):
-            assert len(expected)==len(actual)
+            assert len(expected) == len(actual)
             for index in range(len(expected)):
                 v1, v2 = expected[index], actual[index]
                 assertDeepAlmostEqual(v1, v2,
                                       __trace=repr(index), *args, **kwargs)
         elif isinstance(expected, dict):
-            assert set(expected)==set(actual)
+            assert set(expected) == set(actual)
             for key in expected:
                 assertDeepAlmostEqual(expected[key], actual[key],
                                       __trace=repr(key), *args, **kwargs)
         else:
-            assert expected==actual
+            assert expected == actual
     except AssertionError as exc:
         exc.__dict__.setdefault('traces', []).append(trace)
         if is_root:
@@ -48,7 +50,8 @@ def assertDeepAlmostEqual(expected, actual, *args, **kwargs):
 
 
 def get_dataset(dataset_type, data, autoinspect_func=autoinspect.columns_exist):
-    """For Pandas, data should be either a DataFrame or a dictionary that can be instantiated as a DataFrame
+    """For Pandas, data should be either a DataFrame or a dictionary that can
+    be instantiated as a DataFrame.
     For SQL, data should have the following shape:
         {
             'table':
@@ -148,16 +151,20 @@ def evaluate_json_test(dataset, expectation_type, test):
     dataset.set_default_expectation_argument('result_format', 'COMPLETE')
 
     if 'title' not in test:
-        raise ValueError("Invalid test configuration detected: 'title' is required.")
+        raise ValueError(
+            "Invalid test configuration detected: 'title' is required.")
 
     if 'exact_match_out' not in test:
-        raise ValueError("Invalid test configuration detected: 'exact_match_out' is required.")
+        raise ValueError(
+            "Invalid test configuration detected: 'exact_match_out' is required.")
 
     if 'in' not in test:
-        raise ValueError("Invalid test configuration detected: 'in' is required.")
+        raise ValueError(
+            "Invalid test configuration detected: 'in' is required.")
 
     if 'out' not in test:
-        raise ValueError("Invalid test configuration detected: 'out' is required.")
+        raise ValueError(
+            "Invalid test configuration detected: 'out' is required.")
 
     # Pass the test if we are in a test condition that is a known exception
 
@@ -178,8 +185,9 @@ def evaluate_json_test(dataset, expectation_type, test):
             result = getattr(dataset, expectation_type)(**test['in'])
 
     except NotImplementedError:
-        #Note: This method of checking does not look for false negatives: tests that are incorrectly on the notimplemented_list
-        assert candidate_test_is_on_temporary_notimplemented_list(dataset.__class__.__name__, expectation_type), "Error: this test was supposed to return NotImplementedError"
+        # Note: This method of checking does not look for false negatives: tests that are incorrectly on the notimplemented_list
+        assert candidate_test_is_on_temporary_notimplemented_list(
+            dataset.__class__.__name__, expectation_type), "Error: this test was supposed to return NotImplementedError"
         return
 
     if 'suppress_test_for' in test:
@@ -211,14 +219,19 @@ def evaluate_json_test(dataset, expectation_type, test):
                     assert result['result']['unexpected_index_list'] == value
 
             elif key == 'unexpected_list':
-                assert result['result']['unexpected_list'] == value, "expected " + str(value) + " but got " + str(result['result']['unexpected_list'])
+                assert result['result']['unexpected_list'] == value, "expected " + \
+                    str(value) + " but got " + \
+                    str(result['result']['unexpected_list'])
 
             elif key == 'details':
                 assert result['result']['details'] == value
 
             elif key == 'traceback_substring':
                 assert result['exception_info']['raised_exception']
-                assert value in result['exception_info']['exception_traceback'], "expected to find " + value + " in " + result['exception_info']['exception_traceback']
+                assert value in result['exception_info']['exception_traceback'], "expected to find " + \
+                    value + " in " + \
+                    result['exception_info']['exception_traceback']
 
             else:
-                raise ValueError("Invalid test specification: unknown key " + key + " in 'out'")
+                raise ValueError(
+                    "Invalid test specification: unknown key " + key + " in 'out'")


### PR DESCRIPTION
I accidentally PEP9-ified a file in a previous PR (my text editor runs a flake8 lint on save), and @jpcampb2 mentioned wanting to bring the code closer to PEP8. I figured the more standard and readable the code is, the easier it is to contribute, so I thought I'd run the codebase through my linter to make those changes and isolate them in one PR.

The linting changes include:
- standardizing the number of line breaks between imports and functions
- standardizing spacing in comments and variable assignment
- breaking up long lines
- removing unused imports (I did this by hand, and made sure it didn't affect the functionality)
- removing unused variable assignments (I removed a couple of stray variables from tests by hand)

None of these changes should affect the code functionality in any way. Of course, feel free to close the PR if this doesn't match the style you want for the codebase.