### PR TITLE
Feature/parquet context

### DIFF
--- a/docs/source/data_contexts.rst
+++ b/docs/source/data_contexts.rst
@@ -22,6 +22,7 @@ There are currently four types of data contexts:
   - :ref:`PandasCSVDataContext`: The PandasCSVDataContext ('PandasCSV') exposes a local directory containing files as datasets.
   - :ref:`SqlAlchemyDataContext`: The SqlAlchemyDataContext ('SqlAlchemy') exposes tables from a SQL-compliant database as datasets.
   - :ref:`SparkCSVDataContext`: The SparkCSVDataContext ('SparkCSV') exposes csv files accessible from a SparkSQL context.
+  - :ref:`SparkParquetDataContext`: The SparkParquetDataContext ('SparkParquet') exposes parquet files accessible from a SparkSQL context.
   - :ref:`DatabricksTableContext`: The DatabricksTableContext ('DatabricksTable') exposes tables from a databricks notebook.
 
 All data contexts expose the following methods:
@@ -50,6 +51,14 @@ The `options` parameter for a SqlAlchemyDataContext is the sqlalchemy connection
 ---------------------
 
 The `options` parameter for a SparkCSVDataContext is a directory from which to read a CSV file, and options to pass to the reader.
+
+
+.. _SparkParquetDataContext:
+
+`SparkParquetDataContext`
+-------------------------
+
+The `options` parameter for a SparkParquetDataContext is a directory from which to read a Parquet file, and options to pass to the reader.
 
 
 .. _DatabricksTableContext:

--- a/great_expectations/data_context/__init__.py
+++ b/great_expectations/data_context/__init__.py
@@ -11,7 +11,7 @@ except ImportError:
 
 try:
     from .spark_context import SparkCSVDataContext
-    from .spark_parquet_context import SparkParquetContext
+    from .spark_parquet_context import SparkParquetDataContext
     from .databricks_context import DatabricksTableContext
 except ImportError:
     logger.info("Unable to load Spark contexts; install optional spark dependency for support")

--- a/great_expectations/data_context/__init__.py
+++ b/great_expectations/data_context/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
 
 try:
     from .spark_context import SparkCSVDataContext
+    from .spark_parquet_context import SparkParquetContext
     from .databricks_context import DatabricksTableContext
 except ImportError:
     logger.info("Unable to load Spark contexts; install optional spark dependency for support")
@@ -30,6 +31,8 @@ def get_data_context(context_type, options, *args, **kwargs):
         return PandasCSVDataContext(options, *args, **kwargs)
     elif context_type == "SparkCSV":
         return SparkCSVDataContext(options, *args, **kwargs)
+    elif context_type == "SparkParquet":
+        return SparkParquetDataContext(options, *args, **kwargs)
     elif context_type == "DatabricksTable":
         return DatabricksTableContext(options, *args, **kwargs)
     else:

--- a/great_expectations/data_context/spark_parquet_context.py
+++ b/great_expectations/data_context/spark_parquet_context.py
@@ -1,0 +1,34 @@
+import os
+import logging
+
+from .base import DataContext
+from ..dataset.sparkdf_dataset import SparkDFDataset
+
+logger = logging.getLogger(__name__)
+
+try:
+    from pyspark.sql import SparkSession
+except ImportError:
+    logger.error("Unable to load spark context; install optional spark dependency for support.")
+    raise
+
+class SparkParquetDataContext(DataContext):
+    """For now, functions like PandasCSVDataContext
+    """
+
+    def __init__(self, options, *args, **kwargs):
+        super(SparkParquetDataContext, self).__init__(options, *args, **kwargs)
+        self.spark = SparkSession.builder.getOrCreate()
+
+    def connect(self, options):
+        self.directory = options
+
+    def list_datasets(self):
+        return os.listdir(self.directory)
+
+    def get_dataset(self, dataset_name, caching=False, **kwargs):
+        reader = self.spark.read
+        for option in kwargs.items():
+            reader = reader.option(*option)
+        df = reader.parquet(os.path.join(self.directory, dataset_name))
+        return SparkDFDataset(df, caching=caching)

--- a/tests/test_data_contexts/test_data_contexts.py
+++ b/tests/test_data_contexts/test_data_contexts.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 import pandas as pd
 
 from great_expectations import get_data_context
-from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
+from great_expectations.dataset import PandasDataset, SqlAlchemyDataset, SparkDFDataset
 
 
 @pytest.fixture(scope="module")
@@ -57,3 +57,10 @@ def test_pandas_data_context(test_folder_connection_path):
     assert context.list_datasets() == ['test.csv']
     dataset = context.get_dataset('test.csv')
     assert isinstance(dataset, PandasDataset)
+
+def test_spark_csv_data_context(test_folder_connection_path):
+    context = get_data_context('SparkCSV', test_folder_connection_path)
+
+    assert context.list_datasets() == ['test.csv']
+    dataset = context.get_dataset('test.csv')
+    assert isinstance(dataset, SparkDFDataset)

--- a/tests/test_data_contexts/test_data_contexts.py
+++ b/tests/test_data_contexts/test_data_contexts.py
@@ -33,6 +33,16 @@ def test_folder_connection_path(tmpdir_factory):
     return str(path)
 
 
+@pytest.fixture(scope="module")
+def test_parquet_folder_connection_path(tmpdir_factory):
+    df1 = pd.DataFrame(
+        {'col_1': [1, 2, 3, 4, 5], 'col_2': ['a', 'b', 'c', 'd', 'e']})
+    path = tmpdir_factory.mktemp("parquet_context")
+    df1.to_parquet(path.join("test.parquet"))
+
+    return str(path)
+
+
 def test_invalid_data_context():
     # Test an unknown data context name
     with pytest.raises(ValueError) as err:
@@ -63,4 +73,11 @@ def test_spark_csv_data_context(test_folder_connection_path):
 
     assert context.list_datasets() == ['test.csv']
     dataset = context.get_dataset('test.csv')
+    assert isinstance(dataset, SparkDFDataset)
+
+def test_spark_parquet_data_context(test_parquet_folder_connection_path):
+    context = get_data_context('SparkParquet', test_parquet_folder_connection_path)
+
+    assert context.list_datasets() == ['test.parquet']
+    dataset = context.get_dataset('test.parquet')
     assert isinstance(dataset, SparkDFDataset)


### PR DESCRIPTION
Adds a parquet context for reading parquet files with spark similar to how csv is used.

I think there are probably better ways to do this, such as refactor to have a single class to read either csv or parquet using the fileFormat option.