### PR TITLE
Implement DictOf and make small improvements to base classes

### DIFF
--- a/great_expectations/types/__init__.py
+++ b/great_expectations/types/__init__.py
@@ -1,5 +1,6 @@
 from .base import (
     ListOf,
+    DictOf,
     DotDict,
     RequiredKeysDotDict,
     AllowedKeysDotDict,

--- a/great_expectations/types/base.py
+++ b/great_expectations/types/base.py
@@ -1,12 +1,20 @@
+import logging
+logger = logging.getLogger(__name__)
+
 from collections import Iterable
 import inspect
 import copy
+from six import string_types
 
 from ruamel.yaml import YAML, yaml_object
 yaml = YAML()
 
 
 class ListOf(object):
+    def __init__(self, type_):
+        self.type_ = type_
+
+class DictOf(object):
     def __init__(self, type_):
         self.type_ = type_
 
@@ -96,26 +104,8 @@ class RequiredKeysDotDict(DotDict):
         for key, value in self.items():
             if key in self._key_types:
                 if coerce_types:
-                    # Update values if coerce_types==True
-                    try:
-                        # If the given type is an instance of AllowedKeysDotDict, apply coerce_types recursively
-                        if isinstance(self._key_types[key], ListOf):
-                            if inspect.isclass(self._key_types[key].type_) and issubclass(self._key_types[key].type_,
-                                                                                          RequiredKeysDotDict):
-                                value = [self._key_types[key].type_(coerce_types=True, **v) for v in value]
-                            else:
-                                value = [self._key_types[key].type_(
-                                    v) for v in value]
+                    value = self._coerce_complex_value_to_type(value, self._key_types[key])
 
-                        else:
-                            if inspect.isclass(self._key_types[key]) and issubclass(self._key_types[key],
-                                                                                    RequiredKeysDotDict):
-                                value = self._key_types[key](coerce_types=True, **value)
-                            else:
-                                value = self._key_types[key](value)
-                    except TypeError as e:
-                        raise ("Unable to initialize " + self.__class__.__name__ + ": could not convert type. TypeError "
-                                                                                   "raised: " + str(e))
                 # Validate types
                 self._validate_value_type(key, value, self._key_types[key])
 
@@ -158,6 +148,22 @@ class RequiredKeysDotDict(DotDict):
                         type(v),
                     ))
 
+        elif isinstance(type_, DictOf):
+            if not isinstance(value, dict):
+                raise TypeError("key: {!r} must be a mapping, not {!r}".format(
+                    key,
+                    type(value),
+                ))
+
+            for k, v in value.items():
+                if not isinstance(v, type_.type_):
+                    raise TypeError("values in key: {!r} must be of type: {!r}, not {!r} {!r}".format(
+                        key,
+                        type_.type_,
+                        v,
+                        type(v),
+                    ))
+
         else:
             if isinstance(type_, list):
                 any_match = False
@@ -182,6 +188,54 @@ class RequiredKeysDotDict(DotDict):
                         type_,
                         type(value),
                     ))
+    
+    def _coerce_complex_value_to_type(self, value, type_):
+        logger.debug("RequiredKeysDotDict._coerce_complex_value_to_type")
+
+        try:
+            # If the given type is an instance of AllowedKeysDotDict, apply coerce_types recursively
+            if isinstance(type_, ListOf):
+                if inspect.isclass(type_.type_) and issubclass(type_.type_,
+                                                                                RequiredKeysDotDict):
+                    value = [type_.type_(coerce_types=True, **v) for v in value]
+                else:
+                    value = [
+                        self._coerce_simple_value_to_type(v, type_.type_)
+                        for v in value
+                    ]
+
+            elif isinstance(type_, DictOf):
+                if inspect.isclass(type_.type_) and issubclass(type_.type_,
+                                                                                RequiredKeysDotDict):
+                    value = dict([(k, type_.type_(coerce_types=True, **v)) for k, v in value.items()])
+                else:
+                    value = dict([
+                        (k, self._coerce_simple_value_to_type(v, type_.type_))
+                        for k, v in value.items()
+                    ])
+
+            else:
+                if inspect.isclass(type_) and issubclass(type_,
+                                                                        RequiredKeysDotDict):
+                    value = type_(coerce_types=True, **value)
+                else:
+                    value = self._coerce_simple_value_to_type(value, type_)
+
+        except TypeError as e:
+            raise TypeError("Unable to initialize " + self.__class__.__name__ + ". TypeError raised: " + str(e))
+
+        return value
+
+    def _coerce_simple_value_to_type(self, value, type_):
+        """Convenience method to handle the case where type_ == string type, and any other similarly weird things in the future
+        """
+        logger.debug("RequiredKeysDotDict._coerce_simple_value_to_type")
+
+        if type_ == string_types:
+            return str(value)
+
+        else:
+            return type_(value)
 
 
 @yaml_object(yaml)

