### PR TITLE
Feature/add core methods to expectation suite

### DIFF
--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -615,6 +615,9 @@ class ExpectationSuite(object):
 
           Returns:
               A copy of the provided expectation with `success_on_last_run` and other specified key-value pairs removed
+
+          Note: 
+              This method may move to ExpectationConfiguration, minus the "copy" part.
         """
         new_expectation = deepcopy(expectation)
 

--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -713,7 +713,7 @@ class ExpectationSuite(object):
             expectation_kwargs = {}
 
         if "column" in expectation_kwargs and column is not None and column is not expectation_kwargs["column"]:
-            raise ValueError("Conflicting column names in remove_expectation: %s and %s" % (
+            raise ValueError("Conflicting column names in find_expectation_indexes: %s and %s" % (
                 column, expectation_kwargs["column"]))
 
         if column is not None:

--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -683,62 +683,23 @@ class ExpectationSuite(object):
     ### CRUD methods ###
 
     def append_expectation(self, expectation_config):
-        """Appends an expectation to `DataAsset._expectation_suite` and drops existing expectations of the same type.
-
-           If `expectation_config` is a column expectation, this drops existing expectations that are specific to \
-           that column and only if it is the same expectation type as `expectation_config`. Otherwise, if it's not a \
-           column expectation, this drops existing expectations of the same type as `expectation config`. \
-           After expectations of the same type are dropped, `expectation_config` is appended to \
-           `DataAsset._expectation_suite`.
+        """Appends an expectation.
 
            Args:
-               expectation_config (json): \
-                   The JSON-serializable expectation to be added to the DataAsset expectations in `_expectation_suite`.
+               expectation_config (ExpectationConfiguration): \
+                   The expectation to be added to the list.
 
            Notes:
-               May raise future errors once json-serializable tests are implemented to check for correct arg formatting
-
+               May want to add type-checking in the future.
         """
-        expectation_type = expectation_config.expectation_type
-
-        # Test to ensure the new expectation is serializable.
-        # FIXME: If it's not, are we sure we want to raise an error?
-        # FIXME: Should we allow users to override the error?
-        # FIXME: Should we try to convert the object using something like recursively_convert_to_json_serializable?
-        # json.dumps(expectation_config)
-
-        # Drop existing expectations with the same expectation_type.
-        # For column_expectations, _append_expectation should only replace expectations
-        # where the expectation_type AND the column match
-        # !!! This is good default behavior, but
-        # !!!    it needs to be documented, and
-        # !!!    we need to provide syntax to override it.
-
-        if 'column' in expectation_config.kwargs:
-            column = expectation_config.kwargs['column']
-
-            self.expectations = [f for f in filter(
-                lambda exp: (exp.expectation_type != expectation_type) or (
-                    'column' in exp.kwargs and exp.kwargs['column'] != column),
-                self.expectations
-            )]
-        else:
-            self.expectations = [f for f in filter(
-                lambda exp: exp.expectation_type != expectation_type,
-                self.expectations
-            )]
-
         self.expectations.append(expectation_config)
-
-    def _append_expectation(self, expectation_config):
-        return self.append_expectation(expectation_config)
 
     def find_expectation_indexes(self,
         expectation_type=None,
         column=None,
         expectation_kwargs=None
     ):
-        """Find matching expectations within _expectation_config.
+        """Find matching expectations and return their indexes.
         Args:
             expectation_type=None                : The name of the expectation type to be matched.
             column=None                          : The name of the column to be matched.
@@ -784,7 +745,7 @@ class ExpectationSuite(object):
         discard_include_config_kwargs=True,
         discard_catch_exceptions_kwargs=True,
     ):
-        """Find matching expectations within _expectation_config.
+        """Find matching expectations and return them.
         Args:
             expectation_type=None                : The name of the expectation type to be matched.
             column=None                          : The name of the column to be matched.
@@ -821,7 +782,7 @@ class ExpectationSuite(object):
         remove_multiple_matches=False,
         dry_run=False,
     ):
-        """Remove matching expectation(s) from _expectation_config.
+        """Remove matching expectation(s).
         Args:
             expectation_type=None                : The name of the expectation type to be matched.
             column=None                          : The name of the column to be matched.

