### PR TITLE
Feature/hide data docs how to info

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -8,6 +8,7 @@ develop
 * added execution tests to the NotebookRenderer to mitigate codegen risks
 * Fix AttributeError when validating expectations from a JSON file
 * Data Docs: fix bug that was causing erratic scrolling behavior when table of contents contains many columns
+* Data Docs: add ability to hide how-to buttons and related content in Data Docs
 
 0.9.7
 -----------------

--- a/docs/reference/data_docs_reference.rst
+++ b/docs/reference/data_docs_reference.rst
@@ -89,12 +89,12 @@ do so by setting the `validation_results_limit` key in your Data Docs configurat
   data_docs_sites:
     local_site:
       class_name: SiteBuilder
+      show_how_to_buttons: true
       store_backend:
         class_name: TupleFilesystemStoreBackend
         base_directory: uncommitted/data_docs/local_site/
       site_index_builder:
         class_name: DefaultSiteIndexBuilder
-        show_cta_footer: true
         validation_results_limit: 5
 
 Automatically Publishing Data Docs

--- a/great_expectations/data_context/templates.py
+++ b/great_expectations/data_context/templates.py
@@ -108,14 +108,13 @@ data_docs_sites:
   # profiles from the uncommitted directory. Read more at https://docs.greatexpectations.io/en/latest/features/data_docs.html
   local_site:
     class_name: SiteBuilder
-    # set to false to hide "Show Walkthrough" and "How to Edit This Suite" buttons
+    # set to false to hide how-to buttons in Data Docs
     show_how_to_buttons: true
     store_backend:
         class_name: TupleFilesystemStoreBackend
         base_directory: uncommitted/data_docs/local_site/
     site_index_builder:
         class_name: DefaultSiteIndexBuilder
-        show_cta_footer: true
 """
 
 PROJECT_TEMPLATE = PROJECT_HELP_COMMENT + PROJECT_OPTIONAL_CONFIG_COMMENT

--- a/great_expectations/data_context/templates.py
+++ b/great_expectations/data_context/templates.py
@@ -108,12 +108,14 @@ data_docs_sites:
   # profiles from the uncommitted directory. Read more at https://docs.greatexpectations.io/en/latest/features/data_docs.html
   local_site:
     class_name: SiteBuilder
+    # set to false to hide "Show Walkthrough" and "How to Edit This Suite" buttons
+    show_how_to_buttons: true
     store_backend:
         class_name: TupleFilesystemStoreBackend
         base_directory: uncommitted/data_docs/local_site/
     site_index_builder:
         class_name: DefaultSiteIndexBuilder
-        show_cta_footer: True
+        show_cta_footer: true
 """
 
 PROJECT_TEMPLATE = PROJECT_HELP_COMMENT + PROJECT_OPTIONAL_CONFIG_COMMENT

--- a/great_expectations/render/renderer/call_to_action_renderer.py
+++ b/great_expectations/render/renderer/call_to_action_renderer.py
@@ -21,7 +21,7 @@ class CallToActionRenderer(object):
             }
         }
     }
-    
+
     @classmethod
     def render(cls, cta_object):
         """
@@ -36,10 +36,10 @@ class CallToActionRenderer(object):
                 "buttons": # list of CallToActionButtons
             }
         """
-        
+
         if not cta_object.get("header"):
             cta_object["header"] = cls._document_defaults.get("header")
-        
+
         cta_object["styling"] = cls._document_defaults.get("styling")
         cta_object["tooltip_icon"] = {
             "template": "$icon",
@@ -47,7 +47,7 @@ class CallToActionRenderer(object):
                 "icon": ""
             },
             "tooltip": {
-                "content": "To disable this footer, set the show_cta_footer flag in your project config to false."
+                "content": "To disable this footer, set the show_how_to_buttons flag in your project's data_docs_sites config to false."
             },
             "styling": {
                 "params": {
@@ -58,5 +58,5 @@ class CallToActionRenderer(object):
                 }
             }
         }
