### PR TITLE
CLI commands for validation operators

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -279,31 +279,43 @@ You can then run jupyter.
 
 
 great_expectations validation-operator
-=====================================
+=======================================
 
-All command line operations for working with validation operators are here.
+All command line operations for working with :ref:`validation operators <validation_operators_and_actions>` are here.
 
 ``great_expectations validation-operator list``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Running ``great_expectations validation-operator list`` gives a list of validation operators configured in your project:
+Running ``great_expectations validation-operator list`` gives a list of
+validation operators configured in your project:
 
 .. code-block:: bash
 
     $ great_expectations validation-operator list
-    ...
-    ...
-    ...
+    ... (YOUR VALIDATION OPERATORS)
+
+``great_expectations validation-operator run``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are two modes to run this command:
+
+1. Interactive (good for development):
+**************************************************************
+
+Specify the name of the validation operator using the ``--name`` argument and
+the name of the expectation suite using the ``--suite`` argument.
+
+The cli will help you specify the batch of data that you want to validate
+interactively.
+
+If you want to call a validation operator to validate one batch of data against
+one expectation suite, you can invoke this command:
 
 ``great_expectations validation-operator run --name <VALIDATION_OPERATOR_NAME> --suite <SUITE_NAME>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you want to call a validation operator to validate one batch of data against one expectation suite,
-you can invoke this command.
 
 Use the `--name` argument to specify the name of the validation operator you want to run. This has to be the name
-of one of the valdiation operators configured in your project. You can look up the names by calling
-the `validation-operator list` command or by examining the `validation_operators` section in your project's
+of one of the validation operators configured in your project. You can list the names by calling
+the ``great_expectations validation-operator list`` command or by examining the ``validation_operators`` section in your project's
 ``great_expectations.yml`` config file.
 
 Use the `--suite` argument to specify the name of the expectation suite you want the validation operator to validate the
@@ -311,7 +323,6 @@ batch of data against. This has to be the name of one of the expectation suites 
 the `suite list` command.
 
 The command will help you specify the batch of data that you want the validation operator to validate interactively.
-
 
 .. code-block:: bash
 
@@ -323,21 +334,31 @@ The command will help you specify the batch of data that you want the validation
     : data/npi_small.csv
     Validation Succeeded!
 
-``great_expectations validation-operator run ----validation_config_file <VALIDATION_CONFIG_FILE_PATH>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2. Non-interactive (good for production):
+**************************************************************
 
 If you want run a validation operator non-interactively, use the `--validation_config_file` argument to specify the path of the validation configuration JSON file.
 
+``great_expectations validation-operator run ----validation_config_file <VALIDATION_CONFIG_FILE_PATH>``
+
+This file can be used to instruct a validation operator to validate multiple batches of data and use multiple expectation suites to validate each batch.
+
 .. note::
     A validation operator can validate multiple batches of data and use multiple expectation suites to validate each batch.
+    For example, you might want to validate 3 source files, with 2 tiers of suites each, one for a warning suite and one for a critical stop-the-presses hard failure suite.
+
+This command exits with 0 if the validation operator ran and the "success" attribute in its return object is True.
+Otherwise, the command exits with 1.
+
+.. Tip:: This is an excellent way to use call Great Expectations from within your pipeline if your pipeline code can run shell commands.
 
 A validation config file specifies the name of the validation operator in your project and
 the list of batches of data that you want the operator to validate.
-Each batch is defined using "batch_kwargs".
-The "expectation_suite_names" attribute for each batch specifies the list of the names of expectation suites that the validation o
+Each batch is defined using ``batch_kwargs``.
+The ``expectation_suite_names`` attribute for each batch specifies the list of names of expectation suites that the validation
 operator should use to validate the batch.
 
-Here is an example of a validation config file:
+Here is an example validation config file:
 
 .. code-block:: json
 
@@ -354,8 +375,8 @@ Here is an example of a validation config file:
         },
         {
           "batch_kwargs": {
-            "query": "select * from users where status = 1",
-            "datasource": "my_redshift_datasource",
+            "query": "SELECT * FROM users WHERE status = 1",
+            "datasource": "my_redshift_datasource"
           },
           "expectation_suite_names": ["suite_three"]
         }
