### PR TITLE
Notebook empty suite fixes, suite edit bugfixes

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -2,6 +2,8 @@
 
 develop
 -----------------
+* Fixed unexpected behavior with suite edit, data docs and jupyter
+* pytest pinned to 5.3.5
 
 
 0.9.4

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -803,7 +803,6 @@ def create_expectation_suite(
     show_intro_message=False,
     open_docs=False
 ):
-
     """
     Create a new expectation suite.
 
@@ -822,9 +821,6 @@ Press Enter to continue
 
     msg_prompt_expectation_suite_name = """
 Name the new expectation suite"""
-
-    msg_data_doc_intro = """
-<cyan>========== Data Docs ==========</cyan>"""
 
     msg_suite_already_exists = "<red>An expectation suite named `{}` already exists. If you intend to edit the suite please use `great_expectations suite edit {}`.</red>"
 

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -178,9 +178,8 @@ def _load_suite(context, suite_name):
         return suite
     except ge_exceptions.DataContextError as e:
         cli_message(
-            "<red>Could not find a suite named `{}`. Please check the name and try again.</red>".format(
-                suite_name
-            )
+            f"<red>Could not find a suite named `{suite_name}`.</red> Please check "
+            "the name by running `great_expectations suite list` and try again."
         )
         logger.info(e)
         sys.exit(1)
@@ -252,8 +251,11 @@ def suite_new(suite, directory, empty, jupyter, view, batch_kwargs):
                     suite_name
                 )
             )
-            if jupyter:
-                cli_message("<green>Because you requested an empty suite, we'll open a notebook for you now to edit it!</green>\n\n")
+            if empty:
+                if jupyter:
+                    cli_message("""<green>Because you requested an empty suite, we'll open a notebook for you now to edit it!
+If you wish to avoid this you can add the `--no-jupyter` flag.</green>\n\n""")
+                _suite_edit(suite_name, datasource_name, directory, jupyter=jupyter, batch_kwargs=batch_kwargs)
     except (
         ge_exceptions.DataContextError,
         ge_exceptions.ProfilerError,
@@ -262,8 +264,6 @@ def suite_new(suite, directory, empty, jupyter, view, batch_kwargs):
     ) as e:
         cli_message("<red>{}</red>".format(e))
         sys.exit(1)
-
-    _suite_edit(suite_name, datasource_name, directory, jupyter=jupyter, batch_kwargs=batch_kwargs)
 
 
 @suite.command(name="list")
@@ -283,14 +283,14 @@ def suite_list(directory):
 
     suite_names = context.list_expectation_suite_names()
     if len(suite_names) == 0:
-        cli_message("No expectation suites available")
+        cli_message("No expectation suites found")
         return
 
     if len(suite_names) == 1:
-        cli_message("1 expectation suite available:")
+        cli_message("1 expectation suite found:")
 
     if len(suite_names) > 1:
-        cli_message("{} expectation suites available:".format(len(suite_names)))
+        cli_message("{} expectation suites found:".format(len(suite_names)))
 
     for name in suite_names:
         cli_message("\t{}".format(name))

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -465,7 +465,7 @@ class BaseDataContext(object):
 
         Args:
             batch_kwargs: the batch_kwargs to use; must include a datasource key
-            expectation_suite_name: the name of the expectation_suite to get
+            expectation_suite_name: The ExpectationSuite or the name of the expectation_suite to get
             data_asset_type: the type of data_asset to build, with associated expectation implementations. This can
                 generally be inferred from the datasource.
             batch_parameters: optional parameters to store as the reference description of the batch. They should
@@ -473,7 +473,6 @@ class BaseDataContext(object):
 
         Returns:
             DataAsset
-
         """
         if isinstance(batch_kwargs, dict):
             batch_kwargs = BatchKwargs(batch_kwargs)
@@ -481,16 +480,26 @@ class BaseDataContext(object):
         if not isinstance(batch_kwargs, BatchKwargs):
             raise ge_exceptions.BatchKwargsError("BatchKwargs must be a BatchKwargs object or dictionary.")
 
-        if not isinstance(expectation_suite_name, (ExpectationSuiteIdentifier, string_types)):
-            raise ge_exceptions.DataContextError("expectation_suite_name must be an ExpectationSuiteIdentifier or "
-                                                 "string.")
+        if not isinstance(expectation_suite_name, (ExpectationSuite, ExpectationSuiteIdentifier, string_types)):
+            raise ge_exceptions.DataContextError(
+                "expectation_suite_name must be an ExepctationSuite, "
+                "ExpectationSuiteIdentifier or string."
+            )
+
+        if isinstance(expectation_suite_name, ExpectationSuite):
+            expectation_suite = expectation_suite_name
+        else:
+            expectation_suite = self.get_expectation_suite(expectation_suite_name)
 
         datasource = self.get_datasource(batch_kwargs.get("datasource"))
-        expectation_suite = self.get_expectation_suite(expectation_suite_name)
         batch = datasource.get_batch(batch_kwargs=batch_kwargs, batch_parameters=batch_parameters)
         if data_asset_type is None:
             data_asset_type = datasource.config.get("data_asset_type")
