### PR TITLE
Feature/validation page formatting

### DIFF
--- a/great_expectations/render/renderer/column_section_renderer.py
+++ b/great_expectations/render/renderer/column_section_renderer.py
@@ -76,10 +76,10 @@ class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
             "_render_overview_table",
             "_render_quantile_table",
             "_render_stats_table",
+            "_render_values_set",
             "_render_histogram",
             "_render_bar_chart_table",
             "_render_failed",
-            "_render_values_set",
         ]
 
     #Note: Seems awkward to pass section_name and column_type into this renderer.
@@ -129,7 +129,7 @@ class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
                             },
                             "tag": "h5",
                             "styling": {
-                                "classes": ["m-0"]
+                                "classes": ["m-0", "p-0"]
                             }
                         }
                     }),
@@ -151,7 +151,7 @@ class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
             #     "template": column_type,
             # },
             "styling": {
-                "classes": ["col-12"],
+                "classes": ["col-12", "p-0"],
                 "header": {
                     "classes": ["alert", "alert-secondary"]
                 }
@@ -245,7 +245,7 @@ class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
                 }
             })
             new_content_block.styling = {
-                "classes": ["col-4", "mt-1"],
+                "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
                 "body": {
                     "classes": ["table", "table-sm", "table-unbordered"],
                     "styles": {
@@ -303,7 +303,7 @@ class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
             }),
             "table": table_rows,
             "styling": {
-                "classes": ["col-4", "mt-1"],
+                "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
                 "body": {
                     "classes": ["table", "table-sm", "table-unbordered"],
                 }
@@ -390,7 +390,7 @@ class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
                 }),
                 "table": table_rows,
                 "styling": {
-                    "classes": ["col-4", "mt-1"],
+                    "classes": ["col-3", "mt-1", "pl-1", "pr-1"],
                     "body": {
                         "classes": ["table", "table-sm", "table-unbordered"],
                     }
@@ -417,7 +417,7 @@ class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
         else:
             return
 
-        classes = ["col-4", "mt-1"]
+        classes = ["col-3", "mt-1", "pl-1", "pr-1"]
 
         if any(len(value) > 80 for value in values):
             content_block_type = "bullet_list"
@@ -625,7 +625,7 @@ class ValidationResultsColumnSectionRenderer(ColumnSectionRenderer):
                 }
             }),
             "styling": {
-                "classes": ["col-12"],
+                "classes": ["col-12", "p-0"],
                 "header": {
                     "classes": ["alert", "alert-secondary"]
                 }

--- a/great_expectations/render/renderer/content_block/expectation_string.py
+++ b/great_expectations/render/renderer/content_block/expectation_string.py
@@ -246,7 +246,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
 
         if params["column_list"] is None:
             template_str = "Must have a list of columns in a specific order, but that order is not specified."
-        
+
         else:
             template_str = "Must have these columns in this order: "
             for idx in range(len(params["column_list"]) - 1):
@@ -1536,10 +1536,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
                     "graph": chart,
                     "header": header,
                     "styling": {
-                        "classes": ["col-" + str(chart_container_col_width)],
-                        "styles": {
-                            "margin-top": "20px",
-                        },
+                        "classes": ["col-" + str(chart_container_col_width), "mt-1", "pl-1", "pr-1"],
                         "parent": {
                             "styles": {
                                 "list-style-type": "none"
@@ -1552,10 +1549,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
                     "content_block_type": "graph",
                     "graph": chart,
                     "styling": {
-                        "classes": ["col-" + str(chart_container_col_width)],
-                        "styles": {
-                            "margin-top": "20px",
-                        },
+                        "classes": ["col-" + str(chart_container_col_width), "mt-1", "pl-1", "pr-1"],
                         "parent": {
                             "styles": {
                                 "list-style-type": "none"

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -32,7 +32,7 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
         "body": {
             "classes": ["table"],
         },
-        "classes": ["ml-3", "mr-3", "mt-0", "mb-0", "table-responsive"],
+        "classes": ["ml-2", "mr-2", "mt-0", "mb-0", "table-responsive"],
     }
 
     @classmethod

--- a/great_expectations/render/renderer/other_section_renderer.py
+++ b/great_expectations/render/renderer/other_section_renderer.py
@@ -44,7 +44,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
                 }
             }),
             "styling": {
-                "classes": ["col-12"],
+                "classes": ["col-12", "p-0"],
                 "header": {
                     "classes": ["alert", "alert-secondary"]
                 }
@@ -91,7 +91,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
             }),
             "table": table_rows,
             "styling": {
-                "classes": ["col-6", "mt-1"],
+                "classes": ["col-6", "mt-1", "p-1"],
                 "body": {
                     "classes": ["table", "table-sm"]
                 }

--- a/great_expectations/render/renderer/other_section_renderer.py
+++ b/great_expectations/render/renderer/other_section_renderer.py
@@ -5,7 +5,12 @@ from .renderer import Renderer
 from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
 from great_expectations.render.types import (
     RenderedSectionContent,
-    RenderedHeaderContent, RenderedStringTemplateContent, RenderedTableContent, RenderedBulletListContent)
+    RenderedHeaderContent,
+    RenderedStringTemplateContent,
+    RenderedTableContent,
+    RenderedBulletListContent,
+    CollapseContent
+)
 
 
 class ProfilingResultsOverviewSectionRenderer(Renderer):
@@ -117,7 +122,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
             }),
             "table": table_rows,
             "styling": {
-                "classes": ["col-6", "table-responsive", "mt-1"],
+                "classes": ["col-6", "table-responsive", "mt-1", "p-1"],
                 "body": {
                     "classes": ["table", "table-sm"]
                 }
@@ -132,10 +137,9 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         for evr in evrs.results:
             type_counts[evr.expectation_config.expectation_type] += 1
 
-        # table_rows = sorted(type_counts.items(), key=lambda kv: -1*kv[1])
-        bullet_list = sorted(type_counts.items(), key=lambda kv: -1 * kv[1])
+        bullet_list_items = sorted(type_counts.items(), key=lambda kv: -1 * kv[1])
 
-        bullet_list = [
+        bullet_list_items = [
             RenderedStringTemplateContent(**{
                 "content_block_type": "string_template",
                 "string_template": {
@@ -152,38 +156,36 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
                             }
                         }
                     }
+                },
+                "styling": {
+                    'parent': {
+                        'styles': {
+                            'list-style-type': 'none'
+                        }
+                    }
                 }
-            }) for tr in bullet_list]
+            }) for tr in bullet_list_items]
 
