### PR TITLE
More robust CLI logging testing, sundry bugfixes

### DIFF
--- a/great_expectations/cli/cli_logging.py
+++ b/great_expectations/cli/cli_logging.py
@@ -6,6 +6,12 @@ warnings.filterwarnings("ignore")
 logging.getLogger(
     "great_expectations.datasource.generator.in_memory_generator"
 ).setLevel(logging.CRITICAL)
+logging.getLogger(
+    "great_expectations.dataset.sqlalchemy_dataset"
+).setLevel(logging.CRITICAL)
+logging.getLogger(
+    "great_expectations.profile.basic_dataset_profiler"
+).setLevel(logging.CRITICAL)
 
 # Take over the entire GE module logging namespace when running CLI
 logger = logging.getLogger("great_expectations")

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -267,7 +267,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             # These are the officially included and supported dialects by sqlalchemy
             self.dialect = import_module("sqlalchemy.dialects." + self.engine.dialect.name)
 
-            if engine.dialect.name.lower() == "sqlite":
+            if engine and engine.dialect.name.lower() == "sqlite":
                 # sqlite temp tables only persist within a connection so override the engine
                 self.engine = engine.connect()
         elif self.engine.dialect.name.lower() == "snowflake":

--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -294,7 +294,7 @@ class SampleExpectationsDatasetProfiler(BasicDatasetProfilerBase):
         partition_object = build_categorical_partition_object(dataset, column)
 
         dataset.expect_column_kl_divergence_to_be_less_than(column, partition_object=partition_object,
-                                                            threshold=0.6)
+                                                            threshold=0.6, catch_exceptions=True)
 
     @classmethod
     def _create_non_nullity_expectations(cls, dataset, column):
@@ -354,6 +354,7 @@ class SampleExpectationsDatasetProfiler(BasicDatasetProfilerBase):
                         result.result["observed_value"]["values"]
                     ],
                 },
+                catch_exceptions=True
             )
             dataset.set_config_value('interactive_evaluation', True)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,12 +7,13 @@ from ruamel.yaml import YAML
 from great_expectations import __version__ as ge_version
 from great_expectations.cli import cli
 from great_expectations.exceptions import ConfigNotFoundError
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 yaml = YAML()
 yaml.default_flow_style = False
 
 
-def test_cli_command_entrance():
+def test_cli_command_entrance(caplog):
     runner = CliRunner()
     result = runner.invoke(cli)
     assert result.exit_code == 0
@@ -49,9 +50,10 @@ Commands:
   suite       expectation suite operations
 """
     )
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_cli_command_invalid_command():
+def test_cli_command_invalid_command(caplog,):
     runner = CliRunner()
     result = runner.invoke(cli, ["blarg"])
     assert result.exit_code == 2
@@ -63,15 +65,17 @@ Try "cli --help" for help.
 Error: No such command "blarg".
 """
     )
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_cli_version():
+def test_cli_version(caplog,):
     runner = CliRunner()
     result = runner.invoke(cli, ["--version"])
     assert ge_version in str(result.output)
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_cli_config_not_found(tmp_path_factory):
+def test_cli_config_not_found_raises_error_for_all_commands(tmp_path_factory):
     tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     curdir = os.path.abspath(os.getcwd())
     try:

--- a/tests/cli/test_datasource_pandas.py
+++ b/tests/cli/test_datasource_pandas.py
@@ -5,9 +5,10 @@ from click.testing import CliRunner
 from great_expectations import DataContext
 from great_expectations.cli import cli
 from tests.cli.test_cli import yaml
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
-def test_cli_datasorce_list(empty_data_context, filesystem_csv_2):
+def test_cli_datasorce_list(caplog, empty_data_context, filesystem_csv_2):
     """Test an empty project and after adding a single datasource."""
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
@@ -34,12 +35,10 @@ def test_cli_datasorce_list(empty_data_context, filesystem_csv_2):
 
     stdout = result.output.strip()
     assert "[{'name': 'wow_a_datasource', 'class_name': 'PandasDatasource'}]" in stdout
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_cli_datasorce_new(empty_data_context, filesystem_csv_2, capsys):
+def test_cli_datasorce_new(caplog, empty_data_context, filesystem_csv_2, capsys):
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
     assert context.list_datasources() == []