-        validator = Validator(batch=batch, expectation_suite=expectation_suite, expectation_engine=data_asset_type)
+        validator = Validator(
+            batch=batch,
+            expectation_suite=expectation_suite,
+            expectation_engine=data_asset_type
+        )
         return validator.get_dataset()
 
     def run_validation_operator(

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -276,7 +276,6 @@ class BaseDataContext(object):
         return site_urls
 
     def open_data_docs(self, resource_identifier=None):
-
         """
         A stdlib cross-platform way to open a file in a browser.
 

--- a/great_expectations/render/renderer/notebook_renderer.py
+++ b/great_expectations/render/renderer/notebook_renderer.py
@@ -79,7 +79,7 @@ suite = context.get_expectation_suite(expectation_suite_name)
 suite.expectations = []
 
 batch_kwargs = {}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""".format(
                 suite_name, batch_kwargs
             ),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ psycopg2-binary>=2.7.6
 xlrd>=1.1.0
 boto3>=1.9
 pyarrow>=0.12.0
-pytest>=4.1.1
+pytest==5.3.5
 mock>=3.0.5
 moto>=1.3.7
 pytest-cov>=2.6.1

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
+from great_expectations.core import ExpectationSuite
 from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
@@ -27,39 +28,51 @@ Commands:
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_suite_new_on_context_with_no_datasources(caplog, empty_data_context):
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
+def test_suite_new_on_context_with_no_datasources(
+    mock_webbrowser, mock_subprocess, caplog, empty_data_context
+):
     """
     We call the "suite new" command on a data context that has no datasources
     configured.
 
-    The command should exit with a clear error message
+    The command should:
+    - exit with a clear error message
+    - NOT open Data Docs
+    - NOT open jupyter
     """
-
-    not_so_empty_data_context = empty_data_context
-    project_root_dir = not_so_empty_data_context.root_directory
+    project_root_dir = empty_data_context.root_directory
 
     root_dir = project_root_dir
-    os.chdir(root_dir)
-    context = DataContext(root_dir)
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
-        cli, ["suite", "new", "-d", root_dir, "--no-view"], catch_exceptions=False,
+        cli, ["suite", "new", "-d", root_dir], catch_exceptions=False,
     )
     stdout = result.stdout
 
     assert result.exit_code == 1
     assert "No datasources found in the context" in stdout
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_new_enter_existing_suite_name_as_arg(
-    mock_subprocess, caplog, data_context
+    mock_webbrowser, mock_subprocess, caplog, data_context
 ):
     """
-    We call the "suite new" command with the name of an existing expectation suite in the --suite argument
+    We call the "suite new" command with the name of an existing expectation
+    suite in the --suite argument
 
-    The command should exit with a clear error message
+    The command should:
+    - exit with a clear error message
+    - NOT open Data Docs
+    - NOT open jupyter
     """
 
     not_so_empty_data_context = data_context
@@ -79,44 +92,44 @@ def test_suite_new_enter_existing_suite_name_as_arg(
 
     assert result.exit_code == 1
     assert "already exists. If you intend to edit the suite" in stdout
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_new_answer_suite_name_prompts_with_name_of_existing_suite(
-    mock_subprocess, caplog, data_context, filesystem_csv_2
+    mock_webbrowser, mock_subprocess, caplog, data_context, filesystem_csv_2
 ):
     """
     We call the "suite new" command without the suite name argument
 
-    The command should prompt us to enter the name of the expectation suite that will be
-    created.
+    The command should:
 
-    We answer the prompt with the name of an existing expectation suite.
-
-    The command should display an error message and let us retry until we answer
+    - prompt us to enter the name of the expectation suite that will be
+    created. We answer the prompt with the name of an existing expectation suite.
+    - display an error message and let us retry until we answer
     with a name that is not "taken".
-
+    - create an example suite
+    - NOT open jupyter
+    - open DataDocs to the new example suite page
     """
-
     not_so_empty_data_context = data_context
-    project_root_dir = not_so_empty_data_context.root_directory
-    os.mkdir(os.path.join(project_root_dir, "uncommitted"))
+    root_dir = not_so_empty_data_context.root_directory
+    os.mkdir(os.path.join(root_dir, "uncommitted"))
 
-    root_dir = project_root_dir
-    os.chdir(root_dir)
-    context = DataContext(root_dir)
     runner = CliRunner(mix_stderr=False)
+    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--no-view"],
-        input="{0:s}\nmy_dag_node.default\nmy_new_suite\n\n".format(
-            os.path.join(filesystem_csv_2, "f1.csv")
-        ),
+        ["suite", "new", "-d", root_dir],
+        input=f"{csv_path}\nmy_dag_node.default\nmy_new_suite\n\n",
         catch_exceptions=False,
     )
     stdout = result.stdout
-
     assert result.exit_code == 0
     assert "already exists. If you intend to edit the suite" in stdout
     assert "Enter the path" in stdout
