### PR TITLE
Use non-lossy Series serialization for get_column_value_counts

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -58,6 +58,7 @@ Datetime and JSON parsing
 Aggregate functions
 --------------------------------------------------------------------------------
 
+* :func:`expect_column_distinct_values_to_be_in_set <great_expectations.dataset.dataset.Dataset.expect_column_distinct_values_to_be_in_set>`
 * :func:`expect_column_distinct_values_to_contain_set <great_expectations.dataset.dataset.Dataset.expect_column_distinct_values_to_contain_set>`
 * :func:`expect_column_distinct_values_to_equal_set <great_expectations.dataset.dataset.Dataset.expect_column_distinct_values_to_equal_set>`
 * :func:`expect_column_mean_to_be_between <great_expectations.dataset.dataset.Dataset.expect_column_mean_to_be_between>`

--- a/great_expectations/data_asset/util.py
+++ b/great_expectations/data_asset/util.py
@@ -178,7 +178,14 @@ def recursively_convert_to_json_serializable(test_obj):
         return float(round(test_obj, sys.float_info.dig))
 
     elif isinstance(test_obj, pd.Series):
-        return recursively_convert_to_json_serializable(test_obj.to_dict())
+        # Converting a series is tricky since the index may not be a string, but all json
+        # keys must be strings. So, we use a very ugly serialization strategy
+        index_name = test_obj.index.name or "index"
+        value_name = test_obj.name or "value"
+        return [{
+            index_name: recursively_convert_to_json_serializable(idx),
+            value_name: recursively_convert_to_json_serializable(val)
+        } for idx, val in test_obj.iteritems()]
 
     elif isinstance(test_obj, pd.DataFrame):
         return recursively_convert_to_json_serializable(test_obj.to_dict(orient='records'))

--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -2765,17 +2765,17 @@ class Dataset(MetaDataset):
         na_counts = test_df.isnull().sum()
 
         # Handle NaN: if we expected something that's not there, it's just not there.
-        test_df[column] = test_df[column].fillna(0)
+        test_df["count"] = test_df["count"].fillna(0)
         # Handle NaN: if something's there that was not expected, substitute the relevant value for tail_weight_holdout
-        if na_counts['expected'] > 0:
+        if na_counts["expected"] > 0:
             # Scale existing expected values
-            test_df['expected'] = test_df['expected'] * (1 - tail_weight_holdout)
+            test_df["expected"] = test_df["expected"] * (1 - tail_weight_holdout)
             # Fill NAs with holdout.
-            test_df['expected'] = test_df['expected'].fillna(
-                element_count * (tail_weight_holdout / na_counts['expected']))
+            test_df["expected"] = test_df["expected"].fillna(
+                element_count * (tail_weight_holdout / na_counts["expected"]))
 
         test_result = stats.chisquare(
-            test_df[column], test_df['expected'])[1]
+            test_df["count"], test_df["expected"])[1]
 
         return {
             "success": test_result > p,
@@ -2784,11 +2784,11 @@ class Dataset(MetaDataset):
                 "details": {
                     "observed_partition": {
                         "values": test_df.index.tolist(),
-                        "weights": test_df[column].tolist()
+                        "weights": test_df["count"].tolist()
                     },
                     "expected_partition": {
                         "values": test_df.index.tolist(),
-                        "weights": test_df['expected'].tolist()
+                        "weights": test_df["expected"].tolist()
                     }
                 }
             }
@@ -3028,7 +3028,7 @@ class Dataset(MetaDataset):
             na_counts = test_df.isnull().sum()
 
             # Handle NaN: if we expected something that's not there, it's just not there.
-            pk = test_df[column].fillna(0)
+            pk = test_df["count"].fillna(0)
             # Handle NaN: if something's there that was not expected, substitute the relevant value for tail_weight_holdout
             if na_counts['expected'] > 0:
                 # Scale existing expected values

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -344,7 +344,11 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         return len(nonnull_values)
 
     def get_column_value_counts(self, column):
-        return self[column].value_counts()
+        cnts =  self[column].value_counts()
+        cnts.sort_index(inplace=True)
+        cnts.name = "count"
+        cnts.index.name = "value"
+        return cnts
 
     def get_column_unique_count(self, column):
         return self.get_column_value_counts(column).shape[0]

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -218,13 +218,16 @@ class SparkDFDataset(MetaSparkDFDataset):
             .count()\
             .orderBy(column)\
             .collect()
