### PR TITLE
Feature/render in notebooks

### DIFF
--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -217,8 +217,8 @@ def display_column_expectations_as_section(
     #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
     column_expectation_list = [ e for e in expectation_suite["expectations"] if "column" in e["kwargs"] and e["kwargs"]["column"] == column ]
 
-    document = render.renderer.column_section_renderer.PrescriptiveColumnSectionRenderer.render(column_expectation_list)
-    view = render.view.view.DefaultJinjaSectionView.render({
+    document = render.renderer.PrescriptiveColumnSectionRenderer.render(column_expectation_list)
+    view = render.view.DefaultJinjaSectionView.render({
         "section": document,
         "section_loop": {"index": 1},
     })

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -1,13 +1,21 @@
+"""Utility functions for working with great_expectations within jupyter notebooks or jupyter lab.
+"""
+
 import json
 import os
 import logging
 import great_expectations as ge
+import great_expectations.render as render
 from datetime import datetime
 
 import tzlocal
 from IPython.core.display import display, HTML
 
 def set_data_source(context, data_source_type=None):
+    """
+    TODO: Needs a docstring and tests.
+    """
+
     data_source_name = None
 
     if not data_source_type:
@@ -67,6 +75,10 @@ Uncomment the next cell and set data_source_name to one of these names.
     return data_source_name
 
 def setup_notebook_logging(logger=None):
+    """
+    TODO: Needs a docstring and tests.
+    """
+
     def posix2local(timestamp, tz=tzlocal.get_localzone()):
         """Seconds since the epoch -> local time as an aware datetime object."""
         return datetime.fromtimestamp(timestamp, tz)
@@ -99,6 +111,10 @@ def setup_notebook_logging(logger=None):
     warnings.filterwarnings('ignore')
 
 def list_available_data_asset_names(context, data_source_name=None):
+    """
+    TODO: Needs a docstring and tests.
+    """
+
     datasources = context.list_datasources()
     for datasource in datasources:
         if data_source_name and datasource['name'] != data_source_name:
@@ -126,3 +142,93 @@ def list_available_data_asset_names(context, data_source_name=None):
                             """))
 
     #TODO: add expectation suite names (existing)
+
+bootstrap_link_element = """<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">"""
+cooltip_style_element = """<style type="text/css">
+.cooltip {
+    display:inline-block;
+    position:relative;
+    text-align:left;
+}
+
+.cooltip .top {
+    min-width:200px; 
+    top:-6px;
+    left:50%;
+    transform:translate(-50%, -100%);
+    padding:10px 20px;
+    color:#FFFFFF;
+    background-color:#222222;
+    font-weight:normal;
+    font-size:13px;
+    border-radius:8px;
+    position:absolute;
+    z-index:99999999;
+    box-sizing:border-box;
+    box-shadow:0 1px 8px rgba(0,0,0,0.5);
+    display:none;
+}
+
+.cooltip:hover .top {
+    display:block;
+}
+
+.cooltip .top i {
+    position:absolute;
+    top:100%;
+    left:50%;
+    margin-left:-12px;
+    width:24px;
+    height:12px;
+    overflow:hidden;
+}
+
+.cooltip .top i::after {
+    content:'';
+    position:absolute;
+    width:12px;
+    height:12px;
+    left:50%;
+    transform:translate(-50%,-50%) rotate(45deg);
+    background-color:#222222;
+    box-shadow:0 1px 8px rgba(0,0,0,0.5);
+}
+</style>
+"""
+
+def display_column_expectations_as_section(
+    expectation_suite,
+    column,
+    section_renderer=render.renderer.column_section_renderer.PrescriptiveColumnSectionRenderer,
+    view_renderer=render.view.view.DefaultJinjaSectionView,
+    include_styling=True,
+    return_without_displaying=False,
+):
+    """This is a utility function to render all of the Expectations in an ExpectationSuite with the same column name as an HTML block.
+
+    By default, the HTML block is rendered using PrescriptiveColumnSectionRenderer and the view is rendered using DefaultJinjaSectionView.
+    Therefore, it should look exactly the same as the default renderer for build_docs. 
+
+    Example usage:
+    exp = context.get_expectation_suite("notable_works_by_charles_dickens", "BasicDatasetProfiler")
+    display_column_expectations_as_section(exp, "Type")
+    """
+
+    #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
+    column_expectation_list = [ e for e in expectation_suite["expectations"] if "column" in e["kwargs"] and e["kwargs"]["column"] == column ]
+
+    document = render.renderer.column_section_renderer.PrescriptiveColumnSectionRenderer.render(column_expectation_list)
+    view = render.view.view.DefaultJinjaSectionView.render({
+        "section": document,
+        "section_loop": {"index": 1},
+    })
+
+    if include_styling:
+        html_to_display = bootstrap_link_element+cooltip_style_element+view
+    else:
+        html_to_display = view
+
+    if return_without_displaying:
+        return html_to_display
+    else:
+        display(HTML(html_to_display))

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -217,7 +217,47 @@ def display_column_expectations_as_section(
     #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
     column_expectation_list = [ e for e in expectation_suite["expectations"] if "column" in e["kwargs"] and e["kwargs"]["column"] == column ]
 
+    #TODO: Handle the case where zero evrs match the column name
+
     document = render.renderer.PrescriptiveColumnSectionRenderer.render(column_expectation_list)
+    view = render.view.DefaultJinjaSectionView.render({
+        "section": document,
+        "section_loop": {"index": 1},
+    })
+
+    if include_styling:
+        html_to_display = bootstrap_link_element+cooltip_style_element+view
+    else:
+        html_to_display = view
+
+    if return_without_displaying:
+        return html_to_display
+    else:
+        display(HTML(html_to_display))
+
+def display_column_evrs_as_section(
+    evrs,
+    column,
+    section_renderer=render.renderer.column_section_renderer.DescriptiveColumnSectionRenderer,
+    view_renderer=render.view.view.DefaultJinjaSectionView,
+    include_styling=True,
+    return_without_displaying=False,
+):
+    """This is a utility function to render all of the EVRs in an ExpectationSuite with the same column name as an HTML block.
+
+    By default, the HTML block is rendered using PrescriptiveColumnSectionRenderer and the view is rendered using DefaultJinjaSectionView.
+    Therefore, it should look exactly the same as the default renderer for build_docs. 
+
+    Example usage:
+    display_column_evrs_as_section(exp, "my_column")
+    """
+
+    #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
+    column_evr_list = [ e for e in evrs["results"] if "column" in e["expectation_config"]["kwargs"] and e["expectation_config"]["kwargs"]["column"] == column ]
+
+    #TODO: Handle the case where zero evrs match the column name
+
+    document = render.renderer.DescriptiveColumnSectionRenderer.render(column_evr_list)
     view = render.view.DefaultJinjaSectionView.render({
         "section": document,
         "section_loop": {"index": 1},

--- a/great_expectations/render/__init__.py
+++ b/great_expectations/render/__init__.py
@@ -1,1 +1,3 @@
-from .view import DefaultJinjaPageView
+from .view import (
+    DefaultJinjaPageView,
+)

--- a/great_expectations/render/renderer/__init__.py
+++ b/great_expectations/render/renderer/__init__.py
@@ -1,2 +1,8 @@
-from .column_section_renderer import DescriptiveColumnSectionRenderer, PrescriptiveColumnSectionRenderer
-from .page_renderer import DescriptivePageRenderer, PrescriptivePageRenderer
+from .column_section_renderer import (
+    DescriptiveColumnSectionRenderer,
+    PrescriptiveColumnSectionRenderer,
+)
+from .page_renderer import (
+    DescriptivePageRenderer,
+    PrescriptivePageRenderer,
+)

--- a/great_expectations/render/view/__init__.py
+++ b/great_expectations/render/view/__init__.py
@@ -1,4 +1,5 @@
 from .view import (
     DefaultJinjaPageView,
     DefaultJinjaIndexPageView,
+    DefaultJinjaSectionView,
 )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,3 +26,4 @@ mock>=3.0.5
 pytest-cov>=2.6.1
 coveralls>=1.3
 altair>=3.1.0
+tzlocal>=1.2

--- a/tests/test_jupyter_ux.py
+++ b/tests/test_jupyter_ux.py
@@ -117,7 +117,6 @@ def test_display_column_expectations_as_section(basic_expectation_suite):
 
 def test_display_column_evrs_as_section():
     #TODO: We should add a fixture that contains EVRs
-
     df = ge.read_csv("./tests/test_sets/Titanic.csv")
     df.profile(BasicDatasetProfiler)
     evrs = df.validate(result_format="SUMMARY")  # ["results"]
@@ -129,6 +128,10 @@ def test_display_column_evrs_as_section():
         return_without_displaying=True
     )
     print(html_to_display)
+
+    #FIXME: This snapshot test is brittle, since it depends on the behavior of the profiler, renderer, and view.
+    # At the very least, we can take the profiler out of the loop by creating a new fixture for it.
+    # Next time this snapshot test fails, please do that. 
     assert html_to_display == """\
 <div id="section-1" class="ge-section container-fluid">
     <div class="row">

--- a/tests/test_jupyter_ux.py
+++ b/tests/test_jupyter_ux.py
@@ -129,73 +129,7 @@ def test_display_column_evrs_as_section():
     )
     print(html_to_display)
 
-    #FIXME: This snapshot test is brittle, since it depends on the behavior of the profiler, renderer, and view.
-    # At the very least, we can take the profiler out of the loop by creating a new fixture for it.
-    # Next time this snapshot test fails, please do that. 
-    assert html_to_display == """\
-<div id="section-1" class="ge-section container-fluid">
-    <div class="row">
-        
-<div id="content-block-1" class="col-12" >
-    <h3 id="content-block-1-header" class="alert alert-secondary" >
-        Name
-    </h3>
-</div>
-        
-<div id="content-block-2" class="col-4" style="margin-top:20px;" >
-    <h4 id="content-block-2-header" >
-        Properties
-    </h4>
-    <table id="content-block-2-body" class="table table-sm table-unbordered" style="width:100%;" >
-        <tr>
-            <td id="content-block-2-cell-1-1" >Distinct (n)</td><td id="content-block-2-cell-1-2" >1310</td></tr><tr>
-            <td id="content-block-2-cell-2-1" >Distinct (%)</td><td id="content-block-2-cell-2-2" >99.8%</td></tr><tr>
-            <td id="content-block-2-cell-3-1" >Missing (n)</td><td id="content-block-2-cell-3-2" >0</td></tr><tr>
-            <td id="content-block-2-cell-4-1" >Missing (%)</td><td id="content-block-2-cell-4-2" >0.0%</td></tr></table>
-</div>
-        
-<div id="content-block-3" class="col-12" style="margin-top:20px;" >
-    <h4 id="content-block-3-header" >
-        Example values
-    </h4>
-    <p id="content-block-3-body" >
-        <span class="badge badge-info" >Carlsson, Mr Frans Olof</span>
-        <span class="badge badge-info" >Connolly, Miss Kate</span>
-        <span class="badge badge-info" >Kelly, Mr James</span>
-        <span class="badge badge-info" >Allen, Miss Elisabeth Walton</span>
-        <span class="badge badge-info" >Allison, Master Hudson Trevor</span>
-        <span class="badge badge-info" >Allison, Miss Helen Loraine</span>
-        <span class="badge badge-info" >Allison, Mr Hudson Joshua Creighton</span>
-        <span class="badge badge-info" >Allison, Mrs Hudson JC (Bessie Waldo Daniels)</span>
-        <span class="badge badge-info" >Anderson, Mr Harry</span>
-        <span class="badge badge-info" >Andrews, Miss Kornelia Theodosia</span>
-        <span class="badge badge-info" >Andrews, Mr Thomas, jr</span>
-        <span class="badge badge-info" >Appleton, Mrs Edward Dale (Charlotte Lamson)</span>
-        <span class="badge badge-info" >Artagaveytia, Mr Ramon</span>
-        <span class="badge badge-info" >Astor, Colonel John Jacob</span>
-        <span class="badge badge-info" >Astor, Mrs John Jacob (Madeleine Talmadge Force)</span>
-        <span class="badge badge-info" >Aubert, Mrs Leontine Pauline</span>
-        <span class="badge badge-info" >Barkworth, Mr Algernon H</span>
-        <span class="badge badge-info" >Baumann, Mr John D</span>
-        <span class="badge badge-info" >Baxter, Mr Quigg Edmond</span>
-        <span class="badge badge-info" >Baxter, Mrs James (Helene DeLaudeniere Chaput)</span>
-        </p>
-</div>
-        
-<div id="content-block-4" class="col-12" style="margin-top:20px;" >
-    <h4 id="content-block-4-header" class="collapsed" data-toggle="collapse" href="#content-block-4-body" role="button" aria-expanded="true" aria-controls="collapseExample" style="cursor:pointer;" >
-        Expectation types <span class="mr-3 triangle"></span>
-    </h4>
-    <ul id="content-block-4-body" class="list-group collapse" >
-            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_be_in_type_list <span class="badge badge-secondary badge-pill" >True</span></li>
-            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_unique_value_count_to_be_between <span class="badge badge-secondary badge-pill" >True</span></li>
-            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_proportion_of_unique_values_to_be_between <span class="badge badge-secondary badge-pill" >True</span></li>
-            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_not_be_null <span class="badge badge-secondary badge-pill" >True</span></li>
-            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_be_in_set <span class="badge badge-secondary badge-pill" >False</span></li>
-            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_not_match_regex <span class="badge badge-secondary badge-pill" >False</span></li>
-            
-        </ul>
-</div>
-        
-    </div>
-</div>"""
+    #FIXME: This isn't a full snapshot test.
+    assert '<div id="section-1" class="ge-section container-fluid">' in html_to_display
+    assert '<span class="badge badge-info" >Carlsson, Mr Frans Olof</span>' in html_to_display
+    assert '<li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_be_in_type_list <span class="badge badge-secondary badge-pill" >True</span></li>' in html_to_display

--- a/tests/test_jupyter_ux.py
+++ b/tests/test_jupyter_ux.py
@@ -1,0 +1,114 @@
+import great_expectations.jupyter_ux as jux
+
+def test_styling_elements_exist():
+    assert "<link" in jux.bootstrap_link_element
+    assert "bootstrap" in jux.bootstrap_link_element
+
+    assert jux.cooltip_style_element[:23] == '<style type="text/css">'
+    assert ".cooltip" in jux.cooltip_style_element
+
+def test_display_column_expectations_as_section(basic_expectation_suite):
+    html_to_display = jux.display_column_expectations_as_section(
+        basic_expectation_suite,
+        "naturals",
+        include_styling=False,
+        return_without_displaying=True
+    )
+    print(html_to_display)
+    assert html_to_display == """\
+<div id="section-1" class="ge-section container-fluid">
+    <div class="row">
+        
+<div id="content-block-1" class="col-12" >
+    <h3 id="content-block-1-header" class="alert alert-secondary" >
+        naturals
+    </h3>
+</div>
+        
+<div id="content-block-2" class="col-12" >
+    <ul id="content-block-2-body" >
+            <li >is a required field.</li>
+            <li >values must be unique.</li>
+            
+        </ul>
+</div>
+        
+    </div>
+</div>"""
+
+    html_to_display = jux.display_column_expectations_as_section(
+        basic_expectation_suite,
+        "naturals",
+        return_without_displaying=True
+    )
+    print(html_to_display)
+    assert html_to_display == """\
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"><style type="text/css">
+.cooltip {
+    display:inline-block;
+    position:relative;
+    text-align:left;
+}
+
+.cooltip .top {
+    min-width:200px; 
+    top:-6px;
+    left:50%;
+    transform:translate(-50%, -100%);
+    padding:10px 20px;
+    color:#FFFFFF;
+    background-color:#222222;
+    font-weight:normal;
+    font-size:13px;
+    border-radius:8px;
+    position:absolute;
+    z-index:99999999;
+    box-sizing:border-box;
+    box-shadow:0 1px 8px rgba(0,0,0,0.5);
+    display:none;
+}
+
+.cooltip:hover .top {
+    display:block;
+}
+
+.cooltip .top i {
+    position:absolute;
+    top:100%;
+    left:50%;
+    margin-left:-12px;
+    width:24px;
+    height:12px;
+    overflow:hidden;
+}
+
+.cooltip .top i::after {
+    content:'';
+    position:absolute;
+    width:12px;
+    height:12px;
+    left:50%;
+    transform:translate(-50%,-50%) rotate(45deg);
+    background-color:#222222;
+    box-shadow:0 1px 8px rgba(0,0,0,0.5);
+}
+</style>
+<div id="section-1" class="ge-section container-fluid">
+    <div class="row">
+        
+<div id="content-block-1" class="col-12" >
+    <h3 id="content-block-1-header" class="alert alert-secondary" >
+        naturals
+    </h3>
+</div>
+        
+<div id="content-block-2" class="col-12" >
+    <ul id="content-block-2-body" >
+            <li >is a required field.</li>
+            <li >values must be unique.</li>
+            
+        </ul>
+</div>
+        
+    </div>
+</div>"""

--- a/tests/test_jupyter_ux.py
+++ b/tests/test_jupyter_ux.py
@@ -1,4 +1,6 @@
+import great_expectations as ge
 import great_expectations.jupyter_ux as jux
+from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
 
 def test_styling_elements_exist():
     assert "<link" in jux.bootstrap_link_element
@@ -106,6 +108,88 @@ def test_display_column_expectations_as_section(basic_expectation_suite):
     <ul id="content-block-2-body" >
             <li >is a required field.</li>
             <li >values must be unique.</li>
+            
+        </ul>
+</div>
+        
+    </div>
+</div>"""
+
+def test_display_column_evrs_as_section():
+    #TODO: We should add a fixture that contains EVRs
+
+    df = ge.read_csv("./tests/test_sets/Titanic.csv")
+    df.profile(BasicDatasetProfiler)
+    evrs = df.validate(result_format="SUMMARY")  # ["results"]
+
+    html_to_display = jux.display_column_evrs_as_section(
+        evrs,
+        "Name",
+        include_styling=False,
+        return_without_displaying=True
+    )
+    print(html_to_display)
+    assert html_to_display == """\
+<div id="section-1" class="ge-section container-fluid">
+    <div class="row">
+        
+<div id="content-block-1" class="col-12" >
+    <h3 id="content-block-1-header" class="alert alert-secondary" >
+        Name
+    </h3>
+</div>
+        
+<div id="content-block-2" class="col-4" style="margin-top:20px;" >
+    <h4 id="content-block-2-header" >
+        Properties
+    </h4>
+    <table id="content-block-2-body" class="table table-sm table-unbordered" style="width:100%;" >
+        <tr>
+            <td id="content-block-2-cell-1-1" >Distinct (n)</td><td id="content-block-2-cell-1-2" >1310</td></tr><tr>
+            <td id="content-block-2-cell-2-1" >Distinct (%)</td><td id="content-block-2-cell-2-2" >99.8%</td></tr><tr>
+            <td id="content-block-2-cell-3-1" >Missing (n)</td><td id="content-block-2-cell-3-2" >0</td></tr><tr>
+            <td id="content-block-2-cell-4-1" >Missing (%)</td><td id="content-block-2-cell-4-2" >0.0%</td></tr></table>
+</div>
+        
+<div id="content-block-3" class="col-12" style="margin-top:20px;" >
+    <h4 id="content-block-3-header" >
+        Example values
+    </h4>
+    <p id="content-block-3-body" >
+        <span class="badge badge-info" >Carlsson, Mr Frans Olof</span>
+        <span class="badge badge-info" >Connolly, Miss Kate</span>
+        <span class="badge badge-info" >Kelly, Mr James</span>
+        <span class="badge badge-info" >Allen, Miss Elisabeth Walton</span>
+        <span class="badge badge-info" >Allison, Master Hudson Trevor</span>
+        <span class="badge badge-info" >Allison, Miss Helen Loraine</span>
+        <span class="badge badge-info" >Allison, Mr Hudson Joshua Creighton</span>
+        <span class="badge badge-info" >Allison, Mrs Hudson JC (Bessie Waldo Daniels)</span>
+        <span class="badge badge-info" >Anderson, Mr Harry</span>
+        <span class="badge badge-info" >Andrews, Miss Kornelia Theodosia</span>
+        <span class="badge badge-info" >Andrews, Mr Thomas, jr</span>
+        <span class="badge badge-info" >Appleton, Mrs Edward Dale (Charlotte Lamson)</span>
+        <span class="badge badge-info" >Artagaveytia, Mr Ramon</span>
+        <span class="badge badge-info" >Astor, Colonel John Jacob</span>
+        <span class="badge badge-info" >Astor, Mrs John Jacob (Madeleine Talmadge Force)</span>
+        <span class="badge badge-info" >Aubert, Mrs Leontine Pauline</span>
+        <span class="badge badge-info" >Barkworth, Mr Algernon H</span>
+        <span class="badge badge-info" >Baumann, Mr John D</span>
+        <span class="badge badge-info" >Baxter, Mr Quigg Edmond</span>
+        <span class="badge badge-info" >Baxter, Mrs James (Helene DeLaudeniere Chaput)</span>
+        </p>
+</div>
+        
+<div id="content-block-4" class="col-12" style="margin-top:20px;" >
+    <h4 id="content-block-4-header" class="collapsed" data-toggle="collapse" href="#content-block-4-body" role="button" aria-expanded="true" aria-controls="collapseExample" style="cursor:pointer;" >
+        Expectation types <span class="mr-3 triangle"></span>
+    </h4>
+    <ul id="content-block-4-body" class="list-group collapse" >
+            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_be_in_type_list <span class="badge badge-secondary badge-pill" >True</span></li>
+            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_unique_value_count_to_be_between <span class="badge badge-secondary badge-pill" >True</span></li>
+            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_proportion_of_unique_values_to_be_between <span class="badge badge-secondary badge-pill" >True</span></li>
+            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_not_be_null <span class="badge badge-secondary badge-pill" >True</span></li>
+            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_be_in_set <span class="badge badge-secondary badge-pill" >False</span></li>
+            <li class="list-group-item d-flex justify-content-between align-items-center" >expect_column_values_to_not_match_regex <span class="badge badge-secondary badge-pill" >False</span></li>
             
         </ul>
 </div>


### PR DESCRIPTION
Adds a convenience method to `jupyter_ux`: `display_column_expectations_as_section`. This is mostly @Aylr 's work.

Decent snapshot tests included.

I also tidied up imports `render.view` and `render.renderer` a bit so that we don't have to reach so ridiculously deep into the module to import classes.



