### PR TITLE
Modified the error handling logic in the ConfigOnlyDataContext.profile_data_asset method: we want all the exceptions that are raised in this path, including the ones that are raised within expectation validation to propagate all the way up, e.g., the CLI.

### DIFF
--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -33,6 +33,13 @@ from great_expectations.core import (
 )
 from great_expectations.render.renderer.notebook_renderer import NotebookRenderer
 
+try:
+    from sqlalchemy.exc import SQLAlchemyError
+except ImportError:
+    # We'll redefine this error in code below to catch ProfilerError, which is caught above, so SA errors will
+    # just fall through
+    SQLAlchemyError = ge_exceptions.ProfilerError
+
 
 @click.command()
 @click.option(
@@ -127,7 +134,10 @@ def init(target_directory, view):
 
                 cli_message("""\n<cyan>Great Expectations is now set up.</cyan>""")
 
-    except ge_exceptions.DataContextError as e:
+    except (ge_exceptions.DataContextError,
+            ge_exceptions.ProfilerError,
+            IOError,
+            SQLAlchemyError)  as e:
         cli_message("<red>{}</red>".format(e))
         sys.exit(1)
 

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -14,6 +14,13 @@ from great_expectations.cli.util import cli_message, _offer_to_install_new_templ
 from great_expectations.datasource.generator import ManualGenerator
 from great_expectations.render.renderer.notebook_renderer import NotebookRenderer
 
+try:
+    from sqlalchemy.exc import SQLAlchemyError
+except ImportError:
+    # We'll redefine this error in code below to catch ProfilerError, which is caught above, so SA errors will
+    # just fall through
+    SQLAlchemyError = ge_exceptions.ProfilerError
+
 
 @click.group()
 def suite():
@@ -187,14 +194,21 @@ def suite_new(data_asset, suite, directory, view, batch_kwargs):
                 + "'</cyan>"
             )
 
-    create_expectation_suite_impl(
-        context,
-        datasource_name=datasource_name,
-        generator_name=generator_name,
-        generator_asset=generator_asset,
-        batch_kwargs=batch_kwargs,
-        expectation_suite_name=suite,
-        additional_batch_kwargs=None,
-        show_intro_message=False,
-        open_docs=view,
-    )
+    try:
+        create_expectation_suite_impl(
+            context,
+            datasource_name=datasource_name,
+            generator_name=generator_name,
+            generator_asset=generator_asset,
+            batch_kwargs=batch_kwargs,
+            expectation_suite_name=suite,
+            additional_batch_kwargs=None,
+            show_intro_message=False,
+            open_docs=view,
+        )
+    except (ge_exceptions.DataContextError,
+            ge_exceptions.ProfilerError,
+            IOError,
+            SQLAlchemyError)  as e:
+        cli_message("<red>{}</red>".format(e))
+        sys.exit(1)

--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -383,7 +383,7 @@ class SampleExpectationsDatasetProfiler(BasicDatasetProfilerBase):
     @classmethod
     def _profile(cls, dataset):
 
-        dataset.set_default_expectation_argument("catch_exceptions", True)
+        dataset.set_default_expectation_argument("catch_exceptions", False)
 
         value = dataset.expect_table_row_count_to_be_between(min_value=0, max_value=None).result["observed_value"]
         dataset.expect_table_row_count_to_be_between(min_value=max(0, value-10), max_value=value+10)


### PR DESCRIPTION
1. Modified SampleExpectationsDatasetProfiler to set catch_exceptions = False - let all exceptions be raised.
2. Modified ConfigOnlyDataContext.profile_data_asset  to not let all exceptions bubble up.
3. Modified the CLI to catch these exceptions. For any unknown exception it is OK to print the stack trace - it will make it easier for users to report the error.