### PR TITLE
Feature/data doc config/index layout fixes

### DIFF
--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -167,7 +167,7 @@ class SiteBuilder():
         # validations
 
         validation_section_config = sections_config.get('validations')
-        if profiling_section_config:
+        if validation_section_config:
             try:
                 validation_renderer_module = importlib.import_module(validation_section_config['renderer']['module'])
                 validation_renderer_class = getattr(validation_renderer_module, validation_section_config['renderer']['class'])

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from .renderer import Renderer
 from great_expectations.render.types import (
     RenderedComponentContent,
@@ -7,6 +9,267 @@ from great_expectations.render.types import (
 
 class SiteIndexPageRenderer(Renderer):
 
+    @classmethod
+    def _generate_data_asset_table_section(cls, data_asset_name, link_lists_dict):
+        section_rows = []
+        column_count = 1
+        profiling_links = link_lists_dict["profiling_links"]
+        if profiling_links: column_count += 1
+        validation_links = link_lists_dict["validation_links"]
+        if validation_links: column_count += 1
+        expectation_suite_links = link_lists_dict["expectation_suite_links"]
+        if expectation_suite_links: column_count += 1
+        
+        cell_width_pct = 100.0/column_count
+
+        first_row = []
+        rowspan = str(len(expectation_suite_links)) if expectation_suite_links else "1"
+        
+        data_asset_name = RenderedComponentContent(**{
+            "content_block_type": "string_template",
+            "string_template": {
+                "template": "$data_asset",
+                "params": {
+                    "data_asset": data_asset_name
+                },
+                "tag": "blockquote",
+                "styling": {
+                    "params": {
+                        "data_asset": {
+                            "classes": ["blockquote"],
+                        }
+                    }
+                }
+            },
+            "styling": {
+                "classes": ["col-sm-3", "col-xs-12", "pl-sm-5", "pl-xs-0"],
+                "styles": {
+                    "margin-top": "10px",
+                    "word-break": "break-all"
+                },
+                "parent": {
+                    "styles": {
+                        "width": "{}%".format(cell_width_pct)
+                    },
+                    "attributes": {
+                        "rowspan": rowspan
+                    }
+                }
+            }
+        })
+        first_row.append(data_asset_name)
+        
+        if profiling_links:
+            profiling_results_bullets = [
+                RenderedComponentContent(**{
+                    "content_block_type": "string_template",
+                    "string_template": {
+                        "template": "$link_text",
+                        "params": {
+                            "link_text": link_dict["expectation_suite_name"] + "-ProfilingResults"
+                        },
+                        "tag": "a",
+                        "styling": {
+                            "attributes": {
+                                "href": link_dict["filepath"]
+                            }
+                        }
+                    }
+                }) for link_dict in profiling_links
+            ]
+            profiling_results_bullet_list = RenderedComponentContent(**{
+                "content_block_type": "bullet_list",
+                "bullet_list": profiling_results_bullets,
+                "styling": {
+                    "parent": {
+                        "styles": {
+                            "width": "{}%".format(cell_width_pct),
+                        },
+                        "attributes": {
+                            "rowspan": rowspan
+                        }
+                    }
+                }
+            })
+            first_row.append(profiling_results_bullet_list)
+            
+        if expectation_suite_links:
+            expectation_suite_link_dict = expectation_suite_links[0]
+
+            expectation_suite_name = expectation_suite_link_dict["expectation_suite_name"]
+
+            expectation_suite_link = RenderedComponentContent(**{
+                "content_block_type": "string_template",
+                "string_template": {
+                    "template": "$link_text",
+                    "params": {
+                        "link_text": expectation_suite_name
+                    },
+                    "tag": "a",
+                    "styling": {
+                        "attributes": {
+                            "href": expectation_suite_link_dict["filepath"]
+                        },
+                    }
+                },
+                "styling": {
+                    "parent": {
+                        "styles": {
+                            "width": "{}%".format(cell_width_pct),
+                        }
+                    }
+                }
+            })
+            first_row.append(expectation_suite_link)
+            
+            if validation_links:
+                validation_link_bullets = [
+                    RenderedComponentContent(**{
+                        "content_block_type": "string_template",
+                        "string_template": {
+                            "template": "$link_text",
+                            "params": {
+                                "link_text": link_dict["run_id"]
+                            },
+                            "tag": "a",
+                            "styling": {
+                                "attributes": {
+                                    "href": link_dict["filepath"]
+                                }
+                            }
+                        }
+                    }) for link_dict in validation_links if
+                    link_dict["expectation_suite_name"] == expectation_suite_name
+                ]
+                validation_link_bullet_list = RenderedComponentContent(**{
+                    "content_block_type": "bullet_list",
+                    "bullet_list": validation_link_bullets,
+                    "styling": {
+                        "parent": {
+                            "styles": {
+                                "width": "{}%".format(cell_width_pct)
+                            }
+                        },
+                        "body": {
+                            "styles": {
+                                "max-height": "15em",
+                                "overflow": "scroll"
+                            }
+                        }
+                    }
+                })
+                first_row.append(validation_link_bullet_list)
+
+        if not expectation_suite_links and validation_links:
+            validation_link_bullets = [
+                RenderedComponentContent(**{
+                    "content_block_type": "string_template",
+                    "string_template": {
+                        "template": "$link_text",
+                        "params": {
+                            "link_text": link_dict["run_id"]
+                        },
+                        "tag": "a",
+                        "styling": {
+                            "attributes": {
+                                "href": link_dict["filepath"]
+                            }
+                        }
+                    }
+                }) for link_dict in validation_links
+            ]
+            validation_link_bullet_list = RenderedComponentContent(**{
+                "content_block_type": "bullet_list",
+                "bullet_list": validation_link_bullets,
+                "styling": {
+                    "parent": {
+                        "styles": {
+                            "width": "{}%".format(cell_width_pct)
+                        }
+                    },
+                    "body": {
+                        "styles": {
+                            "max-height": "15em",
+                            "overflow": "scroll"
+                        }
+                    }
+                }
+            })
+            first_row.append(validation_link_bullet_list)
+        
+        section_rows.append(first_row)
+        
+        if len(expectation_suite_links) > 1:
+            for expectation_suite_link_dict in expectation_suite_links[1:]:
+                expectation_suite_row = []
+                expectation_suite_name = expectation_suite_link_dict["expectation_suite_name"]
+    
+                expectation_suite_link = RenderedComponentContent(**{
+                    "content_block_type": "string_template",
+                    "string_template": {
+                        "template": "$link_text",
+                        "params": {
+                            "link_text": expectation_suite_name
+                        },
+                        "tag": "a",
+                        "styling": {
+                            "attributes": {
+                                "href": expectation_suite_link_dict["filepath"]
+                            },
+                        }
+                    },
+                    "styling": {
+                        "parent": {
+                            "styles": {
+                                "width": "{}%".format(cell_width_pct),
+                            }
+                        }
+                    }
+                })
+                expectation_suite_row.append(expectation_suite_link)
+    
+                if validation_links:
+                    validation_link_bullets = [
+                        RenderedComponentContent(**{
+                            "content_block_type": "string_template",
+                            "string_template": {
+                                "template": "$link_text",
+                                "params": {
+                                    "link_text": link_dict["run_id"]
+                                },
+                                "tag": "a",
+                                "styling": {
+                                    "attributes": {
+                                        "href": link_dict["filepath"]
+                                    }
+                                }
+                            }
+                        }) for link_dict in validation_links if
+                        link_dict["expectation_suite_name"] == expectation_suite_name
+                    ]
+                    validation_link_bullet_list = RenderedComponentContent(**{
+                        "content_block_type": "bullet_list",
+                        "bullet_list": validation_link_bullets,
+                        "styling": {
+                            "parent": {
+                                "styles": {
+                                    "width": "{}%".format(cell_width_pct)
+                                }
+                            },
+                            "body": {
+                                "styles": {
+                                    "max-height": "15em",
+                                    "overflow": "scroll"
+                                }
+                            }
+                        }
+                    })
+                    expectation_suite_row.append(validation_link_bullet_list)
+                    
+                section_rows.append(expectation_suite_row)
+            
+        return section_rows
+        
     @classmethod
     def render(cls, index_links_dict):
 
@@ -52,158 +315,40 @@ class SiteIndexPageRenderer(Renderer):
                 })
                 content_blocks.append(horizontal_rule)
 
