### PR TITLE
Moving slack webhook url to profiles.yml

### DIFF
--- a/docs/getting_started/cli_init.rst
+++ b/docs/getting_started/cli_init.rst
@@ -211,7 +211,7 @@ The corresponding config would be:
                     type: queries
             profile: my_db
 
-Note: the CLI will also create a ``uncommitted/credentials/profiles.yml`` files to contain SQL credentials. Note that this file goes in the ``uncommitted/`` directory, which should *NOT* be committed to source control.
+Note: the CLI will also create a ``uncommitted/credentials/profiles.yml`` files to contain SQL credentials. Note that this file goes in the ``uncommitted/`` directory, which should *NOT* be committed to source control. It may also contain a Slack webhook url for notifications.
 
 Strictly speaking, a Great Expectations Datasource is not the data itself, but part of a *pointer* to a data compute environment where Expectations can be evaluated, called a `DataAsset.` Fully describing the pointer requires a 3-ple:
 

--- a/docs/getting_started/pipeline_integration.rst
+++ b/docs/getting_started/pipeline_integration.rst
@@ -198,7 +198,7 @@ Send Notifications
 
 The DataContext can also send notifications using a user-provided callback function based on the validation result. GE
 includes a slack-based notification in the base package. To enable a slack notification for results, simply specify
-the slack webhook in the ???PROFILES??? configuration:
+the slack webhook in the profiles.yml file in uncommitted/credentials/:
 
 .. code-block:: bash
 

--- a/docs/getting_started/pipeline_integration.rst
+++ b/docs/getting_started/pipeline_integration.rst
@@ -198,7 +198,7 @@ Send Notifications
 
 The DataContext can also send notifications using a user-provided callback function based on the validation result. GE
 includes a slack-based notification in the base package. To enable a slack notification for results, simply specify
-the slack webhook in the DataContext configuration:
+the slack webhook in the ???PROFILES??? configuration:
 
 .. code-block:: bash
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1903,11 +1903,6 @@ validations_store:
 #     key_prefix: <your key prefix>
 #   
 
-# Uncomment the lines below to enable a result callback.
-
-# result_callback:
-#   slack: https://slack.com/replace_with_your_webhook
-
 # Uncomment the lines below to save snapshots of data assets that fail validation.
 
 # data_asset_snapshot_store:
@@ -2026,5 +2021,9 @@ A profile can optionally have a single parameter called
 
 Otherwise, all credential options specified here for a 
 given profile will be passed to sqlalchemy's create URL function.
+
+# Uncomment the lines below to enable a Slack webhook result callback.
+# result_callback:
+#   slack: https://slack.com/replace_with_your_webhook
 
 """

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1162,17 +1162,16 @@ class DataContext(object):
                 except Exception:
                     raise
 
-        # try:
-        # except KeyError:
-        # profile = self._datasource_config["profile"]
-        # credentials = self.data_context.get_profile_credentials(profile)
         profile = self._get_all_profile_credentials()
         if "result_callback" in profile:
             result_callback = profile["result_callback"]
-            if isinstance(result_callback, dict) and "slack" in result_callback:
-                get_slack_callback(result_callback["slack"])(validation_results)
-            else:
-                logger.warning("Unrecognized result_callback configuration. Please verify this in your profiles.yml file: {}".format(PROFILE_PATH))
+            try:
+                slack_webhook_url = result_callback["slack"]
+                # TODO move type checking to profile/environment loaders
+                assert isinstance(slack_webhook_url, str), TypeError
+                get_slack_callback(slack_webhook_url)(validation_results)
+            except (KeyError, TypeError):
+                logger.warning("Unrecognized result_slack callback configuration. Please verify this in your profiles.yml file: {}".format(PROFILE_PATH))
 
         if "data_asset_snapshot_store" in self._project_config and validation_results["success"] is False:
             data_asset_snapshot_store = self._project_config["data_asset_snapshot_store"]


### PR DESCRIPTION
## What's Here

- Moved slack webhook to profiles.yml at the top level since the notion of multiple profiles is not currently active

## Known Issues

- There's a bit in the docstring that is unknown to me.
- A real solution for environments will need to include this in a more robust way
- this is not covered by testing