@@ -129,21 +142,32 @@ def test_suite_new_answer_suite_name_prompts_with_name_of_existing_suite(
     assert "Building" in stdout
     assert "The following Data Docs sites were built" in stdout
     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
-
-    # this context fixture does not have Data Docs sites configures, so we are not checking
-    # the HTML files - the other test cases do it.
+    assert "open a notebook for you now" not in stdout
 
     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_subprocess.call_count == 0
+    assert mock_webbrowser.call_count == 1
+
+    foo = os.path.join(
+        root_dir, "uncommitted/data_docs/local_site/validations/my_new_suite/"
+    )
+    assert f"file://{foo}" in mock_webbrowser.call_args[0][0]
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_new_empty_suite_creates_empty_suite(
-    mock_subprocess, caplog, data_context, filesystem_csv_2
+    mock_webbroser, mock_subprocess, caplog, data_context, filesystem_csv_2
 ):
     """
-    Running "suite new --empty" should make an empty suite
+    Running "suite new --empty" should:
+    - make an empty suite
+    - open jupyter
+    - NOT open data docs
     """
     project_root_dir = data_context.root_directory
     os.mkdir(os.path.join(project_root_dir, "uncommitted"))
@@ -153,7 +177,7 @@ def test_suite_new_empty_suite_creates_empty_suite(
     csv = os.path.join(filesystem_csv_2, "f1.csv")
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--empty", "--suite", "foo", "--no-view"],
+        ["suite", "new", "-d", root_dir, "--empty", "--suite", "foo"],
         input=f"{csv}\n",
         catch_exceptions=False,
     )
@@ -169,19 +193,16 @@ def test_suite_new_empty_suite_creates_empty_suite(
     assert "Generating example Expectation Suite..." not in stdout
     assert "The following Data Docs sites were built" not in stdout
     assert "A new Expectation suite 'foo' was added to your project" in stdout
-    assert "Because you requested an empty suite, we'll open a notebook for you now to edit it!" in stdout
+    assert (
+        "Because you requested an empty suite, we'll open a notebook for you now to edit it!"
+        in stdout
+    )
 
     expected_suite_path = os.path.join(root_dir, "expectations", "foo.json")
     assert os.path.isfile(expected_suite_path)
 
     expected_notebook = os.path.join(root_dir, "uncommitted", "foo.ipynb")
     assert os.path.isfile(expected_notebook)
-
-    assert mock_subprocess.call_count == 1
-    call_args = mock_subprocess.call_args[0][0]
-    assert call_args[0] == "jupyter"
-    assert call_args[1] == "notebook"
-    assert expected_notebook in call_args[2]
 
     context = DataContext(root_dir)
     assert "foo" in context.list_expectation_suite_names()
@@ -196,25 +217,99 @@ def test_suite_new_empty_suite_creates_empty_suite(
         "comment": "New suite added via CLI",
     }
 
+    assert mock_subprocess.call_count == 1
+    call_args = mock_subprocess.call_args[0][0]
+    assert call_args[0] == "jupyter"
+    assert call_args[1] == "notebook"
+    assert expected_notebook in call_args[2]
+
+    assert mock_webbroser.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
+def test_suite_new_empty_suite_creates_empty_suite_with_no_jupyter(
+    mock_webbroser, mock_subprocess, caplog, data_context, filesystem_csv_2
+):
+    """
+    Running "suite new --empty --no-jupyter" should:
+    - make an empty suite
+    - NOT open jupyter
+    - NOT open data docs
+    """
+    project_root_dir = data_context.root_directory
+    os.mkdir(os.path.join(project_root_dir, "uncommitted"))
+    root_dir = project_root_dir
+    os.chdir(root_dir)
+    runner = CliRunner(mix_stderr=False)
+    csv = os.path.join(filesystem_csv_2, "f1.csv")
+    result = runner.invoke(
+        cli,
+        ["suite", "new", "-d", root_dir, "--empty", "--suite", "foo", "--no-jupyter"],
+        input=f"{csv}\n",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+
+    assert result.exit_code == 0
+    assert "Enter the path" in stdout
+    assert "Name the new expectation suite" not in stdout
+    assert (
+        "Great Expectations will choose a couple of columns and generate expectations"
+        not in stdout
+    )
+    assert "Generating example Expectation Suite..." not in stdout
+    assert "The following Data Docs sites were built" not in stdout
+    assert "A new Expectation suite 'foo' was added to your project" in stdout
+    assert "open a notebook for you now" not in stdout
+
+    expected_suite_path = os.path.join(root_dir, "expectations", "foo.json")
+    assert os.path.isfile(expected_suite_path)
+
+    expected_notebook = os.path.join(root_dir, "uncommitted", "foo.ipynb")
+    assert os.path.isfile(expected_notebook)
+
+    context = DataContext(root_dir)
+    assert "foo" in context.list_expectation_suite_names()
+    suite = context.get_expectation_suite("foo")
+    assert suite.expectations == []
+    citations = suite.get_citations()
+    citations[0].pop("citation_date")
+    assert citations[0] == {
+        "batch_kwargs": {"datasource": "mydatasource", "path": csv},
+        "batch_markers": None,
+        "batch_parameters": None,
+        "comment": "New suite added via CLI",
+    }
+
+    assert mock_subprocess.call_count == 0
+    assert mock_webbroser.call_count == 0
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_new_one_datasource_without_generator_without_suite_name_argument(
-    mock_subprocess, caplog, empty_data_context, filesystem_csv_2
+    mock_webbrowser, mock_subprocess, caplog, empty_data_context, filesystem_csv_2
 ):
     """
     We call the "suite new" command without the suite name argument
 
-    The data context has one datasource, so the command does not prompt us to choose.
-    The datasource has no generator configured, so we are prompted only to enter the path
-    (and not to choose from the generator's list of available data assets).
+    The command should:
 
-    We enter the path of the file we want the command to use as the batch to create the
-    expectation suite.
-
-    The command should prompt us to enter the name of the expectation suite that will be
-    created.
+    - NOT prompt us to choose a datasource (because there is only one)
+    - prompt us only to enter the path (The datasource has no generator
+     configured and not to choose from the generator's list of available data
+     assets).
+    - We enter the path of the file we want the command to use as the batch to
+    create the expectation suite.
+    - prompt us to enter the name of the expectation suite that will be
+    created
+    - open Data Docs
+    - NOT open jupyter
     """
     empty_data_context.add_datasource(
         "my_datasource",
@@ -222,8 +317,8 @@ def test_suite_new_one_datasource_without_generator_without_suite_name_argument(
         class_name="PandasDatasource",
     )
 
-    not_so_empty_data_context = empty_data_context
-    project_root_dir = not_so_empty_data_context.root_directory
+    context = empty_data_context
+    project_root_dir = context.root_directory
 
     root_dir = project_root_dir
     os.chdir(root_dir)
@@ -231,7 +326,7 @@ def test_suite_new_one_datasource_without_generator_without_suite_name_argument(
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--no-view"],
+        ["suite", "new", "-d", root_dir],
         input="{0:s}\nmy_new_suite\n\n".format(
             os.path.join(filesystem_csv_2, "f1.csv")
         ),
@@ -265,21 +360,31 @@ def test_suite_new_one_datasource_without_generator_without_suite_name_argument(
 
     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 1
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_new_multiple_datasources_with_generator_without_suite_name_argument(
-    mock_subprocess, caplog, site_builder_data_context_with_html_store_titanic_random,
+    mock_webbrowser,
+    mock_subprocess,
+    caplog,
+    site_builder_data_context_with_html_store_titanic_random,
 ):
     """
     We call the "suite new" command without the suite name argument
 
-    The data context has two datasources - we choose one of them. It has a generator
-    configured. We choose to use the generator and select a generator asset from the list.
-
-    The command should prompt us to enter the name of the expectation suite that will be
-    created.
+    - The data context has two datasources - we choose one of them.
+    - It has a generator configured. We choose to use the generator and select a
+    generator asset from the list.
+    - The command should prompt us to enter the name of the expectation suite
+    that will be created.
+    - open Data Docs
+    - NOT open jupyter
     """
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
     os.chdir(root_dir)
@@ -287,7 +392,7 @@ def test_suite_new_multiple_datasources_with_generator_without_suite_name_argume
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--no-view"],
+        ["suite", "new", "-d", root_dir],
         input="1\n1\n1\nmy_new_suite\n\n",
         catch_exceptions=False,
     )
@@ -330,18 +435,29 @@ def test_suite_new_multiple_datasources_with_generator_without_suite_name_argume
 
     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 1
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_new_multiple_datasources_with_generator_with_suite_name_argument(
-    mock_subprocess, caplog, site_builder_data_context_with_html_store_titanic_random,
+    mock_webbrowser,
+    mock_subprocess,
+    caplog,
+    site_builder_data_context_with_html_store_titanic_random,
 ):
     """
     We call the "suite new" command with the suite name argument
 
-    The data context has two datasources - we choose one of them. It has a generator
-    configured. We choose to use the generator and select a generator asset from the list.
+    - The data context has two datasources - we choose one of them.
+    - It has a generator configured. We choose to use the generator and select
+    a generator asset from the list.
+    - open Data Docs
+    - NOT open jupyter
     """
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
     os.chdir(root_dir)
@@ -349,7 +465,7 @@ def test_suite_new_multiple_datasources_with_generator_with_suite_name_argument(
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--suite", "foo_suite", "--no-view"],
+        ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
         input="2\n1\n1\n\n",
         catch_exceptions=False,
     )
@@ -381,10 +497,15 @@ def test_suite_new_multiple_datasources_with_generator_with_suite_name_argument(
 
     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 1
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_suite_edit_without_suite_name_raises_error(caplog):
+def test_suite_edit_without_suite_name_raises_error():
+    """This is really only testing click missing arguments"""
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(cli, "suite edit", catch_exceptions=False)
     assert result.exit_code == 2
@@ -394,9 +515,17 @@ def test_suite_edit_without_suite_name_raises_error(caplog):
     )
 
 
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
-    caplog, empty_data_context
+    mock_webbrowser, mock_subprocess, caplog, empty_data_context
 ):
+    """
+    The command should:
+    - exit with a clear error message
+    - NOT open Data Docs
+    - NOT open jupyter
+    """
     project_dir = empty_data_context.root_directory
     context = DataContext(project_dir)
     context.create_expectation_suite("foo")
@@ -410,13 +539,24 @@ def test_suite_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
     stdout = result.output
     assert result.exit_code == 1
     assert "Please check that your batch_kwargs are valid JSON." in stdout
-    # assert "Expecting value" in stdout # The exact message in the exception varies in Py 2, Py 3
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_with_batch_kwargs_unable_to_load_a_batch_raises_helpful_error(
-    caplog, empty_data_context
+    mock_webbrowser, mock_subprocess, caplog, empty_data_context
 ):
+    """
+    The command should:
+    - exit with a clear error message
+    - NOT open Data Docs
+    - NOT open jupyter
+    """
     project_dir = empty_data_context.root_directory
 
     context = DataContext(project_dir)
@@ -434,12 +574,24 @@ def test_suite_edit_with_batch_kwargs_unable_to_load_a_batch_raises_helpful_erro
     assert result.exit_code == 1
     assert "To continue editing this suite" not in stdout
     assert "Please check that your batch_kwargs are able to load a batch." in stdout
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_with_non_existent_suite_name_raises_error(
-    caplog, empty_data_context
+    mock_webbrowser, mock_subprocess, caplog, empty_data_context
 ):
+    """
+    The command should:
+    - exit with a clear error message
+    - NOT open Data Docs
+    - NOT open jupyter
+    """
     project_dir = empty_data_context.root_directory
     assert not empty_data_context.list_expectation_suites()
 
@@ -450,16 +602,26 @@ def test_suite_edit_with_non_existent_suite_name_raises_error(
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    assert (
-        "Could not find a suite named `not_a_real_suite`. Please check the name and try again"
-        in result.output
-    )
+    assert "Could not find a suite named `not_a_real_suite`." in result.output
+    assert "by running `great_expectations suite list`" in result.output
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_with_non_existent_datasource_shows_helpful_error_message(
-    caplog, empty_data_context
+    mock_webbrowser, mock_subprocess, caplog, empty_data_context
 ):
+    """
+    The command should:
+    - exit with a clear error message
+    - NOT open Data Docs
+    - NOT open jupyter
+    """
     project_dir = empty_data_context.root_directory
     context = DataContext(project_dir)
     context.create_expectation_suite("foo")
@@ -468,7 +630,7 @@ def test_suite_edit_with_non_existent_datasource_shows_helpful_error_message(
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        "suite edit foo -d {} --datasource not_real".format(project_dir),
+        f"suite edit foo -d {project_dir} --datasource not_real",
         catch_exceptions=False,
     )
     assert result.exit_code == 1
@@ -476,12 +638,20 @@ def test_suite_edit_with_non_existent_datasource_shows_helpful_error_message(
         "Unable to load datasource `not_real` -- no configuration found or invalid configuration."
         in result.output
     )
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args_with_suite_without_citations(
-    mock_subprocess, caplog, site_builder_data_context_with_html_store_titanic_random,
+    mock_webbrowser,
+    mock_subprocess,
+    caplog,
+    site_builder_data_context_with_html_store_titanic_random,
 ):
     """
     Here we verify that the "suite edit" command helps the user to specify the batch
@@ -495,51 +665,67 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args_
 
     The data context has two datasources - we choose one of them. It has a generator
     configured. We choose to use the generator and select a generator asset from the list.
+
+    The command should:
+    - NOT open Data Docs
+    - open jupyter
     """
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
     os.chdir(root_dir)
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--suite", "foo_suite", "--no-view"],
+        ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
         input="2\n1\n1\n\n",
         catch_exceptions=False,
     )
-    stdout = result.stdout
     assert result.exit_code == 0
-    assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
+    assert mock_webbrowser.call_count == 1
+    assert mock_subprocess.call_count == 0
+    mock_webbrowser.reset_mock()
+    mock_subprocess.reset_mock()
 
     # remove the citations from the suite
     context = DataContext(root_dir)
     suite = context.get_expectation_suite("foo_suite")
+    assert isinstance(suite, ExpectationSuite)
     suite.meta.pop("citations")
     context.save_expectation_suite(suite)
 
+    # Actual testing really starts here
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "edit", "foo_suite", "-d", root_dir, "--no-jupyter"],
+        ["suite", "edit", "foo_suite", "-d", root_dir,],
         input="2\n1\n1\n\n",
         catch_exceptions=False,
     )
 
     assert result.exit_code == 0
     stdout = result.stdout
+    assert "A batch of data is required to edit the suite" in stdout
     assert "Select a datasource" in stdout
     assert "Which data would you like to use" in stdout
-    assert "To continue editing this suite, run" in stdout
 
     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
     assert os.path.isfile(expected_notebook_path)
 
     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 1
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args_with_suite_containing_citations(
-    mock_subprocess, caplog, site_builder_data_context_with_html_store_titanic_random,
+    mock_webbrowser,
+    mock_subprocess,
+    caplog,
+    site_builder_data_context_with_html_store_titanic_random,
 ):
     """
     Here we verify that the "suite edit" command uses the batch kwargs found in
@@ -550,24 +736,33 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args_
     test will edit - this step is a just a setup.
 
     We call the "suite edit" command without any optional arguments.
+
+    The command should:
+    - NOT open Data Docs
+    - NOT open jupyter
     """
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
     os.chdir(root_dir)
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--suite", "foo_suite", "--no-view"],
+        ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
         input="2\n1\n1\n\n",
         catch_exceptions=False,
     )
-    stdout = result.stdout
+    assert mock_webbrowser.call_count == 1
+    assert mock_subprocess.call_count == 0
+    mock_subprocess.reset_mock()
+    mock_webbrowser.reset_mock()
     assert result.exit_code == 0
-    assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
+    context = DataContext(root_dir)
+    suite = context.get_expectation_suite("foo_suite")
+    assert isinstance(suite, ExpectationSuite)
 
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "edit", "foo_suite", "-d", root_dir, "--no-jupyter"],
+        ["suite", "edit", "foo_suite", "-d", root_dir],
         input="2\n1\n1\n\n",
         catch_exceptions=False,
     )
