### PR TITLE
Refactor/update resourceidentifiers to spec

### DIFF
--- a/great_expectations/data_context/store/namespaced.py
+++ b/great_expectations/data_context/store/namespaced.py
@@ -86,10 +86,7 @@ class NamespacedFilesystemStore(NamespacedStore, FilesystemStore):
             # NOTE : This might be easier to parse as a Jinja template
             middle_path = key.to_string(separator="/")
 
-            filename_core = "-".join([
-                key.expectation_suite_identifier.suite_name,
-                key.expectation_suite_identifier.purpose,
-            ])
+            filename_core = key.expectation_suite_identifier.expectation_suite_name
             file_prefix = self.config.get("file_prefix", "")
             file_extension = self.config.get("file_extension", "")
             filename = file_prefix + filename_core + file_extension
@@ -97,7 +94,7 @@ class NamespacedFilesystemStore(NamespacedStore, FilesystemStore):
             filepath = os.path.join(
                 self.full_base_directory,
                 key.run_id.to_string(include_class_prefix=False, separator="-"),
-                key.expectation_suite_identifier.data_asset_identifier.to_string(include_class_prefix=False, separator="/"),
+                key.expectation_suite_identifier.data_asset_name.to_string(include_class_prefix=False, separator="/"),
                 filename
             )
             return filepath
@@ -115,7 +112,7 @@ class NamespacedFilesystemStore(NamespacedStore, FilesystemStore):
 
             file_prefix = self.config.get("file_prefix", "")
             file_extension = self.config.get("file_extension", "")
-            matches = re.compile("(.*)-(.*)/(.*)/(.*)/(.*)/"+file_prefix+"(.*)-(.*)"+file_extension).match(filepath)
+            matches = re.compile("(.*)-(.*)/(.*)/(.*)/(.*)/"+file_prefix+"(.*)"+file_extension).match(filepath)
 
             args = (
                 matches.groups()[2],
@@ -123,7 +120,7 @@ class NamespacedFilesystemStore(NamespacedStore, FilesystemStore):
                 matches.groups()[4],
 
                 matches.groups()[5],
-                matches.groups()[6],
+                # matches.groups()[6],
 
                 matches.groups()[0],
                 matches.groups()[1],

--- a/great_expectations/data_context/store/namespaced.py
+++ b/great_expectations/data_context/store/namespaced.py
@@ -93,7 +93,7 @@ class NamespacedFilesystemStore(NamespacedStore, FilesystemStore):
 
             filepath = os.path.join(
                 self.full_base_directory,
-                key.run_id.to_string(include_class_prefix=False, separator="-"),
+                key.run_id,#.to_string(include_class_prefix=False, separator="-"),
                 key.expectation_suite_identifier.data_asset_name.to_string(include_class_prefix=False, separator="/"),
                 filename
             )
@@ -112,18 +112,16 @@ class NamespacedFilesystemStore(NamespacedStore, FilesystemStore):
 
             file_prefix = self.config.get("file_prefix", "")
             file_extension = self.config.get("file_extension", "")
-            matches = re.compile("(.*)-(.*)/(.*)/(.*)/(.*)/"+file_prefix+"(.*)"+file_extension).match(filepath)
+            matches = re.compile("(.*)/(.*)/(.*)/(.*)/"+file_prefix+"(.*)"+file_extension).match(filepath)
 
             args = (
+                matches.groups()[1],
                 matches.groups()[2],
                 matches.groups()[3],
+
                 matches.groups()[4],
 
-                matches.groups()[5],
-                # matches.groups()[6],
-
                 matches.groups()[0],
-                matches.groups()[1],
             )
             return self.resource_identifier_class(*args)
 

--- a/great_expectations/data_context/types/__init__.py
+++ b/great_expectations/data_context/types/__init__.py
@@ -9,7 +9,6 @@ from .resource_identifiers import (
     DataContextResourceIdentifier,
     DataAssetIdentifier,
     BatchIdentifier,
-    RunIdentifier,
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,
 )

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -187,18 +187,18 @@ class BatchIdentifier(DataContextResourceIdentifier):
     _allowed_keys = set(_key_order)
 
 
-class RunIdentifier(DataContextResourceIdentifier):
-    _key_order = [
-        "execution_context",
-        "start_time_utc",
-    ]
-    _key_types = {
-        "execution_context" : string_types,
-        "start_time_utc" : int,
-    }
-    # NOTE: This pattern is kinda awkward. It would be nice to ONLY specify _key_order
-    _required_keys = set(_key_order)
-    _allowed_keys = set(_key_order)
+# class RunIdentifier(DataContextResourceIdentifier):
+#     _key_order = [
+#         "execution_context",
+#         "start_time_utc",
+#     ]
+#     _key_types = {
+#         "execution_context" : string_types,
+#         "start_time_utc" : int,
+#     }
+#     # NOTE: This pattern is kinda awkward. It would be nice to ONLY specify _key_order
+#     _required_keys = set(_key_order)
+#     _allowed_keys = set(_key_order)
 
 
 class ExpectationSuiteIdentifier(DataContextResourceIdentifier):
@@ -223,7 +223,7 @@ class ValidationResultIdentifier(DataContextResourceIdentifier):
     ]
     _key_types = {
         "expectation_suite_identifier" : ExpectationSuiteIdentifier,
-        "run_id" : RunIdentifier,
+        "run_id" : string_types,
     }
     # NOTE: This pattern is kinda awkward. It would be nice to ONLY specify _key_order
     _required_keys = set(_key_order)

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -203,14 +203,12 @@ class RunIdentifier(DataContextResourceIdentifier):
 
 class ExpectationSuiteIdentifier(DataContextResourceIdentifier):
     _key_order = [
-        "data_asset_identifier",
-        "suite_name",
-        "purpose"
+        "data_asset_name",
+        "expectation_suite_name",
     ]
     _key_types = {
-        "data_asset_identifier" : DataAssetIdentifier,
-        "suite_name" : string_types,
-        "purpose" : string_types
+        "data_asset_name" : DataAssetIdentifier,
+        "expectation_suite_name" : string_types,
     }
     # NOTE: This pattern is kinda awkward. It would be nice to ONLY specify _key_order
     _required_keys = set(_key_order)

