### PR TITLE
Fixed the logic of stripping the json file extension from suite name

### DIFF
--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -64,7 +64,8 @@ def suite_edit(suite, directory, jupyter, batch_kwargs):
         _offer_to_install_new_template(err, context.root_directory)
         return
 
-    suite = suite.rstrip(".json")
+    if suite.endswith(".json"):
+        suite = suite[:-5]
     suite = _load_suite(context, suite)
 
     if batch_kwargs:


### PR DESCRIPTION
Note: there are no tests for the "suite edit" command in the 0.9.0 branch.
I added tests in https://github.com/great-expectations/great_expectations/pull/1041, so it is easier to add a test with ".json" there