### PR TITLE
Bugfix/data docs toc scrolling

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -6,6 +6,7 @@ develop
 * Update type detection for bigquery based on driver changes in pybigquery driver 0.4.14. Added a warning for users who are running an older pybigquery driver
 * added execution tests to the NotebookRenderer to mitigate codegen risks
 * Fix AttributeError when validating expectations from a JSON file
+* Data Docs: fix bug that was causing erratic scrolling behavior when table of contents contains many columns
 
 0.9.7
 -----------------

--- a/great_expectations/render/view/templates/table_of_contents.j2
+++ b/great_expectations/render/view/templates/table_of_contents.j2
@@ -9,7 +9,7 @@
     <strong>Table of Contents</strong>
   </div>
   <div class="card-body p-0" style="overflow: auto; height: 100%">
-    <nav id="navigation" class="rounded navbar navbar-light bg-light ge-navigation-sidebar-container p-1">
+    <nav id="navigation" class="rounded navbar navbar-light bg-light ge-navigation-sidebar-container p-1" style="max-height: 70vh;">
       <ul class="nav nav-pills flex-column ge-navigation-sidebar-content col-12 p-0">
         {% for section in sections %}
           {% if section['section_name'] == "Overview" %}


### PR DESCRIPTION
- Fix Data Docs bug that was causing erratic page scrolling behavior when page table of contents has lots of columns