### PR TITLE
* a POC suite to notebook converter

### DIFF
--- a/great_expectations/suite_to_notebook.py
+++ b/great_expectations/suite_to_notebook.py
@@ -1,0 +1,157 @@
+import nbformat
+
+
+class SuiteToNotebookConverter(object):
+    """
+    A quick and dirty experiment to convert a suite to a notebook that can create the suite.
+
+    It's a real chicken and egg thing.
+
+    Usage: SuiteToNotebookConverter().run(critical_suite, notebook_file_path)
+    """
+
+    def __init__(self, context=None, data_asset_name=None, suite_name=None):
+        self.context = context
+        self.suite_name = suite_name
+        self.data_asset_name = data_asset_name
+
+    @classmethod
+    def _get_expectations_by_column(cls, suite):
+        expectations_by_column = {"table_expectations": []}
+        for exp in suite["expectations"]:
+            if "_table_" in exp["expectation_type"]:
+                expectations_by_column["table_expectations"].append(exp)
+            else:
+                col = exp["kwargs"]["column"]
+
+                if col not in expectations_by_column.keys():
+                    expectations_by_column[col] = []
+                expectations_by_column[col].append(exp)
+        return expectations_by_column
+
+    @classmethod
+    def _build_kwargs_string(cls, expectation):
+        kwargs = []
+        for k, v in expectation["kwargs"].items():
+            if k == "column":
+                # make the column a positional argument
+                kwargs.append(f"'{v}'")
+            elif isinstance(v, str):
+                # Put strings in quotes
+                kwargs.append(f"{k}='{v}'")
+            else:
+                # Pass other types as is
+                kwargs.append(f"{k}={v}")
+
+        return ", ".join(kwargs)
+
+    def _create_new_notebook(self):
+        nb = nbformat.v4.new_notebook()
+        # TODO better wording in the intro cells
+        title_cell = nbformat.v4.new_markdown_cell(
+            f"""# Create & Edit Expectation Suite
+### Data Asset: `{self.data_asset_name}`
+### Expecation Suite: `{self.suite_name}`
+
+Use this notebook to recreate and modify your expectation suite.
+"""
+        )
+        nb["cells"].append(title_cell)
+
+        # TODO deal with hard coded project root and batch_kwargs situation - they may have to be backend specific.
+        # TODO deal with hard coded project root and batch_kwargs situation - they may have to be backend specific.
+        # TODO deal with hard coded project root and batch_kwargs situation - they may have to be backend specific.
+        # TODO deal with hard coded project root and batch_kwargs situation - they may have to be backend specific.
+        # TODO deal with hard coded project root and batch_kwargs situation - they may have to be backend specific.
+        imports_cell = nbformat.v4.new_code_cell(
+            """\
+import great_expectations as ge
+
+project_root = "/Users/taylor/repos/demo_public_data_test/great_expectations"
+context = ge.data_context.DataContext(project_root)
+# context.get_available_data_asset_names()"""
+        )
+        nb["cells"].append(imports_cell)
+
+        batch_cell = nbformat.v4.new_code_cell(
+            """\
+# If you would like to validate an entire table or view in your database's default schema:
+batch_kwargs = {'table': "YOUR_TABLE"}
+
+# If you would like to validate an entire table or view from a non-default schema in your database:
+batch_kwargs = {'table': "staging_npi", "schema": "pre_prod_staging"}
+
+batch = context.get_batch(\""""
+            + self.data_asset_name
+            + '", "'
+            + self.suite_name
+            + '", batch_kwargs)'
+        )
+        nb["cells"].append(batch_cell)
+        return nb
+
+    @classmethod
+    def _convert_expectation_suite_to_notebook_cells(cls, suite):
+        cells = []
+        expectations_by_column = cls._get_expectations_by_column(suite)
+        md_cell = nbformat.v4.new_markdown_cell(f"## Table Expectation(s)")
+        cells.append(md_cell)
+        if expectations_by_column["table_expectations"]:
+            for exp in expectations_by_column["table_expectations"]:
+                kwargs_string = cls._build_kwargs_string(exp)
+                code_cell = nbformat.v4.new_code_cell(
+                    f"batch.{exp['expectation_type']}({kwargs_string})"
+                )
+                cells.append(code_cell)
+        else:
+            md_cell = nbformat.v4.new_markdown_cell(
+                "No table level expectations are in this suite. Feel free to add some."
+            )
+            cells.append(md_cell)
+
+        # Remove the table expectations since they are dealt with
+        expectations_by_column.pop("table_expectations")
+
+        md_cell = nbformat.v4.new_markdown_cell("## Column Expectation(s)")
+        cells.append(md_cell)
+
+        for column, expectations in expectations_by_column.items():
+            md_cell = nbformat.v4.new_markdown_cell(f"### `{column}`")
+            cells.append(md_cell)
+
+            for exp in expectations:
+                kwargs_string = cls._build_kwargs_string(exp)
+                code_cell = nbformat.v4.new_code_cell(
+                    f"batch.{exp['expectation_type']}({kwargs_string})"
+                )
+                cells.append(code_cell)
+        return cells
+
+    @classmethod
+    def _write_notebook_to_disk(cls, notebook, notebook_file_path):
+        with open(notebook_file_path, "w") as f:
+            nbformat.write(notebook, f)
+
+    def create_notebook_dictionary_from_suite(self, suite):
+        """
+        Create a notebook dict from an expectation suite in dict form.
+
+        :type suite: dict
+        """
+        self.suite_name = suite["expectation_suite_name"]
+        self.data_asset_name = suite["data_asset_name"]
+        notebook = self._create_new_notebook()
+        notebook["cells"] = notebook[
+            "cells"
+        ] + self._convert_expectation_suite_to_notebook_cells(suite)
+        return notebook
+
+    def run(self, suite, notebook_file_path):
+        """
+        Create a notebook on disk from an expectation suite in dict form.
+
+        :type suite: dict
+        :type notebook_file_path: str
+        """
+        notebook = self.create_notebook_dictionary_from_suite(suite)
+        self._write_notebook_to_disk(notebook, notebook_file_path)

