### PR TITLE
More consistent stores

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -142,7 +142,7 @@ class ConfigOnlyDataContext(object):
             # TODO next version re-introduce config_version as required
             # "config_version",
             "plugins_directory",
-            "expectations_store",
+            "expectations_store_name",
             "profiling_store_name",
             "evaluation_parameter_store_name",
             "datasources",
@@ -159,7 +159,7 @@ class ConfigOnlyDataContext(object):
             "result_callback",
             "config_variables_file_path",
             "plugins_directory",
-            "expectations_store",
+            "expectations_store_name",
             "profiling_store_name",
             "evaluation_parameter_store_name",
             "datasources",
@@ -187,11 +187,8 @@ class ConfigOnlyDataContext(object):
         Returns:
             None
         """
-        # if not isinstance(project_config, DataContextConfig):
-
         if not ConfigOnlyDataContext.validate_config(project_config):
-            raise TypeError("project_config is not valid. Try using the CLI check-config command.")
-
+            raise ge_exceptions.InvalidConfigError("Your project_config is not valid. Try using the CLI check-config command.")
 
         self._project_config = project_config
         # FIXME: This should just be a property
@@ -212,7 +209,7 @@ class ConfigOnlyDataContext(object):
         self._stores = DotDict()
         self.add_store(
             "expectations_store",
-            copy.deepcopy(self._project_config["expectations_store"]),
+            copy.deepcopy(self._project_config["stores"][self._project_config["expectations_store_name"]]),
         )
         self._init_stores(self._project_config_with_varibles_substituted["stores"])
 
@@ -1824,9 +1821,6 @@ class DataContext(ConfigOnlyDataContext):
             config = copy.deepcopy(
                 self._project_config
             )
-
-            #the expectation_store shouldn't appear in the list
-            del config["stores"]["expectations_store"]
 
             yaml.dump(config, data)
 

--- a/great_expectations/data_context/templates.py
+++ b/great_expectations/data_context/templates.py
@@ -47,18 +47,21 @@ config_variables_file_path: uncommitted/config_variables.yml
 # used to override and extend Great Expectations.
 plugins_directory: plugins/
 
-expectations_store:
-  # This is where expectations are kept.
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
-
+# Stores are configurable places to store things like expectations, evaluation
+# results, data docs, and more.
+# 
+# Point the required store names to the appropriate `stores` entry.
+expectations_store_name: expectations_store
 profiling_store_name: local_validation_result_store
 evaluation_parameter_store_name: evaluation_parameter_store
 
-# Stores are where things like expectations, evalutation results, etc are stored.
 stores:
+  expectations_store:
+    # This is where expectations are kept.
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
 
   local_validation_result_store:
     class_name: ValidationResultStore

--- a/great_expectations/data_context/templates.py
+++ b/great_expectations/data_context/templates.py
@@ -50,6 +50,10 @@ plugins_directory: plugins/
 # Stores are configurable places to store things like expectations, evaluation
 # results, data docs, and more.
 # 
+# Three stores are required: expectations, profiling, and evaluation parameters,
+# and must be named here. Additional stores can be configured below and used for
+# data_docs, validation_operators or other purposes.
+#
 # Point the required store names to the appropriate `stores` entry.
 expectations_store_name: expectations_store
 profiling_store_name: local_validation_result_store

--- a/tests/actions/test_validation_operators.py
+++ b/tests/actions/test_validation_operators.py
@@ -9,35 +9,30 @@ import pandas as pd
 
 import great_expectations as ge
 from great_expectations.actions.validation_operators import (
-    PerformActionListValidationOperator,
     RunWarningAndFailureExpectationSuitesValidationOperator
 )
 
 from great_expectations.data_context import (
     ConfigOnlyDataContext,
 )
-from great_expectations.data_context.types import (
-    # DataContextConfig,
-    DataAssetIdentifier,
-    ExpectationSuiteIdentifier,
-    ValidationResultIdentifier,
-)
+from great_expectations.data_context.types import DataAssetIdentifier
+
 
 @pytest.fixture()
 def basic_data_context_config_for_validation_operator():
-    # return DataContextConfig(**{
     return {
         "plugins_directory": "plugins/",
         "evaluation_parameter_store_name" : "evaluation_parameter_store",
-        "expectations_store" : {
-            "class_name": "ExpectationStore",
-            "store_backend": {
-                "class_name": "FixedLengthTupleFilesystemStoreBackend",
-                "base_directory": "expectations/",
-            }
-        },
+        "expectations_store_name": "expectations_store",
         "datasources": {},
         "stores": {
+            "expectations_store" : {
+                "class_name": "ExpectationStore",
+                "store_backend": {
+                    "class_name": "FixedLengthTupleFilesystemStoreBackend",
+                    "base_directory": "expectations/",
+                }
+            },
             # This isn't currently used for Validation Actions, but it's required for DataContext to work.
             "evaluation_parameter_store" : {
                 "module_name": "great_expectations.data_context.store",
@@ -57,7 +52,6 @@ def basic_data_context_config_for_validation_operator():
         },
         "validation_operators" : {},
     }
-    # })
 
 
 @freeze_time("09/26/19 13:42:41")

--- a/tests/actions/test_validation_operators_in_data_context.py
+++ b/tests/actions/test_validation_operators_in_data_context.py
@@ -30,14 +30,15 @@ def basic_data_context_config_for_validation_operator():
         "plugins_directory": "plugins/",
         "evaluation_parameter_store_name" : "evaluation_parameter_store",
         "profiling_store_name": "validation_result_store",
-        "expectations_store" : {
-            "class_name": "ExpectationStore",
-            "store_backend": {
-                "class_name": "InMemoryStoreBackend",
-            }
-        },
+        "expectations_store_name": "expectations_store",
         "datasources": {},
         "stores": {
+            "expectations_store" : {
+                "class_name": "ExpectationStore",
+                "store_backend": {
+                    "class_name": "InMemoryStoreBackend",
+                }
+            },
             # This isn't currently used for Validation Actions, but it's required for DataContext to work.
             "evaluation_parameter_store" : {
                 "module_name": "great_expectations.data_context.store",

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -1,18 +1,11 @@
+import os
+import shutil
+
 import pytest
 
-import shutil
-import os
-import json
-import warnings
-
-import numpy as np
-import sqlalchemy as sa
-
 import great_expectations as ge
-from great_expectations.dataset.pandas_dataset import PandasDataset
 from great_expectations.data_context.util import safe_mmkdir
 
-from ..test_utils import get_dataset
 
 @pytest.fixture()
 def data_context_without_config_variables_filepath_configured(tmp_path_factory):

--- a/tests/data_context/fixtures/invalid_config_version/great_expectations.yml
+++ b/tests/data_context/fixtures/invalid_config_version/great_expectations.yml
@@ -17,17 +17,17 @@ datasources:
 
 
 config_variables_file_path: uncommitted/config_variables.yml
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
-
+expectations_store_name: expectations_store
 plugins_directory: plugins/
 evaluation_parameter_store_name: evaluation_parameter_store
 data_docs:
   sites:
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   evaluation_parameter_store:
     module_name: great_expectations.data_context.store
     class_name: EvaluationParameterStore

--- a/tests/data_context/fixtures/invalid_top_level_key/great_expectations.yml
+++ b/tests/data_context/fixtures/invalid_top_level_key/great_expectations.yml
@@ -3,7 +3,7 @@ this_is_a_wildly_invalid_top_level_key: "stuff"
 
 config_version: 1
 plugins_directory: "foo"
-expectations_store: "bar"
+expectations_store_name: expectations_store
 evaluation_parameter_store_name: "baz"
 datasources: "1"
 stores:

--- a/tests/data_context/fixtures/invalid_top_level_value_type/great_expectations.yml
+++ b/tests/data_context/fixtures/invalid_top_level_value_type/great_expectations.yml
@@ -1,7 +1,7 @@
 # This must have all the required keys one with an incorrect type
 config_version: "foo"
 plugins_directory: "foo"
-expectations_store: "foo"
+expectations_store_name: expectations_store
 evaluation_parameter_store_name: "foo"
 datasources: "foo"
 stores: "foo"

--- a/tests/data_context/fixtures/missing_top_level_key/great_expectations.yml
+++ b/tests/data_context/fixtures/missing_top_level_key/great_expectations.yml
@@ -1,6 +1,6 @@
 # This must be missing required keys
 config_version: 1
-expectations_store: "foo"
+expectations_store_name: expectations_store
 evaluation_parameter_store_name: "foo"
 datasources: "foo"
 stores: "foo"

--- a/tests/data_context/fixtures/old_config_version/great_expectations.yml
+++ b/tests/data_context/fixtures/old_config_version/great_expectations.yml
@@ -17,17 +17,18 @@ datasources:
 
 
 config_variables_file_path: uncommitted/config_variables.yml
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
 
 plugins_directory: plugins/
 evaluation_parameter_store_name: evaluation_parameter_store
+expectations_store_name: expectations_store
 data_docs:
   sites:
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   evaluation_parameter_store:
     module_name: great_expectations.data_context.store
     class_name: EvaluationParameterStore

--- a/tests/data_context/fixtures/post_init_project_v0.8.0_A/great_expectations/great_expectations.yml
+++ b/tests/data_context/fixtures/post_init_project_v0.8.0_A/great_expectations/great_expectations.yml
@@ -1,12 +1,7 @@
 config_version: 1
 plugins_directory: plugins/
 
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
-
+expectations_store_name: local_expectations_store
 evaluation_parameter_store_name: evaluation_parameter_store
 profiling_store_name: local_validation_result_store
 
@@ -43,6 +38,11 @@ validation_operators:
           target_store_name: evaluation_parameter_store
 
 stores:
+  local_expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   local_validation_result_store:
     class_name: ValidationResultStore
     store_backend:

--- a/tests/data_context/test_configuration_storage.py
+++ b/tests/data_context/test_configuration_storage.py
@@ -77,20 +77,21 @@ datasources:
 
 config_variables_file_path: uncommitted/config_variables.yml
 
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
 
 plugins_directory: plugins/
 evaluation_parameter_store_name: evaluation_parameter_store
+expectations_store_name: expectations_store
 profiling_store_name: local_validation_result_store
 
 data_docs:
   sites:
 
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   evaluation_parameter_store:
     module_name: great_expectations.data_context.store
     class_name: EvaluationParameterStore

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -728,17 +728,18 @@ def basic_data_context_config():
     return {
         "config_version": 1,
         "plugins_directory": "plugins/",
-        "expectations_store": {
-            "class_name": "ExpectationStore",
-            "store_backend": {
-                "class_name": "FixedLengthTupleFilesystemStoreBackend",
-                "base_directory": "expectations/",
-            },
-        },
         "evaluation_parameter_store_name": "evaluation_parameter_store",
         "profiling_store_name": "does_not_have_to_be_real",
+        "expectations_store_name": "expectations_store",
         "datasources": {},
         "stores": {
+            "expectations_store": {
+                "class_name": "ExpectationStore",
+                "store_backend": {
+                    "class_name": "FixedLengthTupleFilesystemStoreBackend",
+                    "base_directory": "expectations/",
+                },
+            },
             "evaluation_parameter_store" : {
                 "module_name": "great_expectations.data_context.store",
                 "class_name": "EvaluationParameterStore",

--- a/tests/data_context/test_data_context_store_configs.py
+++ b/tests/data_context/test_data_context_store_configs.py
@@ -19,17 +19,19 @@ def totally_empty_data_context(tmp_path_factory):
     config = {
         "config_version": 1,
         "plugins_directory": "plugins/",
-        "expectations_store": {
-            "class_name": "ExpectationStore",
-            "store_backend": {
-                "class_name": "FixedLengthTupleFilesystemStoreBackend",
-                "base_directory": "expectations/"
-            }
-        },
         "evaluation_parameter_store_name": "not_a_real_store_name",
         "profiling_store_name": "another_fake_store",
+        "expectations_store_name": "expectations_store",
         "datasources": {},
-        "stores": {},
+        "stores": {
+            "expectations_store": {
+                "class_name": "ExpectationStore",
+                "store_backend": {
+                    "class_name": "FixedLengthTupleFilesystemStoreBackend",
+                    "base_directory": "expectations/"
+                }
+            },
+        },
         "data_docs": {
             "sites": {}
         }
@@ -86,19 +88,14 @@ def test_config_with_default_yml(tmp_path_factory):
     project_path = str(tmp_path_factory.mktemp('totally_empty_data_context'))
     context = ge.data_context.DataContext.create(project_path)
 
-    print(context.stores.keys())
-    assert len(context.stores.keys()) == 6
-    assert set(context.stores.keys()) == set([
-        'local_validation_result_store',
+    assert set(context.stores.keys()) == set(
+        "local_validation_result_store",
         "expectations_store",
-        # 'local_profiling_store',
-        # 'local_workbench_site_store',
-        'evaluation_parameter_store',
-        'fixture_validation_results_store',
-        # 'shared_team_site_store',
-        'local_site_html_store',
-        'team_site_html_store',
-    ])
+        "evaluation_parameter_store",
+        "fixture_validation_results_store",
+        "local_site_html_store",
+        "team_site_html_store",
+    )
     assert "my_inmemory_store" not in context.stores.keys()
 
     context.add_store(
@@ -110,7 +107,5 @@ def test_config_with_default_yml(tmp_path_factory):
         }
     )
 
-    print(context.stores.keys())
     assert len(context.stores.keys()) == 7
     assert "my_inmemory_store" in context.stores.keys()
-    

--- a/tests/test_fixtures/great_expectations_basic.yml
+++ b/tests/test_fixtures/great_expectations_basic.yml
@@ -21,20 +21,21 @@ datasources:
 
 config_variables_file_path: uncommitted/config_variables.yml
 
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
 
 plugins_directory: plugins/
 evaluation_parameter_store_name: evaluation_parameter_store
+expectations_store_name: expectations_store
 profiling_store_name: local_validation_result_store
 
 data_docs:
   sites:
 
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   evaluation_parameter_store:
     module_name: great_expectations.data_context.store
     class_name: EvaluationParameterStore

--- a/tests/test_fixtures/great_expectations_basic_with_variables.yml
+++ b/tests/test_fixtures/great_expectations_basic_with_variables.yml
@@ -21,12 +21,7 @@ datasources:
 
 
 config_variables_file_path: uncommitted/config_variables.yml
-
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
+expectations_store_name: expectations_store
 
 plugins_directory: plugins/
 evaluation_parameter_store_name: evaluation_parameter_store
@@ -36,6 +31,11 @@ data_docs:
   sites:
 
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   evaluation_parameter_store:
     module_name: great_expectations.data_context.store
     class_name: EvaluationParameterStore

--- a/tests/test_fixtures/great_expectations_basic_without_config_variables_filepath.yml
+++ b/tests/test_fixtures/great_expectations_basic_without_config_variables_filepath.yml
@@ -18,20 +18,21 @@ datasources:
           engine: python
 
 
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
 
 plugins_directory: plugins/
 evaluation_parameter_store_name: evaluation_parameter_store
+expectations_store_name: expectations_store
 profiling_store_name: validation_store
 
 data_docs:
   sites:
 
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   evaluation_parameter_store:
     module_name: great_expectations.data_context.store
     class_name: EvaluationParameterStore

--- a/tests/test_fixtures/great_expectations_site_builder.yml
+++ b/tests/test_fixtures/great_expectations_site_builder.yml
@@ -12,15 +12,15 @@ datasources:
         base_directory: ../data
 plugins_directory: plugins/
 
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
-
+expectations_store_name: expectations_store
 evaluation_parameter_store_name: evaluation_parameter_store
 
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   local_validation_result_store:
     class_name: ValidationResultStore
     store_backend:

--- a/tests/test_fixtures/great_expectations_titanic.yml
+++ b/tests/test_fixtures/great_expectations_titanic.yml
@@ -12,19 +12,20 @@ datasources:
         base_directory: ../data
 plugins_directory: plugins/
 
-expectations_store:
-  class_name: ExpectationStore
-  store_backend:
-    class_name: FixedLengthTupleFilesystemStoreBackend
-    base_directory: expectations/
 
 evaluation_parameter_store_name: evaluation_parameter_store
 profiling_store_name: local_validation_result_store
+expectations_store_name: expectations_store
 
 data_docs:
   sites:
 
 stores:
+  expectations_store:
+    class_name: ExpectationStore
+    store_backend:
+      class_name: FixedLengthTupleFilesystemStoreBackend
+      base_directory: expectations/
   local_validation_result_store:
     class_name: ValidationResultStore
     store_backend:


### PR DESCRIPTION
This was a fun PR. One single line to change the behavior and tons of tests to update.

## What's Here

* the expectations_store config section is now nested inside stores
* This obviously required many many fixtures to be updated.
* Improved documentation in the yml about stores
* Cleaned up a few dead imports in a few random files
