### PR TITLE
Feature/more prescriptive expectations

### DIFF
--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -1,4 +1,5 @@
 import copy
+from sparklines import sparklines
 
 from .content_block import ContentBlockRenderer
 from ...util import ordinal
@@ -672,6 +673,36 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "template": template_str,
             "params": params,
             "styling": styling,
+        }]
+    
+    @classmethod
+    def expect_column_kl_divergence_to_be_less_than(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "partition_object", "threshold"]
+        )
+        
+        if not params.get("partition_object"):
+            template_str = "Kullback-Leibler (KL) divergence with respect to a given distribution must be lower than a \
+            provided threshold but no distribution was specified."
+        else:
+            params["sparklines_histogram"] = sparklines(params.get("partition_object")["weights"])[0]
+            template_str = "Kullback-Leibler (KL) divergence with respect to the following distribution must be lower than $threshold: $sparklines_histogram"
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": {
+                "params":
+                    {
+                        "formatted_json": {
+                            "classes": []
+                        }
+                    }
+            },
         }]
     
     @classmethod

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -107,7 +107,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         if (params["min_value"] is None) and (params["max_value"] is None):
             template_str = "may have any number of unique values."
         else:
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
                 if params["min_value"] is None:
                     template_str = "must have fewer than $max_value unique values, at least $mostly_pct % of the time."
@@ -143,7 +143,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         if (params["min_value"] is None) and (params["max_value"] is None):
             template_str = "may have any numerical value."
         else:
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
                 if params["min_value"] is not None and params["max_value"] is not None:
                     template_str = "values must be between $min_value and $max_value, at least $mostly_pct % of the time."
@@ -355,7 +355,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             ["column", "mostly"],
         )
 
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
             if include_column_name:
                 template_str = "$column values must not be null, at least $mostly_pct % of the time."
@@ -380,7 +380,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             ["column", "mostly"]
         )
         
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
             template_str = "values must be null, at least $mostly_pct % of the time."
         else:
@@ -402,7 +402,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             ["column", "type_", "mostly"]
         )
         
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
             template_str = "values must be of type $type_, at least $mostly_pct % of the time."
         else:
@@ -430,7 +430,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             ["$v__"+str(i) for i, v in enumerate(params["type_list"])]
         )
 
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
 
             if include_column_name:
@@ -472,7 +472,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
 
             template_str = "values must belong to this set: " + values_string
             
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str += ", at least $mostly_pct % of the time."
             else:
@@ -509,7 +509,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         
             template_str = "values must not belong to this set: " + values_string
         
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str += ", at least $mostly_pct % of the time."
             else:
@@ -566,7 +566,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         else:
             template_str = "values must be greater than or equal to previous values"
             
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
             template_str += ", at least $mostly_pct % of the time."
         else:
@@ -597,7 +597,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         else:
             template_str = "values must be less than or equal to previous values"
     
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
             template_str += ", at least $mostly_pct % of the time."
         else:
@@ -625,7 +625,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         if (params["min_value"] is None) and (params["max_value"] is None):
             template_str = "values may have any length."
         else:
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
                 if params["min_value"] is not None and params["max_value"] is not None:
                     template_str = "values must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
@@ -665,7 +665,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             template_str = "values may have any length."
         else:
             template_str = "values must be $value characters long"
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str += ", at least $mostly_pct % of the time."
             else:
@@ -691,7 +691,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             template_str = "values must match a regular expression but none was specified."
         else:
             template_str = "values must match this regular expression: $regex"
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str += ", at least $mostly_pct % of the time."
             else:
@@ -716,7 +716,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         if not params.get("regex"):
             template_str = "values must not match a regular expression but none was specified."
         else:
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 if include_column_name:
                     template_str = "$column values must not match this regular expression: $regex, at least $mostly_pct % of the time."
@@ -755,7 +755,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             else:
                 template_str = "values must match any of the following regular expressions: " + values_string
                 
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str += ", at least $mostly_pct % of the time."
             else:
