### PR TITLE
Infer column order from expect_table_columns_to_match_ordered_list if possible

### DIFF
--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -17,6 +17,7 @@ class PrescriptivePageRenderer(Renderer):
     def render(cls, expectations):
         # Group expectations by column
         columns = {}
+        ordered_columns = None
         for expectation in expectations["expectations"]:
             if "column" in expectation["kwargs"]:
                 column = expectation["kwargs"]["column"]
@@ -26,8 +27,15 @@ class PrescriptivePageRenderer(Renderer):
                 columns[column] = []
             columns[column].append(expectation)
 
-        # TODO: in general, there should be a mechanism for imposing order here.
-        ordered_columns = list(columns.keys())
+            # if possible, get the order of columns from expect_table_columns_to_match_ordered_list
+            if expectation["expectation_type"] == "expect_table_columns_to_match_ordered_list":
+                exp_column_list = expectation["kwargs"]["column_list"]
+                if exp_column_list and len(exp_column_list) > 0:
+                    ordered_columns = exp_column_list
+
+        # if no order of colums is expected, sort alphabetically
+        if not ordered_columns:
+            ordered_columns = sorted(list(columns.keys()))
 
         return {
             "renderer_type": "PrescriptivePageRenderer",
@@ -53,8 +61,7 @@ class DescriptivePageRenderer(Renderer):
                 columns[column] = []
             columns[column].append(evr)
 
-        # TODO: in general, there should be a mechanism for imposing order here.
-        ordered_columns = list(columns.keys())
+        ordered_columns = Renderer._get_column_list_from_evrs(validation_results)
 
         # FIXME: This is a hack to limit output on one training file
         # if "Reporting Area" in ordered_columns:

--- a/great_expectations/render/renderer/renderer.py
+++ b/great_expectations/render/renderer/renderer.py
@@ -68,11 +68,26 @@ class Renderer(object):
 
     @classmethod
     def _get_column_list_from_evrs(cls, evrs):
-        # Group EVRs by column
-        columns = list(set([evr["expectation_config"]["kwargs"]["column"] for evr in evrs["results"] if "column" in evr["expectation_config"]["kwargs"]]))
+        """
+        Get list of column names.
 
-        # TODO: in general, there should be a mechanism for imposing order here.
-        ordered_columns = columns
+        If expect_table_columns_to_match_ordered_list EVR is present, use it as the list, including the order.
+
+        Otherwise, get the list of all columns mentioned in the expectations and order it alphabetically.
+
+        :param evrs:
+        :return: list of columns with best effort sorting
+        """
+        evrs_ = evrs["results"] if "results" in evrs else evrs
+
+        expect_table_columns_to_match_ordered_list_evr = cls._find_evr_by_type(evrs_, "expect_table_columns_to_match_ordered_list")
+        if expect_table_columns_to_match_ordered_list_evr:
+            ordered_columns = expect_table_columns_to_match_ordered_list_evr["result"]["observed_value"]
+        else:
+            # Group EVRs by column
+            columns = list(set([evr["expectation_config"]["kwargs"]["column"] for evr in evrs_ if "column" in evr["expectation_config"]["kwargs"]]))
+
+            ordered_columns = sorted(columns)
 
         return ordered_columns
 


### PR DESCRIPTION
Infer column order from expect_table_columns_to_match_ordered_list if possible in prescriptive and descriptive renderers.

When this expectation is not present, sort columns alphabetically by name.