### PR TITLE
taps for expedited deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,11 +83,12 @@ install:
 - pip install --only-binary=numpy,scipy numpy scipy
 - if [ -z "$PANDAS" ]; then pip install pandas; else pip install pandas==$PANDAS; fi
 - pip install -r requirements-dev.txt
+- pip install -e .
 - pip install pytest-slack
 before_script:
 - psql -c 'create database test_ci;' -U postgres
 script:
-- pytest --cov=great_expectations --slack_hook=$SLACK_WEBHOOK --slack_report_link=$TRAVIS_BUILD_WEB_URL
+- pytest -rxXs --cov=great_expectations --slack_hook=$SLACK_WEBHOOK --slack_report_link=$TRAVIS_BUILD_WEB_URL
   --slack_channel=notifications-great_expectations tests/
 after_success:
 - coveralls

--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -2,6 +2,8 @@
 
 develop
 -----------------
+* New CLI command: `tap new` that generates an executable python file to expedite deployments.
+* bugfix in TableBatchKwargsGenerator docs
 
 
 0.9.6
@@ -11,6 +13,7 @@ develop
 * `great_expectations init`: cli now asks user if csv has header when adding a Spark Datasource with csv file
 * Improve support for using GCP Storage Bucket as a Data Docs Site backend (thanks @hahmed)
 * fix notebook renderer handling for expectations with no column kwarg and table not in their name (`#1194 <https://github.com/great-expectations/great_expectations/issues/1194>`_)
+
 
 0.9.5
 -----------------
@@ -649,4 +652,3 @@ to top-level names.
 * API and examples for custom expectations are available
 * New output formats are available for all expectations
 * Significant improvements to test suite and compatibility
-

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -27,6 +27,7 @@ This is a list of the most common commands you'll use in order of how much you'l
 * ``great_expectations suite new``
 * ``great_expectations suite list``
 * ``great_expectations docs build``
+* ``great_expectations tap new``
 * ``great_expectations datasource list``
 * ``great_expectations datasource new``
 * ``great_expectations datasource profile``
@@ -332,6 +333,62 @@ If you are using a database you will be guided through a series of prompts that 
 For details on profiling, see this :ref:`reference document<profiling_reference>`
 
 .. caution:: Profiling is a beta feature and is not guaranteed to be stable. YMMV
+
+
+great_expectations tap
+=======================
+
+All command line operations for working with taps are here.
+A tap is an executable python file that runs validations that you can create to aid deployment of validations.
+
+``great_expectations tap new``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Creating a tap requires a valid suite name and tap filename.
+This is the name of a a python file that this command will write to.
+
+
+.. note::
+    Taps are a beta feature to speed up deployment.
+    Please
+    `open a new issue <https://github.com/great-expectations/great_expectations/issues/new>`__
+    if you discover a use case that does not yet work
+    or have ideas how to make this feature better!
+
+.. code-block:: bash
+
+    $ great_expectations tap new npi.warning npi.warning.py
+
+    Enter the path (relative or absolute) of a data file
+    : data/npi.csv
+    A new tap has been generated! Open time_series_confirmed.py in an editor to tweak it
+
+You will now see a new tap file on your filesystem.
+
+This can be run by invoking it with:
+
+.. code-block:: bash
+
+    $ python  npi.warning.py
+    Validation Suceeded!
+    $ echo $?
+    0
+
+This posix-compatible exits with a status of ``0`` if validation is successful and a status of ``1`` if validation failed.
+
+A failure will look like:
+
+.. code-block:: bash
+
+    $ python  npi.warning.py
+    Validation Failed!
+    $ echo $?
+    1
+
+This makes adding this to your existing pipeline or scheduler such as cron easy.
+
+If you are using a database you will be guided through a series of prompts that collects and verifies connection details and credentials.
+
 
 
 Miscellaneous

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -343,7 +343,7 @@ A tap is an executable python file that runs validations that you can create to 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Creating a tap requires a valid suite name and tap filename.
-This is the name of a a python file that this command will write to.
+This is the name of a python file that this command will write to.
 
 
 .. note::

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -38,7 +38,7 @@ Each noun command and each verb sub-command has a description, and should help y
 
 .. note::
 
-    All Great Expectations commands have help text. As with most *nix utilities, you can try adding ``--help`` to the end.
+    All Great Expectations commands have help text. As with most posix utilities, you can try adding ``--help`` to the end.
     For example, by running ``great_expectations suite new --help`` you'll see help output for that specific command.
 
 .. code-block:: bash
@@ -277,7 +277,6 @@ If you prefer to disable Great Expectations from automatically opening the gener
 You can then run jupyter.
 
 
-
 great_expectations datasource
 ==============================
 
@@ -334,7 +333,6 @@ For details on profiling, see this :ref:`reference document<profiling_reference>
 
 .. caution:: Profiling is a beta feature and is not guaranteed to be stable. YMMV
 
-
 great_expectations tap
 =======================
 
@@ -358,10 +356,13 @@ This is the name of a a python file that this command will write to.
 .. code-block:: bash
 
     $ great_expectations tap new npi.warning npi.warning.py
+    This is a BETA feature which may change.
 
     Enter the path (relative or absolute) of a data file
     : data/npi.csv
-    A new tap has been generated! Open time_series_confirmed.py in an editor to tweak it
+    A new tap has been generated!
+    To run this tap, run: python npi.warning.py
+    You can edit this script or place this code snippet in your pipeline.
 
 You will now see a new tap file on your filesystem.
 
@@ -385,11 +386,31 @@ A failure will look like:
     $ echo $?
     1
 
-This makes adding this to your existing pipeline or scheduler such as cron easy.
+The :ref:`Typical Workflow <Typical Workflow>` document shows you how taps can be embedded in your existing pipeline or used adjacent to a pipeline.
 
-If you are using a database you will be guided through a series of prompts that collects and verifies connection details and credentials.
+If you are using a SQL datasource you will be guided through a series of prompts that helps you choose a table or write a SQL query.
 
+.. tip::
 
+	 A custom SQL query can be very handy if for example you wanted to validate all records in a table with timestamps.
+
+For example, imagine you have a machine learning model that looks at the last 14 days of customer events to predict churn.
+If you have built a suite called ``churn_model_assumptions`` and a postgres database with a ``user_events`` table with an ``event_timestamp`` column and you wanted to validate all events that occurred in the last 14 days you might do something like:
+
+.. code-block:: bash
+
+    $ great_expectations tap new churn_model_assumptions churn_model_assumptions.py
+    This is a BETA feature which may change.
+
+    Which table would you like to use? (Choose one)
+    1. user_events (table)
+    Don't see the table in the list above? Just type the SQL query
+    : SELECT * FROM user_events WHERE event_timestamp > now() - interval '14 day';
+    A new tap has been generated!
+    To run this tap, run: python churn_model_assumptions.py
+    You can edit this script or place this code snippet in your pipeline.
+
+This tap can then be run nightly before your model makes churn predictions!
 
 Miscellaneous
 ======================

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -12,15 +12,14 @@ and our `blog <https://greatexpectations.io/blog>`__ for more information on how
    :maxdepth: 2
 
    /features/expectations
-   /features/validation
-   /features/profiling
-   /features/data_docs
-   /features/custom_expectations
-   /features/data_context
    /features/validation_operators_and_actions
-   /features/profilers
+   /features/data_docs
+   /features/data_context
    /features/datasource
+   /features/validation
+   /features/metrics
+   /features/custom_expectations
    /features/batch_kwargs_generator
    /features/ge_on_teams
-
-
+   /features/profiling
+   /features/profilers

--- a/docs/features/metrics.rst
+++ b/docs/features/metrics.rst
@@ -19,6 +19,6 @@ cases, it could be easily readable, such as `column=Age`, but when there are mul
 values, it will most likely be an md5 hash of key/value pairs. It can also be None in the case that there are no
 kwargs required to identify the metric.
 
-See the :ref:`metrics_reference` or :ref:`metrics_tutorial <tutorial on saving metrics>` for more information.
+See the :ref:`metrics_reference` or :ref:`Saving Metrics Tutorial <saving_metrics>` for more information.
 
 *Last updated:* |lastupdate|

--- a/docs/module_docs/generator_module.rst
+++ b/docs/module_docs/generator_module.rst
@@ -35,6 +35,15 @@ QueryBatchKwargsGenerator
     :show-inheritance:
 
 
+TableBatchKwargsGenerator
+------------------------------------------------------------------------
+
+.. autoclass:: great_expectations.datasource.generator.table_generator.TableBatchKwargsGenerator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 SubdirReaderBatchKwargsGenerator
 ----------------------------------------------------------------------------------------
 
@@ -69,5 +78,3 @@ DatabricksTableBatchKwargsGenerator
     :members:
     :undoc-members:
     :show-inheritance:
-
-

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,4 +1,3 @@
-.. _reference:
 
 #############
 Reference
@@ -29,6 +28,7 @@ Core GE Types
    /reference/standard_arguments
    /reference/result_format
    /reference/validation_result
+   /reference/datasource_reference
    /reference/batch_kwargs
 
 ************************
@@ -67,6 +67,7 @@ Advanced Features
    /reference/batch_identification
    /reference/validation_operators
    /reference/usage_statistics
+   /reference/metric_reference
 
 *****************************
 Extending Great Expectations
@@ -88,5 +89,4 @@ Supporting Resources
    :maxdepth: 2
 
    /reference/supporting_resources
-
-
+   /reference/glossary

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -13,6 +13,9 @@ from great_expectations.cli.suite import suite
 
 
 # TODO: consider using a specified-order supporting class for help (but wasn't working with python 2)
+from great_expectations.cli.tap import tap
+
+
 @click.group()
 @click.version_option(version=ge_version)
 @click.option(
@@ -52,6 +55,7 @@ cli.add_command(docs)
 cli.add_command(init)
 cli.add_command(project)
 cli.add_command(suite)
+cli.add_command(tap)
 
 
 def main():

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -7,7 +7,6 @@ import click
 
 from great_expectations import DataContext
 from great_expectations import exceptions as ge_exceptions
-from great_expectations.cli.cli_logging import logger
 from great_expectations.cli.datasource import (
     create_expectation_suite as create_expectation_suite_impl,
 )
@@ -15,7 +14,7 @@ from great_expectations.cli.datasource import (
     get_batch_kwargs,
     select_datasource,
 )
-from great_expectations.cli.util import cli_message
+from great_expectations.cli.util import cli_message, load_expectation_suite
 from great_expectations.data_asset import DataAsset
 from great_expectations.render.renderer.notebook_renderer import NotebookRenderer
 
@@ -91,7 +90,7 @@ def _suite_edit(suite, datasource, directory, jupyter, batch_kwargs):
         cli_message("<red>{}</red>".format(err.message))
         return
 
-    suite = _load_suite(context, suite)
+    suite = load_expectation_suite(context, suite)
     citations = suite.get_citations(sort=True, require_batch_kwargs=True)
 
     if batch_kwargs_json:
@@ -168,21 +167,6 @@ A batch of data is required to edit the suite - let's help you to specify it."""
 
     if jupyter:
         subprocess.call(["jupyter", "notebook", notebook_path])
-
-
-def _load_suite(context, suite_name):
-    if suite_name.endswith(".json"):
-        suite_name = suite_name[:-5]
-    try:
-        suite = context.get_expectation_suite(suite_name)
-        return suite
-    except ge_exceptions.DataContextError as e:
-        cli_message(
-            f"<red>Could not find a suite named `{suite_name}`.</red> Please check "
-            "the name by running `great_expectations suite list` and try again."
-        )
-        logger.info(e)
-        sys.exit(1)
 
 
 @suite.command(name="new")

--- a/great_expectations/cli/tap.py
+++ b/great_expectations/cli/tap.py
@@ -47,25 +47,37 @@ def tap_new(suite, tap_filename, directory, csv=None, datasource=None):
     suite = load_expectation_suite(context, suite)
 
     n_expectations = len(suite.expectations)
-    cli_message(f"Loaded suite {suite.expectation_suite_name} that has {n_expectations} expectations.")
+    cli_message(
+        f"Loaded suite {suite.expectation_suite_name} that has {n_expectations} expectations."
+    )
 
-    batch_kwargs = {"datasource": datasource.name, "path": csv,
-            "reader_method": "read_csv"}
+    batch_kwargs = {
+        "datasource": datasource.name,
+        "path": csv,
+        "reader_method": "read_csv",
+    }
     template = _load_template()
-    template = template.format(tap_filename, directory, suite.expectation_suite_name, batch_kwargs)
+    template = template.format(
+        tap_filename, directory, suite.expectation_suite_name, batch_kwargs
+    )
 
     cli_message(f"<yellow>{template}</yellow>")
 
     with open(tap_filename, "w") as f:
         f.write(template)
-    cli_message(f"""<green>A new tap has been made! Open {tap_filename} in an editor to tweak it</green>""")
+    cli_message(
+        f"""<green>A new tap has been made! Open {tap_filename} in an editor to tweak it</green>"""
+    )
 
     # _debugging_stuff(tap_filename)
 
 
 def _file_batch_kwargs(datasource, csv):
-    return {"datasource": datasource, "path": os.path.abspath(csv),
-            "reader_method": "read_csv"}
+    return {
+        "datasource": datasource,
+        "path": os.path.abspath(csv),
+        "reader_method": "read_csv",
+    }
 
 
 def _debugging_stuff(tap_filename):

--- a/great_expectations/cli/tap.py
+++ b/great_expectations/cli/tap.py
@@ -1,12 +1,13 @@
 import os
 import subprocess
+import sys
 
 import click
 
 from great_expectations import DataContext
 from great_expectations import exceptions as ge_exceptions
-from great_expectations.cli.suite import _load_suite
-from great_expectations.cli.util import cli_message
+from great_expectations.cli.datasource import select_datasource
+from great_expectations.cli.util import cli_message, load_expectation_suite
 from great_expectations.data_context.util import file_relative_path
 
 
@@ -19,6 +20,7 @@ def tap():
 @tap.command(name="new")
 @click.argument("suite")
 @click.argument("tap_filename")
+@click.option("--datasource", default=None)
 @click.option("--csv", default=None)
 @click.option(
     "--directory",
@@ -26,8 +28,8 @@ def tap():
     default=None,
     help="The project's great_expectations directory.",
 )
-def tap_new(suite, tap_filename, directory, csv=None):
-    """Create a new tap."""
+def tap_new(suite, tap_filename, directory, csv=None, datasource=None):
+    """BETA! Create a new tap file."""
     try:
         context = DataContext(directory)
     except ge_exceptions.ConfigNotFoundError as err:
@@ -35,13 +37,21 @@ def tap_new(suite, tap_filename, directory, csv=None):
         return
 
     directory = context.root_directory
+    datasource = select_datasource(context, datasource_name=datasource)
 
-    suite = _load_suite(context, suite)
+    if not datasource:
+        cli_message("<red>No datasources found in the context.</red>")
+        sys.exit(1)
+
+    # Note this can exit if no suite is found.
+    suite = load_expectation_suite(context, suite)
+
     n_expectations = len(suite.expectations)
     cli_message(f"Loaded suite {suite.expectation_suite_name} that has {n_expectations} expectations.")
 
+    batch_kwargs = {"datasource": datasource.name, "path": csv,
+            "reader_method": "read_csv"}
     template = _load_template()
-    batch_kwargs = {"datasource": "files_datasource", "path": os.path.abspath(csv), "reader_method": "read_csv"}
     template = template.format(tap_filename, directory, suite.expectation_suite_name, batch_kwargs)
 
     cli_message(f"<yellow>{template}</yellow>")
@@ -51,6 +61,11 @@ def tap_new(suite, tap_filename, directory, csv=None):
     cli_message(f"""<green>A new tap has been made! Open {tap_filename} in an editor to tweak it</green>""")
 
     # _debugging_stuff(tap_filename)
+
+
+def _file_batch_kwargs(datasource, csv):
+    return {"datasource": datasource, "path": os.path.abspath(csv),
+            "reader_method": "read_csv"}
 
 
 def _debugging_stuff(tap_filename):

--- a/great_expectations/cli/tap.py
+++ b/great_expectations/cli/tap.py
@@ -30,6 +30,10 @@ def tap():
 )
 def tap_new(suite, tap_filename, directory, csv=None, datasource=None):
     """BETA! Create a new tap file."""