@@ -576,20 +771,26 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args_
     stdout = result.stdout
     assert "Select a datasource" not in stdout
     assert "Which data would you like to use" not in stdout
-    assert "To continue editing this suite, run" in stdout
-    assert "great_expectations/uncommitted/foo_suite.ipynb" in stdout
 
     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
     assert os.path.isfile(expected_notebook_path)
 
     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 1
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
-    mock_subprocess, caplog, site_builder_data_context_with_html_store_titanic_random,
+    mock_webbrowser,
+    mock_subprocess,
+    caplog,
+    site_builder_data_context_with_html_store_titanic_random,
 ):
     """
     Here we verify that when the "suite edit" command is called with batch_kwargs arg
@@ -605,6 +806,10 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
 
     The data context has two datasources - we choose one of them. It has a generator
     configured. We choose to use the generator and select a generator asset from the list.
+
+    The command should:
+    - NOT open Data Docs
+    - open jupyter
     """
     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
     runner = CliRunner(mix_stderr=False)
@@ -616,6 +821,10 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
     )
     stdout = result.stdout
     assert result.exit_code == 0
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+    mock_subprocess.reset_mock()
+    mock_webbrowser.reset_mock()
     assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
 
     batch_kwargs = {
@@ -640,7 +849,6 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
             "foo_suite",
             "-d",
             root_dir,
-            "--no-jupyter",
             "--batch-kwargs",
             batch_kwargs_arg_str,
         ],
