### PR TITLE
Speed up profiling first pass

### DIFF
--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -603,6 +603,12 @@ class DataAsset(object):
                 else:
                     return expectation
 
+    def set_config_value(self, key, value):
+        self._config[key] = value
+
+    def get_config_value(self, key):
+        return self._config[key]
+
     def get_batch_kwargs(self):
         return self._batch_kwargs
 

--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -103,7 +103,7 @@ class BasicDatasetProfiler(DatasetProfiler):
         columns = df.get_table_columns()
         number_of_columns = len(columns)
         for i, column in enumerate(columns):
-            print(f"            Preparing column {i} of {number_of_columns}: {column}")
+            logger.info("            Preparing column {} of {}: {}".format(i, number_of_columns, column))
 
             if column == 'sizes':
                 print("sizes")

--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -17,17 +17,9 @@ class BasicDatasetProfiler(DatasetProfiler):
     """
 
     @classmethod
-    def _enable_evaluation(cls, df):
-        df._config["interactive_evaluation"] = True
-
-    @classmethod
-    def _disable_evaluation(cls, df):
-        df._config["interactive_evaluation"] = False
-
-    @classmethod
     def _get_column_type(cls, df, column):
         # list of types is used to support pandas and sqlalchemy
-        cls._enable_evaluation(df)
+        df.set_config_value("interactive_evaluation", True)
         try:
             if df.expect_column_values_to_be_in_type_list(column, type_list=sorted(list(Dataset.INT_TYPE_NAMES)))["success"]:
                 type_ = "int"
@@ -47,14 +39,14 @@ class BasicDatasetProfiler(DatasetProfiler):
         except NotImplementedError:
             type_ = "unknown"
 
-        cls._disable_evaluation(df)
+        df.set_config_value('interactive_evaluation', False)
         return type_
 
     @classmethod
     def _get_column_cardinality(cls, df, column):
         num_unique = None
         pct_unique = None
-        cls._enable_evaluation(df)
+        df.set_config_value("interactive_evaluation", True)
 
         try:
             num_unique = df.expect_column_unique_value_count_to_be_between(column, None, None)[
@@ -94,7 +86,7 @@ class BasicDatasetProfiler(DatasetProfiler):
                 cardinality = "many"
         # print('col: {0:s}, num_unique: {1:s}, pct_unique: {2:s}, card: {3:s}'.format(column, str(num_unique), str(pct_unique), cardinality))
 
-        cls._disable_evaluation(df)
+        df.set_config_value('interactive_evaluation', False)
 
         return cardinality
 
@@ -106,7 +98,7 @@ class BasicDatasetProfiler(DatasetProfiler):
 
         df.expect_table_row_count_to_be_between(min_value=0, max_value=None)
         df.expect_table_columns_to_match_ordered_list(None)
-        cls._disable_evaluation(df)
+        df.set_config_value('interactive_evaluation', False)
 
         columns = df.get_table_columns()
         number_of_columns = len(columns)
@@ -193,5 +185,5 @@ class BasicDatasetProfiler(DatasetProfiler):
                     # print(column, type_, cardinality)
                     pass
 
-        cls._enable_evaluation(df)
+        df.set_config_value("interactive_evaluation", True)
         return df.get_expectation_suite(suppress_warnings=True, discard_failed_expectations=False)


### PR DESCRIPTION
* disable and enable evaluation to speed up profiling
* print out columns so users see something happening rather than waiting\

This sped up a few tests by 30-40%.

Results for a 10000 row csv wtih 80 columns

| before | after |
|--------|-------|
|     14 |    21 |
|     17 |    24 |
|     15 |    27 |
