### PR TITLE
CLI suite delete changed from an optional argument to a required one

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ develop
 * Bugfix for the CLI command `docs build` ignoring the --site_name argument (#1378)
 * Bugfix and refactor for `datasource delete` CLI command (#1386) @mzjp2
 * Instantiate datasources and validate config only when datasource is used (#1374) @mzjp2
+* suite delete changed from an optional argument to a required one
 
 0.10.8
 -----------------

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -343,7 +343,7 @@ If you wish to avoid this you can add the `--no-jupyter` flag.</green>\n\n"""
     "--directory",
     "-d",
     default=None,
-    help="Delete an expectation suite.",
+    help="The project's great_expectations directory.",
 )
 @mark.cli_as_experimental
 def suite_delete(suite, directory):

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -353,7 +353,7 @@ def suite_delete(suite, directory):
     usage_event = "cli.suite.delete"
     context = toolkit.load_data_context_with_error_handling(directory)
     suite_names = context.list_expectation_suite_names()
-    if len(suite_names) == 0:
+    if not suite_names
         toolkit.exit_with_failure_message_and_stats(
             context,
             usage_event,

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -353,7 +353,7 @@ def suite_delete(suite, directory):
     usage_event = "cli.suite.delete"
     context = toolkit.load_data_context_with_error_handling(directory)
     suite_names = context.list_expectation_suite_names()
-    if not suite_names
+    if not suite_names:
         toolkit.exit_with_failure_message_and_stats(
             context,
             usage_event,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -145,7 +145,7 @@ def test_cli_config_not_found_raises_error_for_all_commands(tmp_path_factory):
 
         # expectation suite delete
         result = runner.invoke(
-            cli, ["suite", "delete", "-d", "FAKE"], catch_exceptions=False
+            cli, ["suite", "delete", "deleteme", "-d", "FAKE"], catch_exceptions=False
         )
         assert error_message in result.output
         #expectation create new
@@ -154,7 +154,7 @@ def test_cli_config_not_found_raises_error_for_all_commands(tmp_path_factory):
             cli, ["suite", "new", "-d", "./"], catch_exceptions=False
         )
         assert error_message in result.output
-        result = runner.invoke(cli, ["suite", "delete"], catch_exceptions=False)
+        result = runner.invoke(cli, ["suite", "delete", "deleteme"], catch_exceptions=False)
         assert error_message in result.output
 
         # datasource delete

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -1145,6 +1145,104 @@ def test_suite_list_with_multiple_suites(caplog, empty_data_context):
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
+def test_suite_delete_with_zero_suites(mock_emit, caplog, empty_data_context_stats_enabled):
+    project_dir = empty_data_context_stats_enabled.root_directory
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(
+        cli, f"suite delete not_a_suite -d {project_dir}", catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "No expectation suites found in the project" in result.output
+
+    assert mock_emit.call_count == 2
+    assert mock_emit.call_args_list == [
+        mock.call(
+            {"event_payload": {}, "event": "data_context.__init__",
+             "success": True}
+        ),
+        mock.call(
+            {"event": "cli.suite.delete", "event_payload": {},
+             "success": False}
+        ),
+    ]
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
+)
+def test_suite_delete_with_non_existent_suite(mock_emit, caplog, empty_data_context_stats_enabled):
+    context = empty_data_context_stats_enabled
+    project_dir = context.root_directory
+    suite = context.create_expectation_suite("foo")
+    context.save_expectation_suite(suite)
+    mock_emit.reset_mock()
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli, f"suite delete not_a_suite -d {project_dir}", catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "No expectation suite named not_a_suite found" in result.output
+
+    assert mock_emit.call_count == 2
+    assert mock_emit.call_args_list == [
+        mock.call(
+            {"event_payload": {}, "event": "data_context.__init__",
+             "success": True}
+        ),
+        mock.call(
+            {"event": "cli.suite.delete", "event_payload": {},
+             "success": False}
+        ),
+    ]
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
+)
+def test_suite_delete_with_one_suite(mock_emit, caplog, empty_data_context_stats_enabled):
+    project_dir = empty_data_context_stats_enabled.root_directory
+    context = DataContext(project_dir)
+    suite = context.create_expectation_suite("a.warning")
+    context.save_expectation_suite(suite)
+    mock_emit.reset_mock()
+
+    suite_dir = os.path.join(project_dir, "expectations", "a")
+    suite_path = os.path.join(suite_dir, "warning.json")
+    assert os.path.isfile(suite_path)
+
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli, "suite delete a.warning -d {}".format(project_dir), catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "Deleted the expectation suite named: a.warning" in result.output
+
+    assert not os.path.isdir(suite_dir)
+    assert not os.path.isfile(suite_path)
+
+    assert mock_emit.call_count == 2
+    assert mock_emit.call_args_list == [
+        mock.call(
+            {"event_payload": {}, "event": "data_context.__init__",
+             "success": True}
+        ),
+        mock.call(
+            {"event": "cli.suite.delete", "event_payload": {},
+             "success": True}
+        ),
+    ]
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
+
+
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
+)
 @mock.patch("subprocess.call", return_value=True, side_effect=None)
 def test_suite_scaffold_on_context_with_no_datasource_raises_error(
         mock_subprocess, mock_emit, caplog, empty_data_context_stats_enabled


### PR DESCRIPTION
Changes proposed in this pull request:

- This PR brings the `suite delete` command into the same UX as `datasource delete` from PR #1386 
- CLI suite delete changed from an optional argument to a required one
- added tests around CLI suite delete


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
