### PR TITLE
Data docs builder init

### DIFF
--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -257,6 +257,7 @@ class DefaultSiteSectionBuilder(object):
             validation_results_limit=None,
             renderer=None,
             view=None,
+            **kwargs
     ):
         self.name = name
         self.source_store = data_context.stores[source_store_name]
@@ -397,6 +398,7 @@ class DefaultSiteIndexBuilder(object):
             validation_results_limit=None,
             renderer=None,
             view=None,
+            **kwargs
     ):
         # NOTE: This method is almost identical to DefaultSiteSectionBuilder
         self.name = name

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -99,7 +99,8 @@ class SiteBuilder(object):
                  site_index_builder=None,
                  show_how_to_buttons=True,
                  site_section_builders=None,
-                 runtime_environment=None
+                 runtime_environment=None,
+                 **kwargs
                  ):
         self.site_name = site_name
         self.data_context = data_context


### PR DESCRIPTION
- Add **kwargs to __init__ methods of site builders to handle cases where user might have deprecated values in site builder config (in which case TypeError would occur due to unexpected keyword arg)