### PR TITLE
Fix data docs formatting issues

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -3,7 +3,9 @@
 
 0.8.3__develop
 -----------------
-
+* Fix a bug in data-docs' rendering of mostly parameter
+* Correct wording for expect_column_proportion_of_unique_values_to_be_between
+* Avoid use of unicode character in data-docs to skirt encoding issues
 
 0.8.2
 -----------------

--- a/great_expectations/data_context/store/namespaced_read_write_store.py
+++ b/great_expectations/data_context/store/namespaced_read_write_store.py
@@ -310,7 +310,6 @@ class HtmlSiteStore(NamespacedReadWriteStore):
         return [self._convert_tuple_to_resource_identifier(("expectations", key)) for key in self.store_backends[ExpectationSuiteIdentifier].list_keys()] + \
                [self._convert_tuple_to_resource_identifier(("validations", key)) for key in self.store_backends[ValidationResultIdentifier].list_keys()]
 
-
     def write_index_page(self, page):
         """This third store has a special method, which uses a zero-length tuple as a key."""
         return self.store_backends["index_page"].set((), page, content_encoding='utf-8', content_type='text/html')

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -292,7 +292,7 @@ class FixedLengthTupleFilesystemStoreBackend(FixedLengthTupleStoreBackend):
             self.full_base_directory,
             self._convert_key_to_filepath(key)
         )
-        with open(filepath) as infile:
+        with open(filepath, 'r') as infile:
             return infile.read()
 
     def _set(self, key, value, **kwargs):
@@ -374,7 +374,7 @@ class FixedLengthTupleS3StoreBackend(FixedLengthTupleStoreBackend):
         import boto3
         s3 = boto3.client('s3')
         s3_response_object = s3.get_object(Bucket=self.bucket, Key=s3_object_key)
-        return s3_response_object['Body'].read()
+        return s3_response_object['Body'].read().decode(s3_response_object.get("ContentEncoding", 'utf-8'))
 
     def _set(self, key, value, content_encoding='utf-8', content_type='application/json'):
         s3_object_key = os.path.join(

--- a/great_expectations/render/renderer/content_block/expectation_string.py
+++ b/great_expectations/render/renderer/content_block/expectation_string.py
@@ -640,11 +640,11 @@ class ExpectationStringRenderer(ContentBlockRenderer):
             template_str = "may have any percentage of unique values."
         else:
             if params["min_value"] is None:
-                template_str = "must have no more than $max_value% unique values."
+                template_str = "fraction of unique values must be less than $max_value."
             elif params["max_value"] is None:
-                template_str = "must have at least $min_value% unique values."
+                template_str = "fraction of unique values must be at least $min_value."
             else:
-                template_str = "must have between $min_value and $max_value% unique values."
+                template_str = "fraction of unique values must be between $min_value and $max_value."
         
         if include_column_name:
             template_str = "$column " + template_str

--- a/great_expectations/render/renderer/content_block/expectation_string.py
+++ b/great_expectations/render/renderer/content_block/expectation_string.py
@@ -637,7 +637,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
         )
         
         if params["min_value"] is None and params["max_value"] is None:
-            template_str = "may have any percentage of unique values."
+            template_str = "may have any fraction of unique values."
         else:
             if params["min_value"] is None:
                 template_str = "fraction of unique values must be less than $max_value."

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -3,6 +3,7 @@ import logging
 import pypandoc
 
 from great_expectations.data_context.util import instantiate_class_from_config
