### PR TITLE
Remove the 'project new' option from the command line.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ The following instructions provide a step-by-step overview of how to contribute 
     * Run: `git remote add upstream git@github.com:great-expectations/great_expectations.git`
     * This sets up a remote called `upstream` to track changes to the main branch.
 * Install all relevant libraries:
-    * Make a new virtual environment (e.g. using virtualenv or conda), name it "great_expectations_dev" or similar.
+    * Make a new virtual environment (e.g. using virtualenv or conda), name it "great_expectations_dev" or similar, and then activate it, e.g.:
+        * `source great_expectations_dev/bin/activate`
     * Install dependencies from requirements-dev.txt to make sure you have the right libraries, then install great_expectations from the version you just forked:
         * `pip install -r requirements-dev.txt`
         * `pip install .`

--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -2,10 +2,6 @@
 
 develop
 -----------------
-
-
-0.9.8
------------------
 * Remove the "project new" option from the command line (since it is not implemented; users can only run "init" to create a new project).
 
 

--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -4,6 +4,11 @@ develop
 -----------------
 
 
+0.9.8
+-----------------
+* Remove the "project new" option from the command line (since it is not implemented; users can only run "init" to create a new project).
+
+
 0.9.7
 -----------------
 * Update marshmallow dependency to >3. NOTE: as of this release, you MUST use marshamllow >3.0, which REQUIRES python 3. (`#1187 <https://github.com/great-expectations/great_expectations/issues/1187>`_) @jcampbell

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -52,9 +52,9 @@ Each noun command and each verb sub-command has a description, and should help y
       The nouns are: datasource, docs, project, suite
       Most nouns accept the following verbs: new, list, edit
 
-      In addition, the CLI supports the following special commands:
+      In particular, the CLI supports the following special commands:
 
-      - great_expectations init : same as `project new`
+      - great_expectations init : create a new great_expectations project
       - great_expectations datasource profile : profile a  datasource
       - great_expectations docs build : compile documentation from expectations
 

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -35,9 +35,9 @@ The nouns are: datasource, docs, project, suite
 
 Most nouns accept the following verbs: new, list, edit
 
-In addition, the CLI supports the following special commands:
+In particular, the CLI supports the following special commands:
 
-- great_expectations init : same as `project new`
+- great_expectations init : create a new great_expectations project
 
 - great_expectations datasource profile : profile a  datasource
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -30,9 +30,9 @@ def test_cli_command_entrance(caplog):
 
   Most nouns accept the following verbs: new, list, edit
 
-  In addition, the CLI supports the following special commands:
+  In particular, the CLI supports the following special commands:
 
-  - great_expectations init : same as `project new`
+  - great_expectations init : create a new great_expectations project
 
   - great_expectations datasource profile : profile a  datasource
 


### PR DESCRIPTION
Remove the "project new" option from the command line (since it is not implemented; users can only run "init" to create a new project).