-        
+
         return cta_object

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -92,12 +92,14 @@ class SiteBuilder(object):
                  store_backend,
                  site_name=None,
                  site_index_builder=None,
+                 show_how_to_buttons=True,
                  site_section_builders=None,
                  runtime_environment=None
                  ):
         self.site_name = site_name
         self.data_context = data_context
         self.store_backend = store_backend
+        self.show_how_to_buttons = show_how_to_buttons
 
         # set custom_styles_directory if present
         custom_styles_directory = None
@@ -122,6 +124,7 @@ class SiteBuilder(object):
             runtime_environment={
                 "data_context": data_context,
                 "custom_styles_directory": custom_styles_directory,
+                "show_how_to_buttons": self.show_how_to_buttons,
                 "target_store": self.target_store,
                 "site_name": self.site_name
             },
@@ -170,7 +173,8 @@ class SiteBuilder(object):
                 runtime_environment={
                     "data_context": data_context,
                     "target_store": self.target_store,
-                    "custom_styles_directory": custom_styles_directory
+                    "custom_styles_directory": custom_styles_directory,
+                    "show_how_to_buttons": self.show_how_to_buttons,
                 },
                 config_defaults={
                     "name": site_section_name,
@@ -221,6 +225,7 @@ class DefaultSiteSectionBuilder(object):
             target_store,
             source_store_name,
             custom_styles_directory=None,
+            show_how_to_buttons=True,
             run_id_filter=None,
             validation_results_limit=None,
             renderer=None,
@@ -231,6 +236,7 @@ class DefaultSiteSectionBuilder(object):
         self.target_store = target_store
         self.run_id_filter = run_id_filter
         self.validation_results_limit = validation_results_limit
+        self.show_how_to_buttons = show_how_to_buttons
 
         if renderer is None:
             raise exceptions.InvalidConfigError(
@@ -297,7 +303,10 @@ class DefaultSiteSectionBuilder(object):
 
             try:
                 rendered_content = self.renderer_class.render(resource)
-                viewable_content = self.view_class.render(rendered_content)
+                viewable_content = self.view_class.render(
+                    rendered_content,
+                    show_how_to_buttons=self.show_how_to_buttons
+                )
             except Exception as e:
                 logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
                 continue
@@ -333,6 +342,7 @@ class DefaultSiteIndexBuilder(object):
             target_store,
             custom_styles_directory=None,
             show_cta_footer=True,
+            show_how_to_buttons=True,
             validation_results_limit=None,
             renderer=None,
             view=None,
@@ -344,6 +354,7 @@ class DefaultSiteIndexBuilder(object):
         self.target_store = target_store
         self.show_cta_footer = show_cta_footer
         self.validation_results_limit = validation_results_limit
+        self.show_how_to_buttons = show_how_to_buttons
 
         if renderer is None:
             renderer = {
@@ -571,7 +582,10 @@ class DefaultSiteIndexBuilder(object):
 
         try:
             rendered_content = self.renderer_class.render(index_links_dict)
-            viewable_content = self.view_class.render(rendered_content)
+            viewable_content = self.view_class.render(
+                rendered_content,
+                show_how_to_buttons=self.show_how_to_buttons
+            )
         except Exception as e:
             logger.error("Exception occurred during data docs rendering: ", e, exc_info=True)
             return None

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -385,7 +385,6 @@ class DefaultSiteIndexBuilder(object):
             data_context,
             target_store,
             custom_styles_directory=None,
-            show_cta_footer=True,
             show_how_to_buttons=True,
             validation_results_limit=None,
             renderer=None,
@@ -396,7 +395,6 @@ class DefaultSiteIndexBuilder(object):
         self.site_name = site_name
         self.data_context = data_context
         self.target_store = target_store
-        self.show_cta_footer = show_cta_footer
         self.validation_results_limit = validation_results_limit
         self.show_how_to_buttons = show_how_to_buttons
 
@@ -585,7 +583,7 @@ class DefaultSiteIndexBuilder(object):
         index_links_dict = OrderedDict()
         index_links_dict["site_name"] = self.site_name
 
-        if self.show_cta_footer:
+        if self.show_how_to_buttons:
             index_links_dict["cta_object"] = self.get_calls_to_action()
 
         for expectation_suite_key in expectation_suite_keys:

--- a/great_expectations/render/view/templates/index_page.j2
+++ b/great_expectations/render/view/templates/index_page.j2
@@ -23,19 +23,22 @@
           data-target="#navigation"
           data-offset="50"
   >
-    {% include 'carousel_modal.j2' %}
 
-    <script>
-      try {
-        if (localStorage.getItem('ge-walkthrough-modal-dismissed') !== 'true') {
-          $(".ge-walkthrough-modal").modal();
+    {% if show_how_to_buttons | default(True) %}
+      {% include 'carousel_modal.j2' %}
+
+      <script>
+        try {
+          if (localStorage.getItem('ge-walkthrough-modal-dismissed') !== 'true') {
+            $(".ge-walkthrough-modal").modal();
+          }
         }
-      }
-      catch(error) {
-        $(".ge-walkthrough-modal").modal();
-        console.log(error);
-      }
-    </script>
+        catch(error) {
+          $(".ge-walkthrough-modal").modal();
+          console.log(error);
+        }
+      </script>
+    {% endif %}
 
     {% include 'top_navbar.j2' %}
     <div class="container-fluid pt-4 pb-4 pl-5 pr-5">

--- a/great_expectations/render/view/templates/page.j2
+++ b/great_expectations/render/view/templates/page.j2
@@ -24,8 +24,9 @@
     >
     {% if show_how_to_buttons | default(True) %}
       {% include 'carousel_modal.j2' %}
+      {% include 'edit_expectations_instructions_modal.j2' %}
     {% endif %}
-    {% include 'edit_expectations_instructions_modal.j2' %}
+
     {% include 'top_navbar.j2' %}
     {% if renderer_type == "ValidationResultsPageRenderer" and show_how_to_buttons | default(True) %}
       <script>

--- a/great_expectations/render/view/templates/page.j2
+++ b/great_expectations/render/view/templates/page.j2
@@ -24,6 +24,9 @@
     >
     {% if show_how_to_buttons | default(True) %}
       {% include 'carousel_modal.j2' %}
+    {% endif %}
+
+    {% if renderer_type in ["ValidationResultsPageRenderer", "ExpectationSuitePageRenderer"] and show_how_to_buttons | default(True) %}
       {% include 'edit_expectations_instructions_modal.j2' %}
     {% endif %}
 

--- a/great_expectations/render/view/templates/page.j2
+++ b/great_expectations/render/view/templates/page.j2
@@ -22,10 +22,12 @@
         data-target="#navigation"
         data-offset="50"
     >
-    {% include 'carousel_modal.j2' %}
+    {% if show_how_to_buttons | default(True) %}
+      {% include 'carousel_modal.j2' %}
+    {% endif %}
     {% include 'edit_expectations_instructions_modal.j2' %}
     {% include 'top_navbar.j2' %}
-    {% if renderer_type == "ValidationResultsPageRenderer" %}
+    {% if renderer_type == "ValidationResultsPageRenderer" and show_how_to_buttons | default(True) %}
       <script>
         try {
           if (localStorage.getItem('ge-walkthrough-modal-dismissed') !== 'true') {

--- a/great_expectations/render/view/templates/page_action_card.j2
+++ b/great_expectations/render/view/templates/page_action_card.j2
@@ -42,23 +42,24 @@
         </div>
       </div>
     {% endif %}
+    {% if show_how_to_buttons | default(True) %}
+      {% if renderer_type in ["ValidationResultsPageRenderer", "ExpectationSuitePageRenderer"] %}
+        <div class="mb-2">
+          <div class="d-flex justify-content-center">
+            <button type="button" class="btn btn-warning" data-toggle="modal" data-target=".ge-expectation-editing-instructions-modal">
+              <i class="fas fa-edit"></i> How to Edit This Suite
+            </button>
+          </div>
+        </div>
+      {% endif %}
 
-    {% if renderer_type in ["ValidationResultsPageRenderer", "ExpectationSuitePageRenderer"] %}
       <div class="mb-2">
         <div class="d-flex justify-content-center">
-          <button type="button" class="btn btn-warning" data-toggle="modal" data-target=".ge-expectation-editing-instructions-modal">
-            <i class="fas fa-edit"></i> How to Edit This Suite
+          <button type="button" class="btn btn-info" data-toggle="modal" data-target=".ge-walkthrough-modal">
+            Show Walkthrough
           </button>
         </div>
       </div>
     {% endif %}
-
-    <div class="mb-2">
-      <div class="d-flex justify-content-center">
-        <button type="button" class="btn btn-info" data-toggle="modal" data-target=".ge-walkthrough-modal">
-          Show Walkthrough
-        </button>
-      </div>
-    </div>
   </div>
 </div>

--- a/great_expectations/render/view/templates/sidebar.j2
+++ b/great_expectations/render/view/templates/sidebar.j2
@@ -1,7 +1,9 @@
 <div class="col-lg-2 col-md-2 col-sm-12 d-sm-block px-0">
   {% include 'ge_info.j2' %}
   <div class="sticky">
-    {% include 'page_action_card.j2' %}
+    {% if (renderer_type == "ExpectationSuitePageRenderer" and show_how_to_buttons | default(True)) or (renderer_type != "ExpectationSuitePageRenderer") %}
+      {% include 'page_action_card.j2' %}
+    {% endif %}
     {% if renderer_type != "SiteIndexPageRenderer" %}
       {% include 'table_of_contents.j2' %}
     {% endif %}

--- a/great_expectations/render/view/templates/sidebar.j2
+++ b/great_expectations/render/view/templates/sidebar.j2
@@ -1,7 +1,7 @@
 <div class="col-lg-2 col-md-2 col-sm-12 d-sm-block px-0">
   {% include 'ge_info.j2' %}
   <div class="sticky">
-    {% if (renderer_type == "ExpectationSuitePageRenderer" and show_how_to_buttons | default(True)) or (renderer_type != "ExpectationSuitePageRenderer") %}
+    {% if (renderer_type not in ["ValidationResultsPageRenderer", "SiteIndexPageRenderer"] and show_how_to_buttons | default(True)) or (renderer_type in ["ValidationResultsPageRenderer", "SiteIndexPageRenderer"]) %}
       {% include 'page_action_card.j2' %}
     {% endif %}
     {% if renderer_type != "SiteIndexPageRenderer" %}

--- a/great_expectations/render/view/templates/table_of_contents.j2
+++ b/great_expectations/render/view/templates/table_of_contents.j2
@@ -9,7 +9,7 @@
     <strong>Table of Contents</strong>
   </div>
   <div class="card-body p-0" style="overflow: auto; height: 100%">
-    <nav id="navigation" class="rounded navbar navbar-light bg-light ge-navigation-sidebar-container p-1">
+    <nav id="navigation" class="rounded navbar navbar-light bg-light ge-navigation-sidebar-container p-1" style="max-height: 70vh;">
       <ul class="nav nav-pills flex-column ge-navigation-sidebar-content col-12 p-0">
         {% for section in sections %}
           {% if section['section_name'] == "Overview" %}

--- a/tests/data_context/fixtures/contexts/incomplete_uncommitted/great_expectations/great_expectations.yml
+++ b/tests/data_context/fixtures/contexts/incomplete_uncommitted/great_expectations/great_expectations.yml
@@ -25,7 +25,7 @@ datasources:
 # secrets out of source control & 2) environment-based configuration changes
 # such as staging vs prod.
 #
-# When GE encounters substitution syntax (like `my_key: ${my_value}` or 
+# When GE encounters substitution syntax (like `my_key: ${my_value}` or
 # `my_key: $my_value`) in the config file it will attempt to replace the value
 # of `my_key` with the value from an environment variable `my_value` or a
 # corresponding key read from the file specified using
@@ -72,7 +72,7 @@ stores:
 # Stores are configurable places to store things like Expectations, Validations
 # Data Docs, and more. These are for advanced users only - most users can simply
 # leave this section alone.
-# 
+#
 # Three stores are required: expectations, validations, and
 # evaluation_parameters, and must exist with a valid store entry. Additional
 # stores can be configured for uses such as data_docs, validation_operators, etc.
@@ -101,9 +101,9 @@ data_docs_sites:
   # profiles from the uncommitted directory. Read more at https://docs.greatexpectations.io/en/latest/features/data_docs.html
   local_site:
     class_name: SiteBuilder
+    show_how_to_buttons: true
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/data_docs/local_site/
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
-      show_cta_footer: true

--- a/tests/render/test_data_documentation_site_builder.py
+++ b/tests/render/test_data_documentation_site_builder.py
@@ -11,6 +11,72 @@ from great_expectations.render.renderer.site_builder import SiteBuilder
 from great_expectations.data_context.util import safe_mmkdir
 
 
+def assert_how_to_buttons(context, index_page_locator_info: str, index_links_dict: dict, show_how_to_buttons=True):
+    """Helper function to assert presence or non-presence of how-to buttons and related content in various
+        Data Docs pages.
+    """
+
+    # these are simple checks for presence of certain page elements
+    show_walkthrough_button = "Show Walkthrough"
+    walkthrough_modal = "Great Expectations Walkthrough"
+    cta_footer = "To continue exploring Great Expectations check out one of these tutorials..."
+    how_to_edit_suite_button = "How to Edit This Suite"
+    how_to_edit_suite_modal = "How to Edit This Expectation Suite"
+    action_card = "Actions"
+
+    how_to_page_elements_dict = {
+        "index_pages": [show_walkthrough_button, walkthrough_modal, cta_footer],
+        "expectation_suites": [
+            how_to_edit_suite_button,
+            how_to_edit_suite_modal,
+            show_walkthrough_button,
+            walkthrough_modal
+        ],
+        "validation_results": [
+            how_to_edit_suite_button,
+            how_to_edit_suite_modal,
+            show_walkthrough_button,
+            walkthrough_modal
+        ],
+        "profiling_results": [
+            action_card,
+            show_walkthrough_button,
+            walkthrough_modal
+        ]
+    }
+
+    data_docs_site_dir = os.path.join(
+        context._context_root_directory,
+        context._project_config.data_docs_sites["local_site"]["store_backend"]["base_directory"]
+    )
+
+    page_paths_dict = {
+        "index_pages": [index_page_locator_info],
+        "expectation_suites": [
+            os.path.join(data_docs_site_dir, link_dict["filepath"])
+            for link_dict in index_links_dict.get("expectations_links", [])
+        ],
+        "validation_results": [
+            os.path.join(data_docs_site_dir, link_dict["filepath"])
+            for link_dict in index_links_dict.get("validations_links", [])
+        ],
+        "profiling_results": [
+            os.path.join(data_docs_site_dir, link_dict["filepath"])
+            for link_dict in index_links_dict.get("profiling_links", [])
+        ]
+    }
+
+    for page_type, page_paths in page_paths_dict.items():
+        for page_path in page_paths:
+            with open(page_path, 'r') as f:
+                page = f.read()
+                for how_to_element in how_to_page_elements_dict[page_type]:
+                    if show_how_to_buttons:
+                        assert how_to_element in page
+                    else:
+                        assert how_to_element not in page
+
+
 @pytest.mark.rendered_output
 def test_configuration_driven_site_builder(site_builder_data_context_with_html_store_titanic_random):
     context = site_builder_data_context_with_html_store_titanic_random
@@ -119,6 +185,8 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
     index_page_locator_info = res[0]
     index_links_dict = res[1]
 
+    # assert that how-to buttons and related elements are rendered (default behavior)
+    assert_how_to_buttons(context, index_page_locator_info, index_links_dict)
     print(json.dumps(index_page_locator_info, indent=2))
     assert index_page_locator_info == context.root_directory + '/uncommitted/data_docs/local_site/index.html'
 
@@ -211,3 +279,82 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
                                         "index.html") == html_url
 
 
+@pytest.mark.rendered_output
+def test_configuration_driven_site_builder_without_how_to_buttons(site_builder_data_context_with_html_store_titanic_random):
+    context = site_builder_data_context_with_html_store_titanic_random
+
+    context.add_validation_operator(
+        "validate_and_store",
+        {
+            "class_name": "ActionListValidationOperator",
+            "action_list": [{
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction",
+                    "target_store_name": "validations_store",
+                }
+            }, {
+                "name": "extract_and_store_eval_parameters",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction",
+                    "target_store_name": "evaluation_parameter_store",
+                }
+            }]
+            }
+    )
+
+    # profiling the Titanic datasource will generate one expectation suite and one validation
+    # that is a profiling result
+    datasource_name = 'titanic'
+    data_asset_name = "Titanic"
+    profiler_name = 'BasicDatasetProfiler'
+    generator_name = "subdir_reader"
+    context.profile_datasource(datasource_name)
+
+    # creating another validation result using the profiler's suite (no need to use a new expectation suite
+    # for this test). having two validation results - one with run id "profiling" - allows us to test
+    # the logic of run_id_filter that helps filtering validation results to be included in
+    # the profiling and the validation sections.
+    batch_kwargs = context.build_batch_kwargs(
+        datasource=datasource_name,
+        generator=generator_name,
+        name=data_asset_name
+    )
+
+    expectation_suite_name = "{}.{}.{}.{}".format(
+            datasource_name,
+            generator_name,
+            data_asset_name,
+            profiler_name
+        )
+
+    batch = context.get_batch(
+        batch_kwargs=batch_kwargs,
+        expectation_suite_name=expectation_suite_name,
+    )
+    run_id = "test_run_id_12345"
+    context.run_validation_operator(
+        assets_to_validate=[batch],
+        run_id=run_id,
+        validation_operator_name="validate_and_store",
+    )
+
+    data_docs_config = context._project_config.data_docs_sites
+    local_site_config = data_docs_config['local_site']
+    local_site_config.pop('class_name')
+    # set this flag to false in config to hide how-to buttons and related elements
+    local_site_config["show_how_to_buttons"] = False
+
+    site_builder = SiteBuilder(
+            data_context=context,
+            runtime_environment={
+                "root_directory": context.root_directory
+            },
+            **local_site_config
+        )
+    res = site_builder.build()
+
+    index_page_locator_info = res[0]
+    index_links_dict = res[1]
+
+    assert_how_to_buttons(context, index_page_locator_info, index_links_dict, show_how_to_buttons=False)

--- a/tests/test_fixtures/great_expectations_basic.yml
+++ b/tests/test_fixtures/great_expectations_basic.yml
@@ -30,12 +30,12 @@ validations_store_name: validations_store
 data_docs_sites:
   local_site:
     class_name: SiteBuilder
+    show_how_to_buttons: true
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/data_docs/local_site/
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
-      show_cta_footer: true
 
 stores:
   expectations_store:

--- a/tests/test_fixtures/great_expectations_site_builder.yml
+++ b/tests/test_fixtures/great_expectations_site_builder.yml
@@ -114,6 +114,7 @@ data_docs_sites:
 
     module_name: great_expectations.render.renderer.site_builder
     class_name: SiteBuilder
+    show_how_to_buttons: true
     target_store_name: team_site_html_store
 
     site_index_builder:


### PR DESCRIPTION
- Add ability to hide how-to buttons and related content (i.e. "Show Walkthrough" button and related modal) by setting "show_how_to_buttons" key to False in data_docs site config
- Brings control of cta_footer on index page to above key