### PR TITLE
Better documentation of get_batch in the notebooks and the doc (to address Taylor's issue)

### DIFF
--- a/docs/getting_started/create_expectations.rst
+++ b/docs/getting_started/create_expectations.rst
@@ -89,6 +89,50 @@ The argument ``expectation_suite_name`` specifies the name of the expectation su
 
 .. image:: ../images/get_batch.jpg
 
+
+If you want to validate data in Pandas Dataframes or in Spark Dataframes:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* If GE listed and profiled your files correctly:
+
+.. code-block:: python
+
+    data_asset_name = CHOOSE FROM THE LIST ABOVE IN THE NOTEBOOK
+    batch = context.get_batch(data_asset_name,
+                              expectation_suite_name)
+
+* Otherwise (you want to control the logic of reading the data):
+
+.. code-block:: python
+
+    df = load the data into a dataframe, e.g., df = SparkDFDataset(spark.read.csv... or pd.read_csv(...
+    data_asset_name = COME UP WITH A NAME - THIS WILL CREATE A NEW DATA ASSET
+    batch = context.get_batch(data_asset_name,
+                              expectation_suite_name,
+                              df)
+
+
+If you want to validate data in a database:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* To validate an existing table:
+
+.. code-block:: python
+
+    data_asset_name = CHOOSE THE NAME OF YOUR TABLE FROM THE LIST OF DATA ASSETS ABOVE IN THE NOTEBOOK
+    df = context.get_batch(data_asset_name,
+                            expectation_suite_name='my_suite')
+
+* To validate a query result set:
+
+.. code-block:: python
+
+    data_asset_name = NAME YOUR QUERY (E.G., daily_users_query) - THIS WILL CREATE A NEW DATA ASSET
+    df = context.get_batch(data_asset_name,
+                            expectation_suite_name='my_suite',
+                            query='SQL FOR YOUR QUERY')
+
+
 Reader Options
 ---------------
 

--- a/great_expectations/init_notebooks/create_expectations.ipynb
+++ b/great_expectations/init_notebooks/create_expectations.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,22 +44,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "exceptions must derive from BaseException",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-0dd8d48bfd61>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mcontext\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mge\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata_context\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataContext\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Dropbox/coding/superconductive/ge_open_source/great_expectations/great_expectations/data_context/data_context.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, context_root_dir, expectation_explorer, data_asset_name_delimiter)\u001b[0m\n\u001b[1;32m    145\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    146\u001b[0m                 raise(\n\u001b[0;32m--> 147\u001b[0;31m                     \u001b[0;34m\"Unable to locate context root directory. Please provide a directory name.\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    148\u001b[0m                 )\n\u001b[1;32m    149\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: exceptions must derive from BaseException"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "context = ge.data_context.DataContext()"
    ]
@@ -86,9 +73,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Pick one of the data asset names above and use as the value of data_asset_name argument below\n",
+    "### Load a batch of data from the data asset you want to validate\n",
     "\n",
-    "[Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/create_expectations.html?utm_source=notebook&utm_medium=create_expectations#get-batch)\n"
+    "Learn about `get_batch` in [this tutorial](https://docs.greatexpectations.io/en/latest/getting_started/create_expectations.html?utm_source=notebook&utm_medium=create_expectations#get-batch)\n",
+    "\n",
+    "__Quick Guide:__\n",
+    "\n",
+    "##### If you want to validate data in Pandas Dataframes or in Spark Dataframes:\n",
+    "\n",
+    "* A. If GE listed and profiled your files correctly:\n",
+    "\n",
+    "```\n",
+    "data_asset_name = CHOOSE FROM THE LIST ABOVE\n",
+    "batch = context.get_batch(data_asset_name, \n",
+    "                          expectation_suite_name)\n",
+    "```\n",
+    "* B. Otherwise (you want to control the logic of reading the data):\n",
+    "\n",
+    "```\n",
+    "df = load the data into a dataframe, e.g., df = SparkDFDataset(spark.read.csv... or pd.read_csv(...\n",
+    "data_asset_name = COME UP WITH A NAME - THIS WILL CREATE A NEW DATA ASSET.\n",
+    "batch = context.get_batch(data_asset_name, \n",
+    "                          expectation_suite_name, \n",
+    "                          df)\n",
+    "```\n",
+    "\n",
+    "\n",
+    "##### If you want to validate data in a database:\n",
+    "\n",
+    "* A. To validate an existing table:\n",
+    "\n",
+    "```\n",
+    "data_asset_name = 'CHOOSE THE NAME OF YOUR TABLE FROM THE LIST OF DATA ASSETS ABOVE'\n",
+    "df = context.get_batch(data_asset_name, \n",
+    "                        expectation_suite_name='my_suite') \n",
+    "```\n",
+    "\n",
+    "* B. To validate a query result set:\n",
+    "\n",
+    "```\n",
+    "data_asset_name = 'NAME YOUR QUERY (E.G., daily_users_query) - THIS WILL CREATE A NEW DATA ASSET'\n",
+    "df = context.get_batch(data_asset_name, \n",
+    "                        expectation_suite_name='my_suite',\n",
+    "                        query='SQL FOR YOUR QUERY')\n",
+    "```\n",
+    "\n",
+    "\n",
+    "\n"
    ]
   },
   {
@@ -97,8 +128,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = context.get_batch('!!!USE ONE OF THE DATA ASSET NAMES FROM ABOVE!!!', expectation_suite_name='my_suite')\n",
-    "df.head()"
+    "df = context.get_batch(COPY THE APPROPPRIATE CODE SNIPPET FROM THE CELL ABOVE\n",
+    "df.head()\n"
    ]
   },
   {
@@ -242,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/great_expectations/init_notebooks/integrate_validation_into_pipeline.ipynb
+++ b/great_expectations/init_notebooks/integrate_validation_into_pipeline.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "### Obtain the batch to validate\n",
     "\n",
-    "[Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=integrate_validation#obtain-a-batch-to-validate)\n"
+    "Learn about `get_batch` in [this tutorial]](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=integrate_validation#obtain-a-batch-to-validate)\n"
    ]
   },
   {
@@ -150,13 +150,27 @@
     "from great_expectations.dataset import PandasDataset, SqlAlchemyDataset, SparkDFDataset\n",
     "spark = SparkSession.builder.getOrCreate()\n",
     "df = SparkDFDataset(spark.read.csv(file_path_to_validate))\n",
-    "df.spark_df.show()\n",
+    "df.head()\n",
     "batch = context.get_batch(data_asset_name, expectation_suite_name, df)\n",
     "```\n",
     "\n",
     "##### If your pipeline processes SQL querues:\n",
+    "\n",
+    "* A. To validate an existing table:\n",
+    "\n",
     "```\n",
-    "batch = context.get_batch(data_asset_name, expectation_suite_name, query=\"SELECT * from ....\") # the query whose result set you want to validate\n",
+    "data_asset_name = 'USE THE TABLE NAME'\n",
+    "df = context.get_batch(data_asset_name, \n",
+    "                        expectation_suite_name=expectation_suite_name) \n",
+    "```\n",
+    "\n",
+    "* B. To validate a query result set:\n",
+    "\n",
+    "```\n",
+    "data_asset_name = 'USE THE NAME YOU SPECIFIED WHEN YOU CREATED THE EXPECTATION SUITE FOR THIS QUERY'\n",
+    "df = context.get_batch(data_asset_name, \n",
+    "                        expectation_suite_name=expectation_suite_name,\n",
+    "                        query='SQL FOR YOUR QUERY')\n",
     "```\n"
    ]
   },


### PR DESCRIPTION
get_batch for SQLAlchemy confused users by allowing a combination of arguments that do not make sense together:

get_batch('existing_table_name',
                   expectation_suite_name = 'my_suite',
                   query='select * from a_table_that_does_not_exist')

In this case the query was ignored, since the data asset name was believed to be the table name.

For now the fix is to document this method better in the notebooks and in the documentation.

notebook:

![image](https://user-images.githubusercontent.com/80363/63983805-30cd6280-ca7d-11e9-84ea-eb67aaa45da1.png)
