### PR TITLE
Updated the "validation playground" notebooks for the new APIs

### DIFF
--- a/great_expectations/init_notebooks/pandas/validation_playground.ipynb
+++ b/great_expectations/init_notebooks/pandas/validation_playground.ipynb
@@ -8,6 +8,10 @@
     "\n",
     "**Watch** a [short tutorial video](https://greatexpectations.io/videos/getting_started/integrate_expectations) or **read** [the written tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data)\n",
     "\n",
+    "#### This notebook assumes that you created at least one expectation suite in your project.\n",
+    "#### Here you will learn how to validate data loaded into a Pandas DataFrame against an expectation suite.\n",
+    "\n",
+    "\n",
     "We'd love it if you **reach out for help on** the [**Great Expectations Slack Channel**](https://greatexpectations.io/slack)"
    ]
   },
@@ -19,7 +23,6 @@
    "source": [
     "import json\n",
     "import great_expectations as ge\n",
-    "from great_expectations.profile import ColumnsExistProfiler\n",
     "import great_expectations.jupyter_ux\n",
     "from great_expectations.datasource.types import BatchKwargs\n",
     "from datetime import datetime"
@@ -30,7 +33,7 @@
    "metadata": {},
    "source": [
     "## 1. Get a DataContext\n",
-    "This represents your **project** that you just created using `great_expectations init`. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#get-a-datacontext-object)"
+    "This represents your **project** that you just created using `great_expectations init`."
    ]
   },
   {
@@ -46,9 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. List the CSVs in your folder\n",
-    "\n",
-    "The `DataContext` will now introspect your pandas `Datasource` and list the CSVs it finds. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#list-data-assets)"
+    "## 2. Choose an Expectation Suite\n"
    ]
   },
   {
@@ -57,16 +58,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ge.jupyter_ux.list_available_data_asset_names(context)"
+    "# list expectation suites that you created in your project\n",
+    "\n",
+    "for expectation_suite_id in context.list_expectation_suite_keys():\n",
+    "    print(expectation_suite_id.expectation_suite_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expectation_suite_name =  # TODO: set to a name from the list above"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Pick a csv and the expectation suite\n",
+    "## 3. Load a batch of data you want to validate\n",
     "\n",
-    "Internally, Great Expectations represents csvs and dataframes as `DataAsset`s and uses this notion to link them to `Expectation Suites`. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#pick-a-data-asset-and-expectation-suite)\n"
+    "To learn more about `get_batch`, see [this tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#load-a-batch-of-data-to-validate)\n"
    ]
   },
   {
@@ -75,16 +88,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_asset_name = \"ONE_OF_THE_CSV_DATA_ASSET_NAMES_FROM_ABOVE\" # TODO: replace with your value!\n",
-    "normalized_data_asset_name = context.normalize_data_asset_name(data_asset_name)\n",
-    "normalized_data_asset_name"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We recommend naming your first expectation suite for a table `warning`. Later, as you identify some of the expectations that you add to this suite as critical, you can move these expectations into another suite and call it `failure`. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=integrate_validation#choose-data-asset-and-expectation-suite)"
+    "# list datasources of the type PandasDatasource in your project\n",
+    "[datasource['name'] for datasource in context.list_datasources() if datasource['class_name'] == 'PandasDatasource']"
    ]
   },
   {
@@ -93,23 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name = \"warning\" # TODO: replace with your value!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### 3.a. If you don't have an expectation suite, let's create a simple one\n",
-    "\n",
-    "You need expectations to validate your data. Expectations are grouped into Expectation Suites. \n",
-    "\n",
-    "If you don't have an expectation suite for this data asset, the notebook's next cell will create a suite of very basic expectations, so that you have some expectations to play with. The expectation suite will have `expect_column_to_exist` expectations for each column.\n",
-    "\n",
-    "If you created an expectation suite for this data asset, you can skip executing the next cell (if you execute it, it will do nothing).\n",
-    "\n",
-    "To create a more interesting suite, open the [create_expectations.ipynb](create_expectations.ipynb) notebook.\n",
-    "\n"
+    "datasource_name = # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -118,35 +107,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    context.get_expectation_suite(normalized_data_asset_name, expectation_suite_name)\n",
-    "except great_expectations.exceptions.DataContextError:\n",
-    "    context.create_expectation_suite(data_asset_name=normalized_data_asset_name, expectation_suite_name=expectation_suite_name, overwrite_existing=True);\n",
-    "    batch_kwargs = context.yield_batch_kwargs(data_asset_name)\n",
-    "    batch = context.get_batch(normalized_data_asset_name, expectation_suite_name, batch_kwargs)\n",
-    "    ColumnsExistProfiler().profile(batch)\n",
-    "    batch.save_expectation_suite()\n",
-    "    expectation_suite = context.get_expectation_suite(normalized_data_asset_name, expectation_suite_name)\n",
-    "    context.build_data_docs()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4. Load a batch of data you want to validate\n",
+    "# If you would like to validate a file on a filesystem:\n",
+    "batch_kwargs = {'path': \"YOUR_FILE_PATH\", 'datasource': datasource_name}\n",
     "\n",
-    "To learn more about `get_batch` with other data types (such as existing pandas dataframes, SQL tables or Spark), see [this tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#load-a-batch-of-data-to-validate)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "batch_kwargs = context.yield_batch_kwargs(data_asset_name)\n",
-    "batch = context.get_batch(normalized_data_asset_name, expectation_suite_name, batch_kwargs)\n",
+    "# If you already loaded the data into a Pandas Data Frame:\n",
+    "batch_kwargs = {'dataset': \"YOUR_DATAFRAME\", 'datasource': datasource_name}\n",
+    "\n",
+    "\n",
+    "batch = context.get_batch(batch_kwargs, expectation_suite_name)\n",
     "batch.head()"
    ]
   },
