### PR TITLE
Feature/validation results limit; index page exception handling

### DIFF
--- a/docs/reference/data_docs_reference.rst
+++ b/docs/reference/data_docs_reference.rst
@@ -77,6 +77,25 @@ attribute allows to include (``eq`` for exact match) or exclude (``ne``) validat
 
 .. _customizing_data_docs_store_backend:
 
+Limiting Validation Results
+============================
+
+If you would like to limit rendered Validation Results to the n most-recent, you may
+do so by setting the `validation_results_limit` key in your Data Docs configuration:
+
+.. code-block:: yaml
+
+  data_docs_sites:
+    local_site:
+      class_name: SiteBuilder
+      store_backend:
+        class_name: FixedLengthTupleFilesystemStoreBackend
+        base_directory: uncommitted/data_docs/local_site/
+      site_index_builder:
+        class_name: DefaultSiteIndexBuilder
+        show_cta_footer: true
+        validation_results_limit: 5
+
 Automatically Publishing Data Docs
 =====================================
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -447,7 +447,7 @@ class ConfigOnlyDataContext(object):
         """Configurable delimiter character used to parse data asset name strings into \
         ``DataAssetIdentifier`` objects."""
         return self._data_asset_name_delimiter
-    
+
     @data_asset_name_delimiter.setter
     def data_asset_name_delimiter(self, new_delimiter):
         """data_asset_name_delimiter property setter method"""
@@ -553,7 +553,7 @@ class ConfigOnlyDataContext(object):
             raise ValueError(
                 "Datasource names must be a datasource name, list of datasource names or None (to list all datasources)"
             )
-        
+
         if generator_names is not None:
             if isinstance(generator_names, string_types):
                 generator_names = [generator_names]
@@ -789,7 +789,7 @@ class ConfigOnlyDataContext(object):
                 return PandasDatasource
             except ImportError:
                 raise
- 
+
     def get_datasource(self, datasource_name="default"):
         """Get the named datasource
 
@@ -811,7 +811,7 @@ class ConfigOnlyDataContext(object):
         datasource = self._build_datasource_from_config(datasource_name, datasource_config)
         self._datasources[datasource_name] = datasource
         return datasource
-            
+
     def list_expectation_suite_keys(self):
         """Return a list of available expectation suite keys."""
         try:
@@ -845,7 +845,7 @@ class ConfigOnlyDataContext(object):
 
     def normalize_data_asset_name(self, data_asset_name):
         """Normalizes data_asset_names for a data context.
-        
+
         A data_asset_name is defined per-project and consists of three components that together define a "namespace"
         for data assets, encompassing both expectation suites and batches.
 
@@ -893,7 +893,7 @@ class ConfigOnlyDataContext(object):
                         delimiter=self.data_asset_name_delimiter
                 )
             )
-        
+
         elif len(split_name) == 1:
             # In this case, the name *must* refer to a unique data_asset_name
             provider_names = set()
@@ -921,7 +921,7 @@ class ConfigOnlyDataContext(object):
             #         "Ambiguous data_asset_name '{data_asset_name}'. Multiple candidates found: {provider_names}"
             #         .format(data_asset_name=data_asset_name, provider_names=provider_names)
             #     )
-                    
+
             available_names = self.get_available_data_asset_names()
             for datasource in available_names.keys():
                 for generator in available_names[datasource].keys():
@@ -930,7 +930,7 @@ class ConfigOnlyDataContext(object):
                         provider_names.add(
                             DataAssetIdentifier(datasource, generator, generator_asset)
                         )
-            
+
             if len(provider_names) == 1:
                 return provider_names.pop()
 
@@ -1003,7 +1003,7 @@ class ConfigOnlyDataContext(object):
 
             if len(provider_names) == 1:
                 return provider_names.pop()
