### PR TITLE
[BUGFIX] correct syntax error in set creation

### DIFF
--- a/great_expectations/render/renderer/other_section_renderer.py
+++ b/great_expectations/render/renderer/other_section_renderer.py
@@ -291,7 +291,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
                 else:
                     expected_types = set(evr.expectation_config.kwargs["type_list"])
             else:  # assuming expect_column_values_to_be_of_type
-                expected_types = {[evr.expectation_config.kwargs["type_"]]}
+                expected_types = set([evr.expectation_config.kwargs["type_"]])
 
             if expected_types.issubset(BasicDatasetProfiler.INT_TYPE_NAMES):
                 column_types[column] = "int"


### PR DESCRIPTION
Here while using below code we were getting an error with trace: unhashable type: 'list' for which now I have changed that to set only.
document_model = ProfilingResultsPageRenderer().render(validation_result)

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