@@ -154,30 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Get a pipeline run id\n",
-    "\n",
-    "Generate a run id, a timestamp, or a meaningful string that will help you refer to validation results. We recommend they be chronologically sortable.\n",
-    "[Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=validate_data#set-a-run-id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's make a simple sortable timestamp. Note this could come from your pipeline runner.\n",
-    "run_id = datetime.utcnow().isoformat().replace(\":\", \"\") + \"Z\"\n",
-    "run_id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 6. Validate the batch\n",
-    "\n",
-    "This is the \"workhorse\" of Great Expectations. Call it in your pipeline code after loading data and just before passing it to your computation.\n",
+    "## 4. Validate the batch\n",
     "\n",
     "[Read more about the validate method in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#validate-the-batch)\n"
    ]
@@ -188,19 +133,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "validation_result = batch.validate(run_id=run_id)\n",
+    "validation_result = batch.validate()\n",
     "\n",
     "if validation_result[\"success\"]:\n",
-    "    print(\"This data meets all expectations for {}\".format(str(data_asset_name)))\n",
+    "    print(\"This data meets all expectations in {}\".format(expectation_suite_name))\n",
     "else:\n",
-    "    print(\"This data is not a valid batch of {}\".format(str(data_asset_name)))"
+    "    print(\"This data does not meet some expectations in {}\".format(expectation_suite_name))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6.a. OPTIONAL: Review the JSON validation results\n",
+    "## 4.a. OPTIONAL: Review the JSON validation results\n",
     "\n",
     "Don't worry - this blob of JSON is meant for machines. Continue on or skip this to see this in Data Docs!"
    ]
@@ -211,14 +156,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# print(json.dumps(validation_result, indent=4))"
+    "#validation_result"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Validation Operators\n",
+    "## 5. Validation Operators\n",
     "\n",
     "The `validate` method evaluates one batch of data against one expectation suite and returns a dictionary of validation results. This is sufficient when you explore your data and get to know Great Expectations.\n",
     "When deploying Great Expectations in a **real data pipeline, you will typically discover additional needs**:\n",
