### PR TITLE
Hotfix/#450

### DIFF
--- a/great_expectations/data_asset/base.py
+++ b/great_expectations/data_asset/base.py
@@ -817,17 +817,6 @@ If you wish to change this behavior, please set discard_failed_expectations, dis
                 if result_format is not None:
                     expectation['kwargs'].update({'result_format': result_format})
 
-                # Counting the number of unexpected values can be expensive when there is a large
-                # number of np.nan values.
-                # This only happens on expect_column_values_to_not_be_null expectations.
-                # Since there is no reason to look for most common unexpected values in this case,
-                # we will instruct the result formatting method to skip this step.
-
-                if expectation['expectation_type'] in ['expect_column_values_to_not_be_null',
-                                                       'expect_column_values_to_be_null']:
-                    expectation['kwargs']['result_format'] = parse_result_format(expectation['kwargs']['result_format'])
-                    expectation['kwargs']['result_format']['partial_unexpected_count'] = 0
-
                 # A missing parameter should raise a KeyError
                 evaluation_args = self._build_evaluation_parameters(
                     expectation['kwargs'], evaluation_parameters)

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -69,7 +69,12 @@ class MetaPandasDataset(Dataset):
             ignore_values = [None, np.nan]
             if func.__name__ in ['expect_column_values_to_not_be_null', 'expect_column_values_to_be_null']:
                 ignore_values = []
-                result_format['partial_unexpected_count'] = 0  # Optimization to avoid meaningless computation for these expectations
+                # Counting the number of unexpected values can be expensive when there is a large
+                # number of np.nan values.
+                # This only happens on expect_column_values_to_not_be_null expectations.
+                # Since there is no reason to look for most common unexpected values in this case,
+                # we will instruct the result formatting method to skip this step.
+                result_format['partial_unexpected_count'] = 0 
 
             series = self[column]
 
@@ -111,6 +116,7 @@ class MetaPandasDataset(Dataset):
                 del return_obj['result']['unexpected_percent_nonmissing']
                 try:
                     del return_obj['result']['partial_unexpected_counts']
+                    del return_obj['result']['partial_unexpected_list']
                 except KeyError:
                     pass
 


### PR DESCRIPTION
Remove update to result_format from validate, and instead use the decorator-based optimization.