### PR TITLE
Deprecate/data assert. append expectation

### DIFF
--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -894,20 +894,20 @@ class ExpectationSuite(object):
             expectation_type of an Expectation.
         """
 
-        matched_expectations = self.find_expectations(
+        matched_expectation_indexes = self.find_expectation_indexes(
             expectation_type=expectation_type,
             column=column,
             expectation_kwargs=expectation_kwargs
         )
 
         #Ensure that exactly one Expectation matches.
-        if len(matched_expectations) == 0:
+        if len(matched_expectation_indexes) == 0:
             raise ValueError("No matching Expectation found.")
 
-        elif len(matched_expectations) > 1:
+        elif len(matched_expectation_indexes) > 1:
             raise ValueError("Multiple Expectations matched arguments. No Expectations updated.")
 
-        matched_expectation = matched_expectations[0]
+        matched_expectation = self.expectations[matched_expectation_indexes[0]]
 
         matched_expectation.update_kwargs(
             new_kwargs,

--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -839,6 +839,41 @@ class ExpectationSuite(object):
                     return [expectation]
                 else:
                     return expectation
+    
+    def edit_expectation(self,
+        new_kwargs,
+        expectation_type=None,
+        column=None,
+        expectation_kwargs=None,
+        replace_full_kwarg_object=False,
+    ):
+        """Edit exactly one Expectation
+        Args:
+            expectation_type=None                : The name of the expectation type to be matched.
+            column=None                          : The name of the column to be matched.
+            expectation_kwargs=None              : A dictionary of kwargs to match against.
+            replace_full_kwarg_object=False      : Match multiple expectations
+
+        Returns:
+            The revised Expectation
+
+        replace_full_kwarg_object:
+            By default, edit_expectations will keep most of the key-value pairs
+            in kwargs, only replacing those with entries in new_kwargs.
+            However, if replace_full_kwarg_object=True, then the method will
+            replace the full object.
+            In either case, edit_expectation will validate that the kwargs are
+            valid for the specified Expectation.
+
+        Note:
+            If the match criteria specified in column, expectation_type, and
+            expectation_kwargs don't find exactly one match, then
+            edit_expectations raises a ValueError.
+            There is currently no way to use edit_expectation to change the
+            expectation_type of an Expectation.
+        """
+
+        pass
 
 class ExpectationSuiteSchema(Schema):
     expectation_suite_name = fields.Str()

--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -840,10 +840,21 @@ class ExpectationSuite(object):
             expectation_kwargs,
         )
 
-        if len(match_indexes) == 0:
+        return self.remove_expectations_by_index(
+            match_indexes,
+            remove_multiple_matches=remove_multiple_matches,
+            dry_run=dry_run,
+        )
+
+    def remove_expectations_by_index(self,
+        index_list,
+        remove_multiple_matches=False,
+        dry_run=False
+    ):
+        if len(index_list) == 0:
             raise ValueError('No matching expectation found.')
 
-        elif len(match_indexes) > 1:
+        elif len(index_list) > 1:
             if not remove_multiple_matches:
                 raise ValueError(
                     'Multiple expectations matched arguments. No expectations removed.')
@@ -851,24 +862,24 @@ class ExpectationSuite(object):
 
                 if not dry_run:
                     self.expectations = [i for j, i in enumerate(
-                        self.expectations) if j not in match_indexes]
+                        self.expectations) if j not in index_list]
                 else:
-                    return self._copy_and_clean_up_expectations_from_indexes(match_indexes)
+                    return self._copy_and_clean_up_expectations_from_indexes(index_list)
 
         else:  # Exactly one match
             expectation = self._copy_and_clean_up_expectation(
-                self.expectations[match_indexes[0]]
+                self.expectations[index_list[0]]
             )
 
             if not dry_run:
-                del self.expectations[match_indexes[0]]
+                del self.expectations[index_list[0]]
 
             else:
                 if remove_multiple_matches:
                     return [expectation]
                 else:
                     return expectation
-    
+
     def update_expectation(self,
         new_kwargs,
         expectation_type=None,

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -367,13 +367,7 @@ class DataAsset(object):
         # FIXME: Should we try to convert the object using something like recursively_convert_to_json_serializable?
         # json.dumps(expectation_config)
 
-        # Drop existing expectations with the same expectation_type.
-        # For column_expectations, _append_expectation should only replace expectations
-        # where the expectation_type AND the column match
-        # !!! This is good default behavior, but
-        # !!!    it needs to be documented, and
-        # !!!    we need to provide syntax to override it.
-
+        #Logic for column_*_expectations
         if 'column' in expectation_config.kwargs:
             column = expectation_config.kwargs['column']
 
@@ -387,6 +381,38 @@ class DataAsset(object):
                 #In this case, it's okay if we don't match any existing expectations
                 pass
 
+        #Logic for column_pair_*_expectations
+        elif 'column_A' in expectation_config.kwargs and 'column_B' in expectation_config.kwargs:
+
+            try:
+                self._expectation_suite.remove_expectation(
+                    expectation_type=expectation_type,
+                    expectation_kwargs={
+                        "column_A" : expectation_config.kwargs["column_A"],
+                        "column_B" : expectation_config.kwargs["column_B"],
+                    },
+                    remove_multiple_matches=True,
+                )
+            except ValueError:
+                #In this case, it's okay if we don't match any existing expectations
+                pass
+
+        #Logic for multicolumn_expectations
+        elif 'column_list' in expectation_config.kwargs:
+
+            try:
+                self._expectation_suite.remove_expectation(
+                    expectation_type=expectation_type,
+                    expectation_kwargs={
+                        "column_list" : expectation_config.kwargs["column_list"],
+                    },
+                    remove_multiple_matches=True,
+                )
+            except ValueError:
+                #In this case, it's okay if we don't match any existing expectations
+                pass
+
+        #Logic for all remaining expectations
         else:
             try:
                 self._expectation_suite.remove_expectation(

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -343,12 +343,6 @@ class DataAsset(object):
         self._expectation_suite.append_expectation(expectation_config)
 
     def _append_expectation(self, expectation_config):
-        """This method
-        
-        This method should become a thin wrapper for ExpectationSuite.append_expectation
-
-        Included for backwards compatibility.
-        """
         """Appends an expectation to `DataAsset._expectation_suite` and drops existing expectations of the same type.
 
            If `expectation_config` is a column expectation, this drops existing expectations that are specific to \

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -369,59 +369,41 @@ class DataAsset(object):
 
         #Logic for column_*_expectations
         if 'column' in expectation_config.kwargs:
