### PR TITLE
Expectation suite links and init flow update

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -2,7 +2,8 @@
 
 develop
 -----------------
-
+* DataDocs: Expectation Suite name on Validation Result pages now link to Expectation Suite page
+* `great_expectations init`: cli now asks user if csv has header when adding a Spark Datasource with csv file
 
 0.9.4
 -----------------

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -1063,7 +1063,7 @@ We could not determine the format of the file. What is it?
   - Error: {0:s}"""
                 cli_message(file_load_error_message.format(str(e)))
                 if not click.confirm(
-                    "Try again?",
+                    "\nTry again?",
                     default=True
                 ):
                     cli_message("""

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -659,7 +659,6 @@ def _add_spark_datasource(context, passthrough_generator_only=True, prompt_for_d
 }
 )
 
-
     context.add_datasource(name=datasource_name, class_name='SparkDFDatasource', **configuration)
     return datasource_name
 
@@ -1049,11 +1048,28 @@ We could not determine the format of the file. What is it?
 
                 if reader_method is not None:
                     batch_kwargs["reader_method"] = reader_method
+                    if isinstance(datasource, SparkDFDatasource) and reader_method == "csv":
+                        header_row = click.confirm(
+                            "\nDoes this file contain a header row?",
+                            default=True
+                        )
+                        batch_kwargs["reader_options"] = {
+                            "header": header_row
+                        }
                     batch = datasource.get_batch(batch_kwargs=batch_kwargs)
                     break
         else:
             # TODO: read the file and confirm with user that we read it correctly (headers, columns, etc.)
             try:
+                batch_kwargs["reader_method"] = reader_method
+                if isinstance(datasource, SparkDFDatasource) and reader_method == "csv":
+                    header_row = click.confirm(
+                        "\nDoes this file contain a header row?",
+                        default=True
+                    )
+                    batch_kwargs["reader_options"] = {
+                        "header": header_row
+                    }
                 batch = datasource.get_batch(batch_kwargs=batch_kwargs)
                 break
             except Exception as e:

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from marshmallow import ValidationError
 from six import string_types
@@ -142,6 +143,9 @@ class ValidationResultsPageRenderer(Renderer):
     def _render_validation_header(cls, validation_results):
         success = validation_results.success
         expectation_suite_name = validation_results.meta['expectation_suite_name']
+        expectation_suite_path_components = ['..' for _ in range(len(expectation_suite_name.split('.')) + 2)] \
+            + ["expectations"] + expectation_suite_name.split(".")
+        expectation_suite_path = os.path.join(*expectation_suite_path_components) + ".html"
         if success:
             success = '<i class="fas fa-check-circle text-success" aria-hidden="true"></i> Succeeded'
         else:
@@ -175,6 +179,12 @@ class ValidationResultsPageRenderer(Renderer):
                             },
                             "status_title": {
                                 "classes": ["h6"]
+                            },
+                            "expectation_suite_name": {
+                                "tag": "a",
+                                "attributes": {
+                                    "href": expectation_suite_path
+                                }
                             }
                         },
                         "classes": ["mb-0", "mt-1"]

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -211,7 +211,7 @@ def test_suite_new_empty_suite_creates_empty_suite(
     citations = suite.get_citations()
     citations[0].pop("citation_date")
     assert citations[0] == {
-        "batch_kwargs": {"datasource": "mydatasource", "path": csv},
+        "batch_kwargs": {"datasource": "mydatasource", "path": csv, 'reader_method': 'read_csv'},
         "batch_markers": None,
         "batch_parameters": None,
         "comment": "New suite added via CLI",

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -190,11 +190,14 @@ def test_suite_new_empty_suite_creates_empty_suite(
     citations = suite.get_citations()
     citations[0].pop("citation_date")
     assert citations[0] == {
-        "batch_kwargs": {"datasource": "mydatasource", "path": csv},
-        "batch_markers": None,
-        "batch_parameters": None,
-        "comment": "New suite added via CLI",
-    }
+        'batch_kwargs': {
+            'datasource': 'mydatasource',
+            'path': csv,
+            'reader_method': 'read_csv'
+        },
+        'batch_markers': None,
+        'batch_parameters': None,
+        'comment': 'New suite added via CLI'}
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
 

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -161,20 +161,27 @@ def test_ProfilingResultsPageRenderer(titanic_profiled_evrs_1):
 
 def test_ValidationResultsPageRenderer_render_validation_header(titanic_profiled_evrs_1):
     validation_header = ValidationResultsPageRenderer._render_validation_header(titanic_profiled_evrs_1).to_json_dict()
+
     expected_validation_header = {
-        'content_block_type': 'header', 'styling': {'classes': ['col-12', 'p-0'], 'header': {
-            'classes': ['alert', 'alert-secondary']}}, 'header': {'content_block_type': 'string_template',
-                                                                  'string_template': {'template': 'Overview',
-                                                                                      'tag': 'h5',
-                                                                                      'styling': {'classes': ['m-0']}}},
+        'content_block_type': 'header',
+        'styling': {
+            'classes': ['col-12', 'p-0'], 'header': {
+                'classes': ['alert', 'alert-secondary']}}, 'header': {'content_block_type': 'string_template',
+                                                                      'string_template': {'template': 'Overview',
+                                                                                          'tag': 'h5',
+                                                                                          'styling': {
+                                                                                              'classes': ['m-0']}}},
         'subheader': {'content_block_type': 'string_template', 'string_template': {
             'template': '${suite_title} ${expectation_suite_name}\n${status_title} ${success}',
             'params': {'suite_title': 'Expectation Suite:', 'status_title': 'Status:',
                        'expectation_suite_name': 'default',
                        'success': '<i class="fas fa-times text-danger" aria-hidden="true"></i> Failed'},
             'styling': {'params': {'suite_title': {'classes': ['h6']},
-                                   'status_title': {'classes': ['h6']}},
+                                   'status_title': {'classes': ['h6']},
+                                   'expectation_suite_name': {'tag': 'a', 'attributes': {
+                                       'href': '../../../expectations/default.html'}}},
                         'classes': ['mb-0', 'mt-1']}}}}
+
     # print(validation_header)
     assert validation_header == expected_validation_header
 


### PR DESCRIPTION
Addresses:
- https://app.asana.com/0/1119694864223484/1150577554651705/f
- https://app.asana.com/0/1119694864223484/1138929285394303/f

- DataDocs: Expectation Suite name on Validation Results page now links to appropriate page
- `great_expectations init`: cli now asks user if csv has header when adding a Spark Datasource with csv file