--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -592,6 +592,41 @@ class ExpectationSuite(object):
         return sorted(citations, key=lambda x: x["citation_date"])
 
 
+    ### CRUD methods ###
+
+    def append_expectation(self, expectation_config):
+        pass
+
+    def _append_expectation(self, expectation_config):
+        return self.append_expectation(expectation_config)
+
+    def find_expectation_indexes(self,
+                                 expectation_type=None,
+                                 column=None,
+                                 expectation_kwargs=None
+                                 ):
+        pass
+
+    def find_expectations(self,
+                          expectation_type=None,
+                          column=None,
+                          expectation_kwargs=None,
+                          discard_result_format_kwargs=True,
+                          discard_include_config_kwargs=True,
+                          discard_catch_exceptions_kwargs=True,
+                          ):
+        pass
+
+    def remove_expectation(self,
+                           expectation_type=None,
+                           column=None,
+                           expectation_kwargs=None,
+                           remove_multiple_matches=False,
+                           dry_run=False,
+                           ):
+        pass
+
+
 class ExpectationSuiteSchema(Schema):
     expectation_suite_name = fields.Str()
     expectations = fields.List(fields.Nested(ExpectationConfigurationSchema))

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -338,6 +338,10 @@ class DataAsset(object):
             "result_format": 'BASIC',
         }
 
+    def append_expectation(self, expectation_config):
+        """This method is a thin wrapper for ExpectationSuite.append_expectation"""
+        self._expectation_suite.append_expectation(expectation_config)
+
     def _append_expectation(self, expectation_config):
         """This method is a thin wrapper for ExpectationSuite._append_expectation"""
         self._expectation_suite._append_expectation(expectation_config)

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -339,220 +339,65 @@ class DataAsset(object):
         }
 
     def _append_expectation(self, expectation_config):
