### PR TITLE
suite edit improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   - master
   - develop
   - /^\d.*/
-  - aylr*
+  - aylr.*
 # dist: xenial
 language: python
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   - master
   - develop
   - /^\d.*/
+  - aylr//*
 # dist: xenial
 language: python
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   - master
   - develop
   - /^\d.*/
-  - aylr//*
+  - aylr*
 # dist: xenial
 language: python
 cache: pip

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -17,7 +17,7 @@ from great_expectations.cli.util import (
     _offer_to_install_new_template,
     cli_message,
 )
-from great_expectations.datasource.generator import ManualBatchKwargsGenerator
+from great_expectations.data_asset import DataAsset
 from great_expectations.render.renderer.notebook_renderer import (
     NotebookRenderer,
 )
@@ -91,12 +91,16 @@ def suite_edit(suite, datasource, directory, jupyter, batch_kwargs):
     if batch_kwargs:
         try:
             batch_kwargs = json.loads(batch_kwargs)
+            _batch = context.get_batch(batch_kwargs, suite)
+            assert isinstance(_batch, DataAsset)
         except json.decoder.JSONDecodeError as je:
             cli_message("<red>Please check that your batch_kwargs are valid JSON.\n{}</red>".format(je))
             exit(1)
+        except ge_exceptions.DataContextError:
+            cli_message("<red>Please check that your batch_kwargs are able to load a batch.</red>")
+            exit(1)
     else:
-        cli_message(
-            """
+        cli_message("""
 A batch of data is required to edit the suite - let's help you to specify it."""
         )
 

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -91,6 +91,8 @@ def suite_edit(suite, datasource, directory, jupyter, batch_kwargs):
     if batch_kwargs:
         try:
             batch_kwargs = json.loads(batch_kwargs)
+            if datasource:
+                batch_kwargs["datasource"] = datasource
             _batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
             assert isinstance(_batch, DataAsset)
         except json.decoder.JSONDecodeError as je:
@@ -98,6 +100,9 @@ def suite_edit(suite, datasource, directory, jupyter, batch_kwargs):
             sys.exit(1)
         except ge_exceptions.DataContextError:
             cli_message("<red>Please check that your batch_kwargs are able to load a batch.</red>")