@@ -364,7 +385,7 @@ Here is an example of a validation config file:
 
 .. code-block:: bash
 
-    $ great_expectations validation-operator run ----validation_config_file my_val_config.json
+    $ great_expectations validation-operator run --validation_config_file my_val_config.json
     Validation Succeeded!
 
 

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -316,10 +316,12 @@ The command will help you specify the batch of data that you want the validation
 .. code-block:: bash
 
     $ great_expectations validation-operator --name action_list_operator --suite npi.warning
-    ...
-    ...
-    ...
 
+    Let's help you specify the batch of data your want the validation operator to validate.
+
+    Enter the path (relative or absolute) of a data file
+    : data/npi_small.csv
+    Validation Succeeded!
 
 ``great_expectations validation-operator run ----validation_config_file <VALIDATION_CONFIG_FILE_PATH>``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -363,10 +365,7 @@ Here is an example of a validation config file:
 .. code-block:: bash
 
     $ great_expectations validation-operator run ----validation_config_file my_val_config.json
-    ...
-    ...
-    ...
-
+    Validation Succeeded!
 
 
 great_expectations datasource

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -28,6 +28,7 @@ This is a list of the most common commands you'll use in order of how much you'l
 * ``great_expectations suite list``
 * ``great_expectations docs build``
 * ``great_expectations tap new``
+* ``great_expectations validation-operator run``
 * ``great_expectations datasource list``
 * ``great_expectations datasource new``
 * ``great_expectations datasource profile``
@@ -275,6 +276,97 @@ If you prefer to disable Great Expectations from automatically opening the gener
     To continue editing this suite, run jupyter notebook /Users/dickens/Desktop/great_expectations/uncommitted/npi.warning.ipynb
 
 You can then run jupyter.
+
+
+great_expectations validation-operator
+=====================================
+
+All command line operations for working with validation operators are here.
+
+``great_expectations validation-operator list``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Running ``great_expectations validation-operator list`` gives a list of validation operators configured in your project:
+
+.. code-block:: bash
+
+    $ great_expectations validation-operator list
+    ...
+    ...
+    ...
+
+``great_expectations validation-operator run --name <VALIDATION_OPERATOR_NAME> --suite <SUITE_NAME>``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to call a validation operator to validate one batch of data against one expectation suite,
+you can invoke this command.
+
+Use the `--name` argument to specify the name of the validation operator you want to run. This has to be the name
+of one of the valdiation operators configured in your project. You can look up the names by calling
+the `validation-operator list` command or by examining the `validation_operators` section in your project's
+``great_expectations.yml`` config file.
+
+Use the `--suite` argument to specify the name of the expectation suite you want the validation operator to validate the
+batch of data against. This has to be the name of one of the expectation suites that exist in your project. You can look up the names by calling
+the `suite list` command.
+
+The command will help you specify the batch of data that you want the validation operator to validate interactively.
+
+
+.. code-block:: bash
+
+    $ great_expectations validation-operator --name action_list_operator --suite npi.warning
+    ...
+    ...
+    ...
+
+
+``great_expectations validation-operator run ----validation_config_file <VALIDATION_CONFIG_FILE_PATH>``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want run a validation operator non-interactively, use the `--validation_config_file` argument to specify the path of the validation configuration JSON file.
+
+.. note::
+    A validation operator can validate multiple batches of data and use multiple expectation suites to validate each batch.
+
+A validation config file specifies the name of the validation operator in your project and
+the list of batches of data that you want the operator to validate.
+Each batch is defined using "batch_kwargs".
+The "expectation_suite_names" attribute for each batch specifies the list of the names of expectation suites that the validation o
+operator should use to validate the batch.
+
+Here is an example of a validation config file:
+
+.. code-block:: json
+
+    {
+      "validation_operator_name": "action_list_operator",
+      "batches": [
+        {
+          "batch_kwargs": {
+            "path": "/Users/me/projects/my_project/data/data.csv",
+            "datasource": "my_filesystem_datasource",
+            "reader_method": "read_csv"
+          },
+          "expectation_suite_names": ["suite_one", "suite_two"]
+        },
+        {
+          "batch_kwargs": {
+            "query": "select * from users where status = 1",
+            "datasource": "my_redshift_datasource",
+          },
+          "expectation_suite_names": ["suite_three"]
+        }
+      ]
+    }
+
+.. code-block:: bash
+
+    $ great_expectations validation-operator run ----validation_config_file my_val_config.json
+    ...
+    ...
+    ...
+
 
 
 great_expectations datasource

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -10,6 +10,7 @@ from great_expectations.cli.docs import docs
 from great_expectations.cli.init import init
 from great_expectations.cli.project import project
 from great_expectations.cli.suite import suite
