### PR TITLE
Fix CLI text

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -201,10 +201,7 @@ later by running `great_expectations profile`.
     msg_data_doc_intro = """
 ========== Data Documentation ==========
 
-To generate documentation from the data you just profiled, the profiling results should be moved from 
-great_expectations/uncommitted (ignored by git) to great_expectations/fixtures.
-
-Before committing, please make sure that this data does not contain sensitive information!
+Great Expectations can create data documentation from the data you just profiled.
 
 To learn more: <blue>https://docs.greatexpectations.io/en/latest/guides/data_documentation.html\
 ?utm_source=cli&utm_medium=init&utm_campaign={0:s}</blue>
@@ -283,17 +280,6 @@ To learn more: <blue>https://docs.greatexpectations.io/en/latest/guides/data_doc
 
 
     cli_message(msg_data_doc_intro.format(__version__.replace(".", "_")))
-    # if click.confirm("Move the profiled data and build HTML documentation?",
-    #                  default=True
-    #                  ):
-    #     cli_message("\nMoving files...")
-    #
-    #     for profiling_result in profiling_results['results']:
-    #         data_asset_name = profiling_result[1]['meta']['data_asset_name']
-    #         expectation_suite_name = profiling_result[1]['meta']['expectation_suite_name']
-    #         run_id = profiling_result[1]['meta']['run_id']
-    #         context.move_validation_to_fixtures(
-    #             data_asset_name, expectation_suite_name, run_id)
 
     if click.confirm("Build HTML documentation?",
                      default=True


### PR DESCRIPTION
This one is pretty self-explanatory. Removes outdated CLI text about moving files.

The data docs section of the CLI script now reads:

```
========== Data Documentation ==========

Great Expectations can create data documentation from the data you just profiled.

To learn more: https://docs.greatexpectations.io/en/latest/guides/data_documentation.html?utm_source=cli&utm_medium=init&utm_campaign=0_7_8__develop

Build HTML documentation? [Y/n]: 

Building documentation...

The following data documentation HTML sites were generated:
    
local_site:
   /private/var/folders/tc/579dj32d3pjdkx1vbxdm3ss80000gn/T/pytest-of-abe/pytest-1851/test_cli_init_diff0/great_expectations/uncommitted/documentation/local_site/index.html

team_site:
   /private/var/folders/tc/579dj32d3pjdkx1vbxdm3ss80000gn/T/pytest-of-abe/pytest-1851/test_cli_init_diff0/great_expectations/uncommitted/documentation/team_site/index.html
```

