### PR TITLE
cli test fixes

### DIFF
--- a/tests/cli/test_docs.py
+++ b/tests/cli/test_docs.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import os
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner
@@ -21,16 +22,55 @@ def test_docs_help_output(caplog):
 
 
 @pytest.mark.xfail(condition=PY2, reason="legacy python")
-def test_docs_build(caplog, site_builder_data_context_with_html_store_titanic_random):
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
+def test_docs_build_view(
+    mock_webbrowser, caplog, site_builder_data_context_with_html_store_titanic_random
+):
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
 
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
-        cli, ["docs", "build", "-d", root_dir, "--no-view"], catch_exceptions=False
+        cli, ["docs", "build", "-d", root_dir], catch_exceptions=False
     )
     stdout = result.stdout
 
     assert result.exit_code == 0
+    assert mock_webbrowser.call_count == 1
+    assert "Building" in stdout
+    assert "The following Data Docs sites were built" in stdout
+    assert "great_expectations/uncommitted/data_docs/local_site/index.html" in stdout
+
+    context = DataContext(root_dir)
+    obs_urls = context.get_docs_sites_urls()
+
+    assert len(obs_urls) == 1
+    assert (
+        "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]
+    )
+    local_site_dir = os.path.join(root_dir, "uncommitted/data_docs/local_site/")
+
+    assert os.path.isdir(os.path.join(local_site_dir))
+    assert os.path.isfile(os.path.join(local_site_dir, "index.html"))
+    assert os.path.isdir(os.path.join(local_site_dir, "expectations"))
+    assert os.path.isdir(os.path.join(local_site_dir, "validations"))
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+@pytest.mark.xfail(condition=PY2, reason="legacy python")
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
+def test_docs_build_no_view(
+    mock_webbrowser, caplog, site_builder_data_context_with_html_store_titanic_random
+):
+    root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli, ["docs", "build", "--no-view", "-d", root_dir], catch_exceptions=False
+    )
+    stdout = result.stdout
+
+    assert result.exit_code == 0
+    assert mock_webbrowser.call_count == 0
     assert "Building" in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "great_expectations/uncommitted/data_docs/local_site/index.html" in stdout

--- a/tests/cli/test_docs.py
+++ b/tests/cli/test_docs.py
@@ -2,7 +2,10 @@
 from __future__ import unicode_literals
 
 import os
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
 from click.testing import CliRunner

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -2,7 +2,10 @@ from __future__ import unicode_literals
 
 import os
 import shutil
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
 from click.testing import CliRunner

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -44,6 +44,13 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_
     stdout = result.output
     assert result.exit_code == 0
     assert mock_webbrowser.call_count == 1
+    assert (
+        "{}/great_expectations/uncommitted/data_docs/local_site/validations/warning/".format(
+            root_dir
+        )
+        in mock_webbrowser.call_args[0][0]
+    )
+
     assert "Great Expectations is now set up." in stdout
 
     context = DataContext(os.path.join(root_dir, DataContext.GE_DIR))
@@ -101,6 +108,12 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
     )
     assert result.exit_code == 0
     assert mock_webbrowser.call_count == 1
+    assert (
+        "{}/great_expectations/uncommitted/data_docs/local_site/validations/warning/".format(
+            root_dir
+        )
+        in mock_webbrowser.call_args[0][0]
+    )
 
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
@@ -121,9 +134,9 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
 def test_cli_init_connection_string_non_working_db_connection_instructs_user_and_leaves_entries_in_config_files_for_debugging(
     mock_webbrowser, caplog, tmp_path_factory,
 ):
-    basedir = tmp_path_factory.mktemp("bad_con_string_test")
-    basedir = str(basedir)
-    os.chdir(basedir)
+    root_dir = tmp_path_factory.mktemp("bad_con_string_test")
+    root_dir = str(root_dir)
+    os.chdir(root_dir)
 
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
@@ -150,7 +163,7 @@ def test_cli_init_connection_string_non_working_db_connection_instructs_user_and
 
     assert result.exit_code == 1
 