+    if not tap_filename.endswith(".py"):
+        cli_message("<red>Tap filename must end in .py. Please correct and re-run</red>")
+        exit(1)
+
     try:
         context = DataContext(directory)
     except ge_exceptions.ConfigNotFoundError as err:
@@ -43,7 +47,7 @@ def tap_new(suite, tap_filename, directory, csv=None, datasource=None):
         cli_message("<red>No datasources found in the context.</red>")
         sys.exit(1)
 
-    # Note this can exit if no suite is found.
+    # Note this will exit if no suite is found.
     suite = load_expectation_suite(context, suite)
 
     n_expectations = len(suite.expectations)

--- a/great_expectations/cli/tap.py
+++ b/great_expectations/cli/tap.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import click
@@ -37,9 +38,10 @@ def tap_new(suite, tap_filename, directory, datasource=None):
     datasource = _get_datasource(context, datasource)
     suite = load_expectation_suite(context, suite)
     _, _, _, batch_kwargs = get_batch_kwargs(context, datasource.name)
-    cli_message(f"<cyan>BatchKwargs: {batch_kwargs}</cyan>")
 
-    _write_tap_file_to_disk(batch_kwargs, context_directory, suite, tap_filename)
+    tap_filename = _write_tap_file_to_disk(
+        batch_kwargs, context_directory, suite, tap_filename
+    )
     cli_message(
         f"""<green>A new tap has been generated! Open {tap_filename} in an editor to tweak it</green>"""
     )
@@ -77,10 +79,13 @@ def _load_template():
 
 
 def _write_tap_file_to_disk(batch_kwargs, context_directory, suite, tap_filename):
-    template = _load_template()
-    template = template.format(
+    tap_file_path = os.path.abspath(os.path.join(context_directory, "..", tap_filename))
+
+    template = _load_template().format(
         tap_filename, context_directory, suite.expectation_suite_name, batch_kwargs
     )
     linted_code = lint_code(template)
-    with open(tap_filename, "w") as f:
+    with open(tap_file_path, "w") as f:
         f.write(linted_code)
+
+    return tap_file_path

--- a/great_expectations/cli/tap.py
+++ b/great_expectations/cli/tap.py
@@ -1,0 +1,66 @@
+import os
+import subprocess
+
+import click
+
+from great_expectations import DataContext
+from great_expectations import exceptions as ge_exceptions
+from great_expectations.cli.suite import _load_suite
+from great_expectations.cli.util import cli_message
+from great_expectations.data_context.util import file_relative_path
+
+
+@click.group()
+def tap():
+    """tap operations"""
+    pass
+
+
+@tap.command(name="new")
+@click.argument("suite")
+@click.argument("tap_filename")
+@click.option("--csv", default=None)
+@click.option(
+    "--directory",
+    "-d",
+    default=None,
+    help="The project's great_expectations directory.",
+)
+def tap_new(suite, tap_filename, directory, csv=None):
+    """Create a new tap."""
+    try:
+        context = DataContext(directory)
+    except ge_exceptions.ConfigNotFoundError as err:
+        cli_message("<red>{}</red>".format(err.message))
+        return
+
+    directory = context.root_directory
+
+    suite = _load_suite(context, suite)
+    n_expectations = len(suite.expectations)
+    cli_message(f"Loaded suite {suite.expectation_suite_name} that has {n_expectations} expectations.")
+
+    template = _load_template()
+    batch_kwargs = {"datasource": "files_datasource", "path": os.path.abspath(csv), "reader_method": "read_csv"}
+    template = template.format(tap_filename, directory, suite.expectation_suite_name, batch_kwargs)
+
+    cli_message(f"<yellow>{template}</yellow>")
+
+    with open(tap_filename, "w") as f:
+        f.write(template)
+    cli_message(f"""<green>A new tap has been made! Open {tap_filename} in an editor to tweak it</green>""")
+
+    # _debugging_stuff(tap_filename)
+
+
+def _debugging_stuff(tap_filename):
+    print("\n\n")
+    subprocess.call(["cat", tap_filename])
+    print("\n\n")
+    subprocess.call(["python", tap_filename])
+
+
+def _load_template():
+    with open(file_relative_path(__file__, "tap_template.py"), "r") as f:
+        template = f.read()
+    return template

--- a/great_expectations/cli/tap.py
+++ b/great_expectations/cli/tap.py
@@ -32,6 +32,7 @@ def tap():
 )
 def tap_new(suite, tap_filename, directory, datasource=None):
     """BETA! Create a new tap file for easy deployments."""
+    cli_message("<yellow>This is a BETA feature which may change. If you have ideas please file a GitHub issue!</yellow>")
     _validate_tap_filename(tap_filename)
     context = _get_context(directory)
     context_directory = context.root_directory
@@ -43,7 +44,10 @@ def tap_new(suite, tap_filename, directory, datasource=None):
         batch_kwargs, context_directory, suite, tap_filename
     )
     cli_message(
-        f"""<green>A new tap has been generated! Open {tap_filename} in an editor to tweak it</green>"""
+        f"""\
+<green>A new tap has been generated!</green>
+To run this tap, run: <green>python {tap_filename}</green>
+You can edit this script or place this code snippet in your pipeline."""
     )
 
 

--- a/great_expectations/cli/tap_template.py
+++ b/great_expectations/cli/tap_template.py
@@ -17,10 +17,11 @@ Usage:
 pipeline.
 """
 import sys
-import great_expectations as ge
+
+from great_expectations import DataContext
 
 # tap configuration
-context = ge.DataContext("{1}")
+context = DataContext("{1}")
 suite = context.get_expectation_suite("{2}")
 # You can modify your BatchKwargs to select different data
 batch_kwargs = {3}

--- a/great_expectations/cli/tap_template.py
+++ b/great_expectations/cli/tap_template.py
@@ -1,0 +1,28 @@
+"""
+A basic generated Great Expectations Tap that validates a single batch of data.
+
+This file can be run with `python {0}`.
+This can be run manually or via a scheduler such as crontab.
+
+Note this does not save any validation results.
+"""
+import sys
+
+import great_expectations as ge
+
+# Tap configuration
+context = ge.DataContext("{1}")
+suite = context.get_expectation_suite("{2}")
+batch_kwargs = {3}
+
+# Tap process
+batch = context.get_batch(batch_kwargs, suite)
+# TODO validation operator with good error handling
+results = context.run_validation_operator("action_list_operator", [batch])
+
+if not results["success"]:
+    print("Validation Failed!")
+    sys.exit(1)
+
+print("Validation Succeeded!")
+sys.exit(0)

--- a/great_expectations/cli/tap_template.py
+++ b/great_expectations/cli/tap_template.py
@@ -1,23 +1,29 @@
 """
-A basic generated Great Expectations Tap that validates a single batch of data.
+A basic generated Great Expectations tap that validates a single batch of data.
 
-This file can be run with `python {0}`.
-This can be run manually or via a scheduler such as crontab.
+Data that is validated is controlled by BatchKwargs, which can be adjusted in
+this script.
 
-Note this does not save any validation results.
+Data are validated by use of the `ActionListValidationOperator` which is
+configured by default. The default configuration of this Validation Operator
+saves validation results to your results store and then updates Data Docs.
+
+This makes viewing validation results easy for you and your team.
+
+Usage:
+- Run this file: `python time_series_confirmed.py`.
+- This can be run manually or via a scheduler such as cron.
 """
 import sys
-
 import great_expectations as ge
 
-# Tap configuration
+# tap configuration
 context = ge.DataContext("{1}")
 suite = context.get_expectation_suite("{2}")
 batch_kwargs = {3}
 
-# Tap process
+# tap validation process
 batch = context.get_batch(batch_kwargs, suite)
-# TODO validation operator with good error handling
 results = context.run_validation_operator("action_list_operator", [batch])
 
 if not results["success"]:

--- a/great_expectations/cli/tap_template.py
+++ b/great_expectations/cli/tap_template.py
@@ -11,8 +11,10 @@ saves validation results to your results store and then updates Data Docs.
 This makes viewing validation results easy for you and your team.
 
 Usage:
-- Run this file: `python time_series_confirmed.py`.
+- Run this file: `python {0}`.
 - This can be run manually or via a scheduler such as cron.
+- If your pipeline runner supports python snippets you can paste this into your
+pipeline.
 """
 import sys
 import great_expectations as ge
@@ -20,6 +22,7 @@ import great_expectations as ge
 # tap configuration
 context = ge.DataContext("{1}")
 suite = context.get_expectation_suite("{2}")
+# You can modify your BatchKwargs to select different data
 batch_kwargs = {3}
 
 # tap validation process

--- a/great_expectations/cli/util.py
+++ b/great_expectations/cli/util.py
@@ -1,16 +1,10 @@
-import os
 import re
-import shutil
 import sys
 
-import click
 import six
 
-from great_expectations import DataContext
-from great_expectations.cli.init_messages import (
-    NEW_TEMPLATE_INSTALLED,
-    NEW_TEMPLATE_PROMPT,
-)
+from great_expectations import exceptions as ge_exceptions
+from great_expectations.cli.cli_logging import logger
 
 try:
     from termcolor import colored
@@ -46,3 +40,23 @@ def is_sane_slack_webhook(url):
         return False
 
     return "https://hooks.slack.com/" in url.strip()
+
+
+def load_expectation_suite(context, suite_name):
+    """
+    Load an expectation suite from a given context.
+
+    Handles a suite name with or without `.json`
+    """
+    if suite_name.endswith(".json"):
+        suite_name = suite_name[:-5]
+    try:
+        suite = context.get_expectation_suite(suite_name)
+        return suite
+    except ge_exceptions.DataContextError as e:
+        cli_message(
+            f"<red>Could not find a suite named `{suite_name}`.</red> Please check "
+            "the name by running `great_expectations suite list` and try again."
+        )
+        logger.info(e)
+        sys.exit(1)

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -3,7 +3,7 @@ import importlib
 import json
 import logging
 
-import black as black
+import black
 from six import string_types
 
 from great_expectations.core import expectationSuiteSchema

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -3,6 +3,7 @@ import importlib
 import json
 import logging
 
+import black as black
 from six import string_types
 
 from great_expectations.core import expectationSuiteSchema
@@ -499,3 +500,17 @@ def gen_directory_tree_str(startpath):
             output_str += '{}{}\n'.format(subindent, f)
     
     return output_str