@@ -651,18 +859,23 @@ def test_suite_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
     assert result.exit_code == 0
     assert "Select a datasource" not in stdout
     assert "Which data would you like to use" not in stdout
-    assert "To continue editing this suite, run" in stdout
 
     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
     assert os.path.isfile(expected_notebook_path)
 
     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 1
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_on_exsiting_suite_one_datasources_with_batch_kwargs_without_datasource_raises_helpful_error(
-    caplog, titanic_data_context,
+    mock_webbrowser, mock_subprocess, caplog, titanic_data_context,
 ):
     """
     Given:
@@ -672,7 +885,10 @@ def test_suite_edit_on_exsiting_suite_one_datasources_with_batch_kwargs_without_
     great_expectations suite edit foo --batch-kwargs '{"path": "data/10k.csv"}'
 
     Then:
-    - The user should see a nice error and the program halts before notebook compilation.
+    - The user should see a nice error and the program halts before notebook
+    compilation.
+    - NOT open Data Docs
+    - NOT open jupyter
     '"""
     project_dir = titanic_data_context.root_directory
     context = DataContext(project_dir)
@@ -697,11 +913,17 @@ def test_suite_edit_on_exsiting_suite_one_datasources_with_batch_kwargs_without_
     assert result.exit_code == 1
     assert "Please check that your batch_kwargs are able to load a batch." in stdout
     assert "Unable to load datasource `None`" in stdout
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 0
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_on_exsiting_suite_one_datasources_with_datasource_arg_and_batch_kwargs(
-    caplog, titanic_data_context,
+    mock_webbrowser, mock_subprocess, caplog, titanic_data_context,
 ):
     """
     Given:
@@ -712,6 +934,8 @@ def test_suite_edit_on_exsiting_suite_one_datasources_with_datasource_arg_and_ba
 
     Then:
     - The user gets a working notebook
+    - NOT open Data Docs
+    - open jupyter
     """
     project_dir = titanic_data_context.root_directory
     context = DataContext(project_dir)
