### PR TITLE
DOC: Fix datetime reference in create_expectations.rst

### DIFF
--- a/docs/tutorials/create_expectations.rst
+++ b/docs/tutorials/create_expectations.rst
@@ -287,7 +287,7 @@ To view the expectation suite you just created as HTML, rebuild the data docs an
     batch.save_expectation_suite(discard_failed_expectations=False)
 
     # This step is optional, but useful - evaluate the expectations against the current batch of data
-    run_id = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S.%fZ")
+    run_id = datetime.utcnow().strftime("%Y%m%dT%H%M%S.%fZ")
     results = context.run_validation_operator("action_list_operator", assets_to_validate=[batch], run_id=run_id)
     expectation_suite_identifier = list(results["details"].keys())[0]
     validation_result_identifier = ValidationResultIdentifier(


### PR DESCRIPTION
In the [Setup section](https://docs.greatexpectations.io/en/0.10.2/tutorials/create_expectations.html#setup) the `datetime` class is imported via:
```python
from datetime import datetime
```
However, in the [Finalize section](https://docs.greatexpectations.io/en/0.10.2/tutorials/create_expectations.html#finalize) `datetime` is being referenced as if it were imported as a module, i.e. `import datetime`:
```python
run_id = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S.%fZ")
```

Updated the Finalize section to reference the `datetime` class so it's consistent with the Setup section.