### PR TITLE
pass metadata to expectation result

### DIFF
--- a/great_expectations/dataset/base.py
+++ b/great_expectations/dataset/base.py
@@ -185,6 +185,10 @@ class Dataset(object):
                 # Add a "success" object to the config
                 expectation_config["success_on_last_run"] = return_obj["success"]
 
+                # Add meta to return object
+                if meta is not None:
+                    return_obj['meta'] = meta
+
                 return_obj = recursively_convert_to_json_serializable(
                     return_obj)
                 return return_obj

--- a/tests/test_expectation_decorators.py
+++ b/tests/test_expectation_decorators.py
@@ -44,6 +44,21 @@ class TestExpectationDecorators(unittest.TestCase):
                           },
                          out['expectation_config'])
 
+    def test_expectation_decorator_meta(self):
+        metadata = {'meta_key': 'meta_value'}
+        eds = ExpectationOnlyDataset()
+        out = eds.no_op_value_expectation('a', meta=metadata)
+        config = eds.get_expectations_config()
+
+        self.assertEqual({'success': True,
+                          'meta': metadata},
+                         out)
+
+        self.assertEqual({'expectation_type': 'no_op_value_expectation',
+                          'kwargs': {'value': 'a'},
+                          'meta': metadata},
+                         config['expectations'][0])
+
     def test_expectation_decorator_catch_exceptions(self):
         eds = ExpectationOnlyDataset()
 


### PR DESCRIPTION
I noticed in the docs that I couldn't reproduce this code example where `meta` was passed to the expectation output: https://great-expectations.readthedocs.io/en/latest/standard_arguments.html#meta

I looked in the decorator that handles `meta` and saw that the value gets added to `expectation_config` but not `return_obj`, so here is a quick fix below. 

This is my first PR, so please let me know if there's anything I need to fix. Thanks!