### PR TITLE
Feature/content block kl graphs

### DIFF
--- a/great_expectations/render/renderer/fancy_column_section_renderer.py
+++ b/great_expectations/render/renderer/fancy_column_section_renderer.py
@@ -268,6 +268,7 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
             "expect_column_values_to_be_in_set"
         )
 
+        # FIXME: This logic is very brittle. It will work on profiled EVRs, but not much else.
         if set_evr and "partial_unexpected_counts" in set_evr["result"]:
             result_key = "partial_unexpected_counts"
         elif set_evr and "partial_unexpected_list" in set_evr["result"]:
@@ -294,13 +295,13 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
                 },
                 "styling": {
                     "default": {
-                        "classes": ["badge", "badge-secondary"]
+                        "classes": ["badge", "badge-info"]
                     }
                 }
             } for value in values],
             "styling": {
                 "classes": classes,
-                "styles" : {
+                "styles": {
                     "margin-top": "20px",
                 }
             }
@@ -346,13 +347,17 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
         bars = alt.Chart(df).mark_bar().encode(
             x='bins:O',
             y="weights:Q"
-        ).properties(width=286, height=180)
+        ).properties(width=240, height=200)
 
-        chart = bars
+        # chart = bars
+        chart = json.loads(bars.to_json())
+        # print(json.dumps(chart, indent=2))
+        # del chart["config"]
+        print(json.dumps(chart, indent=2))
 
         new_block = {
             "content_block_type": "graph",
-            "graph": chart.to_json(),
+            "graph": json.dumps(chart),
             "styling": {
                 "classes": ["col-6"]
             }

--- a/great_expectations/render/renderer/fancy_column_section_renderer.py
+++ b/great_expectations/render/renderer/fancy_column_section_renderer.py
@@ -40,10 +40,11 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
         # cls._render_column_type(evrs, content_blocks)
         cls._render_overview_table(evrs, content_blocks)
         cls._render_stats_table(evrs, content_blocks)
+
+        cls._render_histogram(evrs, content_blocks)
         cls._render_values_set(evrs, content_blocks)
 
         # cls._render_statistics(evrs, content_blocks)
-        cls._render_histogram(evrs, content_blocks)
         # cls._render_common_values(evrs, content_blocks)
         # cls._render_extreme_values(evrs, content_blocks)
 
@@ -347,21 +348,23 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
         bars = alt.Chart(df).mark_bar().encode(
             x='bins:O',
             y="weights:Q"
-        ).properties(width=240, height=200)
+        ).properties(width=200, height=200, autosize="fit")
 
         # chart = bars
         chart = json.loads(bars.to_json())
         # print(json.dumps(chart, indent=2))
         # del chart["config"]
-        print(json.dumps(chart, indent=2))
+        # print(json.dumps(chart, indent=2))
 
         new_block = {
             "content_block_type": "graph",
+            "header": "Histogram",
             "graph": json.dumps(chart),
             "styling": {
-                "classes": ["col-6"]
+                "classes": ["col-4"]
             }
         }
+        # print(json.dumps(new_block))
         content_blocks.append(new_block)
 
         # TODO: A deprecated version of this code lives in this method. We should review carefully, keep any bits that are useful, then delete.

--- a/great_expectations/render/renderer/fancy_column_section_renderer.py
+++ b/great_expectations/render/renderer/fancy_column_section_renderer.py
@@ -87,7 +87,6 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
             column_type_list = cls._find_evr_by_type(
                 evrs, "expect_column_values_to_be_in_type_list"
             )["expectation_config"]["kwargs"]["type_list"]
-            print(column_type_list)
             column_type = ", ".join(column_type_list)
 
         except TypeError:
@@ -307,7 +306,7 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
                 }
             }
         }
-        print(new_block)
+        # print(new_block)
 
         content_blocks.append(new_block)
 

--- a/great_expectations/render/renderer/fancy_column_section_renderer.py
+++ b/great_expectations/render/renderer/fancy_column_section_renderer.py
@@ -317,13 +317,16 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
         bars = alt.Chart(df).mark_bar().encode(
             x='bins:O',
             y="weights:Q"
-        ).properties(height=240, width=240)
+        ).properties(height=200)
 
-        chart = (bars).properties(height=240)
+        chart = bars
 
         new_block = {
             "content_block_type": "graph",
-            "graph": chart.to_json()
+            "graph": chart.to_json(),
+            "styling": {
+                "classes": ["col-4"]
+            }
         }
         content_blocks.append(new_block)
 

--- a/great_expectations/render/renderer/fancy_column_section_renderer.py
+++ b/great_expectations/render/renderer/fancy_column_section_renderer.py
@@ -295,14 +295,12 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
 
     @classmethod
     def _render_histogram(cls, evrs, content_blocks):