--- a/tests/test_suite_to_notebook.py
+++ b/tests/test_suite_to_notebook.py
@@ -1,0 +1,569 @@
+import pytest
+from great_expectations.suite_to_notebook import SuiteToNotebookConverter
+
+
+@pytest.fixture
+def critical_suite():
+    critical_suite = {
+        "data_asset_name": "edw/default/pre_prod_staging.staging_npi",
+        "expectation_suite_name": "critical",
+        "meta": {"great_expectations.__version__": "0.7.10"},
+        "expectations": [
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "npi"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "provider_type"},
+            },
+        ],
+        "data_asset_type": "Dataset",
+    }
+    return critical_suite
+
+
+@pytest.fixture
+def warning_suite():
+    return {
+        "data_asset_name": "edw/default/pre_prod_staging.staging_npi",
+        "expectation_suite_name": "warning",
+        "meta": {"great_expectations.__version__": "0.8.4.post0"},
+        "expectations": [
+            {
+                "expectation_type": "expect_table_row_count_to_be_between",
+                "kwargs": {"min_value": 800000, "max_value": 1200000},
+            },
+            {
+                "expectation_type": "expect_table_column_count_to_equal",
+                "kwargs": {"value": 71},
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "npi"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "provider_type"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "nppes_provider_last_org_name"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_in_set",
+                "kwargs": {
+                    "column": "nppes_provider_gender",
+                    "value_set": ["M", "F", ""],
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "nppes_entity_code"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_in_set",
+                "kwargs": {"column": "nppes_entity_code", "value_set": ["I", "O"]},
+            },
+            {
+                "expectation_type": "expect_column_kl_divergence_to_be_less_than",
+                "kwargs": {
+                    "column": "nppes_entity_code",
+                    "partition_object": {
+                        "values": ["I", "O"],
+                        "weights": [0.9431769750233306, 0.056823024976669335],
+                    },
+                    "threshold": 0.1,
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_in_set",
+                "kwargs": {
+                    "column": "nppes_provider_state",
+                    "value_set": [
+                        "AL",
+                        "AK",
+                        "AZ",
+                        "AR",
+                        "CA",
+                        "CO",
+                        "CT",
+                        "DE",
+                        "FL",
+                        "GA",
+                        "HI",
+                        "ID",
+                        "IL",
+                        "IN",
+                        "IA",
+                        "KS",
+                        "KY",
+                        "LA",
+                        "ME",
+                        "MD",
+                        "MA",
+                        "MI",
+                        "MN",
+                        "MS",
+                        "MO",
+                        "MT",
+                        "NE",
+                        "NV",
+                        "NH",
+                        "NJ",
+                        "NM",
+                        "NY",
+                        "NC",
+                        "ND",
+                        "OH",
+                        "OK",
+                        "OR",
+                        "PA",
+                        "RI",
+                        "SC",
+                        "SD",
+                        "TN",
+                        "TX",
+                        "UT",
+                        "VT",
+                        "VA",
+                        "WA",
+                        "WV",
+                        "WI",
+                        "WY",
+                        "DC",
+                        "PR",
+                        "AE",
+                        "VI",
+                    ],
+                    "mostly": 0.999,
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "medicare_participation_indicator"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_in_set",
+                "kwargs": {
+                    "column": "medicare_participation_indicator",
+                    "value_set": ["Y", "N"],
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "number_of_hcpcs"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": {
+                    "column": "number_of_hcpcs",
+                    "min_value": 0,
+                    "max_value": 500,
+                    "mostly": 0.999,
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "total_unique_benes"},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": {
+                    "column": "total_unique_benes",
+                    "min_value": 0,
+                    "max_value": 2000,
+                    "mostly": 0.95,
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_null",
+                "kwargs": {"column": "med_suppress_indicator", "mostly": 0.85},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_in_set",
+                "kwargs": {"column": "med_suppress_indicator", "value_set": ["#", "*"]},
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": {
+                    "column": "beneficiary_average_age",
+                    "min_value": 40,
+                    "max_value": 90,
+                    "mostly": 0.995,
+                },
+            },
+            {
+                "expectation_type": "expect_column_kl_divergence_to_be_less_than",
+                "kwargs": {
+                    "column": "beneficiary_average_age",
+                    "partition_object": {
+                        "bins": [8, 16.5, 25, 33.5, 42, 50.5, 59, 67.5, 76, 84.5, 93],
+                        "weights": [
+                            0.00025259576594384474,
+                            0.00013318685840675451,
+                            0.0009653750909344757,
+                            0.0012363414580378728,
+                            0.01081660996274442,
+                            0.030813927854975127,
+                            0.13495227317818748,
+                            0.6919590041664524,
+                            0.1244213260634741,
+                            0.004449359600843578,
+                        ],
+                    },
+                    "threshold": 0.9,
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": {
+                    "column": "total_submitted_chrg_amt",
+                    "min_value": 2000,
+                    "max_value": 5000000,
+                    "mostly": 0.98,
+                },
+            },
+            {
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": "nppes_provider_first_name", "mostly": 0.9},
+            },
+            {
+                "expectation_type": "expect_column_values_to_match_regex",
+                "kwargs": {
+                    "column": "nppes_provider_zip",
+                    "regex": "^\\d*$",
+                    "mostly": 0.999,
+                },
+            },
+        ],
+        "data_asset_type": "Dataset",
+    }
+
+
+def test_simple_suite(critical_suite):
+    obs = SuiteToNotebookConverter().create_notebook_dictionary_from_suite(critical_suite)
+    assert isinstance(obs, dict)
+    expected = {
+        "nbformat": 4,
+        "nbformat_minor": 2,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": "# Create & Edit Expectation Suite\n### Data Asset: `edw/default/pre_prod_staging.staging_npi`\n### Expecation Suite: `critical`\n\nUse this notebook to recreate and modify your expectation suite.\n",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": 'import great_expectations as ge\n\nproject_root = "/Users/taylor/repos/demo_public_data_test/great_expectations"\ncontext = ge.data_context.DataContext(project_root)\n# context.get_available_data_asset_names()',
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": '# If you would like to validate an entire table or view in your database\'s default schema:\nbatch_kwargs = {\'table\': "YOUR_TABLE"}\n\n# If you would like to validate an entire table or view from a non-default schema in your database:\nbatch_kwargs = {\'table\': "staging_npi", "schema": "pre_prod_staging"}\n\nbatch = context.get_batch("edw/default/pre_prod_staging.staging_npi", "critical", batch_kwargs)',
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "## Table Expectation(s)",
+                "metadata": {},
+            },
+            {
+                "cell_type": "markdown",
+                "source": "No table level expectations are in this suite. Feel free to add some.",
+                "metadata": {},
+            },
+            {
+                "cell_type": "markdown",
+                "source": "## Column Expectation(s)",
+                "metadata": {},
+            },
+            {"cell_type": "markdown", "source": "### `npi`", "metadata": {}},
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('npi')",
+                "outputs": [],
+            },
+            {"cell_type": "markdown", "source": "### `provider_type`", "metadata": {}},
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('provider_type')",
+                "outputs": [],
+            },
+        ],
+    }
+    assert obs == expected
+
+
+def test_complex_suite(warning_suite):
+    obs = SuiteToNotebookConverter().create_notebook_dictionary_from_suite(warning_suite)
+    assert isinstance(obs, dict)
+    expected = {
+        "nbformat": 4,
+        "nbformat_minor": 2,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": "# Create & Edit Expectation Suite\n### Data Asset: `edw/default/pre_prod_staging.staging_npi`\n### Expecation Suite: `warning`\n\nUse this notebook to recreate and modify your expectation suite.\n",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": 'import great_expectations as ge\n\nproject_root = "/Users/taylor/repos/demo_public_data_test/great_expectations"\ncontext = ge.data_context.DataContext(project_root)\n# context.get_available_data_asset_names()',
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": '# If you would like to validate an entire table or view in your database\'s default schema:\nbatch_kwargs = {\'table\': "YOUR_TABLE"}\n\n# If you would like to validate an entire table or view from a non-default schema in your database:\nbatch_kwargs = {\'table\': "staging_npi", "schema": "pre_prod_staging"}\n\nbatch = context.get_batch("edw/default/pre_prod_staging.staging_npi", "warning", batch_kwargs)',
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "## Table Expectation(s)",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_table_row_count_to_be_between(min_value=800000, max_value=1200000)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_table_column_count_to_equal(value=71)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "## Column Expectation(s)",
+                "metadata": {},
+            },
+            {"cell_type": "markdown", "source": "### `npi`", "metadata": {}},
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('npi')",
+                "outputs": [],
+            },
+            {"cell_type": "markdown", "source": "### `provider_type`", "metadata": {}},
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('provider_type')",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `nppes_provider_last_org_name`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('nppes_provider_last_org_name')",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `nppes_provider_gender`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_in_set('nppes_provider_gender', value_set=['M', 'F', ''])",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `nppes_entity_code`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('nppes_entity_code')",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_in_set('nppes_entity_code', value_set=['I', 'O'])",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_kl_divergence_to_be_less_than('nppes_entity_code', partition_object={'values': ['I', 'O'], 'weights': [0.9431769750233306, 0.056823024976669335]}, threshold=0.1)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `nppes_provider_state`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_in_set('nppes_provider_state', value_set=['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY', 'DC', 'PR', 'AE', 'VI'], mostly=0.999)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `medicare_participation_indicator`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('medicare_participation_indicator')",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_in_set('medicare_participation_indicator', value_set=['Y', 'N'])",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `number_of_hcpcs`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('number_of_hcpcs')",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_between('number_of_hcpcs', min_value=0, max_value=500, mostly=0.999)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `total_unique_benes`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('total_unique_benes')",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_between('total_unique_benes', min_value=0, max_value=2000, mostly=0.95)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `med_suppress_indicator`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_null('med_suppress_indicator', mostly=0.85)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_in_set('med_suppress_indicator', value_set=['#', '*'])",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `beneficiary_average_age`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_between('beneficiary_average_age', min_value=40, max_value=90, mostly=0.995)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_kl_divergence_to_be_less_than('beneficiary_average_age', partition_object={'bins': [8, 16.5, 25, 33.5, 42, 50.5, 59, 67.5, 76, 84.5, 93], 'weights': [0.00025259576594384474, 0.00013318685840675451, 0.0009653750909344757, 0.0012363414580378728, 0.01081660996274442, 0.030813927854975127, 0.13495227317818748, 0.6919590041664524, 0.1244213260634741, 0.004449359600843578]}, threshold=0.9)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `total_submitted_chrg_amt`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_be_between('total_submitted_chrg_amt', min_value=2000, max_value=5000000, mostly=0.98)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `nppes_provider_first_name`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_not_be_null('nppes_provider_first_name', mostly=0.9)",
+                "outputs": [],
+            },
+            {
+                "cell_type": "markdown",
+                "source": "### `nppes_provider_zip`",
+                "metadata": {},
+            },
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "execution_count": None,
+                "source": "batch.expect_column_values_to_match_regex('nppes_provider_zip', regex='^\\d*$', mostly=0.999)",
+                "outputs": [],
+            },
+        ],
+    }
+    assert obs == expected


### PR DESCRIPTION
## What's here

a suite to notebook converter **proof of concept**

## Known issues

- this has only been tested w/ a single datasource and only on postgres
- there are some super brittle hard coded batch-y things in here.

## Trying this out

```python
from great_expectations.suite_to_notebook import SuiteToNotebookConverter

suite = {...dict version of suite ...}
notebook = "foo.ipynb"
SuiteToNotebookConverter().run(suite, notebook)
```