### PR TITLE
Slack message improvements

### DIFF
--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -11,23 +11,25 @@ class SlackRenderer(Renderer):
     def render(self, validation_json=None):
         # Defaults
         timestamp = datetime.datetime.strftime(datetime.datetime.now(), "%x %X")
+        default_text = "No validation occurred. Please ensure you passed a validation_json."
         status = "Failed :x:"
-        run_id = None
-    
+
         title_block = {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "No validation occurred. Please ensure you passed a validation_json.",
+                "text": default_text,
             },
         }
-    
-        divider_block = {
-            "type": "divider"
+
+        query = {
+            "blocks": [title_block],
+            "text": default_text
         }
-    
-        query = {"blocks": [divider_block, title_block]}
-    
+
+        # TODO improve this nested logic
+        expectation_suite_name = None
+        data_asset_name = None
         if validation_json:
             if "meta" in validation_json:
                 data_asset_name = validation_json["meta"].get(
@@ -39,15 +41,28 @@ class SlackRenderer(Renderer):
             n_checks_succeeded = validation_json["statistics"]["successful_expectations"]
             n_checks = validation_json["statistics"]["evaluated_expectations"]
             run_id = validation_json["meta"].get("run_id", None)
-            check_details_text = "{} of {} expectations were met\n\n".format(
+            check_details_text = "*{}* of *{}* expectations were met".format(
                 n_checks_succeeded, n_checks)
         
             if validation_json["success"]:
                 status = "Success :tada:"
-        
-            query["blocks"][1]["text"]["text"] = "*Validated batch from data asset:* `{}`\n*Status: {}*\n*Run ID:* {}\n*Timestamp:* {}\n*Summary:* {}".format(
-                data_asset_name, status, run_id, timestamp, check_details_text)
-        
+
+            summary_text = """*Batch Validation Status*: {}
+*Data Asset:* `{}`
+*Expectation suite name*: `{}`
+*Run ID*: `{}`
+*Timestamp*: `{}`
+*Summary*: {}""".format(
+                status,
+                data_asset_name,
+                expectation_suite_name,
+                run_id,
+                timestamp,
+                check_details_text
+            )
+            query["blocks"][0]["text"]["text"] = summary_text
+            query["text"] = "{}: {}".format(data_asset_name, status)
+
             if "result_reference" in validation_json["meta"]:
                 report_element = {
                     "type": "section",
@@ -77,10 +92,12 @@ class SlackRenderer(Renderer):
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": "Learn how to review validation results at {}".format(documentation_url),
+                    "text": "Learn how to review validation results: {}".format(documentation_url),
                 }
             ],
         }
+
+        divider_block = {"type": "divider"}
         query["blocks"].append(divider_block)
         query["blocks"].append(footer_section)
         return query

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -24,6 +24,7 @@ class SlackRenderer(Renderer):
 
         query = {
             "blocks": [title_block],
+            # this abbreviated root level "text" will show up in the notification and not the message
             "text": default_text
         }
 
@@ -61,6 +62,7 @@ class SlackRenderer(Renderer):
                 check_details_text
             )
             query["blocks"][0]["text"]["text"] = summary_text
+            # this abbreviated root level "text" will show up in the notification and not the message
             query["text"] = "{}: {}".format(data_asset_name, status)
 
             if "result_reference" in validation_json["meta"]:

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -30,10 +30,29 @@ def test_SlackRenderer():
                                         'data_asset_name': {'datasource': 'x', 'generator': 'y',
                                                             'generator_asset': 'z'},
                                         'expectation_suite_name': 'default', 'run_id': '2019-09-25T060538.829112Z'}}
-    expected_renderer_output = {'blocks': [{'type': 'divider'}, {'type': 'section', 'text': {'type': 'mrkdwn',
-                                                                                             'text': "*Validated batch from data asset:* `{'datasource': 'x', 'generator': 'y', 'generator_asset': 'z'}`\n*Status: Success :tada:*\n*Run ID:* 2019-09-25T060538.829112Z\n*Timestamp:* 09/24/19 23:18:36\n*Summary:* 0 of 0 expectations were met\n\n"}},
-                                           {'type': 'divider'}, {'type': 'context', 'elements': [{'type': 'mrkdwn',
-                                                                                                  'text': 'Learn how to review validation results at https://docs.greatexpectations.io/en/latest/features/validation.html#reviewing-validation-results'}]}]}
+    expected_renderer_output = {
+        'blocks': [
+            {
+                'type': 'section',
+                'text': {
+                    'type': 'mrkdwn',
+                    'text': "*Batch Validation Status*: Success :tada:\n*Data Asset:* `{'datasource': 'x', 'generator': 'y', 'generator_asset': 'z'}`\n*Expectation suite name*: `default`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Timestamp*: `09/24/19 23:18:36`\n*Summary*: *0* of *0* expectations were met"
+                }
+            },
+            {
+                'type': 'divider'
+            },
+            {
+                'type': 'context', 'elements': [
+                    {
+                        'type': 'mrkdwn',
+                        'text': 'Learn how to review validation results: https://docs.greatexpectations.io/en/latest/features/validation.html#reviewing-validation-results'
+                    }
+                ]
+            }
+        ],
+        'text': "{'datasource': 'x', 'generator': 'y', 'generator_asset': 'z'}: Success :tada:"
+    }
     renderer_output = SlackRenderer().render(validation_result_suite)
-    
+
     assert renderer_output == expected_renderer_output


### PR DESCRIPTION
## What's Here

* slack notification no longer says "content can't be displayed"
* improved message shows status up front
* more consistent formatting

Slack notifications look like:
<img width="361" alt="Screen_Shot_2019-10-15_at_2_50_30_PM" src="https://user-images.githubusercontent.com/928247/66872628-4a5a3900-ef5b-11e9-8a99-8e1cbec38945.png">

and messages look like:
<img width="591" alt="Slack___notification_datadocs___superconductive" src="https://user-images.githubusercontent.com/928247/66872668-61009000-ef5b-11e9-9f04-3c903ecae2d6.png">

## Known issues

- the slack renderer logic is overly convoluted