### PR TITLE
Remove Python 2 tags from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ config = {
         'Topic :: Software Development',
         'Topic :: Software Development :: Testing',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Closes #1228 (all details in there).

This PR simply removes the Python 2 lines from `setup.py`.

Ideally, someone with admin access to PyPI would go back through old versions of GE (since you dropped PY2 support and manually remove the Python 2 tags from them (if that's even possible)?) although it's not necessary, since nobody should even be using Python 2 anymore.