-            column = expectation_config.kwargs['column']
-
-            try:
-                self._expectation_suite.remove_expectation(
-                    expectation_type=expectation_type,
-                    column=column,
-                    remove_multiple_matches=True,
-                )
-            except ValueError:
-                #In this case, it's okay if we don't match any existing expectations
-                pass
+            matched_indexes = self._expectation_suite.find_expectation_indexes(
+                expectation_type=expectation_type,
+                column=expectation_config.kwargs['column'],
+            )
 
         #Logic for column_pair_*_expectations
         elif 'column_A' in expectation_config.kwargs and 'column_B' in expectation_config.kwargs:
-
-            try:
-                self._expectation_suite.remove_expectation(
-                    expectation_type=expectation_type,
-                    expectation_kwargs={
-                        "column_A" : expectation_config.kwargs["column_A"],
-                        "column_B" : expectation_config.kwargs["column_B"],
-                    },
-                    remove_multiple_matches=True,
-                )
-            except ValueError:
-                #In this case, it's okay if we don't match any existing expectations
-                pass
+            matched_indexes = self._expectation_suite.find_expectation_indexes(
+                expectation_type=expectation_type,
+                expectation_kwargs={
+                    "column_A" : expectation_config.kwargs["column_A"],
+                    "column_B" : expectation_config.kwargs["column_B"],
+                },
+            )
 
         #Logic for multicolumn_expectations
         elif 'column_list' in expectation_config.kwargs:
-
-            try:
-                self._expectation_suite.remove_expectation(
-                    expectation_type=expectation_type,
-                    expectation_kwargs={
-                        "column_list" : expectation_config.kwargs["column_list"],
-                    },
-                    remove_multiple_matches=True,
-                )
-            except ValueError:
-                #In this case, it's okay if we don't match any existing expectations
-                pass
+            matched_indexes = self._expectation_suite.find_expectation_indexes(
+                expectation_type=expectation_type,
+                expectation_kwargs={
+                    "column_list" : expectation_config.kwargs["column_list"],
+                },
+            )
 
         #Logic for all remaining expectations
         else:
-            try:
-                self._expectation_suite.remove_expectation(
-                    expectation_type=expectation_type,
-                    remove_multiple_matches=True,
-                )
-            except ValueError:
-                #In this case, it's okay if we don't match any existing expectations
-                pass
+            matched_indexes = self._expectation_suite.find_expectation_indexes(
+                expectation_type=expectation_type,
+            )
+
+        if len(matched_indexes) > 0:
+            self._expectation_suite.remove_expectations_by_index(
+                matched_indexes,
+                remove_multiple_matches=True,
+            )
 
         self._expectation_suite.append_expectation(expectation_config)
 

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -377,16 +377,25 @@ class DataAsset(object):
         if 'column' in expectation_config.kwargs:
             column = expectation_config.kwargs['column']
 
-            self._expectation_suite.expectations = [f for f in filter(
-                lambda exp: (exp.expectation_type != expectation_type) or (
-                    'column' in exp.kwargs and exp.kwargs['column'] != column),
-                self._expectation_suite.expectations
-            )]
+            try:
+                self._expectation_suite.remove_expectation(
+                    expectation_type=expectation_type,
+                    column=column,
+                    remove_multiple_matches=True,
+                )
+            except ValueError:
+                #In this case, it's okay if we don't match any existing expectations
+                pass
+
         else:
-            self._expectation_suite.expectations = [f for f in filter(
-                lambda exp: exp.expectation_type != expectation_type,
-                self._expectation_suite.expectations
-            )]
+            try:
+                self._expectation_suite.remove_expectation(
+                    expectation_type=expectation_type,
+                    remove_multiple_matches=True,
+                )
+            except ValueError:
+                #In this case, it's okay if we don't match any existing expectations
+                pass
 
         self._expectation_suite.append_expectation(expectation_config)
 

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -255,7 +255,7 @@ class DataAsset(object):
                     pass
                 else:
                     # Append the expectation to the config.
-                    self._append_expectation(expectation_config)
+                    self.append_or_update_expectation(expectation_config)
 
                 if include_config:
                     return_obj.expectation_config = copy.deepcopy(expectation_config)
@@ -343,6 +343,11 @@ class DataAsset(object):
         self._expectation_suite.append_expectation(expectation_config)
 
     def _append_expectation(self, expectation_config):
+        warnings.warn("DataAsset._append_expectation is deprecated and will be removed. Please use DataAsset.append_or_update instead.", DeprecationWarning)
+
+        return self.append_or_update_expectation(expectation_config)
+
+    def append_or_update_expectation(self, expectation_config):
         """Appends an expectation to `DataAsset._expectation_suite` and drops existing expectations of the same type.
 
            If `expectation_config` is a column expectation, this drops existing expectations that are specific to \
@@ -357,7 +362,6 @@ class DataAsset(object):
 
            Notes:
                May raise future errors once json-serializable tests are implemented to check for correct arg formatting
-
         """
         expectation_type = expectation_config.expectation_type
 

--- a/tests/core/test_expectation_configuration.py
+++ b/tests/core/test_expectation_configuration.py
@@ -97,3 +97,39 @@ def test_expectation_configuration_equivalence(config1, config2, config3, config
     assert config1.isEquivalentTo(config3)  # different meta
     assert config1.isEquivalentTo(config4)  # different result format
     assert not config1.isEquivalentTo(config5)  # different value_set
+
+
+def test_update_kwargs(config1):
+
+    config1.update_kwargs(
+        {"column": "z"}
+    )
+    assert config1.kwargs == {
+        "column": "z",
+        "value_set": [1, 2, 3],
+        "result_format": "BASIC"
+    }
+
+    config1.update_kwargs(
+        {"column": "z"},
+        replace_all_kwargs=True
+    )
+    assert config1.kwargs == {
+        "column": "z",
+    }
+
+    # TODO: Implement this check once ExpectationConfiguration knows how to validate kwargs against expectation_types.
+    # ValueError: Specified kwargs aren't valid for expectation type expect_column_values_to_be_in_set.
+    # with pytest.raises(ValueError):
+    #     config1.update_kwargs(
+    #         new_kwargs={
+    #             "bogus_field": "BOGUS_VALUE",
+    #         },
+    #     )
+
+    #Note: this is degenerate behavior and wouldn't be possible with type checking.
+    config1.update_kwargs(
+        {},
+        replace_all_kwargs=True
+    )
+    assert config1.kwargs == {}

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -328,7 +328,7 @@ def test_update_expectation(baseline_suite):
     })
     assert len(baseline_suite.expectations) == 2
 
