### PR TITLE
More CLI init tests

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -971,10 +971,6 @@ def _load_query_as_data_asset_from_sqlalchemy_datasource(context, datasource_nam
 Enter an SQL query
 """
 
-    msg_prompt_data_asset_name = """
-Give your new data asset a short name
-"""
-
     datasource = context.get_datasource(datasource_name)
 
     while True:

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -1151,7 +1151,7 @@ Give your new data source a short name.
 """
 
 msg_db_config = """
-Next, we will configure database credentials and store them in the "{0:s}" section
+Next, we will configure database credentials and store them in the `{0:s}` section
 of this config file: great_expectations/uncommitted/config_variables.yml:
 """
 

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -74,7 +74,7 @@ def init(target_directory, view):
                 cli_message(PROJECT_IS_COMPLETE)
             except (ge_exceptions.DataContextError, DatasourceInitializationError) as e:
                 cli_message("<red>{}</red>".format(e))
-                exit(5)
+                sys.exit(1)
         else:
             try:
                 _complete_onboarding(target_directory)
@@ -102,7 +102,7 @@ def init(target_directory, view):
             if len(datasources) == 0:
                 datasource_name, data_source_type = add_datasource_impl(context, choose_one_data_asset=True)
                 if not datasource_name:  # no datasource was created
-                    return # TODO: an error message?
+                    sys.exit(1)
 
             datasources = context.list_datasources()
             if len(datasources) == 1:
@@ -128,6 +128,7 @@ def init(target_directory, view):
 
     except ge_exceptions.DataContextError as e:
         cli_message("<red>{}</red>".format(e))
+        sys.exit(1)
 
 
 def _slack_setup(context):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3,34 +3,28 @@
 # Since our cli produces unicode output, but we want tests in python2 as well
 from __future__ import unicode_literals
 
-from datetime import datetime
-from click.testing import CliRunner
+import os
+import re
+import shutil
 
 import pytest
-import json
-import os
-import shutil
-import logging
-import sys
-import re
+from click.testing import CliRunner
 from ruamel.yaml import YAML
 
+from great_expectations import DataContext
+from great_expectations import __version__ as ge_version
+from great_expectations.cli import cli
 from great_expectations.data_context.templates import CONFIG_VARIABLES_TEMPLATE
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import ConfigNotFoundError
-
+from great_expectations.util import gen_directory_tree_str
+from tests.test_utils import is_library_installed
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-from six import PY2
-
-from great_expectations.cli import cli
-from great_expectations.util import gen_directory_tree_str
-from great_expectations import __version__ as ge_version, DataContext
-from tests.test_utils import assertDeepAlmostEqual, expectationSuiteValidationResultSchema
 
 yaml = YAML()
 yaml.default_flow_style = False
@@ -276,6 +270,122 @@ great_expectations/
         raise e
     finally:
         os.chdir(curdir)
+
+
+def _library_not_loaded_test(tmp_path_factory, cli_input, library_name):
+    """
+    This test requires that a library is NOT installed. It tests that:
+    - a helpful error message is returned to install the missing library
+    - the expected tree structure is in place
+    - the config yml contains an empty dict in its datasource entry
+    """
+    basedir = tmp_path_factory.mktemp("test_cli_init_diff")
+    basedir = str(basedir)
+    os.chdir(basedir)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--no-view"], input=cli_input)
+    stdout = result.output
+
+    assert "Always know what to expect from your data" in stdout
+    assert "What data would you like Great Expectations to connect to" in stdout
+    assert "Which database backend are you using" in stdout
+    assert "Which database backend are you using" in stdout
+    assert "Give your new data source a short name" in stdout
+    assert (
+        """Next, we will configure database credentials and store them in the `my_db` section
+of this config file: great_expectations/uncommitted/config_variables.yml"""
+        in stdout
+    )
+    assert "Great Expectations relies on the library `{}`".format(library_name) in stdout
+    assert "Please `pip install {}` before trying again".format(library_name) in stdout
+
+    assert "Profiling" not in stdout
+    assert "Building" not in stdout
+    assert "Data Docs" not in stdout
+    assert "Great Expectations is now set up" not in stdout
+
+    assert result.exit_code == 1
+
+    assert os.path.isdir(os.path.join(basedir, "great_expectations"))
+    config_path = os.path.join(basedir, "great_expectations/great_expectations.yml")
+    assert os.path.isfile(config_path)
+
+    config = yaml.load(open(config_path, "r"))
+    assert config["datasources"] == dict()
+
+    obs_tree = gen_directory_tree_str(os.path.join(basedir, "great_expectations"))
+    assert (
+        obs_tree
+        == """\
+great_expectations/
+    .gitignore
+    great_expectations.yml
+    datasources/
+    expectations/
+    notebooks/
+        pandas/
+            create_expectations.ipynb
+            validation_playground.ipynb
+        spark/
+            create_expectations.ipynb
+            validation_playground.ipynb
+        sql/
+            create_expectations.ipynb
+            validation_playground.ipynb
+    plugins/
+        custom_data_docs/
+            renderers/
+            styles/
+                data_docs_custom_styles.css
+            views/
+    uncommitted/
+        config_variables.yml
+        data_docs/
+        samples/
+        validations/
+"""
+    )
+
+
+@pytest.mark.skipif(
+    is_library_installed("pymysql"),
+    reason="requires pymysql to NOT be installed"
+)
+def test_cli_init_db_mysql_without_library_installed_instructs_user(tmp_path_factory):
+    _library_not_loaded_test(tmp_path_factory, "Y\n2\n1\nmy_db\n", "pymysql")
+
+
+@pytest.mark.skipif(
+    is_library_installed("psycopg2"),
+    reason="requires psycopg2 to NOT be installed"
+)
+def test_cli_init_db_postgres_without_library_installed_instructs_user(
+    tmp_path_factory
+):
+    _library_not_loaded_test(tmp_path_factory, "Y\n2\n2\nmy_db\n", "psycopg2")
+
+
+@pytest.mark.skipif(
+    is_library_installed("psycopg2"),
+    reason="requires psycopg2 to NOT be installed"
+)
+def test_cli_init_db_redshift_without_library_installed_instructs_user(
+    tmp_path_factory
+):
+    _library_not_loaded_test(tmp_path_factory, "Y\n2\n3\nmy_db\n", "psycopg2")
+
+
+@pytest.mark.skipif(
+    is_library_installed("snowflake"),
+    reason="requires snowflake-sqlalchemy to NOT be installed",
+)
+def test_cli_init_db_snowflake_without_library_installed_instructs_user(
+    tmp_path_factory
+):
+    _library_not_loaded_test(
+        tmp_path_factory, "Y\n2\n4\nmy_db\n", "snowflake-sqlalchemy"
+    )
 
 
 @pytest.mark.skip()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -272,7 +272,7 @@ great_expectations/
         os.chdir(curdir)
 
 
-def _library_not_loaded_test(tmp_path_factory, cli_input, library_name):
+def _library_not_loaded_test(tmp_path_factory, cli_input, library_name, library_import_name):
     """
     This test requires that a library is NOT installed. It tests that:
     - a helpful error message is returned to install the missing library
@@ -290,14 +290,13 @@ def _library_not_loaded_test(tmp_path_factory, cli_input, library_name):
     assert "Always know what to expect from your data" in stdout
     assert "What data would you like Great Expectations to connect to" in stdout
     assert "Which database backend are you using" in stdout
-    assert "Which database backend are you using" in stdout
     assert "Give your new data source a short name" in stdout
     assert (
         """Next, we will configure database credentials and store them in the `my_db` section
 of this config file: great_expectations/uncommitted/config_variables.yml"""
         in stdout
     )
-    assert "Great Expectations relies on the library `{}`".format(library_name) in stdout
+    assert "Great Expectations relies on the library `{}`".format(library_import_name) in stdout
     assert "Please `pip install {}` before trying again".format(library_name) in stdout
 
     assert "Profiling" not in stdout
@@ -346,34 +345,33 @@ great_expectations/
         validations/
 """
     )