-        # assuming this won't get too big
-        return pd.Series(
+        series = pd.Series(
             [row['count'] for row in value_counts],
-            index=[row[column] for row in value_counts],
-            # don't know about including name here
-            name=column,
+            index=pd.Index(
+                data=[row[column] for row in value_counts],
+                name="value"
+            ),
+            name="count"
         )
+        series.sort_index(inplace=True)
+        return series
 
     def get_column_unique_count(self, column):
         return self.get_column_value_counts(column).shape[0]

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -283,11 +283,16 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             ]).where(sa.column(column) != None) \
               .group_by(sa.column(column)) \
               .select_from(self._table)).fetchall()
-        return pd.Series(
+        series = pd.Series(
             [row[1] for row in results],
-            index=[row[0] for row in results],
-            name=column
+            index=pd.Index(
+                data=[row[0] for row in results],
+                name="value"
+            ),
+            name="count"
         )
+        series.sort_index(inplace=True)
+        return series
 
     def get_column_mean(self, column):
         return self.engine.execute(

--- a/tests/test_dataset_implementations/test_dataset_implementations.json
+++ b/tests/test_dataset_implementations/test_dataset_implementations.json
@@ -151,30 +151,68 @@
             "expected": 3
         },
         {
+            "_note": "this test tests the value of this method *after serialization* see python test_get_column_value_counts for series test",
             "func": "get_column_value_counts",
             "dataset": "d2",
             "kwargs": {
                 "column": "b"
             },
-            "expected": {
-                "a": 1,
-                "b": 2,
-                "c": 3,
-                "d": 4
-            }
+            "expected": [
+                {
+                    "value": "a",
+                    "count": 1
+                },
+                {
+                    "value": "b",
+                    "count": 2
+                },
+                {
+                    "value": "c",
+                    "count": 3
+                },
+                {
+                    "value": "d",
+                    "count": 4
+                }
+            ]
         },
         {
+            "_note": "this test tests the value of this method *after serialization* see python test_get_column_value_counts for series test",
             "func": "get_column_value_counts",
             "dataset": "d2",
             "kwargs": {
                 "column": "c"
             },
-            "expected": {
-                "a": 1,
-                "b": 2,
-                "c": 3,
-                "d": 1
-            }
+            "expected": [
+                {
+                    "value": "a",
+                    "count": 1
+                },
+                {
+                    "value": "b",
+                    "count": 2
+                },
+                {
+                    "value": "c",
+                    "count": 3
+                },
+                {
+                    "value": "d",
+                    "count": 1
+                }
+            ]
+        },
+        {
+            "_note": "this test tests the value of this method *after serialization* see python test_get_column_value_counts for series test",
+            "func": "get_column_value_counts",
+            "dataset": "d1",
+            "kwargs": {
+                "column": "y"
+            },
+            "expected": [{
+                "value": 5,
+                "count": 2
+            }]
         },
         {
             "func": "get_column_max",

--- a/tests/test_dataset_implementations/test_dataset_implementations.py
+++ b/tests/test_dataset_implementations/test_dataset_implementations.py
@@ -1,13 +1,16 @@
+import pytest
+
 import json
 import os
 from collections import OrderedDict
 
+import numpy as np
+import pandas as pd
+
 from ..conftest import CONTEXTS
 from ..test_utils import get_dataset, candidate_getter_is_on_temporary_notimplemented_list
 
-import pytest
-import numpy as np
-
+from great_expectations.data_asset.util import recursively_convert_to_json_serializable
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 test_config_path = os.path.join(dir_path, 'test_dataset_implementations.json')
@@ -34,11 +37,121 @@ def test_implementations(context, test):
     func = getattr(dataset, test['func'])
     result = func(**test.get('kwargs', {}))
 
-    # can't serialize pd.Series to json, so convert to dict and compare
+    # NOTE: we cannot serialize pd.Series to json directly,
+    # so we're going to test our preferred serialization.
+    # THIS TEST DOES NOT REPRESENT THE EXPECTED RETURN VALUE
+    # OF THE TESTED FUNCTION; THIS IS A JOINT TEST OF THE 
+    # JSON SERIALIZATION AND THE TEST.
+    # See test_get_column_value_counts for a series-specific test
     if test['func'] == 'get_column_value_counts':
-        result = result.to_dict()
+        result = recursively_convert_to_json_serializable(result)
 
     if 'tolerance' in test:
         assert np.allclose(test['expected'], result, test['tolerance'])
+    elif isinstance(test['expected'], list):
+        for item in test['expected']:
+            assert item in result
     else:
         assert test['expected'] == result
+
+@pytest.mark.parametrize('context', CONTEXTS)
+def test_get_column_value_counts(context):
+    schemas = {
+        "SparkDFDataset": {
+            "x": "FloatType",
+            "y": "IntegerType",
+            "z": "IntegerType",
+            "n": "IntegerType",
+            "b": "BooleanType"
+        }
+    }
+    data = {
+                "x": [2.0, 5.0],
+                "y": [5, 5],
+                "z": [0, 10],
+                "n": [0, None],
+                "b": [True, False]
+            }
+    dataset = get_dataset(context, data, schemas=schemas)
+
+    res = dataset.get_column_value_counts("x")
+    expected = pd.Series(data["x"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+
+    assert res.equals(expected)
+
+    res = dataset.get_column_value_counts("y")
+    expected = pd.Series(data["y"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)
+
+    res = dataset.get_column_value_counts("z")
+    expected = pd.Series(data["z"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)
+
+    res = dataset.get_column_value_counts("n")
+    expected = pd.Series(data["n"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)
+
+
+    res = dataset.get_column_value_counts("b")
+    expected = pd.Series(data["b"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)
+
+    data = {
+            "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "b": ["a", "b", "b", "c", "c", "c", "d", "d", "d", "d"],
+            "c": ["a", "b", "b", "c", "c", "c", "d", None, None, None],
+            "d": ["a", "b", "c", "d", "e", "f", "g", None, None, None]
+    }
+    schemas = {
+        "SparkDFDataset": {
+            "a": "IntegerType",
+            "b": "StringType",
+            "c": "StringType",
+            "d": "StringType"
+        }
+    }
+    dataset = get_dataset(context, data, schemas=schemas)
+
+    res = dataset.get_column_value_counts("a")
+    expected = pd.Series(data["a"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)
+
+    res = dataset.get_column_value_counts("b")
+    expected = pd.Series(data["b"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)
+
+
+    res = dataset.get_column_value_counts("c")
+    expected = pd.Series(data["c"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)
+
+    res = dataset.get_column_value_counts("d")
+    expected = pd.Series(data["d"]).value_counts()
+    expected.sort_index(inplace=True)
+    expected.index.name = "value"
+    expected.name = "count"
+    assert res.equals(expected)

--- a/tests/test_definitions/column_aggregate_expectations/expect_column_distinct_values_to_be_in_set.json
+++ b/tests/test_definitions/column_aggregate_expectations/expect_column_distinct_values_to_be_in_set.json
@@ -1,0 +1,189 @@
+{
+  "expectation_type": "expect_column_distinct_values_to_be_in_set",
+  "datasets": [{
+    "data": {
+            "dist1" : [1,2,3,4,5,6,7,8],
+            "dist2" : [1,2,3,4,5,null,null,null],
+            "dist3" : [2,2,2,2,5,6,7,8],
+            "dist4" : [1,1,1,1,2,null,null,null]
+        },
+    "tests": [
+      {
+        "title": "Basic positive test",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist1",
+          "value_set": [1,2,3,4,5,6,7,8,9]
+        },
+        "out": {
+          "success": true,
+          "observed_value": [1,2,3,4,5,6,7,8],
+          "value_counts": [
+            {"value": 1,
+              "count": 1
+            },
+            {"value": 2,
+              "count": 1
+              },
+            {"value": 3,
+              "count": 1
+            },
+            {"value": 4,
+              "count": 1
+            },
+            {"value": 5,
+              "count": 1
+            },
+            {"value": 6,
+              "count": 1
+            },
+            {"value": 7,
+              "count": 1
+            },
+            {"value": 8,
+              "count": 1
+            }
+          ]
+        }
+      },
+      {
+        "title": "Positive test with null values in column",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist2",
+          "value_set": [1,2,3,4,5]
+        },
+        "out": {
+          "success": true,
+          "observed_value": [1,2,3,4,5],
+          "value_counts": [
+            {"value": 1,
+              "count": 1
+            },
+            {"value": 2,
+              "count": 1
+              },
+            {"value": 3,
+              "count": 1
+            },
+            {"value": 4,
+              "count": 1
+            },
+            {"value": 5,
+              "count": 1
+            }
+          ]
+        }
+      },
+      {
+        "title": "Positive test with duplicate values in column",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist3",
+          "value_set": [2,5,6,7,8,9]
+        },
+        "out": {
+          "success": true,
+          "observed_value": [2,5,6,7,8],
+          "value_counts": [
+            {"value": 2,
+              "count": 4
+            },
+            {"value": 5,
+              "count": 1
+            },
+            {"value": 6,
+              "count": 1
+            },
+            {"value": 7,
+              "count": 1
+            },
+            {"value": 8,
+              "count": 1
+            }
+          ]
+        }
+      },
+      {
+        "title": "Positive test; duplicate and null values",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist4",
+          "value_set": [1,2,9]
+        },
+        "out": {
+          "success": true,
+          "observed_value": [1, 2],
+          "value_counts": [
+            {"value": 1,
+              "count": 4
+            },
+            {"value": 2,
+              "count": 1
+            }
+          ]
+        }
+      },
+      {
+        "title": "Basic negative test, no set intersection",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist1",
+          "value_set": [9]
+        },
+        "out": {
+          "success": false,
+          "observed_value": [1,2,3,4,5,6,7,8]
+        }
+      },
+      {
+        "title": "Negative test, some set intersection and extra",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist1",
+          "value_set": [2,3,4,5,6,7,8,9]
+        },
+        "out": {
+          "success": false,
+          "observed_value": [1,2,3,4,5,6,7,8]
+        }
+      },
+      {
+        "title": "Negative test with null values in column",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist2",
+          "value_set": [1,2,3,4]
+        },
+        "out": {
+          "success": false,
+          "observed_value": [1,2,3,4,5]
+        }
+      },
+      {
+        "title": "Negative test with duplicate values in column",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist3",
+          "value_set": [2,5,6,7]
+        },
+        "out": {
+          "success": false,
+          "observed_value": [2,5,6,7,8]
+        }
+      },
+      {
+        "title": "Negative test; duplicate and null values",
+        "exact_match_out": false,
+        "in": {
+          "column": "dist4",
+          "value_set": [1]
+        },
+        "out": {
+          "success": false,
+          "observed_value": [1, 2]
+        }
+      }
+    ]
+  }]
+}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -253,6 +253,7 @@ def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type
             # "expect_column_values_to_be_in_type_list",
             # "expect_column_values_to_be_in_set",
             # "expect_column_values_to_not_be_in_set",
+            # "expect_column_distinct_values_to_be_in_set",
             # "expect_column_distinct_values_to_equal_set",
             # "expect_column_distinct_values_to_contain_set",
             # "expect_column_values_to_be_between",
@@ -299,6 +300,7 @@ def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type
             "expect_column_values_to_be_in_type_list",
             # "expect_column_values_to_be_in_set",
             # "expect_column_values_to_not_be_in_set",
+            # "expect_column_distinct_values_to_be_in_set",
             # "expect_column_distinct_values_to_equal_set",
             # "expect_column_distinct_values_to_contain_set",
             "expect_column_values_to_be_between",
@@ -413,6 +415,10 @@ def evaluate_json_test(data_asset, expectation_type, test):
 
             elif key == 'details':
                 assert result['result']['details'] == value
+
+            elif key == "value_counts":
+                for val_count in value:
+                    assert val_count in result["result"]["details"]["value_counts"]
 
             elif key.startswith("observed_cdf"):
                 if "x_-1" in key:


### PR DESCRIPTION
@eugmandel one part of this PR worth special thought: this changes the behavior of get_column_value_counts to *sort the value counts by index*.

This was a consideration I added more for testing than any other reason; I opted to choose that default behavior because the *json serialized* version of the datastructure, if requested, is an array; consequently it could be useful to accelerate search for a specific value.

But it has one-and-a-half downsides: (1) we are *not* sorted by value (which could also be a common access pattern), and (half) it could be wasted compute for the most common use (i.e. for distributional expectations); counting as half because such a series is likely to be joined to a different distribution, so the sorting on join key will actually help. Meh.