### PR TITLE
Add datasource -> dataset options and persist feature

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -5,6 +5,12 @@ develop
 * Remove the "project new" option from the command line (since it is not implemented; users can only run "init" to create a new project).
 * Update type detection for bigquery based on driver changes in pybigquery driver 0.4.14. Added a warning for users who are running an older pybigquery driver
 * added execution tests to the NotebookRenderer to mitigate codegen risks
+* Add option "persist", true by default, for SparkDFDataset to persist the DataFrame it is passed. This addresses #1133
+in a deeper way (thanks @tejsvirai for the robust debugging support and reproduction on spark).
+  - Disabling this option should *only* be done if the user has *already* externally persisted the DataFrame, or if the
+dataset is too large to persist but *computations are guaranteed to be stable across jobs*.
+* Enable passing dataset kwargs through datasource via dataset_options batch_kwarg.
+
 
 0.9.7
 -----------------

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -480,7 +480,7 @@ class BaseDataContext(object):
         if not isinstance(batch_kwargs, BatchKwargs):
             raise ge_exceptions.BatchKwargsError("BatchKwargs must be a BatchKwargs object or dictionary.")
 
-        if not isinstance(expectation_suite_name, (ExpectationSuite, ExpectationSuiteIdentifier, string_types)):
+        if not isinstance(expectation_suite_name, (ExpectationSuite, ExpectationSuiteIdentifier, str)):
             raise ge_exceptions.DataContextError(
                 "expectation_suite_name must be an ExpectationSuite, "
                 "ExpectationSuiteIdentifier or string."
@@ -488,6 +488,8 @@ class BaseDataContext(object):
 
         if isinstance(expectation_suite_name, ExpectationSuite):
             expectation_suite = expectation_suite_name
+        elif isinstance(expectation_suite_name, ExpectationSuiteIdentifier):
+            expectation_suite = self.get_expectation_suite(expectation_suite_name.expectation_suite_name)
         else:
             expectation_suite = self.get_expectation_suite(expectation_suite_name)
 

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -332,6 +332,9 @@ class SparkDFDataset(MetaSparkDFDataset):
     def __init__(self, spark_df, *args, **kwargs):
         # Creation of the Spark DataFrame is done outside this class
         self.spark_df = spark_df
+        self._persist = kwargs.pop("persist", True)
+        if self._persist:
+            self.spark_df.persist()
         super(SparkDFDataset, self).__init__(*args, **kwargs)
 
     def head(self, n=5):

--- a/great_expectations/datasource/datasource.py
+++ b/great_expectations/datasource/datasource.py
@@ -228,21 +228,28 @@ class Datasource(object):
             })
         return generators
 
-    def process_batch_parameters(self, limit=None):
+    def process_batch_parameters(self, limit=None, dataset_options=None):
         """Use datasource-specific configuration to translate any batch parameters into batch kwargs at the datasource
         level.
 
         Args:
             limit (int): a parameter all datasources must accept to allow limiting a batch to a smaller number of rows.
+            dataset_options (dict): a set of kwargs that will be passed to the constructor of a dataset built using
+                these batch_kwargs
 
         Returns:
-            batch_parameters, batch_kwargs: a tuple containing all defined batch_parameters and batch_kwargs. Result
-            will include both parameters passed via argument and configured parameters.
+            batch_kwargs: Result will include both parameters passed via argument and configured parameters.
         """
         batch_kwargs = self._datasource_config.get("batch_kwargs", {})
 
         if limit is not None:
             batch_kwargs["limit"] = limit
