### PR TITLE
Fix/create expectation suite overwrite

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -21,9 +21,7 @@ from ..types.base import DotDict
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.exceptions import DataContextError
 
-# FIXME : fully deprecate site_builder, by replacing it with new_site_builder.
 # FIXME : Consolidate all builder files and classes in great_expectations/render/builder, to make it clear that they aren't renderers.
-# from great_expectations.render.renderer.site_builder import SiteBuilder
 
 
 try:

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1008,13 +1008,15 @@ class ConfigOnlyDataContext(object):
                 .format(datasource_name=split_name[0], generator_name=split_name[1])
             )
 
-    def create_expectation_suite(self, data_asset_name, expectation_suite_name):
+    def create_expectation_suite(self, data_asset_name, expectation_suite_name, overwrite_existing=False):
         """Build a new expectation suite and save it into the data_context expectation store.
 
         Args:
             data_asset_name: The name of the data_asset for which this suite will be stored.
                 data_asset_name will be normalized if it is a string
             expectation_suite_name: The name of the expectation_suite to create
+            overwrite_existing (boolean): Whether to overwrite expectation suite if expectation suite with given name
+                already exists
 
         Returns:
             A new (empty) expectation suite.
@@ -1033,7 +1035,13 @@ class ConfigOnlyDataContext(object):
             expectation_suite_name=expectation_suite_name,
         )
 
-        self._stores["expectations_store"].set(key, expectation_suite)
+        if self._stores["expectations_store"].has_key(key) and not overwrite_existing:
+            raise DataContextError(
+                "expectation_suite with name {expectation_suite_name} already exists for data_asset {data_asset_name}.\
+                 If you would like to overwrite this expectation_suite, set overwrite_existing=True."
+            )
+        else:
+            self._stores["expectations_store"].set(key, expectation_suite)
 
         return expectation_suite
 
@@ -1611,7 +1619,8 @@ class ConfigOnlyDataContext(object):
                     expectation_suite_name = profiler.__name__
                     self.create_expectation_suite(
                         data_asset_name=normalized_data_asset_name,
-                        expectation_suite_name=expectation_suite_name
+                        expectation_suite_name=expectation_suite_name,
+                        overwrite_existing=True
                     )
                     batch_kwargs = self.yield_batch_kwargs(
                         data_asset_name=normalized_data_asset_name,

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -46,7 +46,7 @@ def parameterized_expectation_suite():
         return json.load(suite)
 
 
-def test_create_expectation_suite(titanic_data_context):
+def test_create_duplicate_expectation_suite(titanic_data_context):
     # create new expectation suite
     assert titanic_data_context.create_expectation_suite(data_asset_name="titanic", expectation_suite_name="test_create_expectation_suite")
     # attempt to create expectation suite with name that already exists on data asset

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -46,6 +46,17 @@ def parameterized_expectation_suite():
         return json.load(suite)
 
 
+def test_create_expectation_suite(titanic_data_context):
+    # create new expectation suite
+    assert titanic_data_context.create_expectation_suite(data_asset_name="titanic", expectation_suite_name="test_create_expectation_suite")
+    # attempt to create expectation suite with name that already exists on data asset
+    with pytest.raises(DataContextError):
+        titanic_data_context.create_expectation_suite(data_asset_name="titanic",
+                                                      expectation_suite_name="test_create_expectation_suite")
+    # create expectation suite with name that already exists on data asset, but pass overwrite_existing=True
+    assert titanic_data_context.create_expectation_suite(data_asset_name="titanic", expectation_suite_name="test_create_expectation_suite", overwrite_existing=True)
+
+
 def test_list_available_data_asset_names(empty_data_context, filesystem_csv):
     empty_data_context.add_datasource("my_datasource",
                                     module_name="great_expectations.datasource",

--- a/tests/profile/test_multi_batch_validation_meta_analysis.py
+++ b/tests/profile/test_multi_batch_validation_meta_analysis.py
@@ -31,7 +31,7 @@ def test_get_metrics_basic(titanic_multibatch_data_context):
     profiler = BasicDatasetProfiler
 
     for batch_kwargs_set in all_batch_kwargs:
-        context.create_expectation_suite("titanic", "foo")
+        context.create_expectation_suite("titanic", "foo", overwrite_existing=True)
         batch = context.get_batch('titanic', "foo", batch_kwargs=batch_kwargs_set)
         expectation_suite, validation_result = profiler.profile(batch, run_id="profiling_" + BatchKwargs.build_batch_fingerprint(
             batch._batch_kwargs).fingerprint)


### PR DESCRIPTION
Add argument overwrite_existing=False to data_context.create_expectation_suite. If user attempts to create expectation suite on given data asset and that expectation suite already exists, exception is thrown unless user passes in overwrite_existing=True (in which case existing suite is overwritten).