@@ -240,18 +185,22 @@
    "source": [
     "# This is an example of invoking a validation operator that is configured by default in the great_expectations.yml file\n",
     "\n",
+    "#Generate a run id, a timestamp, or a meaningful string that will help you refer to validation results. We recommend they be chronologically sortable.\n",
+    "# Let's make a simple sortable timestamp. Note this could come from your pipeline runner (e.g., Airflow run id).\n",
+    "run_id = datetime.utcnow().isoformat().replace(\":\", \"\") + \"Z\"\n",
+    "\n",
     "results = context.run_validation_operator(\n",
-    "    assets_to_validate=[batch],\n",
-    "    run_id=run_id,\n",
-    "    validation_operator_name=\"action_list_operator\",\n",
-    ")"
+    "    \"action_list_operator\", \n",
+    "    assets_to_validate=[batch], \n",
+    "    run_id=run_id)\n",
+    "\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. View the Validation Results in Data Docs\n",
+    "## 6. View the Validation Results in Data Docs\n",
     "\n",
     "Let's now build and look at your Data Docs. These will now include an **data quality report** built from the `ValidationResults` you just created that helps you communicate about your data with both machines and humans.\n",
     "\n",
@@ -275,9 +224,9 @@
     "\n",
     "## Next steps:\n",
     "\n",
-    "### 1. Author more interesting Expectations\n",
+    "### 1. Read about the typical workflow with Great Expectations:\n",
     "\n",
-    "Here we used some **extremely basic** `Expectations`. To really harness the power of Great Expectations you can author much more interesting and specific `Expectations` to protect your data pipelines and defeat pipeline debt. Go to [create_expectations.ipynb](create_expectations.ipynb) to see how!\n",
+    "[typical workflow](https://docs.greatexpectations.io/en/latest/getting_started/typical_workflow.html?utm_source=notebook&utm_medium=validate_data#view-the-validation-results-in-data-docs)\n",
     "\n",
     "### 2. Explore the documentation & community\n",
     "\n",

--- a/great_expectations/init_notebooks/spark/validation_playground.ipynb
+++ b/great_expectations/init_notebooks/spark/validation_playground.ipynb
@@ -109,6 +109,7 @@
    "source": [
     "# If you would like to validate a file on a filesystem:\n",
     "batch_kwargs = {'path': \"YOUR_FILE_PATH\", 'datasource': datasource_name}\n",
+    "# To customize how Spark reads the file, you can add options under reader_options key in batch_kwargs (e.g., header='true') \n",
     "\n",
     "# If you already loaded the data into a PySpark Data Frame:\n",
     "batch_kwargs = {'dataset': \"YOUR_DATAFRAME\", 'datasource': datasource_name}\n",

--- a/great_expectations/init_notebooks/spark/validation_playground.ipynb
+++ b/great_expectations/init_notebooks/spark/validation_playground.ipynb
@@ -8,6 +8,10 @@
     "\n",
     "**Watch** a [short tutorial video](https://greatexpectations.io/videos/getting_started/integrate_expectations) or **read** [the written tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data)\n",
     "\n",
+    "#### This notebook assumes that you created at least one expectation suite in your project.\n",
+    "#### Here you will learn how to validate data loaded into a PySpark DataFrame against an expectation suite.\n",
+    "\n",
+    "\n",
     "We'd love it if you **reach out for help on** the [**Great Expectations Slack Channel**](https://greatexpectations.io/slack)"
    ]
   },
