### PR TITLE
the logic for entering credentials for the supported database flavors (WIP, but is worth merging)

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -109,6 +109,14 @@ def _add_sqlalchemy_datasource(context):
         msg_prompt_datasource_name, default="mydb", show_default=True)
 
     credentials = {}
+    # Since we don't want to save the database credentials in the config file that will be
+    # committed in the repo, we will use our Variable Substitution feature to store the credentials
+    # in the credentials file (that will not be committed, since it is in the uncommitted directory)
+    # with the datasource's name as the variable name.
+    # The value of the datasource's "credentials" key in the config file (great_expectations.yml) will
+    # be ${datasource name}.
+    # GE will replace the ${datasource name} with the value from the credentials file in runtime.
+
     while True:
         cli_message(msg_sqlalchemy_config_connection.format(data_source_name))
 
@@ -116,6 +124,12 @@ def _add_sqlalchemy_datasource(context):
                                   show_default=True)
         if drivername == "postgres":
             credentials = _collect_postgres_credentials(default_credentials=credentials)
+        elif drivername == "snowflake":
+            credentials = _collect_snowflake_credentials(default_credentials=credentials)
+        elif drivername == "redshift":
+            credentials = _collect_redshift_credentials(default_credentials=credentials)
+        elif drivername == "mysql":
+            credentials = _collect_mysql_credentials(default_credentials=credentials)
         else:
             sqlalchemy_url = click.prompt(
 """What is the url/connection string for the sqlalchemy connection?
@@ -168,40 +182,121 @@ def _add_sqlalchemy_datasource(context):
 
 
 def _collect_postgres_credentials(default_credentials={}):
-    host = click.prompt("What is the host for the sqlalchemy connection?",
+    credentials = {}
+
+    credentials["host"] = click.prompt("What is the host for the sqlalchemy connection?",
                         default=default_credentials.get("host", "localhost"),
                         show_default=True)
-    port = click.prompt("What is the port for the sqlalchemy connection?",
+    credentials["port"] = click.prompt("What is the port for the sqlalchemy connection?",
                         default=default_credentials.get("port", "5432"),
                         show_default=True)
-    username = click.prompt("What is the username for the sqlalchemy connection?",
+    credentials["username"] = click.prompt("What is the username for the sqlalchemy connection?",
                             default=default_credentials.get("username", "postgres"),
                             show_default=True)
-    password = click.prompt("What is the password for the sqlalchemy connection?",
+    credentials["password"] = click.prompt("What is the password for the sqlalchemy connection?",
                             default="",
                             show_default=False, hide_input=True)
-    database = click.prompt("What is the database name for the sqlalchemy connection?",
+    credentials["database"] = click.prompt("What is the database name for the sqlalchemy connection?",
                             default=default_credentials.get("database", "postgres"),
                             show_default=True)
 
-    # Since we don't want to save the database credentials in the config file that will be
-    # committed in the repo, we will use our Variable Substitution feature to store the credentials
-    # in the credentials file (that will not be committed, since it is in the uncommitted directory)
-    # with the datasource's name as the variable name.
-    # The value of the datasource's "credentials" key in the config file (great_expectations.yml) will
-    # be ${datasource name}.
-    # GE will replace the ${datasource name} with the value from the credentials file in runtime.
-    credentials = {
-        "drivername": "postgres",
-        "host": host,
-        "port": port,
-        "username": username,
-        "password": password,
-        "database": database
-    }
+    return credentials
+
+def _collect_snowflake_credentials(default_credentials={}):
+    credentials = {}
+
+    # required
+
+    credentials["user_login_name"] = click.prompt("What is the user login name for the snowflake connection?",
+                        default=default_credentials.get("user_login_name", ""),
+                        show_default=True)
+    credentials["password"] = click.prompt("What is the password for the snowflake connection?",
+                            default="",
+                            show_default=False, hide_input=True)
+    credentials["account_name"] = click.prompt("What is the account name for the snowflake connection?",
+                        default=default_credentials.get("account_name", ""),
+                        show_default=True)
+
+    # optional
+
+    credentials["database_name"] = click.prompt("What is database name for the snowflake connection?",
+                        default=default_credentials.get("database_name", ""),
+                        show_default=True)
+    credentials["schema_name"] = click.prompt("What is schema name for the snowflake connection?",
+                        default=default_credentials.get("schema_name", ""),
+                        show_default=True)
+    credentials["warehouse_name"] = click.prompt("What is warehouse name for the snowflake connection?",
+                        default=default_credentials.get("warehouse_name", ""),
+                        show_default=True)
+    credentials["role_name"] = click.prompt("What is role name for the snowflake connection?",
+                        default=default_credentials.get("role_name", ""),
+                        show_default=True)
 
     return credentials
 
+def _collect_mysql_credentials(default_credentials={}):
+    credentials = {}
+
+    # required
+
+    credentials["user_login_name"] = click.prompt("What is the user login name for the snowflake connection?",
+                        default=default_credentials.get("user_login_name", ""),
+                        show_default=True)
+    credentials["password"] = click.prompt("What is the password for the snowflake connection?",
+                            default="",
+                            show_default=False, hide_input=True)
+    credentials["account_name"] = click.prompt("What is the account name for the snowflake connection?",
+                        default=default_credentials.get("account_name", ""),
+                        show_default=True)
+
+    # optional
+
+    credentials["database_name"] = click.prompt("What is database name for the snowflake connection?",
+                        default=default_credentials.get("database_name", ""),
+                        show_default=True)
+    credentials["schema_name"] = click.prompt("What is schema name for the snowflake connection?",
+                        default=default_credentials.get("schema_name", ""),
+                        show_default=True)
+    credentials["warehouse_name"] = click.prompt("What is warehouse name for the snowflake connection?",
+                        default=default_credentials.get("warehouse_name", ""),
+                        show_default=True)
+    credentials["role_name"] = click.prompt("What is role name for the snowflake connection?",
+                        default=default_credentials.get("role_name", ""),
+                        show_default=True)
+
+    return credentials
+
+def _collect_redshift_credentials(default_credentials={}):
+    credentials = {}
+
+    # required
+
+    credentials["user_login_name"] = click.prompt("What is the user login name for the snowflake connection?",
+                        default=default_credentials.get("user_login_name", ""),
+                        show_default=True)
+    credentials["password"] = click.prompt("What is the password for the snowflake connection?",
+                            default="",
+                            show_default=False, hide_input=True)
+    credentials["account_name"] = click.prompt("What is the account name for the snowflake connection?",
+                        default=default_credentials.get("account_name", ""),
+                        show_default=True)
+
+    # optional
+
+    credentials["database_name"] = click.prompt("What is database name for the snowflake connection?",
+                        default=default_credentials.get("database_name", ""),
+                        show_default=True)
+    credentials["schema_name"] = click.prompt("What is schema name for the snowflake connection?",
+                        default=default_credentials.get("schema_name", ""),
+                        show_default=True)
+    credentials["warehouse_name"] = click.prompt("What is warehouse name for the snowflake connection?",
+                        default=default_credentials.get("warehouse_name", ""),
+                        show_default=True)
+    credentials["role_name"] = click.prompt("What is role name for the snowflake connection?",
+                        default=default_credentials.get("role_name", ""),
+                        show_default=True)
+
+    return credentials
 
 def _add_spark_datasource(context):
     path = click.prompt(

--- a/great_expectations/datasource/sqlalchemy_datasource.py
+++ b/great_expectations/datasource/sqlalchemy_datasource.py
@@ -114,7 +114,7 @@ class SqlAlchemyDatasource(Datasource):
                 self.engine = create_engine(self._get_sqlalchemy_connection_options(**kwargs))
                 self.engine.connect()
 
-        except sqlalchemy.exc.OperationalError as sqlalchemy_error:
+        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DatabaseError) as sqlalchemy_error:
             raise DatasourceInitializationError(self._name, str(sqlalchemy_error))
 
         self._build_generators()


### PR DESCRIPTION
1. Added the logic for entering database credentials for MySQL, Snowflake and Redshift.
2. Updated the signature of load_library to allow custom install instructions (needed for Snowflake where the name of the library and the installable module are not the same
3. See "TODO" with "Taylor" in it cli/datasources
4. Need to catch sqlalchemy.exc.DatabaseError in sqlalchemydatasource  - it is raised by the snowflake driver.