+from great_expectations.render.util import num_to_str
 
 from .renderer import Renderer
 from ..types import (
@@ -146,7 +147,8 @@ class ValidationResultsPageRenderer(Renderer):
         for key, value in statistics_dict.items():
             if statistics.get(key) is not None:
                 if key == "success_percent":
-                    table_rows.append([value, "{0:.2f}%".format(statistics[key])])
+                    # table_rows.append([value, "{0:.2f}%".format(statistics[key])])
+                    table_rows.append([value, num_to_str(statistics[key], precision=4) + "%"])
                 else:
                     table_rows.append([value, statistics[key]])
         

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -1,4 +1,5 @@
 import logging
+from six import string_types
 
 import pypandoc
 
@@ -301,18 +302,18 @@ class ExpectationSuitePageRenderer(Renderer):
             notes = expectations["meta"]["notes"]
             note_content = None
             
-            if type(notes) == str:
+            if isinstance(notes, string_types):
                 note_content = [notes]
             
-            elif type(notes) == list:
+            elif isinstance(notes, list):
                 note_content = notes
             
-            elif type(notes) == dict:
+            elif isinstance(notes, dict):
                 if "format" in notes:
                     if notes["format"] == "string":
-                        if type(notes["content"]) == str:
+                        if isinstance(notes["content"], string_types):
                             note_content = [notes["content"]]
-                        elif type(notes["content"]) == list:
+                        elif isinstance(notes["content"], list):
                             note_content = notes["content"]
                         else:
                             logger.warning("Unrecognized Expectation suite notes format. Skipping rendering.")
@@ -320,13 +321,13 @@ class ExpectationSuitePageRenderer(Renderer):
                     elif notes["format"] == "markdown":
                         # ???: Should converting to markdown be the renderer's job, or the view's job?
                         # Renderer is easier, but will end up mixing HTML strings with content_block info.
-                        if type(notes["content"]) == str:
+                        if isinstance(notes["content"], string_types):
                             try:
                                 note_content = [pypandoc.convert_text(notes["content"], format='md', to="html")]
                             except OSError:
                                 note_content = [notes["content"]]
                         
-                        elif type(notes["content"]) == list:
+                        elif isinstance(notes["content"], list):
                             try:
                                 note_content = [pypandoc.convert_text(note, format='md', to="html") for note in
                                             notes["content"]]

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 """Rendering utility"""
 import decimal
 import locale
@@ -38,8 +37,12 @@ def num_to_str(f, precision=DEFAULT_PRECISION, use_locale=False, no_scientific=F
         local_context.prec = precision
     else:
         local_context = ctx
-
-    d = local_context.create_decimal(repr(f))
+    # We cast to string; we want to avoid precision issues, but format everything as though it were a float.
+    # So, if it's not already a float, we will append a decimal point to the string representation
+    s = repr(f)
+    if not isinstance(f, float):
+        s += locale.localeconv().get('decimal_point') + "0"
+    d = local_context.create_decimal(s)
     if no_scientific:
         result = format(d, 'f')
     elif use_locale:
@@ -47,9 +50,9 @@ def num_to_str(f, precision=DEFAULT_PRECISION, use_locale=False, no_scientific=F
     else:
         result = format(d, 'g')
     if f != locale.atof(result):
-        # result = '~' + result
+        # result = '≈' + result
         #  ≈  # \u2248
-        result = '≈' + result
+        result = '~' + result
     if 'e' not in result and 'E' not in result:
         result = result.rstrip('0').rstrip(locale.localeconv().get('decimal_point'))
     return result

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Rendering utility"""
+from __future__ import unicode_literals
 import decimal
 import locale
-# locale.setlocale(locale.LC_ALL, '')
 
 DEFAULT_PRECISION = 4
 # create a new context for this task
@@ -52,7 +52,7 @@ def num_to_str(f, precision=DEFAULT_PRECISION, use_locale=False, no_scientific=F
     if f != locale.atof(result):
         # result = '≈' + result
         #  ≈  # \u2248
-        result = '~' + result
+        result = '≈' + result
     if 'e' not in result and 'E' not in result:
         result = result.rstrip('0').rstrip(locale.localeconv().get('decimal_point'))
     return result

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -307,7 +307,7 @@ def test_ExpectationSuiteColumnSectionRenderer_render_bullet_list(titanic_profil
     assert len(content_block["bullet_list"]) == 4
     assert "value types must belong to this set" in json.dumps(content_block)
     assert "may have any number of unique values" in json.dumps(content_block)
-    assert "may have any percentage of unique values" in json.dumps(content_block)
+    assert "may have any fraction of unique values" in json.dumps(content_block)
     assert "values must not be null, at least $mostly_pct % of the time." in json.dumps(content_block)
     
     
@@ -385,7 +385,7 @@ def test_ValidationResultsColumnSectionRenderer_render_table(titanic_profiled_na
     assert content_block_stringified.count("$icon") == 6
     assert "value types must belong to this set: $v__0 $v__1 $v__2 $v__3 $v__4 $v__5." in content_block_stringified
     assert "may have any number of unique values." in content_block_stringified
-    assert "may have any percentage of unique values." in content_block_stringified
+    assert "may have any fraction of unique values." in content_block_stringified
     assert "values must not be null, at least $mostly_pct % of the time." in content_block_stringified
     assert "values must belong to this set: [ ]." in content_block_stringified
     assert "\\n\\n$unexpected_count unexpected values found. $unexpected_percent of $element_count total rows." in content_block_stringified

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
 import json
 import pypandoc
 
@@ -13,8 +16,8 @@ def test_ExpectationSuitePageRenderer_render_asset_notes():
     # print(pypandoc.convert_text("*hi*", to='html', format="md"))
 
     result = ExpectationSuitePageRenderer._render_asset_notes({
-        "meta" : {
-            "notes" : "*hi*"
+        "meta": {
+            "notes": "*hi*"
         }
     })
     print(result)

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -215,7 +215,7 @@ def test_ValidationResultsPageRenderer_render_validation_statistics(titanic_prof
         ],
         [
           "Success Percent",
-          "≈84.31%"
+          "~84.31%"
         ]
       ],
       "styling": {

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -215,7 +215,7 @@ def test_ValidationResultsPageRenderer_render_validation_statistics(titanic_prof
         ],
         [
           "Success Percent",
-          "84.31%"
+          "≈84.31%"
         ]
       ],
       "styling": {

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -24,16 +24,16 @@ def test_ExpectationSuitePageRenderer_render_asset_notes():
     assert result["content"] == ["*hi*"]
 
     result = ExpectationSuitePageRenderer._render_asset_notes({
-        "meta" : {
-            "notes" : ["*alpha*", "_bravo_", "charlie"]
+        "meta": {
+            "notes": ["*alpha*", "_bravo_", "charlie"]
         }
     })
     print(result)
     assert result["content"] == ["*alpha*", "_bravo_", "charlie"]
 
     result = ExpectationSuitePageRenderer._render_asset_notes({
-        "meta" : {
-            "notes" : {
+        "meta": {
+            "notes": {
                 "format": "string",
                 "content": ["*alpha*", "_bravo_", "charlie"]
             }
@@ -43,8 +43,8 @@ def test_ExpectationSuitePageRenderer_render_asset_notes():
     assert result["content"] == ["*alpha*", "_bravo_", "charlie"]
 
     result = ExpectationSuitePageRenderer._render_asset_notes({
-        "meta" : {
-            "notes" : {
+        "meta": {
+            "notes": {
                 "format": "markdown",
                 "content": "*alpha*"
             }
@@ -59,8 +59,8 @@ def test_ExpectationSuitePageRenderer_render_asset_notes():
         assert result["content"] == ["*alpha*"]
 
     result = ExpectationSuitePageRenderer._render_asset_notes({
-        "meta" : {
-            "notes" : {
+        "meta": {
+            "notes": {
                 "format": "markdown",
                 "content": ["*alpha*", "_bravo_", "charlie"]
             }

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -215,7 +215,7 @@ def test_ValidationResultsPageRenderer_render_validation_statistics(titanic_prof
         ],
         [
           "Success Percent",
-          "~84.31%"
+          "≈84.31%"
         ]
       ],
       "styling": {

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 import json
 
 from great_expectations.render.renderer.content_block import (
@@ -246,7 +245,7 @@ def test_ValidationResultsTableContentBlockRenderer_get_observed_value(evr_succe
     # test _get_observed_value for expect_column_values_to_not_be_null expectation type
     output_3 = ValidationResultsTableContentBlockRenderer._get_observed_value(evr_expect_column_values_to_not_be_null)
     print(output_3)
-    assert output_3 == "≈20.03% not null"
+    assert output_3 == "~20.03% not null"
     # test _get_observed_value for expect_column_values_to_be_null expectation type
     output_4 = ValidationResultsTableContentBlockRenderer._get_observed_value(evr_expect_column_values_to_be_null)
     print(output_4)
@@ -330,7 +329,7 @@ def test_ValidationResultsTableContentBlockRenderer_get_unexpected_statement(evr
         "template": "\n\n$unexpected_count unexpected values found. $unexpected_percent of $element_count total rows.",
         "params": {
           "unexpected_count": '3',
-          "unexpected_percent": "≈0.2285%",
+          "unexpected_percent": "~0.2285%",
           "element_count": '1,313'
         },
         "tag": "strong",

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 import json
 
 from great_expectations.render.renderer.content_block import (
@@ -245,7 +246,7 @@ def test_ValidationResultsTableContentBlockRenderer_get_observed_value(evr_succe
     # test _get_observed_value for expect_column_values_to_not_be_null expectation type
     output_3 = ValidationResultsTableContentBlockRenderer._get_observed_value(evr_expect_column_values_to_not_be_null)
     print(output_3)
-    assert output_3 == "~20.03% not null"
+    assert output_3 == "≈20.03% not null"
     # test _get_observed_value for expect_column_values_to_be_null expectation type
     output_4 = ValidationResultsTableContentBlockRenderer._get_observed_value(evr_expect_column_values_to_be_null)
     print(output_4)
@@ -329,7 +330,7 @@ def test_ValidationResultsTableContentBlockRenderer_get_unexpected_statement(evr
         "template": "\n\n$unexpected_count unexpected values found. $unexpected_percent of $element_count total rows.",
         "params": {
           "unexpected_count": '3',
-          "unexpected_percent": "~0.2285%",
+          "unexpected_percent": "≈0.2285%",
           "element_count": '1,313'
         },
         "tag": "strong",

--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -1,25 +1,23 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
 from great_expectations.render.util import num_to_str
-
-# Set the locale so locale-specific tests will work
-import locale
 
 
 def test_num_to_str():
     f = 0.99999999999999
     # We can round
-    assert num_to_str(f, precision=4) == "~1"
+    assert num_to_str(f, precision=4) == "≈1"
     # Specifying extra precision should not cause a problem
     assert num_to_str(f, precision=20) == "0.99999999999999"
 
     f = 1234567890.123456  # Our float can only hold 17 significant digits
-    assert num_to_str(f, precision=4) == "~1.235e+9"
+    assert num_to_str(f, precision=4) == "≈1.235e+9"
     assert num_to_str(f, precision=20) == "1234567890.123456"
     assert num_to_str(f, use_locale=True, precision=40) == "1,234,567,890.123456"
 
     f = 1.123456789012345  # 17 sig digits mostly after decimal
-    assert num_to_str(f, precision=5) == "~1.1235"
+    assert num_to_str(f, precision=5) == "≈1.1235"
     assert num_to_str(f, precision=20) == "1.123456789012345"
 
     f = 0.1  # A classic difficulty for floating point arithmetic
@@ -29,9 +27,9 @@ def test_num_to_str():
 
     f = 1.23456789012345e-10  # significant digits can come late
     assert num_to_str(f, precision=20) == "1.23456789012345e-10"
-    assert num_to_str(f, precision=5) == "~1.2346e-10"
+    assert num_to_str(f, precision=5) == "≈1.2346e-10"
     assert num_to_str(f, precision=20, no_scientific=True) == "0.000000000123456789012345"
-    assert num_to_str(f, precision=5, no_scientific=True) == "~0.00000000012346"
+    assert num_to_str(f, precision=5, no_scientific=True) == "≈0.00000000012346"
 
     f = 100.0  # floats should have trailing digits and numbers stripped
     assert num_to_str(f, precision=10, no_scientific=True) == "100"
@@ -42,4 +40,3 @@ def test_num_to_str():
     assert num_to_str(f, precision=10, no_scientific=True) == "100"
     assert num_to_str(f, precision=10) == "100"
     assert num_to_str(f, precision=10, use_locale=True) == "100"
-

--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
 from great_expectations.render.util import num_to_str
 
 # Set the locale so locale-specific tests will work
@@ -10,17 +9,17 @@ import locale
 def test_num_to_str():
     f = 0.99999999999999
     # We can round
-    assert num_to_str(f, precision=4) == "≈1"
+    assert num_to_str(f, precision=4) == "~1"
     # Specifying extra precision should not cause a problem
     assert num_to_str(f, precision=20) == "0.99999999999999"
 
     f = 1234567890.123456  # Our float can only hold 17 significant digits
-    assert num_to_str(f, precision=4) == "≈1.235e+9"
+    assert num_to_str(f, precision=4) == "~1.235e+9"
     assert num_to_str(f, precision=20) == "1234567890.123456"
     assert num_to_str(f, use_locale=True, precision=40) == "1,234,567,890.123456"
 
     f = 1.123456789012345  # 17 sig digits mostly after decimal
-    assert num_to_str(f, precision=5) == "≈1.1235"
+    assert num_to_str(f, precision=5) == "~1.1235"
     assert num_to_str(f, precision=20) == "1.123456789012345"
 
     f = 0.1  # A classic difficulty for floating point arithmetic
@@ -30,6 +29,17 @@ def test_num_to_str():
 
     f = 1.23456789012345e-10  # significant digits can come late
     assert num_to_str(f, precision=20) == "1.23456789012345e-10"
-    assert num_to_str(f, precision=5) == "≈1.2346e-10"
+    assert num_to_str(f, precision=5) == "~1.2346e-10"
     assert num_to_str(f, precision=20, no_scientific=True) == "0.000000000123456789012345"
-    assert num_to_str(f, precision=5, no_scientific=True) == "≈0.00000000012346"
+    assert num_to_str(f, precision=5, no_scientific=True) == "~0.00000000012346"
+
+    f = 100.0  # floats should have trailing digits and numbers stripped
+    assert num_to_str(f, precision=10, no_scientific=True) == "100"
+    assert num_to_str(f, precision=10) == "100"
+    assert num_to_str(f, precision=10, use_locale=True) == "100"
+
+    f = 100  # integers should never be stripped!
+    assert num_to_str(f, precision=10, no_scientific=True) == "100"
+    assert num_to_str(f, precision=10) == "100"
+    assert num_to_str(f, precision=10, use_locale=True) == "100"
+

--- a/tests/store/test_store_backends.py
+++ b/tests/store/test_store_backends.py
@@ -158,7 +158,7 @@ def test_FixedLengthTupleFilesystemStoreBackend(tmp_path_factory):
     # assert my_store.get("subdir/my_file_CCC") == "ccc"
 
     print(my_store.list_keys())
-    assert set(my_store.list_keys()) == set([("AAA",), ("BBB",)])
+    assert set(my_store.list_keys()) == {("AAA",), ("BBB",)}
 
     print(gen_directory_tree_str(project_path))
     assert gen_directory_tree_str(project_path) == """\
@@ -166,6 +166,7 @@ test_FixedLengthTupleFilesystemStoreBackend__dir0/
     my_file_AAA
     my_file_BBB
 """
+
 
 @mock_s3
 def test_FixedLengthTupleS3StoreBackend():
@@ -187,26 +188,28 @@ def test_FixedLengthTupleS3StoreBackend():
     conn.create_bucket(Bucket=bucket)
 
     my_store = FixedLengthTupleS3StoreBackend(
-        root_directory=os.path.abspath(path), # NOTE: Eugene: 2019-09-06: root_directory should be removed from the base class
+        # NOTE: Eugene: 2019-09-06: root_directory should be removed from the base class
+        root_directory=os.path.abspath(path),
         key_length=1,
         filepath_template="my_file_{0}",
         bucket=bucket,
         prefix=prefix,
     )
 
-    my_store.set(("AAA",), "aaa", content_type='text/html')
-    assert my_store.get(("AAA",)) == b'aaa'
+    my_store.set(("AAA",), "aaa", content_type='text/html; charset=utf-8')
+    assert my_store.get(("AAA",)) == 'aaa'
 
     # We should have set the raw data content type since we encode as utf-8
     object = boto3.client('s3').get_object(Bucket=bucket, Key=prefix + "/my_file_AAA")
-    assert object["ContentType"] == 'text/html'
+    assert object["ContentType"] == 'text/html; charset=utf-8'
     assert object["ContentEncoding"] == 'utf-8'
 
     my_store.set(("BBB",), "bbb")
-    assert my_store.get(("BBB",)) == b'bbb'
+    assert my_store.get(("BBB",)) == 'bbb'
 
     print(my_store.list_keys())
-    assert set(my_store.list_keys()) == set([("AAA",), ("BBB",)])
+    assert set(my_store.list_keys()) == {("AAA",), ("BBB",)}
 
-    assert set([s3_object_info['Key'] for s3_object_info in boto3.client('s3').list_objects(Bucket=bucket, Prefix=prefix)['Contents']])\
-           == set(['this_is_a_test_prefix/my_file_AAA', 'this_is_a_test_prefix/my_file_BBB'])
+    assert set([s3_object_info['Key'] for s3_object_info in boto3.client('s3').list_objects(
+        Bucket=bucket, Prefix=prefix)['Contents']]) == {'this_is_a_test_prefix/my_file_AAA',
+                                                        'this_is_a_test_prefix/my_file_BBB'}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Since our cli produces unicode output, but we want tests in python2 as well
 from __future__ import unicode_literals
 


### PR DESCRIPTION
Fixes:
1. Update language for rendering proportion of unique_values_to_be_between
2. Use ascii ~ to avoid occasional unicode issues (please die soon, py2!)
3. Fix issue where trailing zeros on an integer could be dropped in datadocs