+
+        if dataset_options is not None:
+            # Then update with any locally-specified reader options
+            if not batch_kwargs.get("dataset_options"):
+                batch_kwargs["dataset_options"] = dict()
+            batch_kwargs["dataset_options"].update(dataset_options)
 
         return batch_kwargs
 

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -32,7 +32,7 @@ class PandasDatasource(Datasource):
     interacting with the local filesystem (the default subdir_reader generator), and from
     existing in-memory dataframes.
     """
-    recognized_batch_parameters = {'reader_method', 'reader_options', 'limit'}
+    recognized_batch_parameters = {'reader_method', 'reader_options', 'limit', 'dataset_options'}
 
     @classmethod
     def build_configuration(cls, data_asset_type=None, generators=None, boto3_options=None, reader_method=None,
@@ -109,9 +109,14 @@ class PandasDatasource(Datasource):
         self._reader_options = configuration_with_defaults.get("reader_options", None)
         self._limit = configuration_with_defaults.get("limit", None)
 
-    def process_batch_parameters(self, reader_method=None, reader_options=None, limit=None):
-        # Note that we do not pass any parameters up, since *all* will be handled by PandasDatasource
-        batch_kwargs = super(PandasDatasource, self).process_batch_parameters()
+    def process_batch_parameters(self,
+                                 reader_method=None,
+                                 reader_options=None,
+                                 limit=None,
+                                 dataset_options=None,
+                                 ):
+        # Note that we do not pass limit up, since even that will be handled by PandasDatasource
+        batch_kwargs = super(PandasDatasource, self).process_batch_parameters(dataset_options=dataset_options)
 
         # Apply globally-configured reader options first
         if self._reader_options:

--- a/great_expectations/datasource/sparkdf_datasource.py
+++ b/great_expectations/datasource/sparkdf_datasource.py
@@ -30,7 +30,7 @@ class SparkDFDatasource(Datasource):
         - InMemoryBatchKwargs ("dataset" key)
         - QueryBatchKwargs ("query" key)
     """
-    recognized_batch_parameters = {'reader_method', 'reader_options', 'limit'}
+    recognized_batch_parameters = {'reader_method', 'reader_options', 'limit', 'dataset_options'}
 
     @classmethod
     def build_configuration(cls, data_asset_type=None, generators=None, spark_config=None, **kwargs):
@@ -100,8 +100,11 @@ class SparkDFDatasource(Datasource):
 
         self._build_generators()
 
-    def process_batch_parameters(self, reader_method=None, reader_options=None, limit=None):
-        batch_kwargs = super(SparkDFDatasource, self).process_batch_parameters(limit=limit)
+    def process_batch_parameters(self, reader_method=None, reader_options=None, limit=None, dataset_options=None):
+        batch_kwargs = super(SparkDFDatasource, self).process_batch_parameters(
+            limit=limit,
+            dataset_options=dataset_options,
+        )
 
         # Apply globally-configured reader options first
         if reader_options:

