### PR TITLE
Fix bug that was breaking imports of great_expectations.jupyter_ux

### DIFF
--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -212,8 +212,6 @@ cooltip_style_element = """<style type="text/css">
 def display_column_expectations_as_section(
     expectation_suite,
     column,
-    section_renderer=render.renderer.column_section_renderer.ExpectationSuiteColumnSectionRenderer,
-    view_renderer=render.view.view.DefaultJinjaSectionView,
     include_styling=True,
     return_without_displaying=False,
 ):
@@ -254,8 +252,6 @@ def display_column_expectations_as_section(
 def display_column_evrs_as_section(
     evrs,
     column,
-    section_renderer=render.renderer.column_section_renderer.ProfilingResultsColumnSectionRenderer,
-    view_renderer=render.view.view.DefaultJinjaSectionView,
     include_styling=True,
     return_without_displaying=False,
 ):


### PR DESCRIPTION
- unused default function arguments of the form:

section_renderer=render.renderer.column_section_renderer.ExpectationSuiteColumnSectionRenderer,
view_renderer=render.view.view.DefaultJinjaSectionView,

were breaking imports