### PR TITLE
Add support for build_categorical_partition_object to dataset util

### DIFF
--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -202,8 +202,20 @@ class Dataset(MetaDataset):
         """Returns: float"""
         raise NotImplementedError
 
-    def get_column_value_counts(self, column):
-        """Returns: pd.Series of value counts for a column, sorted by value"""
+    def get_column_value_counts(self, column, sort="value", collate=None):
+        """
+
+        Args:
+            column: the column for which to obtain value_counts
+            sort (string): must be one of "value", "count", or "none".
+                - if "value" then values in the resulting partition object will be sorted lexigraphically
+                - if "count" then values will be sorted according to descending count (frequency)
+                - if "none" then values will not be sorted
+
+
+        Returns:
+            pd.Series of value counts for a column, sorted according to the value requested in sort
+        """
         raise NotImplementedError
 
     def get_column_sum(self, column):

--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -203,7 +203,7 @@ class Dataset(MetaDataset):
         raise NotImplementedError
 
     def get_column_value_counts(self, column, sort="value", collate=None):
-        """
+        """Get a series containing the frequency counts of unique values from the named column.
 
         Args:
             column: the column for which to obtain value_counts
@@ -211,6 +211,7 @@ class Dataset(MetaDataset):
                 - if "value" then values in the resulting partition object will be sorted lexigraphically
                 - if "count" then values will be sorted according to descending count (frequency)
                 - if "none" then values will not be sorted
+            collate (string): the collate (sort) method to be used on supported backends (SqlAlchemy only)
 
 
         Returns:

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -355,12 +355,23 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
         nonnull_values = series[null_indexes == False]
         return len(nonnull_values)
 
-    def get_column_value_counts(self, column):
-        cnts =  self[column].value_counts()
-        cnts.sort_index(inplace=True)
-        cnts.name = "count"
-        cnts.index.name = "value"
-        return cnts
+    def get_column_value_counts(self, column, sort="value", collate=None):
+        if sort not in ["value", "count", "none"]:
+            raise ValueError(
+                "sort must be either 'value', 'count', or 'none'"
+            )
+        if collate is not None:
+            raise ValueError(
+                "collate parameter is not supported in PandasDataset"
+            )
+        counts = self[column].value_counts()
+        if sort == "value":
+            counts.sort_index(inplace=True)
+        elif sort == "counts":
+            counts.sort_values(inplace=True)
+        counts.name = "count"
+        counts.index.name = "value"
+        return counts
 
     def get_column_unique_count(self, column):
         return self.get_column_value_counts(column).shape[0]

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -325,8 +325,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             # NOTE: depending on the way the underlying database collates columns,
             # ordering can vary. postgresql collate "C" matches default sort
             # for python and most other systems, but is not universally supported,
-            # so we use the default sort for the system
-            # query = query.order_by(sa.column(column).collate("C"))
+            # so we use the default sort for the system, unless specifically overridden
             if collate is not None:
                 query = query.order_by(sa.column(column).collate(collate))
             else:

--- a/great_expectations/dataset/util.py
+++ b/great_expectations/dataset/util.py
@@ -212,6 +212,33 @@ def build_continuous_partition_object(dataset, column, bins='auto', n_bins=10):
     return partition_object
 
 
