### PR TITLE
Improved error detection and handling in CLI "add datasource" feature

### DIFF
--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -214,6 +214,10 @@ def init(target_directory):
     )
 
     data_source_name = add_datasource(context)
+
+    if not data_source_name: # no datasource was created
+        return
+
     cli_message(
         """
 ========== Profiling ==========

--- a/great_expectations/cli/util.py
+++ b/great_expectations/cli/util.py
@@ -23,5 +23,10 @@ def cli_message(string):
         colored("\g<1>", "yellow"),
         mod_string
     )
+    mod_string = re.sub(
+        "<red>(.*?)</red>",
+        colored("\g<1>", "red"),
+        mod_string
+    )
 
     six.print_(colored(mod_string))

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -158,7 +158,7 @@ class DataContext(object):
         
         self._project_config = self._load_project_config()
 
-        if "datasources" not in self._project_config:
+        if not self._project_config.get("datasources"):
             self._project_config["datasources"] = {}
         for datasource in self._project_config["datasources"].keys():
             self.get_datasource(datasource)

--- a/great_expectations/datasource/sqlalchemy_source.py
+++ b/great_expectations/datasource/sqlalchemy_source.py
@@ -5,6 +5,7 @@ from string import Template
 from .datasource import Datasource
 from great_expectations.dataset.sqlalchemy_dataset import SqlAlchemyDataset
 from .generator.query_generator import QueryGenerator
+from great_expectations.exceptions import DatasourceInitializationError
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,9 @@ class SqlAlchemyDatasource(Datasource):
     """
 
     def __init__(self, name="default", data_context=None, profile=None, generators=None, **kwargs):
+        if not sqlalchemy:
+            raise DatasourceInitializationError(name, "ModuleNotFoundError: No module named 'sqlalchemy'")
+
         if generators is None:
             generators = {
                 "default": {"type": "queries"}
@@ -41,21 +45,27 @@ class SqlAlchemyDatasource(Datasource):
             self._datasource_config.update({
                 "profile": profile
             })
-        # if an engine was provided, use that
-        if "engine" in kwargs:
-            self.engine = kwargs.pop("engine")
 
-        # if a connection string or url was provided, use that
-        elif "connection_string" in kwargs:
-            connection_string = kwargs.pop("connection_string")
-            self.engine = create_engine(connection_string, **kwargs)
-        elif "url" in kwargs:
-            url = kwargs.pop("url")
-            self.engine = create_engine(url, **kwargs)
+        try:
+            # if an engine was provided, use that
+            if "engine" in kwargs:
+                self.engine = kwargs.pop("engine")
 
-        # Otherwise, connect using remaining kwargs
-        else:
-            self._connect(self._get_sqlalchemy_connection_options(**kwargs))
+            # if a connection string or url was provided, use that
+            elif "connection_string" in kwargs:
+                connection_string = kwargs.pop("connection_string")
+                self.engine = create_engine(connection_string, **kwargs)
+                self.engine.connect()
+            elif "url" in kwargs:
+                url = kwargs.pop("url")
+                self.engine = create_engine(url, **kwargs)
+                self.engine.connect()
+
+            # Otherwise, connect using remaining kwargs
+            else:
+                self._connect(self._get_sqlalchemy_connection_options(**kwargs))
+        except sqlalchemy.exc.OperationalError as sqlalchemy_error:
+            raise DatasourceInitializationError(self._name, str(sqlalchemy_error))
 
         self._build_generators()
 
@@ -74,6 +84,7 @@ class SqlAlchemyDatasource(Datasource):
 
     def _connect(self, options):
         self.engine = create_engine(options)
+        self.engine.connect()
         self.meta = MetaData()
 
     def _get_generator_class(self, type_):

--- a/great_expectations/exceptions.py
+++ b/great_expectations/exceptions.py
@@ -23,3 +23,8 @@ class BatchKwargsError(DataContextError):
     def __init__(self, message, batch_kwargs):
         self.message = message
         self.batch_kwargs = batch_kwargs
+
+class DatasourceInitializationError(GreatExpectationsError):
+    def __init__(self, datasource_name, message):
+        self.message = "Cannot initialize datasource %s, error: %s" % (datasource_name, message)
+

--- a/tests/datasource/test_datasources.py
+++ b/tests/datasource/test_datasources.py
@@ -102,51 +102,58 @@ def test_standalone_sqlalchemy_datasource(test_db_connection_string):
     assert isinstance(dataset2, SqlAlchemyDataset)
 
 
-def test_create_sqlalchemy_datasource(data_context):
-    name = "test_sqlalchemy_datasource"
-    type_ = "sqlalchemy"
-    connection_kwargs = {
-        "drivername": "postgresql",
-        "username": "user",
-        "password": "pass",
-        "host": "host",
-        "port": 1234,
-        "database": "db",
-    }
-
-    # It should be possible to create a sqlalchemy source using these params without
-    # saving a profile
-    data_context.add_datasource(name, type_, **connection_kwargs)
-    data_context_config = data_context.get_config()
-    assert name in data_context_config["datasources"] 
-    assert data_context_config["datasources"][name]["type"] == type_
-
-    # We should be able to get it in this session even without saving the config
-    source = data_context.get_datasource(name)
-    assert isinstance(source, SqlAlchemyDatasource)
-
-    profile_name = "test_sqlalchemy_datasource"
-    data_context.add_profile_credentials(profile_name, **connection_kwargs)
-
-    # But we should be able to add a source using a profile
-    name = "second_source"
-    data_context.add_datasource(name, type_, profile="test_sqlalchemy_datasource")
-    
-    data_context_config = data_context.get_config()
-    assert name in data_context_config["datasources"] 
-    assert data_context_config["datasources"][name]["type"] == type_
-    assert data_context_config["datasources"][name]["profile"] == profile_name
-
-    source = data_context.get_datasource(name)
-    assert isinstance(source, SqlAlchemyDatasource)
-
-    # Finally, we should be able to confirm that the folder structure is as expected
-    with open(os.path.join(data_context.root_directory, "uncommitted/credentials/profiles.yml"), "r") as profiles_file:
-        profiles = yaml.load(profiles_file)
-    
-    assert profiles == {
-        profile_name: dict(**connection_kwargs)
-    }
+# Disabled this test temporarily - SQLAlchemy datasource's behavior has been
+# changed to connect to the database in the constructor.
+# The connection kwargs in this test point to a Postgres db that does not exist.
+# I could not figure our how to test with SQLLite because it is not clear which
+# kwargs should be passed in. Tried "path", but sqlalchemy.engine.url.URL says
+# "unexpected keyword argument"
+#
+# def test_create_sqlalchemy_datasource(data_context):
+#     name = "test_sqlalchemy_datasource"
+#     type_ = "sqlalchemy"
+#     connection_kwargs = {
+#         "drivername": "postgresql",
+#         "username": "user",
+#         "password": "pass",
+#         "host": "host",
+#         "port": 1234,
+#         "database": "db",
+#     }
+#
+#     # It should be possible to create a sqlalchemy source using these params without
+#     # saving a profile
+#     data_context.add_datasource(name, type_, **connection_kwargs)
+#     data_context_config = data_context.get_config()
+#     assert name in data_context_config["datasources"]
+#     assert data_context_config["datasources"][name]["type"] == type_
+#
+#     # We should be able to get it in this session even without saving the config
+#     source = data_context.get_datasource(name)
+#     assert isinstance(source, SqlAlchemyDatasource)
+#
+#     profile_name = "test_sqlalchemy_datasource"
+#     data_context.add_profile_credentials(profile_name, **connection_kwargs)
+#
+#     # But we should be able to add a source using a profile
+#     name = "second_source"
+#     data_context.add_datasource(name, type_, profile="test_sqlalchemy_datasource")
+#
+#     data_context_config = data_context.get_config()
+#     assert name in data_context_config["datasources"]
+#     assert data_context_config["datasources"][name]["type"] == type_
+#     assert data_context_config["datasources"][name]["profile"] == profile_name
+#
+#     source = data_context.get_datasource(name)
+#     assert isinstance(source, SqlAlchemyDatasource)
+#
+#     # Finally, we should be able to confirm that the folder structure is as expected
+#     with open(os.path.join(data_context.root_directory, "uncommitted/credentials/profiles.yml"), "r") as profiles_file:
+#         profiles = yaml.load(profiles_file)
+#
+#     assert profiles == {
+#         profile_name: dict(**connection_kwargs)
+#     }
 
 
 def test_create_sparkdf_datasource(data_context, tmp_path_factory):

--- a/tests/datasource/test_datasources.py
+++ b/tests/datasource/test_datasources.py
@@ -109,51 +109,51 @@ def test_standalone_sqlalchemy_datasource(test_db_connection_string):
 # kwargs should be passed in. Tried "path", but sqlalchemy.engine.url.URL says
 # "unexpected keyword argument"
 #
-# def test_create_sqlalchemy_datasource(data_context):
-#     name = "test_sqlalchemy_datasource"
-#     type_ = "sqlalchemy"
-#     connection_kwargs = {
-#         "drivername": "postgresql",
-#         "username": "user",
-#         "password": "pass",
-#         "host": "host",
-#         "port": 1234,
-#         "database": "db",
-#     }
-#
-#     # It should be possible to create a sqlalchemy source using these params without
-#     # saving a profile
-#     data_context.add_datasource(name, type_, **connection_kwargs)
-#     data_context_config = data_context.get_config()
-#     assert name in data_context_config["datasources"]
-#     assert data_context_config["datasources"][name]["type"] == type_
-#
-#     # We should be able to get it in this session even without saving the config
-#     source = data_context.get_datasource(name)
-#     assert isinstance(source, SqlAlchemyDatasource)
-#
-#     profile_name = "test_sqlalchemy_datasource"
-#     data_context.add_profile_credentials(profile_name, **connection_kwargs)
-#
-#     # But we should be able to add a source using a profile
-#     name = "second_source"
-#     data_context.add_datasource(name, type_, profile="test_sqlalchemy_datasource")
-#
-#     data_context_config = data_context.get_config()
-#     assert name in data_context_config["datasources"]
-#     assert data_context_config["datasources"][name]["type"] == type_
-#     assert data_context_config["datasources"][name]["profile"] == profile_name
-#
-#     source = data_context.get_datasource(name)
-#     assert isinstance(source, SqlAlchemyDatasource)
-#
-#     # Finally, we should be able to confirm that the folder structure is as expected
-#     with open(os.path.join(data_context.root_directory, "uncommitted/credentials/profiles.yml"), "r") as profiles_file:
-#         profiles = yaml.load(profiles_file)
-#
-#     assert profiles == {
-#         profile_name: dict(**connection_kwargs)
-#     }
+def test_create_sqlalchemy_datasource(data_context):
+    name = "test_sqlalchemy_datasource"
+    type_ = "sqlalchemy"
+    connection_kwargs = {
+        "drivername": "postgresql",
+        "username": "",
+        "password": "",
+        "host": "localhost",
+        "port": 5432,
+        "database": "test_ci",
+    }
+
+    # It should be possible to create a sqlalchemy source using these params without
+    # saving a profile
+    data_context.add_datasource(name, type_, **connection_kwargs)
+    data_context_config = data_context.get_config()
+    assert name in data_context_config["datasources"]
+    assert data_context_config["datasources"][name]["type"] == type_
+
+    # We should be able to get it in this session even without saving the config
+    source = data_context.get_datasource(name)
+    assert isinstance(source, SqlAlchemyDatasource)
+
+    profile_name = "test_sqlalchemy_datasource"
+    data_context.add_profile_credentials(profile_name, **connection_kwargs)
+
+    # But we should be able to add a source using a profile
+    name = "second_source"
+    data_context.add_datasource(name, type_, profile="test_sqlalchemy_datasource")
+
+    data_context_config = data_context.get_config()
+    assert name in data_context_config["datasources"]
+    assert data_context_config["datasources"][name]["type"] == type_
+    assert data_context_config["datasources"][name]["profile"] == profile_name
+
+    source = data_context.get_datasource(name)
+    assert isinstance(source, SqlAlchemyDatasource)
+
+    # Finally, we should be able to confirm that the folder structure is as expected
+    with open(os.path.join(data_context.root_directory, "uncommitted/credentials/profiles.yml"), "r") as profiles_file:
+        profiles = yaml.load(profiles_file)
+
+    assert profiles == {
+        profile_name: dict(**connection_kwargs)
+    }
 
 
 def test_create_sparkdf_datasource(data_context, tmp_path_factory):

--- a/tests/datasource/test_datasources.py
+++ b/tests/datasource/test_datasources.py
@@ -102,13 +102,6 @@ def test_standalone_sqlalchemy_datasource(test_db_connection_string):
     assert isinstance(dataset2, SqlAlchemyDataset)
 
 
-# Disabled this test temporarily - SQLAlchemy datasource's behavior has been
-# changed to connect to the database in the constructor.
-# The connection kwargs in this test point to a Postgres db that does not exist.
-# I could not figure our how to test with SQLLite because it is not clear which
-# kwargs should be passed in. Tried "path", but sqlalchemy.engine.url.URL says
-# "unexpected keyword argument"
-#
 def test_create_sqlalchemy_datasource(data_context):
     name = "test_sqlalchemy_datasource"
     type_ = "sqlalchemy"


### PR DESCRIPTION
The goal of this PR is to make sure that the CLI "add datasource" feature deals better with failures.

Previous behavior was that if the user entered a non-existing path when creating a Pandas datasource or a wrong set of credentials when creating a sqlalchemy datasource, the failure was not detected and the pofiler reported successfully profiling 0 data assets.

Fixing the Pandas datasource was trivial - pass an parameter to click's prompt method to enforce that the path entered by the user is of an existing directory.

Changing the behavior of the sqlalchemy datasource configuration required more changes:
Sqlalchemy datasource tests the credentials by attempting to connect in the constructor, catches specific exception classes that correspond to failure to connect (either bad credentials or bad connectivity) and to missing modules (either sqlalchemy or the database-specific driver).
The CLI detects these failures, reports them to the user and offers to re-enter the credentials or to exit the process.

Had to disable the test_create_sqlalchemy_datasource test in test_datasources.py - SQLAlchemy datasource's behavior has beenchanged to connect to the database in the constructor. The connection kwargs in this test point to a Postgres db that does not exist. I could not figure our how to test with SQLLite because it is not clear which kwargs should be passed in. Tried "path", but sqlalchemy.engine.url.URL says "unexpected keyword argument".