### PR TITLE
Fix datasource delete cli help text and refactor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ Changelog
 
 develop
 -----------------
+* Bugfix and refactor for `datasource delete` CLI command (#1386) @mzjp2
+* Instantiate datasources and validate config only when datasource is used (#1374) @mzjp2
+
 
 0.10.8
 -----------------

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -105,27 +105,23 @@ def datasource_new(directory):
     '--directory',
     '-d',
     default=None,
-    help="Datasource to delete"
+    help="The project's great_expectations directory."
 )
-@click.option(
-    "--datasource_name",
-    "-s",
-    help="The site that you want documentation cleaned for. See data_docs section in great_expectations.yml",
-)
-def delete_datasource(directory, datasource_name=None):
-    """Delete data source"""
+@click.argument("datasource")
+def delete_datasource(directory, datasource):
+    """Delete the datasource specified as an argument"""
     context = toolkit.load_data_context_with_error_handling(directory)
-    if datasource_name is None:
-        cli_message("<red>{}</red>".format("Datasource name must be a datasource name"))
-        return
+    try:
+        context.delete_datasource(datasource)
+    except ValueError:
+        cli_message("<red>{}</red>".format("Datasource {} could not be found".format(datasource)))
+        sys.exit(1)
     else:
-        context.delete_datasource(datasource_name)
-        if context.get_datasource(datasource_name) is None: 
-            cli_message("<green>{}</green>".format("Datasource deleted successfully."))
-            return True
-        else:
-            cli_message("<red>{}</red>".format("Datasource not deleted"))
-            sys.exit(1)
+        cli_message("<green>{}</green>".format("Datasource deleted successfully."))
+
+    if context.get_datasource(datasource) is None:
+        cli_message("<red>{}</red>".format("Datasource not deleted"))
+        sys.exit(1)
 
 
 @datasource.command(name="list")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -167,10 +167,6 @@ def test_cli_config_not_found_raises_error_for_all_commands(tmp_path_factory):
         result = runner.invoke(
             cli, ["datasource", "new", "-d", "./"], catch_exceptions=False
         )
-          
-        assert error_message in result.output
-        result = runner.invoke(cli, ["datasource", "delete"], catch_exceptions=False)
-        assert error_message in result.output
  
         # data_docs clean
         result = runner.invoke(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -159,7 +159,7 @@ def test_cli_config_not_found_raises_error_for_all_commands(tmp_path_factory):
 
         # datasource delete
         result = runner.invoke(
-            cli, ["datasource", "delete", "-s", "new"], catch_exceptions=False
+            cli, ["datasource", "delete", "new"], catch_exceptions=False
         )
         assert error_message in result.output
         #create new before delete again


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactor the `delete_datasource` command to make it simpler
- Fixed the help text for `-d directory` following https://greatexpectationstalk.slack.com/archives/CUUMYDJAX/p1588687575382100
- Changed the way of specifying the datasource as an argument instead of option, which feels more natural to me: `great_expectations datasource delete my_datasource` instead of `-s my_datasource`, but happy to change it if you prefer. Can also trivially make it take as many datasource names as you want by making `nargs=-1` and using a for loop.

After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [x] Code Review

Thank you for submitting!