+
+
+def lint_code(code):
+    """Lint strings of code passed in."""
+    black_file_mode = black.FileMode()
+    if not isinstance(code, str):
+        raise TypeError
+    try:
+        linted_code = black.format_file_contents(
+            code, fast=True, mode=black_file_mode
+        )
+        return linted_code
+    except (black.NothingChanged, RuntimeError):
+        return code

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,3 +32,4 @@ freezegun>=0.3.12
 google-cloud-storage>=1.20.0
 pybigquery>=0.4.11
 autopep8>=1.4.4
+black==19.10b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ future>=0.16
 jinja2>=2.10
 marshmallow>=2.0,<3.0
 autopep8>=1.4.4
+black==19.10b0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -49,6 +49,7 @@ Commands:
   init        Initialize a new Great Expectations project.
   project     project operations
   suite       expectation suite operations
+  tap         tap operations
 """
     )
     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import os
 import shutil
+import pytest
+
 from unittest import mock
 
 from click.testing import CliRunner
@@ -59,9 +61,10 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_
 
     # Test the second invocation of init
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", root_dir], input="Y\nn\n", catch_exceptions=False
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", root_dir], input="Y\nn\n", catch_exceptions=False
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -117,9 +120,10 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
     )
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", root_dir], input="n\n", catch_exceptions=False
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", root_dir], input="n\n", catch_exceptions=False
+        )
     stdout = result.stdout
     assert mock_webbrowser.call_count == 1
 

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -74,7 +74,6 @@ def test_cli_init_on_new_project(mock_webbrowser, caplog, tmp_path_factory):
     guid_safe_obs_tree = re.sub(
         r"[a-z0-9]{32}(?=\.(json|html))", "foobarbazguid", date_safe_obs_tree
     )
-    print(guid_safe_obs_tree)
     assert (
         guid_safe_obs_tree
         == """great_expectations/
@@ -165,12 +164,13 @@ def test_init_on_existing_project_with_no_datasources_should_continue_init_flow_
 
     csv_path = os.path.join(project_dir, "data", "Titanic.csv")
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli,
-        ["init", "-d", project_dir],
-        input="1\n1\n{}\nmy_suite\n\n".format(csv_path, catch_exceptions=False),
-        catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli,
+            ["init", "-d", project_dir],
+            input="1\n1\n{}\nmy_suite\n\n".format(csv_path, catch_exceptions=False),
+            catch_exceptions=False,
+        )
     assert mock_webbrowser.call_count == 1
     assert "{}/great_expectations/uncommitted/data_docs/local_site/validations/my_suite/".format(project_dir) in mock_webbrowser.call_args[0][0]
     stdout = result.stdout
@@ -268,9 +268,10 @@ def test_init_on_existing_project_with_multiple_datasources_exist_do_nothing(
     assert len(context.list_datasources()) == 2
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -292,9 +293,10 @@ def test_init_on_existing_project_with_datasource_with_existing_suite_offer_to_b
     project_dir = initialized_project
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -317,9 +319,10 @@ def test_init_on_existing_project_with_datasource_with_existing_suite_offer_to_b
     project_dir = initialized_project
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", project_dir], input="Y\n", catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", project_dir], input="Y\n", catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -357,12 +360,13 @@ def test_init_on_existing_project_with_datasource_with_no_suite_create_one(
     assert context.list_expectation_suites() == []
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli,
-        ["init", "-d", project_dir],
-        input="{}\nsink_me\n\n\n".format(os.path.join(project_dir, "data/Titanic.csv")),
-        catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli,
+            ["init", "-d", project_dir],
+            input="{}\nsink_me\n\n\n".format(os.path.join(project_dir, "data/Titanic.csv")),
+            catch_exceptions=False,
+        )
     stdout = result.stdout
     assert result.exit_code == 0
     assert mock_browser.call_count == 1

--- a/tests/cli/test_init_sqlite.py
+++ b/tests/cli/test_init_sqlite.py
@@ -259,14 +259,15 @@ def test_init_on_existing_project_with_no_datasources_should_continue_init_flow_
     assert not context.list_expectation_suites()
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli,
-        ["init", "-d", project_dir],
-        input="2\n5\nsqlite\nsqlite:///{}\n1\nmy_suite\n\n".format(
-            titanic_sqlite_db_file
-        ),
-        catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli,
+            ["init", "-d", project_dir],
+            input="2\n5\nsqlite\nsqlite:///{}\n1\nmy_suite\n\n".format(
+                titanic_sqlite_db_file
+            ),
+            catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -374,9 +375,10 @@ def test_init_on_existing_project_with_multiple_datasources_exist_do_nothing(
     assert len(context.list_datasources()) == 2
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -399,9 +401,10 @@ def test_init_on_existing_project_with_datasource_with_existing_suite_offer_to_b
     project_dir = initialized_sqlite_project
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", project_dir], input="n\n", catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -424,9 +427,10 @@ def test_init_on_existing_project_with_datasource_with_existing_suite_offer_to_b
     project_dir = initialized_sqlite_project
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["init", "-d", project_dir], input="Y\n", catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli, ["init", "-d", project_dir], input="Y\n", catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0
@@ -464,12 +468,13 @@ def test_init_on_existing_project_with_datasource_with_no_suite_create_one(
     assert context.list_expectation_suites() == []
 
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli,
-        ["init", "-d", project_dir],
-        input="1\nsink_me\n\n\n".format(os.path.join(project_dir, "data/Titanic.csv")),
-        catch_exceptions=False,
-    )
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        result = runner.invoke(
+            cli,
+            ["init", "-d", project_dir],
+            input="1\nsink_me\n\n\n".format(os.path.join(project_dir, "data/Titanic.csv")),
+            catch_exceptions=False,
+        )
     stdout = result.stdout
 
     assert result.exit_code == 0

--- a/tests/cli/test_taps.py
+++ b/tests/cli/test_taps.py
@@ -20,9 +20,7 @@ def test_tap_help_output(caplog,):
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_tap_new_on_context_with_no_datasources(
-    caplog, empty_data_context
-):
+def test_tap_new_on_context_with_no_datasources(caplog, empty_data_context):
     """
     We call the "tap new" command on a data context that has no datasources
     configured.
@@ -43,9 +41,7 @@ def test_tap_new_on_context_with_no_datasources(
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_tap_new_with_non_existant_suite(
-    caplog, empty_data_context
-):
+def test_tap_new_with_non_existant_suite(caplog, empty_data_context):
     """
     We call the "tap new" command on a data context that has a datasource
     configured and no suites.
@@ -125,9 +121,7 @@ def test_tap_new_on_context_with_1_datasources_with_no_datasource_option_prompts
     root_dir = empty_data_context.root_directory
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
-        cli,
-        f"tap new not_a_suite tap.py -d {root_dir}",
-        catch_exceptions=False,
+        cli, f"tap new not_a_suite tap.py -d {root_dir}", catch_exceptions=False,
     )
     stdout = result.stdout
     print(stdout)

--- a/tests/cli/test_taps.py
+++ b/tests/cli/test_taps.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import os
+import subprocess
+
 from click.testing import CliRunner
 
-from great_expectations import DataContext
 from great_expectations.cli import cli
 from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
@@ -20,7 +22,9 @@ def test_tap_help_output(caplog,):
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_tap_new_with_filename_not_ending_in_py_raises_helpful_error(caplog, empty_data_context):
+def test_tap_new_with_filename_not_ending_in_py_raises_helpful_error(
+    caplog, empty_data_context
+):
     """
     We call the "tap new" command with a bogus filename
 
@@ -124,8 +128,107 @@ def test_tap_new_on_context_with_2_datasources_with_no_datasource_option_prompts
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-def test_tap_new_on_context_with_1_datasources_with_no_datasource_option_prompts_user(
-    caplog, empty_data_context
+def test_tap_new_on_context_builds_runnable_tap_file(
+    caplog, empty_data_context, filesystem_csv
+):
+    """
+    We call the "tap new" command on a data context that has 2 datasources
+    configured.
+
+    The command should:
+    - prompt the user to choose a datasource
+    - create the tap file
+
+    This test then runs the tap file to verify it is runnable.
+    """
+    context = empty_data_context
+    root_dir = context.root_directory
+    csv = os.path.join(filesystem_csv, "f1.csv")
+
+    context.add_datasource(
+        "1_datasource",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+    )
+    context.create_expectation_suite("sweet_suite")
+    suite = context.get_expectation_suite("sweet_suite")
+    context.save_expectation_suite(suite)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        f"tap new sweet_suite tap.py -d {root_dir}",
+        input=f"{csv}\n",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+
+    assert "Enter the path (relative or absolute) of a data file" in stdout
+    assert "A new tap has been generated" in stdout
+    assert result.exit_code == 0
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+    tap_file = os.path.abspath(os.path.join(root_dir, "..", "tap.py"))
+    status, output = subprocess.getstatusoutput(f"python {tap_file}")
+    assert status == 0
+    assert output == "Validation Succeeded!"
+
+
+def test_tap_new_on_context_builds_runnable_tap_file_that_fails_validation(
+    caplog, empty_data_context, filesystem_csv
+):
+    """
+    We call the "tap new" command on a data context that has 1 datasource
+    configured with a suite that will fail.
+
+    The command should:
+    - prompt the user to choose a datasource
+    - create the tap file
+
+    This test then runs the tap file to verify it is runnable and fails
+    correctly.
+    """
+    context = empty_data_context
+    root_dir = context.root_directory
+    csv = os.path.join(filesystem_csv, "f1.csv")
+
+    context.add_datasource(
+        "1_datasource",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+    )
+    context.create_expectation_suite("sweet_suite")
+    suite = context.get_expectation_suite("sweet_suite")
+    context.save_expectation_suite(suite)
+    batch_kwargs = {"datasource": "1_datasource", "path": csv}
+    batch = context.get_batch(batch_kwargs, suite)
+    # Make an expectation that will fail and save it.
+    batch.expect_table_column_count_to_equal(9999)
+    batch.save_expectation_suite(discard_failed_expectations=False)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        f"tap new sweet_suite tap.py -d {root_dir}",
+        input=f"{csv}\n",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+
+    assert "Enter the path (relative or absolute) of a data file" in stdout
+    assert "A new tap has been generated" in stdout
+    assert result.exit_code == 0
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+    tap_file = os.path.abspath(os.path.join(root_dir, "..", "tap.py"))
+    status, output = subprocess.getstatusoutput(f"python {tap_file}")
+    assert status == 1
+    assert output == "Validation Failed!"
+
+
+def test_tap_new_on_context_with_1_datasources_with_no_datasource_option_prompts_user_and_generates_runnable_tap_file(
+    caplog, empty_data_context, filesystem_csv
 ):
     """
     We call the "tap new" command on a data context that has 1 datasources
@@ -133,1062 +236,38 @@ def test_tap_new_on_context_with_1_datasources_with_no_datasource_option_prompts
 
     The command should:
     - NOT prompt the user to choose a datasource
