### PR TITLE
Spark df dataset: optimize finding duplicates

### DIFF
--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -479,8 +479,7 @@ class SparkDFDataset(MetaSparkDFDataset):
         catch_exceptions=None,
         meta=None,
     ):
-        column_name = column[0]
-        return column.withColumn('__success', count(lit(1)).over(Window.partitionBy(column_name)) <= 1)
+        return column.withColumn('__success', count(lit(1)).over(Window.partitionBy(column[0])) <= 1)
 
     @DocInherit
     @MetaSparkDFDataset.column_map_expectation


### PR DESCRIPTION
The old implementation had all the non-unique values loaded to memory. The new one is spark-native.
