### PR TITLE
Use pickle to generate hash for dataframes with unhashable objects.

### DIFF
--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -1,6 +1,5 @@
 import datetime
 import uuid
-import hashlib
 import logging
 from functools import partial
 
@@ -20,7 +19,7 @@ from great_expectations.datasource.types import BatchMarkers
 from great_expectations.core.batch import Batch
 from great_expectations.types import ClassConfig
 from great_expectations.exceptions import BatchKwargsError
-from .util import S3Url
+from .util import S3Url, hash_dataframe
 
 logger = logging.getLogger(__name__)
 
@@ -201,8 +200,7 @@ class PandasDatasource(Datasource):
                                    batch_kwargs)
 
         if df.memory_usage().sum() < HASH_THRESHOLD:
-            batch_markers["pandas_data_fingerprint"] = hashlib.md5(pd.util.hash_pandas_object(
-                df, index=True).values).hexdigest()
+            batch_markers["pandas_data_fingerprint"] = hash_dataframe(df)
 
         return Batch(
             datasource_name=self.name,

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -19,7 +19,7 @@ from great_expectations.datasource.types import BatchMarkers
 from great_expectations.core.batch import Batch
 from great_expectations.types import ClassConfig
 from great_expectations.exceptions import BatchKwargsError
-from .util import S3Url, hash_dataframe
+from .util import S3Url, hash_pandas_dataframe
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +200,7 @@ class PandasDatasource(Datasource):
                                    batch_kwargs)
 
         if df.memory_usage().sum() < HASH_THRESHOLD:
-            batch_markers["pandas_data_fingerprint"] = hash_dataframe(df)
+            batch_markers["pandas_data_fingerprint"] = hash_pandas_dataframe(df)
 
         return Batch(
             datasource_name=self.name,

--- a/great_expectations/datasource/util.py
+++ b/great_expectations/datasource/util.py
@@ -48,7 +48,7 @@ class S3Url(object):
         return self._parsed.geturl()
 
 
-def hash_dataframe(df):
+def hash_pandas_dataframe(df):
     try:
         obj = pd.util.hash_pandas_object(df, index=True).values
     except TypeError:

--- a/great_expectations/datasource/util.py
+++ b/great_expectations/datasource/util.py
@@ -1,4 +1,7 @@
+import pickle
+import hashlib
 from urllib.parse import urlparse
+import pandas as pd
 
 # S3Url class courtesy: https://stackoverflow.com/questions/42641315/s3-urls-get-bucket-name-and-path
 class S3Url(object):
@@ -43,3 +46,13 @@ class S3Url(object):
     @property
     def url(self):
         return self._parsed.geturl()
+
+
+def hash_dataframe(df):
+    try:
+        obj = pd.util.hash_pandas_object(df, index=True).values
+    except TypeError:
+        # In case of facing unhashable objects (like dict), use pickle
+        obj = pickle.dumps(df, pickle.HIGHEST_PROTOCOL)
+
+    return hashlib.md5(obj).hexdigest()

--- a/tests/datasource/test_util.py
+++ b/tests/datasource/test_util.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+from great_expectations.datasource.util import hash_dataframe
+
+
+def test_hash_dataframe_hashable_df():
+    df = pd.DataFrame([{"col_1": 1}])
+    assert hash_dataframe(df) == '03a57802981ad29e22de64b9a374ed86'
+
+
+def test_hash_dataframe_unhashable_df():
+    df = pd.DataFrame([{"col_1": {"val": 1}}])
+    assert hash_dataframe(df) == 'b7f282f9e759690a3092a401e00d2e47'

--- a/tests/datasource/test_util.py
+++ b/tests/datasource/test_util.py
@@ -4,10 +4,14 @@ from great_expectations.datasource.util import hash_dataframe
 
 
 def test_hash_dataframe_hashable_df():
-    df = pd.DataFrame([{"col_1": 1}])
-    assert hash_dataframe(df) == '03a57802981ad29e22de64b9a374ed86'
+    data = [{"col_1": 1}]
+    df1 = pd.DataFrame(data)
+    df2 = pd.DataFrame(data)
+    assert hash_dataframe(df1) == hash_dataframe(df2)
 
 
 def test_hash_dataframe_unhashable_df():
-    df = pd.DataFrame([{"col_1": {"val": 1}}])
-    assert hash_dataframe(df) == 'b7f282f9e759690a3092a401e00d2e47'
+    data = [{"col_1": {"val": 1}}]
+    df1 = pd.DataFrame(data)
+    df2 = pd.DataFrame(data)
+    assert hash_dataframe(df1) == hash_dataframe(df2)

--- a/tests/datasource/test_util.py
+++ b/tests/datasource/test_util.py
@@ -1,17 +1,17 @@
 import pandas as pd
 
-from great_expectations.datasource.util import hash_dataframe
+from great_expectations.datasource.util import hash_pandas_dataframe
 
 
-def test_hash_dataframe_hashable_df():
+def test_hash_pandas_dataframe_hashable_df():
     data = [{"col_1": 1}]
     df1 = pd.DataFrame(data)
     df2 = pd.DataFrame(data)
-    assert hash_dataframe(df1) == hash_dataframe(df2)
+    assert hash_pandas_dataframe(df1) == hash_pandas_dataframe(df2)
 
 
-def test_hash_dataframe_unhashable_df():
+def test_hash_pandas_dataframe_unhashable_df():
     data = [{"col_1": {"val": 1}}]
     df1 = pd.DataFrame(data)
     df2 = pd.DataFrame(data)
-    assert hash_dataframe(df1) == hash_dataframe(df2)
+    assert hash_pandas_dataframe(df1) == hash_pandas_dataframe(df2)


### PR DESCRIPTION
These changes are regarding to fix #1309 issue. According to pandas-dev/pandas#18771 it's not possible to generate hash when the data frame contains a mutable object, so as a fallback solution I used pickle for such data frames. 

Edit: As stated in pandas issue I linked above, these objects are mutable and the `pickle` here doesn't guarantee the generated hash would stay the same on different machines. This implementation is just useful for simple fingerprint. 