### PR TITLE
Fix: change test to allow any Pandas version

### DIFF
--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -462,14 +462,15 @@ class TestIO(unittest.TestCase):
         Since pyarrow is not in our actual requirements, we are not going to adjust up the required numpy version.
         """
 
-        # Skip and pass this test if the available version of pandas is less than 0.21.0, because prior
-        # versions of pandas did not include the read_parquet function.
-        pandas_version = re.match('.+\.(.+)\..+', pd.__version__)
+        # Pass this test if the available version of pandas is less than 0.21.0, because prior
+        # versions of pandas did not include the read_parquet function and the test doesn't apply
+        pandas_version = re.match('(.+)\.(.+)\..+', pd.__version__)
         if pandas_version is None:
             raise ValueError("Unrecognized pandas version!")
         else:
-            pandas_version = int(pandas_version.group(1))
-            if pandas_version < 21:
+            pandas_version_major = int(pandas_version.group(1))
+            pandas_version_minor = int(pandas_version.group(2))
+            if (pandas_version_major == 0) and (pandas_version_minor < 21):
                 return
 
         script_path = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -462,9 +462,9 @@ class TestIO(unittest.TestCase):
         Since pyarrow is not in our actual requirements, we are not going to adjust up the required numpy version.
         """
 
-        # Pass this test if the available version of pandas is less than 0.21.0, because prior
+        # Skip and pass this test if the available version of pandas is less than 0.21.0, because prior
         # versions of pandas did not include the read_parquet function.
-        pandas_version = re.match('0\.(.*)\..*', pd.__version__)
+        pandas_version = re.match('.+\.(.+)\..+', pd.__version__)
         if pandas_version is None:
             raise ValueError("Unrecognized pandas version!")
         else:


### PR DESCRIPTION
Pandas 1.0.0 was just released, so the regex breaks our tests. I also made the regex stricter to enforce valid version number formatting, although I doubt this will ever be an issue here.