### PR TITLE
Change Expectation Notes toggle to inline icon instead of block text

### DIFF
--- a/great_expectations/render/renderer/content_block/expectation_string.py
+++ b/great_expectations/render/renderer/content_block/expectation_string.py
@@ -1420,7 +1420,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
             expectation["kwargs"],
             ["column", "quantile_ranges"]
         )
-        template_str = "Column quantiles must be within the following value ranges:\n\n"
+        template_str = "quantiles must be within the following value ranges."
 
         if include_column_name:
             template_str = "$column " + template_str
@@ -1459,7 +1459,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
             "table": table_rows,
             "styling": {
                 "body": {
-                    "classes": ["table", "table-sm", "table-unbordered", "col-4"],
+                    "classes": ["table", "table-sm", "table-unbordered", "col-4", "mt-2"],
                 },
                 "parent": {
                     "styles": {
@@ -1536,7 +1536,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
                     "graph": chart,
                     "header": header,
                     "styling": {
-                        "classes": ["col-" + str(chart_container_col_width), "mt-1", "pl-1", "pr-1"],
+                        "classes": ["col-" + str(chart_container_col_width), "mt-2", "pl-1", "pr-1"],
                         "parent": {
                             "styles": {
                                 "list-style-type": "none"
@@ -1549,7 +1549,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
                     "content_block_type": "graph",
                     "graph": chart,
                     "styling": {
-                        "classes": ["col-" + str(chart_container_col_width), "mt-1", "pl-1", "pr-1"],
+                        "classes": ["col-" + str(chart_container_col_width), "mt-2", "pl-1", "pr-1"],
                         "parent": {
                             "styles": {
                                 "list-style-type": "none"
@@ -1568,10 +1568,10 @@ class ExpectationStringRenderer(ContentBlockRenderer):
 
         expected_distribution = None
         if not params.get("partition_object"):
-            template_str = "Column can match any distribution."
+            template_str = "can match any distribution."
         else:
             template_str = "Kullback-Leibler (KL) divergence with respect to the following distribution must be " \
-                           "lower than $threshold:\n\n"
+                           "lower than $threshold."
             expected_distribution = cls._get_kl_divergence_chart(params.get("partition_object"))
 
         if include_column_name:

--- a/great_expectations/render/renderer/other_section_renderer.py
+++ b/great_expectations/render/renderer/other_section_renderer.py
@@ -178,7 +178,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         })
 
         bullet_list_collapse = CollapseContent(**{
-            "collapse_toggle_link_text": "Show Expectation Types...",
+            "collapse_toggle_link": "Show Expectation Types...",
             "collapse": [bullet_list],
             "styling": {
                 "classes": ["col-12", "p-1"]

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -95,7 +95,7 @@ class ValidationResultsPageRenderer(Renderer):
             )
 
         collapse_content_block = CollapseContent(**{
-            "collapse_toggle_link_text": "Show more info...",
+            "collapse_toggle_link": "Show more info...",
             "collapse": collapse_content_blocks,
             "styling": {
                 "body": {

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -228,13 +228,14 @@ class TextContent(RenderedComponentContent):
 
 
 class CollapseContent(RenderedComponentContent):
-    def __init__(self, collapse, collapse_toggle_link_text=None, header=None, subheader=None, styling=None,
-                 content_block_type="collapse"):
+    def __init__(self, collapse, collapse_toggle_link=None, header=None, subheader=None, styling=None,
+                 content_block_type="collapse", inline_link=False):
         super(CollapseContent, self).__init__(content_block_type=content_block_type, styling=styling)
-        self.collapse_toggle_link_text = collapse_toggle_link_text
+        self.collapse_toggle_link = collapse_toggle_link
         self.header = header
         self.subheader = subheader
         self.collapse = collapse
+        self.inline_link = inline_link
 
     def to_json_dict(self):
         d = super(CollapseContent, self).to_json_dict()
@@ -248,9 +249,13 @@ class CollapseContent(RenderedComponentContent):
                 d["subheader"] = self.subheader.to_json_dict()
             else:
                 d["subheader"] = self.subheader
-        if self.collapse_toggle_link_text is not None:
-            d["collapse_toggle_link_text"] = self.collapse_toggle_link_text
+        if self.collapse_toggle_link is not None:
+            if isinstance(self.collapse_toggle_link, RenderedContent):
+                d["collapse_toggle_link"] = self.collapse_toggle_link.to_json_dict()
+            else:
+                d["collapse_toggle_link"] = self.collapse_toggle_link
         d["collapse"] = RenderedContent.rendered_content_list_to_json(self.collapse)
+        d["inline_link"] = self.inline_link
 
         return d
 

--- a/great_expectations/render/view/templates/collapse.j2
+++ b/great_expectations/render/view/templates/collapse.j2
@@ -1,4 +1,4 @@
-{% set collapse_toggle_link_text = content_block.get("collapse_toggle_link_text", "Show more...") %}
+{% set collapse_toggle_link = content_block.get("collapse_toggle_link", "Show more...") %}
 
 {% if "styling" in content_block and "parent" in content_block["styling"] -%}
     {% set content_block_parent_styling = content_block["styling"]["parent"] | render_styling -%}
@@ -18,14 +18,30 @@
   {% set content_block_body_styling = content_block_body_styling_dict | render_styling -%}
 {% endif -%}
 
+{% if "styling" in content_block and content_block["styling"].get("collapse_link") %}
+  {% set collapse_link_styling = content_block["styling"].get("collapse_link") %}
+{% else %}
+  {% set collapse_link_styling = "" %}
+{% endif %}
+
 {% set collapse_id = content_block_id ~ "-collapse-body-" | generate_html_element_uuid %}
 
-<div id="{{content_block_id}}-parent" {{ content_block_parent_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
-  <p class="m-0">
-    <a data-toggle="collapse" href="#{{collapse_id}}" aria-expanded="false" aria-controls="{{content_block_id}}-collapse-body">
-      {{ collapse_toggle_link_text | render_content_block }}
+{% if content_block["inline_link"] %}
+  <span class="m-0">
+    <a data-toggle="collapse" href="#{{collapse_id}}" aria-expanded="false" aria-controls="{{content_block_id}}-collapse-body" {{ collapse_link_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
+      {{ collapse_toggle_link | render_content_block }}
     </a>
-  </p>
+  </span>
+{% endif %}
+
+<div id="{{content_block_id}}-parent" {{ content_block_parent_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
+  {% if not content_block["inline_link"] %}
+    <p class="m-0">
+      <a data-toggle="collapse" href="#{{collapse_id}}" aria-expanded="false" aria-controls="{{content_block_id}}-collapse-body" {{ collapse_link_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
+        {{ collapse_toggle_link | render_content_block }}
+      </a>
+    </p>
+  {% endif %}
 
   <div id={{collapse_id}} {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
     {% set content_block_body_styling = "" %}

--- a/great_expectations/render/view/templates/page_action_card.j2
+++ b/great_expectations/render/view/templates/page_action_card.j2
@@ -55,7 +55,7 @@
 
     <div class="mb-2">
       <div class="d-flex justify-content-center">
-        <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".ge-walkthrough-modal">
+        <button type="button" class="btn btn-info" data-toggle="modal" data-target=".ge-walkthrough-modal">
           Show Walkthrough
         </button>
       </div>

--- a/tests/jupyter_ux/test_jupyter_ux.py
+++ b/tests/jupyter_ux/test_jupyter_ux.py
@@ -42,10 +42,20 @@ def test_display_column_expectations_as_section(basic_expectation_suite):
                     is a required field.
                 </span>
             </li>
+        <li style="list-style-type:none;" >
+                <hr class="mt-1 mb-1" >
+                    
+                </hr>
+            </li>
         <li >
                 <span >
                     values must be unique.
                 </span>
+            </li>
+        <li style="list-style-type:none;" >
+                <hr class="mt-1 mb-1" >
+                    
+                </hr>
             </li>
 </ul>
 </div>
@@ -125,10 +135,18 @@ def test_display_column_expectations_as_section(basic_expectation_suite):
                     is a required field.
                 </span>
             </li>
+        <li style="list-style-type:none;" >
+                <hr class="mt-1 mb-1" >
+                </hr>
+            </li>
         <li >
                 <span >
                     values must be unique.
                 </span>
+            </li>
+        <li style="list-style-type:none;" >
+                <hr class="mt-1 mb-1" >
+                </hr>
             </li>
 </ul>
 </div>

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -350,49 +350,58 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_markdown_meta_no
                 'header': {'content_block_type': 'string_template', 'string_template': {
                     'template': 'Car Insurance Premiums ($$)', 'tag': 'h5',
                     'styling': {'classes': ['m-0']}}}},
-            {
-                'content_block_type': 'bullet_list', 'styling': {'classes': ['col-12']},
-                'bullet_list': [
-                    {
-                        'content_block_type': 'string_template',
-                        'string_template': {
-                            'template': 'value types must belong to this set: $v__'
-                                        '0 $v__1 $v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
-                            'params': {"column": "Car Insurance Premiums ($)",
-                                       "type_list": ["DOUBLE_PRECISION",
-                                                     "DoubleType", "FLOAT",
-                                                     "FLOAT4", "FLOAT8",
-                                                     "FloatType", "NUMERIC",
-                                                     "float"],
-                                       "result_format": "SUMMARY",
-                                       "mostly": None,
-                                       "v__0": "DOUBLE_PRECISION",
-                                       "v__1": "DoubleType", "v__2": "FLOAT",
-                                       "v__3": "FLOAT4", "v__4": "FLOAT8",
-                                       "v__5": "FloatType", "v__6": "NUMERIC",
-                                       "v__7": "float"}, 'styling': {
-                                'default': {
-                                    'classes': ['badge', 'badge-secondary']},
-                                'params': {'column': {
-                                    'classes': ['badge', 'badge-primary']}}}}},
-                    {'content_block_type': 'collapse', 'styling': {
-                        'body': {'classes': ['card', 'card-body', 'p-1']},
-                        'parent': {'styles': {'list-style-type': 'none'}}},
-                     'collapse_toggle_link_text': 'Show Expectation notes...',
-                     'collapse': [{'content_block_type': 'text',
-                                   'styling': {'classes': ['col-12', 'mt-2',
-                                                           'mb-2'],
-                                               'parent': {'styles': {
-                                                   'list-style-type': 'none'}}},
-                                   'subheader': 'Notes:', 'text': [
-                             {'content_block_type': 'markdown',
-                              'styling': {'parent': {}},
-                              'markdown': '#### These are expectation notes \n - you can use markdown \n - or just strings'}]}]},
-                    {'content_block_type': 'string_template', 'styling': {
-                        'parent': {'styles': {'list-style-type': 'none'}}},
-                     'string_template': {'template': '', 'tag': 'hr',
-                                         'styling': {
-                                             'classes': ['m-0']}}}]}],
+            {'content_block_type': 'bullet_list', 'styling': {'classes': ['col-12']},
+             'bullet_list': [[{'content_block_type': 'string_template',
+                               'string_template': {
+                                   'template': 'value types must belong to this set: $v__0'
+                                               ' $v__1 $v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
+                                   'params': {"column": "Car Insurance Premiums ($)",
+                                              "type_list": ["DOUBLE_PRECISION",
+                                                            "DoubleType", "FLOAT",
+                                                            "FLOAT4", "FLOAT8",
+                                                            "FloatType", "NUMERIC",
+                                                            "float"],
+                                              "result_format": "SUMMARY",
+                                              "mostly": None,
+                                              "v__0": "DOUBLE_PRECISION",
+                                              "v__1": "DoubleType", "v__2": "FLOAT",
+                                              "v__3": "FLOAT4", "v__4": "FLOAT8",
+                                              "v__5": "FloatType", "v__6": "NUMERIC",
+                                              "v__7": "float"}, 'styling': {
+                                       'default': {
+                                           'classes': ['badge', 'badge-secondary']},
+                                       'params': {'column': {'classes': ['badge',
+                                                                         'badge-primary']}}}}},
+                              {'content_block_type': 'collapse', 'styling': {
+                                  'body': {'classes': ['card', 'card-body', 'p-1']},
+                                  'parent': {'styles': {'list-style-type': 'none'}}},
+                               'collapse_toggle_link': {
+                                   'content_block_type': 'string_template',
+                                   'string_template': {'template': '$icon',
+                                                       'params': {'icon': ''},
+                                                       'styling': {'params': {
+                                                           'icon': {
+                                                               'classes': ['fas',
+                                                                           'fa-comment',
+                                                                           'text-info'],
+                                                               'tag': 'i'}}}}},
+                               'collapse': [{'content_block_type': 'text',
+                                             'styling': {
+                                                 'classes': ['col-12', 'mt-2',
+                                                             'mb-2'], 'parent': {
+                                                     'styles': {
+                                                         'list-style-type': 'none'}}},
+                                             'subheader': 'Notes:', 'text': [
+                                       {'content_block_type': 'markdown',
+                                        'styling': {'parent': {}},
+                                        'markdown': '#### These are expectation notes \n - '
+                                                    'you can use markdown \n - or just strings'}]}],
+                               'inline_link': True}],
+                             {'content_block_type': 'string_template', 'styling': {
+                                 'parent': {'styles': {'list-style-type': 'none'}}},
+                              'string_template': {'template': '', 'tag': 'hr',
+                                                  'styling': {'classes': ['mt-1',
+                                                                          'mb-1']}}}]}],
         'section_name': 'Car Insurance Premiums ($)'}
 
     result_json = ExpectationSuiteColumnSectionRenderer().render(expectations).to_json_dict()
@@ -445,45 +454,56 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_string_list_meta
                     'template': 'Car Insurance Premiums ($$)', 'tag': 'h5',
                     'styling': {'classes': ['m-0']}}}},
             {'content_block_type': 'bullet_list', 'styling': {'classes': ['col-12']},
-             'bullet_list': [{'content_block_type': 'string_template',
-                              'string_template': {
-                                  'template': 'value types must belong to this set: $v__0 $v'
-                                              '__1 $v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
-                                  'params': {"column": "Car Insurance Premiums ($)",
-                                             "type_list": ["DOUBLE_PRECISION",
-                                                           "DoubleType", "FLOAT",
-                                                           "FLOAT4", "FLOAT8",
-                                                           "FloatType", "NUMERIC",
-                                                           "float"],
-                                             "result_format": "SUMMARY",
-                                             "mostly": None,
-                                             "v__0": "DOUBLE_PRECISION",
-                                             "v__1": "DoubleType", "v__2": "FLOAT",
-                                             "v__3": "FLOAT4", "v__4": "FLOAT8",
-                                             "v__5": "FloatType", "v__6": "NUMERIC",
-                                             "v__7": "float"}, 'styling': {
-                                      'default': {
-                                          'classes': ['badge', 'badge-secondary']},
-                                      'params': {'column': {
-                                          'classes': ['badge', 'badge-primary']}}}}},
-                             {'content_block_type': 'collapse', 'styling': {
-                                 'body': {'classes': ['card', 'card-body', 'p-1']},
-                                 'parent': {'styles': {'list-style-type': 'none'}}},
-                              'collapse_toggle_link_text': 'Show Expectation notes...',
-                              'collapse': [{'content_block_type': 'text',
-                                            'styling': {'classes': ['col-12', 'mt-2',
-                                                                    'mb-2'],
-                                                        'parent': {'styles': {
-                                                            'list-style-type': 'none'}}},
-                                            'subheader': 'Notes:',
-                                            'text': ['This is a', 'string list,',
-                                                     "assigned to the 'content' key of a notes dict.",
-                                                     'Cool', 'huh?']}]},
+             'bullet_list': [[{'content_block_type': 'string_template',
+                               'string_template': {
+                                   'template': 'value types must belong to this set: $v__0 $v__1 '
+                                               '$v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
+                                   'params': {"column": "Car Insurance Premiums ($)",
+                                              "type_list": ["DOUBLE_PRECISION",
+                                                            "DoubleType", "FLOAT",
+                                                            "FLOAT4", "FLOAT8",
+                                                            "FloatType", "NUMERIC",
+                                                            "float"],
+                                              "result_format": "SUMMARY",
+                                              "mostly": None,
+                                              "v__0": "DOUBLE_PRECISION",
+                                              "v__1": "DoubleType", "v__2": "FLOAT",
+                                              "v__3": "FLOAT4", "v__4": "FLOAT8",
+                                              "v__5": "FloatType", "v__6": "NUMERIC",
+                                              "v__7": "float"}, 'styling': {
+                                       'default': {
+                                           'classes': ['badge', 'badge-secondary']},
+                                       'params': {'column': {'classes': ['badge',
+                                                                         'badge-primary']}}}}},
+                              {'content_block_type': 'collapse', 'styling': {
+                                  'body': {'classes': ['card', 'card-body', 'p-1']},
+                                  'parent': {'styles': {'list-style-type': 'none'}}},
+                               'collapse_toggle_link': {
+                                   'content_block_type': 'string_template',
+                                   'string_template': {'template': '$icon',
+                                                       'params': {'icon': ''},
+                                                       'styling': {'params': {
+                                                           'icon': {
+                                                               'classes': ['fas',
+                                                                           'fa-comment',
+                                                                           'text-info'],
+                                                               'tag': 'i'}}}}},
+                               'collapse': [{'content_block_type': 'text',
+                                             'styling': {
+                                                 'classes': ['col-12', 'mt-2',
+                                                             'mb-2'], 'parent': {
+                                                     'styles': {
+                                                         'list-style-type': 'none'}}},
+                                             'subheader': 'Notes:',
+                                             'text': ['This is a', 'string list,',
+                                                      "assigned to the 'content' key of a notes dict.",
+                                                      'Cool', 'huh?']}],
+                               'inline_link': True}],
                              {'content_block_type': 'string_template', 'styling': {
                                  'parent': {'styles': {'list-style-type': 'none'}}},
                               'string_template': {'template': '', 'tag': 'hr',
-                                                  'styling': {
-                                                      'classes': ['m-0']}}}]}],
+                                                  'styling': {'classes': ['mt-1',
+                                                                          'mb-1']}}}]}],
         'section_name': 'Car Insurance Premiums ($)'}
 
     result_json = ExpectationSuiteColumnSectionRenderer().render(expectations).to_json_dict()
@@ -530,45 +550,55 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_single_string_me
                     'template': 'Car Insurance Premiums ($$)', 'tag': 'h5',
                     'styling': {'classes': ['m-0']}}}},
             {'content_block_type': 'bullet_list', 'styling': {'classes': ['col-12']},
-             'bullet_list': [{'content_block_type': 'string_template',
-                              'string_template': {
-                                  'template': 'value types must belong to this set: $v__0 $v'
-                                              '__1 $v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
-                                  'params': {"column": "Car Insurance Premiums ($)",
-                                             "type_list": ["DOUBLE_PRECISION",
-                                                           "DoubleType", "FLOAT",
-                                                           "FLOAT4", "FLOAT8",
-                                                           "FloatType", "NUMERIC",
-                                                           "float"],
-                                             "result_format": "SUMMARY",
-                                             "mostly": None,
-                                             "v__0": "DOUBLE_PRECISION",
-                                             "v__1": "DoubleType", "v__2": "FLOAT",
-                                             "v__3": "FLOAT4", "v__4": "FLOAT8",
-                                             "v__5": "FloatType", "v__6": "NUMERIC",
-                                             "v__7": "float"}, 'styling': {
-                                      'default': {
-                                          'classes': ['badge', 'badge-secondary']},
-                                      'params': {'column': {
-                                          'classes': ['badge', 'badge-primary']}}}}},
-                             {'content_block_type': 'collapse', 'styling': {
-                                 'body': {'classes': ['card', 'card-body', 'p-1']},
-                                 'parent': {'styles': {'list-style-type': 'none'}}},
-                              'collapse_toggle_link_text': 'Show Expectation notes...',
-                              'collapse': [
-                                  {'content_block_type': 'text',
-                                   'styling': {'classes': ['col-12', 'mt-2',
-                                                           'mb-2'],
-                                               'parent': {'styles': {
-                                                   'list-style-type': 'none'}}},
-                                   'subheader': 'Notes:', 'text': [
-                                      "This is just a single string, assigned to the 'content' key of a notes dict."]}]
-                              },
+             'bullet_list': [[{'content_block_type': 'string_template',
+                               'string_template': {
+                                   'template': 'value types must belong to this set: $v__0 $v__1 '
+                                               '$v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
+                                   'params': {"column": "Car Insurance Premiums ($)",
+                                              "type_list": ["DOUBLE_PRECISION",
+                                                            "DoubleType", "FLOAT",
+                                                            "FLOAT4", "FLOAT8",
+                                                            "FloatType", "NUMERIC",
+                                                            "float"],
+                                              "result_format": "SUMMARY",
+                                              "mostly": None,
+                                              "v__0": "DOUBLE_PRECISION",
+                                              "v__1": "DoubleType", "v__2": "FLOAT",
+                                              "v__3": "FLOAT4", "v__4": "FLOAT8",
+                                              "v__5": "FloatType", "v__6": "NUMERIC",
+                                              "v__7": "float"}, 'styling': {
+                                       'default': {
+                                           'classes': ['badge', 'badge-secondary']},
+                                       'params': {'column': {'classes': ['badge',
+                                                                         'badge-primary']}}}}},
+                              {'content_block_type': 'collapse', 'styling': {
+                                  'body': {'classes': ['card', 'card-body', 'p-1']},
+                                  'parent': {'styles': {'list-style-type': 'none'}}},
+                               'collapse_toggle_link': {
+                                   'content_block_type': 'string_template',
+                                   'string_template': {'template': '$icon',
+                                                       'params': {'icon': ''},
+                                                       'styling': {'params': {
+                                                           'icon': {
+                                                               'classes': ['fas',
+                                                                           'fa-comment',
+                                                                           'text-info'],
+                                                               'tag': 'i'}}}}},
+                               'collapse': [{'content_block_type': 'text',
+                                             'styling': {
+                                                 'classes': ['col-12', 'mt-2',
+                                                             'mb-2'], 'parent': {
+                                                     'styles': {
+                                                         'list-style-type': 'none'}}},
+                                             'subheader': 'Notes:', 'text': [
+                                       "This is just a single string, assigned to the 'content' key of a notes dict."
+                                   ]}],
+                               'inline_link': True}],
                              {'content_block_type': 'string_template', 'styling': {
                                  'parent': {'styles': {'list-style-type': 'none'}}},
                               'string_template': {'template': '', 'tag': 'hr',
-                                                  'styling': {
-                                                      'classes': ['m-0']}}}]}],
+                                                  'styling': {'classes': ['mt-1',
+                                                                          'mb-1']}}}]}],
         'section_name': 'Car Insurance Premiums ($)'}
 
     result_json = ExpectationSuiteColumnSectionRenderer().render(expectations).to_json_dict()
