### PR TITLE
NotebookRenderer filters out profiler metadata and sundry init wording changes

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -696,6 +696,8 @@ def select_generator(context, datasource_name, available_data_assets_dict=None):
 
         return generator_name
 
+
+# TODO this method needs testing
 def get_batch_kwargs(context,
                      datasource_name=None,
                      generator_name=None,
@@ -736,6 +738,9 @@ def get_batch_kwargs(context,
     except ValueError:
         # the datasource has no generators
         available_data_assets_dict = {datasource_name: {}}
+
+    data_source = select_datasource(context, datasource_name=datasource_name)
+    datasource_name = data_source.name
 
     if generator_name is None:
         generator_name = select_generator(context, datasource_name,

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -813,7 +813,7 @@ def create_expectation_suite(
 Great Expectations will choose a couple of columns and generate expectations about them
 to demonstrate some examples of assertions you can make about your data. 
     
-Press Enter to continue...
+Press Enter to continue
 """
 
     msg_prompt_expectation_suite_name = """
@@ -822,7 +822,7 @@ Name the new expectation suite"""
     msg_data_doc_intro = """
 <cyan>========== Data Docs ==========</cyan>"""
 
-    msg_suite_already_exists = "<red>An expectation suite named `{}` already exists. If you intend to edit the suite please use `great_expectations suite edit foo`.</red>"
+    msg_suite_already_exists = "<red>An expectation suite named `{}` already exists. If you intend to edit the suite please use `great_expectations suite edit {}`.</red>"
 
     if show_intro_message:
         cli_message(msg_intro)
@@ -839,6 +839,7 @@ Name the new expectation suite"""
     if expectation_suite_name in existing_suite_names:
         cli_message(
             msg_suite_already_exists.format(
+                expectation_suite_name,
                 expectation_suite_name
             )
         )
@@ -857,6 +858,7 @@ Name the new expectation suite"""
             if expectation_suite_name in existing_suite_names:
                 cli_message(
                     msg_suite_already_exists.format(
+                        expectation_suite_name,
                         expectation_suite_name
                     )
                 )
@@ -865,9 +867,9 @@ Name the new expectation suite"""
 
     profiler = SampleExpectationsDatasetProfiler
 
-    click.prompt(msg_prompt_what_will_profiler_do, default="Enter", hide_input=True)
+    click.prompt(msg_prompt_what_will_profiler_do, default=True, show_default=False)
 
-    cli_message("\nProfiling...")
+    cli_message("\nGenerating example Expectation Suite...")
     run_id = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S.%fZ")
 
     profiling_results = context.profile_data_asset(

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -644,7 +644,7 @@ def _add_spark_datasource(context, passthrough_generator_only=True, prompt_for_d
 
 
 def select_datasource(context, datasource_name=None):
-    msg_prompt_select_data_source = "Select data source"
+    msg_prompt_select_data_source = "Select a datasource"
     msg_no_datasources_configured = "<red>No datasources found in the context. To add a datasource, run `great_expectations datasource new`</red>"
 
     data_source = None
@@ -731,15 +731,6 @@ def get_batch_kwargs(context,
                 have changed after this method's execution. If the returned batch_kwargs is None, it means
                 that the generator will know to yield batch_kwargs when called.
     """
-
-    msg_prompt_enter_data_asset_name = "\nWhich data would you like to use? (Choose one)\n"
-
-    msg_prompt_enter_data_asset_name_suffix = "    Don't see the data asset in the list above? Just type the name.\n"
-
-    data_source = select_datasource(context, datasource_name=datasource_name)
-
-    batch_kwargs = None
-
     try:
         available_data_assets_dict = context.get_available_data_asset_names(datasource_names=datasource_name)
     except ValueError:
@@ -906,15 +897,15 @@ def _get_batch_kwargs_from_generator_or_from_file_path(context, datasource_name,
                                                        generator_name=None,
                                                        additional_batch_kwargs={}):
     msg_prompt_generator_or_file_path =  """
-Would you like to enter the path of the file or choose from the list of data assets in this datasource? 
-    1. I want a list of data assets in this datasource
-    2. I will enter the path of a data file
+Would you like to: 
+    1. choose from a list of data assets in this datasource
+    2. enter the path of a data file
 """
     msg_prompt_file_path = """
 Enter the path (relative or absolute) of a data file
 """
 
-    msg_prompt_enter_data_asset_name = "\nWhich data would you like to use? (Choose one)\n"
+    msg_prompt_enter_data_asset_name = "\nWhich data would you like to use?\n"
 
     msg_prompt_enter_data_asset_name_suffix = "    Don't see the name of the data asset in the list above? Just type it\n"
 

--- a/great_expectations/cli/docs.py
+++ b/great_expectations/cli/docs.py
@@ -58,7 +58,7 @@ def build_docs(context, site_name=None, view=True):
     """Build documentation in a context"""
     logger.debug("Starting cli.datasource.build_docs")
 
-    cli_message("Building <green>Data Docs</green>...")
+    cli_message("Building Data Docs...")
 
     if site_name is not None:
         site_names = [site_name]

--- a/great_expectations/cli/init_messages.py
+++ b/great_expectations/cli/init_messages.py
@@ -10,7 +10,7 @@ GREETING = """<cyan>\
              ~ Always know what to expect from your data ~             
 </cyan>"""
 
-LETS_BEGIN_PROMPT = """In just a couple of minutes you will see Great Expectations in action on your data.
+LETS_BEGIN_PROMPT = """In a few minutes you will see Great Expectations in action on your data!
 
 First, Great Expectations will create a new directory:
 

--- a/great_expectations/render/renderer/notebook_renderer.py
+++ b/great_expectations/render/renderer/notebook_renderer.py
@@ -159,11 +159,25 @@ context.open_data_docs(validation_result_identifier)"""
 
             for exp in expectations:
                 kwargs_string = self._build_kwargs_string(exp)
-                meta_args = ", meta={}".format(exp.meta) if exp.meta else ""
+                meta_args = self._build_meta_arguments(exp.meta)
                 code = "batch.{}({}{})".format(
                     exp["expectation_type"], kwargs_string, meta_args
                 )
                 self.add_code_cell(code, lint=True)
+
+    @staticmethod
+    def _build_meta_arguments(meta):
+        if not meta:
+            return ""
+
+        profiler = "SampleExpectationsDatasetProfiler"
+        if profiler in meta.keys():
+            meta.pop(profiler)
+
+        if meta.keys():
+            return ", meta={}".format(meta)
+
+        return ""
 
     @classmethod
     def _write_notebook_to_disk(cls, notebook, notebook_file_path):

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -42,7 +42,7 @@ def test_cli_init_on_new_project(caplog, tmp_path_factory):
         "Great Expectations will choose a couple of columns and generate expectations about them"
         in stdout
     )
-    assert "Profiling..." in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "Building" in stdout
     assert "Data Docs" in stdout
     assert "A new Expectation suite 'warning' was added to your project" in stdout
@@ -332,7 +332,7 @@ def test_init_on_existing_project_with_datasource_with_no_suite_create_one(
     assert "Error: invalid input" not in stdout
     assert "Always know what to expect from your data" in stdout
     assert "Enter the path (relative or absolute) of a data file" in stdout
-    assert "Profiling..." in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "Great Expectations is now set up" in stdout
     assert "A new Expectation suite 'sink_me' was added to your project" in stdout

--- a/tests/cli/test_init_sqlite.py
+++ b/tests/cli/test_init_sqlite.py
@@ -65,7 +65,7 @@ def test_cli_init_on_new_project(caplog, tmp_path_factory, titanic_sqlite_db_fil
         "Great Expectations will choose a couple of columns and generate expectations about them"
         in stdout
     )
-    assert "Profiling..." in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "Building" in stdout
     assert "Data Docs" in stdout
     assert "A new Expectation suite 'warning' was added to your project" in stdout
@@ -360,7 +360,7 @@ def test_init_on_existing_project_with_datasource_with_no_suite_create_one(
 
     assert "Always know what to expect from your data" in stdout
     assert "Which table would you like to use?" in stdout
-    assert "Profiling.." in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "Great Expectations is now set up" in stdout
     assert "A new Expectation suite 'sink_me' was added to your project" in stdout

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -82,6 +82,7 @@ def test_suite_new_enter_existing_suite_name_as_arg(
     assert "already exists. If you intend to edit the suite" in stdout
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
+
 def test_suite_new_answer_suite_name_prompts_with_name_of_existing_suite(
     caplog, data_context, filesystem_csv_2
 ):
@@ -123,7 +124,7 @@ def test_suite_new_answer_suite_name_prompts_with_name_of_existing_suite(
         "Great Expectations will choose a couple of columns and generate expectations"
         in stdout
     )
-    assert "Profiling" in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "Building" in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
@@ -181,7 +182,7 @@ def test_suite_new_one_datasource_without_generator_without_suite_name_argument(
         "Great Expectations will choose a couple of columns and generate expectations"
         in stdout
     )
-    assert "Profiling" in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "Building" in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
@@ -235,7 +236,7 @@ def test_suite_new_multiple_datasources_with_generator_without_suite_name_argume
         "Great Expectations will choose a couple of columns and generate expectations"
         in stdout
     )
-    assert "Profiling" in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "Building" in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
@@ -285,7 +286,7 @@ def test_suite_new_multiple_datasources_with_generator_with_suite_name_argument(
         "Great Expectations will choose a couple of columns and generate expectations"
         in stdout
     )
-    assert "Profiling" in stdout
+    assert "Generating example Expectation Suite..." in stdout
     assert "Building" in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "A new Expectation suite 'foo_suite' was added to your project" in stdout

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -229,7 +229,7 @@ def test_suite_new_multiple_datasources_with_generator_without_suite_name_argume
     stdout = result.stdout
 
     assert result.exit_code == 0
-    assert "Select data source" in stdout
+    assert "Select a datasource" in stdout
     assert "Which data would you like to use" in stdout
     assert "Name the new expectation suite [warning]" in stdout
     assert (
@@ -280,7 +280,7 @@ def test_suite_new_multiple_datasources_with_generator_with_suite_name_argument(
     stdout = result.stdout
 
     assert result.exit_code == 0
-    assert "Select data source" in stdout
+    assert "Select a datasource" in stdout
     assert "Which data would you like to use" in stdout
     assert (
         "Great Expectations will choose a couple of columns and generate expectations"
@@ -439,7 +439,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args(
 
     assert result.exit_code == 0
     stdout = result.stdout
-    assert "Select data source" in stdout
+    assert "Select a datasource" in stdout
     assert "Which data would you like to use" in stdout
     assert "To continue editing this suite, run" in stdout
 
@@ -512,7 +512,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
     stdout = result.stdout
 
     assert result.exit_code == 0
-    assert "Select data source" not in stdout
+    assert "Select a datasource" not in stdout
     assert "Which data would you like to use" not in stdout
     assert "To continue editing this suite, run" in stdout
 
@@ -661,7 +661,7 @@ def test_suite_edit_one_datasources_no_generator_with_no_additional_args(
 
     assert result.exit_code == 0
     stdout = result.stdout
-    assert "Select data source" not in stdout
+    assert "Select a datasource" not in stdout
     assert "Which data would you like to use" not in stdout
     assert "Enter the path" in stdout
     assert "To continue editing this suite, run" in stdout

--- a/tests/render/renderer/test_notebook_renderer.py
+++ b/tests/render/renderer/test_notebook_renderer.py
@@ -8,6 +8,10 @@ from great_expectations.render.renderer.notebook_renderer import NotebookRendere
 
 @pytest.fixture
 def critical_suite():
+    """
+    This hand made fixture has a wide range of expectations, and has a mix of
+    metadata including an SampleExpectationsDatasetProfiler entry.
+    """
     schema = ExpectationSuiteSchema(strict=True)
     critical_suite = {
         "expectation_suite_name": "critical",
@@ -19,6 +23,9 @@ def critical_suite():
                 "meta": {
                     "question": True,
                     "Notes": "There are empty strings that should probably be nulls",
+                    'SampleExpectationsDatasetProfiler': {
+                        'confidence': 'very low'
+                    }
                 },
             },
             {
@@ -33,6 +40,10 @@ def critical_suite():
 
 @pytest.fixture
 def warning_suite():
+    """
+    This hand made fixture has a wide range of expectations, and has a mix of
+    metadata including SampleExpectationsDatasetProfiler entries.
+    """
     schema = ExpectationSuiteSchema(strict=True)
     warning_suite = {
         "expectation_suite_name": "warning",
@@ -49,10 +60,20 @@ def warning_suite():
             {
                 "expectation_type": "expect_column_values_to_not_be_null",
                 "kwargs": {"column": "npi"},
+                "meta": {
+                    'SampleExpectationsDatasetProfiler': {
+                        'confidence': 'very low'
+                    }
+                }
             },
             {
                 "expectation_type": "expect_column_values_to_not_be_null",
                 "kwargs": {"column": "provider_type"},
+                "meta": {
+                    'SampleExpectationsDatasetProfiler': {
+                        'confidence': 'very low'
+                    }
+                }
             },
             {
                 "expectation_type": "expect_column_values_to_not_be_null",


### PR DESCRIPTION
## what's here

* minor wording adjustments to init flow
* more helpful suite new error message if suite exists
* NotebookRenderer filters out profiler metadata