### PR TITLE
Update bigquery types support (#1174)

### DIFF
--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -21,11 +21,14 @@ class BasicDatasetProfilerBase(DatasetProfiler):
     that is used by the dataset profiler classes that extend this class.
     """
 
+    # Future support possibility: JSON (RECORD)
+    # Future support possibility: BINARY (BYTES)
     INT_TYPE_NAMES = {"INTEGER", "int", "INT", "TINYINT", "BYTEINT", "SMALLINT", "BIGINT", "IntegerType", "LongType", "DECIMAL"}
     FLOAT_TYPE_NAMES = {"FLOAT", "FLOAT4", "FLOAT8", "DOUBLE_PRECISION", "NUMERIC", "FloatType", "DoubleType", "float"}
-    STRING_TYPE_NAMES = {"CHAR", "VARCHAR", "TEXT", "StringType", "string", "str"}
+    STRING_TYPE_NAMES = {"CHAR", "VARCHAR", "TEXT", "STRING", "StringType", "string", "str"}
     BOOLEAN_TYPE_NAMES = {"BOOLEAN", "BOOL", "bool", "BooleanType"}
-    DATETIME_TYPE_NAMES = {"DATETIME", "DATE", "TIMESTAMP", "DateType", "TimestampType", "datetime64", "Timestamp"}
+    DATETIME_TYPE_NAMES = {"DATETIME", "DATE", "TIME", "TIMESTAMP", "DateType", "TimestampType", "datetime64",
+                           "Timestamp"}
 
     @classmethod
     def _get_column_type(cls, df, column):

--- a/tests/datasource/test_sqlalchemy_datasource_workarounds.py
+++ b/tests/datasource/test_sqlalchemy_datasource_workarounds.py
@@ -1,16 +1,2 @@
 # This file is intended for tests whose functionality is a workaround for deficiencies in upstream libraries.
 # In an ideal world, it is empty. As fixes come to be, we can replace its items.
-
-import pybigquery
-import sqlalchemy as sa
-
-from great_expectations.dataset import SqlAlchemyDataset
-
-
-def test_pybigquery_module_type_import(sqlitedb_engine):
-    # We're really just testing that this particular hack works
-    dataset = SqlAlchemyDataset(engine=sqlitedb_engine, custom_sql='SELECT "cat" as "pet_name"')
-    dataset.engine.dialect = pybigquery.sqlalchemy_bigquery.BigQueryDialect()
-    assert getattr(dataset._get_dialect_type_module(), "RECORD") == sa.types.JSON
-
-    # assert getattr(pybigquery.sqlalchemy_bigquery._type_map, "RECORD") == sa.types.JSON

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -389,6 +389,7 @@ def test_context_profiler_without_generator_name_arg_on_datasource_with_multiple
 
     assert profiling_result == {'success': False, 'error': {'code': 5}}
 
+
 def test_context_profiler_without_generator_name_arg_on_datasource_with_no_generators(not_empty_datacontext):
     """
     If a no generator_name is passed to the profiling method and the datasource has no
@@ -404,6 +405,7 @@ def test_context_profiler_without_generator_name_arg_on_datasource_with_no_gener
     profiling_result = context.profile_datasource("datasource_without_generators", profiler=BasicDatasetProfiler)
 
     assert profiling_result == {'success': False, 'error': {'code': 4}}
+
 
 def test_snapshot_BasicDatasetProfiler_on_titanic():
     """
@@ -422,12 +424,21 @@ def test_snapshot_BasicDatasetProfiler_on_titanic():
 
     # Note: the above already produces an EVR; rerunning isn't strictly necessary just for EVRs
     evrs = df.validate(result_format="SUMMARY")
+    # remove
 
     # THIS IS NOT DEAD CODE. UNCOMMENT TO SAVE A SNAPSHOT WHEN UPDATING THIS TEST
-    # with open('tests/test_sets/expected_evrs_BasicDatasetProfiler_on_titanic.json', 'w+') as file:
+    # with open(
+    #     file_relative_path(
+    #         __file__, '../test_sets/expected_evrs_BasicDatasetProfiler_on_titanic.json'
+    #     ), 'w+'
+    # ) as file:
     #     json.dump(expectationSuiteValidationResultSchema.dump(evrs), file, indent=2)
     #
-    # with open('tests/render/fixtures/BasicDatasetProfiler_evrs.json', 'w+') as file:
+    # with open(
+    #     file_relative_path(
+    #         __file__, '../render/fixtures/BasicDatasetProfiler_evrs.json')
+    #     , 'w+'
+    # ) as file:
     #     json.dump(expectationSuiteValidationResultSchema.dump(evrs), file, indent=2)
 
     with open(
@@ -437,7 +448,7 @@ def test_snapshot_BasicDatasetProfiler_on_titanic():
         "r",
     ) as file:
         expected_evrs = expectationSuiteValidationResultSchema.load(
-            json.load(file, object_pairs_hook=OrderedDict)
+            json.load(file)
         )
 
     # We know that python 2 does not guarantee the order of value_counts, which causes a different
@@ -457,7 +468,6 @@ def test_snapshot_BasicDatasetProfiler_on_titanic():
     del expected_evrs.meta["run_id"]
     del evrs.meta["run_id"]
     del evrs.meta["batch_kwargs"]["ge_batch_id"]
+    del expected_evrs.meta["batch_kwargs"]["ge_batch_id"]
 
-    # DISABLE TEST IN PY2 BECAUSE OF ORDER ISSUE AND NEAR-EOL
-    if not PY2:
-        assert expected_evrs == evrs
+    assert expected_evrs == evrs

--- a/tests/render/fixtures/BasicDatasetProfiler_evrs.json
+++ b/tests/render/fixtures/BasicDatasetProfiler_evrs.json
@@ -1,50 +1,39 @@
 {
-  "success": false,
-  "evaluation_parameters": {},
   "meta": {
-    "great_expectations.__version__": "0.9.0b1+310.g05637d48.dirty",
+    "great_expectations.__version__": "0.9.7+17.g02805059.dirty",
     "expectation_suite_name": "default",
-    "run_id": "20200130T171315.316592Z",
-    "batch_kwargs": {"ge_batch_id": "1234"},
+    "run_id": "20200322T170247.671855Z",
+    "batch_kwargs": {
+      "ge_batch_id": "f499679e-6c5e-11ea-8d20-acde48001122"
+    },
     "batch_markers": {},
     "batch_parameters": {}
   },
-  "statistics": {
-    "evaluated_expectations": 51,
-    "successful_expectations": 43,
-    "unsuccessful_expectations": 8,
-    "success_percent": 84.31372549019608
-  },
+  "success": false,
+  "evaluation_parameters": {},
   "results": [
     {
-      "success": true,
-      "meta": {},
-      "exception_info": {
-        "raised_exception": false,
-        "exception_message": null,
-        "exception_traceback": null
-      },
       "result": {
         "observed_value": 1313
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_table_row_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_table_row_count_to_be_between",
         "kwargs": {
           "min_value": 0,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           "Unnamed: 0",
@@ -56,29 +45,30 @@
           "SexCode"
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_table_columns_to_match_ordered_list",
         "meta": {},
+        "expectation_type": "expect_table_columns_to_match_ordered_list",
         "kwargs": {
           "column_list": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "int64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Unnamed: 0",
           "type_list": [
@@ -95,90 +85,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 1313,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Unnamed: 0",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 1.0,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Unnamed: 0",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Unnamed: 0",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -313,24 +302,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Unnamed: 0",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -342,23 +331,23 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_unique",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_unique",
         "kwargs": {
           "column": "Unnamed: 0",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -370,13 +359,15 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Name",
           "type_list": [
             "CHAR",
+            "STRING",
             "StringType",
             "TEXT",
             "VARCHAR",
@@ -385,90 +376,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 1310,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Name",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.9977151561309977,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Name",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Name",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -603,24 +593,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Name",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": false,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -653,24 +643,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_match_regex",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_match_regex",
         "kwargs": {
           "column": "Name",
           "regex": "^\\s+|\\s+$",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -682,13 +672,15 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "PClass",
           "type_list": [
             "CHAR",
+            "STRING",
             "StringType",
             "TEXT",
             "VARCHAR",
@@ -697,90 +689,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 4,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "PClass",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0030464584920030465,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "PClass",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "PClass",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -851,24 +842,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "PClass",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -880,24 +871,24 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_match_regex",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_match_regex",
         "kwargs": {
           "column": "PClass",
           "regex": "^\\s+|\\s+$",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           "*",
@@ -929,30 +920,31 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "PClass",
           "value_set": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "float64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Age",
           "type_list": [
@@ -967,90 +959,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 75,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0992063492063492,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 557,
         "unexpected_percent": 42.421934501142424,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Age",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 557,
@@ -1185,124 +1176,124 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Age",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.17,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_min_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_min_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 71.0,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_max_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_max_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 30.397989417989418,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_mean_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_mean_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 28.0,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_median_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_median_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": {
           "quantiles": [
@@ -1333,9 +1324,10 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_quantile_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_quantile_values_to_be_between",
         "kwargs": {
           "column": "Age",
           "quantile_ranges": {
@@ -1371,16 +1363,15 @@
           },
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0,
         "element_count": 1313,
@@ -1483,25 +1474,25 @@
           }
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_kl_divergence_to_be_less_than",
         "meta": {},
+        "expectation_type": "expect_column_kl_divergence_to_be_less_than",
         "kwargs": {
           "column": "Age",
           "partition_object": null,
           "threshold": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1513,13 +1504,15 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Sex",
           "type_list": [
             "CHAR",
+            "STRING",
             "StringType",
             "TEXT",
             "VARCHAR",
@@ -1528,90 +1521,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 2,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Sex",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0015232292460015233,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Sex",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Sex",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1674,24 +1666,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Sex",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1703,24 +1695,24 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_match_regex",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_match_regex",
         "kwargs": {
           "column": "Sex",
           "regex": "^\\s+|\\s+$",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           "female",
@@ -1742,30 +1734,31 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "Sex",
           "value_set": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "int64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Survived",
           "type_list": [
@@ -1782,90 +1775,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 2,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Survived",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0015232292460015233,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Survived",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Survived",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1928,24 +1920,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Survived",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           0,
@@ -1967,30 +1959,31 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "Survived",
           "value_set": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "int64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "SexCode",
           "type_list": [
@@ -2007,90 +2000,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 2,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "SexCode",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0015232292460015233,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "SexCode",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "SexCode",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -2153,24 +2145,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "SexCode",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           0,
@@ -2192,15 +2184,28 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "SexCode",
           "value_set": null,
           "result_format": "SUMMARY"
         }
+      },
+      "success": true,
+      "exception_info": {
+        "raised_exception": false,
+        "exception_message": null,
+        "exception_traceback": null
       }
     }
-  ]
+  ],
+  "statistics": {
+    "evaluated_expectations": 51,
+    "successful_expectations": 43,
+    "unsuccessful_expectations": 8,
+    "success_percent": 84.31372549019608
+  }
 }

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -834,7 +834,7 @@ def test_ValidationResultsColumnSectionRenderer_render_table(titanic_profiled_na
     assert content_block.content_block_type == "table"
     assert len(content_block.table) == 6
     assert content_block_stringified.count("$icon") == 6
-    assert "value types must belong to this set: $v__0 $v__1 $v__2 $v__3 $v__4 $v__5." in content_block_stringified
+    assert "value types must belong to this set: $v__0 $v__1 $v__2 $v__3 $v__4 $v__5 $v__6" in content_block_stringified
     assert "may have any number of unique values." in content_block_stringified
     assert "may have any fraction of unique values." in content_block_stringified
     assert "values must not be null, at least $mostly_pct % of the time." in content_block_stringified

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -196,8 +196,8 @@ def test_ValidationResultsPageRenderer_render_validation_info(titanic_profiled_e
                                 'header': {'content_block_type': 'string_template',
                                            'string_template': {'template': 'Info', 'tag': 'h6',
                                                                'styling': {'classes': ['m-0']}}},
-                                'table': [['Great Expectations Version', "0.9.0b1+310.g05637d48.dirty"],
-                                          ['Run ID', "20200130T171315.316592Z"]]}
+                                'table': [['Great Expectations Version', "0.9.7+17.g02805059.dirty"],
+                                          ['Run ID', "20200322T170247.671855Z"]]}
 
     assert validation_info == expected_validation_info
 

--- a/tests/test_sets/expected_evrs_BasicDatasetProfiler_on_titanic.json
+++ b/tests/test_sets/expected_evrs_BasicDatasetProfiler_on_titanic.json
@@ -1,50 +1,39 @@
 {
-  "success": false,
-  "evaluation_parameters": {},
   "meta": {
-    "great_expectations.__version__": "0.9.0b1+310.g05637d48.dirty",
+    "great_expectations.__version__": "0.9.7+17.g02805059.dirty",
     "expectation_suite_name": "default",
-    "run_id": "20200130T171315.316592Z",
-    "batch_kwargs": {},
+    "run_id": "20200322T170247.671855Z",
+    "batch_kwargs": {
+      "ge_batch_id": "f499679e-6c5e-11ea-8d20-acde48001122"
+    },
     "batch_markers": {},
     "batch_parameters": {}
   },
-  "statistics": {
-    "evaluated_expectations": 51,
-    "successful_expectations": 43,
-    "unsuccessful_expectations": 8,
-    "success_percent": 84.31372549019608
-  },
+  "success": false,
+  "evaluation_parameters": {},
   "results": [
     {
-      "success": true,
-      "meta": {},
-      "exception_info": {
-        "raised_exception": false,
-        "exception_message": null,
-        "exception_traceback": null
-      },
       "result": {
         "observed_value": 1313
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_table_row_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_table_row_count_to_be_between",
         "kwargs": {
           "min_value": 0,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           "Unnamed: 0",
@@ -56,29 +45,30 @@
           "SexCode"
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_table_columns_to_match_ordered_list",
         "meta": {},
+        "expectation_type": "expect_table_columns_to_match_ordered_list",
         "kwargs": {
           "column_list": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "int64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Unnamed: 0",
           "type_list": [
@@ -95,90 +85,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 1313,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Unnamed: 0",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 1.0,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Unnamed: 0",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Unnamed: 0",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -313,24 +302,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Unnamed: 0",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -342,23 +331,23 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_unique",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_unique",
         "kwargs": {
           "column": "Unnamed: 0",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -370,13 +359,15 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Name",
           "type_list": [
             "CHAR",
+            "STRING",
             "StringType",
             "TEXT",
             "VARCHAR",
@@ -385,90 +376,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 1310,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Name",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.9977151561309977,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Name",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Name",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -603,24 +593,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Name",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": false,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -653,24 +643,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_match_regex",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_match_regex",
         "kwargs": {
           "column": "Name",
           "regex": "^\\s+|\\s+$",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -682,13 +672,15 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "PClass",
           "type_list": [
             "CHAR",
+            "STRING",
             "StringType",
             "TEXT",
             "VARCHAR",
@@ -697,90 +689,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 4,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "PClass",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0030464584920030465,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "PClass",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "PClass",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -851,24 +842,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "PClass",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -880,24 +871,24 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_match_regex",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_match_regex",
         "kwargs": {
           "column": "PClass",
           "regex": "^\\s+|\\s+$",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           "*",
@@ -929,30 +920,31 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "PClass",
           "value_set": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "float64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Age",
           "type_list": [
@@ -967,90 +959,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 75,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0992063492063492,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 557,
         "unexpected_percent": 42.421934501142424,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Age",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 557,
@@ -1185,124 +1176,124 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Age",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.17,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_min_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_min_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 71.0,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_max_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_max_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 30.397989417989418,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_mean_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_mean_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 28.0,
         "element_count": 1313,
         "missing_count": 557,
         "missing_percent": 42.421934501142424
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_median_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_median_to_be_between",
         "kwargs": {
           "column": "Age",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": {
           "quantiles": [
@@ -1333,9 +1324,10 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_quantile_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_quantile_values_to_be_between",
         "kwargs": {
           "column": "Age",
           "quantile_ranges": {
@@ -1371,16 +1363,15 @@
           },
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0,
         "element_count": 1313,
@@ -1483,25 +1474,25 @@
           }
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_kl_divergence_to_be_less_than",
         "meta": {},
+        "expectation_type": "expect_column_kl_divergence_to_be_less_than",
         "kwargs": {
           "column": "Age",
           "partition_object": null,
           "threshold": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1513,13 +1504,15 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Sex",
           "type_list": [
             "CHAR",
+            "STRING",
             "StringType",
             "TEXT",
             "VARCHAR",
@@ -1528,90 +1521,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 2,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Sex",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0015232292460015233,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Sex",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Sex",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1674,24 +1666,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Sex",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1703,24 +1695,24 @@
         "partial_unexpected_index_list": [],
         "partial_unexpected_counts": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_match_regex",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_match_regex",
         "kwargs": {
           "column": "Sex",
           "regex": "^\\s+|\\s+$",
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           "female",
@@ -1742,30 +1734,31 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "Sex",
           "value_set": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "int64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "Survived",
           "type_list": [
@@ -1782,90 +1775,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 2,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "Survived",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0015232292460015233,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "Survived",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "Survived",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -1928,24 +1920,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "Survived",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           0,
@@ -1967,30 +1959,31 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "Survived",
           "value_set": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": "int64"
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_type_list",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_type_list",
         "kwargs": {
           "column": "SexCode",
           "type_list": [
@@ -2007,90 +2000,89 @@
           ],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 2,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_unique_value_count_to_be_between",
         "kwargs": {
           "column": "SexCode",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": 0.0015232292460015233,
         "element_count": 1313,
         "missing_count": 0,
         "missing_percent": 0.0
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "meta": {},
+        "expectation_type": "expect_column_proportion_of_unique_values_to_be_between",
         "kwargs": {
           "column": "SexCode",
           "min_value": null,
           "max_value": null,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
+      },
       "success": true,
-      "meta": {},
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "unexpected_count": 0,
         "unexpected_percent": 0.0,
         "partial_unexpected_list": []
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_not_be_null",
         "meta": {},
+        "expectation_type": "expect_column_values_to_not_be_null",
         "kwargs": {
           "column": "SexCode",
           "mostly": 0.5,
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": false,
-      "meta": {},
+      },
+      "success": true,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "element_count": 1313,
         "missing_count": 0,
@@ -2153,24 +2145,24 @@
           }
         ]
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
           "column": "SexCode",
           "value_set": [],
           "result_format": "SUMMARY"
         }
-      }
-    },
-    {
-      "success": true,
-      "meta": {},
+      },
+      "success": false,
       "exception_info": {
         "raised_exception": false,
         "exception_message": null,
         "exception_traceback": null
-      },
+      }
+    },
+    {
       "result": {
         "observed_value": [
           0,
@@ -2192,15 +2184,28 @@
           ]
         }
       },
+      "meta": {},
       "expectation_config": {
-        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "meta": {},
+        "expectation_type": "expect_column_distinct_values_to_be_in_set",
         "kwargs": {
           "column": "SexCode",
           "value_set": null,
           "result_format": "SUMMARY"
         }
+      },
+      "success": true,
+      "exception_info": {
+        "raised_exception": false,
+        "exception_message": null,
+        "exception_traceback": null
       }
     }
-  ]
+  ],
+  "statistics": {
+    "evaluated_expectations": 51,
+    "successful_expectations": 43,
+    "unsuccessful_expectations": 8,
+    "success_percent": 84.31372549019608
+  }
 }


### PR DESCRIPTION
This addresses a problem with profiling caused by the confluence of several factors:
1) pybigquery did not previously export its native type map, causing us to have a workaround in place using a namedtuple instead of a class (which does not have a __name__ attribute)
2) the current profiler did not include all possible bigquery type names in its internal type map of names to check
3) In the event that a candidate expectation was proposed for which none of the names were valid type names for a dialect, a debug message was generated, which relied on the __name__ attribute of the current dialect...hence an uncaught stacktrace.