### PR TITLE
Expectation meta notes rendering - first pass

### DIFF
--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -117,6 +117,7 @@ class ContentBlockRenderer(Renderer):
                         result.append(expectation_meta_notes)
             return result
 
+    # TODO: Add tests
     @classmethod
     def _render_expectation_meta_notes(cls, expectation):
         if not expectation.meta.get("notes"):

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -1,10 +1,15 @@
 import logging
 
+from six import string_types
+
 from ..renderer import Renderer
 from ...types import (
-    RenderedComponentContent,
+    RenderedMarkdownContent,
     TextContent)
-from ....core import ExpectationValidationResult
+from ....core import (
+    ExpectationValidationResult,
+    ExpectationConfiguration
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +47,6 @@ class ContentBlockRenderer(Renderer):
                             styling=cls._get_element_styling(),
                             **kwargs
                         )
-                        blocks += result
                     except Exception as e:
                         logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
                         
@@ -55,17 +59,20 @@ class ContentBlockRenderer(Renderer):
                             cls._get_element_styling(),
                             **kwargs
                         )
-                        if result is not None:
-                            blocks += result
                 else:
                     result = cls._missing_content_block_fn(
                         obj_,
                         cls._get_element_styling(),
                         **kwargs
                     )
-                    if result is not None:
-                        blocks += result
-
+                
+                if result is not None:
+                    if type(obj_) == ExpectationConfiguration:
+                        expectation_meta_notes = cls._render_expectation_meta_notes(obj_)
+                        if expectation_meta_notes:
+                            result.append(expectation_meta_notes)
+                    blocks.append(result)
+                
             if len(blocks) > 0:
                 content_block = cls._rendered_component_type(**{
                     cls._content_block_type: blocks,
@@ -74,7 +81,6 @@ class ContentBlockRenderer(Renderer):
                 cls._process_content_block(content_block)
 
                 return content_block
-                
             else:
                 return None
         else:
@@ -86,7 +92,6 @@ class ContentBlockRenderer(Renderer):
                     result = content_block_fn(render_object,
                                             styling=cls._get_element_styling(),
                                             **kwargs)
-                    return result
                 except Exception as e:
                     logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
                     
@@ -94,18 +99,89 @@ class ContentBlockRenderer(Renderer):
                         content_block_fn = cls._get_content_block_fn("_missing_content_block_fn")
                     else:
                         content_block_fn = cls._missing_content_block_fn
-                    return content_block_fn(
+                    result = content_block_fn(
                         render_object,
                         cls._get_element_styling(),
                         **kwargs
                     )
             else:
-                return cls._missing_content_block_fn(
+                result = cls._missing_content_block_fn(
                             render_object,
                             cls._get_element_styling(),
                             **kwargs
                         )
+            if result is not None:
+                if type(render_object) == ExpectationConfiguration:
+                    expectation_meta_notes = cls._render_expectation_meta_notes(render_object)
+                    if expectation_meta_notes:
+                        result.append(expectation_meta_notes)
+            return result
 
+    @classmethod
+    def _render_expectation_meta_notes(cls, expectation):
+        if not expectation.meta.get("notes"):
+            return None
+        notes = expectation.meta["notes"]
+        note_content = None
+
+        if isinstance(notes, string_types):
+            note_content = [notes]
+
+        elif isinstance(notes, list):
+            note_content = notes
+
+        elif isinstance(notes, dict):
+            if "format" in notes:
+                if notes["format"] == "string":
+                    if isinstance(notes["content"], string_types):
+                        note_content = [notes["content"]]
+                    elif isinstance(notes["content"], list):
+                        note_content = notes["content"]
+                    else:
+                        logger.warning("Unrecognized Expectation suite notes format. Skipping rendering.")
+        
+                elif notes["format"] == "markdown":
+                    # ???: Should converting to markdown be the renderer's job, or the view's job?
+                    # Renderer is easier, but will end up mixing HTML strings with content_block info.
+                    if isinstance(notes["content"], string_types):
+                        note_content = [
+                            RenderedMarkdownContent(**{
+                                "content_block_type": "markdown",
+                                "markdown": notes["content"],
+                                "styling": {
+                                    "parent": {
+                                        "styles": {
+                                            "color": "red"
+                                        }
+                                    }
+                                }
+                            })
+                        ]
+                    elif isinstance(notes["content"], list):
+                        note_content = [
+                            RenderedMarkdownContent(**{
+                                "content_block_type": "markdown",
+                                "markdown": note,
+                                "styling": {
+                                    "parent": {
+                                    }
+                                }
+                            }) for note in notes["content"]
+                        ]
+                    else:
+                        logger.warning("Unrecognized Expectation suite notes format. Skipping rendering.")
+            else:
+                logger.warning("Unrecognized Expectation suite notes format. Skipping rendering.")
+                
+        return TextContent(**{
+            "content_block_type": "text",
+            "subheader": "Notes:",
+            "text": note_content,
+            "styling": {
+                    "classes": ["col-12", "mt-2", "mb-2", "alert", "alert-warning"]
+            },
+        })
+    
     @classmethod
     def _process_content_block(cls, content_block):
         header = cls._get_header()

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -451,6 +451,7 @@ class ExpectationSuitePageRenderer(Renderer):
             },
         })
 
+    # TODO: Update tests
     @classmethod
     def _render_asset_notes(cls, expectations):
         

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -13,7 +13,12 @@ from .renderer import Renderer
 from ..types import (
     RenderedDocumentContent,
     RenderedSectionContent,
-    RenderedHeaderContent, RenderedTableContent, TextContent, RenderedStringTemplateContent)
+    RenderedHeaderContent,
+    RenderedTableContent,
+    TextContent,
+    RenderedStringTemplateContent,
+    RenderedMarkdownContent
+)
 from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