@@ -19,7 +23,6 @@
    "source": [
     "import json\n",
     "import great_expectations as ge\n",
-    "from great_expectations.profile import ColumnsExistProfiler\n",
     "import great_expectations.jupyter_ux\n",
     "from great_expectations.datasource.types import BatchKwargs\n",
     "from datetime import datetime"
@@ -30,7 +33,7 @@
    "metadata": {},
    "source": [
     "## 1. Get a DataContext\n",
-    "This represents your **project** that you just created using `great_expectations init`. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#get-a-datacontext-object)"
+    "This represents your **project** that you just created using `great_expectations init`."
    ]
   },
   {
@@ -46,9 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. List the CSVs in your folder\n",
-    "\n",
-    "The `DataContext` will now introspect your pyspark `Datasource` and list the CSVs it finds. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#list-data-assets)"
+    "## 2. Choose an Expectation Suite\n"
    ]
   },
   {
@@ -57,16 +58,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ge.jupyter_ux.list_available_data_asset_names(context)"
+    "# list expectation suites that you created in your project\n",
+    "\n",
+    "for expectation_suite_id in context.list_expectation_suite_keys():\n",
+    "    print(expectation_suite_id.expectation_suite_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expectation_suite_name =  # TODO: set to a name from the list above"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Pick a csv and the expectation suite\n",
+    "## 3. Load a batch of data you want to validate\n",
     "\n",
-    "Internally, Great Expectations represents csvs and dataframes as `DataAsset`s and uses this notion to link them to `Expectation Suites`. [Read more about the validate method in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#pick-a-data-asset-and-expectation-suite)\n"
+    "To learn more about `get_batch`, see [this tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#load-a-batch-of-data-to-validate)\n"
    ]
   },
   {
@@ -75,16 +88,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_asset_name = \"ONE_OF_THE_CSV_DATA_ASSET_NAMES_FROM_ABOVE\" # TODO: replace with your value!\n",
-    "normalized_data_asset_name = context.normalize_data_asset_name(data_asset_name)\n",
-    "normalized_data_asset_name"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We recommend naming your first expectation suite for a table `warning`. Later, as you identify some of the expectations that you add to this suite as critical, you can move these expectations into another suite and call it `failure`. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=integrate_validation#choose-data-asset-and-expectation-suite)"
+    "# list datasources of the type SparkDFDatasource in your project\n",
+    "[datasource['name'] for datasource in context.list_datasources() if datasource['class_name'] == 'SparkDFDatasource']"
    ]
   },
   {
@@ -93,23 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name = \"warning\" # TODO: replace with your value!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### 3.a. If you don't have an expectation suite, let's create a simple one\n",
-    "\n",
-    "You need expectations to validate your data. Expectations are grouped into Expectation Suites. \n",
-    "\n",
-    "If you don't have an expectation suite for this data asset, the notebook's next cell will create a suite of very basic expectations, so that you have some expectations to play with. The expectation suite will have `expect_column_to_exist` expectations for each column.\n",
-    "\n",
-    "If you created an expectation suite for this data asset, you can skip executing the next cell (if you execute it, it will do nothing).\n",
-    "\n",
-    "To create a more interesting suite, open the [create_expectations.ipynb](create_expectations.ipynb) notebook.\n",
-    "\n"
+    "datasource_name = # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -118,35 +107,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    context.get_expectation_suite(normalized_data_asset_name, expectation_suite_name)\n",
-    "except great_expectations.exceptions.DataContextError:\n",
-    "    context.create_expectation_suite(data_asset_name=normalized_data_asset_name, expectation_suite_name=expectation_suite_name, overwrite_existing=True);\n",
-    "    batch_kwargs = context.yield_batch_kwargs(data_asset_name)\n",
-    "    batch = context.get_batch(normalized_data_asset_name, expectation_suite_name, batch_kwargs)\n",
-    "    ColumnsExistProfiler().profile(batch)\n",
-    "    batch.save_expectation_suite()\n",
-    "    expectation_suite = context.get_expectation_suite(normalized_data_asset_name, expectation_suite_name)\n",
-    "    context.build_data_docs()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4. Load a batch of data you want to validate\n",
+    "# If you would like to validate a file on a filesystem:\n",
+    "batch_kwargs = {'path': \"YOUR_FILE_PATH\", 'datasource': datasource_name}\n",
     "\n",
-    "To learn more about `get_batch` with other data types (such as existing pandas dataframes, SQL tables or Spark), see [this tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#load-a-batch-of-data-to-validate)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "batch_kwargs = context.yield_batch_kwargs(data_asset_name)\n",
-    "batch = context.get_batch(normalized_data_asset_name, expectation_suite_name, batch_kwargs)\n",
+    "# If you already loaded the data into a PySpark Data Frame:\n",
+    "batch_kwargs = {'dataset': \"YOUR_DATAFRAME\", 'datasource': datasource_name}\n",
+    "\n",
+    "\n",
+    "batch = context.get_batch(batch_kwargs, expectation_suite_name)\n",
     "batch.head()"
    ]
   },