-        """Appends an expectation to `DataAsset._expectation_suite` and drops existing expectations of the same type.
-
-           If `expectation_config` is a column expectation, this drops existing expectations that are specific to \
-           that column and only if it is the same expectation type as `expectation_config`. Otherwise, if it's not a \
-           column expectation, this drops existing expectations of the same type as `expectation config`. \
-           After expectations of the same type are dropped, `expectation_config` is appended to \
-           `DataAsset._expectation_suite`.
-
-           Args:
-               expectation_config (json): \
-                   The JSON-serializable expectation to be added to the DataAsset expectations in `_expectation_suite`.
-
-           Notes:
-               May raise future errors once json-serializable tests are implemented to check for correct arg formatting
-
-        """
-        expectation_type = expectation_config.expectation_type
-
-        # Test to ensure the new expectation is serializable.
-        # FIXME: If it's not, are we sure we want to raise an error?
-        # FIXME: Should we allow users to override the error?
-        # FIXME: Should we try to convert the object using something like recursively_convert_to_json_serializable?
-        # json.dumps(expectation_config)
-
-        # Drop existing expectations with the same expectation_type.
-        # For column_expectations, _append_expectation should only replace expectations
-        # where the expectation_type AND the column match
-        # !!! This is good default behavior, but
-        # !!!    it needs to be documented, and
-        # !!!    we need to provide syntax to override it.
-
-        if 'column' in expectation_config.kwargs:
-            column = expectation_config.kwargs['column']
-
-            self._expectation_suite.expectations = [f for f in filter(
-                lambda exp: (exp.expectation_type != expectation_type) or (
-                    'column' in exp.kwargs and exp.kwargs['column'] != column),
-                self._expectation_suite.expectations
-            )]
-        else:
-            self._expectation_suite.expectations = [f for f in filter(
-                lambda exp: exp.expectation_type != expectation_type,
-                self._expectation_suite.expectations
-            )]
-
-        self._expectation_suite.expectations.append(expectation_config)
+        self._expectation_suite._append_expectation(expectation_config)
 
     def _copy_and_clean_up_expectation(self,
-                                       expectation,
-                                       discard_result_format_kwargs=True,
-                                       discard_include_config_kwargs=True,
-                                       discard_catch_exceptions_kwargs=True,
-                                       ):
-        """Returns copy of `expectation` without `success_on_last_run` and other specified key-value pairs removed
+        expectation,
+        discard_result_format_kwargs=True,
+        discard_include_config_kwargs=True,
+        discard_catch_exceptions_kwargs=True,
+    ):
+        """Thin wrapper for ExpectationSuite._copy_and_clean_up_expectation"""
+        return self._expectation_suite._copy_and_clean_up_expectation(
+            expectation=expectation,
+            discard_result_format_kwargs=discard_result_format_kwargs,
+            discard_include_config_kwargs=discard_include_config_kwargs,
+            discard_catch_exceptions_kwargs=discard_catch_exceptions_kwargs,
+        )
 
-          Returns a copy of specified expectation will not have `success_on_last_run` key-value. The other key-value \
-          pairs will be removed by default but will remain in the copy if specified.
 
-          Args:
-              expectation (json): \
-                  The expectation to copy and clean.
-              discard_result_format_kwargs (boolean): \
-                  if True, will remove the kwarg `output_format` key-value pair from the copied expectation.
-              discard_include_config_kwargs (boolean):
-                  if True, will remove the kwarg `include_config` key-value pair from the copied expectation.
-              discard_catch_exceptions_kwargs (boolean):
-                  if True, will remove the kwarg `catch_exceptions` key-value pair from the copied expectation.
-
-          Returns:
-              A copy of the provided expectation with `success_on_last_run` and other specified key-value pairs removed
-        """
-        new_expectation = copy.deepcopy(expectation)
-
-        if "success_on_last_run" in new_expectation:
-            del new_expectation["success_on_last_run"]
-
-        if discard_result_format_kwargs:
-            if "result_format" in new_expectation.kwargs:
-                del new_expectation.kwargs["result_format"]
-                # discards["result_format"] += 1
-
-        if discard_include_config_kwargs:
-            if "include_config" in new_expectation.kwargs:
-                del new_expectation.kwargs["include_config"]
-                # discards["include_config"] += 1
-
-        if discard_catch_exceptions_kwargs:
-            if "catch_exceptions" in new_expectation.kwargs:
-                del new_expectation.kwargs["catch_exceptions"]
-                # discards["catch_exceptions"] += 1
-
-        return new_expectation
-
-    def _copy_and_clean_up_expectations_from_indexes(
-        self,
+    def _copy_and_clean_up_expectations_from_indexes(self,
         match_indexes,
         discard_result_format_kwargs=True,
         discard_include_config_kwargs=True,
         discard_catch_exceptions_kwargs=True,
     ):
-        """Copies and cleans all expectations provided by their index in DataAsset._expectation_suite.expectations.
-
-           Applies the _copy_and_clean_up_expectation method to multiple expectations, provided by their index in \
-           `DataAsset,_expectation_suite.expectations`. Returns a list of the copied and cleaned expectations.
-
-           Args:
-               match_indexes (List): \
-                   Index numbers of the expectations from `expectation_config.expectations` to be copied and cleaned.
-               discard_result_format_kwargs (boolean): \
-                   if True, will remove the kwarg `output_format` key-value pair from the copied expectation.
-               discard_include_config_kwargs (boolean):
-                   if True, will remove the kwarg `include_config` key-value pair from the copied expectation.
-               discard_catch_exceptions_kwargs (boolean):
-                   if True, will remove the kwarg `catch_exceptions` key-value pair from the copied expectation.
-
-           Returns:
-               A list of the copied expectations with `success_on_last_run` and other specified \
-               key-value pairs removed.
-
-           See also:
-               _copy_and_clean_expectation
-        """
-        rval = []
-        for i in match_indexes:
-            rval.append(
-                self._copy_and_clean_up_expectation(
-                    self._expectation_suite.expectations[i],
-                    discard_result_format_kwargs,
-                    discard_include_config_kwargs,
-                    discard_catch_exceptions_kwargs,
-                )
-            )
-
-        return rval
-
-    def find_expectation_indexes(self,
-                                 expectation_type=None,
-                                 column=None,
-                                 expectation_kwargs=None
-                                 ):
-        """Find matching expectations within _expectation_config.
-        Args:
-            expectation_type=None                : The name of the expectation type to be matched.
-            column=None                          : The name of the column to be matched.
-            expectation_kwargs=None              : A dictionary of kwargs to match against.
-
-        Returns:
-            A list of indexes for matching expectation objects.
-            If there are no matches, the list will be empty.
-        """
-        if expectation_kwargs is None:
-            expectation_kwargs = {}
-
-        if "column" in expectation_kwargs and column is not None and column is not expectation_kwargs["column"]:
-            raise ValueError("Conflicting column names in remove_expectation: %s and %s" % (
-                column, expectation_kwargs["column"]))
-
-        if column is not None:
-            expectation_kwargs["column"] = column
-
-        match_indexes = []
-        for i, exp in enumerate(self._expectation_suite.expectations):
-            if expectation_type is None or (expectation_type == exp.expectation_type):
-                # if column == None or ('column' not in exp['kwargs']) or
-                # (exp['kwargs']['column'] == column) or (exp['kwargs']['column']==:
-                match = True
-
-                for k, v in expectation_kwargs.items():
-                    if k in exp['kwargs'] and exp['kwargs'][k] == v:
-                        continue
-                    else:
-                        match = False
-
-                if match:
-                    match_indexes.append(i)
-
-        return match_indexes
-
-    def find_expectations(self,
-                          expectation_type=None,
-                          column=None,
-                          expectation_kwargs=None,
-                          discard_result_format_kwargs=True,
-                          discard_include_config_kwargs=True,
-                          discard_catch_exceptions_kwargs=True,
-                          ):
-        """Find matching expectations within _expectation_config.
-        Args:
-            expectation_type=None                : The name of the expectation type to be matched.
-            column=None                          : The name of the column to be matched.
-            expectation_kwargs=None              : A dictionary of kwargs to match against.
-            discard_result_format_kwargs=True    : In returned expectation object(s), \
-            suppress the `result_format` parameter.
-            discard_include_config_kwargs=True  : In returned expectation object(s), \
-            suppress the `include_config` parameter.
-            discard_catch_exceptions_kwargs=True : In returned expectation object(s), \
-            suppress the `catch_exceptions` parameter.
-
-        Returns:
-            A list of matching expectation objects.
-            If there are no matches, the list will be empty.
-        """
-
-        match_indexes = self.find_expectation_indexes(
-            expectation_type,
-            column,
-            expectation_kwargs,
+        """Thin wrapper for ExpectationSuite._copy_and_clean_up_expectations_from_indexes"""
+        return self._expectation_suite._copy_and_clean_up_expectations_from_indexes(
+            match_indexes=match_indexes,
+            discard_result_format_kwargs=discard_result_format_kwargs,
+            discard_include_config_kwargs=discard_include_config_kwargs,
+            discard_catch_exceptions_kwargs=discard_catch_exceptions_kwargs,
         )
 
-        return self._copy_and_clean_up_expectations_from_indexes(
-            match_indexes,
-            discard_result_format_kwargs,
-            discard_include_config_kwargs,
-            discard_catch_exceptions_kwargs,
+    def find_expectation_indexes(self,
+        expectation_type=None,
+        column=None,
+        expectation_kwargs=None
+    ):
+        """Thin wrapper for ExpectationSuite.find_expectation_indexes"""
+        return self._expectation_suite.find_expectation_indexes(
+            expectation_type=expectation_type,
+            column=column,
+            expectation_kwargs=expectation_kwargs,
+        )
+
+    def find_expectations(self,
+        expectation_type=None,
+        column=None,
+        expectation_kwargs=None,
+        discard_result_format_kwargs=True,
+        discard_include_config_kwargs=True,
+        discard_catch_exceptions_kwargs=True,
+    ):
+        """This method is a thin wrapper for ExpectationSuite.find_expectations()"""
+        return self._expectation_suite.find_expectations(
+            expectation_type=expectation_type,
+            column=column,
+            expectation_kwargs=expectation_kwargs,
+            discard_result_format_kwargs=discard_result_format_kwargs,
+            discard_include_config_kwargs=discard_include_config_kwargs,
+            discard_catch_exceptions_kwargs=discard_catch_exceptions_kwargs,
         )
 
     def remove_expectation(self,
@@ -562,60 +407,14 @@ class DataAsset(object):
                            remove_multiple_matches=False,
                            dry_run=False,
                            ):
-        """Remove matching expectation(s) from _expectation_config.
-        Args:
-            expectation_type=None                : The name of the expectation type to be matched.
-            column=None                          : The name of the column to be matched.
-            expectation_kwargs=None              : A dictionary of kwargs to match against.
-            remove_multiple_matches=False        : Match multiple expectations
-            dry_run=False                        : Return a list of matching expectations without removing
-
-        Returns:
-            None, unless dry_run=True.
-            If dry_run=True and remove_multiple_matches=False then return the expectation that *would be* removed.
-            If dry_run=True and remove_multiple_matches=True then return a list of expectations that *would be* removed.
-
-        Note:
-            If remove_expectation doesn't find any matches, it raises a ValueError.
-            If remove_expectation finds more than one matches and remove_multiple_matches!=True, it raises a ValueError.
-            If dry_run=True, then `remove_expectation` acts as a thin layer to find_expectations, with the default \
-            values for discard_result_format_kwargs, discard_include_config_kwargs, and discard_catch_exceptions_kwargs
-        """
-
-        match_indexes = self.find_expectation_indexes(
-            expectation_type,
-            column,
-            expectation_kwargs,
+        """This method is a thin wrapper for ExpectationSuite.remove()"""
+        return self._expectation_suite.remove_expectation(
+            expectation_type=expectation_type,
+            column=column,
+            expectation_kwargs=expectation_kwargs,
+            remove_multiple_matches=remove_multiple_matches,
+            dry_run=dry_run,
         )
-
-        if len(match_indexes) == 0:
-            raise ValueError('No matching expectation found.')
-
-        elif len(match_indexes) > 1:
-            if not remove_multiple_matches:
-                raise ValueError(
-                    'Multiple expectations matched arguments. No expectations removed.')
-            else:
-
-                if not dry_run:
-                    self._expectation_suite.expectations = [i for j, i in enumerate(
-                        self._expectation_suite.expectations) if j not in match_indexes]
-                else:
-                    return self._copy_and_clean_up_expectations_from_indexes(match_indexes)
-
-        else:  # Exactly one match
-            expectation = self._copy_and_clean_up_expectation(
-                self._expectation_suite.expectations[match_indexes[0]]
-            )
-
-            if not dry_run:
-                del self._expectation_suite.expectations[match_indexes[0]]
-
-            else:
-                if remove_multiple_matches:
-                    return [expectation]
-                else:
-                    return expectation
 
     def set_config_value(self, key, value):
         self._config[key] = value

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -389,7 +389,7 @@ class DataAsset(object):
                 self._expectation_suite.expectations
             )]
         else:
-            self.expectations = [f for f in filter(
+            self._expectation_suite.expectations = [f for f in filter(
                 lambda exp: exp.expectation_type != expectation_type,
                 self._expectation_suite.expectations
             )]

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -339,6 +339,7 @@ class DataAsset(object):
         }
 
     def _append_expectation(self, expectation_config):
+        """This method is a thin wrapper for ExpectationSuite._append_expectation"""
         self._expectation_suite._append_expectation(expectation_config)
 
     def _copy_and_clean_up_expectation(self,
@@ -347,7 +348,7 @@ class DataAsset(object):
         discard_include_config_kwargs=True,
         discard_catch_exceptions_kwargs=True,
     ):
-        """Thin wrapper for ExpectationSuite._copy_and_clean_up_expectation"""
+        """This method is a thin wrapper for ExpectationSuite._copy_and_clean_up_expectation"""
         return self._expectation_suite._copy_and_clean_up_expectation(
             expectation=expectation,
             discard_result_format_kwargs=discard_result_format_kwargs,
@@ -362,7 +363,7 @@ class DataAsset(object):
         discard_include_config_kwargs=True,
         discard_catch_exceptions_kwargs=True,
     ):
-        """Thin wrapper for ExpectationSuite._copy_and_clean_up_expectations_from_indexes"""
+        """This method is a thin wrapper for ExpectationSuite._copy_and_clean_up_expectations_from_indexes"""
         return self._expectation_suite._copy_and_clean_up_expectations_from_indexes(
             match_indexes=match_indexes,
             discard_result_format_kwargs=discard_result_format_kwargs,
@@ -375,7 +376,7 @@ class DataAsset(object):
         column=None,
         expectation_kwargs=None
     ):
-        """Thin wrapper for ExpectationSuite.find_expectation_indexes"""
+        """This method is a thin wrapper for ExpectationSuite.find_expectation_indexes"""
         return self._expectation_suite.find_expectation_indexes(
             expectation_type=expectation_type,
             column=column,

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -158,3 +158,76 @@ def test_find_expectation_indexes_on_empty_suite(empty_suite):
         expectation_kwargs={}
     ) == []
 
+def test_find_expectations(baseline_suite, exp1, exp2):
+    # Note: most of the logic in this method is based on
+    # find_expectation_indexes and _copy_and_clean_up_expectations_from_indexes
+    # These tests do not thoroughly cover that logic.
+    # Instead, they focus on the behavior of the discard_* methods
+
+    assert baseline_suite.find_expectations(
+        column="a",
+        expectation_type="expect_column_values_to_be_between",
+    ) == []
+
+    result = baseline_suite.find_expectations(
+        column="a",
+        expectation_type="expect_column_values_to_be_in_set",
+    )
+    assert len(result) == 1
+    assert result[0] == ExpectationConfiguration(
+        expectation_type="expect_column_values_to_be_in_set",
+        kwargs={
+            "column": "a",
+            "value_set": [1, 2, 3],
+            # "result_format": "BASIC"
+        },
+        meta={
+            "notes": "This is an expectation."
+        }
+    )
+
+    exp_with_all_the_params = ExpectationConfiguration(
+        expectation_type="expect_column_values_to_not_be_null",
+        kwargs={
+            "column": "a",
+            "result_format": "BASIC",
+            "include_config": True,
+            "catch_exceptions": True,
+        },
+        meta={}
+    )
+    baseline_suite.append_expectation(exp_with_all_the_params)
+
+    assert baseline_suite.find_expectations(
+        column="a",
+        expectation_type="expect_column_values_to_not_be_null",
+    )[0] == ExpectationConfiguration(
+        expectation_type="expect_column_values_to_not_be_null",
+        kwargs={
+            "column": "a",
+        },
+        meta={}
+    )
+
+    assert baseline_suite.find_expectations(
+        column="a",
+        expectation_type="expect_column_values_to_not_be_null",
+        discard_result_format_kwargs=False,
+        discard_include_config_kwargs=False,
+        discard_catch_exceptions_kwargs=False,
+    )[0] == exp_with_all_the_params
+
+    assert baseline_suite.find_expectations(
+        column="a",
+        expectation_type="expect_column_values_to_not_be_null",
+        discard_result_format_kwargs=False,
+        discard_catch_exceptions_kwargs=False,
+    )[0] == ExpectationConfiguration(
+        expectation_type="expect_column_values_to_not_be_null",
+        kwargs={
+            "column": "a",
+            "result_format": "BASIC",
+            "catch_exceptions": True,
+        },
+        meta={}
+    )

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -231,3 +231,37 @@ def test_find_expectations(baseline_suite, exp1, exp2):
         },
         meta={}
     )
+
+def test_remove_expectation(baseline_suite):
+    # ValueError: Multiple expectations matched arguments. No expectations removed.
+    with pytest.raises(ValueError):
+        baseline_suite.remove_expectation()
+
+    # ValueError: No matching expectation found.
+    with pytest.raises(ValueError):
+        baseline_suite.remove_expectation(
+            column="does_not_exist"
+        )
+
+    # ValueError: Multiple expectations matched arguments. No expectations removed.
+    with pytest.raises(ValueError):
+        baseline_suite.remove_expectation(
+            expectation_type="expect_column_values_to_be_in_set"
+        )
+
+    assert len(baseline_suite.expectations) == 2
+    assert baseline_suite.remove_expectation(
+        column="a"
+    ) == None
+    assert len(baseline_suite.expectations) == 1
+
+    baseline_suite.remove_expectation(
+        expectation_type="expect_column_values_to_be_in_set"
+    )
+    assert len(baseline_suite.expectations) == 0
+
+    # ValueError: No matching expectation found.
+    with pytest.raises(ValueError):
+        baseline_suite.remove_expectation(
+            expectation_type="expect_column_values_to_be_in_set"
+        )

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -1,0 +1,58 @@
+import pytest
+import json
+
+from great_expectations.core import (
+    ExpectationSuite,
+    ExpectationConfiguration,
+)
+
+from .test_expectation_suite import (
+    exp1,
+    exp2,
+    exp3,
+    exp4,
+    baseline_suite,
+)
+
+@pytest.fixture
+def empty_suite():
+    return ExpectationSuite(
+        expectation_suite_name="warning",
+        expectations=[],
+        meta={
+            "notes": "This is an expectation suite."
+        }
+    )
+
+@pytest.fixture
+def exp1():
+    return ExpectationConfiguration(
+        expectation_type="expect_column_values_to_not_be_null",
+        kwargs={
+            "column": "a",
+        },
+        meta={}
+    )
+
+def test_append_expectation(empty_suite, exp1, exp2):
+
+    assert len(empty_suite.expectations) == 0
+
+    empty_suite.append_expectation(exp1)
+    assert len(empty_suite.expectations) == 1
+
+    # Adding the same expectation again *does* add duplicates.
+    empty_suite.append_expectation(exp1)
+    assert len(empty_suite.expectations) == 2
+
+    empty_suite.append_expectation(exp2)
+    assert len(empty_suite.expectations) == 3
+
+    # Turn this on once we're ready to enforce strict typing.
+    # with pytest.raises(TypeError):
+    #     empty_suite.append_expectation("not an expectation")
+
+    # Turn this on once we're ready to enforce strict typing.
+    # with pytest.raises(TypeError):
+    #     empty_suite.append_expectation(exp1.to_json_dict())
+

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -25,7 +25,7 @@ def empty_suite():
     )
 
 @pytest.fixture
