### PR TITLE
Change CLI command from `documentation` to `build-documentation`

### DIFF
--- a/docs/guides/data_documentation.rst
+++ b/docs/guides/data_documentation.rst
@@ -122,7 +122,7 @@ context and validations available in the ``great_expectations/fixtures`` directo
 
 .. code-block:: bash
 
-    great_expectations documentation
+    great_expectations build-documentation
 
 
 When called without additional arguments, this command will render all the sites specified in great_expectations.yml configuration file.
@@ -137,7 +137,7 @@ To render just one data asset (this might be useful for debugging), call
 
 .. code-block:: bash
 
-    great_expectations documentation --site_name SITE_NAME --data_asset_name DATA_ASSET_NAME
+    great_expectations build-documentation --site_name SITE_NAME --data_asset_name DATA_ASSET_NAME
 
 
 Using the raw API

--- a/docs/guides/improving_library_documentation.rst
+++ b/docs/guides/improving_library_documentation.rst
@@ -43,8 +43,9 @@ The CLI has some conventions of its own.
 * Questions are always phrased as conversational sentences.
 * Sections are divided by headers: "========== Profiling =========="
 * We use punctuation: Please finish sentences with periods, questions marks, or an occasional exclamation point.
-* Keep indentation consistent! (We're pythonistas, natch.)
+* Keep indentation and line spacing consistent! (We're pythonistas, natch.)
 * Include exactly one blank line after every question.
 * Within those constraints, shorter is better. When in doubt, shorten.
 * Clickable links (usually to documentation) are blue.
 * Copyable bash commands are green.
+* All top-level bash commands must be verbs: "build documentation", not "documentation"

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -254,7 +254,7 @@ def profile(datasource_name, data_assets, profile_all_data_assets, directory):
               help='The site for which to generate documentation. See data_docs section in great_expectations.yml')
 @click.option('--data_asset_name', '-dan',
               help='The data asset for which to generate documentation. Must also specify --site_name.')
-def documentation(directory, site_name, data_asset_name):
+def build_documentation(directory, site_name, data_asset_name):
     """Build data documentation for a project.
     """
     if data_asset_name is not None and site_name is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,11 +41,11 @@ Options:
   --help         Show this message and exit.
 
 Commands:
-  documentation  Build data documentation for a project.
-  init           Initialize a new Great Expectations project.
-  profile        Profile datasources from the specified context.
-  render         Render a great expectations object to documentation.
-  validate       Validate a CSV file against an expectation suite.
+  build-documentation  Build data documentation for a project.
+  init                 Initialize a new Great Expectations project.
+  profile              Profile datasources from the specified context.
+  render               Render a great expectations object to documentation.
+  validate             Validate a CSV file against an expectation suite.
 """
 
 
@@ -414,10 +414,10 @@ def test_cli_config_not_found(tmp_path_factory):
             cli, ["profile"])
         assert "no great_expectations context configuration" in result.output
         result = runner.invoke(
-            cli, ["documentation", "-d", "./"])
+            cli, ["build-documentation", "-d", "./"])
         assert "no great_expectations context configuration" in result.output
         result = runner.invoke(
-            cli, ["documentation"])
+            cli, ["build-documentation"])
         assert "no great_expectations context configuration" in result.output
     except:
         raise


### PR DESCRIPTION
Switches from `great_expectations documentation` to `great_expectations build-documentation`, for consistency with all the other top-level commands in the CLI.