@@ -788,7 +788,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         
             template_str = "values must not match any of the following regular expressions: " + values_string
         
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str += ", at least $mostly_pct % of the time."
             else:
@@ -814,7 +814,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             template_str = "values must match a strftime format but none was specified."
         else:
             template_str = "values must match the following strftime format: $strftime_format"
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str += ", at least $mostly_pct % of the time."
             else:
@@ -838,7 +838,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         
         template_str = "values must be parseable by dateutil"
         
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
             template_str += ", at least $mostly_pct % of the time."
         else:
@@ -862,7 +862,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
     
         template_str = "values must be parseable as JSON"
     
-        if params.get("mostly"):
+        if params["mostly"] is not None:
             params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
             template_str += ", at least $mostly_pct % of the time."
         else:
@@ -888,7 +888,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             template_str = "values must match a JSON Schema but none was specified."
         else:
             params["formatted_json"] = "<pre>" + json.dumps(params.get("json_schema"), indent=4) + "</pre>"
-            if params.get("mostly"):
+            if params["mostly"] is not None:
                 params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
                 template_str = "values must match the following JSON Schema, at least $mostly_pct % of the time: $formatted_json"
             else:

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -735,6 +735,42 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_values_to_match_regex_list(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "regex_list", "mostly", "match_on"],
+        )
+    
+        if not params.get("regex_list") or len(params.get("regex_list")) == 0:
+            template_str = "values must match a set of regular expressions but none was specified."
+        else:
+            for i, v in enumerate(params["regex_list"]):
+                params["v__"+str(i)] = v
+            values_string = " ".join(
+                ["$v__"+str(i) for i, v in enumerate(params["regex_list"])]
+            )
+            
+            if params.get("match_on") == "all":
+                template_str = "values must match all of the following regular expressions: " + values_string
+            else:
+                template_str = "values must match any of the following regular expressions: " + values_string
+                
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+                
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -972,8 +972,32 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "styling": styling,
         }]
     
+    @classmethod
+    def expect_column_mean_to_be_between(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "min_value", "max_value"]
+        )
+
+        if (params["min_value"] is None) and (params["max_value"] is None):
+            template_str = "mean may have any numerical value."
+        else:
             if params["min_value"] is not None and params["max_value"] is not None:
-                template_str = "values must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
+                template_str = "mean must be between $min_value and $max_value."
+            elif params["min_value"] is None:
+                template_str = "mean must be less than $max_value."
+            elif params["max_value"] is None:
+                template_str = "mean must be more than $min_value."
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
 
             elif params["min_value"] is None:
                 template_str = "values must be less than $max_value characters long, at least $mostly_pct % of the time."

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -613,6 +613,37 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "styling": styling,
         }]
 
+    # TODO: test parse_strings_as_datetimes
+    @classmethod
+    def expect_column_values_to_be_increasing(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "strictly", "mostly", "parse_strings_as_datetimes"]
+        )
+        
+        if params.get("strictly"):
+            template_str = "values must be strictly greater than previous values"
+        else:
+            template_str = "values must be greater than or equal to previous values"
+            
+        if params.get("mostly"):
+            params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+            template_str += ", at least $mostly_pct % of the time."
+        else:
+            template_str += "."
+            
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+            
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
     @classmethod
     def expect_column_values_to_be_unique(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -655,6 +655,32 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_value_lengths_to_equal(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "value", "mostly"]
+        )
+        
+        if params.get("value") is None:
+            template_str = "values may have any length."
+        else:
+            template_str = "values must be $value characters long"
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+        
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -997,6 +997,87 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "params": params,
             "styling": styling,
         }]