+from great_expectations.cli.validation_operator import validation_operator
 
 
 # TODO: consider using a specified-order supporting class for help (but wasn't working with python 2)
@@ -52,6 +53,7 @@ cli.add_command(docs)
 cli.add_command(init)
 cli.add_command(project)
 cli.add_command(suite)
+cli.add_command(validation_operator)
 
 
 def main():

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -32,7 +32,7 @@ Welcome to the great_expectations CLI!
 
 Most commands follow this format: great_expectations <NOUN> <VERB>
 
-The nouns are: datasource, docs, project, suite
+The nouns are: datasource, docs, project, suite, validation-operator
 
 Most nouns accept the following verbs: new, list, edit
 

--- a/great_expectations/cli/validation_operator.py
+++ b/great_expectations/cli/validation_operator.py
@@ -1,0 +1,253 @@
+import json
+import os
+import subprocess
+import sys
+
+import click
+from datetime import datetime
+from great_expectations import DataContext
+from great_expectations import exceptions as ge_exceptions
+from great_expectations.cli.cli_logging import logger
+from great_expectations.cli.datasource import (
+    create_expectation_suite as create_expectation_suite_impl,
+)
+from great_expectations.cli.datasource import (
+    get_batch_kwargs,
+    select_datasource,
+)
+from great_expectations.cli.util import cli_message
+from great_expectations.data_asset import DataAsset
+from ruamel.yaml import YAML, YAMLError
+
+try:
+    json_parse_exception = json.decoder.JSONDecodeError
+except AttributeError:  # Python 2
+    json_parse_exception = ValueError
+
+try:
+    from sqlalchemy.exc import SQLAlchemyError
+except ImportError:
+    # We'll redefine this error in code below to catch ProfilerError, which is caught above, so SA errors will
+    # just fall through
+    SQLAlchemyError = ge_exceptions.ProfilerError
+
+
+@click.group()
+def validation_operator():
+    """validation operator operations"""
+    pass
+
+
+@validation_operator.command(name="run")
+@click.option(
+    "--validation_config_file",
+    "-f",
+    default=None,
+    help="""The path of the validation config file (JSON). """,
+)
+@click.option(
+    "--name",
+    "-n",
+    default=None,
+    help="""The name of the validation operator. """,
+)
+@click.option(
+    "--suite",
+    "-s",
+    default=None,
+    help="""The name of the expectation suite. """,
+)
+@click.option(
+    "--run_id",
+    "-r",
+    default=None,
+    help="""Run id """,
+)
+@click.option(
+    "--datasource",
+    "-ds",
+    default=None,
+    help="""The name of the datasource. The datasource must contain a single BatchKwargGenerator that can list data assets in the datasource """,
+)
+@click.option(
+    "--batch-kwargs",
+    default=None,
+    help="""Batch_kwargs that specify the batch of data to be used a sample when editing the suite. Must be a valid JSON dictionary.
+Make sure to escape quotes. Example: "{\"datasource\": \"my_db\", \"query\": \"select * from my_table\"}"    
+""",
+)
+@click.option(
+    "--directory",
+    "-d",
+    default=None,
+    help="The project's great_expectations directory.",
+)
+@click.option(
+    "--jupyter/--no-jupyter",
+    is_flag=True,
+    help="By default launch jupyter notebooks unless you specify the --no-jupyter flag",
+    default=True,
+)
+def validation_operator_run(name, run_id, validation_config_file, suite, datasource, directory, jupyter, batch_kwargs):
+    """
+    Run validation operator
+
+    The SUITE argument is required. This is the name you gave to the suite
+    when you created it.
+
+    A batch of data is required to edit the suite, which is used as a sample.
+
+    The edit command will help you specify a batch interactively. Or you can
+    specify them manually by providing --batch-kwargs in valid JSON format.
+
+    Read more about specifying batches of data in the documentation: https://docs.greatexpectations.io/
+    """
+
+    try:
+        context = DataContext(directory)
+    except ge_exceptions.ConfigNotFoundError as err:
+        cli_message("<red>{}</red>".format(err.message))
+        return
+
+    if validation_config_file is not None:
+        try:
+            with open(validation_config_file) as f:
+                validation_config = json.load(f)
+        except IOError:
+            raise ge_exceptions.ConfigNotFoundError()
+
+    else:
+
+        if suite.endswith(".json"):
+            suite = suite[:-5]
+        try:
+            suite = context.get_expectation_suite(suite)
+        except ge_exceptions.DataContextError as e:
+            cli_message(
+                f"<red>Could not find a suite named `{suite_name}`.</red> Please check "
+                "the name by running `great_expectations suite list` and try again."
+            )
+            logger.info(e)
+            sys.exit(1)
+
+        batch_kwargs_json = batch_kwargs
+        batch_kwargs = None
+        if batch_kwargs_json:
+            try:
+                batch_kwargs = json.loads(batch_kwargs_json)
+                if datasource:
+                    batch_kwargs["datasource"] = datasource
+                _batch = context.get_batch(batch_kwargs, suite.expectation_suite_name)
+                assert isinstance(_batch, DataAsset)
+            except json_parse_exception as je:
+                cli_message(
+                    "<red>Please check that your batch_kwargs are valid JSON.\n{}</red>".format(
+                        je
+                    )
+                )
+                sys.exit(1)
+            except ge_exceptions.DataContextError:
+                cli_message(
+                    "<red>Please check that your batch_kwargs are able to load a batch.</red>"
+                )
+                sys.exit(1)
+            except ValueError as ve:
+                cli_message(
+                    "<red>Please check that your batch_kwargs are able to load a batch.\n{}</red>".format(
+                        ve
+                    )
+                )
+                sys.exit(1)
+
+        if not batch_kwargs:
+            cli_message(
+                """
+    A batch of data is required - let's help you to specify it."""
+            )
+
+            additional_batch_kwargs = None
+            try:
+                data_source = select_datasource(context, datasource_name=datasource)
+            except ValueError as ve:
+                cli_message("<red>{}</red>".format(ve))
+                sys.exit(1)
+
+            if not data_source:
+                cli_message("<red>No datasources found in the context.</red>")
+                sys.exit(1)
+
+            if batch_kwargs is None:
+                (
+                    datasource_name,
+                    batch_kwarg_generator,
+                    data_asset,
+                    batch_kwargs,
+                ) = get_batch_kwargs(
+                    context,
+                    datasource_name=data_source.name,
+                    generator_name=None,
+                    generator_asset=None,
+                    additional_batch_kwargs=additional_batch_kwargs,
+                )
+
+
+        validation_config = {
+            "validation_operator_name": name,
+            "batches": [
+                {
+                "batch_kwargs": batch_kwargs,
+                "expectation_suite_names": [suite.expectation_suite_name]
+                }
+            ]
+        }
+
+    validation_operator_name = validation_config["validation_operator_name"]
+    batches_to_validate = []
+    for entry in validation_config["batches"]:
+        for expectation_suite_name in entry["expectation_suite_names"]:
+            batch = context.get_batch(entry["batch_kwargs"], expectation_suite_name)
+            batches_to_validate.append(batch)
+
+    if run_id is None:
+        run_id = datetime.utcnow().strftime("%Y%m%dT%H%M%S.%fZ")
+
+    results = context.run_validation_operator(
+        validation_operator_name,
+        assets_to_validate=[batch],
+        run_id=run_id)  # e.g., Airflow run id or some run identifier that your pipeline uses.
+
+    if not results["success"]:
+        cli_message("Validation Failed!")
+        sys.exit(1)
+    else:
+        cli_message("Validation Succeeded!")
+        sys.exit(0)
+
+# @validation_operator.command(name="list")
+# @click.option(
+#     "--directory",
+#     "-d",
+#     default=None,
+#     help="The project's great_expectations directory.",
+# )
+# def suite_list(directory):
+#     """Lists available expectation suites."""
+#     try:
+#         context = DataContext(directory)
+#     except ge_exceptions.ConfigNotFoundError as err:
+#         cli_message("<red>{}</red>".format(err.message))
+#         return
+#
+#     suite_names = context.list_expectation_suite_names()
+#     if len(suite_names) == 0:
+#         cli_message("No expectation suites found")
+#         return
+#
+#     if len(suite_names) == 1:
+#         cli_message("1 expectation suite found:")
+#
+#     if len(suite_names) > 1:
+#         cli_message("{} expectation suites found:".format(len(suite_names)))
+#
+#     for name in suite_names:
+#         cli_message("\t{}".format(name))

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -533,7 +533,7 @@ class BaseDataContext(object):
             **kwargs
         )
 