--- a/tests/data_context/test_store.py
+++ b/tests/data_context/test_store.py
@@ -207,13 +207,13 @@ def test_NamespacedFilesystemStore(tmp_path_factory):
         my_store.get(ValidationResultIdentifier(**{}))
     
     ns_1 = ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.hello.quarantine.prod.100"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.100"
     )
     my_store.set(ns_1,"aaa")
     assert my_store.get(ns_1) == "aaa"
 
     ns_2 = ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.hello.quarantine.prod.200"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.200"
     )
     my_store.set(ns_2, "bbb")
     assert my_store.get(ns_2) == "bbb"
@@ -241,7 +241,7 @@ def test_NamespacedFilesystemStore__validate_key(tmp_path_factory):
     )
 
     my_store._validate_key(ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.hello.quarantine.prod.100"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.100"
     ))
 
     with pytest.raises(TypeError):
@@ -263,9 +263,8 @@ def test_NamespacedFilesystemStore_key_listing(tmp_path_factory):
 
     ns_1 = ValidationResultIdentifier(**{
         "expectation_suite_identifier" : {
-            "data_asset_identifier" : DataAssetIdentifier("a", "b", "c"),
-            "suite_name" : "hello",
-            "purpose" : "quarantine",
+            "data_asset_name" : DataAssetIdentifier("a", "b", "c"),
+            "expectation_suite_name" : "quarantine",
         },
         "run_id" : {
             "execution_context" : "prod",
@@ -276,7 +275,7 @@ def test_NamespacedFilesystemStore_key_listing(tmp_path_factory):
 
     print(my_store.list_keys())
     assert set(my_store.list_keys()) == set([
-        ValidationResultIdentifier(from_string="ValidationResultIdentifier.a.b.c.hello.quarantine.prod.100")
+        ValidationResultIdentifier(from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.100")
     ])
 
     # TODO : Reactivate this
@@ -298,7 +297,7 @@ def test_NamespacedFilesystemStore_pandas_csv_serialization(tmp_path_factory):#,
     )
 
     key1 = ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.default.quarantine.prod.20190801"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.20190801"
     )
     with pytest.raises(AssertionError):
         my_store.set(key1, "hi")
@@ -313,10 +312,10 @@ test_FilesystemStore_pandas_csv_serialization__dir0/
         a/
             b/
                 c/
-                    quarantined-rows-default-quarantine.csv
+                    quarantined-rows-quarantine.csv
 """
 
-    with open(os.path.join(path, "prod-20190801/a/b/c/quarantined-rows-default-quarantine.csv")) as f_:
+    with open(os.path.join(path, "prod-20190801/a/b/c/quarantined-rows-quarantine.csv")) as f_:
         assert f_.read() == """\
 x,y
 1,a

--- a/tests/data_context/test_store.py
+++ b/tests/data_context/test_store.py
@@ -207,17 +207,18 @@ def test_NamespacedFilesystemStore(tmp_path_factory):
         my_store.get(ValidationResultIdentifier(**{}))
     
     ns_1 = ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.100"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod-100"
     )
     my_store.set(ns_1,"aaa")
     assert my_store.get(ns_1) == "aaa"
 
     ns_2 = ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.200"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod-200"
     )
     my_store.set(ns_2, "bbb")
     assert my_store.get(ns_2) == "bbb"
 