+
+    @classmethod
+    def expect_column_median_to_be_between(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "min_value", "max_value"]
+        )
+    
+        if (params["min_value"] is None) and (params["max_value"] is None):
+            template_str = "median may have any numerical value."
+        else:
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "median must be between $min_value and $max_value."
+            elif params["min_value"] is None:
+                template_str = "median must be less than $max_value."
+            elif params["max_value"] is None:
+                template_str = "median must be more than $min_value."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
+    @classmethod
+    def expect_column_stdev_to_be_between(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "min_value", "max_value"]
+        )
+    
+        if (params["min_value"] is None) and (params["max_value"] is None):
+            template_str = "standard deviation may have any numerical value."
+        else:
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "standard deviation must be between $min_value and $max_value."
+            elif params["min_value"] is None:
+                template_str = "standard deviation must be less than $max_value."
+            elif params["max_value"] is None:
+                template_str = "standard deviation must be more than $min_value."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
+    @classmethod
+    def expect_column_max_to_be_between(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "min_value", "max_value", "parse_strings_as_datetimes"]
+        )
+    
+        if (params["min_value"] is None) and (params["max_value"] is None):
+            template_str = "maximum value may have any numerical value."
+        else:
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "maximum value must be between $min_value and $max_value."
+            elif params["min_value"] is None:
+                template_str = "maximum value must be less than $max_value."
+            elif params["max_value"] is None:
+                template_str = "maximum value must be more than $min_value."
+    
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
     
     @classmethod
     def expect_column_min_to_be_between(cls, expectation, styling=None, include_column_name=True):

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -830,6 +830,30 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_values_to_be_dateutil_parseable(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "mostly"],
+        )
+        
+        template_str = "values must be parseable by dateutil"
+        
+        if params.get("mostly"):
+            params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+            template_str += ", at least $mostly_pct % of the time."
+        else:
+            template_str += "."
+            
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -910,6 +910,37 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             },
         }]
     
+    @classmethod
+    def expect_column_distinct_values_to_contain_set(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "value_set", "parse_strings_as_datetimes"]
+        )
+    
+        if params["value_set"] is None or len(params["value_set"]) == 0:
+            template_str = "distinct values must contain a given set, but that set is not specified."
+        else:
+            for i, v in enumerate(params["value_set"]):
+                params["v__" + str(i)] = v
+        
+            values_string = " ".join(
+                ["$v__" + str(i) for i, v in enumerate(params["value_set"])]
+            )
+        
+            template_str = "distinct values must contain this set: " + values_string + "."
+    
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
             if params["min_value"] is not None and params["max_value"] is not None:
                 template_str = "values must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
 

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -232,6 +232,8 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             else:
                 template_str = "Values in $column_A must be greater than or equal to those in $column_B, at least $mostly_pct % of the time."
 
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
 
         return [{
             "template": template_str,

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -998,16 +998,6 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "styling": styling,
         }]
     
-
-            elif params["min_value"] is None:
-                template_str = "values must be less than $max_value characters long, at least $mostly_pct % of the time."
-
-            elif params["max_value"] is None:
-                template_str = "values must be more than $min_value characters long, at least $mostly_pct % of the time."
-        else:
-            if params["min_value"] is not None and params["max_value"] is not None:
-                template_str = "values must always be between $min_value and $max_value characters long."
-    
     @classmethod
     def expect_column_min_to_be_between(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from sparklines import sparklines
 
 from .content_block import ContentBlockRenderer
@@ -648,6 +649,39 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             template_str = "values may have any length."
         elif params.get("mostly"):
             params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
+    @classmethod
+    def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "mostly", "json_schema"],
+        )
+        
+        if not params.get("json_schema"):
+            template_str = "values must match a JSON Schema but none was specified."
+        else:
+            params["formatted_json"] = "<pre>" + json.dumps(params.get("json_schema"), indent=4) + "</pre>"
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str = "values must match the following JSON Schema, at least $mostly_pct % of the time: $formatted_json"
+            else:
+                template_str = "values must match the following JSON Schema: $formatted_json"
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": {
+                "params":
+                    {
+                        "formatted_json": {
+                            "classes": []
+                        }
+                    }
+            },
+        }]
+    
             if params["min_value"] is not None and params["max_value"] is not None:
                 template_str = "values must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
 

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -96,45 +96,6 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
 
     @classmethod
