### PR TITLE
Feature/adding columns to meta

### DIFF
--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -109,6 +109,11 @@ class BasicDatasetProfiler(DatasetProfiler):
         df.set_config_value('interactive_evaluation', False)
 
         columns = df.get_table_columns()
+
+        meta_columns = {}
+        for column in columns:
+            meta_columns[column] = {"description": ""}
+
         number_of_columns = len(columns)
         for i, column in enumerate(columns):
             logger.info("            Preparing column {} of {}: {}".format(i, number_of_columns, column))
@@ -206,4 +211,9 @@ class BasicDatasetProfiler(DatasetProfiler):
 
         df.set_config_value("interactive_evaluation", True)
         expectation_suite = df.get_expectation_suite(suppress_warnings=True, discard_failed_expectations=False)
+        if not "meta" in expectation_suite:
+            expectation_suite["meta"] = {"columns": meta_columns}
+        else:
+            expectation_suite["meta"]["columns"] = meta_columns
+
         return expectation_suite

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -224,6 +224,12 @@ def test_BasicDatasetProfiler_on_titanic():
     df = ge.read_csv("./tests/test_sets/Titanic.csv")
     suite, evrs = df.profile(BasicDatasetProfiler)
 
+    # Check to make sure BasicDatasetProfiler is adding meta.columns with a single "description" field for each column
+    print(json.dumps(suite["meta"], indent=2))
+    assert "columns" in suite["meta"]
+    for k,v in suite["meta"]["columns"].items():
+        assert v == {"description":""}
+
     # Note: the above already produces an EVR; rerunning isn't strictly necessary just for EVRs
     evrs = df.validate(result_format="SUMMARY")  # ["results"]
 


### PR DESCRIPTION
* We've added a `columns` dictionary to the `meta` dictionary of the `expectation_suite` in order to support some data dictionary functionality in rendering down the road.