### PR TITLE
Correct sqlalchemy bug in documentation sample code

### DIFF
--- a/docs/reference/custom_expectations.rst
+++ b/docs/reference/custom_expectations.rst
@@ -199,10 +199,14 @@ A similar implementation for SqlAlchemy would also import the base decorator:
 
             # We will assume that these are already HISTOGRAMS created as a check_dataset
             # either of binned values or of (ordered) value counts
-            rows = sa.select([
-                sa.column(column_A).label("col_A_counts"),
-                sa.column(column_B).label("col_B_counts")
-            ]).select_from(self._table).fetchall()
+            rows = self.engine.execute(
+                sa.select(
+                    [
+                        sa.column(column_A).label("col_A_counts"),
+                        sa.column(column_B).label("col_B_counts"),
+                    ]
+                ).select_from(self._table)
+            ).fetchall()
 
             cols = [col for col in zip(*rows)]
             cdf1 = np.array(cols[0])


### PR DESCRIPTION
Looks like this sqlalchemy bit wasn't actually executing the query in the sample code before calling `fetchall`

Changes proposed in this pull request:
- Correct documentation sample code re making custom expectations


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
