### PR TITLE
Fix links in documentation

### DIFF
--- a/docs/features/ge_on_teams.rst
+++ b/docs/features/ge_on_teams.rst
@@ -21,7 +21,7 @@ If you followed our best practice recommendation of committing the
 question is already answered! Expectations live right in your repo!
 
 It is also possible to store expectations on cloud storage providers--we recommend enabling versioning in that case.
-See the documentation on :ref:`customizing the data docs store backend <customizing_data_docs_store_backend>`_ for
+See the documentation on :ref:`customizing the data docs store backend <customizing_data_docs_store_backend>` for
 more information, or follow the :ref:`tutorial <publishing_data_docs_to_s3>`.
 
 Where Should Validations Live?
@@ -48,7 +48,7 @@ You can configure a store to write these to a cloud provider blob storage such
 as Amazon S3, Google Cloud Storage, or some other securely mounted file system.
 
 See the :ref:`data docs reference <data_docs_reference>` for more information on configuring data docs to use cloud
-storage, or follow the :ref:`tutorial <publishing_data_docs_to_s3>`_ to configure a site now.
+storage, or follow the :ref:`tutorial <publishing_data_docs_to_s3>` to configure a site now.
 
 Where Should Notifications Go?
 ----------------------------------


### PR DESCRIPTION
The syntax for :ref: shouldn't end with an underscore.