### PR TITLE
minor fixes in notebooks

### DIFF
--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -20,6 +20,7 @@ from great_expectations.exceptions import DataContextError, ConfigNotFoundError
 from great_expectations import __version__, read_csv
 from pyfiglet import figlet_format
 import click
+click.disable_unicode_literals_warning = True
 import six
 import os
 import json

--- a/great_expectations/init_notebooks/create_expectations.ipynb
+++ b/great_expectations/init_notebooks/create_expectations.ipynb
@@ -221,12 +221,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "    \n",
+    "    \n",
+    "If you decide not to save some expectations that you created, use [remove_expectaton method](https://docs.greatexpectations.io/en/latest/module_docs/data_asset_module.html?highlight=remove_expectation&utm_source=notebook&utm_medium=create_expectations#great_expectations.data_asset.data_asset.DataAsset.remove_expectation)\n",
+    "\n",
+    "\n",
+    "The following call will save the expectation suite as a JSON file in great_expectations/expectations directory of your project:\n",
+    "    "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.save_expectation_suite()"
+    "df.save_expectation_suite() "
    ]
   },
   {

--- a/great_expectations/init_notebooks/integrate_validation_into_pipeline.ipynb
+++ b/great_expectations/init_notebooks/integrate_validation_into_pipeline.ipynb
@@ -22,10 +22,7 @@
     "import great_expectations as ge\n",
     "import great_expectations.jupyter_ux\n",
     "import pandas as pd\n",
-    "import uuid # used to generate run_id\n",
     "from datetime import datetime\n",
-    "\n",
-    "import tzlocal\n",
     "\n",
     "great_expectations.jupyter_ux.setup_notebook_logging()\n",
     "\n"
@@ -180,7 +177,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n"
+    "df = context.get_batch(COPY THE APPROPPRIATE CODE SNIPPET FROM THE CELL ABOVE)\n",
+    "df.head()\n"
    ]
   },
   {


### PR DESCRIPTION
1. Fixed Remove unused imports in integrate_validation_into_pipeline.ipynb #668

2. Added an explanation how to remove an expectation from a suite to the create_expectations notebook

3. Added click.disable_unicode_literals_warning = True to disable these warnings in Python 2 (see https://click.palletsprojects.com/en/7.x/python3/#unicode-literals)