### PR TITLE
Tiny change to make test suite run on Windows

### DIFF
--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1164,7 +1164,7 @@ def test_scaffold_directories_and_notebooks(tmp_path_factory):
 def test_build_batch_kwargs(titanic_multibatch_data_context):
     data_asset_name = titanic_multibatch_data_context.normalize_data_asset_name("titanic")
     batch_kwargs = titanic_multibatch_data_context.build_batch_kwargs(data_asset_name, "Titanic_1911")
-    assert "./data/titanic/Titanic_1911.csv" in batch_kwargs["path"]
+    assert os.path.relpath("./data/titanic/Titanic_1911.csv") in batch_kwargs["path"]
     assert "partition_id" in batch_kwargs
     assert batch_kwargs["partition_id"] == "Titanic_1911"
 

--- a/tests/test_data_asset_util.py
+++ b/tests/test_data_asset_util.py
@@ -5,6 +5,7 @@ import numpy as np
 import unittest
 from functools import wraps
 import sys
+import platform
 
 import great_expectations as ge
 
@@ -52,13 +53,15 @@ class TestDataAssetUtilMethods(unittest.TestCase):
             'np.float_': np.float_([3.2, 5.6, 7.8]),
             'np.float32': np.float32([5.999999999, 5.6]),
             'np.float64': np.float64([5.9999999999999999999, 10.2]),
-            'np.float128': np.float128([5.999999999998786324399999999, 20.4]),
             # 'np.complex64': np.complex64([10.9999999 + 4.9999999j, 11.2+7.3j]),
             # 'np.complex128': np.complex128([20.999999999978335216827+10.99999999j, 22.4+14.6j]),
             # 'np.complex256': np.complex256([40.99999999 + 20.99999999j, 44.8+29.2j]),
             'np.str': np.unicode_(["hello"]),
             'yyy': decimal.Decimal(123.456)
         }
+        if platform.system() != 'Windows':
+            x['np.float128'] = np.float128([5.999999999998786324399999999, 20.4])
+
         x = ge.data_asset.util.recursively_convert_to_json_serializable(x)
         self.assertEqual(type(x['x']), list)
 
@@ -88,7 +91,8 @@ class TestDataAssetUtilMethods(unittest.TestCase):
 
         self.assertEqual(type(x['np.float32'][0]), float)
         self.assertEqual(type(x['np.float64'][0]), float)
-        self.assertEqual(type(x['np.float128'][0]), float)
+        if platform.system() != 'Windows':
+            self.assertEqual(type(x['np.float128'][0]), float)
         # self.assertEqual(type(x['np.complex64'][0]), complex)
         # self.assertEqual(type(x['np.complex128'][0]), complex)
         # self.assertEqual(type(x['np.complex256'][0]), complex)
@@ -96,8 +100,9 @@ class TestDataAssetUtilMethods(unittest.TestCase):
 
         # Make sure nothing is going wrong with precision rounding
         # self.assertAlmostEqual(x['np.complex128'][0].real, 20.999999999978335216827, places=sys.float_info.dig)
-        self.assertAlmostEqual(
-            x['np.float128'][0], 5.999999999998786324399999999, places=sys.float_info.dig)
+        if platform.system() != 'Windows':
+            self.assertAlmostEqual(
+                x['np.float128'][0], 5.999999999998786324399999999, places=sys.float_info.dig)
 
         # TypeError when non-serializable numpy object is in dataset.
         with self.assertRaises(TypeError):

--- a/tests/test_filedata_asset_expectations.py
+++ b/tests/test_filedata_asset_expectations.py
@@ -2,6 +2,7 @@
 from __future__ import division
 import pytest
 import great_expectations as ge
+import platform
 
 def test_expect_file_line_regex_match_count_to_be_between():
 
@@ -204,7 +205,8 @@ def test_expect_file_size_to_be_between():
     assert not bad_range["success"]
 
     # Test file size in range
-    good_range = titanic_file.expect_file_size_to_be_between(70000, 71000)
+    lower, upper = (70000, 71000) if platform.system() != 'Windows' else (71000, 72000)
+    good_range = titanic_file.expect_file_size_to_be_between(lower, upper)
     assert good_range["success"]
 
 def test_expect_file_to_exist():


### PR DESCRIPTION
Making a tiny pull request to understand the review process. There are more to come so this is a work in progress toward making the test suite work on Windows.

Not sure what's the best way to deal with path separator issues yet as I'm unfamiliar with Python 2.

## Comments

Fixing those two because

* `test_recursively_convert_to_json_serializable`: numpy on Windows does not have `np.float128`
* `test_expect_file_size_to_be_between`: Windows has a different file
size

Please let me know if anything needs to change 😊.