### PR TITLE
PandasDataset value_count fix for mixed types in object columns

### DIFF
--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -369,7 +369,14 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
             )
         counts = self[column].value_counts()
         if sort == "value":
-            counts.sort_index(inplace=True)
+            try:
+                counts.sort_index(inplace=True)
+            except TypeError:
+                # Having values of multiple types in a object dtype column (e.g., strings and floats)
+                # raises a TypeError when the sorting method performs comparisons.
+                if self[column].dtype == object:
+                    counts.index = counts.index.astype(str)
+                    counts.sort_index(inplace=True)
         elif sort == "counts":
             counts.sort_values(inplace=True)
         counts.name = "count"

--- a/tests/dataset/test_pandas_dataset.py
+++ b/tests/dataset/test_pandas_dataset.py
@@ -577,3 +577,17 @@ def test_pandas_deepcopy():
     assert df2.expect_column_to_exist("a").success == True
     assert list(df["a"]) == [2, 3, 4]
     assert list(df2["a"]) == [1, 2, 3]
+
+def test_ge_value_count_of_object_dtype_column_with_mixed_types():
+    """
+    Having mixed type values in a object dtype column (e.g., strings and floats)
+    used to raise a TypeError when sorting value_counts. This test verifies
+    that the issue is fixed.
+    """
+    df = ge.dataset.PandasDataset({
+        'A': [1.5, 0.009, 0.5, "I am a string in an otherwise float column"],
+    })
+
+    value_counts = df.get_column_value_counts("A")
+    assert value_counts["I am a string in an otherwise float column"] == 1
+


### PR DESCRIPTION
Fix: having values of multiple types in a object dtype column (e.g., strings and floats) used to raise a TypeError when sorting value_counts. The fix converts the value_count's index to strings before sorting them in this case.