### PR TITLE
Fixing expectation glossary link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Expectations are assertions for data. They are the workhorse abstraction in Grea
 - `expect_column_values_to_match_strftime_format`
 - `expect_table_row_count_to_be_between`
 - `expect_column_median_to_be_between`
-- ...and [many more](https://docs.greatexpectations.io/en/latest/reference/expectation_glossary.html)
+- ...and [many more](https://docs.greatexpectations.io/en/latest/expectation_glossary.html)
 
 Expectations are <!--[declarative, flexible and extensible]()--> declarative, flexible and extensible.
 <!--To test out Expectations on your own data, check out the [<<step-1 tutorial>>]().-->


### PR DESCRIPTION
The expectation glossary link in the existing README is broken. I've updated the link to reflect what I think is the analogous page in the current build on Read the Docs.