-    def list_validation_operators(self):
+    def list_validation_operator_names(self):
         if self.validation_operators:
             return self.validation_operators.keys()
         else:

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -533,6 +533,12 @@ class BaseDataContext(object):
             **kwargs
         )
 
+    def list_validation_operators(self):
+        if self.validation_operators:
+            return self.validation_operators.keys()
+        else:
+            return []
+
     def add_datasource(self, name, initialize=True, **kwargs):
         """Add a new datasource to the data context, with configuration provided as kwargs.
         Args:

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -534,10 +534,9 @@ class BaseDataContext(object):
         )
 
     def list_validation_operator_names(self):
-        if self.validation_operators:
-            return self.validation_operators.keys()
-        else:
+        if not self.validation_operators:
             return []
+        return list(self.validation_operators.keys())
 
     def add_datasource(self, name, initialize=True, **kwargs):
         """Add a new datasource to the data context, with configuration provided as kwargs.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -26,7 +26,7 @@ def test_cli_command_entrance(caplog):
 
   Most commands follow this format: great_expectations <NOUN> <VERB>
 
-  The nouns are: datasource, docs, project, suite
+  The nouns are: datasource, docs, project, suite, validation-operator
 
   Most nouns accept the following verbs: new, list, edit
 
@@ -44,12 +44,13 @@ Options:
   --help         Show this message and exit.
 
 Commands:
-  datasource  datasource operations
-  docs        data docs operations
-  init        Initialize a new Great Expectations project.
-  project     project operations
-  suite       expectation suite operations
-  tap         tap operations
+  datasource           datasource operations
+  docs                 data docs operations
+  init                 Initialize a new Great Expectations project.
+  project              project operations
+  suite                expectation suite operations
+  tap                  tap operations
+  validation-operator  validation operator operations
 """
     )
     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_validation_operator.py
+++ b/tests/cli/test_validation_operator.py
@@ -9,7 +9,6 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
-from great_expectations.core import ExpectationSuite
 from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
@@ -32,5 +31,201 @@ def test_validation_operator_run_interactive_golden_path(caplog, data_context, f
         catch_exceptions=False,
     )
     stdout = result.stdout
+    assert "Validation Failed" in stdout
     assert result.exit_code == 1
     assert_no_logging_messages_or_tracebacks(caplog, result)
+
+def test_validation_operator_run_interactive_pass_non_existing_expectation_suite(caplog, data_context, filesystem_csv_2
+):
+    """
+    Interactive mode: pass an non-existing suite name and an existing validation
+    operator name, select an existing file.
+    """
+    not_so_empty_data_context = data_context
+    root_dir = not_so_empty_data_context.root_directory
+    os.mkdir(os.path.join(root_dir, "uncommitted"))
+
+    runner = CliRunner(mix_stderr=False)
+    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
+    result = runner.invoke(
+        cli,
+        ["validation-operator", "run", "-d", root_dir, "--name", "default", "--suite", "this.suite.does.not.exist"],
+        input=f"{csv_path}\n",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+    assert "Could not find a suite named" in stdout
+    assert result.exit_code == 1
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+def test_validation_operator_run_interactive_pass_non_existing_operator_name(caplog, data_context, filesystem_csv_2
+):
+    """
+    Interactive mode: pass an non-existing suite name and an existing validation
+    operator name, select an existing file.
+    """
+    not_so_empty_data_context = data_context
+    root_dir = not_so_empty_data_context.root_directory
+    os.mkdir(os.path.join(root_dir, "uncommitted"))
+
+    runner = CliRunner(mix_stderr=False)
+    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
+    result = runner.invoke(
+        cli,
+        ["validation-operator", "run", "-d", root_dir, "--name", "this_val_op_does_not_exist", "--suite", "my_dag_node.default"],
+        input=f"{csv_path}\n",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+    assert "Could not find a validation operator" in stdout
+    assert result.exit_code == 1
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+def test_validation_operator_run_noninteractive_golden_path(caplog, data_context, filesystem_csv_2
+):
+    """
+    Non-nteractive mode golden path - use the --validation_config_file argument to pass the path
+    to a valid validation config file
+    """
+    not_so_empty_data_context = data_context
+    root_dir = not_so_empty_data_context.root_directory
+    os.mkdir(os.path.join(root_dir, "uncommitted"))
+
+    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
+
+    validation_config = {
+      "validation_operator_name": "default",
+      "batches": [
+        {
+          "batch_kwargs": {
+            "path": csv_path,
+            "datasource": "mydatasource",
+            "reader_method": "read_csv"
+          },
+          "expectation_suite_names": ["my_dag_node.default"]
+        }
+      ]
+    }
+    validation_config_file_path = os.path.join(root_dir, "uncommitted", "validation_config_1.json")
+    with open(validation_config_file_path, 'w') as f:
+        json.dump(validation_config, f)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        ["validation-operator", "run", "-d", root_dir, "--validation_config_file", validation_config_file_path],
+        catch_exceptions=False
+    )
+    stdout = result.stdout
+    assert "Validation Failed" in stdout
+    assert result.exit_code == 1
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+def test_validation_operator_run_noninteractive_validation_config_file_does_not_exist(caplog, data_context, filesystem_csv_2
+):
+    """
+    Non-nteractive mode. Use the --validation_config_file argument to pass the path
+    to a validation config file that does not exist.
+    """
+    not_so_empty_data_context = data_context
+    root_dir = not_so_empty_data_context.root_directory
+    os.mkdir(os.path.join(root_dir, "uncommitted"))
+
+    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
+
+    validation_config_file_path = os.path.join(root_dir, "uncommitted", "validation_config_1.json")
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        ["validation-operator", "run", "-d", root_dir, "--validation_config_file", validation_config_file_path],
+        catch_exceptions=False
+    )
+    stdout = result.stdout
+    assert "Failed to process the --validation_config_file argument" in stdout
+    assert result.exit_code == 1
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+def test_validation_operator_run_noninteractive_validation_config_file_does_is_misconfigured(caplog, data_context, filesystem_csv_2
+):
+    """
+    Non-nteractive mode. Use the --validation_config_file argument to pass the path
+    to a validation config file that is misconfigured - one of the batches does not
+    have expectation_suite_names attribute
+    """
+    not_so_empty_data_context = data_context
+    root_dir = not_so_empty_data_context.root_directory
+    os.mkdir(os.path.join(root_dir, "uncommitted"))
+
+    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
+
+    validation_config = {
+      "validation_operator_name": "default",
+      "batches": [
+        {
+          "batch_kwargs": {
+            "path": csv_path,
+            "datasource": "mydatasource",
+            "reader_method": "read_csv"
+          },
+          "wrong_attribute_expectation_suite_names": ["my_dag_node.default1"]
+        }
+      ]
+    }
+    validation_config_file_path = os.path.join(root_dir, "uncommitted", "validation_config_1.json")
+    with open(validation_config_file_path, 'w') as f:
+        json.dump(validation_config, f)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        ["validation-operator", "run", "-d", root_dir, "--validation_config_file", validation_config_file_path],
+        catch_exceptions=False
+    )
+    stdout = result.stdout
+    assert "is misconfigured: Each batch must have a list of expectation suite names" in stdout
+    assert result.exit_code == 1
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+def test_validation_operator_list_with_one_operator(caplog, empty_data_context):
+    project_dir = empty_data_context.root_directory
+    context = DataContext(project_dir)
+    context.create_expectation_suite("a.warning")
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(
+        cli, "validation-operator list -d {}".format(project_dir), catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "1 validation operator found" in result.output
+    assert "\taction_list_operator" in result.output
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+@mock.patch.object(DataContext, 'list_validation_operator_names', return_value=[], side_effect=None)
+def test_validation_operator_list_with_no_operators(caplog, empty_data_context):
+    project_dir = empty_data_context.root_directory
+    context = DataContext(project_dir)
+    context.create_expectation_suite("a.warning")
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(
+        cli, "validation-operator list -d {}".format(project_dir), catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No validation operators are configured in the project" in result.output
+
+
+@mock.patch.object(DataContext, 'list_validation_operator_names', return_value=["op_one", "op_two"], side_effect=None)
+def test_validation_operator_list_with_two_operators(caplog, empty_data_context):
+    project_dir = empty_data_context.root_directory
+    context = DataContext(project_dir)
+    context.create_expectation_suite("a.warning")
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(
+        cli, "validation-operator list -d {}".format(project_dir), catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "2 validation operators" in result.output

--- a/tests/cli/test_validation_operator.py
+++ b/tests/cli/test_validation_operator.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+import os
+
+import mock
+from click.testing import CliRunner
+
+from great_expectations import DataContext
+from great_expectations.cli import cli
+from great_expectations.core import ExpectationSuite
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks
+
+
+def test_validation_operator_run_interactive_golden_path(caplog, data_context, filesystem_csv_2
+):
+    """
+    Interactive mode golden path - pass an existing suite name and an existing validation
+    operator name, select an existing file.
+    """
+    not_so_empty_data_context = data_context
+    root_dir = not_so_empty_data_context.root_directory
+    os.mkdir(os.path.join(root_dir, "uncommitted"))
+
+    runner = CliRunner(mix_stderr=False)
+    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
+    result = runner.invoke(
+        cli,
+        ["validation-operator", "run", "-d", root_dir, "--name", "default", "--suite", "my_dag_node.default"],
+        input=f"{csv_path}\n",
+        catch_exceptions=False,
+    )
+    stdout = result.stdout
+    assert result.exit_code == 1
+    assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_validation_operator.py
+++ b/tests/cli/test_validation_operator.py
@@ -131,8 +131,6 @@ def test_validation_operator_run_noninteractive_validation_config_file_does_not_
     root_dir = not_so_empty_data_context.root_directory
     os.mkdir(os.path.join(root_dir, "uncommitted"))
 
-    csv_path = os.path.join(filesystem_csv_2, "f1.csv")
-
     validation_config_file_path = os.path.join(root_dir, "uncommitted", "validation_config_1.json")
 
     runner = CliRunner(mix_stderr=False)

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -41,11 +41,6 @@ try:
 except ImportError:
     import mock
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 yaml = YAML()
 
 
@@ -1117,3 +1112,12 @@ def test_get_batch_when_passed_a_suite(titanic_data_context):
     batch = context.get_batch(batch_kwargs, suite)
     assert isinstance(batch, Dataset)
     assert isinstance(batch.get_expectation_suite(), ExpectationSuite)
+
+
+def test_list_validation_operators_data_context_with_none_returns_empty_list(titanic_data_context):
+    titanic_data_context.validation_operators = {}
+    assert titanic_data_context.list_validation_operator_names() == []
+
+
+def test_list_validation_operators_data_context_with_one(titanic_data_context):
+    assert titanic_data_context.list_validation_operator_names() == ["default"]


### PR DESCRIPTION
This PR adds two CLI commands for interfacing with validation operators.

Start reviewing by reading the new section in the CLI reference doc (built from the PR).