-
-
 @pytest.mark.skipif(
-    is_library_installed("pymysql"),
-    reason="requires pymysql to NOT be installed"
+    is_library_installed("pymysql"), reason="requires pymysql to NOT be installed"
 )
 def test_cli_init_db_mysql_without_library_installed_instructs_user(tmp_path_factory):
-    _library_not_loaded_test(tmp_path_factory, "Y\n2\n1\nmy_db\n", "pymysql")
+    _library_not_loaded_test(tmp_path_factory, "Y\n2\n1\nmy_db\n", "pymysql", "pymysql")
 
 
 @pytest.mark.skipif(
-    is_library_installed("psycopg2"),
-    reason="requires psycopg2 to NOT be installed"
+    is_library_installed("psycopg2"), reason="requires psycopg2 to NOT be installed"
 )
 def test_cli_init_db_postgres_without_library_installed_instructs_user(
     tmp_path_factory
 ):
-    _library_not_loaded_test(tmp_path_factory, "Y\n2\n2\nmy_db\n", "psycopg2")
+    _library_not_loaded_test(
+        tmp_path_factory, "Y\n2\n2\nmy_db\n", "psycopg2", "psycopg2"
+    )
 
 
 @pytest.mark.skipif(
-    is_library_installed("psycopg2"),
-    reason="requires psycopg2 to NOT be installed"
+    is_library_installed("psycopg2"), reason="requires psycopg2 to NOT be installed"
 )
 def test_cli_init_db_redshift_without_library_installed_instructs_user(
     tmp_path_factory
 ):