+    print(my_store.list_keys())
     assert set(my_store.list_keys()) == set([
         ns_1,
         ns_2,
@@ -241,7 +242,7 @@ def test_NamespacedFilesystemStore__validate_key(tmp_path_factory):
     )
 
     my_store._validate_key(ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.100"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod-100"
     ))
 
     with pytest.raises(TypeError):
@@ -266,16 +267,13 @@ def test_NamespacedFilesystemStore_key_listing(tmp_path_factory):
             "data_asset_name" : DataAssetIdentifier("a", "b", "c"),
             "expectation_suite_name" : "quarantine",
         },
-        "run_id" : {
-            "execution_context" : "prod",
-            "start_time_utc" : "100"
-        },
+        "run_id" : "prod-100",
     })
     my_store.set(ns_1,"aaa")
 
     print(my_store.list_keys())
     assert set(my_store.list_keys()) == set([
-        ValidationResultIdentifier(from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.100")
+        ValidationResultIdentifier(from_string="ValidationResultIdentifier.a.b.c.quarantine.prod-100")
     ])
 
     # TODO : Reactivate this
@@ -297,7 +295,7 @@ def test_NamespacedFilesystemStore_pandas_csv_serialization(tmp_path_factory):#,
     )
 
     key1 = ValidationResultIdentifier(
-        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod.20190801"
+        from_string="ValidationResultIdentifier.a.b.c.quarantine.prod-20190801"
     )
     with pytest.raises(AssertionError):
         my_store.set(key1, "hi")

--- a/tests/types/test_resource_identifiers.py
+++ b/tests/types/test_resource_identifiers.py
@@ -73,7 +73,7 @@ def test_OrderedKeysDotDict__recursively_get_key_length():
 
     assert MyOKDD._recursively_get_key_length() == 3
     assert DataAssetIdentifier._recursively_get_key_length() == 3
-    assert ValidationResultIdentifier._recursively_get_key_length() == 7
+    assert ValidationResultIdentifier._recursively_get_key_length() == 6
 
 
 def test_DataAssetIdentifier():
