### PR TITLE
Limit profiling to first 1000 records in init

### DIFF
--- a/docs/getting_started/cli_init.rst
+++ b/docs/getting_started/cli_init.rst
@@ -183,25 +183,6 @@ Note: the SQL credentials you entered are stored in the ``uncommitted/config_var
 Note that this file goes in the ``uncommitted/`` directory, which should *NOT* be committed to source control.
 The ${my_db} variable is substituted with the credentials at runtime.
 
-A Great Expectations Datasource brings the worlds of data and expectations together. Datasources produce
-Great Expectations DataAssets, which support the core GE api, including validation.
-Fully describing a DataAsset's "name" requires three parts:
-
-1. ``datasource`` (`my_postgresql_db`)
-2. ``generator`` (`queries`)
-3. ``generator_asset`` (`user_events_table`)
-
-In addition, to work with a specific batch of data and validate it against a particular set of expectations, you will
-need to specify:
-
-* ``batch_kwargs`` (`SELECT * FROM user_events_table WHERE created_at>2018-01-01`), and/or
-* ``expectation_suite_name`` (`BasicDatasetProfiler`).
-
-Together, these five elements completely allow you to reference all of the main entities within the DataContext.
-
-You can get started in Great Expectations without learning all the details of the DataContext. To start, you'll mainly
-use elements 1 and 3: ``datasource``s, (with names such as  `my_postgresql_db`) and ``generator_asset``s, which may
-conceptually be similar to a `user_events_table`, for example.
 
 Configuring Slack Notifications
 ----------------------------------------
@@ -239,20 +220,13 @@ please see :ref:`profiling`.
 
 Within the CLI, it's easy to profile our data.
 
-Warning: For large data sets, the current default profiler may run slowly and impose significant I/O and compute load.
-Be cautious when executing against shared databases.
+Note: the current default profiler uses first 1000 records of a table (or a file).
 
 .. code-block:: bash
 
     ========== Profiling ==========
 
     Profiling 'data__dir' will create expectations and documentation.
-
-    Please note: Profiling is still a beta feature in Great Expectations.  The current profiler will evaluate the entire 
-    data source (without sampling), which may be very time consuming. 
-    As a rule of thumb, we recommend starting with data smaller than 100MB.
-
-    To learn more about profiling, visit https://docs.greatexpectations.io/en/latest/reference/profiling.html
 
     Found 1 data assets from generator default
 

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -227,7 +227,7 @@ def init(target_directory, view):
 
         context = _slack_setup(context)
 
-        profile_datasource(context, data_source_name, open_docs=view)
+        profile_datasource(context, data_source_name, open_docs=view, additional_batch_kwargs={"limit": 1000})
         cli_message("""\n<cyan>Great Expectations is now set up in your project!</cyan>""")
 
 def _slack_setup(context):
@@ -340,7 +340,7 @@ def list_datasources(directory):
     help="The project's great_expectations directory."
 )
 @click.option('--batch_kwargs', default=None,
-              help='Additional keyword arguments to be provided to get_batch when loading the data asset.')
+              help='Additional keyword arguments to be provided to get_batch when loading the data asset. Must be a valid JSON dictionary')
 @click.option(
     "--view/--no-view",
     help="By default open in browser unless you specify the --no-view flag",

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -507,7 +507,8 @@ Great Expectations is building Data Docs from the data you just profiled!"""
                 data_assets=data_assets,
                 profile_all_data_assets=profile_all_data_assets,
                 max_data_assets=max_data_assets,
-                dry_run=False
+                dry_run=False,
+                additional_batch_kwargs=additional_batch_kwargs
             )
 
             if profiling_results['success']: # data context is ready to profile


### PR DESCRIPTION
Behavior:
1. Profiling during init works on the first 1000 records (and gives no other option to the user)
2. CLI `profile` command allows user to specify additional args for get_batch as a JSON dictionary. "limit" is one of these arguments. By default, limit is not set, so profiling will use the entire table/file for each data asset. Specifying a JSON dict is clunky and we need to revisit this in the near future, but the main goal of this PR is to prevent the profiling step of init to block for too long.
