### PR TITLE
Workaround to deal with hidden inputs on Windows

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+import platform
 
 import click
 
@@ -463,6 +464,13 @@ After you connect to the datasource, run great_expectations init to continue.
 
     return datasource_name
 
+def _is_windows_platform():
+    """
+        This is a workaround to help identify Windows and adjust the prompts accordingly.
+    """
+    if 'windows' in platform.platform().lower():
+        return True
+    return False
 
 def _collect_postgres_credentials(default_credentials={}):
     credentials = {
@@ -478,10 +486,16 @@ def _collect_postgres_credentials(default_credentials={}):
     credentials["username"] = click.prompt("What is the username for the postgres connection?",
                             default=default_credentials.get("username", "postgres"),
                             show_default=True)
-    credentials["password"] = click.prompt("What is the password for the postgres connection?",
-                            default="",
-                            show_default=False, #hide_input=True
-                                           )
+    # This is a minimal workaround we're doing to deal with hidden input problems using Git Bash on Windows
+    # TODO: Revisit this if we decide to fully support Windows and identify if there is a better solution
+    if _is_windows_platform():
+        credentials["password"] = click.prompt("What is the password for the postgres connection?",
+                                default="",
+                                show_default=False)
+    else:
+        credentials["password"] = click.prompt("What is the password for the postgres connection?",
+                                default="",
+                                show_default=False, hide_input=True)
     credentials["database"] = click.prompt("What is the database name for the postgres connection?",
                             default=default_credentials.get("database", "postgres"),
                             show_default=True)
@@ -576,9 +590,16 @@ def _collect_redshift_credentials(default_credentials={}):
     credentials["username"] = click.prompt("What is the username for the Redshift connection?",
                             default=default_credentials.get("username", ""),
                             show_default=True)
-    credentials["password"] = click.prompt("What is the password for the Redshift connection?",
-                            default="",
-                            show_default=False, hide_input=True)
+    # This is a minimal workaround we're doing to deal with hidden input problems using Git Bash on Windows
+    # TODO: Revisit this if we decide to fully support Windows and identify if there is a better solution
+    if _is_windows_platform():
+        credentials["password"] = click.prompt("What is the password for the Redshift connection?",
+                                default="",
+                                show_default=False)
+    else:
+        credentials["password"] = click.prompt("What is the password for the Redshift connection?",
+                                default="",
+                                show_default=False, hide_input=True)
     credentials["database"] = click.prompt("What is the database name for the Redshift connection?",
                             default=default_credentials.get("database", ""),
                             show_default=True)

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -480,7 +480,8 @@ def _collect_postgres_credentials(default_credentials={}):
                             show_default=True)
     credentials["password"] = click.prompt("What is the password for the postgres connection?",
                             default="",
-                            show_default=False, hide_input=True)
+                            show_default=False, #hide_input=True
+                                           )
     credentials["database"] = click.prompt("What is the database name for the postgres connection?",
                             default=default_credentials.get("database", "postgres"),
                             show_default=True)

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -464,6 +464,7 @@ After you connect to the datasource, run great_expectations init to continue.
 
     return datasource_name
 
+
 def _is_windows_platform():
     """
         This is a workaround to help identify Windows and adjust the prompts accordingly.
@@ -490,12 +491,12 @@ def _collect_postgres_credentials(default_credentials={}):
     # TODO: Revisit this if we decide to fully support Windows and identify if there is a better solution
     if _is_windows_platform():
         credentials["password"] = click.prompt("What is the password for the postgres connection?",
-                                default="",
-                                show_default=False)
+                                               default="",
+                                               show_default=False)
     else:
         credentials["password"] = click.prompt("What is the password for the postgres connection?",
-                                default="",
-                                show_default=False, hide_input=True)
+                                               default="",
+                                               show_default=False, hide_input=True)
     credentials["database"] = click.prompt("What is the database name for the postgres connection?",
                             default=default_credentials.get("database", "postgres"),
                             show_default=True)
@@ -594,12 +595,12 @@ def _collect_redshift_credentials(default_credentials={}):
     # TODO: Revisit this if we decide to fully support Windows and identify if there is a better solution
     if _is_windows_platform():
         credentials["password"] = click.prompt("What is the password for the Redshift connection?",
-                                default="",
-                                show_default=False)
+                                               default="",
+                                               show_default=False)
     else:
         credentials["password"] = click.prompt("What is the password for the Redshift connection?",
-                                default="",
-                                show_default=False, hide_input=True)
+                                               default="",
+                                               show_default=False, hide_input=True)
     credentials["database"] = click.prompt("What is the database name for the Redshift connection?",
                             default=default_credentials.get("database", ""),
                             show_default=True)

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -465,13 +465,14 @@ After you connect to the datasource, run great_expectations init to continue.
     return datasource_name
 
 
-def _is_windows_platform():
+def _should_hide_input():
     """