@@ -731,24 +955,28 @@ def test_suite_edit_on_exsiting_suite_one_datasources_with_datasource_arg_and_ba
             json.dumps(batch_kwargs),
             "--datasource",
             "mydatasource",
-            "--no-jupyter",
         ],
         catch_exceptions=False,
     )
     stdout = result.output
+    assert stdout == ""
     assert result.exit_code == 0
-    assert "To continue editing this suite, run" in stdout
 
     expected_notebook_path = os.path.join(project_dir, "uncommitted", "foo.ipynb")
     assert os.path.isfile(expected_notebook_path)
     expected_suite_path = os.path.join(project_dir, "expectations", "foo.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 1
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_suite_edit_one_datasources_no_generator_with_no_additional_args_and_no_citations(
-    mock_subprocess, caplog, empty_data_context, filesystem_csv_2
+    mock_webbrowser, mock_subprocess, caplog, empty_data_context, filesystem_csv_2
 ):
     """
     Here we verify that the "suite edit" command helps the user to specify the batch
@@ -777,14 +1005,17 @@ def test_suite_edit_one_datasources_no_generator_with_no_additional_args_and_no_
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "new", "-d", root_dir, "--no-view"],
+        ["suite", "new", "-d", root_dir],
         input="{0:s}\nmy_new_suite\n\n".format(
             os.path.join(filesystem_csv_2, "f1.csv")
         ),
         catch_exceptions=False,
     )
     stdout = result.stdout
-
+    assert mock_webbrowser.call_count == 1
+    assert mock_subprocess.call_count == 0
+    mock_subprocess.reset_mock()
+    mock_webbrowser.reset_mock()
     assert result.exit_code == 0
     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
 
@@ -797,7 +1028,7 @@ def test_suite_edit_one_datasources_no_generator_with_no_additional_args_and_no_
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["suite", "edit", "my_new_suite", "-d", root_dir, "--no-jupyter"],
+        ["suite", "edit", "my_new_suite", "-d", root_dir],
         input="{0:s}\n\n".format(os.path.join(filesystem_csv_2, "f1.csv")),
         catch_exceptions=False,
     )
@@ -807,26 +1038,28 @@ def test_suite_edit_one_datasources_no_generator_with_no_additional_args_and_no_
     assert "Select a datasource" not in stdout
     assert "Which data would you like to use" not in stdout
     assert "Enter the path" in stdout
-    assert "To continue editing this suite, run" in stdout
 
     expected_notebook_path = os.path.join(root_dir, "uncommitted", "my_new_suite.ipynb")
     assert os.path.isfile(expected_notebook_path)
 
     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
     assert os.path.isfile(expected_suite_path)
+
+    assert mock_webbrowser.call_count == 0
+    assert mock_subprocess.call_count == 1
+
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_suite_list_with_zero_suites(caplog, empty_data_context):
     project_dir = empty_data_context.root_directory
-    context = DataContext(project_dir)
     runner = CliRunner(mix_stderr=False)
 
     result = runner.invoke(
         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert "No expectation suites available" in result.output
+    assert "No expectation suites found" in result.output
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
@@ -841,7 +1074,7 @@ def test_suite_list_with_one_suite(caplog, empty_data_context):
         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert "1 expectation suite available" in result.output
+    assert "1 expectation suite found" in result.output
     assert "\ta.warning" in result.output
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
@@ -860,7 +1093,7 @@ def test_suite_list_with_multiple_suites(caplog, empty_data_context):
     )
     output = result.output
     assert result.exit_code == 0
-    assert "3 expectation suites available:" in output
+    assert "3 expectation suites found:" in output
     assert "\ta.warning" in output
     assert "\tb.warning" in output
     assert "\tc.warning" in output

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -8,6 +8,7 @@ from ruamel.yaml import YAML
 
 from great_expectations.core import (
     ExpectationConfiguration,
+    ExpectationSuite,
     expectationSuiteSchema,
 )
 from great_expectations.data_context import (
@@ -24,9 +25,14 @@ from great_expectations.data_context.util import (
     file_relative_path,
     safe_mmkdir,
 )
+from great_expectations.dataset import Dataset
 from great_expectations.datasource import Datasource
 from great_expectations.datasource.types.batch_kwargs import PathBatchKwargs
-from great_expectations.exceptions import DataContextError, ProfilerError, ConfigNotFoundError
+from great_expectations.exceptions import (
+    BatchKwargsError,
+    ConfigNotFoundError,
+    DataContextError,
+)
 from great_expectations.util import gen_directory_tree_str
 from tests.test_utils import safe_remove
 
@@ -1044,16 +1050,19 @@ def test_load_config_variables_file(basic_data_context_config, tmp_path_factory)
         # Make sure we unset the environment variable we're using
         del os.environ["TEST_CONFIG_FILE_ENV"]
 
+
 def test_list_expectation_suite_with_no_suites(titanic_data_context):
     observed = titanic_data_context.list_expectation_suite_names()
     assert isinstance(observed, list)
     assert observed == []
+
 
 def test_list_expectation_suite_with_one_suite(titanic_data_context):
     titanic_data_context.create_expectation_suite('warning')
     observed = titanic_data_context.list_expectation_suite_names()
     assert isinstance(observed, list)
     assert observed == ['warning']
+
 
 def test_list_expectation_suite_with_multiple_suites(titanic_data_context):
     titanic_data_context.create_expectation_suite('a.warning')
@@ -1064,3 +1073,47 @@ def test_list_expectation_suite_with_multiple_suites(titanic_data_context):
     assert isinstance(observed, list)
     assert observed == ['a.warning', 'b.warning', 'c.warning']
     assert len(observed) == 3
+
+
+def test_get_batch_raises_error_when_passed_a_non_string_type_for_suite_parameter(
+    titanic_data_context,
+):
+    with pytest.raises(DataContextError):
+        titanic_data_context.get_batch({}, 99)
+
+
+def test_get_batch_raises_error_when_passed_a_non_dict_or_batch_kwarg_type_for_batch_kwarg_parameter(
+    titanic_data_context,
+):
+    with pytest.raises(BatchKwargsError):
+        titanic_data_context.get_batch(99, "foo")
+
+
+def test_get_batch_when_passed_a_suite_name(titanic_data_context):
+    context = titanic_data_context
+    root_dir = context.root_directory
+    batch_kwargs = {
+        "datasource": "mydatasource",
+        "path": os.path.join(root_dir, "..", "data", "Titanic.csv"),
+    }
+    context.create_expectation_suite("foo")
+    assert context.list_expectation_suite_names() == ["foo"]
+    batch = context.get_batch(batch_kwargs, "foo")
+    assert isinstance(batch, Dataset)
+    assert isinstance(batch.get_expectation_suite(), ExpectationSuite)
+
+
+def test_get_batch_when_passed_a_suite(titanic_data_context):
+    context = titanic_data_context
+    root_dir = context.root_directory
+    batch_kwargs = {
+        "datasource": "mydatasource",
+        "path": os.path.join(root_dir, "..", "data", "Titanic.csv"),
+    }
+    context.create_expectation_suite("foo")
+    assert context.list_expectation_suite_names() == ["foo"]
+    suite = context.get_expectation_suite("foo")
+
+    batch = context.get_batch(batch_kwargs, suite)
+    assert isinstance(batch, Dataset)
+    assert isinstance(batch.get_expectation_suite(), ExpectationSuite)

--- a/tests/render/renderer/test_notebook_renderer.py
+++ b/tests/render/renderer/test_notebook_renderer.py
@@ -406,7 +406,7 @@ suite.expectations = []
 batch_kwargs = {
     'path': '/home/foo/data/10k.csv',
     'datasource': 'files_datasource'}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },
@@ -518,7 +518,7 @@ suite.expectations = []
 batch_kwargs = {
     'path': '/home/foo/data/10k.csv',
     'datasource': 'files_datasource'}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },
@@ -618,7 +618,7 @@ suite = context.get_expectation_suite(expectation_suite_name)
 suite.expectations = []
 
 batch_kwargs = {}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },
@@ -730,7 +730,7 @@ suite = context.get_expectation_suite(expectation_suite_name)
 suite.expectations = []
 
 batch_kwargs = {'foo': 'bar', 'datasource': 'things'}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },
@@ -839,7 +839,7 @@ suite = context.get_expectation_suite(expectation_suite_name)
 suite.expectations = []
 
 batch_kwargs = {}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },
@@ -949,7 +949,7 @@ suite = context.get_expectation_suite(expectation_suite_name)
 suite.expectations = []
 
 batch_kwargs = {'foo': 'bar', 'datasource': 'things'}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },
@@ -1058,7 +1058,7 @@ suite = context.get_expectation_suite(expectation_suite_name)
 suite.expectations = []
 
 batch_kwargs = {'path': '../../3.csv', 'datasource': '3'}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },
@@ -1221,7 +1221,7 @@ suite = context.get_expectation_suite(expectation_suite_name)
 suite.expectations = []
 
 batch_kwargs = {'path': '../../foo/data'}
-batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+batch = context.get_batch(batch_kwargs, suite)
 batch.head()""",
                 "outputs": [],
             },