@@ -66,12 +65,12 @@ def test_cli_datasorce_new(empty_data_context, filesystem_csv_2, capsys):
     assert "mynewsource" in datasources.keys()
     data_source_class = datasources["mynewsource"]["data_asset_type"]["class_name"]
     assert data_source_class == "PandasDataset"
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_cli_datasource_profile_answering_no(empty_data_context, filesystem_csv_2):
+def test_cli_datasource_profile_answering_no(
+    caplog, empty_data_context, filesystem_csv_2
+):
     empty_data_context.add_datasource(
         "my_datasource",
         module_name="great_expectations.datasource",
@@ -99,13 +98,11 @@ def test_cli_datasource_profile_answering_no(empty_data_context, filesystem_csv_
     assert result.exit_code == 0
     assert "Profiling 'my_datasource'" in stdout
     assert "Skipping profiling for now." in stdout
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_datasource_arg(
-    empty_data_context, filesystem_csv_2, capsys
+    caplog, empty_data_context, filesystem_csv_2, capsys
 ):
     empty_data_context.add_datasource(
         "my_datasource",
@@ -151,13 +148,11 @@ def test_cli_datasource_profile_with_datasource_arg(
     assert validation.meta["expectation_suite_name"] == "BasicDatasetProfiler"
     assert validation.success is False
     assert len(validation.results) == 13
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_no_datasource_args(
-    empty_data_context, filesystem_csv_2, capsys
+    caplog, empty_data_context, filesystem_csv_2, capsys
 ):
     empty_data_context.add_datasource(
         "my_datasource",
@@ -197,13 +192,11 @@ def test_cli_datasource_profile_with_no_datasource_args(
     assert validation.meta["expectation_suite_name"] == "BasicDatasetProfiler"
     assert validation.success is False
     assert len(validation.results) == 13
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_additional_batch_kwargs(
-    empty_data_context, filesystem_csv_2
+    caplog, empty_data_context, filesystem_csv_2
 ):
     empty_data_context.add_datasource(
         "my_datasource",
@@ -254,13 +247,11 @@ def test_cli_datasource_profile_with_additional_batch_kwargs(
     reader_options = evr.meta["batch_kwargs"]["reader_options"]
     assert reader_options["parse_dates"] == [0]
     assert reader_options["sep"] == ","
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_valid_data_asset_arg(
-    empty_data_context, filesystem_csv_2, capsys
+    caplog, empty_data_context, filesystem_csv_2, capsys
 ):
     empty_data_context.add_datasource(
         "my_datasource",
@@ -309,13 +300,11 @@ def test_cli_datasource_profile_with_valid_data_asset_arg(
     assert validation.meta["expectation_suite_name"] == "BasicDatasetProfiler"
     assert validation.success is False
     assert len(validation.results) == 13
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_invalid_data_asset_arg_answering_no(
-    empty_data_context, filesystem_csv_2
+    caplog, empty_data_context, filesystem_csv_2
 ):
     empty_data_context.add_datasource(
         "my_datasource",
@@ -356,6 +345,4 @@ def test_cli_datasource_profile_with_invalid_data_asset_arg_answering_no(
     expectations_store = context.stores["expectations_store"]
     suites = expectations_store.list_keys()
     assert len(suites) == 0
-
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_datasource_sqlite.py
+++ b/tests/cli/test_datasource_sqlite.py
@@ -6,9 +6,10 @@ from great_expectations import DataContext
 from great_expectations.cli import cli
 from great_expectations.exceptions import DataContextError
 from tests.cli.test_cli import yaml
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
-def test_cli_datasorce_list(empty_data_context, empty_sqlite_db):
+def test_cli_datasorce_list(empty_data_context, empty_sqlite_db, caplog):
     """Test an empty project and after adding a single datasource."""
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
@@ -32,8 +33,7 @@ def test_cli_datasorce_list(empty_data_context, empty_sqlite_db):
         "[{'name': 'wow_a_datasource', 'class_name': 'SqlAlchemyDatasource'}]" in stdout
     )
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def _add_datasource_and_credentials_to_context(context, datasource_name, sqlite_engine):
@@ -60,7 +60,9 @@ def _add_datasource_and_credentials_to_context(context, datasource_name, sqlite_
     return context
 
 
-def test_cli_datasorce_new_connection_string(empty_data_context, empty_sqlite_db):
+def test_cli_datasorce_new_connection_string(
+    empty_data_context, empty_sqlite_db, caplog
+):
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
     assert context.list_datasources() == []
@@ -93,11 +95,12 @@ def test_cli_datasorce_new_connection_string(empty_data_context, empty_sqlite_db
     data_source_class = datasources["mynewsource"]["data_asset_type"]["class_name"]
     assert data_source_class == "SqlAlchemyDataset"
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_cli_datasource_profile_answering_no(empty_data_context, empty_sqlite_db):
+def test_cli_datasource_profile_answering_no(
+    empty_data_context, empty_sqlite_db, caplog
+):
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
     datasource_name = "wow_a_datasource"
@@ -118,12 +121,11 @@ def test_cli_datasource_profile_answering_no(empty_data_context, empty_sqlite_db
     assert "Profiling 'wow_a_datasource'" in stdout
     assert "Skipping profiling for now." in stdout
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_datasource_arg(
-    empty_data_context, titanic_sqlite_db
+    empty_data_context, titanic_sqlite_db, caplog
 ):
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
@@ -167,12 +169,11 @@ def test_cli_datasource_profile_with_datasource_arg(
     assert validation.success is False
     assert len(validation.results) == 51
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_no_datasource_args(
-    empty_data_context, titanic_sqlite_db
+    empty_data_context, titanic_sqlite_db, caplog
 ):
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
@@ -209,12 +210,11 @@ def test_cli_datasource_profile_with_no_datasource_args(
     assert validation.success is False
     assert len(validation.results) == 51
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_data_asset_and_additional_batch_kwargs_should_raise_helpful_error(
-    empty_data_context, titanic_sqlite_db
+    empty_data_context, titanic_sqlite_db, caplog
 ):
     """
     Passing additional batch kwargs along with a data asset name to a sql
@@ -261,12 +261,12 @@ def test_cli_datasource_profile_with_data_asset_and_additional_batch_kwargs_shou
     # TODO is DataContextError the best error to raise? Should it be a CLI error?
     assert isinstance(result.exception, DataContextError)
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    # TODO this may not be appropriate for this test...
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_valid_data_asset_arg(
-    empty_data_context, titanic_sqlite_db
+    empty_data_context, titanic_sqlite_db, caplog
 ):
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
@@ -312,12 +312,11 @@ def test_cli_datasource_profile_with_valid_data_asset_arg(
     assert validation.success is False
     assert len(validation.results) == 51
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_datasource_profile_with_invalid_data_asset_arg_answering_no(
-    empty_data_context, titanic_sqlite_db
+    empty_data_context, titanic_sqlite_db, caplog
 ):
     project_root_dir = empty_data_context.root_directory
     context = DataContext(project_root_dir)
@@ -356,5 +355,4 @@ def test_cli_datasource_profile_with_invalid_data_asset_arg_answering_no(
     suites = expectations_store.list_keys()
     assert len(suites) == 0
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_docs.py
+++ b/tests/cli/test_docs.py
@@ -5,16 +5,18 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
-def test_docs_help_output():
+def test_docs_help_output(caplog):
     runner = CliRunner()
     result = runner.invoke(cli, ["docs"])
     assert result.exit_code == 0
     assert "build  Build Data Docs for a project." in result.stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_docs_build(site_builder_data_context_with_html_store_titanic_random):
+def test_docs_build(caplog, site_builder_data_context_with_html_store_titanic_random):
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
 
     runner = CliRunner()
@@ -38,3 +40,4 @@ def test_docs_build(site_builder_data_context_with_html_store_titanic_random):
         root_dir, "uncommitted/data_docs/local_site/index.html"
     )
     assert os.path.isfile(expected_index_path)
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -9,10 +9,11 @@ from great_expectations.data_context.templates import CONFIG_VARIABLES_TEMPLATE
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.util import gen_directory_tree_str
 from tests.cli.test_cli import yaml
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
 def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_fixing_them(
-    tmp_path_factory,
+    caplog, tmp_path_factory,
 ):
     """
     This test walks through the onboarding experience.
@@ -61,9 +62,11 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_
     with open(config_var_path, "r") as f:
         assert f.read() == CONFIG_VARIABLES_TEMPLATE
 
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
 
 def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_to_fixing_them(
-    tmp_path_factory,
+    caplog, tmp_path_factory,
 ):
     """
     This test walks through the onboarding experience.
@@ -112,7 +115,7 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_to_f
 
 
 def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
-    tmp_path_factory,
+    caplog, tmp_path_factory,
 ):
     """
     This test walks through the onboarding experience.
@@ -146,10 +149,11 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
     assert "appears complete" in stdout
     assert "ready to roll" in stdout
     assert "Would you like to build & view this project's Data Docs" in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_init_connection_string_non_working_mssql_connection_instructs_user_and_leaves_entries_in_config_files_for_debugging(
-    tmp_path_factory,
+    caplog, tmp_path_factory,
 ):
     basedir = tmp_path_factory.mktemp("mssql_test")
     basedir = str(basedir)
@@ -242,3 +246,5 @@ great_expectations/
         validations/
 """
     )
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_init_missing_libraries.py
+++ b/tests/cli/test_init_missing_libraries.py
@@ -6,11 +6,12 @@ from click.testing import CliRunner
 from great_expectations.cli import cli
 from great_expectations.util import gen_directory_tree_str
 from tests.cli.test_cli import yaml
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 from tests.test_utils import is_library_installed
 
 
 def _library_not_loaded_test(
-    tmp_path_factory, cli_input, library_name, library_import_name
+    tmp_path_factory, cli_input, library_name, library_import_name, my_caplog
 ):
     """
     This test requires that a library is NOT installed. It tests that:
@@ -88,22 +89,28 @@ great_expectations/
 """
     )
 
+    assert_no_logging_messages_or_tracebacks(my_caplog, result)
+
 
 @pytest.mark.skipif(
     is_library_installed("pymysql"), reason="requires pymysql to NOT be installed"
 )
-def test_cli_init_db_mysql_without_library_installed_instructs_user(tmp_path_factory):
-    _library_not_loaded_test(tmp_path_factory, "Y\n2\n1\nmy_db\n", "pymysql", "pymysql")
+def test_cli_init_db_mysql_without_library_installed_instructs_user(
+    caplog, tmp_path_factory
+):
+    _library_not_loaded_test(
+        tmp_path_factory, "Y\n2\n1\nmy_db\n", "pymysql", "pymysql", caplog
+    )
 
 
 @pytest.mark.skipif(
     is_library_installed("psycopg2"), reason="requires psycopg2 to NOT be installed"
 )
 def test_cli_init_db_postgres_without_library_installed_instructs_user(
-    tmp_path_factory,
+    caplog, tmp_path_factory,
 ):
     _library_not_loaded_test(
-        tmp_path_factory, "Y\n2\n2\nmy_db\n", "psycopg2", "psycopg2"
+        tmp_path_factory, "Y\n2\n2\nmy_db\n", "psycopg2", "psycopg2", caplog
     )
 
 
@@ -111,10 +118,10 @@ def test_cli_init_db_postgres_without_library_installed_instructs_user(
     is_library_installed("psycopg2"), reason="requires psycopg2 to NOT be installed"
 )
 def test_cli_init_db_redshift_without_library_installed_instructs_user(
-    tmp_path_factory,
+    caplog, tmp_path_factory,
 ):
     _library_not_loaded_test(
-        tmp_path_factory, "Y\n2\n3\nmy_db\n", "psycopg2", "psycopg2"
+        tmp_path_factory, "Y\n2\n3\nmy_db\n", "psycopg2", "psycopg2", caplog
     )
 
 
@@ -123,17 +130,23 @@ def test_cli_init_db_redshift_without_library_installed_instructs_user(
     reason="requires snowflake-sqlalchemy to NOT be installed",
 )
 def test_cli_init_db_snowflake_without_library_installed_instructs_user(
-    tmp_path_factory,
+    caplog, tmp_path_factory,
 ):
     _library_not_loaded_test(
-        tmp_path_factory, "Y\n2\n4\nmy_db\n", "snowflake-sqlalchemy", "snowflake"
+        tmp_path_factory,
+        "Y\n2\n4\nmy_db\n",
+        "snowflake-sqlalchemy",
+        "snowflake",
+        caplog,
     )
 
 
 @pytest.mark.skipif(
     is_library_installed("pyspark"), reason="requires pyspark to NOT be installed"
 )
-def test_cli_init_spark_without_library_installed_instructs_user(tmp_path_factory):
+def test_cli_init_spark_without_library_installed_instructs_user(
+    caplog, tmp_path_factory
+):
     basedir = tmp_path_factory.mktemp("test_cli_init_diff")
     basedir = str(basedir)
     os.chdir(basedir)
@@ -194,3 +207,5 @@ great_expectations/
         validations/
 """
     )
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -10,9 +10,10 @@ from great_expectations.cli import cli
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.util import gen_directory_tree_str
 from tests.cli.test_cli import yaml
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
-def test_cli_init_on_new_project(tmp_path_factory):
+def test_cli_init_on_new_project(caplog, tmp_path_factory):
     basedir = str(tmp_path_factory.mktemp("test_cli_init_diff"))
     os.makedirs(os.path.join(basedir, "data"))
     data_path = os.path.join(basedir, "data/Titanic.csv")
@@ -160,13 +161,12 @@ great_expectations/
 """
     )
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 # TODO this test is failing because the behavior is broken
 def test_init_on_existing_project_with_no_datasources_should_add_one(
-    initialized_project,
+    caplog, initialized_project,
 ):
     project_dir = initialized_project
     ge_dir = os.path.join(project_dir, DataContext.GE_DIR)
@@ -192,8 +192,7 @@ def test_init_on_existing_project_with_no_datasources_should_add_one(
     config = _load_config_file(os.path.join(ge_dir, DataContext.GE_YML))
     assert "my_data_dir" in config["datasources"].keys()
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def _remove_all_datasources(ge_dir):
@@ -242,7 +241,7 @@ def initialized_project(tmp_path_factory):
 
 
 def test_init_on_existing_project_with_multiple_datasources_exist_do_nothing(
-    initialized_project, filesystem_csv_2
+    caplog, initialized_project, filesystem_csv_2
 ):
     project_dir = initialized_project
     ge_dir = os.path.join(project_dir, DataContext.GE_DIR)
@@ -269,12 +268,11 @@ def test_init_on_existing_project_with_multiple_datasources_exist_do_nothing(
     assert "appears complete" in stdout
     assert "Would you like to build & view this project's Data Docs" in stdout
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_init_on_existing_project_with_datasource_with_existing_suite_offer_to_build_docs(
-    initialized_project,
+    caplog, initialized_project,
 ):
     project_dir = initialized_project
 
@@ -291,12 +289,11 @@ def test_init_on_existing_project_with_datasource_with_existing_suite_offer_to_b
     assert "appears complete" in stdout
     assert "Would you like to build & view this project's Data Docs" in stdout
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_init_on_existing_project_with_datasource_with_no_suite_create_one(
-    initialized_project,
+    caplog, initialized_project,
 ):
     project_dir = initialized_project
     ge_dir = os.path.join(project_dir, DataContext.GE_DIR)
@@ -332,8 +329,7 @@ def test_init_on_existing_project_with_datasource_with_no_suite_create_one(
     assert "Great Expectations is now set up" in stdout
     assert "A new Expectation suite 'warning' was added to your project" in stdout
 
-    # This is important to make sure the user isn't seeing tracebacks
-    assert "Traceback" not in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def _delete_and_recreate_dir(directory):

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -3,9 +3,10 @@ import os
 from click.testing import CliRunner
 
 from great_expectations.cli import cli
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
-def test_project_check_on_missing_ge_dir(tmp_path_factory):
+def test_project_check_on_missing_ge_dir(caplog, tmp_path_factory):
     project_dir = str(tmp_path_factory.mktemp("empty_dir"))
     runner = CliRunner()
     result = runner.invoke(cli, ["project", "check-config", "-d", project_dir])
@@ -14,18 +15,22 @@ def test_project_check_on_missing_ge_dir(tmp_path_factory):
     assert "Unfortunately, your config appears to be invalid" in stdout
     assert "Error: No great_expectations directory was found here!" in stdout
     assert result.exit_code == 1
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_project_check_on_valid_project(titanic_data_context):
+def test_project_check_on_valid_project(caplog, titanic_data_context):
     project_dir = titanic_data_context.root_directory
     runner = CliRunner()
     result = runner.invoke(cli, ["project", "check-config", "-d", project_dir])
     assert "Checking your config files for validity" in result.output
     assert "Your config file appears valid" in result.output
     assert result.exit_code == 0
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_project_check_on_project_with_missing_config_file(titanic_data_context):
+def test_project_check_on_project_with_missing_config_file(
+    caplog, titanic_data_context
+):
     project_dir = titanic_data_context.root_directory
     # Remove the config file.
     os.remove(os.path.join(project_dir, "great_expectations.yml"))
@@ -35,3 +40,4 @@ def test_project_check_on_project_with_missing_config_file(titanic_data_context)
     assert result.exit_code == 1
     assert "Checking your config files for validity" in result.output
     assert "Unfortunately, your config appears to be invalid" in result.output
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -5,9 +5,10 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
-def test_suite_help_output():
+def test_suite_help_output(caplog,):
     runner = CliRunner()
     result = runner.invoke(cli, ["suite"])
     assert result.exit_code == 0
@@ -18,10 +19,11 @@ Commands:
   new   Create a new expectation suite."""
         in result.stdout
     )
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_suite_new_without_suite_name_argument(
-    site_builder_data_context_with_html_store_titanic_random,
+    caplog, site_builder_data_context_with_html_store_titanic_random,
 ):
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
     os.chdir(root_dir)
@@ -63,10 +65,11 @@ def test_suite_new_without_suite_name_argument(
         root_dir, "expectations/random/default/f2/my_new_suite.json"
     )
     assert os.path.isfile(expected_suite_path)
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_suite_new_with_suite_name_argument(
-    site_builder_data_context_with_html_store_titanic_random,
+    caplog, site_builder_data_context_with_html_store_titanic_random,
 ):
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
     os.chdir(root_dir)
@@ -107,3 +110,4 @@ def test_suite_new_with_suite_name_argument(
         root_dir, "expectations/random/default/f2/foo_suite.json"
     )
     assert os.path.isfile(expected_suite_path)
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/utils.py
+++ b/tests/cli/utils.py
@@ -1,0 +1,45 @@
+from _pytest.logging import LogCaptureFixture
+from click.testing import Result
+
+
+def assert_no_logging_messages_or_tracebacks(my_caplog, click_result):
+    """
+    Use this assertion in all CLI tests unless you have a very good reason.
+
+    Without this assertion, it is easy to let errors and tracebacks bubble up
+    to users without being detected, unless you are manually inspecting the
+    console output (stderr and stdout), as well as logging output from every
+    test.
+
+    Usage:
+
+    ```
+    def test_my_stuff(caplog):
+        ...
+        result = runner.invoke(...)
+        ...
+        assert_no_logging_messages_or_tracebacks(caplog, result)
+    ```
+
+    :param my_caplog: the caplog pytest fixutre
+    :param click_result: the Result object returned from click runner.invoke()
+    """
+    assert isinstance(
+        my_caplog, LogCaptureFixture
+    ), "Please pass in the caplog object from your test."
+    assert isinstance(
+        click_result, Result
+    ), "Please pass in the click runner invoke result object from your test."
+
+    messages = my_caplog.messages
+    assert isinstance(messages, list)
+    if messages:
+        print(messages)
+    assert not messages
+
+    assert (
+        "traceback" not in click_result.output.lower()
+    ), "Found a traceback in the console output: {}".format(click_result.output)
+    assert (
+        "traceback" not in click_result.stdout.lower()
+    ), "Found a traceback in the console output: {}".format(click_result.stdout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -581,12 +581,12 @@ def site_builder_data_context_with_html_store_titanic_random(tmp_path_factory, f
 
     context.add_datasource(
         "titanic",
-        type="pandas",
+        class_name="PandasDatasource",
         base_directory=os.path.join(project_dir, "data/titanic/")
     )
     context.add_datasource(
         "random",
-        type="pandas",
+        class_name="PandasDatasource",
         base_directory=os.path.join(project_dir, "data/random/")
     )
 

--- a/tests/test_fixtures/great_expectations_site_builder.yml
+++ b/tests/test_fixtures/great_expectations_site_builder.yml
@@ -4,7 +4,7 @@ config_version: 1
 datasources:
   # For example, this one.
   mydatasource:
-    type: pandas
+    class_name: PandasDatasource
     generators:
       # The name default is read if no datasource or generator is specified
       mygenerator:


### PR DESCRIPTION
This introduces much more robust testing against errant loggers in the CLI. This means that many more tests are failing intentionally.

## What's Here

* ramp down logger levels in a few modules that were raising errors u…sers don't need to see in the CLI
* bugfix in sqlite dialect detection
* SampleExpectationsDatasetProfiler made more robust to quantile failures
* all relevant CLI tests made more robust against errant logger output with assert_no_logging_messages_or_tracebacks
* updated an old test fixture that was throwing warnings