+def build_categorical_partition_object(dataset, column, sort="value"):
+    """Convenience method for building a partition object on categorical data from a dataset and column
+
+    Args:
+        dataset (GE Dataset): the dataset for which to compute the partition
+        column (string): The name of the column for which to construct the estimate.
+        sort (string): must be one of "value", "count", or "none".
+            - if "value" then values in the resulting partition object will be sorted lexigraphically
+            - if "count" then values will be sorted according to descending count (frequency)
+            - if "none" then values will not be sorted
+
+    Returns:
+        A new partition_object::
+
+        {
+            "values": (list) the categorical values for which each weight applies,
+            "weights": (list) The densities of the values implied by the partition.
+        }
+        See :ref:`partition_object`.
+    """
+    counts = dataset.get_column_value_counts(column, sort)
+    return {
+        'values': list(counts.index),
+        'weights': list(np.array(counts) / dataset.get_column_nonnull_count(column))
+    }
+
+
 def infer_distribution_parameters(data, distribution, params=None):
     """Convenience method for determining the shape parameters of a given distribution
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,23 +263,103 @@ def non_numeric_high_card_dataset(request):
             "pIX0vhOzql5c6Z6NpLbzc8MvYiONyT54", "nvyCo3MkIK4tS6rkuL4Yw1RgGKwhm4c2", "prQGAOvQbB8fQIrp8xaLXmGwcxDcCnqt",
             "ajcLVizD2vwZlmmGKyXYki03SWn7fnt3", "mty9rQJBeTsBQ7ra8vWRbBaWulzhWRSG", "JL38Vw7yERPC4gBplBaixlbpDg8V7gC6",
             "MylTvGl5L1tzosEcgGCQPjIRN6bCUwtI", "hmr0LNyYObqe5sURs408IhRb50Lnek5K"
+        ],
+        # Built from highcardnonnum using the following:
+        # vals = pd.Series(data["highcardnonnum"])
+        # sample_vals = vals.sample(n=10, random_state=42)
+        # weights = np.random.RandomState(42).rand(10)
+        # weights = weights / np.sum(weights)
+        # new_vals = sample_vals.sample(n=200, weights=weights, replace=True, random_state=11)
+        "medcardnonnum": [
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'mS2AVcLFp6i36sX7yAUrdfM0g0RB2X4D', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'NfX4KfEompMbbKloFq8NQpdXtk5PjaPe',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'NfX4KfEompMbbKloFq8NQpdXtk5PjaPe', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'NfX4KfEompMbbKloFq8NQpdXtk5PjaPe', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'NfX4KfEompMbbKloFq8NQpdXtk5PjaPe', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+            'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4',
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+            'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP', 'NhTsracusfp5V6zVeWqLZnychDl7jjO4',
+            'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+            'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ'
         ]
     }
     schemas = {
         "pandas": {
             "highcardnonnum": "str",
+            "medcardnonnum": "str",
         },
         "postgresql": {
             "highcardnonnum": "TEXT",
+            "medcardnonnum": "TEXT",
         },
         "sqlite": {
             "highcardnonnum": "VARCHAR",
+            "medcardnonnum": "VARCHAR",
         },
         "mysql": {
             "highcardnonnum": "TEXT",
+            "medcardnonnum": "TEXT",
         },
         "spark": {
             "highcardnonnum": "StringType",
+            "medcardnonnum": "StringType",
         }
     }
     return get_dataset(request.param, data, schemas=schemas)

--- a/tests/test_dataset_implementations/test_dataset_implementations.json
+++ b/tests/test_dataset_implementations/test_dataset_implementations.json
@@ -181,6 +181,33 @@
             "func": "get_column_value_counts",
             "dataset": "d2",
             "kwargs": {
+                "column": "b",
+                "sort": "value"
+            },
+            "expected": [
+                {
+                    "value": "d",
+                    "count": 4
+                },
+                {
+                    "value": "c",
+                    "count": 3
+                },
+                {
+                    "value": "b",
+                    "count": 2
+                },
+                {
+                    "value": "a",
+                    "count": 1
+                }
+            ]
+        },
+        {
+            "_note": "this test tests the value of this method *after serialization* see python test_get_column_value_counts for series test",
+            "func": "get_column_value_counts",
+            "dataset": "d2",
+            "kwargs": {
                 "column": "c"
             },
             "expected": [

--- a/tests/test_dataset_util.py
+++ b/tests/test_dataset_util.py
@@ -3,6 +3,59 @@ import numpy as np
 import unittest
 
 import great_expectations as ge
+from great_expectations.dataset.util import build_categorical_partition_object
+
+
+def test_build_categorical_partition(non_numeric_high_card_dataset):
+
+    # Verify that we can build expected categorical partition objects
+    # Note that this relies on the underlying sort behavior of the system in question
+    # For weights, that will be unambiguous, but for values, it could depend on locale
+
+    partition = build_categorical_partition_object(
+        non_numeric_high_card_dataset,
+        "medcardnonnum",
+        sort="count")
+
+    assert partition == {
+        'values': ['hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+                   '2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+                   'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+                   'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'NfX4KfEompMbbKloFq8NQpdXtk5PjaPe',
+                   'mS2AVcLFp6i36sX7yAUrdfM0g0RB2X4D'],
+        'weights': [0.18, 0.17, 0.16, 0.145, 0.125, 0.11, 0.085, 0.02, 0.005]
+    }
+
+    partition = build_categorical_partition_object(
+        non_numeric_high_card_dataset,
+        "medcardnonnum",
+        sort="value")
+
+    try:
+        assert partition == {
+            'values': ['2K8njWnvuq1u6tkzreNhxTEyO8PTeWer', 'NfX4KfEompMbbKloFq8NQpdXtk5PjaPe',
+                       'NhTsracusfp5V6zVeWqLZnychDl7jjO4', 'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP',
+                       'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3', 'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+                       'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J', 'mS2AVcLFp6i36sX7yAUrdfM0g0RB2X4D',
+                       'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ'],
+            'weights': [0.16, 0.02, 0.125, 0.17, 0.085, 0.18, 0.145, 0.005, 0.11]
+        }
+    except AssertionError:
+        # Postgres uses a lexigraphical sort that differs from the one used in python natively
+        # Since we *want* to preserve the underlying system's ability to do compute (and the user
+        # can override if desired), we allow this explicitly.
+        assert partition == {
+            'values': ['2K8njWnvuq1u6tkzreNhxTEyO8PTeWer',
+                       'ajcLVizD2vwZlmmGKyXYki03SWn7fnt3',
+                       'hW0kFZ6ijfciJWN4vvgcFa6MWv8cTeVk',
+                       'k8B9KCXhaQb6Q82zFbAzOESAtDxK174J',
+                       'mS2AVcLFp6i36sX7yAUrdfM0g0RB2X4D',
+                       'NfX4KfEompMbbKloFq8NQpdXtk5PjaPe',
+                       'NhTsracusfp5V6zVeWqLZnychDl7jjO4',
+                       'oRnY5jDWFw2KZRYLh6ihFd021ggy4UxJ',
+                       'T7EUE54HUhyJ9Hnxv1pKY0Bmg42qiggP'],
+            'weights': [0.16, 0.085, 0.18, 0.145, 0.005, 0.02, 0.125, 0.11, 0.17]
+        }
 
 
 class TestUtilMethods(unittest.TestCase):


### PR DESCRIPTION
Add support for build_categorical_partition_object to dataset util
with cross-backend support.
  - move compute to backend for all sorting on get_column_value_counts
  - allow multiple sorting options