-    # TODO: Implement this check one ExpectationConfiguration knows how to validate kwargs against expectation_types.
+    # TODO: Implement this check once ExpectationConfiguration knows how to validate kwargs against expectation_types.
     # ValueError: Specified kwargs aren't valid for expectation type expect_column_values_to_be_in_set.
     # with pytest.raises(ValueError):
     #     baseline_suite.update_expectation(

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -343,6 +343,8 @@ def test_remove_expectation(baseline_suite):
     )
     assert len(baseline_suite.expectations) == 1
 
+# NOTE: Need to add tests for remove_expectations_by_index
+# They will be very similar to remove_expectation
 
 def test_update_expectation(baseline_suite):
     # ValueError: Multiple Expectations matched arguments. No Expectations updated.

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -34,7 +34,7 @@ def exp5():
         meta={}
     )
 
-def test_append_expectation(empty_suite, exp1, exp2):
+def testappend_or_update_expectation(empty_suite, exp1, exp2):
 
     assert len(empty_suite.expectations) == 0
 

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -266,79 +266,82 @@ def test_remove_expectation(baseline_suite):
             expectation_type="expect_column_values_to_be_in_set"
         )
 
-def test_edit_expectation(baseline_suite):
-    # ValueError: Multiple expectations matched arguments. No expectations removed.
+def test_update_expectation(baseline_suite):
+    # ValueError: Multiple Expectations matched arguments. No Expectations updated.
     with pytest.raises(ValueError):
-        baseline_suite.edit_expectation(
+        baseline_suite.update_expectation(
             new_kwargs={}
         )
 
-    # ValueError: No matching expectation found.
+    # ValueError: No matching Expectation found.
     with pytest.raises(ValueError):
-        baseline_suite.edit_expectation(
+        baseline_suite.update_expectation(
             new_kwargs={},
             column="does_not_exist"
         )
 
-    # ValueError: Multiple expectations matched arguments. No expectations removed.
+    # ValueError: Multiple Expectations matched arguments. No Expectations updated.
     with pytest.raises(ValueError):
-        baseline_suite.edit_expectation(
+        baseline_suite.update_expectation(
             new_kwargs={},
             expectation_type="expect_column_values_to_be_in_set"
         )
 
     assert len(baseline_suite.expectations) == 2
-    assert baseline_suite.edit_expectation(
+    assert baseline_suite.update_expectation(
         new_kwargs={
             "column": "c",
         },
         column="a"
-    ) == {
+    ) == ExpectationConfiguration(**{
         "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
             "column": "c",
             "value_set": [1, 2, 3],
-        }
-    }
+        },
+        "meta": {"notes": "This is an expectation."}
+    })
     assert len(baseline_suite.expectations) == 2
 
-    assert baseline_suite.edit_expectation(
+    assert baseline_suite.update_expectation(
         new_kwargs={
             "value_set": [1,2,3],
         },
         column="b"
-    ) == {
+    ) == ExpectationConfiguration(**{
         "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
             "column": "b",
             "value_set": [1, 2, 3],
-        }
-    }
+        },
+        "meta": {"notes": "This is an expectation."}
+    })
     assert len(baseline_suite.expectations) == 2
 
+    # TODO: Implement this check one ExpectationConfiguration knows how to validate kwargs against expectation_types.
     # ValueError: Specified kwargs aren't valid for expectation type expect_column_values_to_be_in_set.
-    with pytest.raises(ValueError):
-        baseline_suite.edit_expectation(
-            new_kwargs={
-                "value_set": [1,2,3],
-            },
-            column="b",
-            replace_full_kwargs_object=True
-        )
-        
-        
-    baseline_suite.edit_expectation(
+    # with pytest.raises(ValueError):
+    #     baseline_suite.update_expectation(
+    #         new_kwargs={
+    #             "value_set": [1,2,3],
+    #         },
+    #         column="b",
+    #         replace_all_kwargs=True
+    #     )
+                
+    baseline_suite.update_expectation(
         new_kwargs={
             "column": "d",
             "value_set": [3,4,5],
         },
         column="b",
-        replace_full_kwargs_object=True
-    ) == {
+        replace_all_kwargs=True
+    ) == ExpectationConfiguration(**{
         "expectation_type": "expect_column_values_to_be_in_set",
         "kwargs": {
             "column": "d",
             "value_set": [3, 4, 5],
-        }
-    }
+        },
+        "meta": {"notes": "This is an expectation."}
+    })
     assert len(baseline_suite.expectations) == 2

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -265,3 +265,80 @@ def test_remove_expectation(baseline_suite):
         baseline_suite.remove_expectation(
             expectation_type="expect_column_values_to_be_in_set"
         )