--- a/tests/types/test_base_types.py
+++ b/tests/types/test_base_types.py
@@ -8,6 +8,7 @@ from great_expectations.types import (
     AllowedKeysDotDict,
     RequiredKeysDotDict,
     ListOf,
+    DictOf,
 )
 
 from ruamel.yaml import YAML, yaml_object
@@ -250,14 +251,65 @@ def test_allowed_keys_dot_dict_ListOf_typing():
             }
         )
 
+def test_allowed_keys_dot_dict_DictOf_typing():
+    class MyAllowedKeysDotDict(AllowedKeysDotDict):
+        _allowed_keys = {"a", "b", "c" }
+        _key_types = {
+            "a": int,
+            "b": DictOf(int),
+        }
+    
+    d = MyAllowedKeysDotDict(
+        **{
+            "a": 10,
+            "b": {
+                "x" : 10,
+                "y" : 20,
+                "z" : 30
+            }
+        }
+    )
+
+    d = MyAllowedKeysDotDict(
+        coerce_types=True,
+        **{
+            "a": 10,
+            "b": {
+                "x" : "10",
+                "y" : "20",
+                "z" : "30"
+            }
+        }
+    )
+
+    with pytest.raises(TypeError):
+        d = MyAllowedKeysDotDict(
+            **{
+                "a": 10,
+                "b": {
+                    "x" : 10,
+                    "y" : 20,
+                    "z" : "duck"
+                }
+            }
+        )
+
+    with pytest.raises(TypeError):
+        d = MyAllowedKeysDotDict(
+            **{
+                "a": 10,
+                "b": [10, 20, 30],
+            }
+        )
 
 def test_allowed_keys_dot_dict_recursive_coercion():
     class MyNestedDotDict(AllowedKeysDotDict):
-        _allowed_keys = {"a", "b", "c"}
+        _allowed_keys = {"a", "b", "c", "d"}
         _required_keys = {"a"}
         _key_types = {
             "a": int,
             "b": str,
+            "d": string_types,
         }
 
     class MyAllowedKeysDotDict(AllowedKeysDotDict):
@@ -274,7 +326,8 @@ def test_allowed_keys_dot_dict_recursive_coercion():
             "x": "hello",
             "y": {
                 "a": 1,
-                "b": "hello"
+                "b": "hello",
+                "d": "hi"
             },
         }
     )
@@ -282,7 +335,8 @@ def test_allowed_keys_dot_dict_recursive_coercion():
         "x": "hello",
         "y": {
             "a": 1,
-            "b": "hello"
+            "b": "hello",
+            "d": "hi",
         },
     }
 
@@ -357,6 +411,64 @@ def test_allowed_keys_dot_dict_recursive_coercion_with_ListOf():
             }
         )
 
+def test_allowed_keys_dot_dict_recursive_coercion_with_DictOf():
+    class MyNestedDotDict(AllowedKeysDotDict):
+        _allowed_keys = {"a"}
+        _required_keys = {"a"}
+        _key_types = {
+            "a": int,
+        }
+
+    class MyAllowedKeysDotDict(AllowedKeysDotDict):
+        _allowed_keys = {"x", "y", "z"}
+        _required_keys = {"x"}
+        _key_types = {
+            "x": str,
+            "y": DictOf(MyNestedDotDict),
+        }
+
+    d = MyAllowedKeysDotDict(
+        coerce_types=True,
+        **{
+            "x": "hello",
+            "y": {
+                "who" : {"a": 1},
+                "what" : {"a": 2},
+                "when" : {"a": 3},
+            }
+        }
+    )
+    assert d == {
+        "x": "hello",
+        "y": {
+            "who" : {"a": 1},
+            "what" : {"a": 2},
+            "when" : {"a": 3},
+        }
+    }
+
+    with pytest.raises(TypeError):
+        d = MyAllowedKeysDotDict(
+            coerce_types=True,
+            **{
+                "x": "hello",
+                "y": {
+                    "a": [1, 2, 3, 4],
+                },
+            }
+        )
+
+    with pytest.raises(ValueError):
+        d = MyAllowedKeysDotDict(
+            coerce_types=True,
+            **{
+                "x": "hello",
+                "y": {
+                    "who" : {"a": 1},
+                    "what" : {"a": "not an int"},
+                },
+            }
+        )
 
 def test_allowed_keys_dot_dict_unicode_issues():
     class MyLTDD(AllowedKeysDotDict):


### PR DESCRIPTION
This PR introduces a new DictOf semantic into our base types.
It also introduces small fixes to allow for `string_types`, etc.

Note: I've discussed `DictOf` with @jcampbell . We're not sure this is a pattern that we want to use long-term, but we agree that rolling it back will be relatively easy.

Merging this branch will unblock other work on `Stores` and `ValidationActions.`