### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@
 Welcome to Great Expectations!
 ################################
 
-Great Expectations a leading tool for :ref:`profiling <profiling>`, :ref:`validating <expectations>`, and
+Great Expectations is a leading tool for :ref:`profiling <profiling>`, :ref:`validating <expectations>`, and
 :ref:`documenting <data_docs>` your data to maintain quality and improve communication between teams.
 Head over to the :ref:`intro` to learn more, or jump straight to our :ref:`getting_started` guide.
 


### PR DESCRIPTION
I would expect this to read "Great Expectations is a leading tool for ...", or "Great Expectations, a leading tool for ..."

![image](https://user-images.githubusercontent.com/11096727/68423164-8f931480-016f-11ea-83b4-46b713ec2dfb.png)


Feel free to disregard if this was intended...