@@ -154,30 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Get a pipeline run id\n",
-    "\n",
-    "Generate a run id, a timestamp, or a meaningful string that will help you refer to validation results. We recommend they be chronologically sortable.\n",
-    "[Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=validate_data#set-a-run-id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's make a simple sortable timestamp. Note this could come from your pipeline runner.\n",
-    "run_id = datetime.utcnow().isoformat().replace(\":\", \"\") + \"Z\"\n",
-    "run_id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 6. Validate the batch\n",
-    "\n",
-    "This is the \"workhorse\" of Great Expectations. Call it in your pipeline code after loading data and just before passing it to your computation.\n",
+    "## 4. Validate the batch\n",
     "\n",
     "[Read more about the validate method in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#validate-the-batch)\n"
    ]
@@ -188,19 +133,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "validation_result = batch.validate(run_id=run_id)\n",
+    "validation_result = batch.validate()\n",
     "\n",
     "if validation_result[\"success\"]:\n",
-    "    print(\"This data meets all expectations for {}\".format(str(data_asset_name)))\n",
+    "    print(\"This data meets all expectations in {}\".format(expectation_suite_name))\n",
     "else:\n",
-    "    print(\"This data is not a valid batch of {}\".format(str(data_asset_name)))"
+    "    print(\"This data does not meet some expectations in {}\".format(expectation_suite_name))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6.a. OPTIONAL: Review the JSON validation results\n",
+    "## 4.a. OPTIONAL: Review the JSON validation results\n",
     "\n",
     "Don't worry - this blob of JSON is meant for machines. Continue on or skip this to see this in Data Docs!"
    ]
@@ -211,14 +156,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# print(json.dumps(validation_result, indent=4))"
+    "#validation_result"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Validation Operators\n",
+    "## 5. Validation Operators\n",
     "\n",
     "The `validate` method evaluates one batch of data against one expectation suite and returns a dictionary of validation results. This is sufficient when you explore your data and get to know Great Expectations.\n",
     "When deploying Great Expectations in a **real data pipeline, you will typically discover additional needs**:\n",