+    - create the tap file
+
+    This test then runs the tap file to verify it is runnable.
     """
-    empty_data_context.add_datasource(
+    context = empty_data_context
+    root_dir = context.root_directory
+    csv = os.path.join(filesystem_csv, "f1.csv")
+
+    context.add_datasource(
         "1_datasource",
         module_name="great_expectations.datasource",
         class_name="PandasDatasource",
     )
-    root_dir = empty_data_context.root_directory
+    context.create_expectation_suite("sweet_suite")
+    suite = context.get_expectation_suite("sweet_suite")
+    context.save_expectation_suite(suite)
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
-        cli, f"tap new not_a_suite tap.py -d {root_dir}", catch_exceptions=False,
+        cli,
+        f"tap new sweet_suite tap.py -d {root_dir}",
+        input=f"{csv}\n",
+        catch_exceptions=False,
     )
     stdout = result.stdout
-    print(stdout)
 
     assert "Select a datasource" not in stdout
-    assert result.exit_code == 1
+    assert "A new tap has been generated" in stdout
+    assert result.exit_code == 0
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
-
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_new_enter_existing_suite_name_as_arg(
-#     mock_webbrowser, mock_subprocess, caplog, data_context
-# ):
-#     """
-#     We call the "suite new" command with the name of an existing expectation
-#     suite in the --suite argument
-#
-#     The command should:
-#     - exit with a clear error message
-#     - NOT open Data Docs
-#     - NOT open jupyter
-#     """
-#
-#     not_so_empty_data_context = data_context
-#     project_root_dir = not_so_empty_data_context.root_directory
-#     os.mkdir(os.path.join(project_root_dir, "uncommitted"))
-#
-#     root_dir = project_root_dir
-#     os.chdir(root_dir)
-#     context = DataContext(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir, "--suite", "my_dag_node.default", "--no-view"],
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#
-#     assert result.exit_code == 1
-#     assert "already exists. If you intend to edit the suite" in stdout
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_new_answer_suite_name_prompts_with_name_of_existing_suite(
-#     mock_webbrowser, mock_subprocess, caplog, data_context, filesystem_csv_2
-# ):
-#     """
-#     We call the "suite new" command without the suite name argument
-#
-#     The command should:
-#
-#     - prompt us to enter the name of the expectation suite that will be
-#     created. We answer the prompt with the name of an existing expectation suite.
-#     - display an error message and let us retry until we answer
-#     with a name that is not "taken".
-#     - create an example suite
-#     - NOT open jupyter
-#     - open DataDocs to the new example suite page
-#     """
-#     not_so_empty_data_context = data_context
-#     root_dir = not_so_empty_data_context.root_directory
-#     os.mkdir(os.path.join(root_dir, "uncommitted"))
-#
-#     runner = CliRunner(mix_stderr=False)
-#     csv_path = os.path.join(filesystem_csv_2, "f1.csv")
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir],
-#         input=f"{csv_path}\nmy_dag_node.default\nmy_new_suite\n\n",
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#     assert result.exit_code == 0
-#     assert "already exists. If you intend to edit the suite" in stdout
-#     assert "Enter the path" in stdout
-#     assert "Name the new expectation suite [f1.warning]" in stdout
-#     assert (
-#         "Great Expectations will choose a couple of columns and generate expectations"
-#         in stdout
-#     )
-#     assert "Generating example Expectation Suite..." in stdout
-#     assert "Building" in stdout
-#     assert "The following Data Docs sites were built" in stdout
-#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
-#     assert "open a notebook for you now" not in stdout
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_subprocess.call_count == 0
-#     assert mock_webbrowser.call_count == 1
-#
-#     foo = os.path.join(
-#         root_dir, "uncommitted/data_docs/local_site/validations/my_new_suite/"
-#     )
-#     assert f"file://{foo}" in mock_webbrowser.call_args[0][0]
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_new_empty_suite_creates_empty_suite(
-#     mock_webbroser, mock_subprocess, caplog, data_context, filesystem_csv_2
-# ):
-#     """
-#     Running "suite new --empty" should:
-#     - make an empty suite
-#     - open jupyter
-#     - NOT open data docs
-#     """
-#     project_root_dir = data_context.root_directory
-#     os.mkdir(os.path.join(project_root_dir, "uncommitted"))
-#     root_dir = project_root_dir
-#     os.chdir(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     csv = os.path.join(filesystem_csv_2, "f1.csv")
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir, "--empty", "--suite", "foo"],
-#         input=f"{csv}\n",
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#
-#     assert result.exit_code == 0
-#     assert "Enter the path" in stdout
-#     assert "Name the new expectation suite" not in stdout
-#     assert (
-#         "Great Expectations will choose a couple of columns and generate expectations"
-#         not in stdout
-#     )
-#     assert "Generating example Expectation Suite..." not in stdout
-#     assert "The following Data Docs sites were built" not in stdout
-#     assert "A new Expectation suite 'foo' was added to your project" in stdout
-#     assert (
-#         "Because you requested an empty suite, we'll open a notebook for you now to edit it!"
-#         in stdout
-#     )
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "foo.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     expected_notebook = os.path.join(root_dir, "uncommitted", "foo.ipynb")
-#     assert os.path.isfile(expected_notebook)
-#
-#     context = DataContext(root_dir)
-#     assert "foo" in context.list_expectation_suite_names()
-#     suite = context.get_expectation_suite("foo")
-#     assert suite.expectations == []
-#     citations = suite.get_citations()
-#     citations[0].pop("citation_date")
-#     assert citations[0] == {
-#         "batch_kwargs": {"datasource": "mydatasource", "path": csv},
-#         "batch_markers": None,
-#         "batch_parameters": None,
-#         "comment": "New suite added via CLI",
-#     }
-#
-#     assert mock_subprocess.call_count == 1
-#     call_args = mock_subprocess.call_args[0][0]
-#     assert call_args[0] == "jupyter"
-#     assert call_args[1] == "notebook"
-#     assert expected_notebook in call_args[2]
-#
-#     assert mock_webbroser.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_new_empty_suite_creates_empty_suite_with_no_jupyter(
-#     mock_webbroser, mock_subprocess, caplog, data_context, filesystem_csv_2
-# ):
-#     """
-#     Running "suite new --empty --no-jupyter" should:
-#     - make an empty suite
-#     - NOT open jupyter
-#     - NOT open data docs
-#     """
-#     project_root_dir = data_context.root_directory
-#     os.mkdir(os.path.join(project_root_dir, "uncommitted"))
-#     root_dir = project_root_dir
-#     os.chdir(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     csv = os.path.join(filesystem_csv_2, "f1.csv")
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir, "--empty", "--suite", "foo", "--no-jupyter"],
-#         input=f"{csv}\n",
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#
-#     assert result.exit_code == 0
-#     assert "Enter the path" in stdout
-#     assert "Name the new expectation suite" not in stdout
-#     assert (
-#         "Great Expectations will choose a couple of columns and generate expectations"
-#         not in stdout
-#     )
-#     assert "Generating example Expectation Suite..." not in stdout
-#     assert "The following Data Docs sites were built" not in stdout
-#     assert "A new Expectation suite 'foo' was added to your project" in stdout
-#     assert "open a notebook for you now" not in stdout
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "foo.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     expected_notebook = os.path.join(root_dir, "uncommitted", "foo.ipynb")
-#     assert os.path.isfile(expected_notebook)
-#
-#     context = DataContext(root_dir)
-#     assert "foo" in context.list_expectation_suite_names()
-#     suite = context.get_expectation_suite("foo")
-#     assert suite.expectations == []
-#     citations = suite.get_citations()
-#     citations[0].pop("citation_date")
-#     assert citations[0] == {
-#         "batch_kwargs": {"datasource": "mydatasource", "path": csv},
-#         "batch_markers": None,
-#         "batch_parameters": None,
-#         "comment": "New suite added via CLI",
-#     }
-#
-#     assert mock_subprocess.call_count == 0
-#     assert mock_webbroser.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_new_one_datasource_without_generator_without_suite_name_argument(
-#     mock_webbrowser, mock_subprocess, caplog, empty_data_context, filesystem_csv_2
-# ):
-#     """
-#     We call the "suite new" command without the suite name argument
-#
-#     The command should:
-#
-#     - NOT prompt us to choose a datasource (because there is only one)
-#     - prompt us only to enter the path (The datasource has no generator
-#      configured and not to choose from the generator's list of available data
-#      assets).
-#     - We enter the path of the file we want the command to use as the batch to
-#     create the expectation suite.
-#     - prompt us to enter the name of the expectation suite that will be
-#     created
-#     - open Data Docs
-#     - NOT open jupyter
-#     """
-#     empty_data_context.add_datasource(
-#         "my_datasource",
-#         module_name="great_expectations.datasource",
-#         class_name="PandasDatasource",
-#     )
-#
-#     context = empty_data_context
-#     project_root_dir = context.root_directory
-#
-#     root_dir = project_root_dir
-#     os.chdir(root_dir)
-#     context = DataContext(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir],
-#         input="{0:s}\nmy_new_suite\n\n".format(
-#             os.path.join(filesystem_csv_2, "f1.csv")
-#         ),
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#
-#     assert result.exit_code == 0
-#     assert "Enter the path" in stdout
-#     assert "Name the new expectation suite [f1.warning]" in stdout
-#     assert (
-#         "Great Expectations will choose a couple of columns and generate expectations"
-#         in stdout
-#     )
-#     assert "Generating example Expectation Suite..." in stdout
-#     assert "Building" in stdout
-#     assert "The following Data Docs sites were built" in stdout
-#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
-#
-#     obs_urls = context.get_docs_sites_urls()
-#
-#     assert len(obs_urls) == 1
-#     assert (
-#         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]
-#     )
-#
-#     expected_index_path = os.path.join(
-#         root_dir, "uncommitted", "data_docs", "local_site", "index.html"
-#     )
-#     assert os.path.isfile(expected_index_path)
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 1
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_new_multiple_datasources_with_generator_without_suite_name_argument(
-#     mock_webbrowser,
-#     mock_subprocess,
-#     caplog,
-#     site_builder_data_context_with_html_store_titanic_random,
-# ):
-#     """
-#     We call the "suite new" command without the suite name argument
-#
-#     - The data context has two datasources - we choose one of them.
-#     - It has a generator configured. We choose to use the generator and select a
-#     generator asset from the list.
-#     - The command should prompt us to enter the name of the expectation suite
-#     that will be created.
-#     - open Data Docs
-#     - NOT open jupyter
-#     """
-#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
-#     os.chdir(root_dir)
-#     context = DataContext(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir],
-#         input="1\n1\n1\nmy_new_suite\n\n",
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#
-#     assert result.exit_code == 0
-#     assert (
-#         """Select a datasource
-#     1. random
-#     2. titanic"""
-#         in stdout
-#     )
-#     assert (
-#         """Which data would you like to use?
-#     1. f1 (file)
-#     2. f2 (file)"""
-#         in stdout
-#     )
-#     assert "Name the new expectation suite [f1.warning]" in stdout
-#     assert (
-#         "Great Expectations will choose a couple of columns and generate expectations"
-#         in stdout
-#     )
-#     assert "Generating example Expectation Suite..." in stdout
-#     assert "Building" in stdout
-#     assert "The following Data Docs sites were built" in stdout
-#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
-#
-#     obs_urls = context.get_docs_sites_urls()
-#
-#     assert len(obs_urls) == 1
-#     assert (
-#         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]
-#     )
-#
-#     expected_index_path = os.path.join(
-#         root_dir, "uncommitted", "data_docs", "local_site", "index.html"
-#     )
-#     assert os.path.isfile(expected_index_path)
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 1
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_new_multiple_datasources_with_generator_with_suite_name_argument(
-#     mock_webbrowser,
-#     mock_subprocess,
-#     caplog,
-#     site_builder_data_context_with_html_store_titanic_random,
-# ):
-#     """
-#     We call the "suite new" command with the suite name argument
-#
-#     - The data context has two datasources - we choose one of them.
-#     - It has a generator configured. We choose to use the generator and select
-#     a generator asset from the list.
-#     - open Data Docs
-#     - NOT open jupyter
-#     """
-#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
-#     os.chdir(root_dir)
-#     context = DataContext(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
-#         input="2\n1\n1\n\n",
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#
-#     assert result.exit_code == 0
-#     assert "Select a datasource" in stdout
-#     assert "Which data would you like to use" in stdout
-#     assert (
-#         "Great Expectations will choose a couple of columns and generate expectations"
-#         in stdout
-#     )
-#     assert "Generating example Expectation Suite..." in stdout
-#     assert "Building" in stdout
-#     assert "The following Data Docs sites were built" in stdout
-#     assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
-#
-#     obs_urls = context.get_docs_sites_urls()
-#
-#     assert len(obs_urls) == 1
-#     assert (
-#         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]
-#     )
-#
-#     expected_index_path = os.path.join(
-#         root_dir, "uncommitted", "data_docs", "local_site", "index.html"
-#     )
-#     assert os.path.isfile(expected_index_path)
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 1
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# def test_tap_edit_without_suite_name_raises_error():
-#     """This is really only testing click missing arguments"""
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(cli, "suite edit", catch_exceptions=False)
-#     assert result.exit_code == 2
-#     assert (
-#         'Error: Missing argument "SUITE".' in result.stderr
-#         or "Error: Missing argument 'SUITE'." in result.stderr
-#     )
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
-#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
-# ):
-#     """
-#     The command should:
-#     - exit with a clear error message
-#     - NOT open Data Docs
-#     - NOT open jupyter
-#     """
-#     project_dir = empty_data_context.root_directory
-#     context = DataContext(project_dir)
-#     context.create_expectation_suite("foo")
-#
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "edit", "foo", "-d", project_dir, "--batch-kwargs", "'{foobar}'"],
-#         catch_exceptions=False,
-#     )
-#     stdout = result.output
-#     assert result.exit_code == 1
-#     assert "Please check that your batch_kwargs are valid JSON." in stdout
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_with_batch_kwargs_unable_to_load_a_batch_raises_helpful_error(
-#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
-# ):
-#     """
-#     The command should:
-#     - exit with a clear error message
-#     - NOT open Data Docs
-#     - NOT open jupyter
-#     """
-#     project_dir = empty_data_context.root_directory
-#
-#     context = DataContext(project_dir)
-#     context.create_expectation_suite("foo")
-#     context.add_datasource("source", class_name="PandasDatasource")
-#
-#     runner = CliRunner(mix_stderr=False)
-#     batch_kwargs = '{"table": "fake", "datasource": "source"}'
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "edit", "foo", "-d", project_dir, "--batch-kwargs", batch_kwargs],
-#         catch_exceptions=False,
-#     )
-#     stdout = result.output
-#     assert result.exit_code == 1
-#     assert "To continue editing this suite" not in stdout
-#     assert "Please check that your batch_kwargs are able to load a batch." in stdout
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_with_non_existent_suite_name_raises_error(
-#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
-# ):
-#     """
-#     The command should:
-#     - exit with a clear error message
-#     - NOT open Data Docs
-#     - NOT open jupyter
-#     """
-#     project_dir = empty_data_context.root_directory
-#     assert not empty_data_context.list_expectation_suites()
-#
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         "suite edit not_a_real_suite -d {}".format(project_dir),
-#         catch_exceptions=False,
-#     )
-#     assert result.exit_code == 1
-#     assert "Could not find a suite named `not_a_real_suite`." in result.output
-#     assert "by running `great_expectations suite list`" in result.output
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_with_non_existent_datasource_shows_helpful_error_message(
-#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
-# ):
-#     """
-#     The command should:
-#     - exit with a clear error message
-#     - NOT open Data Docs
-#     - NOT open jupyter
-#     """
-#     project_dir = empty_data_context.root_directory
-#     context = DataContext(project_dir)
-#     context.create_expectation_suite("foo")
-#     assert context.list_expectation_suites()[0].expectation_suite_name == "foo"
-#
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         f"suite edit foo -d {project_dir} --datasource not_real",
-#         catch_exceptions=False,
-#     )
-#     assert result.exit_code == 1
-#     assert (
-#         "Unable to load datasource `not_real` -- no configuration found or invalid configuration."
-#         in result.output
-#     )
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_multiple_datasources_with_generator_with_no_additional_args_with_suite_without_citations(
-#     mock_webbrowser,
-#     mock_subprocess,
-#     caplog,
-#     site_builder_data_context_with_html_store_titanic_random,
-# ):
-#     """
-#     Here we verify that the "suite edit" command helps the user to specify the batch
-#     kwargs when it is called without the optional arguments that specify the batch.
-#
-#     First, we call the "suite new" command to create the expectation suite our test
-#     will edit - this step is a just a setup.
-#
-#     We call the "suite edit" command without any optional arguments. This means that
-#     the command will help us specify the batch kwargs interactively.
-#
-#     The data context has two datasources - we choose one of them. It has a generator
-#     configured. We choose to use the generator and select a generator asset from the list.
-#
-#     The command should:
-#     - NOT open Data Docs
-#     - open jupyter
-#     """
-#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
-#     os.chdir(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
-#         input="2\n1\n1\n\n",
-#         catch_exceptions=False,
-#     )
-#     assert result.exit_code == 0
-#     assert mock_webbrowser.call_count == 1
-#     assert mock_subprocess.call_count == 0
-#     mock_webbrowser.reset_mock()
-#     mock_subprocess.reset_mock()
-#
-#     # remove the citations from the suite
-#     context = DataContext(root_dir)
-#     suite = context.get_expectation_suite("foo_suite")
-#     assert isinstance(suite, ExpectationSuite)
-#     suite.meta.pop("citations")
-#     context.save_expectation_suite(suite)
-#
-#     # Actual testing really starts here
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "edit", "foo_suite", "-d", root_dir,],
-#         input="2\n1\n1\n\n",
-#         catch_exceptions=False,
-#     )
-#
-#     assert result.exit_code == 0
-#     stdout = result.stdout
-#     assert "A batch of data is required to edit the suite" in stdout
-#     assert "Select a datasource" in stdout
-#     assert "Which data would you like to use" in stdout
-#
-#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
-#     assert os.path.isfile(expected_notebook_path)
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 1
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_multiple_datasources_with_generator_with_no_additional_args_with_suite_containing_citations(
-#     mock_webbrowser,
-#     mock_subprocess,
-#     caplog,
-#     site_builder_data_context_with_html_store_titanic_random,
-# ):
-#     """
-#     Here we verify that the "suite edit" command uses the batch kwargs found in
-#     citations in the existing suite when it is called without the optional
-#     arguments that specify the batch.
-#
-#     First, we call the "suite new" command to create the expectation suite our
-#     test will edit - this step is a just a setup.
-#
-#     We call the "suite edit" command without any optional arguments.
-#
-#     The command should:
-#     - NOT open Data Docs
-#     - NOT open jupyter
-#     """
-#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
-#     os.chdir(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
-#         input="2\n1\n1\n\n",
-#         catch_exceptions=False,
-#     )
-#     assert mock_webbrowser.call_count == 1
-#     assert mock_subprocess.call_count == 0
-#     mock_subprocess.reset_mock()
-#     mock_webbrowser.reset_mock()
-#     assert result.exit_code == 0
-#     context = DataContext(root_dir)
-#     suite = context.get_expectation_suite("foo_suite")
-#     assert isinstance(suite, ExpectationSuite)
-#
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "edit", "foo_suite", "-d", root_dir],
-#         input="2\n1\n1\n\n",
-#         catch_exceptions=False,
-#     )
-#
-#     assert result.exit_code == 0
-#     stdout = result.stdout
-#     assert "Select a datasource" not in stdout
-#     assert "Which data would you like to use" not in stdout
-#
-#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
-#     assert os.path.isfile(expected_notebook_path)
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 1
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
-#     mock_webbrowser,
-#     mock_subprocess,
-#     caplog,
-#     site_builder_data_context_with_html_store_titanic_random,
-# ):
-#     """
-#     Here we verify that when the "suite edit" command is called with batch_kwargs arg
-#     that specifies the batch that will be used as a sample for editing the suite,
-#     the command processes the batch_kwargs correctly and skips all the prompts
-#     that help users to specify the batch (when called without batch_kwargs).
-#
-#     First, we call the "suite new" command to create the expectation suite our test
-#     will edit - this step is a just a setup.
-#
-#     We call the "suite edit" command without any optional arguments. This means that
-#     the command will help us specify the batch kwargs interactively.
-#
-#     The data context has two datasources - we choose one of them. It has a generator
-#     configured. We choose to use the generator and select a generator asset from the list.
-#
-#     The command should:
-#     - NOT open Data Docs
-#     - open jupyter
-#     """
-#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite", "--no-view"],
-#         input="2\n1\n1\n\n",
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#     assert result.exit_code == 0
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 0
-#     mock_subprocess.reset_mock()
-#     mock_webbrowser.reset_mock()
-#     assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
-#
-#     batch_kwargs = {
-#         "datasource": "random",
-#         "path": str(
-#             os.path.join(
-#                 os.path.abspath(os.path.join(root_dir, os.pardir)),
-#                 "data",
-#                 "random",
-#                 "f1.csv",
-#             )
-#         ),
-#     }
-#     batch_kwargs_arg_str = json.dumps(batch_kwargs)
-#
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         [
-#             "suite",
-#             "edit",
-#             "foo_suite",
-#             "-d",
-#             root_dir,
-#             "--batch-kwargs",
-#             batch_kwargs_arg_str,
-#         ],
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#
-#     assert result.exit_code == 0
-#     assert "Select a datasource" not in stdout
-#     assert "Which data would you like to use" not in stdout
-#
-#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
-#     assert os.path.isfile(expected_notebook_path)
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 1
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_on_exsiting_suite_one_datasources_with_batch_kwargs_without_datasource_raises_helpful_error(
-#     mock_webbrowser, mock_subprocess, caplog, titanic_data_context,
-# ):
-#     """
-#     Given:
-#     - the suite foo exists
-#     - the a datasource exists
-#     - and the users runs this
-#     great_expectations suite edit foo --batch-kwargs '{"path": "data/10k.csv"}'
-#
-#     Then:
-#     - The user should see a nice error and the program halts before notebook
-#     compilation.
-#     - NOT open Data Docs
-#     - NOT open jupyter
-#     '"""
-#     project_dir = titanic_data_context.root_directory
-#     context = DataContext(project_dir)
-#     context.create_expectation_suite("foo")
-#
-#     runner = CliRunner(mix_stderr=False)
-#     batch_kwargs = {"path": "../data/Titanic.csv"}
-#     result = runner.invoke(
-#         cli,
-#         [
-#             "suite",
-#             "edit",
-#             "foo",
-#             "-d",
-#             project_dir,
-#             "--batch-kwargs",
-#             json.dumps(batch_kwargs),
-#         ],
-#         catch_exceptions=False,
-#     )
-#     stdout = result.output
-#     assert result.exit_code == 1
-#     assert "Please check that your batch_kwargs are able to load a batch." in stdout
-#     assert "Unable to load datasource `None`" in stdout
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 0
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_on_exsiting_suite_one_datasources_with_datasource_arg_and_batch_kwargs(
-#     mock_webbrowser, mock_subprocess, caplog, titanic_data_context,
-# ):
-#     """
-#     Given:
-#     - the suite foo exists
-#     - the a datasource bar exists
-#     - and the users runs this
-#     great_expectations suite edit foo --datasource bar --batch-kwargs '{"path": "data/10k.csv"}'
-#
-#     Then:
-#     - The user gets a working notebook
-#     - NOT open Data Docs
-#     - open jupyter
-#     """
-#     project_dir = titanic_data_context.root_directory
-#     context = DataContext(project_dir)
-#     context.create_expectation_suite("foo")
-#
-#     runner = CliRunner(mix_stderr=False)
-#     batch_kwargs = {"path": os.path.join(project_dir, "../", "data", "Titanic.csv")}
-#     result = runner.invoke(
-#         cli,
-#         [
-#             "suite",
-#             "edit",
-#             "foo",
-#             "-d",
-#             project_dir,
-#             "--batch-kwargs",
-#             json.dumps(batch_kwargs),
-#             "--datasource",
-#             "mydatasource",
-#         ],
-#         catch_exceptions=False,
-#     )
-#     stdout = result.output
-#     assert stdout == ""
-#     assert result.exit_code == 0
-#
-#     expected_notebook_path = os.path.join(project_dir, "uncommitted", "foo.ipynb")
-#     assert os.path.isfile(expected_notebook_path)
-#     expected_suite_path = os.path.join(project_dir, "expectations", "foo.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 1
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# @mock.patch("subprocess.call", return_value=True, side_effect=None)
-# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-# def test_tap_edit_one_datasources_no_generator_with_no_additional_args_and_no_citations(
-#     mock_webbrowser, mock_subprocess, caplog, empty_data_context, filesystem_csv_2
-# ):
-#     """
-#     Here we verify that the "suite edit" command helps the user to specify the batch
-#     kwargs when it is called without the optional arguments that specify the batch.
-#
-#     First, we call the "suite new" command to create the expectation suite our test
-#     will edit - this step is a just a setup.
-#
-#     We call the "suite edit" command without any optional arguments. This means that
-#     the command will help us specify the batch kwargs interactively.
-#
-#     The data context has one datasource. The datasource has no generators
-#     configured. The command prompts us to enter the file path.
-#     """
-#     empty_data_context.add_datasource(
-#         "my_datasource",
-#         module_name="great_expectations.datasource",
-#         class_name="PandasDatasource",
-#     )
-#
-#     not_so_empty_data_context = empty_data_context
-#     project_root_dir = not_so_empty_data_context.root_directory
-#
-#     root_dir = project_root_dir
-#     os.chdir(root_dir)
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "new", "-d", root_dir],
-#         input="{0:s}\nmy_new_suite\n\n".format(
-#             os.path.join(filesystem_csv_2, "f1.csv")
-#         ),
-#         catch_exceptions=False,
-#     )
-#     stdout = result.stdout
-#     assert mock_webbrowser.call_count == 1
-#     assert mock_subprocess.call_count == 0
-#     mock_subprocess.reset_mock()
-#     mock_webbrowser.reset_mock()
-#     assert result.exit_code == 0
-#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
-#
-#     # remove the citations from the suite
-#     context = DataContext(project_root_dir)
-#     suite = context.get_expectation_suite("my_new_suite")
-#     suite.meta.pop("citations")
-#     context.save_expectation_suite(suite)
-#
-#     runner = CliRunner(mix_stderr=False)
-#     result = runner.invoke(
-#         cli,
-#         ["suite", "edit", "my_new_suite", "-d", root_dir],
-#         input="{0:s}\n\n".format(os.path.join(filesystem_csv_2, "f1.csv")),
-#         catch_exceptions=False,
-#     )
-#
-#     assert result.exit_code == 0
-#     stdout = result.stdout
-#     assert "Select a datasource" not in stdout
-#     assert "Which data would you like to use" not in stdout
-#     assert "Enter the path" in stdout
-#
-#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "my_new_suite.ipynb")
-#     assert os.path.isfile(expected_notebook_path)
-#
-#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
-#     assert os.path.isfile(expected_suite_path)
-#
-#     assert mock_webbrowser.call_count == 0
-#     assert mock_subprocess.call_count == 1
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# def test_tap_list_with_zero_suites(caplog, empty_data_context):
-#     project_dir = empty_data_context.root_directory
-#     runner = CliRunner(mix_stderr=False)
-#
-#     result = runner.invoke(
-#         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
-#     )
-#     assert result.exit_code == 0
-#     assert "No expectation suites found" in result.output
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# def test_tap_list_with_one_suite(caplog, empty_data_context):
-#     project_dir = empty_data_context.root_directory
-#     context = DataContext(project_dir)
-#     context.create_expectation_suite("a.warning")
-#     runner = CliRunner(mix_stderr=False)
-#
-#     result = runner.invoke(
-#         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
-#     )
-#     assert result.exit_code == 0
-#     assert "1 expectation suite found" in result.output
-#     assert "\ta.warning" in result.output
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
-#
-#
-# def test_tap_list_with_multiple_suites(caplog, empty_data_context):
-#     project_dir = empty_data_context.root_directory
-#     context = DataContext(project_dir)
-#     context.create_expectation_suite("a.warning")
-#     context.create_expectation_suite("b.warning")
-#     context.create_expectation_suite("c.warning")
-#
-#     runner = CliRunner(mix_stderr=False)
-#
-#     result = runner.invoke(
-#         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
-#     )
-#     output = result.output
-#     assert result.exit_code == 0
-#     assert "3 expectation suites found:" in output
-#     assert "\ta.warning" in output
-#     assert "\tb.warning" in output
-#     assert "\tc.warning" in output
-#
-#     assert_no_logging_messages_or_tracebacks(caplog, result)
+    tap_file = os.path.abspath(os.path.join(root_dir, "..", "tap.py"))
+    status, output = subprocess.getstatusoutput(f"python {tap_file}")
+    assert status == 0
+    assert output == "Validation Succeeded!"

--- a/tests/cli/test_taps.py
+++ b/tests/cli/test_taps.py
@@ -1,0 +1,1179 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from click.testing import CliRunner
+
+from great_expectations import DataContext
+from great_expectations.cli import cli
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
+
+
+def test_tap_help_output(caplog,):
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(cli, ["tap"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert (
+        """Commands:
+  new  BETA! Create a new tap file"""
+        in result.stdout
+    )
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+def test_tap_new_on_context_with_no_datasources(
+    caplog, empty_data_context
+):
+    """
+    We call the "tap new" command on a data context that has no datasources
+    configured.
+
+    The command should:
+    - exit with a clear error message
+    """
+    root_dir = empty_data_context.root_directory
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli, f"tap new not_a_suite tap.py -d {root_dir}", catch_exceptions=False,
+    )
+    stdout = result.stdout
+
+    assert result.exit_code == 1
+    assert "No datasources found in the context" in stdout
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+def test_tap_new_with_non_existant_suite(
+    caplog, empty_data_context
+):
+    """
+    We call the "tap new" command on a data context that has a datasource
+    configured and no suites.
+
+    The command should:
+    - exit with a clear error message
+    """
+    empty_data_context.add_datasource(
+        "my_datasource",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+    )
+    root_dir = empty_data_context.root_directory
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli, f"tap new not_a_suite tap.py -d {root_dir}", catch_exceptions=False,
+    )
+    stdout = result.stdout
+
+    assert result.exit_code == 1
+    assert "Could not find a suite named `not_a_suite`" in stdout
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+def test_tap_new_on_context_with_2_datasources_with_no_datasource_option_prompts_user(
+    caplog, empty_data_context
+):
+    """
+    We call the "tap new" command on a data context that has 2 datasources
+    configured.
+
+    The command should:
+    - prompt the user to choose a datasource
+    """
+    empty_data_context.add_datasource(
+        "1_datasource",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+    )
+    empty_data_context.add_datasource(
+        "2_my_datasource",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+    )
+    root_dir = empty_data_context.root_directory
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        f"tap new not_a_suite tap.py -d {root_dir}",
+        input="1\n",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+
+    assert "Select a datasource" in stdout
+    assert result.exit_code == 1
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+def test_tap_new_on_context_with_1_datasources_with_no_datasource_option_prompts_user(
+    caplog, empty_data_context
+):
+    """
+    We call the "tap new" command on a data context that has 1 datasources
+    configured.
+
+    The command should:
+    - NOT prompt the user to choose a datasource
+    """
+    empty_data_context.add_datasource(
+        "1_datasource",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+    )
+    root_dir = empty_data_context.root_directory
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        f"tap new not_a_suite tap.py -d {root_dir}",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+    print(stdout)
+
+    assert "Select a datasource" not in stdout
+    assert result.exit_code == 1
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_new_enter_existing_suite_name_as_arg(
+#     mock_webbrowser, mock_subprocess, caplog, data_context
+# ):
+#     """
+#     We call the "suite new" command with the name of an existing expectation
+#     suite in the --suite argument
+#
+#     The command should:
+#     - exit with a clear error message
+#     - NOT open Data Docs
+#     - NOT open jupyter
+#     """
+#
+#     not_so_empty_data_context = data_context
+#     project_root_dir = not_so_empty_data_context.root_directory
+#     os.mkdir(os.path.join(project_root_dir, "uncommitted"))
+#
+#     root_dir = project_root_dir
+#     os.chdir(root_dir)
+#     context = DataContext(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir, "--suite", "my_dag_node.default", "--no-view"],
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#
+#     assert result.exit_code == 1
+#     assert "already exists. If you intend to edit the suite" in stdout
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_new_answer_suite_name_prompts_with_name_of_existing_suite(
+#     mock_webbrowser, mock_subprocess, caplog, data_context, filesystem_csv_2
+# ):
+#     """
+#     We call the "suite new" command without the suite name argument
+#
+#     The command should:
+#
+#     - prompt us to enter the name of the expectation suite that will be
+#     created. We answer the prompt with the name of an existing expectation suite.
+#     - display an error message and let us retry until we answer
+#     with a name that is not "taken".
+#     - create an example suite
+#     - NOT open jupyter
+#     - open DataDocs to the new example suite page
+#     """
+#     not_so_empty_data_context = data_context
+#     root_dir = not_so_empty_data_context.root_directory
+#     os.mkdir(os.path.join(root_dir, "uncommitted"))
+#
+#     runner = CliRunner(mix_stderr=False)
+#     csv_path = os.path.join(filesystem_csv_2, "f1.csv")
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir],
+#         input=f"{csv_path}\nmy_dag_node.default\nmy_new_suite\n\n",
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#     assert result.exit_code == 0
+#     assert "already exists. If you intend to edit the suite" in stdout
+#     assert "Enter the path" in stdout
+#     assert "Name the new expectation suite [f1.warning]" in stdout
+#     assert (
+#         "Great Expectations will choose a couple of columns and generate expectations"
+#         in stdout
+#     )
+#     assert "Generating example Expectation Suite..." in stdout
+#     assert "Building" in stdout
+#     assert "The following Data Docs sites were built" in stdout
+#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
+#     assert "open a notebook for you now" not in stdout
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_subprocess.call_count == 0
+#     assert mock_webbrowser.call_count == 1
+#
+#     foo = os.path.join(
+#         root_dir, "uncommitted/data_docs/local_site/validations/my_new_suite/"
+#     )
+#     assert f"file://{foo}" in mock_webbrowser.call_args[0][0]
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_new_empty_suite_creates_empty_suite(
+#     mock_webbroser, mock_subprocess, caplog, data_context, filesystem_csv_2
+# ):
+#     """
+#     Running "suite new --empty" should:
+#     - make an empty suite
+#     - open jupyter
+#     - NOT open data docs
+#     """
+#     project_root_dir = data_context.root_directory
+#     os.mkdir(os.path.join(project_root_dir, "uncommitted"))
+#     root_dir = project_root_dir
+#     os.chdir(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     csv = os.path.join(filesystem_csv_2, "f1.csv")
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir, "--empty", "--suite", "foo"],
+#         input=f"{csv}\n",
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#
+#     assert result.exit_code == 0
+#     assert "Enter the path" in stdout
+#     assert "Name the new expectation suite" not in stdout
+#     assert (
+#         "Great Expectations will choose a couple of columns and generate expectations"
+#         not in stdout
+#     )
+#     assert "Generating example Expectation Suite..." not in stdout
+#     assert "The following Data Docs sites were built" not in stdout
+#     assert "A new Expectation suite 'foo' was added to your project" in stdout
+#     assert (
+#         "Because you requested an empty suite, we'll open a notebook for you now to edit it!"
+#         in stdout
+#     )
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "foo.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     expected_notebook = os.path.join(root_dir, "uncommitted", "foo.ipynb")
+#     assert os.path.isfile(expected_notebook)
+#
+#     context = DataContext(root_dir)
+#     assert "foo" in context.list_expectation_suite_names()
+#     suite = context.get_expectation_suite("foo")
+#     assert suite.expectations == []
+#     citations = suite.get_citations()
+#     citations[0].pop("citation_date")
+#     assert citations[0] == {
+#         "batch_kwargs": {"datasource": "mydatasource", "path": csv},
+#         "batch_markers": None,
+#         "batch_parameters": None,
+#         "comment": "New suite added via CLI",
+#     }
+#
+#     assert mock_subprocess.call_count == 1
+#     call_args = mock_subprocess.call_args[0][0]
+#     assert call_args[0] == "jupyter"
+#     assert call_args[1] == "notebook"
+#     assert expected_notebook in call_args[2]
+#
+#     assert mock_webbroser.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_new_empty_suite_creates_empty_suite_with_no_jupyter(
+#     mock_webbroser, mock_subprocess, caplog, data_context, filesystem_csv_2
+# ):
+#     """
+#     Running "suite new --empty --no-jupyter" should:
+#     - make an empty suite
+#     - NOT open jupyter
+#     - NOT open data docs
+#     """
+#     project_root_dir = data_context.root_directory
+#     os.mkdir(os.path.join(project_root_dir, "uncommitted"))
+#     root_dir = project_root_dir
+#     os.chdir(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     csv = os.path.join(filesystem_csv_2, "f1.csv")
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir, "--empty", "--suite", "foo", "--no-jupyter"],
+#         input=f"{csv}\n",
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#
+#     assert result.exit_code == 0
+#     assert "Enter the path" in stdout
+#     assert "Name the new expectation suite" not in stdout
+#     assert (
+#         "Great Expectations will choose a couple of columns and generate expectations"
+#         not in stdout
+#     )
+#     assert "Generating example Expectation Suite..." not in stdout
+#     assert "The following Data Docs sites were built" not in stdout
+#     assert "A new Expectation suite 'foo' was added to your project" in stdout
+#     assert "open a notebook for you now" not in stdout
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "foo.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     expected_notebook = os.path.join(root_dir, "uncommitted", "foo.ipynb")
+#     assert os.path.isfile(expected_notebook)
+#
+#     context = DataContext(root_dir)
+#     assert "foo" in context.list_expectation_suite_names()
+#     suite = context.get_expectation_suite("foo")
+#     assert suite.expectations == []
+#     citations = suite.get_citations()
+#     citations[0].pop("citation_date")
+#     assert citations[0] == {
+#         "batch_kwargs": {"datasource": "mydatasource", "path": csv},
+#         "batch_markers": None,
+#         "batch_parameters": None,
+#         "comment": "New suite added via CLI",
+#     }
+#
+#     assert mock_subprocess.call_count == 0
+#     assert mock_webbroser.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_new_one_datasource_without_generator_without_suite_name_argument(
+#     mock_webbrowser, mock_subprocess, caplog, empty_data_context, filesystem_csv_2
+# ):
+#     """
+#     We call the "suite new" command without the suite name argument
+#
+#     The command should:
+#
+#     - NOT prompt us to choose a datasource (because there is only one)
+#     - prompt us only to enter the path (The datasource has no generator
+#      configured and not to choose from the generator's list of available data
+#      assets).
+#     - We enter the path of the file we want the command to use as the batch to
+#     create the expectation suite.
+#     - prompt us to enter the name of the expectation suite that will be
+#     created
+#     - open Data Docs
+#     - NOT open jupyter
+#     """
+#     empty_data_context.add_datasource(
+#         "my_datasource",
+#         module_name="great_expectations.datasource",
+#         class_name="PandasDatasource",
+#     )
+#
+#     context = empty_data_context
+#     project_root_dir = context.root_directory
+#
+#     root_dir = project_root_dir
+#     os.chdir(root_dir)
+#     context = DataContext(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir],
+#         input="{0:s}\nmy_new_suite\n\n".format(
+#             os.path.join(filesystem_csv_2, "f1.csv")
+#         ),
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#
+#     assert result.exit_code == 0
+#     assert "Enter the path" in stdout
+#     assert "Name the new expectation suite [f1.warning]" in stdout
+#     assert (
+#         "Great Expectations will choose a couple of columns and generate expectations"
+#         in stdout
+#     )
+#     assert "Generating example Expectation Suite..." in stdout
+#     assert "Building" in stdout
+#     assert "The following Data Docs sites were built" in stdout
+#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
+#
+#     obs_urls = context.get_docs_sites_urls()
+#
+#     assert len(obs_urls) == 1
+#     assert (
+#         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]
+#     )
+#
+#     expected_index_path = os.path.join(
+#         root_dir, "uncommitted", "data_docs", "local_site", "index.html"
+#     )
+#     assert os.path.isfile(expected_index_path)
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 1
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_new_multiple_datasources_with_generator_without_suite_name_argument(
+#     mock_webbrowser,
+#     mock_subprocess,
+#     caplog,
+#     site_builder_data_context_with_html_store_titanic_random,
+# ):
+#     """
+#     We call the "suite new" command without the suite name argument
+#
+#     - The data context has two datasources - we choose one of them.
+#     - It has a generator configured. We choose to use the generator and select a
+#     generator asset from the list.
+#     - The command should prompt us to enter the name of the expectation suite
+#     that will be created.
+#     - open Data Docs
+#     - NOT open jupyter
+#     """
+#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
+#     os.chdir(root_dir)
+#     context = DataContext(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir],
+#         input="1\n1\n1\nmy_new_suite\n\n",
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#
+#     assert result.exit_code == 0
+#     assert (
+#         """Select a datasource
+#     1. random
+#     2. titanic"""
+#         in stdout
+#     )
+#     assert (
+#         """Which data would you like to use?
+#     1. f1 (file)
+#     2. f2 (file)"""
+#         in stdout
+#     )
+#     assert "Name the new expectation suite [f1.warning]" in stdout
+#     assert (
+#         "Great Expectations will choose a couple of columns and generate expectations"
+#         in stdout
+#     )
+#     assert "Generating example Expectation Suite..." in stdout
+#     assert "Building" in stdout
+#     assert "The following Data Docs sites were built" in stdout
+#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
+#
+#     obs_urls = context.get_docs_sites_urls()
+#
+#     assert len(obs_urls) == 1
+#     assert (
+#         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]
+#     )
+#
+#     expected_index_path = os.path.join(
+#         root_dir, "uncommitted", "data_docs", "local_site", "index.html"
+#     )
+#     assert os.path.isfile(expected_index_path)
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 1
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_new_multiple_datasources_with_generator_with_suite_name_argument(
+#     mock_webbrowser,
+#     mock_subprocess,
+#     caplog,
+#     site_builder_data_context_with_html_store_titanic_random,
+# ):
+#     """
+#     We call the "suite new" command with the suite name argument
+#
+#     - The data context has two datasources - we choose one of them.
+#     - It has a generator configured. We choose to use the generator and select
+#     a generator asset from the list.
+#     - open Data Docs
+#     - NOT open jupyter
+#     """
+#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
+#     os.chdir(root_dir)
+#     context = DataContext(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
+#         input="2\n1\n1\n\n",
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#
+#     assert result.exit_code == 0
+#     assert "Select a datasource" in stdout
+#     assert "Which data would you like to use" in stdout
+#     assert (
+#         "Great Expectations will choose a couple of columns and generate expectations"
+#         in stdout
+#     )
+#     assert "Generating example Expectation Suite..." in stdout
+#     assert "Building" in stdout
+#     assert "The following Data Docs sites were built" in stdout
+#     assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
+#
+#     obs_urls = context.get_docs_sites_urls()
+#
+#     assert len(obs_urls) == 1
+#     assert (
+#         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]
+#     )
+#
+#     expected_index_path = os.path.join(
+#         root_dir, "uncommitted", "data_docs", "local_site", "index.html"
+#     )
+#     assert os.path.isfile(expected_index_path)
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 1
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# def test_tap_edit_without_suite_name_raises_error():
+#     """This is really only testing click missing arguments"""
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(cli, "suite edit", catch_exceptions=False)
+#     assert result.exit_code == 2
+#     assert (
+#         'Error: Missing argument "SUITE".' in result.stderr
+#         or "Error: Missing argument 'SUITE'." in result.stderr
+#     )
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_with_invalid_json_batch_kwargs_raises_helpful_error(
+#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
+# ):
+#     """
+#     The command should:
+#     - exit with a clear error message
+#     - NOT open Data Docs
+#     - NOT open jupyter
+#     """
+#     project_dir = empty_data_context.root_directory
+#     context = DataContext(project_dir)
+#     context.create_expectation_suite("foo")
+#
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "edit", "foo", "-d", project_dir, "--batch-kwargs", "'{foobar}'"],
+#         catch_exceptions=False,
+#     )
+#     stdout = result.output
+#     assert result.exit_code == 1
+#     assert "Please check that your batch_kwargs are valid JSON." in stdout
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_with_batch_kwargs_unable_to_load_a_batch_raises_helpful_error(
+#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
+# ):
+#     """
+#     The command should:
+#     - exit with a clear error message
+#     - NOT open Data Docs
+#     - NOT open jupyter
+#     """
+#     project_dir = empty_data_context.root_directory
+#
+#     context = DataContext(project_dir)
+#     context.create_expectation_suite("foo")
+#     context.add_datasource("source", class_name="PandasDatasource")
+#
+#     runner = CliRunner(mix_stderr=False)
+#     batch_kwargs = '{"table": "fake", "datasource": "source"}'
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "edit", "foo", "-d", project_dir, "--batch-kwargs", batch_kwargs],
+#         catch_exceptions=False,
+#     )
+#     stdout = result.output
+#     assert result.exit_code == 1
+#     assert "To continue editing this suite" not in stdout
+#     assert "Please check that your batch_kwargs are able to load a batch." in stdout
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_with_non_existent_suite_name_raises_error(
+#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
+# ):
+#     """
+#     The command should:
+#     - exit with a clear error message
+#     - NOT open Data Docs
+#     - NOT open jupyter
+#     """
+#     project_dir = empty_data_context.root_directory
+#     assert not empty_data_context.list_expectation_suites()
+#
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         "suite edit not_a_real_suite -d {}".format(project_dir),
+#         catch_exceptions=False,
+#     )
+#     assert result.exit_code == 1
+#     assert "Could not find a suite named `not_a_real_suite`." in result.output
+#     assert "by running `great_expectations suite list`" in result.output
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_with_non_existent_datasource_shows_helpful_error_message(
+#     mock_webbrowser, mock_subprocess, caplog, empty_data_context
+# ):
+#     """
+#     The command should:
+#     - exit with a clear error message
+#     - NOT open Data Docs
+#     - NOT open jupyter
+#     """
+#     project_dir = empty_data_context.root_directory
+#     context = DataContext(project_dir)
+#     context.create_expectation_suite("foo")
+#     assert context.list_expectation_suites()[0].expectation_suite_name == "foo"
+#
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         f"suite edit foo -d {project_dir} --datasource not_real",
+#         catch_exceptions=False,
+#     )
+#     assert result.exit_code == 1
+#     assert (
+#         "Unable to load datasource `not_real` -- no configuration found or invalid configuration."
+#         in result.output
+#     )
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_multiple_datasources_with_generator_with_no_additional_args_with_suite_without_citations(
+#     mock_webbrowser,
+#     mock_subprocess,
+#     caplog,
+#     site_builder_data_context_with_html_store_titanic_random,
+# ):
+#     """
+#     Here we verify that the "suite edit" command helps the user to specify the batch
+#     kwargs when it is called without the optional arguments that specify the batch.
+#
+#     First, we call the "suite new" command to create the expectation suite our test
+#     will edit - this step is a just a setup.
+#
+#     We call the "suite edit" command without any optional arguments. This means that
+#     the command will help us specify the batch kwargs interactively.
+#
+#     The data context has two datasources - we choose one of them. It has a generator
+#     configured. We choose to use the generator and select a generator asset from the list.
+#
+#     The command should:
+#     - NOT open Data Docs
+#     - open jupyter
+#     """
+#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
+#     os.chdir(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
+#         input="2\n1\n1\n\n",
+#         catch_exceptions=False,
+#     )
+#     assert result.exit_code == 0
+#     assert mock_webbrowser.call_count == 1
+#     assert mock_subprocess.call_count == 0
+#     mock_webbrowser.reset_mock()
+#     mock_subprocess.reset_mock()
+#
+#     # remove the citations from the suite
+#     context = DataContext(root_dir)
+#     suite = context.get_expectation_suite("foo_suite")
+#     assert isinstance(suite, ExpectationSuite)
+#     suite.meta.pop("citations")
+#     context.save_expectation_suite(suite)
+#
+#     # Actual testing really starts here
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "edit", "foo_suite", "-d", root_dir,],
+#         input="2\n1\n1\n\n",
+#         catch_exceptions=False,
+#     )
+#
+#     assert result.exit_code == 0
+#     stdout = result.stdout
+#     assert "A batch of data is required to edit the suite" in stdout
+#     assert "Select a datasource" in stdout
+#     assert "Which data would you like to use" in stdout
+#
+#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
+#     assert os.path.isfile(expected_notebook_path)
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 1
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_multiple_datasources_with_generator_with_no_additional_args_with_suite_containing_citations(
+#     mock_webbrowser,
+#     mock_subprocess,
+#     caplog,
+#     site_builder_data_context_with_html_store_titanic_random,
+# ):
+#     """
+#     Here we verify that the "suite edit" command uses the batch kwargs found in
+#     citations in the existing suite when it is called without the optional
+#     arguments that specify the batch.
+#
+#     First, we call the "suite new" command to create the expectation suite our
+#     test will edit - this step is a just a setup.
+#
+#     We call the "suite edit" command without any optional arguments.
+#
+#     The command should:
+#     - NOT open Data Docs
+#     - NOT open jupyter
+#     """
+#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
+#     os.chdir(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite"],
+#         input="2\n1\n1\n\n",
+#         catch_exceptions=False,
+#     )
+#     assert mock_webbrowser.call_count == 1
+#     assert mock_subprocess.call_count == 0
+#     mock_subprocess.reset_mock()
+#     mock_webbrowser.reset_mock()
+#     assert result.exit_code == 0
+#     context = DataContext(root_dir)
+#     suite = context.get_expectation_suite("foo_suite")
+#     assert isinstance(suite, ExpectationSuite)
+#
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "edit", "foo_suite", "-d", root_dir],
+#         input="2\n1\n1\n\n",
+#         catch_exceptions=False,
+#     )
+#
+#     assert result.exit_code == 0
+#     stdout = result.stdout
+#     assert "Select a datasource" not in stdout
+#     assert "Which data would you like to use" not in stdout
+#
+#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
+#     assert os.path.isfile(expected_notebook_path)
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 1
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_multiple_datasources_with_generator_with_batch_kwargs_arg(
+#     mock_webbrowser,
+#     mock_subprocess,
+#     caplog,
+#     site_builder_data_context_with_html_store_titanic_random,
+# ):
+#     """
+#     Here we verify that when the "suite edit" command is called with batch_kwargs arg
+#     that specifies the batch that will be used as a sample for editing the suite,
+#     the command processes the batch_kwargs correctly and skips all the prompts
+#     that help users to specify the batch (when called without batch_kwargs).
+#
+#     First, we call the "suite new" command to create the expectation suite our test
+#     will edit - this step is a just a setup.
+#
+#     We call the "suite edit" command without any optional arguments. This means that
+#     the command will help us specify the batch kwargs interactively.
+#
+#     The data context has two datasources - we choose one of them. It has a generator
+#     configured. We choose to use the generator and select a generator asset from the list.
+#
+#     The command should:
+#     - NOT open Data Docs
+#     - open jupyter
+#     """
+#     root_dir = site_builder_data_context_with_html_store_titanic_random.root_directory
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir, "--suite", "foo_suite", "--no-view"],
+#         input="2\n1\n1\n\n",
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#     assert result.exit_code == 0
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 0
+#     mock_subprocess.reset_mock()
+#     mock_webbrowser.reset_mock()
+#     assert "A new Expectation suite 'foo_suite' was added to your project" in stdout
+#
+#     batch_kwargs = {
+#         "datasource": "random",
+#         "path": str(
+#             os.path.join(
+#                 os.path.abspath(os.path.join(root_dir, os.pardir)),
+#                 "data",
+#                 "random",
+#                 "f1.csv",
+#             )
+#         ),
+#     }
+#     batch_kwargs_arg_str = json.dumps(batch_kwargs)
+#
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         [
+#             "suite",
+#             "edit",
+#             "foo_suite",
+#             "-d",
+#             root_dir,
+#             "--batch-kwargs",
+#             batch_kwargs_arg_str,
+#         ],
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#
+#     assert result.exit_code == 0
+#     assert "Select a datasource" not in stdout
+#     assert "Which data would you like to use" not in stdout
+#
+#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "foo_suite.ipynb")
+#     assert os.path.isfile(expected_notebook_path)
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 1
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_on_exsiting_suite_one_datasources_with_batch_kwargs_without_datasource_raises_helpful_error(
+#     mock_webbrowser, mock_subprocess, caplog, titanic_data_context,
+# ):
+#     """
+#     Given:
+#     - the suite foo exists
+#     - the a datasource exists
+#     - and the users runs this
+#     great_expectations suite edit foo --batch-kwargs '{"path": "data/10k.csv"}'
+#
+#     Then:
+#     - The user should see a nice error and the program halts before notebook
+#     compilation.
+#     - NOT open Data Docs
+#     - NOT open jupyter
+#     '"""
+#     project_dir = titanic_data_context.root_directory
+#     context = DataContext(project_dir)
+#     context.create_expectation_suite("foo")
+#
+#     runner = CliRunner(mix_stderr=False)
+#     batch_kwargs = {"path": "../data/Titanic.csv"}
+#     result = runner.invoke(
+#         cli,
+#         [
+#             "suite",
+#             "edit",
+#             "foo",
+#             "-d",
+#             project_dir,
+#             "--batch-kwargs",
+#             json.dumps(batch_kwargs),
+#         ],
+#         catch_exceptions=False,
+#     )
+#     stdout = result.output
+#     assert result.exit_code == 1
+#     assert "Please check that your batch_kwargs are able to load a batch." in stdout
+#     assert "Unable to load datasource `None`" in stdout
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 0
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_on_exsiting_suite_one_datasources_with_datasource_arg_and_batch_kwargs(
+#     mock_webbrowser, mock_subprocess, caplog, titanic_data_context,
+# ):
+#     """
+#     Given:
+#     - the suite foo exists
+#     - the a datasource bar exists
+#     - and the users runs this
+#     great_expectations suite edit foo --datasource bar --batch-kwargs '{"path": "data/10k.csv"}'
+#
+#     Then:
+#     - The user gets a working notebook
+#     - NOT open Data Docs
+#     - open jupyter
+#     """
+#     project_dir = titanic_data_context.root_directory
+#     context = DataContext(project_dir)
+#     context.create_expectation_suite("foo")
+#
+#     runner = CliRunner(mix_stderr=False)
+#     batch_kwargs = {"path": os.path.join(project_dir, "../", "data", "Titanic.csv")}
+#     result = runner.invoke(
+#         cli,
+#         [
+#             "suite",
+#             "edit",
+#             "foo",
+#             "-d",
+#             project_dir,
+#             "--batch-kwargs",
+#             json.dumps(batch_kwargs),
+#             "--datasource",
+#             "mydatasource",
+#         ],
+#         catch_exceptions=False,
+#     )
+#     stdout = result.output
+#     assert stdout == ""
+#     assert result.exit_code == 0
+#
+#     expected_notebook_path = os.path.join(project_dir, "uncommitted", "foo.ipynb")
+#     assert os.path.isfile(expected_notebook_path)
+#     expected_suite_path = os.path.join(project_dir, "expectations", "foo.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 1
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# @mock.patch("subprocess.call", return_value=True, side_effect=None)
+# @mock.patch("webbrowser.open", return_value=True, side_effect=None)
+# def test_tap_edit_one_datasources_no_generator_with_no_additional_args_and_no_citations(
+#     mock_webbrowser, mock_subprocess, caplog, empty_data_context, filesystem_csv_2
+# ):
+#     """
+#     Here we verify that the "suite edit" command helps the user to specify the batch
+#     kwargs when it is called without the optional arguments that specify the batch.
+#
+#     First, we call the "suite new" command to create the expectation suite our test
+#     will edit - this step is a just a setup.
+#
+#     We call the "suite edit" command without any optional arguments. This means that
+#     the command will help us specify the batch kwargs interactively.
+#
+#     The data context has one datasource. The datasource has no generators
+#     configured. The command prompts us to enter the file path.
+#     """
+#     empty_data_context.add_datasource(
+#         "my_datasource",
+#         module_name="great_expectations.datasource",
+#         class_name="PandasDatasource",
+#     )
+#
+#     not_so_empty_data_context = empty_data_context
+#     project_root_dir = not_so_empty_data_context.root_directory
+#
+#     root_dir = project_root_dir
+#     os.chdir(root_dir)
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "new", "-d", root_dir],
+#         input="{0:s}\nmy_new_suite\n\n".format(
+#             os.path.join(filesystem_csv_2, "f1.csv")
+#         ),
+#         catch_exceptions=False,
+#     )
+#     stdout = result.stdout
+#     assert mock_webbrowser.call_count == 1
+#     assert mock_subprocess.call_count == 0
+#     mock_subprocess.reset_mock()
+#     mock_webbrowser.reset_mock()
+#     assert result.exit_code == 0
+#     assert "A new Expectation suite 'my_new_suite' was added to your project" in stdout
+#
+#     # remove the citations from the suite
+#     context = DataContext(project_root_dir)
+#     suite = context.get_expectation_suite("my_new_suite")
+#     suite.meta.pop("citations")
+#     context.save_expectation_suite(suite)
+#
+#     runner = CliRunner(mix_stderr=False)
+#     result = runner.invoke(
+#         cli,
+#         ["suite", "edit", "my_new_suite", "-d", root_dir],
+#         input="{0:s}\n\n".format(os.path.join(filesystem_csv_2, "f1.csv")),
+#         catch_exceptions=False,
+#     )
+#
+#     assert result.exit_code == 0
+#     stdout = result.stdout
+#     assert "Select a datasource" not in stdout
+#     assert "Which data would you like to use" not in stdout
+#     assert "Enter the path" in stdout
+#
+#     expected_notebook_path = os.path.join(root_dir, "uncommitted", "my_new_suite.ipynb")
+#     assert os.path.isfile(expected_notebook_path)
+#
+#     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
+#     assert os.path.isfile(expected_suite_path)
+#
+#     assert mock_webbrowser.call_count == 0
+#     assert mock_subprocess.call_count == 1
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# def test_tap_list_with_zero_suites(caplog, empty_data_context):
+#     project_dir = empty_data_context.root_directory
+#     runner = CliRunner(mix_stderr=False)
+#
+#     result = runner.invoke(
+#         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
+#     )
+#     assert result.exit_code == 0
+#     assert "No expectation suites found" in result.output
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# def test_tap_list_with_one_suite(caplog, empty_data_context):
+#     project_dir = empty_data_context.root_directory
+#     context = DataContext(project_dir)
+#     context.create_expectation_suite("a.warning")
+#     runner = CliRunner(mix_stderr=False)
+#
+#     result = runner.invoke(
+#         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
+#     )
+#     assert result.exit_code == 0
+#     assert "1 expectation suite found" in result.output
+#     assert "\ta.warning" in result.output
+#     assert_no_logging_messages_or_tracebacks(caplog, result)
+#
+#
+# def test_tap_list_with_multiple_suites(caplog, empty_data_context):
+#     project_dir = empty_data_context.root_directory
+#     context = DataContext(project_dir)
+#     context.create_expectation_suite("a.warning")
+#     context.create_expectation_suite("b.warning")
+#     context.create_expectation_suite("c.warning")
+#
+#     runner = CliRunner(mix_stderr=False)
+#
+#     result = runner.invoke(
+#         cli, "suite list -d {}".format(project_dir), catch_exceptions=False,
+#     )
+#     output = result.output
+#     assert result.exit_code == 0
+#     assert "3 expectation suites found:" in output
+#     assert "\ta.warning" in output
+#     assert "\tb.warning" in output
+#     assert "\tc.warning" in output
+#
+#     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_taps.py
+++ b/tests/cli/test_taps.py
@@ -20,6 +20,27 @@ def test_tap_help_output(caplog,):
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+def test_tap_new_with_filename_not_ending_in_py_raises_helpful_error(caplog, empty_data_context):
+    """
+    We call the "tap new" command with a bogus filename
+
+    The command should:
+    - exit with a clear error message
+    """
+    context = empty_data_context
+    root_dir = context.root_directory
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli, f"tap new sweet_suite tap -d {root_dir}", catch_exceptions=False,
+    )
+    stdout = result.stdout
+
+    assert result.exit_code == 1
+    assert "Tap filename must end in .py. Please correct and re-run" in stdout
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
 def test_tap_new_on_context_with_no_datasources(caplog, empty_data_context):
     """
     We call the "tap new" command on a data context that has no datasources

--- a/tests/cli/test_taps.py
+++ b/tests/cli/test_taps.py
@@ -14,7 +14,7 @@ def test_tap_help_output(caplog,):
     assert result.exit_code == 0
     assert (
         """Commands:
-  new  BETA! Create a new tap file"""
+  new  BETA! Create a new tap file for easy deployments"""
         in result.stdout
     )
     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_taps_pandas.py
+++ b/tests/cli/test_taps_pandas.py
@@ -40,6 +40,7 @@ def test_tap_new_with_filename_not_ending_in_py_raises_helpful_error(
     stdout = result.stdout
 
     assert result.exit_code == 1
+    assert "This is a BETA feature which may change" in stdout
     assert "Tap filename must end in .py. Please correct and re-run" in stdout
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
@@ -61,6 +62,7 @@ def test_tap_new_on_context_with_no_datasources(caplog, empty_data_context):
     stdout = result.stdout
 
     assert result.exit_code == 1
+    assert "This is a BETA feature which may change" in stdout
     assert "No datasources found in the context" in stdout
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
@@ -87,6 +89,7 @@ def test_tap_new_with_non_existant_suite(caplog, empty_data_context):
     stdout = result.stdout
 
     assert result.exit_code == 1
+    assert "This is a BETA feature which may change" in stdout
     assert "Could not find a suite named `not_a_suite`" in stdout
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
@@ -122,6 +125,7 @@ def test_tap_new_on_context_with_2_datasources_with_no_datasource_option_prompts
     )
     stdout = result.stdout
 
+    assert "This is a BETA feature which may change" in stdout
     assert "Select a datasource" in stdout
     assert result.exit_code == 1
 
@@ -162,6 +166,7 @@ def test_tap_new_on_context_builds_runnable_tap_file(
     )
     stdout = result.stdout
 
+    assert "This is a BETA feature which may change" in stdout
     assert "Enter the path (relative or absolute) of a data file" in stdout
     assert "A new tap has been generated" in stdout
     assert result.exit_code == 0
@@ -215,6 +220,7 @@ def test_tap_new_on_context_builds_runnable_tap_file_that_fails_validation(
     )
     stdout = result.stdout
 
+    assert "This is a BETA feature which may change" in stdout
     assert "Enter the path (relative or absolute) of a data file" in stdout
     assert "A new tap has been generated" in stdout
     assert result.exit_code == 0
@@ -261,6 +267,7 @@ def test_tap_new_on_context_with_1_datasources_with_no_datasource_option_prompts
     )
     stdout = result.stdout
 
+    assert "This is a BETA feature which may change" in stdout
     assert "Select a datasource" not in stdout
     assert "A new tap has been generated" in stdout
     assert result.exit_code == 0

--- a/tests/data_asset/test_data_asset_internals.py
+++ b/tests/data_asset/test_data_asset_internals.py
@@ -901,7 +901,8 @@ def test_discard_failing_expectations():
             kwargs={'column': 'D', 'value_set': ['e', 'f', 'g', 'h']}
         )
     ]
-    sub1.discard_failing_expectations()
+    with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
+        sub1.discard_failing_expectations()
     assert sub1.find_expectations() == exp1
 
     sub1 = df[['A']]
@@ -915,7 +916,8 @@ def test_discard_failing_expectations():
             kwargs={'column': 'A', 'value_set': [1, 2, 3, 4]}
         ),
     ]
-    sub1.discard_failing_expectations()
+    with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
+        sub1.discard_failing_expectations()
     assert sub1.find_expectations() == exp1
 
     sub1 = df.iloc[:3, 1:4]
@@ -945,7 +947,8 @@ def test_discard_failing_expectations():
             kwargs={'column': 'D', 'value_set': ['e', 'f', 'g', 'h']}
         )
     ]
-    sub1.discard_failing_expectations()
+    with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
+        sub1.discard_failing_expectations()
     assert sub1.find_expectations() == exp1
 
     sub1 = df.loc[0:, 'A':'B']
@@ -967,7 +970,8 @@ def test_discard_failing_expectations():
             kwargs={'column': 'B', 'value_set': [5, 6, 7, 8]}
         ),
     ]