--- a/great_expectations/datasource/sqlalchemy_datasource.py
+++ b/great_expectations/datasource/sqlalchemy_datasource.py
@@ -35,7 +35,7 @@ class SqlAlchemyDatasource(Datasource):
         that query. The query can be parameterized according to the standard python Template engine, which
         uses $parameter, with additional kwargs passed to the get_batch method.
     """
-    recognized_batch_parameters = {'query_parameters', 'limit'}
+    recognized_batch_parameters = {'query_parameters', 'limit', 'dataset_options'}
 
     @classmethod
     def build_configuration(cls, data_asset_type=None, generators=None, **kwargs):
@@ -189,7 +189,10 @@ class SqlAlchemyDatasource(Datasource):
             data_context=self._data_context
         )
 
-    def process_batch_parameters(self, query_parameters=None, limit=None):
-        batch_kwargs = super(SqlAlchemyDatasource, self).process_batch_parameters(limit=limit)
+    def process_batch_parameters(self, query_parameters=None, limit=None, dataset_options=None):
+        batch_kwargs = super(SqlAlchemyDatasource, self).process_batch_parameters(
+            limit=limit,
+            dataset_options=dataset_options,
+        )
         nested_update(batch_kwargs, {"query_parameters": query_parameters})
         return batch_kwargs

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -59,7 +59,8 @@ class Validator(object):
                 batch_parameters=self.batch.batch_parameters,
                 batch_markers=self.batch.batch_markers,
                 data_context=self.batch.data_context,
-                **self.init_kwargs
+                **self.init_kwargs,
+                **self.batch.batch_kwargs.get("dataset_options", {}),
             )
 
         elif issubclass(self.expectation_engine, SqlAlchemyDataset):
@@ -73,12 +74,12 @@ class Validator(object):
                 batch_markers=self.batch.batch_markers,
                 data_context=self.batch.data_context,
                 expectation_suite=self.expectation_suite,
-                **init_kwargs
+                **init_kwargs,
+                **self.batch.batch_kwargs.get("dataset_options", {}),
             )
 
         elif issubclass(self.expectation_engine, SparkDFDataset):
             import pyspark
-            caching = self.init_kwargs.pop("caching", True)
 
             if not isinstance(self.batch.data, pyspark.sql.DataFrame):
                 raise ValueError("SparkDFDataset expectation_engine requires a spark DataFrame for its batch")
@@ -89,6 +90,6 @@ class Validator(object):
                 batch_parameters=self.batch.batch_parameters,
                 batch_markers=self.batch.batch_markers,
                 data_context=self.batch.data_context,
-                caching=caching,
-                **self.init_kwargs
+                **self.init_kwargs,
+                **self.batch.batch_kwargs.get("dataset_options", {}),
             )

--- a/tests/dataset/test_sparkdfdataset.py
+++ b/tests/dataset/test_sparkdfdataset.py
@@ -1,0 +1,22 @@
+from unittest import mock
+import pandas as pd
+
+from great_expectations.dataset.sparkdf_dataset import SparkDFDataset
+
+
+def test_sparkdfdataset_persist(spark_session):
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    sdf = spark_session.createDataFrame(df)
+    sdf.persist = mock.MagicMock()
+    _ = SparkDFDataset(sdf, persist=True)
+    sdf.persist.assert_called_once()
+
+    sdf = spark_session.createDataFrame(df)
+    sdf.persist = mock.MagicMock()
+    _ = SparkDFDataset(sdf, persist=False)
+    sdf.persist.assert_not_called()
+
+    sdf = spark_session.createDataFrame(df)
+    sdf.persist = mock.MagicMock()
+    _ = SparkDFDataset(sdf)
+    sdf.persist.assert_called_once()

--- a/tests/dataset/test_sqlalchemydataset.py
+++ b/tests/dataset/test_sqlalchemydataset.py
@@ -4,7 +4,7 @@ except ImportError:
     import mock
 import pytest
 import pandas as pd
-from ..test_utils import get_dataset
+from tests.test_utils import get_dataset
 
 from great_expectations.dataset import MetaSqlAlchemyDataset, SqlAlchemyDataset
 

--- a/tests/datasource/test_sqlalchemy_datasource.py
+++ b/tests/datasource/test_sqlalchemy_datasource.py
@@ -197,3 +197,32 @@ def test_sqlalchemy_datasource_query_and_table_handling(sqlitedb_engine):
         })
     mock_batch.assert_called_once_with(engine=sqlitedb_engine, schema=None, query="select * from foo;",
                                        table_name="bar")
+
+
+def test_sqlalchemy_datasource_processes_dataset_options(test_db_connection_string):
+    datasource = SqlAlchemyDatasource('SqlAlchemy', credentials={"url": test_db_connection_string})
+    batch_kwargs = datasource.process_batch_parameters(dataset_options={"caching": False})
+    batch_kwargs["query"] = "select * from table_1;"
+    batch = datasource.get_batch(batch_kwargs)
+    validator = Validator(batch, ExpectationSuite(expectation_suite_name="foo"))
+    dataset = validator.get_dataset()
+    assert dataset.caching is False
+
+    batch_kwargs = datasource.process_batch_parameters(dataset_options={"caching": True})
+    batch_kwargs["query"] = "select * from table_1;"
+    batch = datasource.get_batch(batch_kwargs)
+    validator = Validator(batch, ExpectationSuite(expectation_suite_name="foo"))
+    dataset = validator.get_dataset()
+    assert dataset.caching is True
+
+
+    batch_kwargs = {
+        "query": "select * from table_1;",
+        "dataset_options": {
+            "caching": False
+        }
+    }
+    batch = datasource.get_batch(batch_kwargs)
+    validator = Validator(batch, ExpectationSuite(expectation_suite_name="foo"))
+    dataset = validator.get_dataset()
+    assert dataset.caching is False


### PR DESCRIPTION
* Add option "persist", true by default, for SparkDFDataset to persist the DataFrame it is passed. This addresses #1133
in a deeper way (thanks @tejsvirai for the robust debugging support and reproduction on spark).
  - Disabling this option should *only* be done if the user has *already* externally persisted the DataFrame, or if the
dataset is too large to persist but *computations are guaranteed to be stable across jobs*.
* Enable passing dataset kwargs through datasource via dataset_options batch_kwarg.

Signed-off-by: James Campbell <james.p.campbell@gmail.com>