### PR TITLE
Added an initial implementation of FixedLengthTupleS3StoreBackend

### DIFF
--- a/great_expectations/data_context/store/__init__.py
+++ b/great_expectations/data_context/store/__init__.py
@@ -3,6 +3,7 @@ from .store_backend import (
     InMemoryStoreBackend,
     # FilesystemStoreBackend,
     FixedLengthTupleFilesystemStoreBackend,
+    FixedLengthTupleS3StoreBackend,
 )
 
 from .store import (

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -346,7 +346,7 @@ class InMemoryStoreBackend(StoreBackend):
 
 class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
     """Uses a local filepath as a store.
-    
+
     The key to this StoreBackend must be a tuple with fixed length equal to key_length.
     The filepath_template is a string template used to convert the key to a filepath.
     There's a bit of regex magic in _convert_filepath_to_key that reverses this process,
@@ -354,14 +354,14 @@ class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
     """
 
     def __init__(
-        self,
-        base_directory,
-        filepath_template,
-        key_length,
-        root_directory,
-        forbidden_substrings=["/", "\\"],
-        file_extension=None,
-        file_prefix=None,
+            self,
+            base_directory,
+            filepath_template,
+            key_length,
+            root_directory,
+            forbidden_substrings=["/", "\\"],
+            file_extension=None,
+            file_prefix=None,
     ):
         self.base_directory = base_directory
         self.key_length = key_length
@@ -374,7 +374,7 @@ class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
 
         if not os.path.isabs(root_directory):
             raise ValueError("root_directory must be an absolute path. Got {0} instead.".format(root_directory))
-        
+
         self.root_directory = root_directory
 
         self.full_base_directory = os.path.join(
@@ -425,7 +425,6 @@ class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
                 type(value),
             ))
 
-        
     def list_keys(self):
         key_list = []
         for root, dirs, files in os.walk(self.full_base_directory):
@@ -464,41 +463,39 @@ class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
         self._validate_key(key)
 
         converted_string = self.filepath_template.format(*list(key), **{
-            "file_extension" : self.file_extension,
-            "file_prefix" : self.file_prefix,
+            "file_extension": self.file_extension,
+            "file_prefix": self.file_prefix,
         })
 
         return converted_string
-
 
     def _convert_filepath_to_key(self, filepath):
 
         # Convert the template to a regex
         indexed_string_substitutions = re.findall("\{\d+\}", self.filepath_template)
-        tuple_index_list = ["(?P<tuple_index_{0}>.*)".format(i,) for i in range(len(indexed_string_substitutions))]
+        tuple_index_list = ["(?P<tuple_index_{0}>.*)".format(i, ) for i in range(len(indexed_string_substitutions))]
         intermediate_filepath_regex = re.sub(
             "\{\d+\}",
             lambda m, r=iter(tuple_index_list): next(r),
             self.filepath_template
         )
         filepath_regex = intermediate_filepath_regex.format(*tuple_index_list, **{
-            "file_extension" : self.file_extension,
-            "file_prefix" : self.file_prefix,            
+            "file_extension": self.file_extension,
+            "file_prefix": self.file_prefix,
         })
 
-        #Apply the regex to the filepath
+        # Apply the regex to the filepath
         matches = re.compile(filepath_regex).match(filepath)
 
-        #Map key elements into the apprpriate parts of the tuple
+        # Map key elements into the apprpriate parts of the tuple
         new_key = list([None for element in range(self.key_length)])
         for i in range(len(tuple_index_list)):
             tuple_index = int(re.search('\d+', indexed_string_substitutions[i]).group(0))
-            key_element = matches.group('tuple_index_'+str(i))
+            key_element = matches.group('tuple_index_' + str(i))
             new_key[tuple_index] = key_element
 
         new_key = tuple(new_key)
         return new_key
-
 
     def verify_that_key_to_filepath_operation_is_reversible(self):
         # NOTE: There's actually a fairly complicated problem here, similar to magic autocomplete for dataAssetNames.
@@ -514,11 +511,179 @@ class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
         filepath = self._convert_key_to_filepath(key)
         new_key = self._convert_filepath_to_key(filepath)
         if key != new_key:
