### PR TITLE
Fixing some tests for Windows

### DIFF
--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -12,6 +12,7 @@ import shutil
 import json
 from collections import OrderedDict
 from ruamel.yaml import YAML
+from pathlib import Path
 
 from great_expectations.exceptions import DataContextError
 from great_expectations.data_context import (
@@ -753,8 +754,10 @@ def test_ConfigOnlyDataContext__initialization(tmp_path_factory, basic_data_cont
         config_path,
     )
 
-    assert context.root_directory.split("/")[-1] == "test_ConfigOnlyDataContext__initialization__dir0"
-    assert context.plugins_directory.split("/")[-3:] == ["test_ConfigOnlyDataContext__initialization__dir0", "plugins",""]
+    print(context.plugins_directory)
+    assert Path(context.root_directory).as_posix().split("/")[-1] == "test_ConfigOnlyDataContext__initialization__dir0"
+    assert context.plugins_directory.rstrip("/").split(os.path.sep)[-2:] == ["test_ConfigOnlyDataContext__initialization__dir0", "plugins"]
+    assert context.plugins_directory.endswith("/")
 
 
 def test_evaluation_parameter_store_methods(basic_data_context_config):
@@ -794,9 +797,9 @@ def test__normalize_absolute_or_relative_path(tmp_path_factory, basic_data_conte
     )
 
     print(context._normalize_absolute_or_relative_path("yikes"))
-    assert "test__normalize_absolute_or_relative_path__dir0/yikes" in context._normalize_absolute_or_relative_path("yikes")
+    assert str(Path("test__normalize_absolute_or_relative_path__dir0/yikes")) in context._normalize_absolute_or_relative_path("yikes")
 
-    context._normalize_absolute_or_relative_path("/yikes")
+    print(context._normalize_absolute_or_relative_path("/yikes"))
     assert "test__normalize_absolute_or_relative_path__dir" not in context._normalize_absolute_or_relative_path("/yikes")
     assert "/yikes" == context._normalize_absolute_or_relative_path("/yikes")
 
@@ -806,12 +809,13 @@ def test__get_normalized_data_asset_name_filepath(basic_data_context_config):
         project_config=basic_data_context_config,
         context_root_dir="testing/",
     )
-    assert context._get_normalized_data_asset_name_filepath(
+    actual = context._get_normalized_data_asset_name_filepath(
         NormalizedDataAssetName("my_db", "default", "my_table"),
         "default",
         "my/base/path",
         ".json"
-    ) == "my/base/path/my_db/default/my_table/default.json"
+    )
+    assert Path(actual).as_posix() == "my/base/path/my_db/default/my_table/default.json"
 
 
 def test_load_data_context_from_environment_variables(tmp_path_factory):
@@ -1164,7 +1168,7 @@ def test_scaffold_directories_and_notebooks(tmp_path_factory):
 def test_build_batch_kwargs(titanic_multibatch_data_context):
     data_asset_name = titanic_multibatch_data_context.normalize_data_asset_name("titanic")
     batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(data_asset_name, "Titanic_1911")
-    assert "./data/titanic/Titanic_1911.csv" in batch_kwargs["path"]
+    assert str(Path("./data/titanic/Titanic_1911.csv")) in batch_kwargs["path"]
     assert "partition_id" in batch_kwargs
     assert batch_kwargs["partition_id"] == "Titanic_1911"
 

--- a/tests/test_data_asset_util.py
+++ b/tests/test_data_asset_util.py
@@ -1,6 +1,8 @@
 import decimal
 import json
 import datetime
+import platform
+
 import numpy as np
 import unittest
 from functools import wraps
@@ -52,13 +54,16 @@ class TestDataAssetUtilMethods(unittest.TestCase):
             'np.float_': np.float_([3.2, 5.6, 7.8]),
             'np.float32': np.float32([5.999999999, 5.6]),
             'np.float64': np.float64([5.9999999999999999999, 10.2]),
-            'np.float128': np.float128([5.999999999998786324399999999, 20.4]),
             # 'np.complex64': np.complex64([10.9999999 + 4.9999999j, 11.2+7.3j]),
             # 'np.complex128': np.complex128([20.999999999978335216827+10.99999999j, 22.4+14.6j]),
             # 'np.complex256': np.complex256([40.99999999 + 20.99999999j, 44.8+29.2j]),
             'np.str': np.unicode_(["hello"]),
             'yyy': decimal.Decimal(123.456)
         }
+
+        if platform.system() != 'Windows':
+            x['np.float128'] = np.float128([5.999999999998786324399999999, 20.4])
+
         x = ge.data_asset.util.recursively_convert_to_json_serializable(x)
         self.assertEqual(type(x['x']), list)
 
@@ -88,7 +93,8 @@ class TestDataAssetUtilMethods(unittest.TestCase):
 
         self.assertEqual(type(x['np.float32'][0]), float)
         self.assertEqual(type(x['np.float64'][0]), float)
-        self.assertEqual(type(x['np.float128'][0]), float)
+        if platform.system() != 'Windows':
+            self.assertEqual(type(x['np.float128'][0]), float)
         # self.assertEqual(type(x['np.complex64'][0]), complex)
         # self.assertEqual(type(x['np.complex128'][0]), complex)
         # self.assertEqual(type(x['np.complex256'][0]), complex)
@@ -96,8 +102,9 @@ class TestDataAssetUtilMethods(unittest.TestCase):
 
         # Make sure nothing is going wrong with precision rounding
         # self.assertAlmostEqual(x['np.complex128'][0].real, 20.999999999978335216827, places=sys.float_info.dig)
-        self.assertAlmostEqual(
-            x['np.float128'][0], 5.999999999998786324399999999, places=sys.float_info.dig)
+        if platform.system() != 'Windows':
+            self.assertAlmostEqual(
+                x['np.float128'][0], 5.999999999998786324399999999, places=sys.float_info.dig)
 
         # TypeError when non-serializable numpy object is in dataset.
         with self.assertRaises(TypeError):

--- a/tests/test_filedata_asset_expectations.py
+++ b/tests/test_filedata_asset_expectations.py
@@ -1,6 +1,7 @@
 #Test File Expectations
 from __future__ import division
 import pytest
+import platform
 import great_expectations as ge
 
 def test_expect_file_line_regex_match_count_to_be_between():
@@ -205,6 +206,9 @@ def test_expect_file_size_to_be_between():
 
     # Test file size in range
     good_range = titanic_file.expect_file_size_to_be_between(70000, 71000)
+    if platform.system() == 'Windows':
+        # size = 71680, WSL gives same number so still fails for WSL
+        good_range = titanic_file.expect_file_size_to_be_between(71000, 72000)
     assert good_range["success"]
 
 def test_expect_file_to_exist():


### PR DESCRIPTION
Making a small pull request to understand the review process. There are more to come so this is a work in progress toward making the test suite work on Windows.

Some Windows gotchas I learned:

1. Windows uses a different path separator `\`.
2. Windows calculates file size differently.
3. Some packages like `numpy` have different implementation on Windows and some data types are inconsistent or unavailable

## Comments

* `test_recursively_convert_to_json_serializable`: numpy on Windows does not have `np.float128`
* `test_ConfigOnlyDataContext__initialization`: WIndows prints out `C:\...\pytest-20\test_ConfigOnlyDataContext__initialization__dir0\plugins/`. Don't know if there's a better way to handle the trailing `/`.
* `test_expect_file_size_to_be_between`: Windows has a different file
size

Please let me know if anything needs to change 😂.