### PR TITLE
* added migration help on three additional commands

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,7 @@ Options:
 Commands:
   add-datasource       Add a new datasource to the data context
   build-documentation  Build data documentation for a project.
-  check-config         Check a config and raise helpful messages about...
+  check-config         Check a config for validity and help with migrations.
   init                 Initialize a new Great Expectations project.
   profile              Profile datasources from the specified context.
   render               Render a great expectations object to documentation.


### PR DESCRIPTION
## What's Here

The following commands now catch the `ZeroDotSevenConfigVersionError` and offer to create a new template as `check-config` does.
- build-documentation
- profile
- add-datasource