### PR TITLE
Fix AttributeError when validating expectations from a JSON file

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -5,6 +5,7 @@ develop
 * Remove the "project new" option from the command line (since it is not implemented; users can only run "init" to create a new project).
 * Update type detection for bigquery based on driver changes in pybigquery driver 0.4.14. Added a warning for users who are running an older pybigquery driver
 * added execution tests to the NotebookRenderer to mitigate codegen risks
+* Fix AttributeError when validating expectations from a JSON file
 
 0.9.7
 -----------------

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -936,7 +936,7 @@ class DataAsset(object):
             elif isinstance(expectation_suite, string_types):
                 try:
                     with open(expectation_suite, 'r') as infile:
-                        expectation_suite = expectationSuiteSchema.loads(infile.read()).data
+                        expectation_suite = expectationSuiteSchema.loads(infile.read())
                 except ValidationError:
                     raise
                 except IOError:


### PR DESCRIPTION
When validating expectations from a JSON file (`ge_df.validate(expectation_suite='a-ge-suite.json')`) the following error is raised:

```
AttributeError: 'ExpectationSuite' object has no attribute 'data'
```
This issue is raised when trying to access the `data` attribute in the `ExpectationSuite` object created from the JSON file. 

This PR removes the invalid attribute access.