### PR TITLE
Feature/better site section builder configurability

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -4,6 +4,7 @@ develop
 -----------------
 * Add log_level parameter to jupyter_ux.setup_notebook_logging.
 * Add experimental display_profiled_column_evrs_as_section and display_column_evrs_as_section methods, with a minor (nonbreaking) refactor to create a new _render_for_jupyter method.
+* Data Docs: improve configurability of site_section_builders
 
 0.9.8
 -----------------

--- a/docs/reference/data_docs_reference.rst
+++ b/docs/reference/data_docs_reference.rst
@@ -32,6 +32,8 @@ The default Data Docs site configuration looks like this:
       store_backend:
         class_name: TupleFilesystemStoreBackend
         base_directory: uncommitted/data_docs/local_site/
+      site_index_builder:
+        class_name: DefaultSiteIndexBuilder
 
 Here is an example of a site configuration from great_expectations.yml with defaults defined explicitly:
 
@@ -47,14 +49,14 @@ Here is an example of a site configuration from great_expectations.yml with defa
       site_index_builder:
         class_name: DefaultSiteIndexBuilder
       site_section_builders:
-        expectations: # if not present, expectation suites are not rendered
+        expectations:  # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
           class_name: DefaultSiteSectionBuilder
           source_store_name: expectations_store
           renderer:
             module_name: great_expectations.render.renderer
             class_name: ExpectationSuitePageRenderer
 
-        validations: # if not present, validation results are not rendered
+        validations:  # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
           class_name: DefaultSiteSectionBuilder
           source_store_name: validations_store
           run_id_filter:
@@ -63,7 +65,7 @@ Here is an example of a site configuration from great_expectations.yml with defa
             module_name: great_expectations.render.renderer
             class_name: ValidationResultsPageRenderer
 
-        profiling: # if not present, profiling results are not rendered
+        profiling:  # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
           class_name: DefaultSiteSectionBuilder
           source_store_name: validations_store
           run_id_filter:
@@ -135,14 +137,7 @@ the validations renderer, and no profiling results are rendered at all.
           class_name: TupleFilesystemStoreBackend
           base_directory: uncommitted/data_docs/local_site/
         site_section_builders:
-          expectations:
-            class_name: DefaultSiteSectionBuilder
-            source_store_name: expectations_store
-            renderer:
-              module_name: great_expectations.render.renderer
-              class_name: ExpectationSuitePageRenderer
-
-          validations:
+          validations:  # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
             class_name: DefaultSiteSectionBuilder
             source_store_name: validations_store
             run_id_filter:
@@ -155,6 +150,8 @@ the validations renderer, and no profiling results are rendered at all.
                 table_renderer:
                   module_name: custom_renderers.custom_table_content_block
                   class_name: CustomTableContentBlockRenderer
+
+          profiling:  # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
 
 To support that custom renderer, we need to ensure the implementation is available in our plugins/ directory.
 Note that we can use a subdirectory and standard python submodule notation, but that we need to include an __init__.py
@@ -368,6 +365,8 @@ Before modifying your project configuration, the relevant section looks like thi
       store_backend:
         class_name: TupleFilesystemStoreBackend
         base_directory: uncommitted/data_docs/local_site/
+      site_index_builder:
+        class_name: DefaultSiteIndexBuilder
 
 This is what it looks like after your changes are added:
 
@@ -379,10 +378,10 @@ This is what it looks like after your changes are added:
         store_backend:
           class_name: TupleFilesystemStoreBackend
           base_directory: uncommitted/data_docs/local_site/
+        site_index_builder:
+          class_name: DefaultSiteIndexBuilder
         site_section_builders:
           expectations:
-            class_name: DefaultSiteSectionBuilder
-            source_store_name: expectations_store
             renderer:
               module_name: custom_data_docs.renderers.custom_expectation_suite_page_renderer
               class_name: CustomExpectationSuitePageRenderer
@@ -390,10 +389,6 @@ This is what it looks like after your changes are added:
               module_name: custom_data_docs.views.custom_expectation_suite_view
               class_name: CustomExpectationSuiteView
           validations:
-            class_name: DefaultSiteSectionBuilder
-            source_store_name: validations_store
-            run_id_filter:
-              ne: profiling
             renderer:
               module_name: great_expectations.render.renderer
               class_name: ValidationResultsPageRenderer
@@ -402,10 +397,11 @@ This is what it looks like after your changes are added:
                 table_renderer:
                   module_name: custom_data_docs.renderers.custom_table_renderer
                   class_name: CustomTableRenderer
+          profiling:
 
-Note that if your ``data_docs_sites`` configuration contains a ``site_section_builders`` key, you must now explicitly provide
-defaults for anything you would like rendered. By omitting the ``profiling`` key within ``site_section_builders``, your third goal
-is achieved and Data Docs will no longer render Profiling Results pages.
+By providing an empty ``profiling`` key within ``site_section_builders``, your third goal
+is achieved and Data Docs will no longer render Profiling Results pages. The same can be achieved by setting the \
+``profiling`` key to any of the following values: ``['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE']``.
 
 Lastly, to compile your newly-customized Data Docs local site, you run ``great_expectations docs build`` from the command line.
 
@@ -414,14 +410,14 @@ Lastly, to compile your newly-customized Data Docs local site, you run ``great_e
 .. code-block:: yaml
 
     site_section_builders:
-      expectations: # if not present, expectation suites are not rendered
+      expectations: # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
         class_name: DefaultSiteSectionBuilder
         source_store_name: expectations_store
         renderer:
           module_name: great_expectations.render.renderer
           class_name: ExpectationSuitePageRenderer
 
-      validations: # if not present, validation results are not rendered
+      validations: # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
         class_name: DefaultSiteSectionBuilder
         source_store_name: validations_store
         run_id_filter:
@@ -430,7 +426,7 @@ Lastly, to compile your newly-customized Data Docs local site, you run ``great_e
           module_name: great_expectations.render.renderer
           class_name: ValidationResultsPageRenderer
 
-      profiling: # if not present, profiling results are not rendered
+      profiling: # if empty, or one of ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE'], section not rendered
         class_name: DefaultSiteSectionBuilder
         source_store_name: validations_store
         run_id_filter:

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -185,6 +185,9 @@ class SiteBuilder(object):
             site_section_builders = nested_update(default_site_section_builders_config, site_section_builders)
         self.site_section_builders = {}
         for site_section_name, site_section_config in site_section_builders.items():
