### PR TITLE
Remove commented code

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1301,35 +1301,6 @@ class ConfigOnlyDataContext(object):
         else:
             return results_dict
 
-    # TODO: refactor this into a snapshot getter based on project_config
-    # def get_failed_dataset(self, validation_result, **kwargs):
-    #     try:
-    #         reference_url = validation_result["meta"]["dataset_reference"]
-    #     except KeyError:
-    #         raise ValueError("Validation result must have a dataset_reference in the meta object to fetch")
-        
-    #     if reference_url.startswith("s3://"):
-    #         try:
-    #             import boto3
-    #             s3 = boto3.client('s3')
-    #         except ImportError:
-    #             raise ImportError("boto3 is required for retrieving a dataset from s3")
-        
-    #         parsed_url = urlparse(reference_url)
-    #         bucket = parsed_url.netloc
-    #         key = parsed_url.path[1:]
-            
-    #         s3_response_object = s3.get_object(Bucket=bucket, Key=key)
-    #         if key.endswith(".csv"):
-    #             # Materialize as dataset
-    #             # TODO: check the associated config for the correct data_asset_type to use
-    #             return read_csv(s3_response_object['Body'], **kwargs)
-    #         else:
-    #             return s3_response_object['Body']
-
-    #     else:
-    #         raise ValueError("Only s3 urls are supported.")
-
     def update_return_obj(self, data_asset, return_obj):
         """Helper called by data_asset.
 


### PR DESCRIPTION
Small PR to remove the already-commented-and-deprecated method, `get_failed_dataset`.

Stores and Actions will support the functionality that used to live in this method.