+            sys.exit(1)
+        except ValueError as ve:
+            cli_message("<red>Please check that your batch_kwargs are able to load a batch.\n{}</red>".format(ve))
             sys.exit(1)
     else:
         cli_message("""

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -620,7 +620,7 @@ class BaseDataContext(object):
                 self._project_config_with_variables_substituted["datasources"][datasource_name])
         else:
             raise ValueError(
-                "Unable to load datasource %s -- no configuration found or invalid configuration." % datasource_name
+                "Unable to load datasource `%s` -- no configuration found or invalid configuration." % datasource_name
             )
         datasource = self._build_datasource_from_config(datasource_name, datasource_config)
         self._datasources[datasource_name] = datasource

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -204,6 +204,26 @@ def test_suite_edit_without_suite_name_raises_error(caplog):
     assert 'Error: Missing argument "SUITE".' in result.stderr
 
 
+def test_suite_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
+    caplog,
+    empty_data_context
+):
+    project_dir = empty_data_context.root_directory
+    context = DataContext(project_dir)
+    context.create_expectation_suite("foo")
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        ["suite", "edit", "foo", "-d", project_dir, "--batch_kwargs", "'{foobar}'"],
+        catch_exceptions=False
+    )
+    stdout = result.output
+    assert result.exit_code == 1
+    assert 'Please check that your batch_kwargs are valid JSON.'
+    assert 'Expecting value' in stdout
+
+
 def test_suite_edit_with_non_existent_suite_name_raises_error(
     caplog, empty_data_context
 ):
@@ -359,6 +379,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@pytest.mark.xfail(reason="not implemented")
 def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_batch_kwargs_without_datasource(
     caplog
 ):
@@ -374,9 +395,9 @@ def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_batch_kw
     - The user should see a nice error and the program halts before notebook compilation.
     '"""
     assert False
-    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@pytest.mark.xfail(reason="not implemented")
 def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_batch_kwargs_inlcuding_datasource_in_batch_kwargs(
     caplog
 ):
@@ -391,9 +412,9 @@ def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_batch_kw
     - The user gets a working notebook
     '"""
     assert False
-    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@pytest.mark.xfail(reason="not implemented")
 def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_datasource_arg_and_batch_kwargs(
     caplog
 ):
@@ -408,9 +429,9 @@ def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_datasour
     - The user gets a working notebook
     '"""
     assert False
-    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@pytest.mark.xfail(reason="not implemented")
 def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_datasource_arg_and_batch_kwargs(
     caplog
 ):
@@ -425,7 +446,6 @@ def test_suite_edit_on_exsiting_suite_one_datasources_no_generator_with_datasour
     - The user gets a working notebook
     '"""
     assert False
-    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_suite_edit_one_datasources_no_generator_with_no_additional_args(

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -20,7 +20,7 @@ def test_suite_help_output(caplog,):
 Commands:
   edit  Generate a Jupyter notebook for editing an existing expectation suite.
   new   Create a new expectation suite."""
-          in result.stdout
+        in result.stdout
     )
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
@@ -205,8 +205,7 @@ def test_suite_edit_without_suite_name_raises_error(caplog):
 
 
 def test_suite_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
-    caplog,
-    empty_data_context
+    caplog, empty_data_context
 ):
     project_dir = empty_data_context.root_directory
     context = DataContext(project_dir)
@@ -216,18 +215,17 @@ def test_suite_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
     result = runner.invoke(
         cli,
         ["suite", "edit", "foo", "-d", project_dir, "--batch_kwargs", "'{foobar}'"],
-        catch_exceptions=False
+        catch_exceptions=False,
     )
     stdout = result.output
     assert result.exit_code == 1
-    assert 'Please check that your batch_kwargs are valid JSON.' in stdout
-    assert 'Expecting value' in stdout
+    assert "Please check that your batch_kwargs are valid JSON." in stdout
+    assert "Expecting value" in stdout
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_suite_edit_with_batch_kwargs_unable_to_load_a_batch_raises_helpful_error(
-    caplog,
-    empty_data_context
+    caplog, empty_data_context
 ):
     project_dir = empty_data_context.root_directory
 
@@ -236,16 +234,16 @@ def test_suite_edit_with_batch_kwargs_unable_to_load_a_batch_raises_helpful_erro
     context.add_datasource("source", class_name="PandasDatasource")
 
     runner = CliRunner(mix_stderr=False)
-    batch_kwargs = '{\"table\": \"fake\", \"datasource\": \"source\"}'
+    batch_kwargs = '{"table": "fake", "datasource": "source"}'
     result = runner.invoke(
         cli,
         ["suite", "edit", "foo", "-d", project_dir, "--batch_kwargs", batch_kwargs],
-        catch_exceptions=False
+        catch_exceptions=False,
     )
     stdout = result.output
     assert result.exit_code == 1
-    assert 'To continue editing this suite' not in stdout
-    assert 'Please check that your batch_kwargs are able to load a batch.' in stdout
+    assert "To continue editing this suite" not in stdout
+    assert "Please check that your batch_kwargs are able to load a batch." in stdout
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
@@ -314,7 +312,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args(
         cli,
         ["suite", "new", "-d", root_dir, "--suite", "foo_suite", "--no-view"],
         input="2\n1\n1\n\n",
-        catch_exceptions=False
+        catch_exceptions=False,
     )
     stdout = result.stdout
     assert result.exit_code == 0
@@ -325,7 +323,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args(
         cli,
         ["suite", "edit", "foo_suite", "-d", root_dir, "--no-jupyter"],
         input="2\n1\n1\n\n",
-        catch_exceptions=False
+        catch_exceptions=False,
     )
 
     assert result.exit_code == 0
@@ -334,9 +332,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args(
     assert "Which data would you like to use" in stdout
     assert "To continue editing this suite, run" in stdout
 
-    expected_notebook_path = os.path.join(
-        root_dir, "uncommitted", "foo_suite.ipynb"
-    )
+    expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
     assert os.path.isfile(expected_notebook_path)
 
     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
@@ -368,20 +364,39 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
         cli,
         ["suite", "new", "-d", root_dir, "--suite", "foo_suite", "--no-view"],
         input="2\n1\n1\n\n",
-        catch_exceptions=False
+        catch_exceptions=False,
     )
     stdout = result.stdout
     assert result.exit_code == 0
     assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
 
-    batch_kwargs = {"datasource": "random", "path": str(os.path.join(os.path.abspath(os.path.join(root_dir, os.pardir)), "data", "random", "f1.csv"))}
+    batch_kwargs = {
+        "datasource": "random",
+        "path": str(
+            os.path.join(
+                os.path.abspath(os.path.join(root_dir, os.pardir)),
+                "data",
+                "random",
+                "f1.csv",
+            )
+        ),
+    }
     batch_kwargs_arg_str = json.dumps(batch_kwargs)
 
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "edit", "foo_suite", "-d", root_dir, "--no-jupyter", "--batch_kwargs", batch_kwargs_arg_str],
-        catch_exceptions=False
+        [
+            "suite",
+            "edit",
+            "foo_suite",
+            "-d",
+            root_dir,
+            "--no-jupyter",
+            "--batch_kwargs",
+            batch_kwargs_arg_str,
+        ],
+        catch_exceptions=False,
     )
     stdout = result.stdout
 
@@ -390,9 +405,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
     assert "Which data would you like to use" not in stdout
     assert "To continue editing this suite, run" in stdout
 
-    expected_notebook_path = os.path.join(
-        root_dir, "uncommitted", "foo_suite.ipynb"
-    )
+    expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
     assert os.path.isfile(expected_notebook_path)
 
     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
@@ -401,8 +414,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
 
 
 def test_suite_edit_on_exsiting_suite_one_datasources_with_batch_kwargs_without_datasource_raises_helpful_error(
-    caplog,
-    titanic_data_context,
+    caplog, titanic_data_context,
 ):
     """
     Given:
@@ -422,19 +434,26 @@ def test_suite_edit_on_exsiting_suite_one_datasources_with_batch_kwargs_without_
     batch_kwargs = {"path": "../data/Titanic.csv"}
     result = runner.invoke(
         cli,
-        ["suite", "edit", "foo", "-d", project_dir, "--batch_kwargs", json.dumps(batch_kwargs)],
-        catch_exceptions=False
+        [
+            "suite",
+            "edit",
+            "foo",
+            "-d",
+            project_dir,
+            "--batch_kwargs",
+            json.dumps(batch_kwargs),
+        ],
+        catch_exceptions=False,
     )
     stdout = result.output
     assert result.exit_code == 1
-    assert 'Please check that your batch_kwargs are able to load a batch.' in stdout
-    assert 'Unable to load datasource `None`' in stdout
+    assert "Please check that your batch_kwargs are able to load a batch." in stdout
+    assert "Unable to load datasource `None`" in stdout
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_suite_edit_on_exsiting_suite_one_datasources_with_datasource_arg_and_batch_kwargs(
-    caplog,
-    titanic_data_context,
+    caplog, titanic_data_context,
 ):
     """
     Given:
@@ -454,21 +473,25 @@ def test_suite_edit_on_exsiting_suite_one_datasources_with_datasource_arg_and_ba
     batch_kwargs = {"path": os.path.join(project_dir, "../", "data", "Titanic.csv")}
     result = runner.invoke(
         cli,
-        ["suite", "edit", "foo", "-d", project_dir, "--batch_kwargs",
-         json.dumps(batch_kwargs),
-         "--datasource",
-         "mydatasource",
-         "--no-jupyter"
-         ],
-        catch_exceptions=False
+        [
+            "suite",
+            "edit",
+            "foo",
+            "-d",
+            project_dir,
+            "--batch_kwargs",
+            json.dumps(batch_kwargs),
+            "--datasource",
+            "mydatasource",
+            "--no-jupyter",
+        ],
+        catch_exceptions=False,
     )
     stdout = result.output
     assert result.exit_code == 0
-    assert 'To continue editing this suite, run' in stdout
+    assert "To continue editing this suite, run" in stdout
 
-    expected_notebook_path = os.path.join(
-        project_dir, "uncommitted", "foo.ipynb"
-    )
+    expected_notebook_path = os.path.join(project_dir, "uncommitted", "foo.ipynb")
     assert os.path.isfile(expected_notebook_path)
     expected_suite_path = os.path.join(project_dir, "expectations", "foo.json")
     assert os.path.isfile(expected_suite_path)
@@ -506,8 +529,10 @@ def test_suite_edit_one_datasources_no_generator_with_no_additional_args(
     result = runner.invoke(
         cli,
         ["suite", "new", "-d", root_dir, "--no-view"],
-        input="{0:s}\nmy_new_suite\n\n".format(os.path.join(filesystem_csv_2, "f1.csv")),
-        catch_exceptions=False
+        input="{0:s}\nmy_new_suite\n\n".format(
+            os.path.join(filesystem_csv_2, "f1.csv")
+        ),
+        catch_exceptions=False,
     )
     stdout = result.stdout
 
@@ -519,7 +544,7 @@ def test_suite_edit_one_datasources_no_generator_with_no_additional_args(
         cli,
         ["suite", "edit", "my_new_suite", "-d", root_dir, "--no-jupyter"],
         input="{0:s}\n\n".format(os.path.join(filesystem_csv_2, "f1.csv")),
-        catch_exceptions=False
+        catch_exceptions=False,
     )
 
     assert result.exit_code == 0
@@ -529,9 +554,7 @@ def test_suite_edit_one_datasources_no_generator_with_no_additional_args(
     assert "Enter the path" in stdout
     assert "To continue editing this suite, run" in stdout
 
-    expected_notebook_path = os.path.join(
-        root_dir, "uncommitted", "my_new_suite.ipynb"
-    )
+    expected_notebook_path = os.path.join(root_dir, "uncommitted", "my_new_suite.ipynb")
     assert os.path.isfile(expected_notebook_path)
 
     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -220,8 +220,33 @@ def test_suite_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
     )
     stdout = result.output
     assert result.exit_code == 1
-    assert 'Please check that your batch_kwargs are valid JSON.'
+    assert 'Please check that your batch_kwargs are valid JSON.' in stdout
     assert 'Expecting value' in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+def test_suite_edit_with_batch_kwargs_unable_to_load_a_batch_raises_helpful_error(
+    caplog,
+    empty_data_context
+):
+    project_dir = empty_data_context.root_directory
+
+    context = DataContext(project_dir)
+    context.create_expectation_suite("foo")
+    context.add_datasource("source", class_name="PandasDatasource")
+
+    runner = CliRunner(mix_stderr=False)
+    batch_kwargs = '{\"path\": \"fake.csv\", \"datasource\": \"source\"}'
+    result = runner.invoke(
+        cli,
+        ["suite", "edit", "foo", "-d", project_dir, "--batch_kwargs", batch_kwargs],
+        catch_exceptions=False
+    )
+    stdout = result.output
+    assert result.exit_code == 1
+    assert 'To continue editing this suite' not in stdout
+    assert 'Please check that your batch_kwargs are able to load a batch.' in stdout
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_suite_edit_with_non_existent_suite_name_raises_error(


### PR DESCRIPTION
# What's Here

* if a user passes in `batch_kwargs` they are validated and various errors handled nicely
* args to `suite new` simplified
* bugfix when datasource and `batch_kwargs` without datasource were passed