-            raise ValueError("filepath template {0} for class {1} is not reversible for a tuple of length {2}. Have you included all elements in the key tuple?".format(
-                self.filepath_template,
+            raise ValueError(
+                "filepath template {0} for class {1} is not reversible for a tuple of length {2}. Have you included all elements in the key tuple?".format(
+                    self.filepath_template,
+                    self.__class__.__name__,
+                    self.key_length,
+                ))
+            # raise AssertionError("Cannot reverse key conversion in {}\nThis is most likely a problem with your filepath_template:\n\t{}".format(
+            #     self.__class__.__name__,
+            #     self.filepath_template
+            # ))
+
+
+class FixedLengthTupleS3StoreBackend(StoreBackend):
+    """
+    TODO: edit
+    Uses a local filepath as a store.
+
+    The key to this StoreBackend must be a tuple with fixed length equal to key_length.
+    The filepath_template is a string template used to convert the key to a filepath.
+    There's a bit of regex magic in _convert_filepath_to_key that reverses this process,
+    so that we can write AND read using filenames as keys.
+    """
+
+    def __init__(
+            self,
+            root_directory,
+            filepath_template,
+            key_length,
+            bucket,
+            prefix,
+            forbidden_substrings=["/", "\\"],
+            file_extension=None,
+            file_prefix=None,
+    ):
+        self.bucket = bucket
+        self.prefix = prefix
+        self.key_length = key_length
+        self.forbidden_substrings = forbidden_substrings
+        self.file_extension = file_extension
+        self.file_prefix = file_prefix
+
+        self.filepath_template = filepath_template
+        self.verify_that_key_to_filepath_operation_is_reversible()
+
+
+    def _get(self, key):
+        s3_object_key = os.path.join(
+            self.prefix,
+            self._convert_key_to_filepath(key)
+        )
+
+        import boto3
+        s3 = boto3.resource('s3')
+        s3_response_object = s3.get_object(Bucket=self.bucket, Key=key)
+        return s3_response_object['Body'].read()
+
+    def _set(self, key, value):
+        s3_object_key = os.path.join(
+            self.prefix,
+            self._convert_key_to_filepath(key)
+        )
+
+        import boto3
+        s3 = boto3.resource('s3')
+        result_s3 = s3.Object(self.bucket, s3_object_key)
+        result_s3.put(Body=value.encode('utf-8'))
+
+    def _validate_key(self, key):
+        pass
+        super(FixedLengthTupleS3StoreBackend, self)._validate_key(key)
+
+        for key_element in key:
+            for substring in self.forbidden_substrings:
+                if substring in key_element:
+                    raise ValueError("Keys in {0} must not contain substrings in {1} : {2}".format(
+                        self.__class__.__name__,
+                        self.forbidden_substrings,
+                        key,
+                    ))
+
+    def _validate_value(self, value):
+        # NOTE: We may want to allow bytes here as well.
+
+        if not isinstance(value, string_types):
+            raise TypeError("Values in {0} must be instances of {1}, not {2}".format(
                 self.__class__.__name__,
-                self.key_length,
+                string_types,
+                type(value),
             ))
+
+    def list_keys(self):
+        key_list = []
+
+        import boto3
+        s3 = boto3.client('s3')
+
+        for s3_object_info in s3.list_objects(Bucket=self.bucket, Prefix=self.prefix)['Contents']:
+            s3_object_key = s3_object_info['Key']
+            key_list.append(
+                self._convert_filepath_to_key(s3_object_key)
+            )
+
+        return key_list
+
+    def has_key(self, key):
+        assert isinstance(key, string_types)
+
+        all_keys = self.list_keys()
+        return key in all_keys
+
+    def _convert_key_to_filepath(self, key):
+        # NOTE: At some point in the future, it might be better to replace this logic with os.path.join.
+        # That seems more correct, but the configs will be a lot less intuitive.
+        # In the meantime, there is some chance that configs will not be cross-OS compatible.
+
+        # NOTE : These methods support fixed-length keys, but not variable.
+        self._validate_key(key)
+
+        converted_string = self.filepath_template.format(*list(key), **{
+            "file_extension": self.file_extension,
+            "file_prefix": self.file_prefix,
+        })
+
+        return converted_string
+
+    def _convert_filepath_to_key(self, filepath):
+
+        # Convert the template to a regex
+        indexed_string_substitutions = re.findall("\{\d+\}", self.filepath_template)
+        tuple_index_list = ["(?P<tuple_index_{0}>.*)".format(i, ) for i in range(len(indexed_string_substitutions))]
+        intermediate_filepath_regex = re.sub(
+            "\{\d+\}",
+            lambda m, r=iter(tuple_index_list): next(r),
+            self.filepath_template
+        )
+        filepath_regex = intermediate_filepath_regex.format(*tuple_index_list, **{
+            "file_extension": self.file_extension,
+            "file_prefix": self.file_prefix,
+        })
+
+        # Apply the regex to the filepath
+        matches = re.compile(filepath_regex).match(filepath)
+
+        # Map key elements into the apprpriate parts of the tuple
+        new_key = list([None for element in range(self.key_length)])
+        for i in range(len(tuple_index_list)):
+            tuple_index = int(re.search('\d+', indexed_string_substitutions[i]).group(0))
+            key_element = matches.group('tuple_index_' + str(i))
+            new_key[tuple_index] = key_element
+
+        new_key = tuple(new_key)
+        return new_key
+
+    def verify_that_key_to_filepath_operation_is_reversible(self):
+        # NOTE: There's actually a fairly complicated problem here, similar to magic autocomplete for dataAssetNames.
+        # "Under what conditions does an incomplete key tuple fully specify an object within the GE namespace?"
+        # This doesn't just depend on the structure of keys.
+        # It also depends on uniqueness of combinations of named elements within the namespace tree.
+        # For now, I do the blunt thing and force filepaths to fully specify keys.
+
+        def get_random_hex(len=4):
+            return "".join([random.choice(list("ABCDEF0123456789")) for i in range(len)])
+
+        key = tuple([get_random_hex() for j in range(self.key_length)])
+        filepath = self._convert_key_to_filepath(key)
+        new_key = self._convert_filepath_to_key(filepath)
+        if key != new_key:
+            raise ValueError(
+                "filepath template {0} for class {1} is not reversible for a tuple of length {2}. Have you included all elements in the key tuple?".format(
+                    self.filepath_template,
+                    self.__class__.__name__,
+                    self.key_length,
+                ))
             # raise AssertionError("Cannot reverse key conversion in {}\nThis is most likely a problem with your filepath_template:\n\t{}".format(
             #     self.__class__.__name__,
             #     self.filepath_template

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -37,12 +37,6 @@ class StoreBackend(object):
     """a key-value store, to abstract away reading and writing to a persistence layer
     """
 
-    def __init__(
-        self,
-        root_directory=None, # NOTE: Eugene: 2019-09-06: I think this should be moved into filesystem-specific children classes
-    ):
-        self.root_directory = root_directory
-
     def get(self, key):
         self._validate_key(key)
         value = self._get(key)
@@ -99,7 +93,6 @@ class InMemoryStoreBackend(StoreBackend):
     def __init__(
         self,
         separator=".",
-        root_directory=None
     ):
         self.store = {}
         self.separator = separator
@@ -357,7 +350,6 @@ class FixedLengthTupleStoreBackend(StoreBackend):
 
     def __init__(
             self,
-            root_directory,
             filepath_template,
             key_length,
             forbidden_substrings=["/", "\\"],
@@ -484,13 +476,14 @@ class FixedLengthTupleFilesystemStoreBackend(FixedLengthTupleStoreBackend):
             file_extension=None,
             file_prefix=None,
     ):
-        super(FixedLengthTupleFilesystemStoreBackend, self).__init__(root_directory,
+        super(FixedLengthTupleFilesystemStoreBackend, self).__init__(
                         filepath_template,
                         key_length,
                         forbidden_substrings=forbidden_substrings,
                         file_extension=file_extension,
                         file_prefix=file_prefix)
 
+        self.root_directory = root_directory
         self.base_directory = base_directory
 
         if not os.path.isabs(root_directory):
@@ -565,7 +558,6 @@ class FixedLengthTupleS3StoreBackend(FixedLengthTupleStoreBackend):
     """
     def __init__(
             self,
-            root_directory,
             filepath_template,
             key_length,
             bucket,
@@ -574,7 +566,7 @@ class FixedLengthTupleS3StoreBackend(FixedLengthTupleStoreBackend):
             file_extension=None,
             file_prefix=None,
     ):
-        super(FixedLengthTupleS3StoreBackend, self).__init__(root_directory,
+        super(FixedLengthTupleS3StoreBackend, self).__init__(
                         filepath_template,
                         key_length,
                         forbidden_substrings=forbidden_substrings,

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -484,7 +484,7 @@ class FixedLengthTupleFilesystemStoreBackend(FixedLengthTupleStoreBackend):
             file_extension=None,
             file_prefix=None,
     ):
-        super().__init__(root_directory,
+        super(FixedLengthTupleFilesystemStoreBackend, self).__init__(root_directory,
                         filepath_template,
                         key_length,
                         forbidden_substrings=forbidden_substrings,
@@ -574,7 +574,7 @@ class FixedLengthTupleS3StoreBackend(FixedLengthTupleStoreBackend):
             file_extension=None,
             file_prefix=None,
     ):
-        super().__init__(root_directory,
+        super(FixedLengthTupleS3StoreBackend, self).__init__(root_directory,
                         filepath_template,
                         key_length,
                         forbidden_substrings=forbidden_substrings,

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -39,7 +39,7 @@ class StoreBackend(object):
 
     def __init__(
         self,
-        root_directory=None,
+        root_directory=None, # NOTE: Eugene: 2019-09-06: I think this should be moved into filesystem-specific children classes
     ):
         self.root_directory = root_directory
 
@@ -344,6 +344,127 @@ class InMemoryStoreBackend(StoreBackend):
 #                 self.config.filepath_template
 #             ))
 
+class FixedLengthTupleStoreBackend(StoreBackend):
+    """
+
+    The key to this StoreBackend abstract class must be a tuple with fixed length equal to key_length.
+    The filepath_template is a string template used to convert the key to a filepath.
+    There's a bit of regex magic in _convert_filepath_to_key that reverses this process,
+    so that we can write AND read using filenames as keys.
+
+    Another class should get this logic through multiple inheritance.
+    """
+
+    def __init__(
+            self,
+            root_directory,
+            filepath_template,
+            key_length,
+            forbidden_substrings=["/", "\\"],
+            file_extension=None,
+            file_prefix=None,
+    ):
+        self.key_length = key_length
+        self.forbidden_substrings = forbidden_substrings
+        self.file_extension = file_extension
+        self.file_prefix = file_prefix
+
+        self.filepath_template = filepath_template
+        self.verify_that_key_to_filepath_operation_is_reversible()
+
+
+
+    def _validate_key(self, key):
+        super(FixedLengthTupleStoreBackend, self)._validate_key(key)
+
+        for key_element in key:
+            for substring in self.forbidden_substrings:
+                if substring in key_element:
+                    raise ValueError("Keys in {0} must not contain substrings in {1} : {2}".format(
+                        self.__class__.__name__,
+                        self.forbidden_substrings,
+                        key,
+                    ))
+
+    def _validate_value(self, value):
+        # NOTE: We may want to allow bytes here as well.
+
+        if not isinstance(value, string_types):
+            raise TypeError("Values in {0} must be instances of {1}, not {2}".format(
+                self.__class__.__name__,
+                string_types,
+                type(value),
+            ))
+
+
+    def _convert_key_to_filepath(self, key):
+        # NOTE: At some point in the future, it might be better to replace this logic with os.path.join.
+        # That seems more correct, but the configs will be a lot less intuitive.
+        # In the meantime, there is some chance that configs will not be cross-OS compatible.
+
+        # NOTE : These methods support fixed-length keys, but not variable.
+        self._validate_key(key)
+
+        converted_string = self.filepath_template.format(*list(key), **{
+            "file_extension": self.file_extension,
+            "file_prefix": self.file_prefix,
+        })
+
+        return converted_string
+
+    def _convert_filepath_to_key(self, filepath):
+
+        # Convert the template to a regex
+        indexed_string_substitutions = re.findall("\{\d+\}", self.filepath_template)
+        tuple_index_list = ["(?P<tuple_index_{0}>.*)".format(i, ) for i in range(len(indexed_string_substitutions))]
+        intermediate_filepath_regex = re.sub(
+            "\{\d+\}",
+            lambda m, r=iter(tuple_index_list): next(r),
+            self.filepath_template
+        )
+        filepath_regex = intermediate_filepath_regex.format(*tuple_index_list, **{
+            "file_extension": self.file_extension,
+            "file_prefix": self.file_prefix,
+        })
+
+        # Apply the regex to the filepath
+        matches = re.compile(filepath_regex).match(filepath)
+
+        # Map key elements into the apprpriate parts of the tuple
+        new_key = list([None for element in range(self.key_length)])
+        for i in range(len(tuple_index_list)):
+            tuple_index = int(re.search('\d+', indexed_string_substitutions[i]).group(0))
+            key_element = matches.group('tuple_index_' + str(i))
+            new_key[tuple_index] = key_element
+
+        new_key = tuple(new_key)
+        return new_key
+
+    def verify_that_key_to_filepath_operation_is_reversible(self):
+        # NOTE: There's actually a fairly complicated problem here, similar to magic autocomplete for dataAssetNames.
+        # "Under what conditions does an incomplete key tuple fully specify an object within the GE namespace?"
+        # This doesn't just depend on the structure of keys.
+        # It also depends on uniqueness of combinations of named elements within the namespace tree.
+        # For now, I do the blunt thing and force filepaths to fully specify keys.
+
+        def get_random_hex(len=4):
+            return "".join([random.choice(list("ABCDEF0123456789")) for i in range(len)])
+
+        key = tuple([get_random_hex() for j in range(self.key_length)])
+        filepath = self._convert_key_to_filepath(key)
+        new_key = self._convert_filepath_to_key(filepath)
+        if key != new_key:
+            raise ValueError(
+                "filepath template {0} for class {1} is not reversible for a tuple of length {2}. Have you included all elements in the key tuple?".format(
+                    self.filepath_template,
+                    self.__class__.__name__,
+                    self.key_length,
+                ))
+            # raise AssertionError("Cannot reverse key conversion in {}\nThis is most likely a problem with your filepath_template:\n\t{}".format(
+            #     self.__class__.__name__,
+            #     self.filepath_template
+            # ))
+
 class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
     """Uses a local filepath as a store.
 
@@ -523,17 +644,15 @@ class FixedLengthTupleFilesystemStoreBackend(StoreBackend):
             # ))
 
 
-class FixedLengthTupleS3StoreBackend(StoreBackend):
+class FixedLengthTupleS3StoreBackend(FixedLengthTupleStoreBackend):
     """
-    TODO: edit
-    Uses a local filepath as a store.
+    Uses an S3 bucket as a store.
 
     The key to this StoreBackend must be a tuple with fixed length equal to key_length.
     The filepath_template is a string template used to convert the key to a filepath.
     There's a bit of regex magic in _convert_filepath_to_key that reverses this process,
     so that we can write AND read using filenames as keys.
     """
-
     def __init__(
             self,
             root_directory,
@@ -545,15 +664,14 @@ class FixedLengthTupleS3StoreBackend(StoreBackend):
             file_extension=None,
             file_prefix=None,
     ):
+        super().__init__(root_directory,
+                        filepath_template,
+                        key_length,
+                        forbidden_substrings=forbidden_substrings,
+                        file_extension=file_extension,
+                        file_prefix=file_prefix)
         self.bucket = bucket
         self.prefix = prefix
-        self.key_length = key_length
-        self.forbidden_substrings = forbidden_substrings
-        self.file_extension = file_extension
-        self.file_prefix = file_prefix
-
-        self.filepath_template = filepath_template
-        self.verify_that_key_to_filepath_operation_is_reversible()
 
 
     def _get(self, key):
@@ -563,8 +681,8 @@ class FixedLengthTupleS3StoreBackend(StoreBackend):
         )
 
         import boto3
-        s3 = boto3.resource('s3')
-        s3_response_object = s3.get_object(Bucket=self.bucket, Key=key)
+        s3 = boto3.client('s3')
+        s3_response_object = s3.get_object(Bucket=self.bucket, Key=s3_object_key)
         return s3_response_object['Body'].read()
 
     def _set(self, key, value):
@@ -578,28 +696,6 @@ class FixedLengthTupleS3StoreBackend(StoreBackend):
         result_s3 = s3.Object(self.bucket, s3_object_key)
         result_s3.put(Body=value.encode('utf-8'))
 
-    def _validate_key(self, key):
-        pass
-        super(FixedLengthTupleS3StoreBackend, self)._validate_key(key)
-
-        for key_element in key:
-            for substring in self.forbidden_substrings:
-                if substring in key_element:
-                    raise ValueError("Keys in {0} must not contain substrings in {1} : {2}".format(
-                        self.__class__.__name__,
-                        self.forbidden_substrings,
-                        key,
-                    ))
-
-    def _validate_value(self, value):
-        # NOTE: We may want to allow bytes here as well.
-
-        if not isinstance(value, string_types):
-            raise TypeError("Values in {0} must be instances of {1}, not {2}".format(
-                self.__class__.__name__,
-                string_types,
-                type(value),
-            ))
 
     def list_keys(self):
         key_list = []
@@ -609,6 +705,11 @@ class FixedLengthTupleS3StoreBackend(StoreBackend):
 
         for s3_object_info in s3.list_objects(Bucket=self.bucket, Prefix=self.prefix)['Contents']:
             s3_object_key = s3_object_info['Key']
+            s3_object_key = os.path.relpath(
+                s3_object_key,
+                self.prefix,
+            )
+
             key_list.append(
                 self._convert_filepath_to_key(s3_object_key)
             )
@@ -621,70 +722,3 @@ class FixedLengthTupleS3StoreBackend(StoreBackend):
         all_keys = self.list_keys()
         return key in all_keys
 
-    def _convert_key_to_filepath(self, key):
-        # NOTE: At some point in the future, it might be better to replace this logic with os.path.join.
-        # That seems more correct, but the configs will be a lot less intuitive.
-        # In the meantime, there is some chance that configs will not be cross-OS compatible.
-
-        # NOTE : These methods support fixed-length keys, but not variable.
-        self._validate_key(key)
-
-        converted_string = self.filepath_template.format(*list(key), **{
-            "file_extension": self.file_extension,
-            "file_prefix": self.file_prefix,
-        })
-
-        return converted_string
-
-    def _convert_filepath_to_key(self, filepath):
-
-        # Convert the template to a regex
-        indexed_string_substitutions = re.findall("\{\d+\}", self.filepath_template)
-        tuple_index_list = ["(?P<tuple_index_{0}>.*)".format(i, ) for i in range(len(indexed_string_substitutions))]
-        intermediate_filepath_regex = re.sub(
-            "\{\d+\}",
-            lambda m, r=iter(tuple_index_list): next(r),
-            self.filepath_template
-        )
-        filepath_regex = intermediate_filepath_regex.format(*tuple_index_list, **{
-            "file_extension": self.file_extension,
-            "file_prefix": self.file_prefix,
-        })
-
-        # Apply the regex to the filepath
-        matches = re.compile(filepath_regex).match(filepath)
-
-        # Map key elements into the apprpriate parts of the tuple
-        new_key = list([None for element in range(self.key_length)])
-        for i in range(len(tuple_index_list)):
-            tuple_index = int(re.search('\d+', indexed_string_substitutions[i]).group(0))
-            key_element = matches.group('tuple_index_' + str(i))
-            new_key[tuple_index] = key_element
-
-        new_key = tuple(new_key)
-        return new_key
-
-    def verify_that_key_to_filepath_operation_is_reversible(self):
-        # NOTE: There's actually a fairly complicated problem here, similar to magic autocomplete for dataAssetNames.
-        # "Under what conditions does an incomplete key tuple fully specify an object within the GE namespace?"
-        # This doesn't just depend on the structure of keys.
-        # It also depends on uniqueness of combinations of named elements within the namespace tree.
-        # For now, I do the blunt thing and force filepaths to fully specify keys.
-
-        def get_random_hex(len=4):
-            return "".join([random.choice(list("ABCDEF0123456789")) for i in range(len)])
-
-        key = tuple([get_random_hex() for j in range(self.key_length)])
-        filepath = self._convert_key_to_filepath(key)
-        new_key = self._convert_filepath_to_key(filepath)
-        if key != new_key:
-            raise ValueError(
-                "filepath template {0} for class {1} is not reversible for a tuple of length {2}. Have you included all elements in the key tuple?".format(
-                    self.filepath_template,
-                    self.__class__.__name__,
-                    self.key_length,
-                ))
-            # raise AssertionError("Cannot reverse key conversion in {}\nThis is most likely a problem with your filepath_template:\n\t{}".format(
-            #     self.__class__.__name__,
-            #     self.filepath_template
-            # ))

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -37,6 +37,12 @@ class StoreBackend(object):
     """a key-value store, to abstract away reading and writing to a persistence layer
     """
 
+    def __init__(
+        self,
+        root_directory=None, # NOTE: Eugene: 2019-09-06: I think this should be moved into filesystem-specific children classes
+    ):
+        self.root_directory = root_directory
+
     def get(self, key):
         self._validate_key(key)
         value = self._get(key)
@@ -93,6 +99,7 @@ class InMemoryStoreBackend(StoreBackend):
     def __init__(
         self,
         separator=".",
+        root_directory=None
     ):
         self.store = {}
         self.separator = separator
@@ -350,6 +357,7 @@ class FixedLengthTupleStoreBackend(StoreBackend):
 
     def __init__(
             self,
+            root_directory,
             filepath_template,
             key_length,
             forbidden_substrings=["/", "\\"],
@@ -476,14 +484,13 @@ class FixedLengthTupleFilesystemStoreBackend(FixedLengthTupleStoreBackend):
             file_extension=None,
             file_prefix=None,
     ):
-        super(FixedLengthTupleFilesystemStoreBackend, self).__init__(
+        super(FixedLengthTupleFilesystemStoreBackend, self).__init__(root_directory,
                         filepath_template,
                         key_length,
                         forbidden_substrings=forbidden_substrings,
                         file_extension=file_extension,
                         file_prefix=file_prefix)
 
-        self.root_directory = root_directory
         self.base_directory = base_directory
 
         if not os.path.isabs(root_directory):
@@ -558,6 +565,7 @@ class FixedLengthTupleS3StoreBackend(FixedLengthTupleStoreBackend):
     """
     def __init__(
             self,
+            root_directory,
             filepath_template,
             key_length,
             bucket,
@@ -566,7 +574,7 @@ class FixedLengthTupleS3StoreBackend(FixedLengthTupleStoreBackend):
             file_extension=None,
             file_prefix=None,
     ):
-        super(FixedLengthTupleS3StoreBackend, self).__init__(
+        super(FixedLengthTupleS3StoreBackend, self).__init__(root_directory,
                         filepath_template,
                         key_length,
                         forbidden_substrings=forbidden_substrings,

--- a/great_expectations/data_context/store/validation_store.py
+++ b/great_expectations/data_context/store/validation_store.py
@@ -48,6 +48,11 @@ class ValidationStore(ReadWriteStore):
                 "key_length" : 5,
                 "module_name" : "great_expectations.data_context.store",
             }
+        elif store_backend_config["class_name"] == "FixedLengthTupleS3StoreBackend":
+            config_defaults = {
+                "key_length": 5, # NOTE: Eugene: 2019-09-06: ???
+                "module_name": "great_expectations.data_context.store",
+            }
         else:
             config_defaults = {
                 "module_name" : "great_expectations.data_context.store",

--- a/great_expectations/data_context/templates.py
+++ b/great_expectations/data_context/templates.py
@@ -42,6 +42,15 @@ stores:
       file_extension: json
       filepath_template: '{4}/{0}/{1}/{2}/{3}.{file_extension}'
 
+  # s3_validation_result_store:
+  #   class_name: ValidationStore
+  #   store_backend:
+  #     class_name: FixedLengthTupleS3StoreBackend
+  #     bucket: ???
+  #     prefix: ???
+  #     file_extension: json
+  #     filepath_template: '{4}/{0}/{1}/{2}/{3}.{file_extension}'
+
   # FIXME: These configs are temporarily commented out to facititate refactoring Stores.
 
   # local_profiling_store:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,3 +25,4 @@ mock>=3.0.5
 pytest-cov>=2.6.1
 coveralls>=1.3
 freezegun>=0.3.12
+moto>=1.3.7

--- a/tests/store/test_store_backends.py
+++ b/tests/store/test_store_backends.py
@@ -173,8 +173,18 @@ test_FixedLengthTupleFilesystemStoreBackend__dir0/
 
 @mock_s3
 def test_FixedLengthTupleS3StoreBackend():
+    """
+    What does this test test and why?
+
+    We will exercise the store backend's set method twice and then verify
+    that the we calling get and list methods will return the expected keys.
+
+    We will also check that the objects are stored on S3 at the expected location.
+
+    """
     path = "dummy_str"
     bucket = "leakybucket"
+    prefix = "this_is_a_test_prefix"
 
     # create a bucket in Moto's mock AWS environment
     conn = boto3.resource('s3', region_name='us-east-1')
@@ -185,7 +195,7 @@ def test_FixedLengthTupleS3StoreBackend():
         key_length=1,
         filepath_template= "my_file_{0}",
         bucket=bucket,
-        prefix="this_is_a_test_prefix",
+        prefix=prefix,
     )
 
     my_store.set(("AAA",), "aaa")
@@ -196,3 +206,6 @@ def test_FixedLengthTupleS3StoreBackend():
 
     print(my_store.list_keys())
     assert set(my_store.list_keys()) == set([("AAA",), ("BBB",)])
+
+    assert set([s3_object_info['Key'] for s3_object_info in boto3.client('s3').list_objects(Bucket=bucket, Prefix=prefix)['Contents']])\
+           == set(['this_is_a_test_prefix/my_file_AAA', 'this_is_a_test_prefix/my_file_BBB'])

--- a/tests/store/test_store_backends.py
+++ b/tests/store/test_store_backends.py
@@ -23,7 +23,7 @@ from great_expectations.util import (
 )
 
 def test_StoreBackendValidation():
-    backend = StoreBackend({})
+    backend = StoreBackend()
 
     backend._validate_key( ("I", "am", "a", "string", "tuple") )
 
@@ -181,7 +181,6 @@ def test_FixedLengthTupleS3StoreBackend():
     conn.create_bucket(Bucket=bucket)
 
     my_store = FixedLengthTupleS3StoreBackend(
-        root_directory=os.path.abspath(path), # NOTE: Eugene: 2019-09-06: root_directory should be removed from the base class
         key_length=1,
         filepath_template= "my_file_{0}",
         bucket=bucket,

--- a/tests/store/test_store_backends.py
+++ b/tests/store/test_store_backends.py
@@ -3,6 +3,8 @@ import json
 import importlib
 import os
 import re
+import boto3
+from moto import mock_s3
 
 import six
 if six.PY2: FileNotFoundError = IOError
@@ -14,6 +16,7 @@ from great_expectations.data_context.store import (
     StoreBackend,
     InMemoryStoreBackend,
     FixedLengthTupleFilesystemStoreBackend,
+    FixedLengthTupleS3StoreBackend,
 )
 from great_expectations.util import (
     gen_directory_tree_str,
@@ -167,3 +170,29 @@ test_FixedLengthTupleFilesystemStoreBackend__dir0/
     my_file_AAA
     my_file_BBB
 """
+
+@mock_s3
+def test_FixedLengthTupleS3StoreBackend():
+    path = "dummy_str"
+    bucket = "leakybucket"
+
+    # create a bucket in Moto's mock AWS environment
+    conn = boto3.resource('s3', region_name='us-east-1')
+    conn.create_bucket(Bucket=bucket)
+
+    my_store = FixedLengthTupleS3StoreBackend(
+        root_directory=os.path.abspath(path), # NOTE: Eugene: 2019-09-06: root_directory should be removed from the base class
+        key_length=1,
+        filepath_template= "my_file_{0}",
+        bucket=bucket,
+        prefix="this_is_a_test_prefix",
+    )
+
+    my_store.set(("AAA",), "aaa")
+    assert my_store.get(("AAA",)) == b'aaa'
+
+    my_store.set(("BBB",), "bbb")
+    assert my_store.get(("BBB",)) == b'bbb'
+
+    print(my_store.list_keys())
+    assert set(my_store.list_keys()) == set([("AAA",), ("BBB",)])

--- a/tests/store/test_store_backends.py
+++ b/tests/store/test_store_backends.py
@@ -23,7 +23,7 @@ from great_expectations.util import (
 )
 
 def test_StoreBackendValidation():
-    backend = StoreBackend()
+    backend = StoreBackend({})
 
     backend._validate_key( ("I", "am", "a", "string", "tuple") )
 
@@ -181,6 +181,7 @@ def test_FixedLengthTupleS3StoreBackend():
     conn.create_bucket(Bucket=bucket)
 
     my_store = FixedLengthTupleS3StoreBackend(
+        root_directory=os.path.abspath(path), # NOTE: Eugene: 2019-09-06: root_directory should be removed from the base class
         key_length=1,
         filepath_template= "my_file_{0}",
         bucket=bucket,


### PR DESCRIPTION
Ready for review.

1. Add a new store backend - FixedLengthTupleS3StoreBackend.
2. Since all the logic of fixed length tuples in the new class is identical to the one in FixedLengthTupleFilesystemStoreBackend, refactor this logic into a new class - FixedLengthTupleStoreBackend, and make both FixedLengthTupleFilesystemStoreBackend and FixedLengthTupleS3StoreBackend extend it.
3. Added a basic test for the new FixedLengthTupleS3StoreBackend class using the AWS mock library moto (https://github.com/spulec/moto). Looked at localstack, but it seemed a bit more heavy-handed and less user-friendly. If we need to mock more AWS services in the future, we should revisit this.
4. Added a s3_validation_result_store section to the config template. It is commented out by default. 