### PR TITLE
[FEATURE]  instantiate datasource and validate config only when datasource is used

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -114,7 +114,6 @@ def datasource_new(directory):
 )
 def delete_datasource(directory, datasource_name=None):
     """Delete data source"""
-    print(datasource_name) 
     context = toolkit.load_data_context_with_error_handling(directory)
     if datasource_name is None:
         cli_message("<red>{}</red>".format("Datasource name must be a datasource name"))
@@ -122,7 +121,7 @@ def delete_datasource(directory, datasource_name=None):
     else:
         context.delete_datasource(datasource_name)
         if context.get_datasource(datasource_name) is None: 
-            cli_message("<green>{}</greem>".format("Datasource deleted successfully."))
+            cli_message("<green>{}</green>".format("Datasource deleted successfully."))
             return True
         else:
             cli_message("<red>{}</red>".format("Datasource not deleted"))

--- a/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
@@ -14,19 +14,18 @@ class DatasourceAnonymizer(Anonymizer):
             Datasource
         ]
 
-    def anonymize_datasource_info(self, datasource_obj):
+    def anonymize_datasource_info(self, name, config):
         anonymized_info_dict = dict()
-        name = datasource_obj.name
         anonymized_info_dict["anonymized_name"] = self.anonymize(name)
 
         self.anonymize_object_info(
-            object_=datasource_obj,
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes
+            ge_classes=self._ge_classes,
+            object_config=config
         )
 
         if anonymized_info_dict.get("parent_class") == "SqlAlchemyDatasource":