-            
+
             elif len(provider_names) > 1:
                 raise ge_exceptions.AmbiguousDataAssetNameError(
                     "Ambiguous data_asset_name '{data_asset_name}'. Multiple candidates found: {provider_names}"
@@ -1222,7 +1222,7 @@ class ConfigOnlyDataContext(object):
                                 #     run_id, desired_param, result.result["details"])
                             else:
                                 logger.warning("Unrecognized key for parameter %s" % desired_param)
-                
+
                 # Next, bind parameters that do not have column parameter
                 for type_key, desired_parameters in self._compiled_parameters["data_assets"][data_asset_name][expectation_suite_name][expectation_type].items():
                     if type_key == "columns":
@@ -1312,14 +1312,14 @@ class ConfigOnlyDataContext(object):
     # A more descriptive name would have helped me grok this faster when I first encountered it
     def _compile(self):
         """Compiles all current expectation configurations in this context to be ready for result registration.
-        
+
         Compilation only respects parameters with a URN structure beginning with urn:great_expectations:validations
         It splits parameters by the : (colon) character; valid URNs must have one of the following structures to be
         automatically recognized.
 
         "urn" : "great_expectations" : "validations" : data_asset_name : expectation_suite_name : "expectations" : expectation_name : "columns" : column_name : "result": result_key
          [0]            [1]                 [2]              [3]                   [4]                  [5]             [6]              [7]         [8]        [9]        [10]
-        
+
         "urn" : "great_expectations" : "validations" : data_asset_name : expectation_suite_name : "expectations" : expectation_name : "columns" : column_name : "details": details_key
          [0]            [1]                 [2]              [3]                   [4]                  [5]             [6]              [7]         [8]        [9]         [10]
 
@@ -1408,12 +1408,12 @@ class ConfigOnlyDataContext(object):
                                 if param_key not in self._compiled_parameters["data_assets"][data_asset_name][expectation_suite_name][expectation_name]["columns"][column_name]:
                                     self._compiled_parameters["data_assets"][data_asset_name][expectation_suite_name][expectation_name]["columns"][column_name][param_key] = set()
                                 self._compiled_parameters["data_assets"][data_asset_name][expectation_suite_name][expectation_name]["columns"][column_name][param_key].add(parameter)
-                            
+
                             elif param_key in ["result", "details"]:
                                 if param_key not in self._compiled_parameters["data_assets"][data_asset_name][expectation_suite_name][expectation_name]:
                                     self._compiled_parameters["data_assets"][data_asset_name][expectation_suite_name][expectation_name][param_key] = set()
                                 self._compiled_parameters["data_assets"][data_asset_name][expectation_suite_name][expectation_name][param_key].add(parameter)
-                            
+
                             else:
                                 logger.warning("Invalid parameter urn (unrecognized structure): %s" % parameter)
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1540,7 +1540,9 @@ class ConfigOnlyDataContext(object):
                             "module_name": "great_expectations.render.renderer.site_builder"
                         }
                     )
-                    index_page_locator_info = site_builder.build(resource_identifiers)[0]
+                    index_page_resource_identifier_tuple = site_builder.build(resource_identifiers)
+                    index_page_locator_info = site_builder.build(
+                        resource_identifiers)[0] if index_page_resource_identifier_tuple else None
 
                     if index_page_locator_info:
                         index_page_locator_infos[site_name] = index_page_locator_info

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -270,10 +270,10 @@ class DefaultSiteSectionBuilder(object):
             if self.run_id_filter:
                 if not self._resource_key_passes_run_id_filter(resource_key):
                     continue
-                    
+
             if not self._resource_key_passes_datasource_whitelist(resource_key, datasource_whitelist):
                 continue
-                
+
             resource = self.source_store.get(resource_key)
 
             if isinstance(resource_key, ExpectationSuiteIdentifier):
@@ -291,7 +291,7 @@ class DefaultSiteSectionBuilder(object):
                 if run_id == "profiling":
                     logger.debug("        Rendering profiling for data asset {}".format(data_asset_name))
                 else:
-                    
+
                     logger.debug("        Rendering validation: run id: {}, suite {} for data asset {}".format(run_id,
                                                                                                               expectation_suite_name,
                                                                                                               data_asset_name))
@@ -313,7 +313,7 @@ class DefaultSiteSectionBuilder(object):
         elif type(resource_key) is ValidationResultIdentifier:
             datasource = resource_key.expectation_suite_identifier.data_asset_name.datasource
         return datasource in datasource_whitelist
-    
+
     def _resource_key_passes_run_id_filter(self, resource_key):
         if type(resource_key) == ValidationResultIdentifier:
             run_id = resource_key.run_id
@@ -391,22 +391,22 @@ class DefaultSiteIndexBuilder(object):
 
         if datasource not in index_links_dict:
             index_links_dict[datasource] = OrderedDict()
-    
+
         if generator not in index_links_dict[datasource]:
             index_links_dict[datasource][generator] = OrderedDict()
-    
+
         if generator_asset not in index_links_dict[datasource][generator]:
             index_links_dict[datasource][generator][generator_asset] = {
                 'profiling_links': [],
                 'validations_links': [],
                 'expectations_links': []
             }
-    
+
         if run_id:
             base_path = "validations/" + run_id
         else:
             base_path = "expectations"
-    
+
         index_links_dict[datasource][generator][generator_asset][section_name + "_links"].append(
             {
                 "full_data_asset_name": str(data_asset_name),
@@ -419,7 +419,7 @@ class DefaultSiteIndexBuilder(object):
                 "validation_success": validation_success
             }
         )
-    
+
         return index_links_dict
 
     def get_calls_to_action(self):

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -159,7 +159,8 @@ class SiteBuilder(object):
                     },
                     "renderer": {
                         "class_name": "ValidationResultsPageRenderer"
-                    }
+                    },
+                    "validation_results_limit": site_index_builder.get("validation_results_limit")
                 },
                 "profiling": {
                     "class_name": "DefaultSiteSectionBuilder",
@@ -220,6 +221,7 @@ class DefaultSiteSectionBuilder(object):
             source_store_name,
             custom_styles_directory=None,
             run_id_filter=None,
+            validation_results_limit=None,
             renderer=None,
             view=None,
     ):
@@ -227,6 +229,7 @@ class DefaultSiteSectionBuilder(object):
         self.source_store = data_context.stores[source_store_name]
         self.target_store = target_store
         self.run_id_filter = run_id_filter
+        self.validation_results_limit = validation_results_limit
 
         if renderer is None:
             raise exceptions.InvalidConfigError(
@@ -258,7 +261,11 @@ class DefaultSiteSectionBuilder(object):
         )
 
     def build(self, datasource_whitelist, resource_identifiers=None):
-        for resource_key in self.source_store.list_keys():
+        source_store_keys = self.source_store.list_keys()
+        if self.name == "validations" and self.validation_results_limit:
+            source_store_keys = sorted(source_store_keys, key=lambda x: x.run_id, reverse=True)[:self.validation_results_limit]
+
+        for resource_key in source_store_keys:
 
             # if no resource_identifiers are passed, the section builder will build
             # a page for every keys in its source store.
@@ -296,8 +303,12 @@ class DefaultSiteSectionBuilder(object):
                                                                                                               expectation_suite_name,
                                                                                                               data_asset_name))
 
-            rendered_content = self.renderer_class.render(resource)
-            viewable_content = self.view_class.render(rendered_content)
+            try:
+                rendered_content = self.renderer_class.render(resource)
+                viewable_content = self.view_class.render(rendered_content)
+            except Exception as e:
+                logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
+                continue
 
             self.target_store.set(
                 SiteSectionIdentifier(
@@ -336,6 +347,7 @@ class DefaultSiteIndexBuilder(object):
             target_store,
             custom_styles_directory=None,
             show_cta_footer=True,
+            validation_results_limit=None,
             renderer=None,
             view=None,
     ):
@@ -344,6 +356,7 @@ class DefaultSiteIndexBuilder(object):
         self.data_context = data_context
         self.target_store = target_store
         self.show_cta_footer = show_cta_footer
+        self.validation_results_limit = validation_results_limit
 
         if renderer is None:
             renderer = {
@@ -496,56 +509,93 @@ class DefaultSiteIndexBuilder(object):
     def build(self):
         # Loop over sections in the HtmlStore
         logger.debug("DefaultSiteIndexBuilder.build")
+        expectation_suite_keys = [
+            ExpectationSuiteIdentifier.from_tuple(expectation_suite_tuple) for expectation_suite_tuple in
+            self.target_store.store_backends[ExpectationSuiteIdentifier].list_keys()
+        ]
+        validation_and_profiling_result_keys = [
+            ValidationResultIdentifier.from_tuple(validation_result_tuple) for validation_result_tuple in
+            self.target_store.store_backends[ValidationResultIdentifier].list_keys()
+        ]
+        profiling_result_keys = [
+            validation_result_key for validation_result_key in validation_and_profiling_result_keys
+            if validation_result_key.run_id == "profiling"
+        ]
+        validation_result_keys = [
+            validation_result_key for validation_result_key in validation_and_profiling_result_keys
+            if validation_result_key.run_id != "profiling"
+        ]
+        validation_result_keys = sorted(validation_result_keys, key=lambda x: x.run_id, reverse=True)
+        if self.validation_results_limit:
+            validation_result_keys = validation_result_keys[:self.validation_results_limit]
 
-        target_store = self.target_store
-        resource_keys = target_store.list_keys()
         index_links_dict = OrderedDict()
 
         if self.show_cta_footer:
             index_links_dict["cta_object"] = self.get_calls_to_action()
 
-        for key_resource_identifier in resource_keys:
+        for expectation_suite_key in expectation_suite_keys:
+            self.add_resource_info_to_index_links_dict(
+                data_context=self.data_context,
+                index_links_dict=index_links_dict,
+                data_asset_name=expectation_suite_key.data_asset_name,
+                datasource=expectation_suite_key.data_asset_name.datasource,
+                generator=expectation_suite_key.data_asset_name.generator,
+                generator_asset=expectation_suite_key.data_asset_name.generator_asset,
+                expectation_suite_name=expectation_suite_key.expectation_suite_name,
+                section_name="expectations"
+            )
 
-            if type(key_resource_identifier) == ExpectationSuiteIdentifier:
-                self.add_resource_info_to_index_links_dict(
-                    data_context=self.data_context,
-                    index_links_dict=index_links_dict,
-                    data_asset_name=key_resource_identifier.data_asset_name,
-                    datasource=key_resource_identifier.data_asset_name.datasource,
-                    generator=key_resource_identifier.data_asset_name.generator,
-                    generator_asset=key_resource_identifier.data_asset_name.generator_asset,
-                    expectation_suite_name=key_resource_identifier.expectation_suite_name,
-                    section_name="expectations"
-                )
-            elif type(key_resource_identifier) == ValidationResultIdentifier:
-                # FIXME: review and correct this hardcoded logic
-                if key_resource_identifier.run_id == "profiling":
-                    section_name = "profiling"
-                else:
-                    section_name = "validations"
-                validation = self.data_context.get_validation_result(
-                    data_asset_name=key_resource_identifier.expectation_suite_identifier.data_asset_name,
-                    expectation_suite_name=key_resource_identifier.expectation_suite_identifier.expectation_suite_name,
-                    run_id=key_resource_identifier.run_id
-                )
-                
-                validation_success = validation.success
-                
-                self.add_resource_info_to_index_links_dict(
-                    data_context=self.data_context,
-                    index_links_dict=index_links_dict,
-                    data_asset_name=key_resource_identifier.expectation_suite_identifier.data_asset_name,
-                    datasource=key_resource_identifier.expectation_suite_identifier.data_asset_name.datasource,
-                    generator=key_resource_identifier.expectation_suite_identifier.data_asset_name.generator,
-                    generator_asset=key_resource_identifier.expectation_suite_identifier.data_asset_name.generator_asset,
-                    expectation_suite_name=key_resource_identifier.expectation_suite_identifier.expectation_suite_name,
-                    section_name=section_name,
-                    run_id=key_resource_identifier.run_id,
-                    validation_success=validation_success
-                )
+        for profiling_result_key in profiling_result_keys:
+            validation = self.data_context.get_validation_result(
+                data_asset_name=profiling_result_key.expectation_suite_identifier.data_asset_name,
+                expectation_suite_name=profiling_result_key.expectation_suite_identifier.expectation_suite_name,
+                run_id=profiling_result_key.run_id
+            )
 
-        rendered_content = self.renderer_class.render(index_links_dict)
-        viewable_content = self.view_class.render(rendered_content)
+            validation_success = validation.success
+
+            self.add_resource_info_to_index_links_dict(
+                data_context=self.data_context,
+                index_links_dict=index_links_dict,
+                data_asset_name=profiling_result_key.expectation_suite_identifier.data_asset_name,
+                datasource=profiling_result_key.expectation_suite_identifier.data_asset_name.datasource,
+                generator=profiling_result_key.expectation_suite_identifier.data_asset_name.generator,
+                generator_asset=profiling_result_key.expectation_suite_identifier.data_asset_name.generator_asset,
+                expectation_suite_name=profiling_result_key.expectation_suite_identifier.expectation_suite_name,
+                section_name="profiling",
+                run_id=profiling_result_key.run_id,
+                validation_success=validation_success
+            )
+
+        for validation_result_key in validation_result_keys:
+            validation = self.data_context.get_validation_result(
+                data_asset_name=validation_result_key.expectation_suite_identifier.data_asset_name,
+                expectation_suite_name=validation_result_key.expectation_suite_identifier.expectation_suite_name,
+                run_id=validation_result_key.run_id
+            )
+
+            validation_success = validation.success
+
+            self.add_resource_info_to_index_links_dict(
+                data_context=self.data_context,
+                index_links_dict=index_links_dict,
+                data_asset_name=validation_result_key.expectation_suite_identifier.data_asset_name,
+                datasource=validation_result_key.expectation_suite_identifier.data_asset_name.datasource,
+                generator=validation_result_key.expectation_suite_identifier.data_asset_name.generator,
+                generator_asset=validation_result_key.expectation_suite_identifier.data_asset_name.generator_asset,
+                expectation_suite_name=validation_result_key.expectation_suite_identifier.expectation_suite_name,
+                section_name="validations",
+                run_id=validation_result_key.run_id,
+                validation_success=validation_success
+            )
+
+        try:
+            rendered_content = self.renderer_class.render(index_links_dict)
+            viewable_content = self.view_class.render(rendered_content)
+        except Exception as e:
+            logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
+            return None
 
         return (
             self.target_store.write_index_page(viewable_content),

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -21,12 +21,12 @@ class SiteIndexPageRenderer(Renderer):
         profiling_links = link_lists_dict.get("profiling_links")
         validations_links = link_lists_dict.get("validations_links")
         expectations_links = link_lists_dict.get("expectations_links")
-        
+
         cell_width_pct = 100.0/(column_count + 1)
 
         first_row = []
         rowspan = str(len(expectations_links)) if expectations_links else "1"
-        
+
         data_asset_name = RenderedStringTemplateContent(**{
             "content_block_type": "string_template",
             "string_template": {
@@ -60,7 +60,7 @@ class SiteIndexPageRenderer(Renderer):
             }
         })
         first_row.append(data_asset_name)
-        
+
         if "profiling_links" in link_list_keys_to_render:
             profiling_results_bullets = [
                 RenderedStringTemplateContent(**{
@@ -98,7 +98,7 @@ class SiteIndexPageRenderer(Renderer):
                 }
             })
             first_row.append(profiling_results_bullet_list)
-            
+
         if "expectations_links" in link_list_keys_to_render:
             if len(expectations_links) > 0:
                 expectation_suite_link_dict = expectations_links[0]
@@ -134,7 +134,7 @@ class SiteIndexPageRenderer(Renderer):
                 }
             })
             first_row.append(expectation_suite_link)
-            
+
             if "validations_links" in link_list_keys_to_render and "expectations_links" in link_list_keys_to_render:
                 sorted_validations_links = [
                     link_dict for link_dict in sorted(validations_links, key=lambda x: x["run_id"], reverse=True)
@@ -240,14 +240,14 @@ class SiteIndexPageRenderer(Renderer):
                 }
             })
             first_row.append(validation_link_bullet_list)
-        
+
         section_rows.append(first_row)
-        
+
         if "expectations_links" in link_list_keys_to_render and len(expectations_links) > 1:
             for expectation_suite_link_dict in expectations_links[1:]:
                 expectation_suite_row = []
                 expectation_suite_name = expectation_suite_link_dict["expectation_suite_name"]
-    
+
                 expectation_suite_link = RenderedStringTemplateContent(**{
                     "content_block_type": "string_template",
                     "string_template": {
@@ -272,7 +272,7 @@ class SiteIndexPageRenderer(Renderer):
                     }
                 })
                 expectation_suite_row.append(expectation_suite_link)
-    
+
                 if "validations_links" in link_list_keys_to_render:
                     sorted_validations_links = [
                         link_dict for link_dict in sorted(validations_links, key=lambda x: x["run_id"], reverse=True)
@@ -325,11 +325,11 @@ class SiteIndexPageRenderer(Renderer):
                         }
                     })
                     expectation_suite_row.append(validation_link_bullet_list)
-                    
+
                 section_rows.append(expectation_suite_row)
-            
+
         return section_rows
-        
+
     @classmethod
     def render(cls, index_links_dict):
 

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import logging
 
 from .renderer import Renderer
 from great_expectations.render.types import (
@@ -8,6 +9,8 @@ from great_expectations.render.types import (
 )
 
 from .call_to_action_renderer import CallToActionRenderer
+
+logger = logging.getLogger(__name__)
 
 # FIXME : This class needs to be rebuilt to accept SiteSectionIdentifiers as input.
 # FIXME : This class needs tests.

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -337,49 +337,18 @@ class SiteIndexPageRenderer(Renderer):
         cta_object = index_links_dict.pop("cta_object", None)
 
         for source, generators in index_links_dict.items():
-            content_blocks = []
-
-            # datasource header
-            source_header_block = RenderedHeaderContent(**{
-                "content_block_type": "header",
-                "header": RenderedStringTemplateContent(**{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "$title_prefix | $source",
-                        "params": {
-                            "source": source,
-                            "title_prefix": "Datasource"
-                        },
-                        "styling": {
-                            "params": {
-                                "title_prefix": {
-                                    "tag": "strong"
-                                }
-                            }
-                        },
-                    }
-                }),
-                "styling": {
-                    "classes": ["col-12", "ge-index-page-datasource-title"],
-                    "header": {
-                        "classes": ["alert", "alert-secondary"]
-                    }
-                }
-            })
-            content_blocks.append(source_header_block)
-
-            # generator header
-            for generator, data_assets in generators.items():
-                generator_header_block = RenderedHeaderContent(**{
+            try:
+                content_blocks = []
+                # datasource header
+                source_header_block = RenderedHeaderContent(**{
                     "content_block_type": "header",
-                    "header": "",
-                    "subheader": RenderedStringTemplateContent(**{
+                    "header": RenderedStringTemplateContent(**{
                         "content_block_type": "string_template",
                         "string_template": {
-                            "template": "$title_prefix | $generator",
+                            "template": "$title_prefix | $source",
                             "params": {
-                                "generator": generator,
-                                "title_prefix": "Data Asset Generator"
+                                "source": source,
+                                "title_prefix": "Datasource"
                             },
                             "styling": {
                                 "params": {
@@ -391,75 +360,113 @@ class SiteIndexPageRenderer(Renderer):
                         }
                     }),
                     "styling": {
-                        "classes": ["col-12", "ml-4", "ge-index-page-generator-title"],
-                    }
-                })
-                content_blocks.append(generator_header_block)
-
-                generator_table_rows = []
-                generator_table_header_row = [RenderedStringTemplateContent(**{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": "Data Asset",
-                        "params": {},
-                        "styling": {
-                            "classes": ["ge-index-page-generator-table-data-asset-header"],
+                        "classes": ["col-12", "ge-index-page-datasource-title"],
+                        "header": {
+                            "classes": ["alert", "alert-secondary"]
                         }
                     }
-                })]
-                link_list_keys_to_render = []
-                
-                header_dict = OrderedDict([
-                    ["profiling_links", "Profiling Results"],
-                    ["expectations_links", "Expectation Suite"],
-                    ["validations_links", "Validation Results"]
-                ])
-                
-                for link_lists_key, header in header_dict.items():
-                    for data_asset, link_lists in data_assets.items():
-                        if header in generator_table_header_row:
-                            continue
-                        if link_lists.get(link_lists_key):
-                            class_header_str = link_lists_key.replace("_", "-")
-                            class_str = "ge-index-page-generator-table-{}-header".format(class_header_str)
-                            header = RenderedStringTemplateContent(**{
-                                "content_block_type": "string_template",
-                                "string_template": {
-                                    "template": header,
-                                    "params": {},
-                                    "styling": {
-                                        "classes": [class_str],
+                })
+                content_blocks.append(source_header_block)
+
+                # generator header
+                for generator, data_assets in generators.items():
+                    generator_header_block = RenderedHeaderContent(**{
+                        "content_block_type": "header",
+                        "header": "",
+                        "subheader": RenderedStringTemplateContent(**{
+                            "content_block_type": "string_template",
+                            "string_template": {
+                                "template": "$title_prefix | $generator",
+                                "params": {
+                                    "generator": generator,
+                                    "title_prefix": "Data Asset Generator"
+                                },
+                                "styling": {
+                                    "params": {
+                                        "title_prefix": {
+                                            "tag": "strong"
+                                        }
                                     }
-                                }
-                            })
-                            generator_table_header_row.append(header)
-                            link_list_keys_to_render.append(link_lists_key)
-                
-                generator_table = RenderedTableContent(**{
-                    "content_block_type": "table",
-                    "header_row": generator_table_header_row,
-                    "table": generator_table_rows,
-                    "styling": {
-                        "classes": ["col-12", "ge-index-page-generator-table-container", "pl-5", "pr-4"],
-                        "styles": {
-                            "margin-top": "10px"
-                        },
-                        "body": {
-                            "classes": ["table", "table-sm", "ge-index-page-generator-table"]
+                                },
+                            }
+                        }),
+                        "styling": {
+                            "classes": ["col-12", "ml-4", "ge-index-page-generator-title"],
                         }
-                    }
-                })
-                # data_assets
-                for data_asset, link_lists in data_assets.items():
-                    generator_table_rows += cls._generate_data_asset_table_section(data_asset, link_lists, link_list_keys_to_render=link_list_keys_to_render)
-                    
-                content_blocks.append(generator_table)
+                    })
+                    content_blocks.append(generator_header_block)
 
-            section = RenderedSectionContent(**{
-                "section_name": source,
-                "content_blocks": content_blocks
-            })
-            sections.append(section)
+                    generator_table_rows = []
+                    generator_table_header_row = [RenderedStringTemplateContent(**{
+                        "content_block_type": "string_template",
+                        "string_template": {
+                            "template": "Data Asset",
+                            "params": {},
+                            "styling": {
+                                "classes": ["ge-index-page-generator-table-data-asset-header"],
+                            }
+                        }
+                    })]
+                    link_list_keys_to_render = []
+
+                    header_dict = OrderedDict([
+                        ["profiling_links", "Profiling Results"],
+                        ["expectations_links", "Expectation Suite"],
+                        ["validations_links", "Validation Results"]
+                    ])
+
+                    for link_lists_key, header in header_dict.items():
+                        for data_asset, link_lists in data_assets.items():
+                            if header in generator_table_header_row:
+                                continue
+                            if link_lists.get(link_lists_key):
+                                class_header_str = link_lists_key.replace("_", "-")
+                                class_str = "ge-index-page-generator-table-{}-header".format(class_header_str)
+                                header = RenderedStringTemplateContent(**{
+                                    "content_block_type": "string_template",
+                                    "string_template": {
+                                        "template": header,
+                                        "params": {},
+                                        "styling": {
+                                            "classes": [class_str],
+                                        }
+                                    }
+                                })
+                                generator_table_header_row.append(header)
+                                link_list_keys_to_render.append(link_lists_key)
+
+                    generator_table = RenderedTableContent(**{
+                        "content_block_type": "table",
+                        "header_row": generator_table_header_row,
+                        "table": generator_table_rows,
+                        "styling": {
+                            "classes": ["col-12", "ge-index-page-generator-table-container", "pl-5", "pr-4"],
+                            "styles": {
+                                "margin-top": "10px"
+                            },
+                            "body": {
+                                "classes": ["table", "table-sm", "ge-index-page-generator-table"]
+                            }
+                        }
+                    })
+                    # data_assets
+                    for data_asset, link_lists in data_assets.items():
+                        try:
+                            generator_table_rows += cls._generate_data_asset_table_section(data_asset, link_lists, link_list_keys_to_render=link_list_keys_to_render)
+                        except Exception as e:
+                            logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
+                            continue
+
+                    content_blocks.append(generator_table)
+
+                section = RenderedSectionContent(**{
+                    "section_name": source,
+                    "content_blocks": content_blocks
+                })
+                sections.append(section)
+            except Exception as e:
+                logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
+                continue
 
         index_page_document = RenderedDocumentContent(**{
             "renderer_type": "SiteIndexPageRenderer",


### PR DESCRIPTION
- add ability to limit validations rendered by setting `validation_results_limit` in site config:
```
    site_index_builder:
      class_name: DefaultSiteIndexBuilder
      show_cta_footer: true
      validation_results_limit: 5
```
- add exception handling in site builder and index page renderer