-        # FIXME: Eugene, here's where the logic for using "cardinality" in form of which expectations are defined
-        # should determine which blocks are generated
-        # Relatedly, this will change to grab values_list and to use expect_column_distinct_values_to_be_in_set
+        # NOTE: This code is very brittle
         kl_divergence_evr = cls._find_evr_by_type(
             evrs,
             "expect_column_kl_divergence_to_be_less_than"
         )
-        print(json.dumps(kl_divergence_evr, indent=2))
+        # print(json.dumps(kl_divergence_evr, indent=2))
         if kl_divergence_evr == None:
             return
 
@@ -329,7 +327,7 @@ class FancyDescriptiveColumnSectionRenderer(ColumnSectionRenderer):
         }
         content_blocks.append(new_block)
 
-        # TODO:
+        # TODO: A deprecated version of this code lives in this method. We should review carefully, keep any bits that are useful, then delete.
         # content_blocks.append(
         #     GraphContentBlockRenderer.render(
         #         kl_divergence_evr,

--- a/great_expectations/render/view/templates/component.j2
+++ b/great_expectations/render/view/templates/component.j2
@@ -67,7 +67,9 @@
             // Assign the specification to a local variable vlSpec.
             const vlSpec = {{content_block["graph"]}};
             // Embed the visualization in the container with id `vis`