+
+def test_edit_expectation(baseline_suite):
+    # ValueError: Multiple expectations matched arguments. No expectations removed.
+    with pytest.raises(ValueError):
+        baseline_suite.edit_expectation(
+            new_kwargs={}
+        )
+
+    # ValueError: No matching expectation found.
+    with pytest.raises(ValueError):
+        baseline_suite.edit_expectation(
+            new_kwargs={},
+            column="does_not_exist"
+        )
+
+    # ValueError: Multiple expectations matched arguments. No expectations removed.
+    with pytest.raises(ValueError):
+        baseline_suite.edit_expectation(
+            new_kwargs={},
+            expectation_type="expect_column_values_to_be_in_set"
+        )
+
+    assert len(baseline_suite.expectations) == 2
+    assert baseline_suite.edit_expectation(
+        new_kwargs={
+            "column": "c",
+        },
+        column="a"
+    ) == {
+        "expectation_type": "expect_column_values_to_be_in_set",
+        "kwargs": {
+            "column": "c",
+            "value_set": [1, 2, 3],
+        }
+    }
+    assert len(baseline_suite.expectations) == 2
+
+    assert baseline_suite.edit_expectation(
+        new_kwargs={
+            "value_set": [1,2,3],
+        },
+        column="b"
+    ) == {
+        "expectation_type": "expect_column_values_to_be_in_set",
+        "kwargs": {
+            "column": "b",
+            "value_set": [1, 2, 3],
+        }
+    }
+    assert len(baseline_suite.expectations) == 2
+
+    # ValueError: Specified kwargs aren't valid for expectation type expect_column_values_to_be_in_set.
+    with pytest.raises(ValueError):
+        baseline_suite.edit_expectation(
+            new_kwargs={
+                "value_set": [1,2,3],
+            },
+            column="b",
+            replace_full_kwargs_object=True
+        )
+        
+        
+    baseline_suite.edit_expectation(
+        new_kwargs={
+            "column": "d",
+            "value_set": [3,4,5],
+        },
+        column="b",
+        replace_full_kwargs_object=True
+    ) == {
+        "expectation_type": "expect_column_values_to_be_in_set",
+        "kwargs": {
+            "column": "d",
+            "value_set": [3, 4, 5],
+        }
+    }
+    assert len(baseline_suite.expectations) == 2

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -287,6 +287,8 @@ def test_update_expectation(baseline_suite):
             expectation_type="expect_column_values_to_be_in_set"
         )
 
+
+    # Verify that update_expectation returns a correct ExpectationConfiguration
     assert len(baseline_suite.expectations) == 2
     assert baseline_suite.update_expectation(
         new_kwargs={
@@ -298,10 +300,17 @@ def test_update_expectation(baseline_suite):
         "kwargs": {
             "column": "c",
             "value_set": [1, 2, 3],
+            "result_format": "BASIC",
         },
         "meta": {"notes": "This is an expectation."}
     })
     assert len(baseline_suite.expectations) == 2
+
+    # Verify that the Expectation was indeed changed in place.
+    assert baseline_suite.find_expectation_indexes(
+        expectation_type="expect_column_values_to_be_in_set",
+        column="c"
+    ) == [0]
 
     assert baseline_suite.update_expectation(
         new_kwargs={
@@ -313,6 +322,7 @@ def test_update_expectation(baseline_suite):
         "kwargs": {
             "column": "b",
             "value_set": [1, 2, 3],
+            "result_format": "BASIC",
         },
         "meta": {"notes": "This is an expectation."}
     })

--- a/tests/core/test_expectation_suite_crud_methods.py
+++ b/tests/core/test_expectation_suite_crud_methods.py
@@ -266,6 +266,84 @@ def test_remove_expectation(baseline_suite):
             expectation_type="expect_column_values_to_be_in_set"
         )
 