-def exp1():
+def exp5():
     return ExpectationConfiguration(
         expectation_type="expect_column_values_to_not_be_null",
         kwargs={
@@ -55,4 +55,106 @@ def test_append_expectation(empty_suite, exp1, exp2):
     # Turn this on once we're ready to enforce strict typing.
     # with pytest.raises(TypeError):
     #     empty_suite.append_expectation(exp1.to_json_dict())
+
+def test_find_expectation_indexes(baseline_suite, exp5):
+    
+    # Passing no parameters "finds" all Expectations
+    assert baseline_suite.find_expectation_indexes() == [0,1]
+
+    # Match on single columns
+    assert baseline_suite.find_expectation_indexes(
+        column="a"
+    ) == [0]
+    assert baseline_suite.find_expectation_indexes(
+        column="b"
+    ) == [1]
+
+    # Non-existent column returns no matches
+    assert baseline_suite.find_expectation_indexes(
+        column="z"
+    ) == []
+
+    # It can return multiple expectation_type matches
+    assert baseline_suite.find_expectation_indexes(
+        expectation_type="expect_column_values_to_be_in_set"
+    ) == [0,1]
+
+    # It can return multiple column matches
+    baseline_suite.append_expectation(exp5)
+    assert baseline_suite.find_expectation_indexes(
+        column="a"
+    ) == [0,2]
+
+    # It can match a single expectation_type
+    assert baseline_suite.find_expectation_indexes(
+        expectation_type="expect_column_values_to_not_be_null"
+    ) == [2]
+
+    # expectation_kwargs can match full kwargs
+    assert baseline_suite.find_expectation_indexes(
+        expectation_kwargs={
+            "column": "b",
+            "value_set": [-1, -2, -3],
+            "result_format": "BASIC",
+        }
+    ) == [1]
+
+    # expectation_kwargs can match partial kwargs
+    assert baseline_suite.find_expectation_indexes(
+        expectation_kwargs={
+            "column": "a"
+        }
+    ) == [0, 2]
+
+    # expectation_type and expectation_kwargs work in conjunction
+    assert baseline_suite.find_expectation_indexes(
+        expectation_type="expect_column_values_to_not_be_null",
+        expectation_kwargs={
+            "column": "a"
+        }
+    ) == [2]
+
+    # column and expectation_kwargs work in conjunction
+    assert baseline_suite.find_expectation_indexes(
+        column="a",
+        expectation_kwargs={
+            "result_format": "BASIC"
+        }
+    ) == [0]
+
+    # column and expectation_type work in conjunction
+    assert baseline_suite.find_expectation_indexes(
+        column="a",
+        expectation_type="expect_column_values_to_not_be_null",
+    ) == [2]
+    assert baseline_suite.find_expectation_indexes(
+        column="a",
+        expectation_type="expect_column_values_to_be_between",
+    ) == []
+    assert baseline_suite.find_expectation_indexes(
+        column="zzz",
+        expectation_type="expect_column_values_to_be_between",
+    ) == []
+
+    with pytest.raises(ValueError):
+        assert baseline_suite.find_expectation_indexes(
+            column="a",
+            expectation_kwargs={
+                "column": "b"
+            }
+        ) == []
+
+def test_find_expectation_indexes_on_empty_suite(empty_suite):
+
+    assert empty_suite.find_expectation_indexes(
+        expectation_type="expect_column_values_to_not_be_null"
+    ) == []
+
+    assert empty_suite.find_expectation_indexes(
+        column="x"
+    ) == []
+
+    assert empty_suite.find_expectation_indexes(
+        expectation_kwargs={}
+    ) == []
 

--- a/tests/data_asset/test_data_asset_internals.py
+++ b/tests/data_asset/test_data_asset_internals.py
@@ -682,7 +682,7 @@ def test_find_expectations():
     with pytest.raises(ValueError) as exc:
         my_df.find_expectations("expect_column_to_exist", "x", {"column": "y"})
 
-    assert 'Conflicting column names in remove_expectation:' in str(exc.value)
+    assert 'Conflicting column names in find_expectation_indexes:' in str(exc.value)
 
     exp1 = [
         ExpectationConfiguration(
@@ -767,7 +767,7 @@ def test_remove_expectation():
         my_df.remove_expectation("expect_column_to_exist", "x", {
                                  "column": "y"}, dry_run=True)
 
-    assert 'Conflicting column names in remove_expectation' in str(exc.value)
+    assert 'Conflicting column names in find_expectation_indexes' in str(exc.value)
 
     exp1 = [
         ExpectationConfiguration(


### PR DESCRIPTION
This PR adds four CLUD methods to `ExpectationSuite`.

All of these methods already existed in `DataAsset`. This PR moves their core logic into `ExpectationSuite`. `DataAsset` calls through to `ExpectationSuite` methods.
```
    def _append_expectation(self, expectation_config):
    def find_expectation_indexes(self,
    def find_expectations(self,
    def remove_expectation(self,
```

To make this work, I’ve also copied `_copy_and_clean_expectation` and `_copy_and_clean_up_expectations_from_indexes` from `DataAsset` to `ExpectationSuite`.

All these changes should be nonbreaking.

Notes on `append_expectation`:
* `DataAsset` has an `_append_expectation` method. In `ExpectationSuite`, I've renamed it to `append_expectation`, since it should be externally accessible.
* Also, `DataAsset._append_expectation` is a misnomer, since it doesn't always append---sometimes it overwrites. `write_expectation` would be a better name.
* I've left the (still messy and not thoroughly tested) overwriting logic where it is. We can+should fix it later.

Note on testing:
`DataAsset` has pretty good testing of all four of the CLUD methods. 

```
tests/dataset/test_dataset.py
    test_repeated_append_expectations

tests/data_asset/test_data_asset_internals.py: 
    test_find_expectations
    test_remove_expectation
```

There is no direct testing of the `_copy_and_clean_*` methods.

I haven't added any additional testing to `DataAsset`, but I *have* tried to thoroughly test all the CLUD methods in `ExpectationSuite`.

Since this is intended to be a non-breaking refactor, the only pre-existing tests that I've changed are a few error messages.

Note: this PR does not include an `update` method. That can be developed in a future PR.