-                # data_asset section
-                for data_asset, link_lists in data_assets.items():
-                    # data_asset header
-                    data_asset_heading = RenderedComponentContent(**{
-                        "content_block_type": "string_template",
-                        "string_template": {
-                            "template": "$data_asset",
-                            "params": {
-                                "data_asset": data_asset
-                            },
-                            "tag": "blockquote",
-                            "styling": {
-                                "params": {
-                                    "data_asset": {
-                                        "classes": ["blockquote"],
-                                    }
-                                }
-                            }
+                generator_table_rows = []
+                generator_table_header_row = ["Data Asset"]
+                
+                header_dict = OrderedDict([
+                    ["profiling_links", "Profiling Results"],
+                    ["expectation_suite_links", "Expectation Suite"],
+                    ["validation_links", "Validation Results"]
+                ])
+                
+                link_lists_example = list(data_assets.items())[0][1]
+                
+                for link_lists_key, header in header_dict.items():
+                    if link_lists_example[link_lists_key]:
+                        generator_table_header_row.append(header)
+                
+                generator_table = RenderedComponentContent(**{
+                    "content_block_type": "table",
+                    "header_row": generator_table_header_row,
+                    "table": generator_table_rows,
+                    "styling": {
+                        "classes": ["col-12"],
+                        "styles": {
+                            "margin-top": "10px"
                         },
-                        "styling": {
-                            "classes": ["col-sm-3", "col-xs-12", "pl-sm-5", "pl-xs-0"],
-                            "styles": {
-                                "margin-top": "10px",
-                                "word-break": "break-all"
-                            }
+                        "body": {
+                            "classes": ["table", "table-sm"]
                         }
-                    })
-                    content_blocks.append(data_asset_heading)
-
-                    # profiling_results links
-                    profiling_results_links = link_lists["profiling_links"]
-                    profiling_results_bullets = [
-                        RenderedComponentContent(**{
-                            "content_block_type": "string_template",
-                            "string_template": {
-                                "template": "$link_text",
-                                "params": {
-                                    "link_text": link_dict["expectation_suite_name"] + "-ProfilingResults"
-                                },
-                                "tag": "a",
-                                "styling": {
-                                    "attributes": {
-                                        "href": link_dict["filepath"]
-                                    }
-                                }
-                            }
-                        }) for link_dict in profiling_results_links
-                    ]
-                    profiling_results_bullet_list = RenderedComponentContent(**{
-                        "content_block_type": "bullet_list",
-                        "bullet_list": profiling_results_bullets
-                    })
-                    profiling_results_table = RenderedComponentContent(**{
-                        "content_block_type": "table",
-                        "subheader": "Profiling Results",
-                        "table": [[profiling_results_bullet_list]],
-                        "styling": {
-                            "classes": ["col-sm-3", "col-xs-12"],
-                            "styles": {
-                                "margin-top": "10px"
-                            },
-                            "body": {
-                                "classes": ["table", "table-sm", ],
-                            }
-                        },
-                    })
-                    content_blocks.append(profiling_results_table)
+                    }
+                })
+                # data_assets
+                for data_asset, link_lists in data_assets.items():
+                    generator_table_rows += cls._generate_data_asset_table_section(data_asset, link_lists)
                     
-                    # expectation_suite/validations table
-                    expectation_suite_links = link_lists["expectation_suite_links"]
-                    validation_links = link_lists["validation_links"]
-                    expectation_suite_validation_table_rows = []
-                    
-                    for expectation_suite_link_dict in expectation_suite_links:
-                        expectation_suite_name = expectation_suite_link_dict["expectation_suite_name"]
-                        
-                        table_row = [
-                            RenderedComponentContent(**{
-                                "content_block_type": "string_template",
-                                "string_template": {
-                                    "template": "$link_text",
-                                    "params": {
-                                        "link_text": expectation_suite_link_dict["expectation_suite_name"]
-                                    },
-                                    "tag": "a",
-                                    "styling": {
-                                        "attributes": {
-                                            "href": expectation_suite_link_dict["filepath"]
-                                        },
-                                    }
-                                },
-                                "styling": {
-                                    "parent": {
-                                        "styles": {
-                                            "width": "40%"
-                                        }
-                                    }
-                                }
-                            })
-                        ]
-                        validation_link_bullets = [
-                            RenderedComponentContent(**{
-                                "content_block_type": "string_template",
-                                "string_template": {
-                                    "template": "$link_text",
-                                    "params": {
-                                        "link_text": link_dict["run_id"]
-                                    },
-                                    "tag": "a",
-                                    "styling": {
-                                        "attributes": {
-                                            "href": link_dict["filepath"]
-                                        }
-                                    }
-                                }
-                            }) for link_dict in validation_links if link_dict["expectation_suite_name"] == expectation_suite_name
-                        ]
-                        validation_link_bullet_list = RenderedComponentContent(**{
-                            "content_block_type": "bullet_list",
-                            "bullet_list": validation_link_bullets,
-                            "styling": {
-                                "parent": {
-                                    "styles": {
-                                        "width": "60%"
-                                    }
-                                },
-                                "body": {
-                                    "styles": {
-                                        "max-height": "15em",
-                                        "overflow": "scroll"
-                                    }
-                                }
-                            }
-                        })
-                        table_row.append(validation_link_bullet_list)
-                        expectation_suite_validation_table_rows.append(table_row)
-                        
-                    expectation_suite_validation_table = RenderedComponentContent(**{
-                        "content_block_type": "table",
-                        "header_row": ["Expectation Suites", "Validation Results"],
-                        "table": expectation_suite_validation_table_rows,
-                        "styling": {
-                            "classes": ["col-sm-6", "col-xs-12",],
-                            "styles": {
-                                "margin-top": "10px"
-                            },
-                            "body": {
-                                "classes": ["table", "table-sm", ],
-                            }
-                        },
-                    })
-                    content_blocks.append(expectation_suite_validation_table)
+                content_blocks.append(generator_table)
 
             section = RenderedSectionContent(**{
                 "section_name": source,


### PR DESCRIPTION
- Index page renderer now handles configurable data docs - handles all permutations of profiling links, validation links, and expectation suite links

<img width="1669" alt="Screenshot 2019-08-09 12 12 04" src="https://user-images.githubusercontent.com/3468435/62803574-a9a15600-ba9f-11e9-96c2-e764ca65e928.png">
<img width="1657" alt="Screenshot 2019-08-09 12 10 29" src="https://user-images.githubusercontent.com/3468435/62803575-a9a15600-ba9f-11e9-9088-d409d94e13ad.png">
<img width="1659" alt="Screenshot 2019-08-09 12 09 26" src="https://user-images.githubusercontent.com/3468435/62803576-a9a15600-ba9f-11e9-8c26-e39b36776961.png">
<img width="1658" alt="Screenshot 2019-08-09 12 08 01" src="https://user-images.githubusercontent.com/3468435/62803577-a9a15600-ba9f-11e9-8fcd-5a326f8c9048.png">