+    #Tests for dry_run
+    baseline_suite.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_be_in_set",
+            kwargs={
+                "column": "z",
+                "value_set": [1,2,3,4,5]
+            }
+        )
+    )
+    baseline_suite.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_be_in_set",
+            kwargs={
+                "column": "z",
+                "value_set": [1,2,3,4,5]
+            }
+        )
+    )
+    baseline_suite.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_to_exist",
+            kwargs={
+                "column": "z",
+            }
+        )
+    )
+    assert len(baseline_suite.expectations) == 3
+
+    assert baseline_suite.remove_expectation(
+        expectation_type="expect_column_to_exist",
+        dry_run=True
+    ) == ExpectationConfiguration(
+        expectation_type="expect_column_to_exist",
+        kwargs={"column": "z"},
+        meta={},
+    )
+    assert len(baseline_suite.expectations) == 3
+
+    with pytest.raises(ValueError):
+        baseline_suite.remove_expectation(
+            expectation_type="expect_column_values_to_be_in_set",
+            dry_run=True
+        )
+    assert len(baseline_suite.expectations) == 3
+
+    assert baseline_suite.remove_expectation(
+        expectation_type="expect_column_values_to_be_in_set",
+        remove_multiple_matches=True,
+        dry_run=True
+    ) == [
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_be_in_set",
+            kwargs={
+                "column": "z",
+                "value_set": [1,2,3,4,5],
+            },
+            meta={},
+        ),
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_be_in_set",
+            kwargs={
+                "column": "z",
+                "value_set": [1,2,3,4,5]
+            },
+            meta={},
+        )
+    ]
+    assert len(baseline_suite.expectations) == 3
+
+    # Tests for remove_multiple_matches
+    baseline_suite.remove_expectation(
+        expectation_type="expect_column_values_to_be_in_set",
+        remove_multiple_matches=True,
+    )
+    assert len(baseline_suite.expectations) == 1
+
+
 def test_update_expectation(baseline_suite):
     # ValueError: Multiple Expectations matched arguments. No Expectations updated.
     with pytest.raises(ValueError):

--- a/tests/data_asset/test_data_asset.py
+++ b/tests/data_asset/test_data_asset.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 from great_expectations import __version__ as ge_version
 from great_expectations.core import ExpectationSuite, ExpectationConfiguration, ExpectationKwargs
@@ -83,6 +84,27 @@ def test_catch_exceptions_with_bad_expectation_type():
 
     with pytest.raises(AttributeError):
         result = my_df.validate(catch_exceptions=False)
+
+def test__append_expectation_deprecation_warning():
+    # Note: some asserts within this test rely on strong assumptions about the ordering of expectation_suite._expectations
+
+    asset = DataAsset()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        asset._append_expectation(
+            ExpectationConfiguration(
+                expectation_type="expect_column_to_exist",
+                kwargs={
+                    "column": "a"
+                },
+            )
+        )
+
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "DataAsset._append_expectation is deprecated" in str(w[-1].message)
 
 def test_append_or_update_expectation():
     # Note: some asserts within this test rely on strong assumptions about the ordering of expectation_suite._expectations

--- a/tests/data_asset/test_data_asset.py
+++ b/tests/data_asset/test_data_asset.py
@@ -171,3 +171,99 @@ def test__append_expectation():
     )
     assert len(asset._expectation_suite.expectations) == 4
     assert asset._expectation_suite.expectations[3].kwargs["max_value"] == 80
