### PR TITLE
Update get/save expectation_suite operations in DataContext with tests

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -206,10 +206,6 @@ class ConfigOnlyDataContext(object):
 
         # Init stores
         self._stores = DotDict()
-        self.add_store(
-            "expectations_store",
-            copy.deepcopy(self._project_config["stores"][self._project_config["expectations_store_name"]]),
-        )
         self._init_stores(self._project_config_with_varibles_substituted["stores"])
 
         # Init validation operators
@@ -341,6 +337,10 @@ class ConfigOnlyDataContext(object):
     def datasources(self):
         """A single holder for all Datasources in this context"""
         return self._datasources
+
+    @property
+    def expectations_store_name(self):
+        return self._project_config_with_varibles_substituted["expectations_store_name"]
 
     # TODO: Decide whether this stays here or moves into NamespacedStore
     @property
@@ -776,7 +776,7 @@ class ConfigOnlyDataContext(object):
         """Returns a list of available expectation suite keys
         """
 
-        keys = self.stores["expectations_store"].list_keys()
+        keys = self.stores[self.expectations_store_name].list_keys()
         return keys
 
     def list_datasources(self):
@@ -1037,13 +1037,13 @@ class ConfigOnlyDataContext(object):
             expectation_suite_name=expectation_suite_name,
         )
 
-        if self._stores["expectations_store"].has_key(key) and not overwrite_existing:
+        if self._stores[self.expectations_store_name].has_key(key) and not overwrite_existing:
             raise DataContextError(
                 "expectation_suite with name {expectation_suite_name} already exists for data_asset {data_asset_name}.\
                  If you would like to overwrite this expectation_suite, set overwrite_existing=True."
             )
         else:
-            self._stores["expectations_store"].set(key, expectation_suite)
+            self._stores[self.expectations_store_name].set(key, expectation_suite)
 
         return expectation_suite
 
@@ -1065,8 +1065,8 @@ class ConfigOnlyDataContext(object):
             expectation_suite_name=expectation_suite_name,
         )
 