-    _library_not_loaded_test(tmp_path_factory, "Y\n2\n3\nmy_db\n", "psycopg2")
+    _library_not_loaded_test(
+        tmp_path_factory, "Y\n2\n3\nmy_db\n", "psycopg2", "psycopg2"
+    )
 
 
 @pytest.mark.skipif(
@@ -384,7 +382,73 @@ def test_cli_init_db_snowflake_without_library_installed_instructs_user(
     tmp_path_factory
 ):
     _library_not_loaded_test(
-        tmp_path_factory, "Y\n2\n4\nmy_db\n", "snowflake-sqlalchemy"
+        tmp_path_factory, "Y\n2\n4\nmy_db\n", "snowflake-sqlalchemy", "snowflake"
+    )
+
+
+@pytest.mark.skipif(
+    is_library_installed("pyspark"), reason="requires pyspark to NOT be installed"
+)
+def test_cli_init_spark_without_library_installed_instructs_user(tmp_path_factory):
+    basedir = tmp_path_factory.mktemp("test_cli_init_diff")
+    basedir = str(basedir)
+    os.chdir(basedir)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--no-view"], input="Y\n1\n2\n")
+    stdout = result.output
+
+    assert "Always know what to expect from your data" in stdout
+    assert "What data would you like Great Expectations to connect to" in stdout
+    assert "What are you processing your files with" in stdout
+    assert "Great Expectations relies on the library `pyspark`" in stdout
+    assert "Please `pip install pyspark` before trying again" in stdout
+
+    assert "Profiling" not in stdout
+    assert "Building" not in stdout
+    assert "Data Docs" not in stdout
+    assert "Great Expectations is now set up" not in stdout
+
+    assert result.exit_code == 1
+
+    assert os.path.isdir(os.path.join(basedir, "great_expectations"))
+    config_path = os.path.join(basedir, "great_expectations/great_expectations.yml")
+    assert os.path.isfile(config_path)
+
+    config = yaml.load(open(config_path, "r"))
+    assert config["datasources"] == dict()
+
+    obs_tree = gen_directory_tree_str(os.path.join(basedir, "great_expectations"))
+    assert (
+        obs_tree
+        == """\
+great_expectations/
+    .gitignore
+    great_expectations.yml
+    datasources/
+    expectations/
+    notebooks/
+        pandas/
+            create_expectations.ipynb
+            validation_playground.ipynb
+        spark/
+            create_expectations.ipynb
+            validation_playground.ipynb
+        sql/
+            create_expectations.ipynb
+            validation_playground.ipynb
+    plugins/
+        custom_data_docs/
+            renderers/
+            styles/
+                data_docs_custom_styles.css
+            views/
+    uncommitted/
+        config_variables.yml
+        data_docs/
+        samples/
+        validations/
+"""
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,24 +1,27 @@
 from __future__ import division
 
-import pytest
+import copy
+import importlib
 import locale
-from functools import wraps
 import random
 import string
-import copy
-from collections import (
-    OrderedDict,
-    Mapping
-)
+from functools import wraps
 
+import numpy as np
+import pandas as pd
+import pytest
 from dateutil.parser import parse
 
-import pandas as pd
-import numpy as np
-
-from great_expectations.dataset import PandasDataset, SqlAlchemyDataset, SparkDFDataset
+from great_expectations.core import (
+    ExpectationSuiteValidationResultSchema,
+    ExpectationValidationResultSchema,
+)
+from great_expectations.dataset import (
+    PandasDataset,
+    SparkDFDataset,
+    SqlAlchemyDataset,
+)
 from great_expectations.profile import ColumnsExistProfiler
-from great_expectations.core import ExpectationValidationResultSchema, ExpectationSuiteValidationResultSchema
 
 expectationValidationResultSchema = ExpectationValidationResultSchema(strict=True)
 expectationSuiteValidationResultSchema = ExpectationSuiteValidationResultSchema(strict=True)
@@ -574,11 +577,17 @@ def evaluate_json_test(data_asset, expectation_type, test):
                     "Invalid test specification: unknown key " + key + " in 'out'")
 
 
-# def dict_to_ordered_dict(plain_dict):
-#     ordered_dict = OrderedDict()
-#     for key, val in plain_dict.items():
-#         if isinstance(val, Mapping):
-#             ordered_dict[key] = dict_to_ordered_dict(val)
-#         else:
-#             ordered_dict[key] = val
-#     return ordered_dict
+def is_library_installed(library_name: str) -> bool:
+    """
+    Tests if a library is installed.
+
+    :rtype: bool
+    :type library_name: str
+    :param library_name:
+    :return:
+    """
+    try:
+        importlib.import_module(library_name)
+        return True
+    except ModuleNotFoundError as e:
+        return False


### PR DESCRIPTION
## What's here

* cli init library loading tests for: pymysql, postgres, redshift, snowflake, pyspark, and a random bad MSSQL connection string. This will work great on local dev machines, and may work well in CI depending on what we install there.
* library load util function
* removed a chunk of dead code in utils
* cleaned up some imports using isort