--- a/tests/test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json
+++ b/tests/test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json
@@ -2,6 +2,7 @@
     "expectation_suite_name": "my_dag_node.default",
     "data_asset_type": "Dataset",
     "meta": {
+        "great_expectations.__version__": "0.9.4"
     },
     "expectations": [
         {

--- a/tests/test_fixtures/great_expectations_basic.yml
+++ b/tests/test_fixtures/great_expectations_basic.yml
@@ -27,7 +27,15 @@ evaluation_parameter_store_name: evaluation_parameter_store
 expectations_store_name: expectations_store
 validations_store_name: validations_store
 
-data_docs_sites: {}
+data_docs_sites:
+  local_site:
+    class_name: SiteBuilder
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: uncommitted/data_docs/local_site/
+    site_index_builder:
+      class_name: DefaultSiteIndexBuilder
+      show_cta_footer: true
 
 stores:
   expectations_store:


### PR DESCRIPTION
## Background

- In the excellent hackathon work we thought we enabled suites in notebooks to have their expectations removed. This was not the case. `get_batch` reloads a suite internally from the suite name. This means that users still have to manually remove expectations they do not want.

## What's Here

- Bugfixes in `suite edit` behavior with regard to jupyter
- Bugfixes in the edit flow surrounding empty suites

### Before
<img width="1015" alt="22_-_Jupyter_Notebook" src="https://user-images.githubusercontent.com/928247/76369833-86bb7680-62fa-11ea-8d2d-e8b1b29a43e6.png">

### After
<img width="996" alt="37_-_Jupyter_Notebook" src="https://user-images.githubusercontent.com/928247/76544182-3c96da00-644d-11ea-9fc5-3b7965794943.png">