+
+    #Behavior for append_expectation is a true append. It never overwrites.
+    asset.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_table_row_count_to_be_between",
+            kwargs={
+                "min_value": 20,
+                "max_value": 80,
+            },
+        )
+    )
+    asset.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_table_row_count_to_be_between",
+            kwargs={
+                "min_value": 20,
+                "max_value": 80,
+            },
+        )
+    )
+    asset.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_table_row_count_to_be_between",
+            kwargs={
+                "min_value": 20,
+                "max_value": 80,
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 7
+
+    # We should have 4 copies of this puppy
+    assert len(asset._expectation_suite.find_expectations(
+        expectation_type="expect_table_row_count_to_be_between"
+    ))==4
+
+    #...and if we now _append a matching one, they should all be deleted except the new one
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_table_row_count_to_be_between",
+            kwargs={
+                "min_value": 30,
+                "max_value": 70,
+            },
+        )
+    )
+    assert len(asset._expectation_suite.find_expectations(
+        expectation_type="expect_table_row_count_to_be_between"
+    ))==1
+    assert len(asset._expectation_suite.expectations) == 4
+    assert asset._expectation_suite.expectations[3].kwargs["max_value"] == 70
+
+    #Note: This behavior is questionable. You could imagine circumstances where
+    # appending a fifth expectation, or updating all four in place would be better.
+    # For now, that's how it works.
+
+    # appending (not _appending) a couple more expectations with column names also adds duplicates...
+    asset.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_not_be_null",
+            kwargs={
+                "column": "b",
+                "mostly": .9
+            },
+        )
+    )
+    asset.append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_not_be_null",
+            kwargs={
+                "column": "b",
+                "mostly": .9
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 6
+
+    # We should have 3 copies of this puppy
+    assert len(asset._expectation_suite.find_expectations(
+        expectation_type="expect_column_values_to_not_be_null"
+    ))==3
+
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_not_be_null",
+            kwargs={
+                "column": "b",
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.find_expectations(
+        expectation_type="expect_column_values_to_not_be_null"
+    ))==1
+    assert len(asset._expectation_suite.expectations) == 4
+    assert asset._expectation_suite.expectations[3].kwargs["mostly"] == .8

--- a/tests/data_asset/test_data_asset.py
+++ b/tests/data_asset/test_data_asset.py
@@ -65,7 +65,7 @@ def test_data_asset_name_inheritance(dataset):
 def test_catch_exceptions_with_bad_expectation_type():
     # We want to catch degenerate cases where an expectation suite is incompatible with
     my_df = PandasDataset({"x": range(10)})
-    my_df._append_expectation(ExpectationConfiguration(expectation_type='foobar', kwargs={}))
+    my_df.append_or_update_expectation(ExpectationConfiguration(expectation_type='foobar', kwargs={}))
     result = my_df.validate(catch_exceptions=True)
 
     # Find the foobar result
@@ -84,15 +84,13 @@ def test_catch_exceptions_with_bad_expectation_type():
     with pytest.raises(AttributeError):
         result = my_df.validate(catch_exceptions=False)
 
-def test__append_expectation():
-    # Note: _append_expectation is a misnomer. It should be append_or_update_expectation.
-
+def test_append_or_update_expectation():
     # Note: some asserts within this test rely on strong assumptions about the ordering of expectation_suite._expectations
 
     asset = DataAsset()
     assert len(asset._expectation_suite.expectations) == 0
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_to_exist",
             kwargs={
@@ -103,7 +101,7 @@ def test__append_expectation():
     assert len(asset._expectation_suite.expectations) == 1
 
     #If we try to append_or_update an expectation with the same type and column, it gets overwritten
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_to_exist",
             kwargs={
@@ -114,7 +112,7 @@ def test__append_expectation():
     assert len(asset._expectation_suite.expectations) == 1
 
     #An expectation with the same type and different column creates a new expectation
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_to_exist",
             kwargs={
@@ -125,7 +123,7 @@ def test__append_expectation():
     assert len(asset._expectation_suite.expectations) == 2
 
     #An expectation with the same column and different type creates a new expectation
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_values_to_not_be_null",
             kwargs={
@@ -137,7 +135,7 @@ def test__append_expectation():
 
     #If we try to append_or_update an expectation with the same type and column, parameters get overwritten, too.
     assert "mostly" not in asset._expectation_suite.expectations[2].kwargs
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_values_to_not_be_null",
             kwargs={
@@ -149,7 +147,7 @@ def test__append_expectation():
     assert len(asset._expectation_suite.expectations) == 3
     assert "mostly" in asset._expectation_suite.expectations[2].kwargs
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_table_row_count_to_be_between",
             kwargs={
@@ -162,7 +160,7 @@ def test__append_expectation():
     assert asset._expectation_suite.expectations[3].kwargs["max_value"] == 90
 
     #If an Expectation doesn't have a column kwarg, then the expectation_type alone is enough to match and overwrite
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_table_row_count_to_be_between",
             kwargs={
@@ -210,7 +208,7 @@ def test__append_expectation():
     ))==4
 
     #...and if we now _append a matching one, they should all be deleted except the new one
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_table_row_count_to_be_between",
             kwargs={
@@ -255,7 +253,7 @@ def test__append_expectation():
         expectation_type="expect_column_values_to_not_be_null"
     ))==3
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_values_to_not_be_null",
             kwargs={
@@ -271,7 +269,7 @@ def test__append_expectation():
     assert asset._expectation_suite.expectations[3].kwargs["mostly"] == .8
 
     # It works for column pair expectations
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_pair_values_to_be_equal",
             kwargs={
@@ -283,7 +281,7 @@ def test__append_expectation():
     )
     assert len(asset._expectation_suite.expectations) == 5
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_pair_values_to_be_equal",
             kwargs={
@@ -295,7 +293,7 @@ def test__append_expectation():
     )
     assert len(asset._expectation_suite.expectations) == 5
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_pair_values_to_be_equal",
             kwargs={
@@ -307,7 +305,7 @@ def test__append_expectation():
     )
     assert len(asset._expectation_suite.expectations) == 6
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_column_pair_values_to_be_equal",
             kwargs={
@@ -320,7 +318,7 @@ def test__append_expectation():
     assert len(asset._expectation_suite.expectations) == 7
 
     # It works for multicolumn expectations
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_multicolumn_values_to_be_unique",
             kwargs={
@@ -331,7 +329,7 @@ def test__append_expectation():
     )
     assert len(asset._expectation_suite.expectations) == 8
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_multicolumn_values_to_be_unique",
             kwargs={
@@ -342,7 +340,7 @@ def test__append_expectation():
     )
     assert len(asset._expectation_suite.expectations) == 8
 
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_multicolumn_values_to_be_unique",
             kwargs={
@@ -355,7 +353,7 @@ def test__append_expectation():
 
     # Note: this specific behavior is a bit dubious, since uniqueness is commutative,
     # so ["a", "b"] is identical to ["b", "a"]
-    asset._append_expectation(
+    asset.append_or_update_expectation(
         ExpectationConfiguration(
             expectation_type="expect_multicolumn_values_to_be_unique",
             kwargs={

--- a/tests/data_asset/test_data_asset.py
+++ b/tests/data_asset/test_data_asset.py
@@ -85,7 +85,9 @@ def test_catch_exceptions_with_bad_expectation_type():
         result = my_df.validate(catch_exceptions=False)
 
 def test__append_expectation():
-    # Note _append_expectation is a misnomer. It should be append_or_update_expectation.
+    # Note: _append_expectation is a misnomer. It should be append_or_update_expectation.
+
+    # Note: some asserts within this test rely on strong assumptions about the ordering of expectation_suite._expectations
 
     asset = DataAsset()
     assert len(asset._expectation_suite.expectations) == 0

--- a/tests/data_asset/test_data_asset.py
+++ b/tests/data_asset/test_data_asset.py
@@ -269,3 +269,99 @@ def test__append_expectation():
     ))==1
     assert len(asset._expectation_suite.expectations) == 4
     assert asset._expectation_suite.expectations[3].kwargs["mostly"] == .8
+
+    # It works for column pair expectations
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_pair_values_to_be_equal",
+            kwargs={
+                "column_A": "a",
+                "column_B": "b",
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 5
+
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_pair_values_to_be_equal",
+            kwargs={
+                "column_A": "a",
+                "column_B": "b",
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 5
+
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_pair_values_to_be_equal",
+            kwargs={
+                "column_A": "a",
+                "column_B": "c",
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 6
+
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_pair_values_to_be_equal",
+            kwargs={
+                "column_A": "b",
+                "column_B": "a",
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 7
+
+    # It works for multicolumn expectations
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_multicolumn_values_to_be_unique",
+            kwargs={
+                "column_list": ["a","b"],
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 8
+
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_multicolumn_values_to_be_unique",
+            kwargs={
+                "column_list": ["a","b"],
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 8
+
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_multicolumn_values_to_be_unique",
+            kwargs={
+                "column_list": ["a",],
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 9
+
+    # Note: this specific behavior is a bit dubious, since uniqueness is commutative,
+    # so ["a", "b"] is identical to ["b", "a"]
+    asset._append_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_multicolumn_values_to_be_unique",
+            kwargs={
+                "column_list": ["b","a"],
+                "mostly": .8
+            },
+        )
+    )
+    assert len(asset._expectation_suite.expectations) == 10

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,4 +1,4 @@
-def test_repeated_append_expectations(dataset):
+def test_repeatedappend_or_update_expectations(dataset):
     # Repeatedly evaluating the "same" expectation should add it only one time.
     assert 3 == len(dataset.get_expectation_suite().expectations)
     dataset.expect_column_to_exist('nulls')


### PR DESCRIPTION
Stacks on tops of #1298 to deprecate `DataAsset._append_expectation` in favor of `append_or_update_expectation`, since
1. That's what it does, and
2. It's a method that could be used externally, not just internally.