@@ -489,24 +494,30 @@ class ExpectationSuitePageRenderer(Renderer):
                             logger.warning("Unrecognized Expectation suite notes format. Skipping rendering.")
                     
                     elif notes["format"] == "markdown":
-                        # ???: Should converting to markdown be the renderer's job, or the view's job?
-                        # Renderer is easier, but will end up mixing HTML strings with content_block info.
                         if isinstance(notes["content"], string_types):
-                            try:
-                                note_content = [pypandoc.convert_text(notes["content"], format='md', to="html")]
-                            except OSError:
-                                note_content = [notes["content"]]
-                        
+                            note_content = [
+                                RenderedMarkdownContent(**{
+                                    "content_block_type": "markdown",
+                                    "markdown": notes["content"],
+                                    "styling": {
+                                        "parent": {
+                                        }
+                                    }
+                                })
+                            ]
                         elif isinstance(notes["content"], list):
-                            try:
-                                note_content = [pypandoc.convert_text(note, format='md', to="html") for note in
-                                            notes["content"]]
-                            except OSError:
-                                note_content = [note for note in notes["content"]]
-                        
+                            note_content = [
+                                RenderedMarkdownContent(**{
+                                    "content_block_type": "markdown",
+                                    "markdown": note,
+                                    "styling": {
+                                        "parent": {
+                                        }
+                                    }
+                                }) for note in notes["content"]
+                            ]
                         else:
                             logger.warning("Unrecognized Expectation suite notes format. Skipping rendering.")
-                
                 else:
                     logger.warning("Unrecognized Expectation suite notes format. Skipping rendering.")
             

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -103,6 +103,17 @@ class RenderedTableContent(RenderedComponentContent):
         return d
 
 
+class RenderedMarkdownContent(RenderedComponentContent):
+    def __init__(self, markdown, styling=None, content_block_type="markdown"):
+        super(RenderedMarkdownContent, self).__init__(content_block_type=content_block_type, styling=styling)
+        self.markdown = markdown
+
+    def to_json_dict(self):
+        d = super(RenderedMarkdownContent, self).to_json_dict()
+        d["markdown"] = self.markdown
+        return d
+
+
 class RenderedStringTemplateContent(RenderedComponentContent):
     def __init__(self, string_template, styling=None, content_block_type="string_template"):
         super(RenderedStringTemplateContent, self).__init__(content_block_type=content_block_type, styling=styling)

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -142,15 +142,19 @@ class ValueListContent(RenderedComponentContent):
 
 
 class TextContent(RenderedComponentContent):