@@ -612,45 +642,56 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_string_list_meta
                     'template': 'Car Insurance Premiums ($$)', 'tag': 'h5',
                     'styling': {'classes': ['m-0']}}}},
             {'content_block_type': 'bullet_list', 'styling': {'classes': ['col-12']},
-             'bullet_list': [{'content_block_type': 'string_template',
-                              'string_template': {
-                                  'template': 'value types must belong to this set: $v__0'
-                                              ' $v__1 $v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
-                                  'params': {"column": "Car Insurance Premiums ($)",
-                                             "type_list": ["DOUBLE_PRECISION",
-                                                           "DoubleType", "FLOAT",
-                                                           "FLOAT4", "FLOAT8",
-                                                           "FloatType", "NUMERIC",
-                                                           "float"],
-                                             "result_format": "SUMMARY",
-                                             "mostly": None,
-                                             "v__0": "DOUBLE_PRECISION",
-                                             "v__1": "DoubleType", "v__2": "FLOAT",
-                                             "v__3": "FLOAT4", "v__4": "FLOAT8",
-                                             "v__5": "FloatType", "v__6": "NUMERIC",
-                                             "v__7": "float"}, 'styling': {
-                                      'default': {
-                                          'classes': ['badge', 'badge-secondary']},
-                                      'params': {'column': {
-                                          'classes': ['badge', 'badge-primary']}}}}},
-                             {'content_block_type': 'collapse', 'styling': {
-                                 'body': {'classes': ['card', 'card-body', 'p-1']},
-                                 'parent': {'styles': {'list-style-type': 'none'}}},
-                              'collapse_toggle_link_text': 'Show Expectation notes...',
-                              'collapse': [{'content_block_type': 'text',
-                                            'styling': {'classes': ['col-12', 'mt-2',
-                                                                    'mb-2'],
-                                                        'parent': {'styles': {
-                                                            'list-style-type': 'none'}}},
-                                            'subheader': 'Notes:',
-                                            'text': ['This is a list', 'of strings',
-                                                     'assigned to the notes',
-                                                     'key.']}]},
+             'bullet_list': [[{'content_block_type': 'string_template',
+                               'string_template': {
+                                   'template': 'value types must belong to this set: $v__0 $v__1 '
+                                               '$v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
+                                   'params': {"column": "Car Insurance Premiums ($)",
+                                              "type_list": ["DOUBLE_PRECISION",
+                                                            "DoubleType", "FLOAT",
+                                                            "FLOAT4", "FLOAT8",
+                                                            "FloatType", "NUMERIC",
+                                                            "float"],
+                                              "result_format": "SUMMARY",
+                                              "mostly": None,
+                                              "v__0": "DOUBLE_PRECISION",
+                                              "v__1": "DoubleType", "v__2": "FLOAT",
+                                              "v__3": "FLOAT4", "v__4": "FLOAT8",
+                                              "v__5": "FloatType", "v__6": "NUMERIC",
+                                              "v__7": "float"}, 'styling': {
+                                       'default': {
+                                           'classes': ['badge', 'badge-secondary']},
+                                       'params': {'column': {'classes': ['badge',
+                                                                         'badge-primary']}}}}},
+                              {'content_block_type': 'collapse', 'styling': {
+                                  'body': {'classes': ['card', 'card-body', 'p-1']},
+                                  'parent': {'styles': {'list-style-type': 'none'}}},
+                               'collapse_toggle_link': {
+                                   'content_block_type': 'string_template',
+                                   'string_template': {'template': '$icon',
+                                                       'params': {'icon': ''},
+                                                       'styling': {'params': {
+                                                           'icon': {
+                                                               'classes': ['fas',
+                                                                           'fa-comment',
+                                                                           'text-info'],
+                                                               'tag': 'i'}}}}},
+                               'collapse': [{'content_block_type': 'text',
+                                             'styling': {
+                                                 'classes': ['col-12', 'mt-2',
+                                                             'mb-2'], 'parent': {
+                                                     'styles': {
+                                                         'list-style-type': 'none'}}},
+                                             'subheader': 'Notes:',
+                                             'text': ['This is a list', 'of strings',
+                                                      'assigned to the notes',
+                                                      'key.']}],
+                               'inline_link': True}],
                              {'content_block_type': 'string_template', 'styling': {
                                  'parent': {'styles': {'list-style-type': 'none'}}},
                               'string_template': {'template': '', 'tag': 'hr',
-                                                  'styling': {
-                                                      'classes': ['m-0']}}}]}],
+                                                  'styling': {'classes': ['mt-1',
+                                                                          'mb-1']}}}]}],
         'section_name': 'Car Insurance Premiums ($)'}
 
     result_json = ExpectationSuiteColumnSectionRenderer().render(expectations).to_json_dict()
