### PR TITLE
tweaks to 1041 - merge this into 1041 first

### DIFF
--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -153,12 +153,12 @@ def _load_suite(context, suite_name):
         suite = context.get_expectation_suite(suite_name)
     except ge_exceptions.DataContextError as e:
         cli_message(
-            "<red>Could not locate a suite named {}</red>".format(
+            "<red>Could not find a suite named `{}`. Please check the name and try again.</red>".format(
                 suite_name
             )
         )
         logger.info(e)
-        sys.exit(-1)
+        sys.exit(1)
     return suite
 
 

--- a/great_expectations/render/renderer/notebook_renderer.py
+++ b/great_expectations/render/renderer/notebook_renderer.py
@@ -81,7 +81,8 @@ batch_kwargs = {}
 batch = context.get_batch(batch_kwargs, expectation_suite_name)
 batch.head()""".format(
                 suite_name, batch_kwargs
-            )
+            ),
+            lint=True
         )
 
     def add_footer(self):

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -224,6 +224,30 @@ def test_suite_edit_with_non_existent_suite_name_raises_error(
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+def test_suite_edit_with_non_existent_datasource_name_shows_helpful_error_message(
+    caplog, empty_data_context
+):
+    project_dir = empty_data_context.root_directory
+    context = DataContext(project_dir)
+    context.create_expectation_suite("foo")
+    assert context.list_expectation_suite_keys()[0].expectation_suite_name == "foo"
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        "suite edit foo -d {} --datasource_name not_real".format(project_dir),
+        catch_exceptions=False,
+    )
+    print(result.output)
+    assert result.exit_code == 1
+    # TODO this may not be the most helpful error message, but it is a start
+    assert (
+        "Unable to load datasource not_real -- no configuration found or invalid configuration."
+        in result.output
+    )
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
 def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args(
     caplog, site_builder_data_context_with_html_store_titanic_random,
 ):

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -197,6 +197,33 @@ def test_suite_new_multiple_datasources_with_generator_with_suite_name_argument(
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+def test_suite_edit_without_suite_name_raises_error(caplog):
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(cli, "suite edit", catch_exceptions=False)
+    assert result.exit_code == 2
+    assert 'Error: Missing argument "SUITE".' in result.stderr
+
+
+def test_suite_edit_with_non_existent_suite_name_raises_error(
+    caplog, empty_data_context
+):
+    project_dir = empty_data_context.root_directory
+    assert not empty_data_context.list_expectation_suite_keys()
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        "suite edit not_a_real_suite -d {}".format(project_dir),
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert (
+        "Could not find a suite named `not_a_real_suite`. Please check the name and try again"
+        in result.output
+    )
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
 def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args(
     caplog, site_builder_data_context_with_html_store_titanic_random,
 ):
@@ -238,7 +265,6 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args(
     assert "Select data source" in stdout
     assert "Which data would you like to use" in stdout
     assert "To continue editing this suite, run" in stdout
-
 
     expected_notebook_path = os.path.join(
         root_dir, "uncommitted", "foo_suite.ipynb"

--- a/tests/render/renderer/test_notebook_renderer.py
+++ b/tests/render/renderer/test_notebook_renderer.py
@@ -268,8 +268,8 @@ def test_simple_suite(critical_suite):
                 "cell_type": "code",
                 "metadata": {},
                 "execution_count": None,
-                "source": 'from datetime import datetime\nimport great_expectations as ge\nimport great_expectations.jupyter_ux\nfrom great_expectations.data_context.types.resource_identifiers import ValidationResultIdentifier\n\ncontext = ge.data_context.DataContext()\n\nexpectation_suite_name = "critical"  # Feel free to change the name of your suite here. Renaming this will not remove the other one.\ncontext.create_expectation_suite(expectation_suite_name, overwrite_existing=True)\n\nbatch_kwargs = {\'path\': \'../../foo/data\'}\nbatch = context.get_batch(batch_kwargs, expectation_suite_name)\nbatch.head()',
-                "outputs": [],
+                "source": 'from datetime import datetime\nimport great_expectations as ge\nimport great_expectations.jupyter_ux\nfrom great_expectations.data_context.types.resource_identifiers import ValidationResultIdentifier\n\ncontext = ge.data_context.DataContext()\n\n# Feel free to change the name of your suite here. Renaming this will not\n# remove the other one.\nexpectation_suite_name = "critical"\ncontext.create_expectation_suite(\n    expectation_suite_name,\n    overwrite_existing=True)\n\nbatch_kwargs = {\'path\': \'../../foo/data\'}\nbatch = context.get_batch(batch_kwargs, expectation_suite_name)\nbatch.head()',
+                "outputs": []
             },
             {
                 "cell_type": "markdown",
@@ -390,6 +390,7 @@ def test_batch_kwarg_path_absolute_is_not_modified_and_is_found_in_a_code_cell(
 
     assert found_expected
 
+
 @pytest.mark.xfail(condition=PY2, reason="legacy python")
 def test_complex_suite(warning_suite):
     obs = NotebookRenderer().render(warning_suite, {"path": "foo/data"})
@@ -408,7 +409,7 @@ def test_complex_suite(warning_suite):
                 "cell_type": "code",
                 "metadata": {},
                 "execution_count": None,
-                "source": 'from datetime import datetime\nimport great_expectations as ge\nimport great_expectations.jupyter_ux\nfrom great_expectations.data_context.types.resource_identifiers import ValidationResultIdentifier\n\ncontext = ge.data_context.DataContext()\n\nexpectation_suite_name = "warning"  # Feel free to change the name of your suite here. Renaming this will not remove the other one.\ncontext.create_expectation_suite(expectation_suite_name, overwrite_existing=True)\n\nbatch_kwargs = {\'path\': \'../../foo/data\'}\nbatch = context.get_batch(batch_kwargs, expectation_suite_name)\nbatch.head()',
+                "source": 'from datetime import datetime\nimport great_expectations as ge\nimport great_expectations.jupyter_ux\nfrom great_expectations.data_context.types.resource_identifiers import ValidationResultIdentifier\n\ncontext = ge.data_context.DataContext()\n\n# Feel free to change the name of your suite here. Renaming this will not\n# remove the other one.\nexpectation_suite_name = "warning"\ncontext.create_expectation_suite(\n    expectation_suite_name,\n    overwrite_existing=True)\n\nbatch_kwargs = {\'path\': \'../../foo/data\'}\nbatch = context.get_batch(batch_kwargs, expectation_suite_name)\nbatch.head()',
                 "outputs": [],
             },
             {


### PR DESCRIPTION
While I'm reviewing #1041 I'm adding a few automated tests to cover manual tests I'm running during usability review. This should be considered **only a partial review of 1041**.

## What's Here

* updated cli message in suite new when suite not found
* changed exit code in same case
* more basic tests for suite new
* additional cell linted in `NotebookRenderer`