### PR TITLE
tiny bigquery bugfix

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -3,7 +3,7 @@
 develop
 -----------------
 * Remove the "project new" option from the command line (since it is not implemented; users can only run "init" to create a new project).
-
+* fixed bug where expect_column_values_to_not_be_null fails if user does not have bigquery libray installed
 
 0.9.7
 -----------------

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -51,6 +51,7 @@ try:
         BigQueryTypes = namedtuple('BigQueryTypes', sorted(pybigquery.sqlalchemy_bigquery._type_map))
         bigquery_types_tuple = BigQueryTypes(**pybigquery.sqlalchemy_bigquery._type_map)
 except ImportError:
+    bigquery_types_tuple = None
     pybigquery = None
 
 


### PR DESCRIPTION
* fixed bug where expect_column_values_to_not_be_null fails if user does not have bigquery libray installed﻿

## Before:

```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-3-4faf63065bd8> in <module>
      2 
      3 profiler = SampleExpectationsDatasetProfiler()
----> 4 profiler.profile(batch)

~/repos/great_expectations/great_expectations/profile/base.py in profile(cls, data_asset, run_id)
     60             raise GreatExpectationsError("Invalid data_asset for profiler; aborting")
     61 
---> 62         expectation_suite = cls._profile(data_asset)
     63 
     64         batch_kwargs = data_asset.batch_kwargs

~/repos/great_expectations/great_expectations/profile/sample_expectations_dataset_profiler.py in _profile(cls, dataset)
    268 
    269 
--> 270         column = cls._find_next_numeric_column(dataset, columns, profiled_columns, column_cache)
    271         if column:
    272             cls._create_expectations_for_numeric_column(dataset, column)

~/repos/great_expectations/great_expectations/profile/sample_expectations_dataset_profiler.py in _find_next_numeric_column(cls, dataset, columns, profiled_columns, column_cache)
    166 
    167             cardinality = cls._get_column_cardinality_with_caching(dataset, column, column_cache)
--> 168             type = cls._get_column_type_with_caching(dataset, column, column_cache)
    169 
    170             if cardinality in ["many", "very many", "unique"] and type in ["int", "float"]:

~/repos/great_expectations/great_expectations/profile/sample_expectations_dataset_profiler.py in _get_column_type_with_caching(cls, dataset, column_name, cache)
     32         column_type = column_cache_entry.get("type")
     33         if not column_type:
---> 34             column_type = cls._get_column_type(dataset, column_name)
     35             column_cache_entry["type"] = column_type
     36             # remove the expectation

~/repos/great_expectations/great_expectations/profile/basic_dataset_profiler.py in _get_column_type(cls, df, column)
     37         df.set_config_value("interactive_evaluation", True)
     38         try:
---> 39             if df.expect_column_values_to_be_in_type_list(column, type_list=sorted(list(cls.INT_TYPE_NAMES))).success:
     40                 type_ = "int"
     41 

~/repos/great_expectations/great_expectations/data_asset/util.py in f(*args, **kwargs)
     83         @wraps(self.mthd, assigned=('__name__', '__module__'))
     84         def f(*args, **kwargs):
---> 85             return self.mthd(obj, *args, **kwargs)
     86 
     87         f.__doc__ = doc

~/repos/great_expectations/great_expectations/data_asset/data_asset.py in wrapper(self, *args, **kwargs)
    240 
    241                         else:
--> 242                             raise err
    243 
    244                 else:

~/repos/great_expectations/great_expectations/data_asset/data_asset.py in wrapper(self, *args, **kwargs)
    227                 if self._config.get("interactive_evaluation", True) or self._active_validation:
    228                     try:
--> 229                         return_obj = func(self, **evaluation_args)
    230                         if isinstance(return_obj, dict):
    231                             return_obj = ExpectationValidationResult(**return_obj)

~/repos/great_expectations/great_expectations/dataset/sqlalchemy_dataset.py in expect_column_values_to_be_in_type_list(self, column, type_list, mostly, result_format, include_config, catch_exceptions, meta)
    803         else:
    804             types = []
--> 805             type_module = self._get_dialect_type_module()
    806             for type_ in type_list:
    807                 try:

~/repos/great_expectations/great_expectations/dataset/sqlalchemy_dataset.py in _get_dialect_type_module(self)
    718 
    719         # Bigquery
--> 720         if bigquery_types_tuple is not None:
    721             return bigquery_types_tuple
    722 

NameError: name 'bigquery_types_tuple' is not defined
```