### PR TITLE
 DataContext.run_validation_operator() now raises errors if no batches are passed or if they are of the wrong type.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ develop
   - Fix bullet list spacing issues
   - Fix 0.10. formatting
   - Drop roadmap_and_changelog.rst and move changelog.rst to the top level of the table of contents
-
+* DataContext.run_validation_operator() now raises DataContextErrors if no batches are passed or if they are the wrong type.
 
 0.10.4
 -----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,10 @@ develop
   - Fix bullet list spacing issues
   - Fix 0.10. formatting
   - Drop roadmap_and_changelog.rst and move changelog.rst to the top level of the table of contents
-* DataContext.run_validation_operator() now raises DataContextErrors if no batches are passed or if they are the wrong type.
+* DataContext.run_validation_operator() now raises a DataContextError if:
+  - no batches are passed
+  - batches are of the the wrong type
+  - no matching validation operator is found in the project
 
 0.10.4
 -----------------

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -700,19 +700,23 @@ class BaseDataContext(object):
 
         for batch in assets_to_validate:
             if not isinstance(batch, (tuple, DataAsset)):
-                raise ge_exceptions.DataContextError("Batches are requried to be of type DataAsset")
+                raise ge_exceptions.DataContextError("Batches are required to be of type DataAsset")
+        try:
+            validation_operator = self.validation_operators[validation_operator_name]
+        except KeyError:
+            raise ge_exceptions.DataContextError(f"No validation operator `{validation_operator_name}` was found in your project. Please verify this in your great_expectations.yml")
 
         if run_id is None:
             run_id = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S.%fZ")
             logger.info("Setting run_id to: {}".format(run_id))
         if evaluation_parameters is None:
-            return self.validation_operators[validation_operator_name].run(
+            return validation_operator.run(
                 assets_to_validate=assets_to_validate,
                 run_id=run_id,
                 **kwargs
             )
         else:
-            return self.validation_operators[validation_operator_name].run(
+            return validation_operator.run(
                 assets_to_validate=assets_to_validate,
                 run_id=run_id,
                 evaluation_parameters=evaluation_parameters,

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -695,6 +695,13 @@ class BaseDataContext(object):
         Returns:
             ValidationOperatorResult
         """
+        if not assets_to_validate:
+            raise ge_exceptions.DataContextError("No batches of data were passed in. These are required")
+
+        for batch in assets_to_validate:
+            if not isinstance(batch, (tuple, DataAsset)):
+                raise ge_exceptions.DataContextError("Batches are requried to be of type DataAsset")
+
         if run_id is None:
             run_id = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S.%fZ")
             logger.info("Setting run_id to: {}".format(run_id))

--- a/tests/actions/test_validation_operators_in_data_context.py
+++ b/tests/actions/test_validation_operators_in_data_context.py
@@ -11,6 +11,7 @@ from great_expectations.core import (
 from great_expectations.data_context.util import (
     file_relative_path,
 )
+from great_expectations.exceptions import DataContextError
 
 
 @pytest.fixture()
@@ -52,6 +53,32 @@ def validation_operators_data_context(basic_data_context_config_for_validation_o
     data_context.save_expectation_suite(warning_expectations, expectation_suite_name="f1.warning")
 
     return data_context
+
+
+def test_run_validation_operator_raises_error_if_no_batches_are_passed(
+    validation_operators_data_context,
+):
+    context = validation_operators_data_context
+
+    with pytest.raises(DataContextError) as e:
+        context.run_validation_operator(
+            validation_operator_name="store_val_res_and_extract_eval_params",
+            assets_to_validate=[],
+        )
+        assert e.msg == "No batches of data were passed in. These are required"
+
+
+def test_run_validation_operator_raises_error_if_non_batches_are_passed_in_list(
+    validation_operators_data_context,
+):
+    context = validation_operators_data_context
+
+    with pytest.raises(DataContextError) as e:
+        context.run_validation_operator(
+            validation_operator_name="store_val_res_and_extract_eval_params",
+            assets_to_validate=["foo"],
+        )
+        assert e.msg == "Batches are requried to be of type DataAsset"
 
 
 def test_validation_operator_evaluation_parameters(validation_operators_data_context, parameterized_expectation_suite):

--- a/tests/actions/test_validation_operators_in_data_context.py
+++ b/tests/actions/test_validation_operators_in_data_context.py
@@ -1,16 +1,10 @@
-import pytest
 import json
 
-from great_expectations.data_context import (
-    BaseDataContext,
-)
-from great_expectations.core import (
-    expectationSuiteSchema,
-)
+import pytest
 
-from great_expectations.data_context.util import (
-    file_relative_path,
-)
+from great_expectations.core import expectationSuiteSchema
+from great_expectations.data_context import BaseDataContext
+from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import DataContextError
 
 
@@ -59,26 +53,38 @@ def test_run_validation_operator_raises_error_if_no_batches_are_passed(
     validation_operators_data_context,
 ):
     context = validation_operators_data_context
-
     with pytest.raises(DataContextError) as e:
         context.run_validation_operator(
             validation_operator_name="store_val_res_and_extract_eval_params",
             assets_to_validate=[],
         )
-        assert e.msg == "No batches of data were passed in. These are required"
+    assert e.value.message == "No batches of data were passed in. These are required"
 
 
 def test_run_validation_operator_raises_error_if_non_batches_are_passed_in_list(
     validation_operators_data_context,
 ):
     context = validation_operators_data_context
-
     with pytest.raises(DataContextError) as e:
         context.run_validation_operator(
             validation_operator_name="store_val_res_and_extract_eval_params",
             assets_to_validate=["foo"],
         )
-        assert e.msg == "Batches are requried to be of type DataAsset"
+    assert e.value.message == "Batches are required to be of type DataAsset"
+
+
+def test_run_validation_operator_raises_error_if_no_matching_validation_operator_is_found(
+    validation_operators_data_context,
+):
+    context = validation_operators_data_context
+    with pytest.raises(DataContextError) as e:
+        context.run_validation_operator(
+            validation_operator_name="blarg", assets_to_validate=[(1, 2)],
+        )
+    assert (
+        e.value.message
+        == "No validation operator `blarg` was found in your project. Please verify this in your great_expectations.yml"
+    )
 
 
 def test_validation_operator_evaluation_parameters(validation_operators_data_context, parameterized_expectation_suite):


### PR DESCRIPTION
Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [x] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