-            sqlalchemy_dialect = datasource_obj.engine.name
+            sqlalchemy_dialect = config["engine"]
             anonymized_info_dict["sqlalchemy_dialect"] = sqlalchemy_dialect
 
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/usage_statistics.py
+++ b/great_expectations/core/usage_statistics/usage_statistics.py
@@ -109,8 +109,10 @@ class UsageStatisticsHandler(object):
             "platform.release": platform.release(),
             "version_info": str(sys.version_info),
             "anonymized_datasources": [
-                self._datasource_anonymizer.anonymize_datasource_info(datasource)
-                for datasource in self._data_context.datasources.values()
+                self._datasource_anonymizer.anonymize_datasource_info(
+                    datasource_name, datasource_config
+                )
+                for datasource_name, datasource_config in self._data_context._project_config_with_variables_substituted.datasources.items()
             ],
             "anonymized_stores": [
                 self._store_anonymizer.anonymize_store_info(store_name, store_obj)

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -168,7 +168,6 @@ class BaseDataContext(object):
         self._evaluation_parameter_dependencies_compiled = False
         self._evaluation_parameter_dependencies = {}
 
-
     def _build_store(self, store_name, store_config):
         module_name = 'great_expectations.data_context.store'
         new_store = instantiate_class_from_config(
@@ -858,7 +857,7 @@ class BaseDataContext(object):
         """
         if datasource_name in self._cached_datasources:
             return self._cached_datasources[datasource_name]
-        elif datasource_name in self._project_config_with_variables_substituted.datasources:
+        if datasource_name in self._project_config_with_variables_substituted.datasources:
             datasource_config = copy.deepcopy(
                 self._project_config_with_variables_substituted.datasources[datasource_name])
         else:

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -150,10 +150,8 @@ class BaseDataContext(object):
         self._in_memory_instance_id = None  # This variable *may* be used in case we cannot save an instance id
         self._initialize_usage_statistics(project_config.anonymous_usage_statistics)
 
-        # Init data sources
-        self._datasources = {}
-        for datasource in self._project_config_with_variables_substituted.datasources.keys():
-            self.get_datasource(datasource)
+        # Store cached datasources but don't init them
+        self._cached_datasources = {}
 
         # Init stores
         self._stores = dict()
@@ -169,6 +167,7 @@ class BaseDataContext(object):
 
         self._evaluation_parameter_dependencies_compiled = False
         self._evaluation_parameter_dependencies = {}
+
 
     def _build_store(self, store_name, store_config):
         module_name = 'great_expectations.data_context.store'
@@ -459,7 +458,9 @@ class BaseDataContext(object):
     @property
     def datasources(self):
         """A single holder for all Datasources in this context"""
-        return self._datasources
+        return {
+            datasource: self.get_datasource(datasource) for datasource in self._project_config_with_variables_substituted.datasources
+        }
 
     @property
     def expectations_store_name(self):
@@ -546,11 +547,13 @@ class BaseDataContext(object):
         with open(config_variables_filepath, "w") as config_variables_file:
             yaml.dump(config_variables, config_variables_file)
 
-    def delete_datasource(self,datasource_name=None):
-        """Delete data source 
+    def delete_datasource(self, datasource_name=None):
+        """Delete a data source
         Args:
+            datasource_name: The name of the datasource to delete.
 
-        Returns:
+        Raises:
+            ValueError: If the datasource name isn't provided or cannot be found.
         """
         if datasource_name is None:
             raise ValueError(
@@ -562,10 +565,10 @@ class BaseDataContext(object):
                #remove key until we have a delete method on project_config
                #self._project_config_with_variables_substituted.datasources[datasource_name].remove()
                #del self._project_config["datasources"][datasource_name]
-               del self._datasources[datasource_name]
+               del self._cached_datasources[datasource_name]
             else:
                 raise ValueError(
-                    "Datasource not found"
+                    "Datasource {} not found".format(datasource_name)
                 )
 
     def get_available_data_asset_names(self, datasource_names=None, batch_kwargs_generator_names=None):
@@ -792,7 +795,7 @@ class BaseDataContext(object):
         if initialize:
             datasource = self._build_datasource_from_config(
                 name, self._project_config_with_variables_substituted.datasources[name])
-            self._datasources[name] = datasource
+            self._cached_datasources[name] = datasource
         else:
             datasource = None
 
@@ -853,8 +856,8 @@ class BaseDataContext(object):
         Returns:
             datasource (Datasource)
         """
-        if datasource_name in self._datasources:
-            return self._datasources[datasource_name]
+        if datasource_name in self._cached_datasources:
+            return self._cached_datasources[datasource_name]
         elif datasource_name in self._project_config_with_variables_substituted.datasources:
             datasource_config = copy.deepcopy(
                 self._project_config_with_variables_substituted.datasources[datasource_name])
@@ -864,7 +867,7 @@ class BaseDataContext(object):
             )
         datasource_config = datasourceConfigSchema.load(datasource_config)
         datasource = self._build_datasource_from_config(datasource_name, datasource_config)
-        self._datasources[datasource_name] = datasource
+        self._cached_datasources[datasource_name] = datasource
         return datasource
 
     def list_expectation_suites(self):

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -515,7 +515,7 @@ class DefaultSiteIndexBuilder(object):
         #     last_datasource_class_by_name = datasource_classes_by_name[-1]
         #     last_datasource_class_name = last_datasource_class_by_name["class_name"]
         #     last_datasource_name = last_datasource_class_by_name["name"]
-        #     last_datasource = self.data_context.datasources[last_datasource_name]
+        #     last_datasource = self.data_context.get_datasource(last_datasource_name)
         #
         #     if last_datasource_class_name == "SqlAlchemyDatasource":
         #         try:


### PR DESCRIPTION
Closes #1201 

Changes proposed in this pull request:
* Removes datasource loading in data context init, but caches datasources on the data context instance to maintain performance. Almost everywhere else in the code uses `get_datasource` anyway so that's fine. Updated uses of `.datasources` to use `get_datasource` instead in the minimal places they happened.
* Refactored the `datasources` property to maintain backwards compatibility, but ideally this would go away imo. Alternatively, happy to make this a custom subclass of `dict` that implement the `__missing_item__` (or whatever the Python dunderscore method for handling missing dict gets is) to use `get_datasource`. I'm not too fussed so haven't done this, but let me know if you want me to.
* You'll need to double check this is still okay, but had to refactor the anonymous usage stats thingy for datasource anonymisation to use the config instead of loading the datasource objects and using that (because it does so on init, invalidating the previous work).
* Fixed some docstrings, a typo and an accidental `print` in a command line. Might be worth running a linter to catch accidental `print`s 👀 

After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [x] Code Review

Thank you for submitting!