-    def expect_column_value_lengths_to_be_between(cls, expectation, styling=None, include_column_name=True):
-        params = substitute_none_for_missing(
-            expectation["kwargs"],
-            ["column", "min_value", "max_value", "mostly"],
-        )
-
-        if (params["min_value"] is None) and (params["max_value"] is None):
-            template_str = "values may have any length."
-        elif params.get("mostly"):
-            params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
-            if params["min_value"] is not None and params["max_value"] is not None:
-                template_str = "must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
-
-            elif params["min_value"] is None:
-                template_str = "must be less than $max_value characters long, at least $mostly_pct % of the time."
-
-            elif params["max_value"] is None:
-                template_str = "must be more than $min_value characters long, at least $mostly_pct % of the time."
-
-        else:
-            if params["min_value"] is not None and params["max_value"] is not None:
-                template_str = "must always be between $min_value and $max_value characters long."
-
-            elif params["min_value"] is None:
-                template_str = "must always be less than $max_value characters long."
-
-            elif params["max_value"] is None:
-                template_str = "must always be more than $min_value characters long."
-
-        if include_column_name:
-            template_str = "$column " + template_str
-
-        return [{
-            "template": template_str,
-            "params": params,
-            "styling": styling,
-        }]
-
-    @classmethod
     def expect_column_unique_value_count_to_be_between(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],
@@ -675,6 +636,44 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "styling": styling,
         }]
 
+    @classmethod
+    def expect_column_value_lengths_to_be_between(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "min_value", "max_value", "mostly"],
+        )
+
+        if (params["min_value"] is None) and (params["max_value"] is None):
+            template_str = "values may have any length."
+        elif params.get("mostly"):
+            params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "values must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
+
+            elif params["min_value"] is None:
+                template_str = "values must be less than $max_value characters long, at least $mostly_pct % of the time."
+
+            elif params["max_value"] is None:
+                template_str = "values must be more than $min_value characters long, at least $mostly_pct % of the time."
+        else:
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "values must always be between $min_value and $max_value characters long."
+
+            elif params["min_value"] is None:
+                template_str = "values must always be less than $max_value characters long."
+
+            elif params["max_value"] is None:
+                template_str = "values must always be more than $min_value characters long."
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
     @classmethod
     def expect_column_values_to_be_unique(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -941,6 +941,37 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "styling": styling,
         }]
 
+    @classmethod
+    def expect_column_distinct_values_to_equal_set(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "value_set", "parse_strings_as_datetimes"]
+        )
+    
+        if params["value_set"] is None or len(params["value_set"]) == 0:
+            template_str = "distinct values must match a given set, but that set is not specified."
+        else:
+            for i, v in enumerate(params["value_set"]):
+                params["v__" + str(i)] = v
+        
+            values_string = " ".join(
+                ["$v__" + str(i) for i, v in enumerate(params["value_set"])]
+            )
+        
+            template_str = "distinct values must match this set: " + values_string + "."
+    
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
             if params["min_value"] is not None and params["max_value"] is not None:
                 template_str = "values must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
 

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -482,7 +482,7 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             template_str += " Values should be parsed as datetimes."
             
         if include_column_name:
-            template_str = "$column"
+            template_str = "$column " + template_str
 
         return [{
             "template": template_str,

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -771,6 +771,39 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_values_to_not_match_regex_list(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "regex_list", "mostly"],
+        )
+    
+        if not params.get("regex_list") or len(params.get("regex_list")) == 0:
+            template_str = "values must match a list of regular expressions but none was specified."
+        else:
+            for i, v in enumerate(params["regex_list"]):
+                params["v__" + str(i)] = v
+            values_string = " ".join(
+                ["$v__" + str(i) for i, v in enumerate(params["regex_list"])]
+            )
+        
+            template_str = "values must not match any of the following regular expressions: " + values_string
+        
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -697,8 +697,32 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             elif params["min_value"] is None:
                 template_str = "values must always be less than $max_value characters long."
 
+    @classmethod
+    def expect_column_sum_to_be_between(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "min_value", "max_value"]
+        )
+
+        if (params["min_value"] is None) and (params["max_value"] is None):
+            template_str = "sum may have any numerical value."
+        else:
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "sum must be between $min_value and $max_value."
+            elif params["min_value"] is None:
+                template_str = "sum must be less than $max_value."
             elif params["max_value"] is None:
-                template_str = "values must always be more than $min_value characters long."
+                template_str = "sum must be more than $min_value."
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
     @classmethod
     def expect_column_most_common_value_to_be_in_set(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -644,6 +644,37 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             "styling": styling,
         }]
 
+    # TODO: test parse_strings_as_datetimes
+    @classmethod
+    def expect_column_values_to_be_decreasing(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "strictly", "mostly", "parse_strings_as_datetimes"]
+        )
+    
+        if params.get("strictly"):
+            template_str = "values must be strictly less than previous values"
+        else:
+            template_str = "values must be less than or equal to previous values"
+    
+        if params.get("mostly"):
+            params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+            template_str += ", at least $mostly_pct % of the time."
+        else:
+            template_str += "."
+    
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
     @classmethod
     def expect_column_values_to_be_unique(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -723,10 +723,36 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         else:
             if params["min_value"] is not None and params["max_value"] is not None:
                 template_str = "values must always be between $min_value and $max_value characters long."
+    
+    @classmethod
+    def expect_column_min_to_be_between(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "min_value", "max_value", "parse_strings_as_datetimes"]
+        )
 
+        if (params["min_value"] is None) and (params["max_value"] is None):
+            template_str = "minimum value may have any numerical value."
+        else:
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "minimum value must be between $min_value and $max_value."
             elif params["min_value"] is None:
-                template_str = "values must always be less than $max_value characters long."
+                template_str = "minimum value must be less than $max_value."
+            elif params["max_value"] is None:
+                template_str = "minimum value must be more than $min_value."
 
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
     @classmethod
     def expect_column_sum_to_be_between(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -106,21 +106,22 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
 
         if (params["min_value"] is None) and (params["max_value"] is None):
             template_str = "may have any number of unique values."
-        elif params.get("mostly"):
-            params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
-            if params["min_value"] is None:
-                template_str = "must have fewer than $max_value unique values, at least $mostly_pct % of the time."
-            elif params["max_value"] is None:
-                template_str = "must have more than $min_value unique values, at least $mostly_pct % of the time."
-            else:
-                template_str = "must have between $min_value and $max_value unique values, at least $mostly_pct % of the time."
         else:
-            if params["min_value"] is None:
-                template_str = "must have fewer than $max_value unique values."
-            elif params["max_value"] is None:
-                template_str = "must have more than $min_value unique values."
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
+                if params["min_value"] is None:
+                    template_str = "must have fewer than $max_value unique values, at least $mostly_pct % of the time."
+                elif params["max_value"] is None:
+                    template_str = "must have more than $min_value unique values, at least $mostly_pct % of the time."
+                else:
+                    template_str = "must have between $min_value and $max_value unique values, at least $mostly_pct % of the time."
             else:
-                template_str = "must have between $min_value and $max_value unique values."
+                if params["min_value"] is None:
+                    template_str = "must have fewer than $max_value unique values."
+                elif params["max_value"] is None:
+                    template_str = "must have more than $min_value unique values."
+                else:
+                    template_str = "must have between $min_value and $max_value unique values."
 
         if include_column_name:
             template_str = "$column " + template_str
@@ -141,27 +142,26 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
 
         if (params["min_value"] is None) and (params["max_value"] is None):
             template_str = "may have any numerical value."
-
-        elif params.get("mostly"):
-            params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
-            if params["min_value"] is not None and params["max_value"] is not None:
-                template_str = "must be between $min_value and $max_value, at least $mostly_pct % of the time."
-
-            elif params["min_value"] is None:
-                template_str = "must be less than $max_value, at least $mostly_pct % of the time."
-
-            elif params["max_value"] is None:
-                template_str = "must be less than $max_value, at least $mostly_pct % of the time."
-
         else:
-            if params["min_value"] is not None and params["max_value"] is not None:
-                template_str = "must always be between $min_value and $max_value."
-
-            elif params["min_value"] is None:
-                template_str = "must always be less than $max_value."
-
-            elif params["max_value"] is None:
-                template_str = "must always be more than $min_value."
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
+                if params["min_value"] is not None and params["max_value"] is not None:
+                    template_str = "values must be between $min_value and $max_value, at least $mostly_pct % of the time."
+    
+                elif params["min_value"] is None:
+                    template_str = "values must be less than $max_value, at least $mostly_pct % of the time."
+    
+                elif params["max_value"] is None:
+                    template_str = "values must be less than $max_value, at least $mostly_pct % of the time."
+            else:
+                if params["min_value"] is not None and params["max_value"] is not None:
+                    template_str = "values must always be between $min_value and $max_value."
+    
+                elif params["min_value"] is None:
+                    template_str = "values must always be less than $max_value."
+    
+                elif params["max_value"] is None:
+                    template_str = "values must always be more than $min_value."
 
         if include_column_name:
             template_str = "$column " + template_str
@@ -284,14 +284,15 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             ["min_value", "max_value"]
         )
 
