### PR TITLE
Better error message when config substitution variable is missing

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -2,7 +2,7 @@
 
 develop
 -----------------
-
+* Better error message when config substitution variable is missing
 
 0.9.3
 -----------------

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -63,7 +63,6 @@ def init(target_directory, view):
     """
     target_directory = os.path.abspath(target_directory)
     ge_dir = _get_full_path_to_ge_dir(target_directory)
-
     cli_message(GREETING)
 
     if DataContext.does_config_exist_on_disk(ge_dir):
@@ -74,17 +73,17 @@ def init(target_directory, view):
         except (DataContextError, DatasourceInitializationError) as e:
             cli_message("<red>{}</red>".format(e.message))
             sys.exit(1)
-        else:
-            try:
-                context = DataContext.create(target_directory)
-                cli_message(ONBOARDING_COMPLETE)
-                # TODO if this is correct, ensure this is covered by a test
-                # cli_message(SETUP_SUCCESS)
-                # exit(0)
-            except DataContextError as e:
-                cli_message("<red>{}</red>".format(e.message))
-                # TODO ensure this is covered by a test
-                exit(5)
+
+        try:
+            context = DataContext.create(target_directory)
+            cli_message(ONBOARDING_COMPLETE)
+            # TODO if this is correct, ensure this is covered by a test
+            # cli_message(SETUP_SUCCESS)
+            # exit(0)
+        except DataContextError as e:
+            cli_message("<red>{}</red>".format(e.message))
+            # TODO ensure this is covered by a test
+            exit(5)
     else:
         if not click.confirm(LETS_BEGIN_PROMPT, default=True):
             cli_message(RUN_INIT_AGAIN)

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1601,7 +1601,7 @@ class DataContext(BaseDataContext):
             ge_exceptions.DataContextError,
             ge_exceptions.InvalidDataContextConfigError
         ) as e:
-            logger.warning(e)
+            logger.debug(e)
 
 
 class ExplorerDataContext(DataContext):

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -12,7 +12,8 @@ from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.exceptions import (
     PluginModuleNotFoundError,
     PluginClassNotFoundError,
-    InvalidConfigError)
+    MissingConfigVariableError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,12 @@ def substitute_config_variable(template_str, config_variables_dict):
             else:
                 return template_str[:match.start()] + config_variable_value + template_str[match.end():]
 
-        raise InvalidConfigError("Unable to find match for config variable {:s}. See https://great-expectations.readthedocs.io/en/latest/reference/data_context_reference.html#managing-environment-and-secrets".format(match.group(1)))
+        raise MissingConfigVariableError(
+                    f"""\n\nUnable to find a match for config substitution variable: `{match.group(1)}`.
+Please add this missing variable to your `uncommitted/config_variables.yml` file or your environment variables.
+See https://great-expectations.readthedocs.io/en/latest/reference/data_context_reference.html#managing-environment-and-secrets""",
+                    missing_config_variable=match.group(1)
+                )
 
     return template_str
 

--- a/great_expectations/exceptions.py
+++ b/great_expectations/exceptions.py
@@ -77,6 +77,14 @@ class InvalidConfigError(DataContextError):
         self.message = message
 
 
+class MissingConfigVariableError(InvalidConfigError):
+    def __init__(self, message, missing_config_variable=None):
+        if not missing_config_variable:
+            missing_config_variable = []
+        self.message = message
+        self.missing_config_variable = missing_config_variable
+
+
 class AmbiguousDataAssetNameError(DataContextError):
     def __init__(self, message, candidates=None):
         self.message = message

--- a/tests/data_context/test_data_context_on_teams.py
+++ b/tests/data_context/test_data_context_on_teams.py
@@ -18,7 +18,8 @@ def test_incomplete_uncommitted():
                 "./fixtures/contexts/incomplete_uncommitted/great_expectations",
             )
         )
-    assert (
-        exc.value.message
-        == "Unable to find match for config variable my_postgres_db. See https://great-expectations.readthedocs.io/en/latest/reference/data_context_reference.html#managing-environment-and-secrets"
-    )
+        assert (
+            "Unable to find match for config variable my_postgres_db. See "
+            "https://great-expectations.readthedocs.io/en/latest/reference/data_context_reference.html#managing-environment-and-secrets"
+            in exc.value.message
+        )


### PR DESCRIPTION
# What's Here

- A better error message when a config var is missing.
- A specific error type for this condition
- minor logic simplificationsox﻿