### PR TITLE
Follow-up on PR 1031 - added the missing tests

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -1155,6 +1155,7 @@ Great Expectations is building Data Docs from the data you just profiled!"""
         if data_assets or profile_all_data_assets or click.confirm(msg_confirm_ok_to_proceed.format(datasource_name), default=True):
             profiling_results = context.profile_datasource(
                 datasource_name,
+                generator_name=generator_name,
                 data_assets=data_assets,
                 profile_all_data_assets=profile_all_data_assets,
                 max_data_assets=max_data_assets,

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -985,7 +985,7 @@ class BaseDataContext(object):
                 available_data_asset_name_list = datasource_data_asset_names_dict[generator_name]["names"]
             except KeyError:
                 raise ge_exceptions.ProfilerError(
-                    "Generator {} not found. Specify generator name")
+                    "Generator {} not found. Specify the name of a generator configured in this datasource".format(generator_name))
 
         available_data_asset_name_list = sorted(available_data_asset_name_list, key=lambda x: x[0])
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -985,7 +985,7 @@ class BaseDataContext(object):
                 available_data_asset_name_list = datasource_data_asset_names_dict[generator_name]["names"]
             except KeyError:
                 raise ge_exceptions.ProfilerError(
-                    "Generator {} not found. Specify the name of a generator configured in this datasource".format(generator_name))
+                    "Batch Kwarg Generator {} not found. Specify the name of a generator configured in this datasource".format(generator_name))
 
         available_data_asset_name_list = sorted(available_data_asset_name_list, key=lambda x: x[0])
 

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -13,7 +13,7 @@ from great_expectations.profile.base import DatasetProfiler
 from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
 from great_expectations.profile.columns_exist import ColumnsExistProfiler
 from tests.test_utils import expectationSuiteValidationResultSchema
-
+import great_expectations.exceptions as ge_exceptions
 
 @pytest.fixture()
 def not_empty_datacontext(empty_data_context, filesystem_csv_2):
@@ -360,6 +360,49 @@ def test_context_profiler_with_nonexisting_data_asset_name(not_empty_datacontext
                   'data_assets': [('f1', 'file')]}
     }
 
+def test_context_profiler_with_non_existing_generator(not_empty_datacontext):
+    """
+    If a non-existing generator name is passed to the profiling method
+    in the generator_name argument, the profiling method must return raise an exception.
+    """
+    context = not_empty_datacontext
+
+    assert isinstance(context.datasources["rad_datasource"], PandasDatasource)
+    assert context.list_expectation_suite_keys() == []
+    with pytest.raises(ge_exceptions.ProfilerError):
+        profiling_result = context.profile_datasource("rad_datasource", data_assets=["this_asset_doesnot_exist"], profiler=BasicDatasetProfiler, generator_name="this_gen_does_not_exist")
+
+
+def test_context_profiler_without_generator_name_arg_on_datasource_with_multiple_generators(not_empty_datacontext, filesystem_csv_2):
+    """
+    If a no generator_name is passed to the profiling method and the datasource has more than one
+    generators configured, the profiling method must return an error code in the result
+    """
+    context = not_empty_datacontext
+    context.add_generator("rad_datasource", "second_generator", "SubdirReaderGenerator", **{
+                "base_directory": str(filesystem_csv_2),
+            })
+
+    assert isinstance(context.datasources["rad_datasource"], PandasDatasource)
+    profiling_result = context.profile_datasource("rad_datasource", data_assets=["this_asset_doesnot_exist"], profiler=BasicDatasetProfiler)
+
+    assert profiling_result == {'success': False, 'error': {'code': 5}}
+
+def test_context_profiler_without_generator_name_arg_on_datasource_with_no_generators(not_empty_datacontext):
+    """
+    If a no generator_name is passed to the profiling method and the datasource has no
+    generators configured, the profiling method must return an error code in the result
+    """
+    context = not_empty_datacontext
+    context.add_datasource(
+        "datasource_without_generators",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+    )
+    assert isinstance(context.datasources["datasource_without_generators"], PandasDatasource)
+    profiling_result = context.profile_datasource("datasource_without_generators", profiler=BasicDatasetProfiler)
+
+    assert profiling_result == {'success': False, 'error': {'code': 4}}
 
 def test_snapshot_BasicDatasetProfiler_on_titanic():
     """

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -363,7 +363,7 @@ def test_context_profiler_with_nonexisting_data_asset_name(not_empty_datacontext
 def test_context_profiler_with_non_existing_generator(not_empty_datacontext):
     """
     If a non-existing generator name is passed to the profiling method
-    in the generator_name argument, the profiling method must return raise an exception.
+in the generator_name argument, the profiling method must raise an exception.
     """
     context = not_empty_datacontext
 


### PR DESCRIPTION
Since we already merged PR 1031, present PR adds the tests requested in @Aylr 's change request.

One group of tests in the test_profile tests various paths of wrong generator name, no generator name, multiple generator names in data_context.profile_datasource.

One additional test in tests/cli/test_datasource_sqlite verifies that the new generator_name cmd line argument to the "datasource profile" command is passed correctly to the methods downstream.