-        content_blocks.append(RenderedBulletListContent(**{
+        bullet_list = RenderedBulletListContent(**{
             "content_block_type": "bullet_list",
-            "header": RenderedStringTemplateContent(**{
-                "content_block_type": "string_template",
-                "string_template": {
-                    "template": 'Expectation types <span class="mr-3 triangle"></span>',
-                    "tag": "h6"
-                }
-            }),
-            "bullet_list": bullet_list,
+            "bullet_list": bullet_list_items,
             "styling": {
                 "classes": ["col-12", "mt-1"],
-                "header": {
-                    "classes": ["collapsed"],
-                    "attributes": {
-                        "data-toggle": "collapse",
-                        "href": "#{{content_block_id}}-body",
-                        "aria-expanded": "true",
-                        "aria-controls": "collapseExample",
-                    },
-                    "styles": {
-                        "cursor": "pointer"
-                    }
-                },
                 "body": {
-                    "classes": ["list-group", "collapse"],
+                    "classes": ["list-group"],
                 },
             },
-        }))
+        })
+
+        bullet_list_collapse = CollapseContent(**{
+            "collapse_toggle_link_text": "Show Expectation Types...",
+            "collapse": [bullet_list],
+            "styling": {
+                "classes": ["col-12", "p-1"]
+            }
+        })
+
+        content_blocks.append(bullet_list_collapse)
 
     @classmethod
     def _render_warnings(cls, evrs, content_blocks):

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -188,7 +188,7 @@ class ValidationResultsPageRenderer(Renderer):
                 }
             }),
             "styling": {
-                "classes": ["col-12"],
+                "classes": ["col-12", "p-0"],
                 "header": {
                     "classes": ["alert", "alert-secondary"]
                 }
@@ -319,7 +319,7 @@ class ValidationResultsPageRenderer(Renderer):
                 "content_block_type": "table",
                 "table": table_rows,
                 "styling": {
-                    "classes": ["col-12", "table-responsive"],
+                    "classes": ["col-6", "table-responsive"],
                     "body": {
                         "classes": ["table", "table-sm", "m-0"]
                     },
@@ -343,7 +343,7 @@ class ValidationResultsPageRenderer(Renderer):
             }),
                 "table": table_rows,
                 "styling": {
-                    "classes": ["col-12", "table-responsive", "mt-1"],
+                    "classes": ["col-6", "table-responsive", "mt-1"],
                     "body": {
                         "classes": ["table", "table-sm"]
                     }
@@ -382,7 +382,7 @@ class ValidationResultsPageRenderer(Renderer):
             }),
             "table": table_rows,
             "styling": {
-                "classes": ["col-6", "table-responsive", "mt-1"],
+                "classes": ["col-6", "table-responsive", "mt-1", "p-1"],
                 "body": {
                     "classes": ["table", "table-sm"]
                 }

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -227,6 +227,34 @@ class TextContent(RenderedComponentContent):
         return d
 
 
+class CollapseContent(RenderedComponentContent):
+    def __init__(self, collapse, collapse_toggle_link_text=None, header=None, subheader=None, styling=None,
+                 content_block_type="collapse"):
+        super(CollapseContent, self).__init__(content_block_type=content_block_type, styling=styling)
+        self.collapse_toggle_link_text = collapse_toggle_link_text
+        self.header = header
+        self.subheader = subheader
+        self.collapse = collapse
+
+    def to_json_dict(self):
+        d = super(CollapseContent, self).to_json_dict()
+        if self.header is not None:
+            if isinstance(self.header, RenderedContent):
+                d["header"] = self.header.to_json_dict()
+            else:
+                d["header"] = self.header
+        if self.subheader is not None:
+            if isinstance(self.subheader, RenderedContent):
+                d["subheader"] = self.subheader.to_json_dict()
+            else:
+                d["subheader"] = self.subheader
+        if self.collapse_toggle_link_text is not None:
+            d["collapse_toggle_link_text"] = self.collapse_toggle_link_text
+        d["collapse"] = RenderedContent.rendered_content_list_to_json(self.collapse)
+
+        return d
+
+
 class RenderedDocumentContent(RenderedContent):
     # NOTE: JPC 20191028 - review these keys to consolidate and group
     def __init__(self, sections, data_asset_name=None, full_data_asset_identifier=None, renderer_type=None,

--- a/great_expectations/render/view/static/styles/data_docs_default_styles.css
+++ b/great_expectations/render/view/static/styles/data_docs_default_styles.css
@@ -39,27 +39,6 @@ body {
   padding-bottom: 20px;
 }
 
-.triangle {
-  border: solid #222;
-  border-width: 0 1px 1px 0;
-  display: inline;
-  cursor: pointer;
-  padding: 3px;
-  position: absolute;
-  right: 0;
-  margin-top: 10px;
-
-  transform: rotate(40deg);
-  -webkit-transform: rotate(40deg);
-  transition: .3s transform ease-in-out;
-}
-
-.collapsed .triangle {
-  transform: rotate(-140deg);
-  -webkit-transform: rotate(-140deg);
-  transition: .3s transform ease-in-out;
-}
-
 .popover {
   max-width: 100%;
 }

--- a/great_expectations/render/view/templates/collapse.j2
+++ b/great_expectations/render/view/templates/collapse.j2
@@ -1,0 +1,35 @@
+{% set collapse_toggle_link_text = content_block.get("collapse_toggle_link_text", "Show more...") %}
+
+{% if "styling" in content_block and "parent" in content_block["styling"] -%}
+    {% set content_block_parent_styling = content_block["styling"]["parent"] | render_styling -%}
+{% else -%}
+    {% set content_block_parent_styling = "" -%}
+{% endif -%}
+
+{% if "styling" in content_block and content_block["styling"].get("body") -%}
+  {% set content_block_body_styling_dict = content_block["styling"]["body"] %}
+  {% if content_block_body_styling_dict.get("classes") %}
+    {% do content_block_body_styling_dict["classes"].append("collapse") %}
+  {% endif %}
+    {% set content_block_body_styling = content_block_body_styling_dict | render_styling -%}
+{% else -%}
+  {% set content_block_body_styling_dict = {"classes": ["collapse"]} %}
+  {% set content_block_body_styling = content_block_body_styling_dict | render_styling -%}
+{% endif -%}
+
+<div id="{{content_block_id}}-parent" {{ content_block_parent_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
+  <p>
+    <a data-toggle="collapse" href="#{{content_block_id}}-collapse-body" aria-expanded="false" aria-controls="{{content_block_id}}-collapse-body">
+      {{ collapse_toggle_link_text | render_content_block }}
+    </a>
+  </p>
+
+  <div id="{{content_block_id}}-collapse-body" {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
+    {% include 'content_block_header.j2' %}
+    {% for block in content_block["collapse"] %}
+      {% set collapse_block_loop = loop %}
+      {% set content_block_id = content_block_id ~ "-collapse-item-" ~ collapse_block_loop.index %}
+      {{ block | render_content_block }}
+    {% endfor %}
+  </div>
+</div>

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -91,7 +91,8 @@ class DefaultJinjaView(object):
 
         env = Environment(
             loader=ChoiceLoader(loaders),
-            autoescape=select_autoescape(['html', 'xml'])
+            autoescape=select_autoescape(['html', 'xml']),
+            extensions=["jinja2.ext.do"]
         )
         env.filters['render_string_template'] = self.render_string_template
         env.filters['render_styling_from_string_template'] = self.render_styling_from_string_template


### PR DESCRIPTION
- reintroduced validation result info, batch_id, and batch_kwargs and place in new collapse content block
- switched over "expectation types" section in profiling page to new collapse content block
- minor ui refinements to increase UI density (margin/padding adjustments)

<img width="1675" alt="Screenshot 2019-12-18 23 32 30" src="https://user-images.githubusercontent.com/3468435/71154318-1d8f0000-21f0-11ea-848e-c7055b77403c.png">
<img width="1676" alt="Screenshot 2019-12-18 23 32 48" src="https://user-images.githubusercontent.com/3468435/71154333-2384e100-21f0-11ea-9c58-78d228c32cbe.png">
<img width="1680" alt="Screenshot 2019-12-18 23 30 34" src="https://user-images.githubusercontent.com/3468435/71154357-34cded80-21f0-11ea-9d51-766bd5b9ab4c.png">
<img width="1676" alt="Screenshot 2019-12-18 23 30 51" src="https://user-images.githubusercontent.com/3468435/71154360-38fa0b00-21f0-11ea-8cad-1f7defb18350.png">
