### PR TITLE
Add support for custom_sql for databases with multiple schemas (#387)

### DIFF
--- a/docs/source/roadmap_changelog.rst
+++ b/docs/source/roadmap_changelog.rst
@@ -14,6 +14,8 @@ Planned Features
 
 v.0.4.4__develop
 ----------------
+* Enable custom_sql datasets for databases with multiple schemas, by
+  adding a fallback for column reflection (#387)
 * Remove `IF NOT EXISTS` check for custom sql temporary tables, for
   Redshift compatibility (#372)
 * Allow users to pass args/kwargs for engine creation in

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -5,7 +5,6 @@ from great_expectations.dataset import Dataset
 from functools import wraps
 import inspect
 from six import PY3
-import warnings
 
 from .util import DocInherit, parse_result_format, create_multiple_expectations
 
@@ -246,7 +245,9 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         try:
             insp = reflection.Inspector.from_engine(engine)
             self.columns = insp.get_columns(table_name, schema=schema)
-        except:
+        except KeyError:
+            # we will get a KeyError for temporary tables, since
+            # reflection will not find the temporary schema
             self.columns = self.column_reflection_fallback()
 
         # Only call super once connection is established and table_name and columns known to allow autoinspection

--- a/tests/column_aggregate_expectations/expect_column_mean_to_be_between.json
+++ b/tests/column_aggregate_expectations/expect_column_mean_to_be_between.json
@@ -112,6 +112,7 @@
       "tests": [{
           "title": "type mismatch: null observed_value",
           "exact_match_out": false,
+	  "suppress_test_for": ["SQLAlchemy"],
           "in": {
             "column": "s",
             "min_value": 0,

--- a/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
+++ b/tests/sqlalchemy_dataset/test_sqlalchemydataset.py
@@ -124,7 +124,7 @@ def test_sqlalchemydataset_with_custom_sql():
     assert result['success'] == False
 
 
-def test_column_fallback_error():
+def test_column_fallback():
     engine = sa.create_engine('sqlite://')
 
     data = pd.DataFrame({
@@ -134,10 +134,18 @@ def test_column_fallback_error():
     })
 
     data.to_sql(name='test_sql_data', con=engine, index=False)
+    dataset = SqlAlchemyDataset('test_sql_data', engine=engine)
     fallback_dataset = SqlAlchemyDataset('test_sql_data', engine=engine)
     # override columns attribute to test fallback
     fallback_dataset.columns = fallback_dataset.column_reflection_fallback()
 
-    with pytest.raises(NotImplementedError) as err:
-        fallback_dataset.expect_column_mean_to_be_between('age', min_value=10, max_value=38)
-        assert "This method is not supported for tables which cannot be reflected." in str(err)
+    # check that the results are the same for a few expectations
+    assert (dataset.expect_column_to_exist('age') == 
+            fallback_dataset.expect_column_to_exist('age'))
+
+    assert (dataset.expect_column_mean_to_be_between('age', min_value=10) == 
+            fallback_dataset.expect_column_mean_to_be_between('age', min_value=10))
+
+    # Test a failing expectation
+    assert (dataset.expect_table_row_count_to_equal(value=3) == 
+            fallback_dataset.expect_table_row_count_to_equal(value=3))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,7 +125,7 @@ def evaluate_json_test(dataset, expectation_type, test):
     """
     This method will evaluate the result of a test build using the Great Expectations json test format.
 
-    NOTE: Tests can be suppressed for certain data types if the test contains the Key 'suppress_tests_for' with a list
+    NOTE: Tests can be suppressed for certain data types if the test contains the Key 'suppress_test_for' with a list
         of Dataset types to suppress, such as ['SQLAlchemy', 'Pandas'].
 
     :param dataset: (Dataset) A great expectations Dataset


### PR DESCRIPTION
This was seriously a rabbit hole. As reported in #387, `SQLAlchemyDataset`s would fail during instantiation with `custom_sql` for databases with multiple schemas. This is because `insp.get_columns` requires a schema name, which is not available for the temporary tables created with the custom sql.

My approach here was to find a fallback for getting column information. Querying the database directly lets us get the column names, which is all that is needed for everything but `_is_numeric`, which requires column types. I noticed that `_is_numeric` is only called by `expect_column_mean_to_be_between`; since it's not called by `expect_column_median_to_be_between` or any other expectations, this suggested to me that the check is not that important, so I removed it. An alternate approach would be to raise a `NotImplementedError` when we don't have access to the column types, or to run a duck type check as a fallback in `_is_numeric`.

It looks like type-related checks aren't really supported for sql datasets right now in any case, so this seemed like the best option for now. Of course, I'm happy to revise if removing the numeric check will cause problems.

This is also functionality that should be tested as part of #386, but until the test suite includes postgres, I added a basic test that the fallback method doesn't break anything in sqlite.

Closes #387.