+            if not site_section_config or site_section_config in \
+                    ['0', 'None', 'False', 'false', 'FALSE', 'none', 'NONE']:
+                continue
             module_name = site_section_config.get('module_name') or 'great_expectations.render.renderer.site_builder'
             self.site_section_builders[site_section_name] = instantiate_class_from_config(
                 config=site_section_config,

--- a/tests/test_fixtures/great_expectations_custom_local_site_config.yml
+++ b/tests/test_fixtures/great_expectations_custom_local_site_config.yml
@@ -1,0 +1,116 @@
+# This is a basic configuration for testing.
+# It has comments that should be preserved.
+config_version: 1
+datasources:
+  # For example, this one.
+  mydatasource:
+    class_name: PandasDatasource
+    generators:
+      # The name default is read if no datasource or generator is specified
+      mygenerator:
+        type: subdir_reader
+        base_directory: ../data
+plugins_directory: plugins/
+
+expectations_store_name: expectations_store
+evaluation_parameter_store_name: evaluation_parameter_store
+validations_store_name: validations_store
+
+stores:
+  expectations_store:
+    class_name: ExpectationsStore
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: expectations/
+  validations_store:
+    class_name: ValidationsStore
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: uncommitted/validations/
+
+  # These next three blocks are never used in tests.
+
+  # local_profiling_store:
+  #   module_name: great_expectations.data_context.store
+  #   class_name: FilesystemStore
+  #   store_config:
+  #     base_directory: uncommitted/profiling/
+  #     serialization_type: json
+  #     file_extension: .json
+
+  # local_workbench_site_store:
+  #   module_name: great_expectations.data_context.store
+  #   class_name: FilesystemStore
+  #   store_config:
+  #     base_directory: uncommitted/data_docs/local_site
+  #     file_extension: .html
+
+  # shared_team_site_store:
+  #   module_name: great_expectations.data_context.store
+  #   class_name: FilesystemStore
+  #   store_config:
+  #     base_directory: uncommitted/data_docs/team_site
+  #     file_extension: .html
+
+  fixture_validation_results_store:
+    class_name: ValidationsStore
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: fixtures/validations
+
+  evaluation_parameter_store:
+      module_name: great_expectations.data_context.store
+      class_name: EvaluationParameterStore
+
+data_docs_sites:
+  local_site: # site name
+  # “local_site” renders documentation for all the datasources in the project from GE artifacts in the local repo.
+  # The site includes expectation suites and profiling and validation results from uncommitted directory.
+  # Local site provides the convenience of visualizing all the entities stored in JSON files as HTML.
+
+    module_name: great_expectations.render.renderer.site_builder
+    class_name: SiteBuilder
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: uncommitted/data_docs/local_site/
+
+    site_index_builder:
+      class_name: DefaultSiteIndexBuilder
+
+    site_section_builders:
+      expectations:
+        source_store_name: validations_store
+
+      validations:
+        source_store_name: expectations_store
+        run_id_filter:
+          ne: custom_validations_filter
+
+      profiling:
+        source_store_name: expectations_store
+        run_id_filter:
+          eq: custom_profiling_filter
+
+validation_operators:
+  # Read about validation operators at: https://docs.greatexpectations.io/en/latest/guides/validation_operators.html
+  default:
+    class_name: ActionListValidationOperator
+    action_list:
+      - name: store_validation_result
+        action:
+          class_name: StoreValidationResultAction
+          target_store_name: validations_store
+      - name: store_evaluation_params
+        action:
+          class_name: StoreEvaluationParametersAction
+          target_store_name: evaluation_parameter_store
+      # Uncomment the notify_slack action below to send notifications during evaluation
+      # - name: notify_slack
+      #   action:
+      #     class_name: SlackNotificationAction
+      #     slack_webhook: ${validation_notification_slack_webhook}
+      #     notify_on: all
+      #     renderer:
+      #       module_name: great_expectations.render.renderer.slack_renderer
+      #       class_name: SlackRenderer
+


### PR DESCRIPTION
- Allow users to customize site_section_builders in site_config by specifying only those parts they wish to customize

For example, before, when user wished to specify a different source_store_name for expectations, user had to manually specify the entire site_sections_builder part of the site config:

```
  local_site: # site name
    module_name: great_expectations.render.renderer.site_builder
    class_name: SiteBuilder
    store_backend:
      class_name: TupleFilesystemStoreBackend
      base_directory: uncommitted/data_docs/local_site/

    site_index_builder:
      class_name: DefaultSiteIndexBuilder

    site_section_builders:
      expectations:
        class_name: DefaultSiteSectionBuilder
        source_store_name: my_different_source_store_name
        renderer:
          module_name: great_expectations.render.renderer
          class_name: ExpectationSuitePageRenderer

      validations:
        class_name: DefaultSiteSectionBuilder
        source_store_name: validations_store
        run_id_filter:
          ne: profiling
        renderer:
          module_name: great_expectations.render.renderer
          class_name: ValidationResultsPageRenderer

      profiling:
        class_name: DefaultSiteSectionBuilder
        source_store_name: validations_store
        run_id_filter:
          eq: profiling
        renderer:
          module_name: great_expectations.render.renderer
          class_name: ProfilingResultsPageRenderer
```

Now, user can just specify the customized source store name:

```
  local_site: # site name
    module_name: great_expectations.render.renderer.site_builder
    class_name: SiteBuilder
    store_backend:
      class_name: TupleFilesystemStoreBackend
      base_directory: uncommitted/data_docs/local_site/

    site_index_builder:
      class_name: DefaultSiteIndexBuilder

    site_section_builders:
      expectations:
        source_store_name: my_different_source_store_name
```