-    sub1.discard_failing_expectations()
+    with pytest.warns(UserWarning, match=r"Removed \d expectations that were 'False'"):
+        sub1.discard_failing_expectations()
     assert sub1.find_expectations() == exp1
 
 

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -781,10 +781,10 @@ def test_data_context_create_makes_uncommitted_dirs_when_all_are_missing(tmp_pat
     uncommitted_dir = os.path.join(ge_dir, "uncommitted")
     shutil.rmtree(uncommitted_dir)
 
-    # re-run create to simulate onboarding
-    DataContext.create(project_path)
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        # re-run create to simulate onboarding
+        DataContext.create(project_path)
     obs = gen_directory_tree_str(ge_dir)
-    print(obs)
 
     assert os.path.isdir(uncommitted_dir), "No uncommitted directory created"
     assert obs == """\
@@ -841,12 +841,12 @@ great_expectations/
 
     DataContext.create(project_path)
     fixture = gen_directory_tree_str(ge_dir)
-    print(fixture)
 
     assert fixture == expected
 
-    # re-run create to simulate onboarding
-    DataContext.create(project_path)
+    with pytest.warns(UserWarning, match="Warning. An existing `great_expectations.yml` was found"):
+        # re-run create to simulate onboarding
+        DataContext.create(project_path)
 
     obs = gen_directory_tree_str(ge_dir)
     assert obs == expected

--- a/tests/test_ge_utils.py
+++ b/tests/test_ge_utils.py
@@ -5,6 +5,7 @@ from six import PY2
 
 import great_expectations as ge
 from great_expectations.core.util import nested_update
+from great_expectations.util import lint_code
 
 
 def test_validate_non_dataset(file_data_asset, empty_expectation_suite):
@@ -152,3 +153,18 @@ def test_nested_update_lists():
             "metric.blarg": [""]
         }
     }
+
+
+def test_linter_raises_error_on_non_string_input():
+    with pytest.raises(TypeError):
+        lint_code(99)
+
+
+def test_linter_changes_dirty_code():
+    code = "foo = [1,2,3]"
+    assert lint_code(code) == "foo = [1, 2, 3]\n"
+
+
+def test_linter_leaves_clean_code():
+    code = "foo = [1, 2, 3]\n"
+    assert lint_code(code) == "foo = [1, 2, 3]\n"

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -432,7 +432,7 @@ class TestIO(unittest.TestCase):
         # Note that pandas changed the parameter name from sheetname to sheet_name.
         # We will test with both options to ensure that the versions are correct.
         pandas_version = pd.__version__
-        if re.match('0\.2[012]\.', pandas_version) is not None:
+        if re.match(r'0\.2[012]\.', pandas_version) is not None:
             dfs_dict = ge.read_excel(
                 script_path+'/test_sets/Titanic_multi_sheet.xlsx',
                 sheetname=None
@@ -470,7 +470,7 @@ class TestIO(unittest.TestCase):
 
         # Pass this test if the available version of pandas is less than 0.21.0, because prior
         # versions of pandas did not include the read_parquet function.
-        pandas_version = re.match('(\d+)\.(\d+)\..+', pd.__version__)
+        pandas_version = re.match(r'(\d+)\.(\d+)\..+', pd.__version__)
         if pandas_version is None:
             raise ValueError("Unrecognized pandas version!")
         else:


### PR DESCRIPTION
## What's Here

* New CLI command: `tap new` that generates an executable python file to expedite deployments.
* bugfix in TableBatchKwargsGenerator docs
* fixed a small pile of orphaned sphinx doc warnings
* fixed 35 pytest warnings

## Feature Story

Given I'm an DE/DS
When I run `great_expectations tap new` with the appropriate arguments
Then I should get a new tap file that:
- is named to my desire (maybe default to the suite name?
- is a linted, runnable python file
- validates a batch of data using a ValidationOperator
- returns proper exit codes 0 if success and 1 if failure to support cron usage
- has very light documentation at the top of the file
- is easy to modify by a user

## Testing This

* update your environment (new requirement)
* run `great_expectations tap new`
* run the tap you created with `python YOUR_TAP.py`

## Known Issues

* not (yet) tested outside pandas csv backends.