### PR TITLE
* bugfix for 0.7 to 0.8 template migration

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -39,11 +39,13 @@ See <blue>https://docs.greatexpectations.io/en/latest/core_concepts/datasource.h
     #     context.add_datasource("dbt", "dbt", profile=dbt_profile)
     if data_source_selection == "4":  # None of the above
         cli_message(msg_unknown_data_source)
-        cli_message("""
+        cli_message(
+            """
 Skipping datasource configuration.
     - Add one by running `<green>great_expectations add-datasource</green>` or
-    - ... by editing the great_expectations.yml file
-""")
+    - ... by editing the `{}` file
+""".format(DataContext.GE_YML)
+        )
 
     return data_source_name
 
@@ -160,8 +162,8 @@ def _add_sqlalchemy_datasource(context):
                 cli_message(
                     """You can add a datasource later by:
   - Running <green>great_expectations add-datasource</green>
-  - Editing the great_expectations.yml file.
-""")
+  - Editing the {} file.
+""".format(DataContext.GE_YML))
                 return None
 
     return data_source_name

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1082,14 +1082,14 @@ uncommitted/
     assert fixture == expected
 
     # Test that all exist
-    assert DataContext.do_all_uncommitted_directories_exist(ge_dir)
+    assert DataContext.all_uncommitted_directories_exist(ge_dir)
 
     # remove a few
     shutil.rmtree(os.path.join(uncommitted_dir, "data_docs"))
     shutil.rmtree(os.path.join(uncommitted_dir, "validations"))
 
     # Test that not all exist
-    assert not DataContext.do_all_uncommitted_directories_exist(project_path)
+    assert not DataContext.all_uncommitted_directories_exist(project_path)
 
 
 def test_data_context_create_does_not_overwrite_existing_config_variables_yml(tmp_path_factory):


### PR DESCRIPTION
* consolidated a pile of magic strings that were contributing to the bug
* made docstrings and args more consistent and honest