-        if params["min_value"] is not None and params["max_value"] is not None:
-            template_str = "Must have between $min_value and $max_value rows."
-
-        elif params["min_value"] is None:
-            template_str = "Must have less than than $max_value rows."
-
-        elif params["max_value"] is None:
-            template_str = "Must have more than $min_value rows."
+        if params["min_value"] is None and params["max_value"] is None:
+            template_str = "May have any number of rows."
+        else:
+            if params["min_value"] is not None and params["max_value"] is not None:
+                template_str = "Must have between $min_value and $max_value rows."
+            elif params["min_value"] is None:
+                template_str = "Must have less than than $max_value rows."
+            elif params["max_value"] is None:
+                template_str = "Must have more than $min_value rows."
 
         return [{
             "template": template_str,
@@ -560,12 +561,13 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
 
         if params["min_value"] is None and params["max_value"] is None:
             template_str = "may have any percentage of unique values."
-        elif params["min_value"] is None:
-            template_str = "must have no more than $max_value% unique values."
-        elif params["max_value"] is None:
-            template_str = "must have at least $min_value% unique values."
         else:
-            template_str = "must have between $min_value and $max_value% unique values."
+            if params["min_value"] is None:
+                template_str = "must have no more than $max_value% unique values."
+            elif params["max_value"] is None:
+                template_str = "must have at least $min_value% unique values."
+            else:
+                template_str = "must have between $min_value and $max_value% unique values."
 
         if include_column_name:
             template_str = "$column " + template_str
@@ -647,8 +649,36 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
 
         if (params["min_value"] is None) and (params["max_value"] is None):
             template_str = "values may have any length."
-        elif params.get("mostly"):
-            params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
+        else:
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"]*100,)
+                if params["min_value"] is not None and params["max_value"] is not None:
+                    template_str = "values must be between $min_value and $max_value characters long, at least $mostly_pct % of the time."
+    
+                elif params["min_value"] is None:
+                    template_str = "values must be less than $max_value characters long, at least $mostly_pct % of the time."
+    
+                elif params["max_value"] is None:
+                    template_str = "values must be more than $min_value characters long, at least $mostly_pct % of the time."
+            else:
+                if params["min_value"] is not None and params["max_value"] is not None:
+                    template_str = "values must always be between $min_value and $max_value characters long."
+    
+                elif params["min_value"] is None:
+                    template_str = "values must always be less than $max_value characters long."
+    
+                elif params["max_value"] is None:
+                    template_str = "values must always be more than $min_value characters long."
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
     @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -325,9 +325,9 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         if params["value_set"] is None:
 
             if include_column_name:
-                template_str = "$column values must belong to a set, but that set is not specified."
+                template_str = "$column distinct values must belong to a set, but that set is not specified."
             else:
-                template_str = "values must belong to a set, but that set is not specified."
+                template_str = "distinct values must belong to a set, but that set is not specified."
 
         else:
 
@@ -338,34 +338,9 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
             )
 
             if include_column_name:
-                template_str = "$column values must belong to this set: "+values_string+"."
+                template_str = "$column distinct values must belong to this set: "+values_string+"."
             else:
-                template_str = "values must belong to this set: "+values_string+"."
-
-        return [{
-            "template": template_str,
-            "params": params,
-            "styling": styling,
-        }]
-
-    @classmethod
-    def expect_column_values_to_not_match_regex(cls, expectation, styling=None, include_column_name=True):
-        params = substitute_none_for_missing(
-            expectation["kwargs"],
-            ["column", "regex", "mostly"],
-        )
-
-        if params.get("mostly"):
-            params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
-            if include_column_name:
-                template_str = "$column values must not match this regular expression: $regex, at least $mostly_pct % of the time."
-            else:
-                template_str = "values must not match this regular expression: $regex, at least $mostly_pct % of the time."
-        else:
-            if include_column_name:
-                template_str = "$column values must not match this regular expression: $regex."
-            else:
-                template_str = "values must not match this regular expression: $regex."
+                template_str = "distinct values must belong to this set: "+values_string+"."
 
         return [{
             "template": template_str,

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -681,6 +681,32 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_values_to_match_regex(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "regex", "mostly"]
+        )
+        
+        if not params.get("regex"):
+            template_str = "values must match a regular expression but none was specified."
+        else:
+            template_str = "values must match this regular expression: $regex"
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+                
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -707,6 +707,34 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_values_to_not_match_regex(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "regex", "mostly"],
+        )
+
+        if not params.get("regex"):
+            template_str = "values must not match a regular expression but none was specified."
+        else:
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                if include_column_name:
+                    template_str = "$column values must not match this regular expression: $regex, at least $mostly_pct % of the time."
+                else:
+                    template_str = "values must not match this regular expression: $regex, at least $mostly_pct % of the time."
+            else:
+                if include_column_name:
+                    template_str = "$column values must not match this regular expression: $regex."
+                else:
+                    template_str = "values must not match this regular expression: $regex."
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -515,6 +515,43 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
 
     @classmethod
+    def expect_column_values_to_be_in_set(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "value_set", "mostly", "parse_strings_as_datetimes"]
+        )
+
+        if params["value_set"] is None or len(params["value_set"]) == 0:
+                template_str = "values must belong to a set, but that set is not specified."
+        else:
+            for i, v in enumerate(params["value_set"]):
+                params["v__"+str(i)] = v
+                
+            values_string = " ".join(
+                ["$v__"+str(i) for i, v in enumerate(params["value_set"])]
+            )
+
+            template_str = "values must belong to this set: " + values_string
+            
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+                
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+            
+        if include_column_name:
+            template_str = "$column"
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
+    @classmethod
     def expect_column_proportion_of_unique_values_to_be_between(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -854,6 +854,30 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_values_to_be_json_parseable(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "mostly"],
+        )
+    
+        template_str = "values must be parseable as JSON"
+    
+        if params.get("mostly"):
+            params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+            template_str += ", at least $mostly_pct % of the time."
+        else:
+            template_str += "."
+    
+        if include_column_name:
+            template_str = "$column " + template_str
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -552,6 +552,43 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
 
     @classmethod