@@ -240,18 +185,22 @@
    "source": [
     "# This is an example of invoking a validation operator that is configured by default in the great_expectations.yml file\n",
     "\n",
+    "#Generate a run id, a timestamp, or a meaningful string that will help you refer to validation results. We recommend they be chronologically sortable.\n",
+    "# Let's make a simple sortable timestamp. Note this could come from your pipeline runner (e.g., Airflow run id).\n",
+    "run_id = datetime.utcnow().isoformat().replace(\":\", \"\") + \"Z\"\n",
+    "\n",
     "results = context.run_validation_operator(\n",
-    "    assets_to_validate=[batch],\n",
-    "    run_id=run_id,\n",
-    "    validation_operator_name=\"action_list_operator\",\n",
-    ")"
+    "    \"action_list_operator\", \n",
+    "    assets_to_validate=[batch], \n",
+    "    run_id=run_id)\n",
+    "\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. View the Validation Results in Data Docs\n",
+    "## 6. View the Validation Results in Data Docs\n",
     "\n",
     "Let's now build and look at your Data Docs. These will now include an **data quality report** built from the `ValidationResults` you just created that helps you communicate about your data with both machines and humans.\n",
     "\n",
@@ -275,9 +224,9 @@
     "\n",
     "## Next steps:\n",
     "\n",
-    "### 1. Author more interesting Expectations\n",
+    "### 1. Read about the typical workflow with Great Expectations:\n",
     "\n",
-    "Here we used some **extremely basic** `Expectations`. To really harness the power of Great Expectations you can author much more interesting and specific `Expectations` to protect your data pipelines and defeat pipeline debt. Go to [create_expectations.ipynb](create_expectations.ipynb) to see how!\n",
+    "[typical workflow](https://docs.greatexpectations.io/en/latest/getting_started/typical_workflow.html?utm_source=notebook&utm_medium=validate_data#view-the-validation-results-in-data-docs)\n",
     "\n",
     "### 2. Explore the documentation & community\n",
     "\n",

--- a/great_expectations/init_notebooks/sql/validation_playground.ipynb
+++ b/great_expectations/init_notebooks/sql/validation_playground.ipynb
@@ -8,6 +8,10 @@
     "\n",
     "**Watch** a [short tutorial video](https://greatexpectations.io/videos/getting_started/integrate_expectations) or **read** [the written tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data)\n",
     "\n",
+    "#### This notebook assumes that you created at least one expectation suite in your project.\n",
+    "#### Here you will learn how to validate data in a SQL database against an expectation suite.\n",
+    "\n",
+    "\n",
     "We'd love it if you **reach out for help on** the [**Great Expectations Slack Channel**](https://greatexpectations.io/slack)"
    ]
   },