-        This is a workaround to help identify Windows and adjust the prompts accordingly.
+        This is a workaround to help identify Windows and adjust the prompts accordingly
+        since hidden prompts may freeze in certain Windows terminals
     """
     if 'windows' in platform.platform().lower():
-        return True
-    return False
+        return False
+    return True
 
 def _collect_postgres_credentials(default_credentials={}):
     credentials = {
@@ -489,14 +490,9 @@ def _collect_postgres_credentials(default_credentials={}):
                             show_default=True)
     # This is a minimal workaround we're doing to deal with hidden input problems using Git Bash on Windows
     # TODO: Revisit this if we decide to fully support Windows and identify if there is a better solution
-    if _is_windows_platform():
-        credentials["password"] = click.prompt("What is the password for the postgres connection?",
-                                               default="",
-                                               show_default=False)
-    else:
-        credentials["password"] = click.prompt("What is the password for the postgres connection?",
-                                               default="",
-                                               show_default=False, hide_input=True)
+    credentials["password"] = click.prompt("What is the password for the postgres connection?",
+                                           default="",
+                                           show_default=False, hide_input=_should_hide_input())
     credentials["database"] = click.prompt("What is the database name for the postgres connection?",
                             default=default_credentials.get("database", "postgres"),
                             show_default=True)
@@ -593,14 +589,9 @@ def _collect_redshift_credentials(default_credentials={}):
                             show_default=True)
     # This is a minimal workaround we're doing to deal with hidden input problems using Git Bash on Windows
     # TODO: Revisit this if we decide to fully support Windows and identify if there is a better solution
-    if _is_windows_platform():
-        credentials["password"] = click.prompt("What is the password for the Redshift connection?",
-                                               default="",
-                                               show_default=False)
-    else:
-        credentials["password"] = click.prompt("What is the password for the Redshift connection?",
-                                               default="",
-                                               show_default=False, hide_input=True)
+    credentials["password"] = click.prompt("What is the password for the Redshift connection?",
+                                           default="",
+                                           show_default=False, hide_input=_should_hide_input())
     credentials["database"] = click.prompt("What is the database name for the Redshift connection?",
                             default=default_credentials.get("database", ""),
                             show_default=True)

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -76,8 +76,6 @@ def init(target_directory, view):
             sys.exit(1)
         else:
             try:
-                cli_message("Target directory: " + target_directory)
-                sys.exit(0)
                 context = DataContext.create(target_directory)
                 cli_message(ONBOARDING_COMPLETE)
                 # TODO if this is correct, ensure this is covered by a test

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -76,6 +76,8 @@ def init(target_directory, view):
             sys.exit(1)
         else:
             try:
+                cli_message("Target directory: " + target_directory)
+                sys.exit(0)
                 context = DataContext.create(target_directory)
                 cli_message(ONBOARDING_COMPLETE)
                 # TODO if this is correct, ensure this is covered by a test


### PR DESCRIPTION
This seems to be a known issue with terminals such as Git Bash, e.g. https://stackoverflow.com/questions/24544353/python-getpass-getpass-function-call-hangs (`click` and `getpass` show the same behavior, I assume it's the same underlying issue)

As discussed with @Aylr, I only implemented a minimal workaround touching Redshift and Postgres for now to show the password when on Windows. I can write a more manual alternative to hide the password if we consider that absolutely crucial, let me know.