### PR TITLE
Make expectation suite json deterministically human-parseable

### DIFF
--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -836,7 +836,12 @@ class DataAsset(object):
             self._data_context.save_expectation_suite(expectation_suite)
         elif filepath is not None:
             with open(filepath, 'w') as outfile:
-                json.dump(expectationSuiteSchema.dump(expectation_suite), outfile, indent=2)
+                json.dump(
+                    expectationSuiteSchema.dump(expectation_suite),
+                    outfile,
+                    indent=2,
+                    sort_keys=True,
+                )
         else:
             raise ValueError("Unable to save config: filepath or data_context must be available.")
 

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -33,7 +33,7 @@ class ExpectationsStore(Store):
         super().__init__(store_backend=store_backend, runtime_environment=runtime_environment)
 
     def serialize(self, key, value):
-        return self._expectationSuiteSchema.dumps(value)
+        return self._expectationSuiteSchema.dumps(value, indent=2, sort_keys=True)
 
     def deserialize(self, key, value):
         return self._expectationSuiteSchema.loads(value)


### PR DESCRIPTION
Closes #1236 

I add the `indent=2` and `sort_keys=True` paramters to the `.dump` section of the expectation suite store and add `sort_keys=True` in the `save_expectation_suite` method in `data_asset` when a `filename` is provided.

I couldn't find the stuff that needed to change in the tests, but let me know if I've missed anything. :)