### PR TITLE
Fix styling for data documentation site

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -323,7 +323,7 @@ The following data documentation HTML sites were generated:
     for site_name, index_page_locator_info in index_page_locator_infos.items():
         msg += site_name + ":\n"
         for key, value in index_page_locator_info[0].items():
-            msg += "   <green>" + key + ": " + value + "</green>\n"
+            msg += "   <green>" + value + "</green>\n\n"
 
     cli_message(msg)
 


### PR DESCRIPTION
Quick styling fix to keep the CLI consistent with our style guide/implied promise for copy-pasteable green links:

Before:
<img width="883" alt="Screen Shot 2019-08-12 at 7 14 18 AM" src="https://user-images.githubusercontent.com/1239085/62871764-ee600380-bcd0-11e9-88eb-fe723de63f8a.png">

After:
<img width="858" alt="Screen Shot 2019-08-12 at 7 13 59 AM" src="https://user-images.githubusercontent.com/1239085/62871779-f455e480-bcd0-11e9-900d-d20f81aab6ae.png">