-        if self.stores["expectations_store"].has_key(key):
-            return self.stores["expectations_store"].get(key)
+        if self.stores[self.expectations_store_name].has_key(key):
+            return self.stores[self.expectations_store_name].get(key)
         else:
             raise DataContextError(
                 "No expectation_suite found for data_asset_name %s and expectation_suite_name %s" %
@@ -1093,7 +1093,10 @@ class ConfigOnlyDataContext(object):
                 raise DataContextError(
                     "data_asset_name must either be specified or present in the provided expectation suite")
         else:
-            expectation_suite['data_asset_name'] = data_asset_name
+            # Note: we ensure that the suite name is a string here, until we have typed ExpectationSuite
+            # objects that will know how to read the correct type back in
+            expectation_suite['data_asset_name'] = str(data_asset_name)
+            # expectation_suite['data_asset_name'] = data_asset_name
 
         if expectation_suite_name is None:
             try:
@@ -1107,7 +1110,7 @@ class ConfigOnlyDataContext(object):
         if not isinstance(data_asset_name, NormalizedDataAssetName):
             data_asset_name = self._normalize_data_asset_name(data_asset_name)
 
-        self.stores["expectations_store"].set(ExpectationSuiteIdentifier(
+        self.stores[self.expectations_store_name].set(ExpectationSuiteIdentifier(
             data_asset_name=DataAssetIdentifier(*data_asset_name),
             expectation_suite_name=expectation_suite_name,
         ), expectation_suite)
@@ -1262,8 +1265,8 @@ class ConfigOnlyDataContext(object):
             "data_assets": {}
         }
 
-        for key in self.stores["expectations_store"].list_keys():
-            config = self.stores["expectations_store"].get(key)
+        for key in self.stores[self.expectations_store_name].list_keys():
+            config = self.stores[self.expectations_store_name].get(key)
             for expectation in config["expectations"]:
                 for _, value in expectation["kwargs"].items():
                     if isinstance(value, dict) and '$PARAMETER' in value:

--- a/great_expectations/data_context/store/__init__.py
+++ b/great_expectations/data_context/store/__init__.py
@@ -14,8 +14,8 @@ from .store import (
 
 from .namespaced_read_write_store import (
     NamespacedReadWriteStore,
-    ValidationResultStore,
-    ExpectationStore,
+    ValidationsStore,
+    ExpectationsStore,
     HtmlSiteStore,
 )
 

--- a/great_expectations/data_context/store/namespaced_read_write_store.py
+++ b/great_expectations/data_context/store/namespaced_read_write_store.py
@@ -116,7 +116,7 @@ class NamespacedReadWriteStore(ReadWriteStore):
             ))
 
 
-class ExpectationStore(NamespacedReadWriteStore):
+class ExpectationsStore(NamespacedReadWriteStore):
     # Note : As of 2019/09/06, this method is untested.
     # It shares virtually all of its business logic with ValidationStore, which is under test.
 
@@ -125,13 +125,13 @@ class ExpectationStore(NamespacedReadWriteStore):
 
         if store_backend_config["class_name"] == "FixedLengthTupleFilesystemStoreBackend":
             config_defaults = {
-                "key_length" : 4,
-                "module_name" : "great_expectations.data_context.store",
-                "filepath_template": '{0}/{1}/{2}/{3}.json',
+                "key_length": 4,
+                "module_name": "great_expectations.data_context.store",
+                "filepath_template": "{0}/{1}/{2}/{3}.json",
             }
         else:
             config_defaults = {
-                "module_name" : "great_expectations.data_context.store",
+                "module_name": "great_expectations.data_context.store",
             }
 
         return instantiate_class_from_config(
@@ -140,19 +140,21 @@ class ExpectationStore(NamespacedReadWriteStore):
             config_defaults=config_defaults,
         )
 
-class ValidationResultStore(NamespacedReadWriteStore):
+
+class ValidationsStore(NamespacedReadWriteStore):
     
     def _init_store_backend(self, store_backend_config, runtime_config):
         self.key_class = ValidationResultIdentifier
 
         if store_backend_config["class_name"] == "FixedLengthTupleFilesystemStoreBackend":
             config_defaults = {
-                "key_length" : 5,
-                "module_name" : "great_expectations.data_context.store",
+                "key_length": 5,
+                "module_name": "great_expectations.data_context.store",
+                "filepath_template": "{4}/{0}/{1}/{2}/{3}.json"
             }
         else:
             config_defaults = {
-                "module_name" : "great_expectations.data_context.store",
+                "module_name": "great_expectations.data_context.store",
             }
 
         return instantiate_class_from_config(

--- a/great_expectations/data_context/templates.py
+++ b/great_expectations/data_context/templates.py
@@ -71,17 +71,16 @@ evaluation_parameter_store_name: evaluation_parameter_store
 
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/
 
   local_validation_result_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: uncommitted/validations/
-      filepath_template: '{4}/{0}/{1}/{2}/{3}.json'
 
   # Uncomment the lines below to enable s3 as a result store. When enabled,
   # validation results will be saved in the store according to `run id`.
@@ -89,13 +88,12 @@ stores:
   # set where validation happens.
   
   # s3_validation_result_store:
-  #   class_name: ValidationResultStore
+  #   class_name: ValidationsStore
   #   store_backend:
   #     class_name: FixedLengthTupleS3StoreBackend
   #     bucket: <my_bucket>
   #     prefix: <my_prefix>
   #     file_extension: json
-  #     filepath_template: '{4}/{0}/{1}/{2}/{3}.{file_extension}'
 
 
   evaluation_parameter_store:
@@ -105,11 +103,10 @@ stores:
     class_name: EvaluationParameterStore
   
   fixture_validation_results_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: fixtures/validations
-      filepath_template: '{4}/{0}/{1}/{2}/{3}.json'
   
   local_site_html_store:
     module_name: great_expectations.data_context.store

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -14,10 +14,10 @@ from great_expectations.datasource.types.batch_kwargs import BatchFingerprint
 # TODO: Rename to DataAssetKey, for consistency
 class DataAssetIdentifier(OrderedDataContextKey):
 
-    # def __init__(self, *args, delimiter='/', **kwargs):
     def __init__(self, *args, **kwargs):
+        delimiter = kwargs.pop('delimiter', '/')
         super(DataAssetIdentifier, self).__init__(*args, **kwargs)
-        # self.__delimiter = delimiter
+        self.__delimiter = delimiter
 
     _key_order = [
         "datasource",
@@ -31,14 +31,17 @@ class DataAssetIdentifier(OrderedDataContextKey):
     }
     # NOTE: This pattern is kinda awkward. It would be nice to ONLY specify _key_order
     _required_keys = set(_key_order)
-    _allowed_keys = set(_key_order)  # | {"_DataAssetIdentifier__delimiter"}
+    _allowed_keys = set(_key_order) | {"_DataAssetIdentifier__delimiter"}
 
     def __str__(self):
         return self.__delimiter.join(
-            self.datasource,
-            self.generator,
-            self.generator_asset
+            (self.datasource,
+             self.generator,
+             self.generator_asset)
         )
+
+    def __repr__(self):
+        return str(self)
 
 
 # TODO: Rename to ExpectationSuiteKey, for consistency

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -426,7 +426,7 @@ class RunWarningAndFailureExpectationSuitesValidationOperator(PerformActionListV
 
             failure_expectation_suite = None
             try:
-                failure_expectation_suite = self.data_context.stores["expectations_store"].get(
+                failure_expectation_suite = self.data_context.stores[self.data_context.expectations_store_name].get(
                     failure_expectation_suite_identifier
                 )
 
@@ -460,7 +460,7 @@ class RunWarningAndFailureExpectationSuitesValidationOperator(PerformActionListV
 
             warning_expectation_suite = None
             try:
-                warning_expectation_suite = self.data_context.stores["expectations_store"].get(
+                warning_expectation_suite = self.data_context.stores[self.data_context.expectations_store_name].get(
                     warning_expectation_suite_identifier
                 )
             except Exception as e:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,3 +32,6 @@ pytest-cov>=2.6.1
 coveralls>=1.3
 freezegun>=0.3.12
 moto>=1.3.7
+# TEMPORARY FOR BROKEN PROMPT-TOOLKIT BUILDS
+prompt-toolkit<2.0.10;python_version>="3"  # downstream dependency of ipykernel -> ipython -> prompt-toolkit
+prompt-toolkit<1.0.17;python_version<"3"  # downstream dependency of ipykernel -> ipython -> prompt-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ pypandoc>=1.4
 future>=0.16
 jinja2>=2.10
 marshmallow>=2.0,<3.0
+# TEMPORARY FOR BROKEN PROMPT-TOOLKIT BUILDS
+prompt-toolkit<2.0.10;python_version>="3"  # downstream dependency of ipykernel -> ipython -> prompt-toolkit
+prompt-toolkit<1.0.17;python_version<"3"  # downstream dependency of ipykernel -> ipython -> prompt-toolkit

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -16,7 +16,7 @@ from great_expectations.validation_operators import (
 # )
 from great_expectations.data_context.store import (
     # NamespacedInMemoryStore
-    ValidationResultStore,
+    ValidationsStore,
 )
 from great_expectations.data_context.types.resource_identifiers import (
     ValidationResultIdentifier,
@@ -47,7 +47,7 @@ def test_subclass_of_BasicValidationAction():
 
 
 def test_StoreAction():
-    fake_in_memory_store = ValidationResultStore(
+    fake_in_memory_store = ValidationsStore(
         root_directory = None,
         store_backend = {
             "class_name": "InMemoryStoreBackend",
@@ -121,7 +121,7 @@ def test_SlackNotificationAction(data_context):
 
 
 # def test_ExtractAndStoreEvaluationParamsAction():
-#     fake_in_memory_store = ValidationResultStore(
+#     fake_in_memory_store = ValidationsStore(
 #         root_directory = None,
 #         store_backend = {
 #             "class_name": "InMemoryStoreBackend",

--- a/tests/actions/test_validation_operators.py
+++ b/tests/actions/test_validation_operators.py
@@ -28,7 +28,7 @@ def basic_data_context_config_for_validation_operator():
         "datasources": {},
         "stores": {
             "expectations_store" : {
-                "class_name": "ExpectationStore",
+                "class_name": "ExpectationsStore",
                 "store_backend": {
                     "class_name": "FixedLengthTupleFilesystemStoreBackend",
                     "base_directory": "expectations/",
@@ -41,7 +41,7 @@ def basic_data_context_config_for_validation_operator():
             },
             "validation_result_store" : {
                 "module_name": "great_expectations.data_context.store",
-                "class_name": "ValidationResultStore",
+                "class_name": "ValidationsStore",
                 "store_backend": {
                     "class_name": "InMemoryStoreBackend",
                 }
@@ -143,9 +143,9 @@ def test_errors_warnings_validation_operator_run_slack_query(basic_data_context_
                                        {'type': 'divider'},
                                        {'type': 'section', 'text': {'type': 'mrkdwn', 'text': '*Status*: Failed :x:'}},
                                        {'type': 'section', 'text': {'type': 'mrkdwn',
-                                                                    'text': "*Data Asset List:* [{'datasource': 'my_datasource', 'generator': 'default', 'generator_asset': 'f1'}, {'datasource': 'my_datasource', 'generator': 'default', 'generator_asset': 'f2'}, {'datasource': 'my_datasource', 'generator': 'default', 'generator_asset': 'f3'}]"}},
+                                                                    'text': '*Data Asset List:* [my_datasource/default/f1, my_datasource/default/f2, my_datasource/default/f3]'}},
                                        {'type': 'section', 'text': {'type': 'mrkdwn',
-                                                                    'text': "*Failed Data Assets:* [{'datasource': 'my_datasource', 'generator': 'default', 'generator_asset': 'f2'}]"}},
+                                                                    'text': '*Failed Data Assets:* [my_datasource/default/f2]'}},
                                        {'type': 'section', 'text': {'type': 'mrkdwn', 'text': '*Run ID:* test_100'}},
                                        {'type': 'section',
                                         'text': {'type': 'mrkdwn', 'text': '*Timestamp:* 09/26/19 13:42:41'}},

--- a/tests/actions/test_validation_operators_in_data_context.py
+++ b/tests/actions/test_validation_operators_in_data_context.py
@@ -29,7 +29,7 @@ def basic_data_context_config_for_validation_operator():
         "datasources": {},
         "stores": {
             "expectations_store" : {
-                "class_name": "ExpectationStore",
+                "class_name": "ExpectationsStore",
                 "store_backend": {
                     "class_name": "InMemoryStoreBackend",
                 }
@@ -41,7 +41,7 @@ def basic_data_context_config_for_validation_operator():
             },
             "validation_result_store" : {
                 "module_name": "great_expectations.data_context.store",
-                "class_name": "ValidationResultStore",
+                "class_name": "ValidationsStore",
                 "store_backend": {
                     "class_name": "InMemoryStoreBackend",
                 }

--- a/tests/data_context/fixtures/invalid_config_version/great_expectations.yml
+++ b/tests/data_context/fixtures/invalid_config_version/great_expectations.yml
@@ -24,7 +24,7 @@ data_docs:
   sites:
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/

--- a/tests/data_context/fixtures/invalid_top_level_key/great_expectations.yml
+++ b/tests/data_context/fixtures/invalid_top_level_key/great_expectations.yml
@@ -8,7 +8,7 @@ evaluation_parameter_store_name: "baz"
 datasources: "1"
 stores:
   local_validation_result_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: uncommitted/validations/

--- a/tests/data_context/fixtures/old_config_version/great_expectations.yml
+++ b/tests/data_context/fixtures/old_config_version/great_expectations.yml
@@ -25,7 +25,7 @@ data_docs:
   sites:
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/

--- a/tests/data_context/fixtures/post_init_project_v0.8.0_A/great_expectations/great_expectations.yml
+++ b/tests/data_context/fixtures/post_init_project_v0.8.0_A/great_expectations/great_expectations.yml
@@ -34,12 +34,12 @@ validation_operators:
 
 stores:
   local_expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/
   local_validation_result_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: uncommitted/validations/
@@ -55,7 +55,7 @@ stores:
   #     filepath_template: '{4}/{0}/{1}/{2}/{3}.{file_extension}'
 
   fixture_validation_results_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: fixtures/validations

--- a/tests/data_context/test_configuration_storage.py
+++ b/tests/data_context/test_configuration_storage.py
@@ -92,7 +92,7 @@ data_docs:
 
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -11,7 +11,6 @@ except ImportError:
 import os
 import shutil
 import json
-from glob import glob
 from collections import OrderedDict
 
 from great_expectations.exceptions import DataContextError
@@ -23,15 +22,10 @@ from great_expectations.data_context import (
 from great_expectations.data_context.util import safe_mmkdir
 from great_expectations.data_context.types import (
     NormalizedDataAssetName,
+    DataAssetIdentifier,
     ExpectationSuiteIdentifier,
 )
 from great_expectations.cli.init import scaffold_directories_and_notebooks
-from great_expectations.dataset import PandasDataset
-from great_expectations.util import gen_directory_tree_str
-
-# from great_expectations.data_context.types import (
-#     DataContextConfig,
-# )
 from great_expectations.data_context.store import (
     BasicInMemoryStore,
     EvaluationParameterStore,
@@ -39,6 +33,7 @@ from great_expectations.data_context.store import (
 from great_expectations.util import (
     gen_directory_tree_str,
 )
+
 
 @pytest.fixture()
 def parameterized_expectation_suite():
@@ -734,7 +729,7 @@ def basic_data_context_config():
         "datasources": {},
         "stores": {
             "expectations_store": {
-                "class_name": "ExpectationStore",
+                "class_name": "ExpectationsStore",
                 "store_backend": {
                     "class_name": "FixedLengthTupleFilesystemStoreBackend",
                     "base_directory": "expectations/",
@@ -845,3 +840,144 @@ def test__get_normalized_data_asset_name_filepath(basic_data_context_config):
         "my/base/path",
         ".json"
     ) == "my/base/path/my_db/default/my_table/default.json"
+
+
+def test_data_context_updates_expectation_suite_names(data_context):
+    # A data context should update the data_asset_name and expectation_suite_name of expectation suites
+    # that it creates when it saves them.
+
+    expectation_suites = data_context.list_expectation_suite_keys()
+
+    # We should have a single expectation suite defined
+    assert len(expectation_suites) == 1
+
+    data_asset_name = expectation_suites[0]['data_asset_name']
+    expectation_suite_name = expectation_suites[0]['expectation_suite_name']
+
+    # We'll get that expectation suite and then update its name and re-save, then verify that everything
+    # has been properly updated
+    expectation_suite = data_context.get_expectation_suite(
+        data_asset_name=data_asset_name,
+        expectation_suite_name=expectation_suite_name
+    )
+
+    # Note we codify here the current behavior of having a string data_asset_name though typed ExpectationSuite objects
+    # will enable changing that
+    assert expectation_suite['data_asset_name'] == str(data_asset_name)
+    assert expectation_suite['expectation_suite_name'] == expectation_suite_name
+
+    # We will now change the data_asset_name and then save the suite in three ways:
+    #   1. Directly using the new name,
+    #   2. Using a different name that should be overwritten
+    #   3. Using the new name but having the context draw that from the suite
+
+    # Finally, we will try to save without a name (deleting it first) to demonstrate that saving will fail.
+    expectation_suite['data_asset_name'] = str(DataAssetIdentifier(
+        data_asset_name.datasource,
+        data_asset_name.generator,
+        "a_new_data_asset"
+    ))
+    expectation_suite['expectation_suite_name'] = 'a_new_suite_name'
+
+    data_context.save_expectation_suite(
+        expectation_suite=expectation_suite,
+        data_asset_name=DataAssetIdentifier(
+            data_asset_name.datasource,
+            data_asset_name.generator,
+            "a_new_data_asset"
+        ),
+        expectation_suite_name='a_new_suite_name'
+    )
+
+    fetched_expectation_suite = data_context.get_expectation_suite(
+        data_asset_name=DataAssetIdentifier(
+            data_asset_name.datasource,
+            data_asset_name.generator,
+            "a_new_data_asset"
+        ),
+        expectation_suite_name='a_new_suite_name'
+    )
+
+    assert fetched_expectation_suite['data_asset_name'] == str(
+        DataAssetIdentifier(
+            data_asset_name.datasource,
+            data_asset_name.generator,
+            "a_new_data_asset"
+        )
+    )
+    assert fetched_expectation_suite['expectation_suite_name'] == 'a_new_suite_name'
+
+    #   2. Using a different name that should be overwritten
+    data_context.save_expectation_suite(
+        expectation_suite=expectation_suite,
+        data_asset_name=DataAssetIdentifier(
+            data_asset_name.datasource,
+            data_asset_name.generator,
+            "a_new_new_data_asset"
+        ),
+        expectation_suite_name='a_new_new_suite_name'
+    )
+
+    fetched_expectation_suite = data_context.get_expectation_suite(
+        data_asset_name=DataAssetIdentifier(
+            data_asset_name.datasource,
+            data_asset_name.generator,
+            "a_new_new_data_asset"
+        ),
+        expectation_suite_name='a_new_new_suite_name'
+    )
+
+    assert fetched_expectation_suite['data_asset_name'] == str(
+        DataAssetIdentifier(
+            data_asset_name.datasource,
+            data_asset_name.generator,
+            "a_new_new_data_asset"
+        )
+    )
+    assert fetched_expectation_suite['expectation_suite_name'] == 'a_new_new_suite_name'
+
+    # Check that the saved name difference is actually persisted on disk
+    with open(os.path.join(
+                data_context.root_directory,
+                "expectations",
+                data_asset_name.datasource,
+                data_asset_name.generator,
+                "a_new_new_data_asset",
+                "a_new_new_suite_name.json"
+                ), 'r') as suite_file:
+        loaded_suite = json.load(suite_file)
+        assert loaded_suite['data_asset_name'] == str(
+            DataAssetIdentifier(
+                data_asset_name.datasource,
+                data_asset_name.generator,
+                "a_new_new_data_asset"
+            )
+        )
+        assert loaded_suite['expectation_suite_name'] == 'a_new_new_suite_name'
+
+
+    #   3. Using the new name but having the context draw that from the suite
+    expectation_suite['data_asset_name'] = str(DataAssetIdentifier(
+        data_asset_name.datasource,
+        data_asset_name.generator,
+        "a_third_name"
+    ))
+    expectation_suite['expectation_suite_name'] = "a_third_suite_name"
+    data_context.save_expectation_suite(
+        expectation_suite=expectation_suite
+    )
+
+    fetched_expectation_suite = data_context.get_expectation_suite(
+        data_asset_name=DataAssetIdentifier(
+            data_asset_name.datasource,
+            data_asset_name.generator,
+            "a_third_name"
+        ),
+        expectation_suite_name="a_third_suite_name"
+    )
+    assert fetched_expectation_suite['data_asset_name'] == str(DataAssetIdentifier(
+        data_asset_name.datasource,
+        data_asset_name.generator,
+        "a_third_name"
+    ))
+    assert fetched_expectation_suite['expectation_suite_name'] == "a_third_suite_name"

--- a/tests/data_context/test_data_context_store_configs.py
+++ b/tests/data_context/test_data_context_store_configs.py
@@ -25,7 +25,7 @@ def totally_empty_data_context(tmp_path_factory):
         "datasources": {},
         "stores": {
             "expectations_store": {
-                "class_name": "ExpectationStore",
+                "class_name": "ExpectationsStore",
                 "store_backend": {
                     "class_name": "FixedLengthTupleFilesystemStoreBackend",
                     "base_directory": "expectations/"

--- a/tests/store/test_validation_store.py
+++ b/tests/store/test_validation_store.py
@@ -1,7 +1,7 @@
 import pytest
 
 from great_expectations.data_context.store import (
-    ValidationResultStore,
+    ValidationsStore,
 )
 from great_expectations.data_context.types import (
     ValidationResultIdentifier,
@@ -13,7 +13,7 @@ from great_expectations.util import (
 
 def test_ValidationResultStore_with_InMemoryStoreBackend():
 
-    my_store = ValidationResultStore(
+    my_store = ValidationsStore(
         store_backend = {
             "module_name" : "great_expectations.data_context.store",
             "class_name" : "InMemoryStoreBackend",
@@ -54,7 +54,7 @@ def test_ValidationResultStore_with_InMemoryStoreBackend():
 
 def test_ValidationResultStore__convert_resource_identifier_to_list():
 
-    my_store = ValidationResultStore(
+    my_store = ValidationsStore(
         store_backend = {
             "module_name" : "great_expectations.data_context.store",
             "class_name" : "InMemoryStoreBackend",
@@ -71,7 +71,7 @@ def test_ValidationResultStore_with_FixedLengthTupleFileSystemStoreBackend(tmp_p
     path = str(tmp_path_factory.mktemp('test_ValidationResultStore_with_FixedLengthTupleFileSystemStoreBackend__dir'))
     project_path = str(tmp_path_factory.mktemp('my_dir'))
 
-    my_store = ValidationResultStore(
+    my_store = ValidationsStore(
         store_backend = {
             "module_name" : "great_expectations.data_context.store",
             "class_name" : "FixedLengthTupleFilesystemStoreBackend",

--- a/tests/test_fixtures/great_expectations_basic.yml
+++ b/tests/test_fixtures/great_expectations_basic.yml
@@ -32,7 +32,7 @@ data_docs:
 
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/

--- a/tests/test_fixtures/great_expectations_basic_with_variables.yml
+++ b/tests/test_fixtures/great_expectations_basic_with_variables.yml
@@ -32,7 +32,7 @@ data_docs:
 
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/

--- a/tests/test_fixtures/great_expectations_basic_without_config_variables_filepath.yml
+++ b/tests/test_fixtures/great_expectations_basic_without_config_variables_filepath.yml
@@ -29,7 +29,7 @@ data_docs:
 
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/

--- a/tests/test_fixtures/great_expectations_site_builder.yml
+++ b/tests/test_fixtures/great_expectations_site_builder.yml
@@ -18,16 +18,15 @@ profiling_store_name: local_validation_result_store
 
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/
   local_validation_result_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: uncommitted/validations/
-      filepath_template: '{4}/{0}/{1}/{2}/{3}.json'
 
   local_site_html_store:
     module_name: great_expectations.data_context.store
@@ -59,11 +58,10 @@ stores:
   #     file_extension: .html
 
   fixture_validation_results_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: fixtures/validations
-      filepath_template: '{4}/{0}/{1}/{2}/{3}.json'
 
   evaluation_parameter_store:
       module_name: great_expectations.data_context.store

--- a/tests/test_fixtures/great_expectations_titanic.yml
+++ b/tests/test_fixtures/great_expectations_titanic.yml
@@ -22,16 +22,15 @@ data_docs:
 
 stores:
   expectations_store:
-    class_name: ExpectationStore
+    class_name: ExpectationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: expectations/
   local_validation_result_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: uncommitted/validations/
-      filepath_template: '{4}/{0}/{1}/{2}/{3}.json'
 
   # These next three blocks are never used in tests.
 
@@ -58,11 +57,10 @@ stores:
   #     file_extension: .html
 
   fixture_validation_results_store:
-    class_name: ValidationResultStore
+    class_name: ValidationsStore
     store_backend:
       class_name: FixedLengthTupleFilesystemStoreBackend
       base_directory: fixtures/validations
-      filepath_template: '{4}/{0}/{1}/{2}/{3}.json'
 
   evaluation_parameter_store:
       module_name: great_expectations.data_context.store


### PR DESCRIPTION
HERE:
 - Fully removes the hard-coded "expectation_store"
 - Renames ExpectationStore class to ExpectationsStore
 - Renames ValidationsResultStore class to ValidationsStore
 - Fully removes the filepath_template where it is default
 - Adds a test for expectation saving
 - Updates the behavior of DataAssetIdentifier to support current string-first usage in expectation_suites