@@ -94,13 +94,12 @@ def test_ValidationResultIdentifier__init__totally_nested():
         coerce_types=True,
         **{
             "expectation_suite_identifier" : {
-                "data_asset_identifier" : {
+                "data_asset_name" : {
                     "datasource" : "a",
                     "generator" : "b",
                     "generator_asset" : "c",
                 },
-                "suite_name": "hello",
-                "purpose": "testing",
+                "expectation_suite_name": "failure",
             },
             "run_id" : {
                 "execution_context": "testing",
@@ -109,16 +108,15 @@ def test_ValidationResultIdentifier__init__totally_nested():
         }
     )
 
-    assert my_id.to_string() == "ValidationResultIdentifier.a.b.c.hello.testing.testing.12345"
+    assert my_id.to_string() == "ValidationResultIdentifier.a.b.c.failure.testing.12345"
 
 def test_ValidationResultIdentifier__init__mostly_nested():
     ValidationResultIdentifier(
         coerce_types=True,
         **{
             "expectation_suite_identifier" : {
-                "data_asset_identifier" : ("a", "b", "c"),
-                "suite_name": "hello",
-                "purpose": "testing",
+                "data_asset_name" : ("a", "b", "c"),
+                "expectation_suite_name": "warning",
             },
             "run_id" : {
                 "execution_context": "testing",
@@ -132,9 +130,8 @@ def test_ValidationResultIdentifier__init__mostly_nested_with_typed_child():
         coerce_types=True,
         **{
             "expectation_suite_identifier" : {
-                "data_asset_identifier" : DataAssetIdentifier("a", "b", "c"),
-                "suite_name": "hello",
-                "purpose": "testing",
+                "data_asset_name" : DataAssetIdentifier("a", "b", "c"),
+                "expectation_suite_name": "quarantine",
             },
             "run_id" : {
                 "execution_context": "testing",
@@ -148,9 +145,8 @@ def test_ValidationResultIdentifier__init__partially_flat():
         coerce_types=True,
         **{
             "expectation_suite_identifier" : {
-                "data_asset_identifier" : ("a", "b", "c"),
-                "suite_name": "hello",
-                "purpose": "testing",
+                "data_asset_name" : ("a", "b", "c"),
+                "expectation_suite_name": "hello",
             },
             "run_id" : ("testing", 12345)
         }
@@ -176,13 +172,12 @@ def test_ValidationResultIdentifier__init__partially_flat():
 def test_ValidationResultIdentifier__init__nested_except_the_top_layer():
     ValidationResultIdentifier(
         {
-            "data_asset_identifier" : {
+            "data_asset_name" : {
                 "datasource" : "a",
                 "generator" : "b",
                 "generator_asset" : "c",
             },
-            "suite_name": "hello",
-            "purpose": "testing",
+            "expectation_suite_name": "hello",
         },{
             "execution_context": "testing",
             "start_time_utc": 12345,
@@ -192,30 +187,29 @@ def test_ValidationResultIdentifier__init__nested_except_the_top_layer():
 
 def test_ValidationResultIdentifier__init__entirely_flat():
     ValidationResultIdentifier(
-        "a", "b", "c", "hello", "testing", "testing", 12345,
+        "a", "b", "c", "warning", "testing", 12345,
         coerce_types=True,
     )
 
 def test_OrderedKeysDotDict__zip_keys_and_args_to_dict():
     assert ValidationResultIdentifier._zip_keys_and_args_to_dict(
-        ["a", "b", "c", "hello", "testing", "testing", 12345],
+        ["a", "b", "c", "warning", "testing", 12345],
     ) == {
-        "expectation_suite_identifier" : ["a", "b", "c", "hello", "testing"],
+        "expectation_suite_identifier" : ["a", "b", "c", "warning"],
         "run_id" : ["testing", 12345],
     }
 
     assert ExpectationSuiteIdentifier._zip_keys_and_args_to_dict(
-        ["a", "b", "c", "hello", "testing"]
+        ["a", "b", "c", "warning"]
     ) == {
-        "data_asset_identifier" : ["a", "b", "c"],
-        "suite_name" : "hello",
-        "purpose" : "testing",
+        "data_asset_name" : ["a", "b", "c"],
+        "expectation_suite_name" : "warning",
     }
 
     assert ValidationResultIdentifier._zip_keys_and_args_to_dict(
-        ["a", "b", "c", "hello", "testing", "testing", 12345],
+        ["a", "b", "c", "hello", "testing", 12345],
     ) == {
-        "expectation_suite_identifier" : ["a", "b", "c", "hello", "testing"],
+        "expectation_suite_identifier" : ["a", "b", "c", "hello",],
         "run_id" : ["testing", 12345],
     }
 
@@ -225,18 +219,17 @@ def test_parse_string_to_data_context_resource_identifier():
     assert parse_string_to_data_context_resource_identifier("DataAssetIdentifier.A.B.C") == DataAssetIdentifier("A", "B", "C")
 
     assert parse_string_to_data_context_resource_identifier(
-        "ValidationResultIdentifier.a.b.c.hello.testing.testing.12345"
+        "ValidationResultIdentifier.a.b.c.hello.testing.12345"
     ) == ValidationResultIdentifier(
         coerce_types=True,
         **{
             "expectation_suite_identifier" : {
-                "data_asset_identifier" : {
+                "data_asset_name" : {
                     "datasource" : "a",
                     "generator" : "b",
                     "generator_asset" : "c",
                 },
-                "suite_name": "hello",
-                "purpose": "testing",
+                "expectation_suite_name": "hello",
             },
             "run_id" : {
                 "execution_context": "testing",

--- a/tests/types/test_resource_identifiers.py
+++ b/tests/types/test_resource_identifiers.py
@@ -73,7 +73,7 @@ def test_OrderedKeysDotDict__recursively_get_key_length():
 
     assert MyOKDD._recursively_get_key_length() == 3
     assert DataAssetIdentifier._recursively_get_key_length() == 3
-    assert ValidationResultIdentifier._recursively_get_key_length() == 6
+    assert ValidationResultIdentifier._recursively_get_key_length() == 5
 
 
 def test_DataAssetIdentifier():
@@ -101,14 +101,11 @@ def test_ValidationResultIdentifier__init__totally_nested():
                 },
                 "expectation_suite_name": "failure",
             },
-            "run_id" : {
-                "execution_context": "testing",
-                "start_time_utc": 12345,
-            },
+            "run_id" : "testing-12345",
         }
     )
 
-    assert my_id.to_string() == "ValidationResultIdentifier.a.b.c.failure.testing.12345"
+    assert my_id.to_string() == "ValidationResultIdentifier.a.b.c.failure.testing-12345"
 
 def test_ValidationResultIdentifier__init__mostly_nested():
     ValidationResultIdentifier(
@@ -187,16 +184,16 @@ def test_ValidationResultIdentifier__init__nested_except_the_top_layer():
 
 def test_ValidationResultIdentifier__init__entirely_flat():
     ValidationResultIdentifier(
-        "a", "b", "c", "warning", "testing", 12345,
+        "a", "b", "c", "warning", "testing-12345",
         coerce_types=True,
     )
 
 def test_OrderedKeysDotDict__zip_keys_and_args_to_dict():
     assert ValidationResultIdentifier._zip_keys_and_args_to_dict(
-        ["a", "b", "c", "warning", "testing", 12345],
+        ["a", "b", "c", "warning", "testing-12345"],
     ) == {
         "expectation_suite_identifier" : ["a", "b", "c", "warning"],
-        "run_id" : ["testing", 12345],
+        "run_id" : "testing-12345",
     }
 
     assert ExpectationSuiteIdentifier._zip_keys_and_args_to_dict(
@@ -207,10 +204,10 @@ def test_OrderedKeysDotDict__zip_keys_and_args_to_dict():
     }
 
     assert ValidationResultIdentifier._zip_keys_and_args_to_dict(
-        ["a", "b", "c", "hello", "testing", 12345],
+        ["a", "b", "c", "hello", "testing-12345"]
     ) == {
         "expectation_suite_identifier" : ["a", "b", "c", "hello",],
-        "run_id" : ["testing", 12345],
+        "run_id" : "testing-12345",
     }
 
 # TODO: Put this with the other tests for utils.
@@ -219,7 +216,7 @@ def test_parse_string_to_data_context_resource_identifier():
     assert parse_string_to_data_context_resource_identifier("DataAssetIdentifier.A.B.C") == DataAssetIdentifier("A", "B", "C")
 
     assert parse_string_to_data_context_resource_identifier(
-        "ValidationResultIdentifier.a.b.c.hello.testing.12345"
+        "ValidationResultIdentifier.a.b.c.hello.testing-12345"
     ) == ValidationResultIdentifier(
         coerce_types=True,
         **{
@@ -231,9 +228,6 @@ def test_parse_string_to_data_context_resource_identifier():
                 },
                 "expectation_suite_name": "hello",
             },
-            "run_id" : {
-                "execution_context": "testing",
-                "start_time_utc": 12345,
-            },
+            "run_id" : "testing-12345",
         }
     )


### PR DESCRIPTION
@jcampbell : Small PR implementing the reversions to `ResourceIdentifiers` that we talked about.

Note : I'm PRing into `refactor/typed_resource_identifiers`, since that's essentially my working branch for soon-to-be-mergeable stuff. (The validationAction stuff is a little further out.)