### PR TITLE
Add log_level param to jupyter_ux.setup_notebook_logging

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -2,6 +2,7 @@
 
 develop
 -----------------
+* Add log_level parameter to jupyter_ux.setup_notebook_logging.
 
 0.9.8
 -----------------

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -79,7 +79,7 @@ Uncomment the next cell and set data_source_name to one of these names.
     return data_source_name
 
 
-def setup_notebook_logging(logger=None):
+def setup_notebook_logging(logger=None, log_level=logging.INFO):
     """Set up the provided logger for the GE default logging configuration.
 
     Args:
@@ -111,8 +111,8 @@ def setup_notebook_logging(logger=None):
     # chandler.setFormatter(Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s", "%Y-%m-%dT%H:%M:%S%z"))
     chandler.setFormatter(Formatter("%(asctime)s - %(levelname)s - %(message)s", "%Y-%m-%dT%H:%M:%S%z"))
     logger.addHandler(chandler)
-    logger.setLevel(logging.INFO)
-    logger.info("Great Expectations logging enabled at INFO level by JupyterUX module.")
+    logger.setLevel(log_level)
+    logger.info("Great Expectations logging enabled at %s level by JupyterUX module." % (log_level,) )
     #
     # # Filter warnings
     # import warnings


### PR DESCRIPTION
Quick PR to add a helpful parameter to `jupyter_ux.setup_notebook_logging`.

I don't know how to test this---could use a quick tutorial from @jcampbell to explain `test_jupyter_ux.test_configure_logging`.