@@ -685,51 +726,63 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_single_string_me
     expectations = [expectation_with_single_string_note]
     expected_result_json = {
         'content_blocks': [
-            {'content_block_type': 'header', 'styling': {'classes': ['col-12'],
-                                                         'header': {
-                                                             'classes': ['alert',
-                                                                         'alert-secondary']}},
-             'header': {'content_block_type': 'string_template', 'string_template': {
-                 'template': 'Car Insurance Premiums ($$)', 'tag': 'h5',
-                 'styling': {'classes': ['m-0']}}}},
+            {
+                'content_block_type': 'header', 'styling': {'classes': ['col-12'],
+                                                            'header': {
+                                                                'classes': ['alert',
+                                                                            'alert-secondary']}},
+                'header': {'content_block_type': 'string_template', 'string_template': {
+                    'template': 'Car Insurance Premiums ($$)', 'tag': 'h5',
+                    'styling': {'classes': ['m-0']}}}},
             {'content_block_type': 'bullet_list', 'styling': {'classes': ['col-12']},
-             'bullet_list': [{'content_block_type': 'string_template',
-                              'string_template': {
-                                  'template': 'value types must belong to this set: $v__0 '
-                                              '$v__1 $v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
-                                  'params': {"column": "Car Insurance Premiums ($)",
-                                             "type_list": ["DOUBLE_PRECISION",
-                                                           "DoubleType", "FLOAT",
-                                                           "FLOAT4", "FLOAT8",
-                                                           "FloatType", "NUMERIC",
-                                                           "float"],
-                                             "result_format": "SUMMARY",
-                                             "mostly": None,
-                                             "v__0": "DOUBLE_PRECISION",
-                                             "v__1": "DoubleType", "v__2": "FLOAT",
-                                             "v__3": "FLOAT4", "v__4": "FLOAT8",
-                                             "v__5": "FloatType", "v__6": "NUMERIC",
-                                             "v__7": "float"}, 'styling': {
-                                      'default': {
-                                          'classes': ['badge', 'badge-secondary']},
-                                      'params': {'column': {
-                                          'classes': ['badge', 'badge-primary']}}}}},
-                             {'content_block_type': 'collapse', 'styling': {
-                                 'body': {'classes': ['card', 'card-body', 'p-1']},
-                                 'parent': {'styles': {'list-style-type': 'none'}}},
-                              'collapse_toggle_link_text': 'Show Expectation notes...',
-                              'collapse': [{'content_block_type': 'text',
-                                            'styling': {'classes': ['col-12', 'mt-2',
-                                                                    'mb-2'],
-                                                        'parent': {'styles': {
-                                                            'list-style-type': 'none'}}},
-                                            'subheader': 'Notes:', 'text': [
-                                      "This is a single string assigned to the 'notes' key."]}]},
+             'bullet_list': [[{'content_block_type': 'string_template',
+                               'string_template': {
+                                   'template': 'value types must belong to this set: $v__0'
+                                               ' $v__1 $v__2 $v__3 $v__4 $v__5 $v__6 $v__7.',
+                                   'params': {"column": "Car Insurance Premiums ($)",
+                                              "type_list": ["DOUBLE_PRECISION",
+                                                            "DoubleType", "FLOAT",
+                                                            "FLOAT4", "FLOAT8",
+                                                            "FloatType", "NUMERIC",
+                                                            "float"],
+                                              "result_format": "SUMMARY",
+                                              "mostly": None,
+                                              "v__0": "DOUBLE_PRECISION",
+                                              "v__1": "DoubleType", "v__2": "FLOAT",
+                                              "v__3": "FLOAT4", "v__4": "FLOAT8",
+                                              "v__5": "FloatType", "v__6": "NUMERIC",
+                                              "v__7": "float"}, 'styling': {
+                                       'default': {
+                                           'classes': ['badge', 'badge-secondary']},
+                                       'params': {'column': {'classes': ['badge',
+                                                                         'badge-primary']}}}}},
+                              {'content_block_type': 'collapse', 'styling': {
+                                  'body': {'classes': ['card', 'card-body', 'p-1']},
+                                  'parent': {'styles': {'list-style-type': 'none'}}},
+                               'collapse_toggle_link': {
+                                   'content_block_type': 'string_template',
+                                   'string_template': {'template': '$icon',
+                                                       'params': {'icon': ''},
+                                                       'styling': {'params': {
+                                                           'icon': {
+                                                               'classes': ['fas',
+                                                                           'fa-comment',
+                                                                           'text-info'],
+                                                               'tag': 'i'}}}}},
+                               'collapse': [{'content_block_type': 'text',
+                                             'styling': {
+                                                 'classes': ['col-12', 'mt-2',
+                                                             'mb-2'], 'parent': {
+                                                     'styles': {
+                                                         'list-style-type': 'none'}}},
+                                             'subheader': 'Notes:', 'text': [
+                                       "This is a single string assigned to the 'notes' key."]}],
+                               'inline_link': True}],
                              {'content_block_type': 'string_template', 'styling': {
                                  'parent': {'styles': {'list-style-type': 'none'}}},
                               'string_template': {'template': '', 'tag': 'hr',
-                                                  'styling': {
-                                                      'classes': ['m-0']}}}]}],
+                                                  'styling': {'classes': ['mt-1',
+                                                                          'mb-1']}}}]}],
         'section_name': 'Car Insurance Premiums ($)'}
 
     result_json = ExpectationSuiteColumnSectionRenderer().render(expectations).to_json_dict()