-            vegaEmbed('#{{content_block_id}}-body', vlSpec, {actions: false}).then(result=>console.log(result)).catch(console.warn);
+            vegaEmbed('#{{content_block_id}}-body', vlSpec, {
+                actions: false
+            }).then(result=>console.log(result)).catch(console.warn);
         </script>
     {%- elif content_block["content_block_type"] == "table" -%}
         <table id="{{content_block_id}}-body" {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>

--- a/great_expectations/render/view/templates/component.j2
+++ b/great_expectations/render/view/templates/component.j2
@@ -45,13 +45,14 @@
         {{ content_block["header"] }}
     </h3>
     {%- elif content_block["content_block_type"] == "text" -%}
-        <p id="{{content-block-id}}-body" {{ content_block_body_styling }}>
+        <p id="{{content_sblock_id}}-body" {{ content_block_body_styling }}>
             {{content_block["content"][0]}}
         </p>
     {%- elif content_block["content_block_type"] == "value_list" -%}
-        <p id="{{content-block-id}}-body" {{ content_block_body_styling }}>
-        {% for value_count in content_block["value_list"] %}
-            <span class="param-span">{{value_count["value"]}}</span>
+        <p id="{{content_block_id}}-body" {{ content_block_body_styling }}>
+        {% for value in content_block["value_list"] %}
+            {# <span class="param-span">{{value}}</span> #}
+            {{ value | render_string_template }}
         {% endfor %}
         </p>
     {%- elif content_block["content_block_type"] == "bullet_list" -%}

--- a/great_expectations/render/view/templates/component.j2
+++ b/great_expectations/render/view/templates/component.j2
@@ -36,32 +36,32 @@
     </h4>
     {% endif -%}
     {%- if "subheader" in content_block -%}
-    <h5 id="{{content_block_id}}-subheader" {{ content_block_subheader_styling }}>
+    <h5 id="{{content_block_id}}-subheader" {{ content_block_subheader_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
         {{ content_block["subheader"] | render_string_template }}
     </h5>
     {% endif -%}
     {%- if content_block["content_block_type"] == "header" -%}
-    <h3 id="{{content_block_id}}-header" {{ content_block_header_styling }}>
+    <h3 id="{{content_block_id}}-header" {{ content_block_header_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
         {{ content_block["header"] }}
     </h3>
     {%- elif content_block["content_block_type"] == "text" -%}
-        <p id="{{content_sblock_id}}-body" {{ content_block_body_styling }}>
+        <p id="{{content_sblock_id}}-body" {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
             {{content_block["content"][0]}}
         </p>
     {%- elif content_block["content_block_type"] == "value_list" -%}
-        <p id="{{content_block_id}}-body" {{ content_block_body_styling }}>
+        <p id="{{content_block_id}}-body" {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
         {% for value in content_block["value_list"] -%}
             {{ value | render_string_template }}
         {% endfor -%}
         </p>
     {%- elif content_block["content_block_type"] == "bullet_list" -%}
-        <ul id="{{content_block_id}}-body" {{ content_block_body_styling }}>
+        <ul id="{{content_block_id}}-body" {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
             {% for bullet_point in content_block["bullet_list"] -%}
             <li {{ bullet_point | render_styling_from_string_template }}>{{ bullet_point | render_string_template }}</li>
             {% endfor %}
         </ul>
     {%- elif content_block["content_block_type"] == "graph" -%}
-        <div id="{{content_block_id}}-body" {{content_block_body_styling}}></div>
+        <div id="{{content_block_id}}-body" {{content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id)}}></div>
         <script>
             // Assign the specification to a local variable vlSpec.
             const vlSpec = {{content_block["graph"]}};

--- a/great_expectations/render/view/templates/component.j2
+++ b/great_expectations/render/view/templates/component.j2
@@ -50,10 +50,9 @@
         </p>
     {%- elif content_block["content_block_type"] == "value_list" -%}
         <p id="{{content_block_id}}-body" {{ content_block_body_styling }}>
-        {% for value in content_block["value_list"] %}
-            {# <span class="param-span">{{value}}</span> #}
+        {% for value in content_block["value_list"] -%}
             {{ value | render_string_template }}
-        {% endfor %}
+        {% endfor -%}
         </p>
     {%- elif content_block["content_block_type"] == "bullet_list" -%}
         <ul id="{{content_block_id}}-body" {{ content_block_body_styling }}>

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -118,8 +118,6 @@ def render_string_template(template):
                 })
 
         string = pTemplate(template["template"]).substitute(params)
-        print(template)
-        print(string)
         return string
 
     return pTemplate(template["template"]).substitute(template["params"])

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -33,7 +33,7 @@ def render_styling(styling):
     Other dictionary keys are also allowed and ignored.
     This makes it possible for styling objects to be nested, so that different DOM elements
 
-    #NOTE: We should add some kind of type-checking to styling
+    # NOTE: We should add some kind of type-checking to styling
     """
 
     class_list = styling.get("classes", None)
@@ -89,7 +89,6 @@ def render_string_template(template):
         return template
 
     if "styling" in template:
-
         params = template["params"]
 
         # Apply default styling
@@ -119,6 +118,8 @@ def render_string_template(template):
                 })
 
         string = pTemplate(template["template"]).substitute(params)
+        print(template)
+        print(string)
         return string
 
     return pTemplate(template["template"]).substitute(template["params"])

--- a/tests/render/test_default_jinja_view.py
+++ b/tests/render/test_default_jinja_view.py
@@ -95,8 +95,7 @@ def test_render_section_page():
     })
 
     print(rendered_doc)
-    assert rendered_doc == """\
-<div id="section-1" class="ge-section container-fluid">
+    assert rendered_doc == """<div id="section-1" class="ge-section container-fluid">
     <div class="row">
         
 <div id="content-block-1" >
@@ -307,6 +306,77 @@ def test_render_table_component():
             <td id="section-1-content-block-2-cell-1-1" >Mean</td><td id="section-1-content-block-2-cell-1-2" >446</td></tr><tr>
             <td id="section-1-content-block-2-cell-2-1" >Minimum</td><td id="section-1-content-block-2-cell-2-2" >1</td></tr></table>
 </div>"""
+
+
+def test_render_value_list():
+    value_list_component_content = {
+        'content_block_type': 'value_list',
+        'header': 'Example values',
+        'value_list': [{
+            'template': '$value',
+            'params': {'value': '0'},
+            'styling': {'default': {'classes': ['badge', 'badge-info']}}
+        }, {
+            'template': '$value',
+            'params': {'value': '1'},
+            'styling': {'default': {'classes': ['badge', 'badge-info']}}
+        }],
+        'styling': {
+            'classes': ['col-4'],
+            'styles': {'margin-top': '20px'}
+        }
+    }
+
+    rendered_doc = ge.render.view.view.DefaultJinjaComponentView.render({
+        "content_block": value_list_component_content,
+        "section_loop": {"index": 1},
+        "content_block_loop": {"index": 2},
+    })
+    print(rendered_doc)
+    assert rendered_doc == """
+<div id="section-1-content-block-2" class="col-4" style="margin-top:20px;" >
+    <h4 id="section-1-content-block-2-header" >
+        Example values
+    </h4>
+    <p id="section-1-content-block-2-body" >
+        <span class="badge badge-info" >0</span>
+        <span class="badge badge-info" >1</span>
+        </p>
+</div>"""
+
+
+def test_render_graph():
+    graph_component_content = {
+        "content_block_type": "graph",
+        "header": "Histogram",
+        "graph": "{\"$schema\": \"https://vega.github.io/schema/vega-lite/v2.6.0.json\", \"autosize\": \"fit\", \"config\": {\"view\": {\"height\": 300, \"width\": 400}}, \"data\": {\"name\": \"data-a681d02fb484e64eadd9721b37015d5b\"}, \"datasets\": {\"data-a681d02fb484e64eadd9721b37015d5b\": [{\"bins\": 3.7, \"weights\": 5.555555555555555}, {\"bins\": 10.8, \"weights\": 3.439153439153439}, {\"bins\": 17.9, \"weights\": 17.857142857142858}, {\"bins\": 25.0, \"weights\": 24.206349206349206}, {\"bins\": 32.0, \"weights\": 16.137566137566136}, {\"bins\": 39.1, \"weights\": 12.3015873015873}, {\"bins\": 46.2, \"weights\": 9.788359788359788}, {\"bins\": 53.3, \"weights\": 5.423280423280423}, {\"bins\": 60.4, \"weights\": 3.439153439153439}, {\"bins\": 67.5, \"weights\": 1.8518518518518516}]}, \"encoding\": {\"x\": {\"field\": \"bins\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"weights\", \"type\": \"quantitative\"}}, \"height\": 200, \"mark\": \"bar\", \"width\": 200}",
+        "styling": {
+            "classes": ["col-4"]
+        }
+    }
+
+    rendered_doc = ge.render.view.view.DefaultJinjaComponentView.render({
+        "content_block": graph_component_content,
+        "section_loop": {"index": 1},
+        "content_block_loop": {"index": 2},
+    })
+    print(rendered_doc)
+    assert rendered_doc == """
+<div id="section-1-content-block-2" class="col-4" >
+    <h4 id="section-1-content-block-2-header" >
+        Histogram
+    </h4>
+    <div id="section-1-content-block-2-body" ></div>
+        <script>
+            // Assign the specification to a local variable vlSpec.
+            const vlSpec = {"$schema": "https://vega.github.io/schema/vega-lite/v2.6.0.json", "autosize": "fit", "config": {"view": {"height": 300, "width": 400}}, "data": {"name": "data-a681d02fb484e64eadd9721b37015d5b"}, "datasets": {"data-a681d02fb484e64eadd9721b37015d5b": [{"bins": 3.7, "weights": 5.555555555555555}, {"bins": 10.8, "weights": 3.439153439153439}, {"bins": 17.9, "weights": 17.857142857142858}, {"bins": 25.0, "weights": 24.206349206349206}, {"bins": 32.0, "weights": 16.137566137566136}, {"bins": 39.1, "weights": 12.3015873015873}, {"bins": 46.2, "weights": 9.788359788359788}, {"bins": 53.3, "weights": 5.423280423280423}, {"bins": 60.4, "weights": 3.439153439153439}, {"bins": 67.5, "weights": 1.8518518518518516}]}, "encoding": {"x": {"field": "bins", "type": "ordinal"}, "y": {"field": "weights", "type": "quantitative"}}, "height": 200, "mark": "bar", "width": 200};
+            // Embed the visualization in the container with id `vis`
+            vegaEmbed('#section-1-content-block-2-body', vlSpec, {
+                actions: false
+            }).then(result=>console.log(result)).catch(console.warn);
+        </script>
+</div>"""
+
 
 # TODO: Add tests for the remaining component types
 # * text

--- a/tests/render/test_render_new.py
+++ b/tests/render/test_render_new.py
@@ -153,4 +153,4 @@ def test_full_oobe_flow():
     with open('./test_full_oobe_flow.html', 'w') as f:
         f.write(rendered_page)
 
-    assert False
+    # assert False

--- a/tests/render/test_render_new.py
+++ b/tests/render/test_render_new.py
@@ -146,8 +146,8 @@ def test_full_oobe_flow():
     # print(json.dumps(rendered_json, indent=2))
     rendered_page = DefaultJinjaPageView.render(rendered_json)
     assert rendered_page != None
+    # print(rendered_page)
 
-    print(rendered_page)
     # TODO: Add an gitignored directory for test output files.
     # TODO: Add a pytest CLI switch to produce or not produce these files.
     with open('./test_full_oobe_flow.html', 'w') as f:

--- a/tests/render/test_render_new.py
+++ b/tests/render/test_render_new.py
@@ -153,4 +153,4 @@ def test_full_oobe_flow():
     with open('./test_full_oobe_flow.html', 'w') as f:
         f.write(rendered_page)
 
-    # assert False
+    assert False


### PR DESCRIPTION
This PR implements KL-divergence graphs, plus example values.

To get there, I re-upped `graph` and `value-list`-type content blocks. Both have light testing, and are fully implemented AFAICT. I have *NOT* put them through serious stress testing yet.

<img width="1440" alt="Screen Shot 2019-07-01 at 9 08 05 PM" src="https://user-images.githubusercontent.com/1239085/60482645-3f4af980-9c47-11e9-9cd1-4b9eaca20803.png">
