### PR TITLE
Feature/add jupyter ux rendering methods

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -2,6 +2,7 @@
 
 develop
 -----------------
+* Add experimental display_profiled_column_evrs_as_section and display_column_evrs_as_section methods, with a minor (nonbreaking) refactor to create a new _render_for_jupyter method.
 
 0.9.8
 -----------------

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -239,6 +239,25 @@ cooltip_style_element = """<style type="text/css">
 </style>
 """
 
+# NOTE: Abe 2020/04/04: display_column_expectations_as_section, display_profiled_column_evrs_as_section, and display_column_evrs_as_section
+# all follow a very similar pattern, with quite a bit of redundant code.
+# 
+
+def _render_for_jupyter(
+    view,
+    include_styling,
+    return_without_displaying,
+):
+    if include_styling:
+        html_to_display = bootstrap_link_element+cooltip_style_element+view
+    else:
+        html_to_display = view
+
+    if return_without_displaying:
+        return html_to_display
+    else:
+        display(HTML(html_to_display))
+
 
 def display_column_expectations_as_section(
     expectation_suite,
@@ -264,15 +283,11 @@ def display_column_expectations_as_section(
     document = ExpectationSuiteColumnSectionRenderer().render(column_expectation_list).to_json_dict()
     view = DefaultJinjaSectionView().render({"section": document, "section_loop": 1})
 
-    if include_styling:
-        html_to_display = bootstrap_link_element+cooltip_style_element+view
-    else:
-        html_to_display = view
-
-    if return_without_displaying:
-        return html_to_display
-    else:
-        display(HTML(html_to_display))
+    return _render_for_jupyter(
+        view,
+        include_styling,
+        return_without_displaying,
+    )
 
 
 def display_profiled_column_evrs_as_section(
@@ -303,16 +318,11 @@ def display_profiled_column_evrs_as_section(
         }
     )
 
-    if include_styling:
-        html_to_display = bootstrap_link_element+cooltip_style_element+view
-    else:
-        html_to_display = view
-
-    if return_without_displaying:
-        return html_to_display
-    else:
-        display(HTML(html_to_display))
-
+    return _render_for_jupyter(
+        view,
+        include_styling,
+        return_without_displaying,
+    )
 
 def display_column_evrs_as_section(
     evrs,
@@ -334,15 +344,11 @@ def display_column_evrs_as_section(
         }
     )
 
-    if include_styling:
-        html_to_display = bootstrap_link_element+cooltip_style_element+view
-    else:
-        html_to_display = view
-
-    if return_without_displaying:
-        return html_to_display
-    else:
-        display(HTML(html_to_display))
+    return _render_for_jupyter(
+        view,
+        include_styling,
+        return_without_displaying,
+    )
 
 
 # When importing the jupyter_ux module, we set up a preferred logging configuration

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -9,8 +9,11 @@ from datetime import datetime
 import tzlocal
 from IPython.core.display import display, HTML
 
-from great_expectations.render.renderer import ProfilingResultsColumnSectionRenderer, \
-    ExpectationSuiteColumnSectionRenderer
+from great_expectations.render.renderer import (
+    ExpectationSuiteColumnSectionRenderer,
+    ProfilingResultsColumnSectionRenderer,
+    ValidationResultsColumnSectionRenderer,
+)
 from great_expectations.render.types import RenderedSectionContent
 from great_expectations.render.view import DefaultJinjaSectionView
 
@@ -272,43 +275,74 @@ def display_column_expectations_as_section(
         display(HTML(html_to_display))
 
 
-# def display_column_evrs_as_section(
-#     evrs,
-#     column,
-#     include_styling=True,
-#     return_without_displaying=False,
-# ):
-#     """This is a utility function to render all of the EVRs in an ExpectationSuite with the same column name as an HTML block.
-#
-#     By default, the HTML block is rendered using ExpectationSuiteColumnSectionRenderer and the view is rendered using DefaultJinjaSectionView.
-#     Therefore, it should look exactly the same as the default renderer for build_docs.
-#
-#     Example usage:
-#     display_column_evrs_as_section(exp, "my_column")
-#     """
-#
-#     #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
-#     column_evr_list = [ e for e in evrs.results if "column" in e.expectation_config.kwargs and e.expectation_config.kwargs["column"] == column ]
-#
-#     #TODO: Handle the case where zero evrs match the column name
-#
-#     document = ProfilingResultsColumnSectionRenderer().render(column_evr_list)
-#     view = DefaultJinjaSectionView().render(
-#         {
-#             "section": document,
-#             "section_loop": {"index": 1},
-#         }
-#     )
-#
-#     if include_styling:
-#         html_to_display = bootstrap_link_element+cooltip_style_element+view
-#     else:
-#         html_to_display = view
-#
-#     if return_without_displaying:
-#         return html_to_display
-#     else:
-#         display(HTML(html_to_display))
+def display_profiled_column_evrs_as_section(
+    evrs,
+    column,
+    include_styling=True,
+    return_without_displaying=False,
+):
+    """This is a utility function to render all of the EVRs in an ExpectationSuite with the same column name as an HTML block.
+
+    By default, the HTML block is rendered using ExpectationSuiteColumnSectionRenderer and the view is rendered using DefaultJinjaSectionView.
+    Therefore, it should look exactly the same as the default renderer for build_docs.
+
+    Example usage:
+    display_column_evrs_as_section(exp, "my_column")
+    """
+
+    #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
+    column_evr_list = [ e for e in evrs.results if "column" in e.expectation_config.kwargs and e.expectation_config.kwargs["column"] == column ]
+
+    #TODO: Handle the case where zero evrs match the column name
+
+    document = ProfilingResultsColumnSectionRenderer().render(column_evr_list).to_json_dict()
+    view = DefaultJinjaSectionView().render(
+        {
+            "section": document,
+            "section_loop": {"index": 1},
+        }
+    )
+
+    if include_styling:
+        html_to_display = bootstrap_link_element+cooltip_style_element+view
+    else:
+        html_to_display = view
+
+    if return_without_displaying:
+        return html_to_display
+    else:
+        display(HTML(html_to_display))
+
+
+def display_column_evrs_as_section(
+    evrs,
+    column,
+    include_styling=True,
+    return_without_displaying=False,
+):
+
+    #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
+    column_evr_list = [ e for e in evrs.results if "column" in e.expectation_config.kwargs and e.expectation_config.kwargs["column"] == column ]
+
+    #TODO: Handle the case where zero evrs match the column name
+
+    document = ValidationResultsColumnSectionRenderer().render(column_evr_list).to_json_dict()
+    view = DefaultJinjaSectionView().render(
+        {
+            "section": document,
+            "section_loop": {"index": 1},
+        }
+    )
+
+    if include_styling:
+        html_to_display = bootstrap_link_element+cooltip_style_element+view
+    else:
+        html_to_display = view
+
+    if return_without_displaying:
+        return html_to_display
+    else:
+        display(HTML(html_to_display))
 
 
 # When importing the jupyter_ux module, we set up a preferred logging configuration

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -239,10 +239,6 @@ cooltip_style_element = """<style type="text/css">
 </style>
 """
 
-# NOTE: Abe 2020/04/04: display_column_expectations_as_section, display_profiled_column_evrs_as_section, and display_column_evrs_as_section
-# all follow a very similar pattern, with quite a bit of redundant code.
-# 
-
 def _render_for_jupyter(
     view,
     include_styling,
@@ -303,6 +299,8 @@ def display_profiled_column_evrs_as_section(
 
     Example usage:
     display_column_evrs_as_section(exp, "my_column")
+
+    WARNING: This method is experimental.
     """
 
     #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
@@ -330,6 +328,11 @@ def display_column_evrs_as_section(
     include_styling=True,
     return_without_displaying=False,
 ):
+    """
+    Display validation results for a single column as a section.
+
+    WARNING: This method is experimental.
+    """
 
     #TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
     column_evr_list = [ e for e in evrs.results if "column" in e.expectation_config.kwargs and e.expectation_config.kwargs["column"] == column ]

--- a/tests/jupyter_ux/test_jupyter_ux.py
+++ b/tests/jupyter_ux/test_jupyter_ux.py
@@ -1,4 +1,5 @@
 import logging
+import pytest
 
 import great_expectations as ge
 import great_expectations.jupyter_ux as jux
@@ -10,6 +11,7 @@ def test_styling_elements_exist():
 
     assert jux.cooltip_style_element[:23] == '<style type="text/css">'
     assert ".cooltip" in jux.cooltip_style_element
+
 
 
 def test_display_column_expectations_as_section(basic_expectation_suite):
@@ -150,6 +152,24 @@ def test_display_column_expectations_as_section(basic_expectation_suite):
     </div>
 </div>
 """.replace(" ", "").replace("\t", "").replace("\n", "")
+
+@pytest.mark.smoketest
+def test_display_profiled_column_evrs_as_section(titanic_profiled_evrs_1):
+    section_html = jux.display_profiled_column_evrs_as_section(
+        titanic_profiled_evrs_1,
+        "SexCode",
+        include_styling=False,
+        return_without_displaying=True
+    )
+
+@pytest.mark.smoketest
+def test_display_column_evrs_as_section(titanic_profiled_evrs_1):
+    section_html = jux.display_column_evrs_as_section(
+        titanic_profiled_evrs_1,
+        "SexCode",
+        include_styling=False,
+        return_without_displaying=True
+    )
 
 
 def test_configure_logging(caplog):


### PR DESCRIPTION
Add experimental `display_profiled_column_evrs_as_section` and `display_column_evrs_as_section` methods, with a minor (nonbreaking) refactor to create a new `_render_for_jupyter` method.

They create friendly notebook output like:

<img width="1302" alt="Screen Shot 2020-04-04 at 12 54 24 PM" src="https://user-images.githubusercontent.com/1239085/78460204-b2b8e600-7673-11ea-8167-6d33a4500cfc.png">
<img width="1309" alt="Screen Shot 2020-04-04 at 12 54 43 PM" src="https://user-images.githubusercontent.com/1239085/78460205-bd737b00-7673-11ea-8b1d-7884446d07d7.png">
<img width="1300" alt="Screen Shot 2020-04-04 at 12 54 32 PM" src="https://user-images.githubusercontent.com/1239085/78460207-bf3d3e80-7673-11ea-8434-f760e801f15b.png">