@@ -745,7 +798,7 @@ def test_ExpectationSuiteColumnSectionRenderer_render_bullet_list(titanic_profil
     stringified_dump = json.dumps(content_block.to_json_dict())
 
     assert content_block.content_block_type == "bullet_list"
-    assert len(content_block.bullet_list) == 4
+    assert len(content_block.bullet_list) == 8
     assert "value types must belong to this set" in stringified_dump
     assert "may have any number of unique values" in stringified_dump
     assert "may have any fraction of unique values" in stringified_dump

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -16,53 +16,23 @@ def test_ValidationResultsTableContentBlockRenderer_generate_expectation_row_wit
     print(result)
     expected_result = {
         'content_block_type': 'table',
-        'styling': {'body': {'classes': ['table']},
-                    'classes': ['ml-2', 'mr-2', 'mt-0', 'mb-0',
-                                'table-responsive']}, 'table': [[{
-            'content_block_type': 'string_template',
-            'string_template': {
-                'template': '$icon',
-                'params': {
-                    'icon': ''},
-                'styling': {
-                    'params': {
-                        'icon': {
-                            'classes': [
-                                'fas',
-                                'fa-exclamation-triangle',
-                                'text-warning'],
-                            'tag': 'i'}}}}},
-            [{
-                'content_block_type': 'string_template',
-                'string_template': {
-                    'template': '$column Column can match any distribution.',
-                    'params': {
-                        "column": "live",
-                        "partition_object": None,
-                        "threshold": None,
-                        "result_format": "SUMMARY"}}},
-                {
-                    'content_block_type': 'string_template',
-                    'string_template': {
-                        'template': '\n\n$expectation_type raised an exception:\n$exception_message',
-                        'params': {
-                            'expectation_type': 'expect_column_kl_divergence_to_be_less_than',
-                            'exception_message': 'Invalid partition object.'},
-                        'tag': 'strong',
-                        'styling': {
-                            'classes': [
-                                'text-danger'],
-                            'params': {
-                                'exception_message': {
-                                    'tag': 'code'},
-                                'expectation_type': {
-                                    'classes': [
-                                        'badge',
-                                        'badge-danger',
-                                        'mb-2']}}}}},
-                None],
-            '--']],
-        'header_row': ['Status', 'Expectation', 'Observed Value']}
+        'styling': {'body': {'classes': ['table']}, 'classes': ['ml-2', 'mr-2', 'mt-0', 'mb-0', 'table-responsive']},
+        'table': [[{'content_block_type': 'string_template',
+                    'string_template': {'template': '$icon', 'params': {'icon': ''}, 'styling': {'params': {
+                        'icon': {'classes': ['fas', 'fa-exclamation-triangle', 'text-warning'], 'tag': 'i'}}}}}, [
+                       {'content_block_type': 'string_template',
+                        'string_template': {'template': '$column can match any distribution.',
+                                            'params': {"column": "live", "partition_object": None, "threshold": None,
+                                                       "result_format": "SUMMARY"}}},
+                       {'content_block_type': 'string_template', 'string_template': {
+                           'template': '\n\n$expectation_type raised an exception:\n$exception_message',
+                           'params': {'expectation_type': 'expect_column_kl_divergence_to_be_less_than',
+                                      'exception_message': 'Invalid partition object.'}, 'tag': 'strong',
+                           'styling': {'classes': ['text-danger'], 'params': {'exception_message': {'tag': 'code'},
+                                                                              'expectation_type': {
+                                                                                  'classes': ['badge', 'badge-danger',
+                                                                                              'mb-2']}}}}}, None],
+                   '--']], 'header_row': ['Status', 'Expectation', 'Observed Value']}
     assert result == expected_result
 
 


### PR DESCRIPTION
- update collapse content block to allow inline toggle links
- add horizontal rules under each expectation
- change Expectation notes toggle to an inline icon instead of block text
- minor UI adjustments

<img width="1679" alt="Screenshot 2020-01-06 23 34 00" src="https://user-images.githubusercontent.com/3468435/71933637-85819800-3157-11ea-98d1-5d1d5973e851.png">
