### PR TITLE
correct faulty isnull operator on table column with non null constraint for Redshift

### DIFF
--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -63,9 +63,20 @@ class MetaSqlAlchemyDataset(Dataset):
                         sa.column(column).is_(None) if None in ignore_values else False), 1)], else_=0)
                 ).label('null_count'),
                 sa.func.sum(
-                    sa.case([(sa.and_(sa.not_(expected_condition),
-                                      sa.column(column).is_(None) == False if None in ignore_values else True),
-                              1)], else_=0)
+                    sa.case([
+                        (
+                            sa.and_(
+                                sa.not_(expected_condition),
+                                sa.case([
+                                    (
+                                        sa.column(column).is_(None),
+                                        False
+                                    )
+                                ], else_=True) if None in ignore_values else True
+                            ),
+                            1
+                        )
+                    ], else_=0)
                 ).label('unexpected_count')
             ]).select_from(self._table)
 
@@ -86,8 +97,12 @@ class MetaSqlAlchemyDataset(Dataset):
                             sa.or_(
                                 # SA normally evaluates `== None` as `IS NONE`. However `sa.in_()`
                                 # replaces `None` as `NULL` in the list and incorrectly uses `== NULL`
-                                sa.column(column).is_(
-                                    None) == False if None in ignore_values else False,
+                                sa.case([
+                                    (
+                                        sa.column(column).is_(None),
+                                        False
+                                    )
+                                ], else_=True) if None in ignore_values else False,
                                 # Ignore any other values that are in the ignore list
                                 sa.column(column).in_(ignore_values) == False))
                 ).limit(unexpected_count_limit)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ six>=1.9.0
 jsonschema>=2.5.1
 sqlalchemy>=1.2
 xlrd>=1.1.0
-pyarrow==0.9.0
+pyarrow==0.11.0
 sphinxcontrib-napoleon>=0.6.1
 pypandoc>=1.4
 pytest>=3.2.5


### PR DESCRIPTION
Modified column_map_expectation in MetaSqlAlchemyDataset to cope with Redshift behaviour discussed [here](https://github.com/great-expectations/great_expectations/issues/392).

In addition, running tests on Mac required me to upgrade pyarrow to version 0.11.0.