-    def __init__(self, text, header=None, styling=None, content_block_type="text"):
+    def __init__(self, text, header=None, subheader=None, styling=None, content_block_type="text"):
         super(TextContent, self).__init__(content_block_type=content_block_type, styling=styling)
         self.text = text
         self.header = header
+        self.subheader = subheader
 
     def to_json_dict(self):
         d = super(TextContent, self).to_json_dict()
-        d["header"] = self.header
-        d["text"] = self.text
+        if self.header is not None:
+            d["header"] = self.header
+        if self.subheader is not None:
+            d["subheader"] = self.subheader
+        d["text"] = RenderedContent.rendered_content_list_to_json(self.text)
         return d
 
 

--- a/great_expectations/render/view/templates/markdown.j2
+++ b/great_expectations/render/view/templates/markdown.j2
@@ -1,0 +1,1 @@
+{{ content_block["markdown"] | render_markdown }}

--- a/great_expectations/render/view/templates/text.j2
+++ b/great_expectations/render/view/templates/text.j2
@@ -1,7 +1,20 @@
-{% include 'content_block_header.j2' %}
+{% if not content_block_body_styling and content_block.get("styling") %}
+    {% set content_block_body_styling = content_block.get("styling") | render_styling %}
+{% endif %}
 
 <div id="{{content_block_id}}-body" {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
-    {% for text in content_block["text"] -%}
-        <p>{{text}}</p>
+  {% include 'content_block_header.j2' %}
+  {% for text in content_block["text"] -%}
+      {% if text is mapping and "styling" in text -%}
+          {% set paragraph_styling = text["styling"].get("parent", {}) | render_styling -%}
+      {% else -%}
+          {% set paragraph_styling = "" -%}
+      {% endif -%}
+
+      {% if text is mapping and text.get("content_block_type") == "markdown" %}
+        <div {{ paragraph_styling }}>{{ text | render_content_block }}</div>
+      {% else %}
+        <p {{ paragraph_styling }}>{{ text | render_content_block }}</p>
+      {% endif %}
     {% endfor -%}
 </div>

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -15,6 +15,7 @@ from jinja2 import (
     select_autoescape,
     contextfilter
 )
+import pypandoc
 
 from great_expectations import __version__ as ge_version
 from great_expectations.render.types import (
@@ -97,6 +98,7 @@ class DefaultJinjaView(object):
         env.filters['render_styling_from_string_template'] = self.render_styling_from_string_template
         env.filters['render_styling'] = self.render_styling
         env.filters['render_content_block'] = self.render_content_block
+        env.filters['render_markdown'] = self.render_markdown
         env.globals['ge_version'] = ge_version
 
         template = env.get_template(template)
@@ -127,6 +129,7 @@ class DefaultJinjaView(object):
         return template.render(context, content_block=content_block, index=index)
 
     def render_styling(self, styling):
+        
         """Adds styling information suitable for an html tag.
 
         Example styling block::
@@ -197,6 +200,12 @@ class DefaultJinjaView(object):
     
         else:
             return ""
+
+    def render_markdown(self, markdown):
+        try:
+            return pypandoc.convert_text(markdown, format="md", to="html")
+        except OSError:
+            return markdown
 
     def render_string_template(self, template):
         #NOTE: Using this line for debugging. This should probably be logged...? 

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -201,6 +201,7 @@ class DefaultJinjaView(object):
         else:
             return ""
 
+    # TODO: Add test
     def render_markdown(self, markdown):
         try:
             return pypandoc.convert_text(markdown, format="md", to="html")


### PR DESCRIPTION
- moved markdown processing from renderer to view for expectation suite meta notes
- created new jinja template and view method for markdown
- modified text content block to handle markdown blocks
- added processing method to add meta notes to single expectations