@@ -19,7 +23,6 @@
    "source": [
     "import json\n",
     "import great_expectations as ge\n",
-    "from great_expectations.profile import ColumnsExistProfiler\n",
     "import great_expectations.jupyter_ux\n",
     "from great_expectations.datasource.types import BatchKwargs\n",
     "from datetime import datetime"
@@ -30,7 +33,7 @@
    "metadata": {},
    "source": [
     "## 1. Get a DataContext\n",
-    "This represents your **project** that you just created using `great_expectations init`. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#get-a-datacontext-object)"
+    "This represents your **project** that you just created using `great_expectations init`."
    ]
   },
   {
@@ -46,9 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. List the tables in your database\n",
-    "\n",
-    "The `DataContext` will now introspect your database `Datasource` and list the tables. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#list-data-assets)"
+    "## 2. Choose an Expectation Suite\n"
    ]
   },
   {
@@ -57,16 +58,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ge.jupyter_ux.list_available_data_asset_names(context)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3. Pick a table and set the expectation suite name\n",
+    "# list expectation suites that you created in your project\n",
     "\n",
-    "Internally, Great Expectations represents tables and views as `DataAsset`s and uses this notion to link them to `Expectation Suites`. [Read more about the validate method in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#pick-a-data-asset-and-expectation-suite)\n"
+    "for expectation_suite_id in context.list_expectation_suite_keys():\n",
+    "    print(expectation_suite_id.expectation_suite_name)"
    ]
   },
   {
@@ -75,16 +70,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_asset_name = \"YOUR_TABLE_NAME_LISTED_ABOVE\" # TODO: replace with your value!\n",
-    "normalized_data_asset_name = context.normalize_data_asset_name(data_asset_name)\n",
-    "normalized_data_asset_name"
+    "expectation_suite_name =  # TODO: set to a name from the list above"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We recommend naming your first expectation suite for a table `warning`. Later, as you identify some of the expectations that you add to this suite as critical, you can move these expectations into another suite and call it `failure`. [Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=integrate_validation#choose-data-asset-and-expectation-suite)"
+    "## 3. Load a batch of data you want to validate\n",
+    "\n",
+    "To learn more about `get_batch`, see [this tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#load-a-batch-of-data-to-validate)\n"
    ]
   },
   {
@@ -93,23 +88,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name = \"warning\" # TODO: replace with your value!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### 3.a. If you don't have an expectation suite, let's create a simple one\n",
-    "\n",
-    "You need expectations to validate your data. Expectations are grouped into Expectation Suites. \n",
-    "\n",
-    "If you don't have an expectation suite for this data asset, the notebook's next cell will create a suite of very basic expectations, so that you have some expectations to play with. The expectation suite will have `expect_column_to_exist` expectations for each column.\n",
-    "\n",
-    "If you created an expectation suite for this data asset, you can skip executing the next cell (if you execute it, it will do nothing).\n",
-    "\n",
-    "To create a more interesting suite, open the [create_expectations.ipynb](create_expectations.ipynb) notebook.\n",
-    "\n"
+    "# list datasources of the type SqlAlchemyDatasource in your project\n",
+    "[datasource['name'] for datasource in context.list_datasources() if datasource['class_name'] == 'SqlAlchemyDatasource']"
    ]
   },
   {
@@ -118,25 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    context.get_expectation_suite(normalized_data_asset_name, expectation_suite_name)\n",
-    "except great_expectations.exceptions.DataContextError:\n",
-    "    context.create_expectation_suite(data_asset_name=normalized_data_asset_name, expectation_suite_name=expectation_suite_name, overwrite_existing=True);\n",
-    "    batch_kwargs = context.yield_batch_kwargs(data_asset_name)\n",
-    "    batch = context.get_batch(normalized_data_asset_name, expectation_suite_name, batch_kwargs)\n",
-    "    ColumnsExistProfiler().profile(batch)\n",
-    "    batch.save_expectation_suite()\n",
-    "    expectation_suite = context.get_expectation_suite(normalized_data_asset_name, expectation_suite_name)\n",
-    "    context.build_data_docs()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4. Load a batch of data you want to validate\n",
-    "\n",
-    "To learn more about `get_batch` with other data types (such as csv files, pandas, or Spark), see [this tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#load-a-batch-of-data-to-validate)\n"
+    "datasource_name = # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -146,15 +108,17 @@
    "outputs": [],
    "source": [
     "# If you would like to validate an entire table or view in your database's default schema:\n",
-    "batch_kwargs = {'table': \"YOUR_TABLE\"}\n",
+    "batch_kwargs = {'table': \"YOUR_TABLE\", 'datasource': datasource_name}\n",
     "\n",
     "# If you would like to validate an entire table or view from a non-default schema in your database:\n",
-    "batch_kwargs = {'table': \"YOUR_TABLE\", \"schema\": \"YOUR_SCHEMA\"}\n",
+    "batch_kwargs = {'table': \"YOUR_TABLE\", \"schema\": \"YOUR_SCHEMA\", 'datasource': datasource_name}\n",
     "\n",
-    "# If you would like to validate using a query to construct a temporary table:\n",
-    "# batch_kwargs = {'query': 'SELECT YOUR_ROWS FROM YOUR_TABLE'}\n",
+    "# If you would like to validate the result set of a query:\n",
+    "# batch_kwargs = {'query': 'SELECT YOUR_ROWS FROM YOUR_TABLE', 'datasource': datasource_name}\n",
     "\n",
-    "batch = context.get_batch(normalized_data_asset_name, expectation_suite_name, batch_kwargs)\n",
+    "\n",
+    "\n",
+    "batch = context.get_batch(batch_kwargs, expectation_suite_name)\n",
     "batch.head()"
    ]
   },
@@ -162,30 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Get a pipeline run id\n",
-    "\n",
-    "Generate a run id, a timestamp, or a meaningful string that will help you refer to validation results. We recommend they be chronologically sortable.\n",
-    "[Read more in the tutorial](https://docs.greatexpectations.io/en/latest/getting_started/pipeline_integration.html?utm_source=notebook&utm_medium=validate_data#set-a-run-id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's make a simple sortable timestamp. Note this could come from your pipeline runner.\n",
-    "run_id = datetime.utcnow().isoformat().replace(\":\", \"\") + \"Z\"\n",
-    "run_id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 6. Validate the batch\n",
-    "\n",
-    "This is the \"workhorse\" of Great Expectations. Call it in your pipeline code after loading data and just before passing it to your computation.\n",
+    "## 4. Validate the batch\n",
     "\n",
     "[Read more about the validate method in the tutorial](https://docs.greatexpectations.io/en/latest/tutorials/validate_data.html?utm_source=notebook&utm_medium=validate_data#validate-the-batch)\n"
    ]
