### PR TITLE
Deprecate data_doc_directory

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -132,17 +132,11 @@ class ConfigOnlyDataContext(object):
         for datasource in self._project_config["datasources"].keys():
             self.get_datasource(datasource)
 
-
+        # Init stores
         self._stores = DotDict()
         self._init_stores(self._project_config["stores"])
 
-
-        # Stuff below this comment is legacy code, not yet fully converted to new-style Stores.
-        self.data_doc_directory = os.path.join(self.root_directory, "uncommitted/documentation")
-
         self._compiled = False
-        # /End store stuff
-
 
         if data_asset_name_delimiter not in ALLOWED_DELIMITERS:
             raise DataContextError("Invalid delimiter: delimiter must be '.' or '/'")

--- a/tests/render/test_data_documentation_site_builder.py
+++ b/tests/render/test_data_documentation_site_builder.py
@@ -92,7 +92,7 @@ def test_configuration_driven_site_builder(titanic_data_context, filesystem_csv_
         """`unused_datasource` must not appear in this documentation, 
         because `datasources` config option specifies only `mydatasource`"""
 
-    assert index_page_locator_info['path'] == titanic_data_context.data_doc_directory + '/local_site/index.html'
+    assert index_page_locator_info['path'] == titanic_data_context.root_directory + '/uncommitted/documentation/local_site/index.html'
 
     assert len(index_links_dict['mydatasource']['mygenerator']['Titanic']['expectations_links']) == 1, \
     """


### PR DESCRIPTION
Since implementing `site_builder`, `DataContext.data_doc_directory` has been replaced by the configured value: `site_store.base_directory`.

This PR fully removes `data_doc_directory` from `DataContext`.