### PR TITLE
Make the return object of get_available_data_asset_names method consistent across all generator classes

### DIFF
--- a/great_expectations/datasource/generator/databricks_generator.py
+++ b/great_expectations/datasource/generator/databricks_generator.py
@@ -29,10 +29,10 @@ class DatabricksTableGenerator(BatchKwargsGenerator):
     def get_available_data_asset_names(self):
         if self.spark is None:
             logger.warning("No sparkSession available to query for tables.")
-            return set()
+            return {"names": []}
 
         tables = self.spark.sql('show tables in {}'.format(self.database))
-        return [row.tableName for row in tables.collect()]
+        return {"names": [(row.tableName, "table") for row in tables.collect()]}
 
     def _get_iterator(self, generator_asset, **kwargs):
         query = 'select * from {}.{}'.format(self.database, generator_asset)

--- a/great_expectations/datasource/generator/glob_reader_generator.py
+++ b/great_expectations/datasource/generator/glob_reader_generator.py
@@ -99,13 +99,13 @@ class GlobReaderGenerator(BatchKwargsGenerator):
     def get_available_data_asset_names(self):
         known_assets = []
         if not os.path.isdir(self.base_directory):
-            return known_assets
+            return {"names": [(asset, "path") for asset in known_assets]}
         for generator_asset in self.asset_globs.keys():
             batch_paths = self._get_generator_asset_paths(generator_asset)
             if len(batch_paths) > 0 and generator_asset not in known_assets:
                 known_assets.append(generator_asset)
 
-        return [(asset, "path") for asset in known_assets]
+        return {"names": [(asset, "path") for asset in known_assets]}
 
     def get_available_partition_ids(self, generator_asset):
         glob_config = self._get_generator_asset_config(generator_asset)

--- a/great_expectations/datasource/generator/query_generator.py
+++ b/great_expectations/datasource/generator/query_generator.py
@@ -87,7 +87,7 @@ class QueryGenerator(BatchKwargsGenerator):
     def get_available_data_asset_names(self):
         defined_queries = self._store_backend.list_keys()
         # Backends must have a tuple key; we use only a single-element tuple
-        return [(query_key_tuple[0], "query") for query_key_tuple in defined_queries]
+        return {"names": [(query_key_tuple[0], "query") for query_key_tuple in defined_queries]}
 
     def _build_batch_kwargs(self, batch_parameters):
         """Build batch kwargs from a partition id."""

--- a/great_expectations/datasource/generator/s3_generator.py
+++ b/great_expectations/datasource/generator/s3_generator.py
@@ -112,7 +112,8 @@ class S3Generator(BatchKwargsGenerator):
         return self._bucket
 
     def get_available_data_asset_names(self):
-        return self._assets.keys()
+        return {"names": [(key, "file") for key in self._assets.keys()]}
+
 
     def _get_iterator(self, generator_asset, reader_options=None, limit=None):
         logger.debug("Beginning S3Generator _get_iterator for generator_asset: %s" % generator_asset)

--- a/tests/datasource/generator/test_glob_reader_generator.py
+++ b/tests/datasource/generator/test_glob_reader_generator.py
@@ -110,7 +110,7 @@ def test_glob_reader_generator_partitioning(basic_pandas_datasource):
         is_dir.return_value = True
         names = glob_generator.get_available_data_asset_names()
         # Use set in test to avoid order issues
-        assert set(names) == {("asset1", "path"), ("asset2", "path"), ("asset3", "path"), ("no_partition_asset1", \
+        assert set(names["names"]) == {("asset1", "path"), ("asset2", "path"), ("asset3", "path"), ("no_partition_asset1", \
                                                                                          "path"),
                               ("no_partition_asset2", "path")}
 

--- a/tests/datasource/generator/test_query_generator.py
+++ b/tests/datasource/generator/test_query_generator.py
@@ -66,4 +66,4 @@ def test_get_available_data_asset_names_for_query_path(empty_data_context):
     data_source = Datasource(name="mydatasource", data_context=empty_data_context)
     generator = QueryGenerator(name="mygenerator", datasource=data_source)
     sql_list = generator.get_available_data_asset_names()
-    assert ("dummy", "query") in sql_list
+    assert ("dummy", "query") in sql_list["names"]

--- a/tests/datasource/generator/test_s3_generator.py
+++ b/tests/datasource/generator/test_s3_generator.py
@@ -87,7 +87,7 @@ def s3_generator(mock_s3_bucket, basic_sparkdf_datasource):
 def test_s3_generator_basic_operation(s3_generator):
     # S3 Generator sees *only* configured assets
     assets = s3_generator.get_available_data_asset_names()
-    assert set(assets) == {"data", "data_dirs", "other", "delta_files", "other_empty_delimiter"}
+    assert set(assets["names"]) == set([('data', 'file'), ('data_dirs', 'file'), ('other', 'file'), ('delta_files', 'file'), ('other_empty_delimiter', 'file')])
 
     # We should observe that glob, prefix, delimiter all work together
     # They can be defined in the generator or overridden by a particular asset

--- a/tests/datasource/test_batch_generators.py
+++ b/tests/datasource/test_batch_generators.py
@@ -95,7 +95,7 @@ def test_glob_reader_generator(basic_pandas_datasource, tmp_path_factory):
 
     g2_assets = g2.get_available_data_asset_names()
     # Use set in test to avoid order issues
-    assert set(g2_assets) == {("blargs", "path"), ("fs", "path")}
+    assert set(g2_assets["names"]) == {("blargs", "path"), ("fs", "path")}
 
     blargs_kwargs = [x["path"] for x in g2.get_iterator("blargs")]
     real_blargs = [
@@ -161,7 +161,7 @@ def test_databricks_generator(basic_sparkdf_datasource):
     available_assets = generator.get_available_data_asset_names()
 
     # We have no tables available
-    assert available_assets == []
+    assert available_assets == {"names": []}
 
     databricks_kwargs_iterator = generator.get_iterator("foo")
     kwargs = [batch_kwargs for batch_kwargs in databricks_kwargs_iterator]


### PR DESCRIPTION
Made sure that get_available_data_asset_names method in all batch kwargs generator classes returns a structure of this type: {'names': [(asset_name, asset_type),...]}