### PR TITLE
Renamed CLI command build-documentation to build-docs

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -35,7 +35,7 @@ Highlights include:
      begin adding additional features.
    - Restructured documentation: our docs have a new structure and have been reorganized to provide space for more
      easily adding and accessing reference material. Stay tuned for additional detail.
-
+   - The command build-documentation has been renamed build-docs.
 
 v0.7.11__develop
 -----------------

--- a/docs/reference/data_documentation_reference.rst
+++ b/docs/reference/data_documentation_reference.rst
@@ -83,7 +83,7 @@ context and validations available in the ``great_expectations/fixtures`` directo
 
 .. code-block:: bash
 
-    great_expectations build-documentation
+    great_expectations build-docs
 
 
 When called without additional arguments, this command will render all the sites specified in great_expectations.yml configuration file.
@@ -98,7 +98,7 @@ To render just one data asset (this might be useful for debugging), call
 
 .. code-block:: bash
 
-    great_expectations build-documentation --site_name SITE_NAME --data_asset_name DATA_ASSET_NAME
+    great_expectations build-docs --site_name SITE_NAME --data_asset_name DATA_ASSET_NAME
 
 
 Using the raw API

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -286,16 +286,21 @@ def profile(datasource_name, data_assets, profile_all_data_assets, directory, ba
 
 
 @cli.command()
+def build_documentation():
+    # TODO remove this warning
+    raise DeprecationWarning("This command has been renamed to build-docs.")
+
+
+@cli.command()
 @click.option('--directory', '-d', default="./great_expectations",
               help='The root of a project directory containing a great_expectations/ config.')
 @click.option('--site_name', '-s',
               help='The site for which to generate documentation. See data_docs section in great_expectations.yml')
 @click.option('--data_asset_name', '-dan',
               help='The data asset for which to generate documentation. Must also specify --site_name.')
-def build_documentation(directory, site_name, data_asset_name):
-    """Build data documentation for a project.
-    """
-    logger.debug("Starting cli.build_documentation")
+def build_docs(directory, site_name, data_asset_name):
+    """Build data documentation for a project."""
+    logger.debug("Starting cli.build_docs")
 
     if data_asset_name is not None and site_name is None:
         cli_message("Error: When specifying data_asset_name, must also specify site_name.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ def test_cli_command_entrance():
 
     result = runner.invoke(cli)
     assert result.exit_code == 0
+    print(result.output)
     assert result.output == """Usage: cli [OPTIONS] COMMAND [ARGS]...
 
   great_expectations command-line interface
@@ -46,13 +47,14 @@ Options:
   --help         Show this message and exit.
 
 Commands:
-  add-datasource  Add a new datasource to the data context
-  build-docs      Build data documentation for a project.
-  check-config    Check a config for validity and help with migrations.
-  init            Initialize a new Great Expectations project.
-  profile         Profile datasources from the specified context.
-  render          Render a great expectations object to documentation.
-  validate        Validate a CSV file against an expectation suite.
+  add-datasource       Add a new datasource to the data context
+  build-docs           Build data documentation for a project.
+  build-documentation
+  check-config         Check a config for validity and help with migrations.
+  init                 Initialize a new Great Expectations project.
+  profile              Profile datasources from the specified context.
+  render               Render a great expectations object to documentation.
+  validate             Validate a CSV file against an expectation suite.
 """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,13 +46,13 @@ Options:
   --help         Show this message and exit.
 
 Commands:
-  add-datasource       Add a new datasource to the data context
-  build-documentation  Build data documentation for a project.
-  check-config         Check a config for validity and help with migrations.
-  init                 Initialize a new Great Expectations project.
-  profile              Profile datasources from the specified context.
-  render               Render a great expectations object to documentation.
-  validate             Validate a CSV file against an expectation suite.
+  add-datasource  Add a new datasource to the data context
+  build-docs      Build data documentation for a project.
+  check-config    Check a config for validity and help with migrations.
+  init            Initialize a new Great Expectations project.
+  profile         Profile datasources from the specified context.
+  render          Render a great expectations object to documentation.
+  validate        Validate a CSV file against an expectation suite.
 """
 
 
@@ -499,7 +499,7 @@ def test_cli_documentation(empty_data_context, filesystem_csv_2, capsys):
     assert "Note: You will need to review and revise Expectations before using them in production." in captured.out
 
     result = runner.invoke(
-        cli, ["build-documentation", "-d", project_root_dir])
+        cli, ["build-docs", "-d", project_root_dir])
 
     # print(json.dumps(not_so_empty_data_context.get_project_config()["stores"], indent=2))
     print(result.output)
@@ -533,10 +533,10 @@ def test_cli_config_not_found(tmp_path_factory):
             cli, ["profile"])
         assert "no great_expectations context configuration" in result.output
         result = runner.invoke(
-            cli, ["build-documentation", "-d", "./"])
+            cli, ["build-docs", "-d", "./"])
         assert "no great_expectations context configuration" in result.output
         result = runner.invoke(
-            cli, ["build-documentation"])
+            cli, ["build-docs"])
         assert "no great_expectations context configuration" in result.output
     except:
         raise


### PR DESCRIPTION
## What's Here

- a renamed command
- a deprecation warning for the original name