@@ -196,19 +137,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "validation_result = batch.validate(run_id=run_id)\n",
+    "validation_result = batch.validate()\n",
     "\n",
     "if validation_result[\"success\"]:\n",
-    "    print(\"This data meets all expectations for {}\".format(str(data_asset_name)))\n",
+    "    print(\"This data meets all expectations in {}\".format(expectation_suite_name))\n",
     "else:\n",
-    "    print(\"This data is not a valid batch of {}\".format(str(data_asset_name)))"
+    "    print(\"This data does not meet some expectations in {}\".format(expectation_suite_name))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6.a. OPTIONAL: Review the JSON validation results\n",
+    "## 4.a. OPTIONAL: Review the JSON validation results\n",
     "\n",
     "Don't worry - this blob of JSON is meant for machines. Continue on or skip this to see this in Data Docs!"
    ]
@@ -219,14 +160,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# print(json.dumps(validation_result, indent=4))"
+    "#validation_result"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Validation Operators\n",
+    "## 5. Validation Operators\n",
     "\n",
     "The `validate` method evaluates one batch of data against one expectation suite and returns a dictionary of validation results. This is sufficient when you explore your data and get to know Great Expectations.\n",
     "When deploying Great Expectations in a **real data pipeline, you will typically discover additional needs**:\n",
@@ -248,18 +189,22 @@
    "source": [
     "# This is an example of invoking a validation operator that is configured by default in the great_expectations.yml file\n",
     "\n",
+    "#Generate a run id, a timestamp, or a meaningful string that will help you refer to validation results. We recommend they be chronologically sortable.\n",
+    "# Let's make a simple sortable timestamp. Note this could come from your pipeline runner (e.g., Airflow run id).\n",
+    "run_id = datetime.utcnow().isoformat().replace(\":\", \"\") + \"Z\"\n",
+    "\n",
     "results = context.run_validation_operator(\n",
-    "    assets_to_validate=[batch],\n",
-    "    run_id=run_id,\n",
-    "    validation_operator_name=\"action_list_operator\",\n",
-    ")"
+    "    \"action_list_operator\", \n",
+    "    assets_to_validate=[batch], \n",
+    "    run_id=run_id)\n",
+    "\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. View the Validation Results in Data Docs\n",
+    "## 6. View the Validation Results in Data Docs\n",
     "\n",
     "Let's now build and look at your Data Docs. These will now include an **data quality report** built from the `ValidationResults` you just created that helps you communicate about your data with both machines and humans.\n",
     "\n",
@@ -283,9 +228,9 @@
     "\n",
     "## Next steps:\n",
     "\n",
-    "### 1. Author more interesting Expectations\n",
+    "### 1. Read about the typical workflow with Great Expectations:\n",
     "\n",
-    "Here we used some **extremely basic** `Expectations`. To really harness the power of Great Expectations you can author much more interesting and specific `Expectations` to protect your data pipelines and defeat pipeline debt. Go to [create_expectations.ipynb](create_expectations.ipynb) to see how!\n",
+    "[typical workflow](https://docs.greatexpectations.io/en/latest/getting_started/typical_workflow.html?utm_source=notebook&utm_medium=validate_data#view-the-validation-results-in-data-docs)\n",
     "\n",
     "### 2. Explore the documentation & community\n",
     "\n",


### PR DESCRIPTION
1. Remove all references to data assets and their normalization
2. Removed unnecessary steps like auto-creation of a notebook, since the user can easily do it using the suite new command
3. Added basic examples of batch kwargs for the datasources
4. Updated some wording

Doc and video links are outdated until we update the documentation.