-    ge_dir = os.path.join(basedir, DataContext.GE_DIR)
+    ge_dir = os.path.join(root_dir, DataContext.GE_DIR)
     assert os.path.isdir(ge_dir)
     config_path = os.path.join(ge_dir, DataContext.GE_YML)
     assert os.path.isfile(config_path)
@@ -174,7 +187,7 @@ def test_cli_init_connection_string_non_working_db_connection_instructs_user_and
     config = yaml.load(open(config_path, "r"))
     assert config["my_db"] == {"url": "sqlite:////not_a_real.db"}
 
-    obs_tree = gen_directory_tree_str(os.path.join(basedir, "great_expectations"))
+    obs_tree = gen_directory_tree_str(os.path.join(root_dir, "great_expectations"))
     assert (
         obs_tree
         == """\

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os
 import shutil
+from unittest import mock
 
 import pytest
 from click.testing import CliRunner
@@ -17,8 +18,9 @@ from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
 @pytest.mark.xfail(condition=PY2, reason="legacy python")
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_fixing_them(
-    caplog, tmp_path_factory,
+    mock_webbrowser, caplog, tmp_path_factory,
 ):
     """
     This test walks through the onboarding experience.
@@ -36,11 +38,12 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["init", "--no-view", "-d", root_dir],
+        ["init", "-d", root_dir],
         input="Y\n1\n1\n{}\n\n\n\n".format(data_path, catch_exceptions=False),
     )
     stdout = result.output
     assert result.exit_code == 0
+    assert mock_webbrowser.call_count == 1
     assert "Great Expectations is now set up." in stdout
 
     context = DataContext(os.path.join(root_dir, DataContext.GE_DIR))
@@ -73,8 +76,9 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
-    caplog, tmp_path_factory,
+    mock_webbrowser, caplog, tmp_path_factory,
 ):
     """
     This test walks through the onboarding experience.
@@ -92,18 +96,18 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["init", "--no-view", "-d", root_dir],
+        ["init", "-d", root_dir],
         input="Y\n1\n1\n{}\n\n\n\n".format(data_path, catch_exceptions=False),
     )
-    stdout = result.output
     assert result.exit_code == 0
+    assert mock_webbrowser.call_count == 1
 
-    # Test the second invocation of init
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
-        cli, ["init", "--no-view", "-d", root_dir], input="n\n", catch_exceptions=False
+        cli, ["init", "-d", root_dir], input="n\n", catch_exceptions=False
     )
     stdout = result.stdout
+    assert mock_webbrowser.call_count == 1
 
     assert result.exit_code == 0
     assert "This looks like an existing project that" in stdout
@@ -113,8 +117,9 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_cli_init_connection_string_non_working_postgres_connection_instructs_user_and_leaves_entries_in_config_files_for_debugging(
-    caplog, tmp_path_factory,
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
+def test_cli_init_connection_string_non_working_db_connection_instructs_user_and_leaves_entries_in_config_files_for_debugging(
+    mock_webbrowser, caplog, tmp_path_factory,
 ):
     basedir = tmp_path_factory.mktemp("bad_con_string_test")
     basedir = str(basedir)
@@ -123,11 +128,12 @@ def test_cli_init_connection_string_non_working_postgres_connection_instructs_us
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["init", "--no-view"],
+        ["init"],
         input="Y\n2\n5\nmy_db\nsqlite:////not_a_real.db\nn\n",
         catch_exceptions=False,
     )
     stdout = result.output
+    assert mock_webbrowser.call_count == 0
 
     assert "Always know what to expect from your data" in stdout
     assert "What data would you like Great Expectations to connect to" in stdout

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 import os
 import re
 import shutil
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
 from click.testing import CliRunner

--- a/tests/cli/test_init_sqlite.py
+++ b/tests/cli/test_init_sqlite.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 import os
 import re
 import shutil
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
 from click.testing import CliRunner


### PR DESCRIPTION
## What's here

- removed generators from a few cli init tests since that no longer reflects context use
- silenced browser tab spawning from many cli init tests while increasing coverage﻿