### PR TITLE
Automatic expectations notebook

### DIFF
--- a/examples/notebooks/Automatic_Expectations.ipynb
+++ b/examples/notebooks/Automatic_Expectations.ipynb
@@ -1,0 +1,1151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Automatic Expectations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import great_expectations as ge\n",
+    "\n",
+    "import json\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "pd.options.display.float_format = '{:.2f}'.format\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2. Import Data & Transformations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_train = ge.read_csv(\"../data/FAO-Rice-Production-Asia.csv\")\n",
+    "\n",
+    "#Adding random NaN values to dataset: \n",
+    "nan_mat = np.random.random(df_train.shape)<0.5\n",
+    "df_train_NaN = df_train.mask(nan_mat)\n",
+    "df_train_NaN.head()\n",
+    "\n",
+    "#Adding unique id column\n",
+    "df_train = df_train_NaN.assign(id=[i for i in range(len(df_train))])[['id'] + df_train.columns.tolist()]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>Domain Code</th>\n",
+       "      <th>Domain</th>\n",
+       "      <th>Area Code</th>\n",
+       "      <th>Area</th>\n",
+       "      <th>Element Code</th>\n",
+       "      <th>Element</th>\n",
+       "      <th>Item Code</th>\n",
+       "      <th>Item</th>\n",
+       "      <th>Year Code</th>\n",
+       "      <th>Year</th>\n",
+       "      <th>Unit</th>\n",
+       "      <th>Value</th>\n",
+       "      <th>Flag</th>\n",
+       "      <th>Flag Description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Crops</td>\n",
+       "      <td>2.00</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>27.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>1961.00</td>\n",
+       "      <td>hg/ha</td>\n",
+       "      <td>15190.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>5419.00</td>\n",
+       "      <td>Yield</td>\n",
+       "      <td>27.00</td>\n",
+       "      <td>Rice, paddy</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>hg/ha</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>Fc</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>QC</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>5419.00</td>\n",
+       "      <td>Yield</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>Rice, paddy</td>\n",
+       "      <td>1963.00</td>\n",
+       "      <td>1963.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>15190.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Calculated data</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>QC</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1964.00</td>\n",
+       "      <td>1964.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>QC</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>5419.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>27.00</td>\n",
+       "      <td>Rice, paddy</td>\n",
+       "      <td>1965.00</td>\n",
+       "      <td>1965.00</td>\n",
+       "      <td>hg/ha</td>\n",
+       "      <td>17273.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id Domain Code Domain  Area Code         Area  Element Code Element  \\\n",
+       "0   0         NaN  Crops       2.00  Afghanistan           nan     NaN   \n",
+       "1   1         NaN    NaN        nan          NaN       5419.00   Yield   \n",
+       "2   2          QC    NaN        nan  Afghanistan       5419.00   Yield   \n",
+       "3   3          QC    NaN       2.00          NaN           nan     NaN   \n",
+       "4   4          QC    NaN        nan          NaN       5419.00     NaN   \n",
+       "\n",
+       "   Item Code         Item  Year Code    Year   Unit    Value Flag  \\\n",
+       "0      27.00          NaN        nan 1961.00  hg/ha 15190.00  NaN   \n",
+       "1      27.00  Rice, paddy        nan     nan  hg/ha      nan   Fc   \n",
+       "2        nan  Rice, paddy    1963.00 1963.00    NaN 15190.00  NaN   \n",
+       "3        nan          NaN    1964.00 1964.00    NaN      nan  NaN   \n",
+       "4      27.00  Rice, paddy    1965.00 1965.00  hg/ha 17273.00  NaN   \n",
+       "\n",
+       "  Flag Description  \n",
+       "0              NaN  \n",
+       "1              NaN  \n",
+       "2  Calculated data  \n",
+       "3              NaN  \n",
+       "4              NaN  "
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_train.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. Setting the Expectations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.1 Setting Expected Accuracy Margin Variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Null category:\n",
+    "expected_accuracy_in_not_nulls_perc=10\n",
+    "\n",
+    "#Volume category:\n",
+    "expected_row_count_window_perc=10\n",
+    "\n",
+    "#Stats category:\n",
+    "expected_accuracy_in_stats_perc=10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.2 Column Name & Order & Type Expectations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['id',\n",
+       " 'Domain Code',\n",
+       " 'Domain',\n",
+       " 'Area Code',\n",
+       " 'Area',\n",
+       " 'Element Code',\n",
+       " 'Element',\n",
+       " 'Item Code',\n",
+       " 'Item',\n",
+       " 'Year Code',\n",
+       " 'Year',\n",
+       " 'Unit',\n",
+       " 'Value',\n",
+       " 'Flag',\n",
+       " 'Flag Description']"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "column_names=list(df_train.columns)\n",
+    "column_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True,\n",
+       " 'result': {'observed_value': ['id',\n",
+       "   'Domain Code',\n",
+       "   'Domain',\n",
+       "   'Area Code',\n",
+       "   'Area',\n",
+       "   'Element Code',\n",
+       "   'Element',\n",
+       "   'Item Code',\n",
+       "   'Item',\n",
+       "   'Year Code',\n",
+       "   'Year',\n",
+       "   'Unit',\n",
+       "   'Value',\n",
+       "   'Flag',\n",
+       "   'Flag Description']}}"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_train.expect_table_columns_to_match_ordered_list(column_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "id                    int64\n",
+      "Domain Code          object\n",
+      "Domain               object\n",
+      "Area Code           float64\n",
+      "Area                 object\n",
+      "Element Code        float64\n",
+      "Element              object\n",
+      "Item Code           float64\n",
+      "Item                 object\n",
+      "Year Code           float64\n",
+      "Year                float64\n",
+      "Unit                 object\n",
+      "Value               float64\n",
+      "Flag                 object\n",
+      "Flag Description     object\n",
+      "dtype: object\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Checking the column types\n",
+    "column_types=df_train.dtypes\n",
+    "print(column_types)\n",
+    "\n",
+    "for column_name, column_type in column_types.items():\n",
+    "    df_train.expect_column_values_to_be_of_type(column_name, str(column_type))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.3 Null Expectations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expecting_no_changes_column_names = ['id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Getting the not null fractions per column\n",
+    "not_null_fraction_dict=(((df_train.isnull() == False)&(df_train.isna() == False)).sum()\n",
+    "                        /df_train.index.size).round(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "id                 1.00\n",
+      "Domain Code        0.51\n",
+      "Domain             0.50\n",
+      "Area Code          0.48\n",
+      "Area               0.49\n",
+      "Element Code       0.50\n",
+      "Element            0.51\n",
+      "Item Code          0.51\n",
+      "Item               0.50\n",
+      "Year Code          0.49\n",
+      "Year               0.50\n",
+      "Unit               0.49\n",
+      "Value              0.49\n",
+      "Flag               0.49\n",
+      "Flag Description   0.48\n",
+      "dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Current State\n",
+    "print(not_null_fraction_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Setting up expected null fractions per column\n",
+    "for key, value in not_null_fraction_dict.items():\n",
+    "    if key not in expecting_no_changes_column_names:\n",
+    "        not_null_fraction_dict[key] = value-(value*expected_accuracy_in_not_nulls_perc/100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "id                 1.00\n",
+       "Domain Code        0.46\n",
+       "Domain             0.45\n",
+       "Area Code          0.43\n",
+       "Area               0.44\n",
+       "Element Code       0.45\n",
+       "Element            0.46\n",
+       "Item Code          0.46\n",
+       "Item               0.45\n",
+       "Year Code          0.44\n",
+       "Year               0.45\n",
+       "Unit               0.44\n",
+       "Value              0.44\n",
+       "Flag               0.44\n",
+       "Flag Description   0.43\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Expected State\n",
+    "not_null_fraction_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Setting up NOT NULL expectations: \n",
+    "for column_name, expected_not_null_fraction in not_null_fraction_dict.items():\n",
+    "    df_train.expect_column_values_to_not_be_null(column_name, \n",
+    "                                                            mostly=expected_not_null_fraction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.4 Volume Expectations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_high_end(value, perc):\n",
+    "    if value < 0:\n",
+    "        return value-(value*perc/100)\n",
+    "    else:\n",
+    "        return value+(value*perc/100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_low_end(value, perc):\n",
+    "    if value < 0:\n",
+    "        return value+(value*perc/100)\n",
+    "    else:\n",
+    "        return value-(value*perc/100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_value_range(value, perc):\n",
+    "    return (get_low_end(value, perc), get_high_end(value, perc))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1591"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "row_count=len(df_train)\n",
+    "row_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1431.9, 1750.1)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True, 'result': {'observed_value': 1591}}"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "value_range = get_value_range(row_count, expected_row_count_window_perc)\n",
+    "print(value_range)\n",
+    "df_train.expect_table_row_count_to_be_between(int(value_range[0]), int(value_range[1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.5 Numerical Column Stats Expectations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Get all numberical columns of the training report\n",
+    "numerical_columns = df_train.columns[(df_train.dtypes.values == np.dtype('float64'))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Get stats of numerical columns\n",
+    "min_values=df_train[numerical_columns].min().dropna()\n",
+    "max_values=df_train[numerical_columns].max().dropna()\n",
+    "mean_values=df_train[numerical_columns].mean().dropna()\n",
+    "median_values=df_train[numerical_columns].median().dropna()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MIN\n",
+      "Area Code         2.00\n",
+      "Element Code   5419.00\n",
+      "Item Code        27.00\n",
+      "Year Code      1961.00\n",
+      "Year           1961.00\n",
+      "Value          5263.00\n",
+      "dtype: float64\n",
+      "MAX\n",
+      "Area Code         237.00\n",
+      "Element Code     5419.00\n",
+      "Item Code          27.00\n",
+      "Year Code        2014.00\n",
+      "Year             2014.00\n",
+      "Value          101765.00\n",
+      "dtype: float64\n",
+      "MEAN\n",
+      "Area Code        117.54\n",
+      "Element Code    5419.00\n",
+      "Item Code         27.00\n",
+      "Year Code       1987.60\n",
+      "Year            1987.80\n",
+      "Value          30580.09\n",
+      "dtype: float64\n",
+      "MEDIAN\n",
+      "Area Code        115.00\n",
+      "Element Code    5419.00\n",
+      "Item Code         27.00\n",
+      "Year Code       1988.00\n",
+      "Year            1989.00\n",
+      "Value          27148.50\n",
+      "dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('MIN')\n",
+    "print(min_values)\n",
+    "print('MAX')\n",
+    "print(max_values)\n",
+    "print('MEAN')\n",
+    "print(mean_values)\n",
+    "print('MEDIAN')\n",
+    "print(median_values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MIN-MAX\n",
+      "Area Code 1.8 260.7\n",
+      "Element Code 4877.1 5960.9\n",
+      "Item Code 24.3 29.7\n",
+      "Year Code 1764.9 2215.4\n",
+      "Year 1764.9 2215.4\n",
+      "Value 4736.7 111941.5\n",
+      "MEAN\n",
+      "Area Code 105.78974025974026 129.29857142857142\n",
+      "Element Code 4877.1 5960.9\n",
+      "Item Code 24.3 29.7\n",
+      "Year Code 1788.8413793103448 2186.3616858237547\n",
+      "Year 1789.0231939163498 2186.5839036755387\n",
+      "Value 27522.08358778626 33638.10216284987\n",
+      "MEDIAN\n",
+      "Area Code 103.5 126.5\n",
+      "Element Code 4877.1 5960.9\n",
+      "Item Code 24.3 29.7\n",
+      "Year Code 1789.2 2186.8\n",
+      "Year 1790.1 2187.9\n",
+      "Value 24433.65 29863.35\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Setting up stats expectations:\n",
+    "\n",
+    "#Min-Max\n",
+    "print('MIN-MAX')\n",
+    "for column_name, min_value in min_values.items():\n",
+    "    expected_min_value=get_low_end(min_value, expected_accuracy_in_stats_perc)\n",
+    "    expected_max_value=get_high_end(max_values[column_name], expected_accuracy_in_stats_perc)\n",
+    "    print(column_name, expected_min_value, expected_max_value)\n",
+    "    \n",
+    "    df_train.expect_column_values_to_be_between(column_name, \n",
+    "                                                           expected_min_value,\n",
+    "                                                           expected_max_value)\n",
+    "    \n",
+    "#Mean\n",
+    "print('MEAN')\n",
+    "for column_name, mean_value in mean_values.items():\n",
+    "    value_range=get_value_range(mean_value, expected_accuracy_in_stats_perc)\n",
+    "    print(column_name, value_range[0], value_range[1])\n",
+    "    \n",
+    "    df_train.expect_column_mean_to_be_between(column_name, \n",
+    "                                                         min_value=value_range[0],\n",
+    "                                                         max_value=value_range[1])\n",
+    "  \n",
+    "#Median\n",
+    "print('MEDIAN')\n",
+    "for column_name, median_value in median_values.items():\n",
+    "    value_range=get_value_range(median_value, expected_accuracy_in_stats_perc)\n",
+    "    print(column_name, value_range[0], value_range[1])\n",
+    "    \n",
+    "    df_train.expect_column_median_to_be_between(column_name, \n",
+    "                                                         min_value=value_range[0],\n",
+    "                                                         max_value=value_range[1])\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.6 Miscellaneous"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True,\n",
+       " 'result': {'element_count': 1591,\n",
+       "  'missing_count': 0,\n",
+       "  'missing_percent': 0.0,\n",
+       "  'unexpected_count': 0,\n",
+       "  'unexpected_percent': 0.0,\n",
+       "  'unexpected_percent_nonmissing': 0.0,\n",
+       "  'partial_unexpected_list': []}}"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_train.expect_column_values_to_be_unique('id')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.7 Distributional Expectations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([ 90.,  72.,  71.,  85.,  63.,  70., 101.,  74.,  70.,  93.]),\n",
+       " array([1961. , 1966.3, 1971.6, 1976.9, 1982.2, 1987.5, 1992.8, 1998.1,\n",
+       "        2003.4, 2008.7, 2014. ]),\n",
+       " <a list of 10 Patch objects>)"
+      ]
+     },
+     "execution_count": 100,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAPOklEQVR4nO3df4xlZX3H8fdHVqJgCYsMFIG4mKCWtFpxilgbJdJagcalqaSorRsl4R/a4q/q2jbxj6YJGKPW2NhsBLukxh9FE2i1ErrFmlalDsjvVXehFrds2bGAWE2K6Ld/3GflZp1Z9t4zw9x5eL+SyT3nOb+e7567nz3z3HPPpqqQJPXlKWvdAUnSyjPcJalDhrskdchwl6QOGe6S1KENa90BgGOPPbY2bdq01t2QpHXlpptu+m5VzS21bCbCfdOmTSwsLKx1NyRpXUnyn8stc1hGkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1KHHDfckVybZl+SOsbZjklyfZFd73djak+RDSXYnuS3J6avZeUnS0g7lG6p/A3wYuGqsbSuwo6ouS7K1zb8LOAc4tf28BPhIe5U0oU1bP7cmx/32ZeetyXG1sh73yr2qvgQ8cEDzZmB7m94OnD/WflWNfBU4OskJK9VZSdKhmXbM/fiq2gvQXo9r7ScC3xlbb09r+xlJLk6ykGRhcXFxym5Ikpay0h+oZom2Jf+T1qraVlXzVTU/N7fkQ80kSVOaNtzv3z/c0l73tfY9wMlj650E3Dd99yRJ05g23K8FtrTpLcA1Y+1vbHfNnAl8b//wjSTpifO4d8sk+QRwFnBskj3Ae4DLgE8nuQi4F7igrf554FxgN/BD4E2r0GdJ0uN43HCvqtcts+jsJdYt4JKhnZIkDeM3VCWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdOpTnuUtS19bq2fmwes/P98pdkjpkuEtShwx3SeqQ4S5JHTLcJalD6/5umR4/5Zakobxyl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShdf/4AT2x1upxDz7qQZqMV+6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4PCPclbk9yZ5I4kn0jytCSnJLkxya4kn0py+Ep1VpJ0aKYO9yQnAn8EzFfVLwKHARcClwMfqKpTgQeBi1aio5KkQzd0WGYD8PQkG4AjgL3AK4Gr2/LtwPkDjyFJmtDU4V5V/wW8D7iXUah/D7gJeKiqHm2r7QFOXGr7JBcnWUiysLi4OG03JElLGDIssxHYDJwCPAs4EjhniVVrqe2raltVzVfV/Nzc3LTdkCQtYciwzK8D/1FVi1X1I+CzwK8CR7dhGoCTgPsG9lGSNKEh4X4vcGaSI5IEOBu4C7gBeG1bZwtwzbAuSpImNWTM/UZGH5zeDNze9rUNeBfwtiS7gWcCV6xAPyVJExj0yN+qeg/wngOa7wHOGLJfSdIwfkNVkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdWjQrZCS+rNp6+fW7Njfvuy8NTt2b7xyl6QOGe6S1CHDXZI65Jj7AGs1Num4pKTH45W7JHXIK/d1aC3vZpC0PnjlLkkd8spdOgh/S3pi+ee9crxyl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkd8pG/Whd8FKw0Ga/cJalDhrskdWhQuCc5OsnVSb6RZGeSlyY5Jsn1SXa1140r1VlJ0qEZeuX+l8AXqur5wAuBncBWYEdVnQrsaPOSpCfQ1OGe5Cjg5cAVAFX1SFU9BGwGtrfVtgPnD+2kJGkyQ67cnwMsAh9L8vUkH01yJHB8Ve0FaK/HLbVxkouTLCRZWFxcHNANSdKBhoT7BuB04CNV9SLgB0wwBFNV26pqvqrm5+bmBnRDknSgIeG+B9hTVTe2+asZhf39SU4AaK/7hnVRkjSpqcO9qv4b+E6S57Wms4G7gGuBLa1tC3DNoB5KkiY29Buqfwh8PMnhwD3Amxj9g/HpJBcB9wIXDDyGJGlCg8K9qm4B5pdYdPaQ/UqShvEbqpLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QODQ73JIcl+XqSf2jzpyS5McmuJJ9KcvjwbkqSJrESV+6XAjvH5i8HPlBVpwIPAhetwDEkSRMYFO5JTgLOAz7a5gO8Eri6rbIdOH/IMSRJkxt65f5B4J3AT9r8M4GHqurRNr8HOHGpDZNcnGQhycLi4uLAbkiSxk0d7kl+C9hXVTeNNy+xai21fVVtq6r5qpqfm5ubthuSpCVsGLDty4DXJDkXeBpwFKMr+aOTbGhX7ycB9w3vpiRpElNfuVfVu6vqpKraBFwI/HNVvQG4AXhtW20LcM3gXkqSJrIa97m/C3hbkt2MxuCvWIVjSJIOYsiwzE9V1ReBL7bpe4AzVmK/kqTp+A1VSeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUoemDvckJye5IcnOJHcmubS1H5Pk+iS72uvGleuuJOlQDLlyfxR4e1X9AnAmcEmS04CtwI6qOhXY0eYlSU+gqcO9qvZW1c1t+vvATuBEYDOwva22HTh/aCclSZNZkTH3JJuAFwE3AsdX1V4Y/QMAHLfMNhcnWUiysLi4uBLdkCQ1g8M9yTOAzwBvqaqHD3W7qtpWVfNVNT83Nze0G5KkMYPCPclTGQX7x6vqs635/iQntOUnAPuGdVGSNKkhd8sEuALYWVXvH1t0LbClTW8Brpm+e5KkaWwYsO3LgN8Hbk9yS2v7E+Ay4NNJLgLuBS4Y1kVJ0qSmDveq+lcgyyw+e9r9SpKG8xuqktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA6tSrgneXWSbybZnWTrahxDkrS8FQ/3JIcBfwWcA5wGvC7JaSt9HEnS8lbjyv0MYHdV3VNVjwCfBDavwnEkScvYsAr7PBH4ztj8HuAlB66U5GLg4jb7v0m+eQj7Phb47uAezjZr7MeToc4nQ42winXm8kGbP3u5BasR7lmirX6moWobsG2iHScLVTU/bcfWA2vsx5OhzidDjbA+61yNYZk9wMlj8ycB963CcSRJy1iNcP8acGqSU5IcDlwIXLsKx5EkLWPFh2Wq6tEkfwBcBxwGXFlVd67Q7icaxlmnrLEfT4Y6nww1wjqsM1U/MxwuSVrn/IaqJHXIcJekDq1puCe5Msm+JHeMtb0wyVeS3J7k75McNbbsBW3ZnW3501r7i9v87iQfSrLU7ZhrYpIak7whyS1jPz9J8stt2czWCBPX+dQk21v7ziTvHttmZh9dMWGNhyf5WGu/NclZY9vM7LlMcnKSG9p5uTPJpa39mCTXJ9nVXje29rQadie5LcnpY/va0tbflWTLWtW0lCnqfH47z/+X5B0H7Gs237NVtWY/wMuB04E7xtq+BryiTb8Z+PM2vQG4DXhhm38mcFib/nfgpYzusf9H4Jy1rGvaGg/Y7peAe8bmZ7bGKc7l64FPtukjgG8Dmxh9AH838BzgcOBW4LS1rm3KGi8BPtamjwNuAp4y6+cSOAE4vU3/HPAtRo8ReS+wtbVvBS5v0+e2GgKcCdzY2o8B7mmvG9v0xrWub0CdxwG/AvwF8I6x/czse3ZNr9yr6kvAAwc0Pw/4Upu+HvidNv0q4LaqurVt+z9V9eMkJwBHVdVXavSnfRVw/ur3/tBMWOO41wGfAJj1GmHiOgs4MskG4OnAI8DDzPijKyas8TRgR9tuH/AQMD/r57Kq9lbVzW36+8BORt863wxsb6tt57E+bwauqpGvAke3Gn8TuL6qHqiqBxn92bz6CSzloCats6r2VdXXgB8dsKuZfc/O4pj7HcBr2vQFPPaFqOcCleS6JDcneWdrP5HRF6f229PaZtlyNY77XVq4sz5rhOXrvBr4AbAXuBd4X1U9wNKPrpj1Oper8VZgc5INSU4BXtyWrZtzmWQT8CLgRuD4qtoLo2BkdCULy5+zdXMuD7HO5cxsnbMY7m8GLklyE6Nflx5p7RuAXwPe0F5/O8nZHOLjDmbMcjUCkOQlwA+rav/Y7nqsEZav8wzgx8CzgFOAtyd5DuuzzuVqvJLRX/QF4IPAl4FHWSc1JnkG8BngLVX18MFWXaKtDtI+Uyaoc9ldLNE2E3WuxrNlBqmqbzAagiHJc4Hz2qI9wL9U1Xfbss8zGv/8W0aPONhv5h93cJAa97uQx67aYVT7uqoRDlrn64EvVNWPgH1J/g2YZ3QFtK4eXbFcjVX1KPDW/esl+TKwC3iQGT+XSZ7KKPA+XlWfbc33Jzmhqva2YZd9rX25x43sAc46oP2Lq9nvSU1Y53Jm9nErM3flnuS49voU4M+Av26LrgNekOSINlb7CuCu9qvT95Oc2e46eCNwzRp0/ZAdpMb9bRcwGrsDfvrr4bqqEQ5a573AK9udFkcy+iDuG6zDR1csV2N7nx7Zpn8DeLSqZv792vp0BbCzqt4/tuhaYP8dL1t4rM/XAm9s5/JM4HutxuuAVyXZ2O44eVVrmwlT1Lmc2X3PruWnuYyuTvcy+pBiD3ARcCmjT66/BVxG+xZtW//3gDsZjXO+d6x9vrXdDXx4fJu1/pmixrOAry6xn5mtcdI6gWcAf9fO5V3AH4/t59y2/t3An651XQNq3AR8k9EHdf8EPHs9nEtGQ57F6M60W9rPuYzuTtvB6LePHcAxbf0w+s957gZuB+bH9vVmYHf7edNa1zawzp9v5/xhRh+O72H0wfjMvmd9/IAkdWjmhmUkScMZ7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalD/w9tKWZWsxAq5AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(df_train['Year'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'success': True,\n",
+       " 'result': {'observed_value': 1.0,\n",
+       "  'element_count': 1591,\n",
+       "  'missing_count': 802,\n",
+       "  'missing_percent': 50.40854808296669}}"
+      ]
+     },
+     "execution_count": 101,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Setting up categorical distribution expectation for Year\n",
+    "property_type_partition=ge.dataset.util.categorical_partition_data(df_train['Year'])\n",
+    "df_train.expect_column_chisquare_test_p_value_to_be_greater_than('Year', property_type_partition)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.8 Exporting & Saving the Expectations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data_asset_name': None,\n",
+       " 'expectation_suite_name': 'default',\n",
+       " 'meta': {'great_expectations.__version__': '0.8.5'},\n",
+       " 'expectations': [{'expectation_type': 'expect_table_columns_to_match_ordered_list',\n",
+       "   'kwargs': {'column_list': ['id',\n",
+       "     'Domain Code',\n",
+       "     'Domain',\n",
+       "     'Area Code',\n",
+       "     'Area',\n",
+       "     'Element Code',\n",
+       "     'Element',\n",
+       "     'Item Code',\n",
+       "     'Item',\n",
+       "     'Year Code',\n",
+       "     'Year',\n",
+       "     'Unit',\n",
+       "     'Value',\n",
+       "     'Flag',\n",
+       "     'Flag Description']}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'id', 'type_': 'int64'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Domain Code', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Domain', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Area Code', 'type_': 'float64'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Area', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Element Code', 'type_': 'float64'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Element', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Item Code', 'type_': 'float64'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Item', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Year Code', 'type_': 'float64'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Year', 'type_': 'float64'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Unit', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Value', 'type_': 'float64'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Flag', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_of_type',\n",
+       "   'kwargs': {'column': 'Flag Description', 'type_': 'object'}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'id', 'mostly': 1.0}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Domain Code', 'mostly': 0.459}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Domain', 'mostly': 0.45}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Area Code', 'mostly': 0.432}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Area', 'mostly': 0.441}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Element Code', 'mostly': 0.45}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Element', 'mostly': 0.459}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Item Code', 'mostly': 0.459}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Item', 'mostly': 0.45}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Year Code', 'mostly': 0.441}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Year', 'mostly': 0.45}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Unit', 'mostly': 0.441}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Value', 'mostly': 0.441}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Flag', 'mostly': 0.441}},\n",
+       "  {'expectation_type': 'expect_column_values_to_not_be_null',\n",
+       "   'kwargs': {'column': 'Flag Description', 'mostly': 0.432}},\n",
+       "  {'expectation_type': 'expect_table_row_count_to_be_between',\n",
+       "   'kwargs': {'min_value': 1431, 'max_value': 1750}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_between',\n",
+       "   'kwargs': {'column': 'Area Code', 'min_value': 1.8, 'max_value': 260.7}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_between',\n",
+       "   'kwargs': {'column': 'Element Code',\n",
+       "    'min_value': 4877.1,\n",
+       "    'max_value': 5960.9}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_between',\n",
+       "   'kwargs': {'column': 'Item Code', 'min_value': 24.3, 'max_value': 29.7}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_between',\n",
+       "   'kwargs': {'column': 'Year Code',\n",
+       "    'min_value': 1764.9,\n",
+       "    'max_value': 2215.4}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_between',\n",
+       "   'kwargs': {'column': 'Year', 'min_value': 1764.9, 'max_value': 2215.4}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_between',\n",
+       "   'kwargs': {'column': 'Value', 'min_value': 4736.7, 'max_value': 111941.5}},\n",
+       "  {'expectation_type': 'expect_column_mean_to_be_between',\n",
+       "   'kwargs': {'column': 'Area Code',\n",
+       "    'min_value': 105.78974025974026,\n",
+       "    'max_value': 129.29857142857142}},\n",
+       "  {'expectation_type': 'expect_column_mean_to_be_between',\n",
+       "   'kwargs': {'column': 'Element Code',\n",
+       "    'min_value': 4877.1,\n",
+       "    'max_value': 5960.9}},\n",
+       "  {'expectation_type': 'expect_column_mean_to_be_between',\n",
+       "   'kwargs': {'column': 'Item Code', 'min_value': 24.3, 'max_value': 29.7}},\n",
+       "  {'expectation_type': 'expect_column_mean_to_be_between',\n",
+       "   'kwargs': {'column': 'Year Code',\n",
+       "    'min_value': 1788.8413793103448,\n",
+       "    'max_value': 2186.3616858237547}},\n",
+       "  {'expectation_type': 'expect_column_mean_to_be_between',\n",
+       "   'kwargs': {'column': 'Year',\n",
+       "    'min_value': 1789.0231939163498,\n",
+       "    'max_value': 2186.5839036755387}},\n",
+       "  {'expectation_type': 'expect_column_mean_to_be_between',\n",
+       "   'kwargs': {'column': 'Value',\n",
+       "    'min_value': 27522.08358778626,\n",
+       "    'max_value': 33638.10216284987}},\n",
+       "  {'expectation_type': 'expect_column_median_to_be_between',\n",
+       "   'kwargs': {'column': 'Area Code', 'min_value': 103.5, 'max_value': 126.5}},\n",
+       "  {'expectation_type': 'expect_column_median_to_be_between',\n",
+       "   'kwargs': {'column': 'Element Code',\n",
+       "    'min_value': 4877.1,\n",
+       "    'max_value': 5960.9}},\n",
+       "  {'expectation_type': 'expect_column_median_to_be_between',\n",
+       "   'kwargs': {'column': 'Item Code', 'min_value': 24.3, 'max_value': 29.7}},\n",
+       "  {'expectation_type': 'expect_column_median_to_be_between',\n",
+       "   'kwargs': {'column': 'Year Code',\n",
+       "    'min_value': 1789.2,\n",
+       "    'max_value': 2186.8}},\n",
+       "  {'expectation_type': 'expect_column_median_to_be_between',\n",
+       "   'kwargs': {'column': 'Year', 'min_value': 1790.1, 'max_value': 2187.9}},\n",
+       "  {'expectation_type': 'expect_column_median_to_be_between',\n",
+       "   'kwargs': {'column': 'Value',\n",
+       "    'min_value': 24433.65,\n",
+       "    'max_value': 29863.35}},\n",
+       "  {'expectation_type': 'expect_column_values_to_be_unique',\n",
+       "   'kwargs': {'column': 'id'}},\n",
+       "  {'expectation_type': 'expect_column_chisquare_test_p_value_to_be_greater_than',\n",
+       "   'kwargs': {'column': 'Year',\n",
+       "    'partition_object': {'values': [1966.0,\n",
+       "      2012.0,\n",
+       "      1993.0,\n",
+       "      1999.0,\n",
+       "      1995.0,\n",
+       "      1994.0,\n",
+       "      1965.0,\n",
+       "      2010.0,\n",
+       "      1982.0,\n",
+       "      1971.0,\n",
+       "      1992.0,\n",
+       "      1967.0,\n",
+       "      1990.0,\n",
+       "      1975.0,\n",
+       "      2008.0,\n",
+       "      2009.0,\n",
+       "      2000.0,\n",
+       "      1974.0,\n",
+       "      1980.0,\n",
+       "      1977.0,\n",
+       "      1973.0,\n",
+       "      1996.0,\n",
+       "      2013.0,\n",
+       "      1997.0,\n",
+       "      1970.0,\n",
+       "      2001.0,\n",
+       "      1981.0,\n",
+       "      1964.0,\n",
+       "      2004.0,\n",
+       "      1998.0,\n",
+       "      2005.0,\n",
+       "      2006.0,\n",
+       "      1987.0,\n",
+       "      1986.0,\n",
+       "      1963.0,\n",
+       "      2003.0,\n",
+       "      1969.0,\n",
+       "      1991.0,\n",
+       "      1985.0,\n",
+       "      1976.0,\n",
+       "      1989.0,\n",
+       "      1972.0,\n",
+       "      1962.0,\n",
+       "      2007.0,\n",
+       "      1983.0,\n",
+       "      1978.0,\n",
+       "      1979.0,\n",
+       "      2014.0,\n",
+       "      2002.0,\n",
+       "      1988.0,\n",
+       "      1968.0,\n",
+       "      2011.0,\n",
+       "      1961.0,\n",
+       "      1984.0],\n",
+       "     'weights': [0.026615969581749048,\n",
+       "      0.026615969581749048,\n",
+       "      0.025348542458808618,\n",
+       "      0.025348542458808618,\n",
+       "      0.024081115335868188,\n",
+       "      0.024081115335868188,\n",
+       "      0.022813688212927757,\n",
+       "      0.022813688212927757,\n",
+       "      0.021546261089987327,\n",
+       "      0.021546261089987327,\n",
+       "      0.021546261089987327,\n",
+       "      0.021546261089987327,\n",
+       "      0.020278833967046894,\n",
+       "      0.020278833967046894,\n",
+       "      0.020278833967046894,\n",
+       "      0.020278833967046894,\n",
+       "      0.020278833967046894,\n",
+       "      0.019011406844106463,\n",
+       "      0.019011406844106463,\n",
+       "      0.019011406844106463,\n",
+       "      0.019011406844106463,\n",
+       "      0.019011406844106463,\n",
+       "      0.019011406844106463,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.017743979721166033,\n",
+       "      0.016476552598225603,\n",
+       "      0.016476552598225603,\n",
+       "      0.016476552598225603,\n",
+       "      0.016476552598225603,\n",
+       "      0.016476552598225603,\n",
+       "      0.016476552598225603,\n",
+       "      0.015209125475285171,\n",
+       "      0.015209125475285171,\n",
+       "      0.015209125475285171,\n",
+       "      0.015209125475285171,\n",
+       "      0.015209125475285171,\n",
+       "      0.015209125475285171,\n",
+       "      0.015209125475285171,\n",
+       "      0.01394169835234474,\n",
+       "      0.01394169835234474,\n",
+       "      0.01394169835234474,\n",
+       "      0.01394169835234474,\n",
+       "      0.01394169835234474,\n",
+       "      0.012674271229404309]}}}],\n",
+       " 'data_asset_type': 'Dataset'}"
+      ]
+     },
+     "execution_count": 102,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_train.get_expectation_suite()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#df_train.save_expectation_suite(\"../expectations/automatic.expectations.json\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook aims to create expectations automatically with using basic pandas/python functions given the training set. 

The purpose is avoiding explicit expectation definitions as much as possible and let the given training set define the expectations automatically.

The following groups are taken into consideration with disparate expected accuracy margins:
- Column names, order, type
- Not Null ratios per column
- Volume per input
- Stats for numerical columns