+    def expect_column_values_to_not_be_in_set(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "value_set", "mostly", "parse_strings_as_datetimes"]
+        )
+    
+        if params["value_set"] is None or len(params["value_set"]) == 0:
+            template_str = "values must not belong to a set, but that set is not specified."
+        else:
+            for i, v in enumerate(params["value_set"]):
+                params["v__" + str(i)] = v
+        
+            values_string = " ".join(
+                ["$v__" + str(i) for i, v in enumerate(params["value_set"])]
+            )
+        
+            template_str = "values must not belong to this set: " + values_string
+        
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+    
+        if params.get("parse_strings_as_datetimes"):
+            template_str += " Values should be parsed as datetimes."
+    
+        if include_column_name:
+            template_str = "$column"
+    
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling,
+        }]
+
+    @classmethod
     def expect_column_proportion_of_unique_values_to_be_between(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -804,6 +804,32 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
         }]
     
     @classmethod
+    def expect_column_values_to_match_strftime_format(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "strftime_format", "mostly"],
+        )
+    
+        if not params.get("strftime_format"):
+            template_str = "values must match a strftime format but none was specified."
+        else:
+            template_str = "values must match the following strftime format: $strftime_format"
+            if params.get("mostly"):
+                params["mostly_pct"] = "%.1f" % (params["mostly"] * 100,)
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+        
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        return [{
+            "template": template_str,
+            "params": params,
+            "styling": styling
+        }]
+    
+    @classmethod
     def expect_column_values_to_match_json_schema(cls, expectation, styling=None, include_column_name=True):
         params = substitute_none_for_missing(
             expectation["kwargs"],

--- a/great_expectations/render/renderer/content_block/bullet_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/bullet_list_content_block.py
@@ -699,6 +699,27 @@ class PrescriptiveBulletListContentBlockRenderer(ContentBlockRenderer):
 
             elif params["max_value"] is None:
                 template_str = "values must always be more than $min_value characters long."
+    @classmethod
+    def expect_column_most_common_value_to_be_in_set(cls, expectation, styling=None, include_column_name=True):
+        params = substitute_none_for_missing(
+            expectation["kwargs"],
+            ["column", "value_set", "ties_okay"]
+        )
+
+        if params["value_set"] is None or len(params["value_set"]) == 0:
+            template_str = "most common value must belong to a set, but that set is not specified."
+        else:
+            for i, v in enumerate(params["value_set"]):
+                params["v__" + str(i)] = v
+
+            values_string = " ".join(
+                ["$v__" + str(i) for i, v in enumerate(params["value_set"])]
+            )
+
+            template_str = "most common value must belong to this set: " + values_string + "."
+
+            if params.get("ties_okay"):
+                template_str += " Values outside this set that are as common (but not more common) are allowed."
 
         if include_column_name:
             template_str = "$column " + template_str

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@ sphinxcontrib-napoleon>=0.6.1
 sphinx_rtd_theme>=0.4.3
 pypandoc>=1.4
 pytest>=4.1.1
+sparklines>=0.4.2
 mock>=3.0.5
 pytest-cov>=2.6.1
 coveralls>=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ backports.functools_lru_cache>=1.5
 ruamel.yaml>=0.15.24
 ipywidgets>=7.4.2
 requests>=2.20
+sparklines>=0.4.2
 Click>=7.0
 pyfiglet>=0.8
 termcolor>=1.1.0


### PR DESCRIPTION
Add prescriptive renderers for following expectations:

expect_column_values_to_be_null
expect_column_values_to_be_of_type
expect_column_values_to_be_in_set
expect_column_values_to_not_be_in_set
expect_column_values_to_be_increasing
expect_column_values_to_be_decreasing
expect_column_value_lengths_to_equal
expect_column_values_to_match_regex
expect_column_values_to_match_regex_list
expect_column_values_to_not_match_regex_list
expect_column_values_to_match_strftime_format
expect_column_values_to_be_dateutil_parseable
expect_column_values_to_be_json_parseable
expect_column_values_to_match_json_schema
expect_column_distinct_values_to_contain_set
expect_column_distinct_values_to_equal_set
expect_column_mean_to_be_between
expect_column_median_to_be_between
expect_column_stdev_to_be_between
expect_column_most_common_value_to_be_in_set 
expect_column_max_to_be_between
expect_column_min_to_be_between
expect_column_sum_to_be_between
expect_column_kl_divergence_to_be_less_than