### PR TITLE
[BUGFIX] fix issues with remove_key on ExpectationStore and TupleFilesystemStoreBackend

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
 develop
 -----------------
+* tuplefilestore backend, expectationstore backend remove_key bugs fixed
+* no url is returned on empty data_docs site
+* return url for resource only if key exists
+* Test added for the period special char case
 
 0.10.9
 -----------------

--- a/great_expectations/cli/docs.py
+++ b/great_expectations/cli/docs.py
@@ -54,7 +54,12 @@ def docs_list(directory):
 
     docs_sites_url_dicts = context.get_docs_sites_urls()
     docs_sites_strings = [
-        " - <cyan>{}</cyan>: {}".format(docs_site_dict["site_name"], docs_site_dict["site_url"])\
+        " - <cyan>{}</cyan>: {}".format(
+            docs_site_dict["site_name"],
+            docs_site_dict.get("site_url") or
+            f'site configured but does not exist. Run the following command to build site: great_expectations '
+            f'docs build --site-name {docs_site_dict["site_name"]}'
+        )
         for docs_site_dict in docs_sites_url_dicts
     ]
 
@@ -100,7 +105,7 @@ def clean_data_docs(directory, site_name=None, all=None):
             success=True
         )
         cli_message("<green>{}</green>".format("Cleaned data docs"))
-     
+
     if failed and context is not None:
         send_usage_message(
             data_context=context,
@@ -112,9 +117,9 @@ def clean_data_docs(directory, site_name=None, all=None):
 def _build_intro_string(docs_sites_strings):
     doc_string_count = len(docs_sites_strings)
     if doc_string_count == 1:
-        list_intro_string = "1 Data Docs site found:"
+        list_intro_string = "1 Data Docs site configured:"
     elif doc_string_count > 1:
-        list_intro_string = f"{doc_string_count} Data Docs sites found:"
+        list_intro_string = f"{doc_string_count} Data Docs sites configured:"
     return list_intro_string
 
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -408,6 +408,8 @@ class BaseDataContext(object):
             url = site_builder.get_resource_url(resource_identifier=resource_identifier)
             if url is not None:
                 site_urls.append({"site_name": _site_name, "site_url": url})
+            if url is None:
+                site_urls.append({"site_name": _site_name, "site_url": ""})
 
         return site_urls
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -368,7 +368,7 @@ class BaseDataContext(object):
         return resource_store
 
     def get_docs_sites_urls(
-        self, resource_identifier=None, site_name: Optional[str] = None
+        self, resource_identifier=None, site_name: Optional[str] = None, only_if_exists=True
     ) -> List[Dict[str, str]]:
         """
         Get URLs for a resource for all data docs sites.
@@ -399,13 +399,13 @@ class BaseDataContext(object):
                 raise ge_exceptions.DataContextError(f"Could not find site named {site_name}. Please check your configurations")
             site = sites[site_name]
             site_builder = self._load_site_builder_from_site_config(site)
-            url = site_builder.get_resource_url(resource_identifier=resource_identifier)
+            url = site_builder.get_resource_url(resource_identifier=resource_identifier, only_if_exists=only_if_exists)
             return [{"site_name": site_name, "site_url": url}]
 
         site_urls = []
         for _site_name, site_config in sites.items():
             site_builder = self._load_site_builder_from_site_config(site_config)
-            url = site_builder.get_resource_url(resource_identifier=resource_identifier)
+            url = site_builder.get_resource_url(resource_identifier=resource_identifier, only_if_exists=only_if_exists)
             site_urls.append({"site_name": _site_name, "site_url": url})
 
         return site_urls
@@ -430,7 +430,7 @@ class BaseDataContext(object):
 
     @usage_statistics_enabled_method(event_name="data_context.open_data_docs",)
     def open_data_docs(
-        self, resource_identifier: Optional[str] = None, site_name: Optional[str] = None
+        self, resource_identifier: Optional[str] = None, site_name: Optional[str] = None, only_if_exists=True
     ) -> None:
         """
         A stdlib cross-platform way to open a file in a browser.
@@ -444,7 +444,7 @@ class BaseDataContext(object):
                 open all docs found in the project.
         """
         data_docs_urls = self.get_docs_sites_urls(
-            resource_identifier=resource_identifier, site_name=site_name,
+            resource_identifier=resource_identifier, site_name=site_name, only_if_exists=only_if_exists
         )
         urls_to_open = [site["site_url"] for site in data_docs_urls]
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -968,12 +968,6 @@ class BaseDataContext(object):
             True for Success and False for Failure.
         """
         key = ExpectationSuiteIdentifier(expectation_suite_name)
-        if key is None:
-            keys = self.stores[self.expectations_store_name].list_keys()
-            for item in keys:
-                sval = repr(item).replace("/",".")
-                if expectation_suite_name.expectation_suite_name in sval:
-                    key=item
         if not self._stores[self.expectations_store_name].has_key(key):
             raise ge_exceptions.DataContextError(
                 "expectation_suite with name {} does not exist."

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -406,10 +406,7 @@ class BaseDataContext(object):
         for _site_name, site_config in sites.items():
             site_builder = self._load_site_builder_from_site_config(site_config)
             url = site_builder.get_resource_url(resource_identifier=resource_identifier)
-            if url is not None:
-                site_urls.append({"site_name": _site_name, "site_url": url})
-            if url is None:
-                site_urls.append({"site_name": _site_name, "site_url": ""})
+            site_urls.append({"site_name": _site_name, "site_url": url})
 
         return site_urls
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -968,6 +968,12 @@ class BaseDataContext(object):
             True for Success and False for Failure.
         """
         key = ExpectationSuiteIdentifier(expectation_suite_name)
+        if key is None:
+            keys = self.stores[self.expectations_store_name].list_keys()
+            for item in keys:
+                sval = repr(item).replace("/",".")
+                if expectation_suite_name.expectation_suite_name in sval:
+                    key=item
         if not self._stores[self.expectations_store_name].has_key(key):
             raise ge_exceptions.DataContextError(
                 "expectation_suite with name {} does not exist."

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -408,8 +408,6 @@ class BaseDataContext(object):
             url = site_builder.get_resource_url(resource_identifier=resource_identifier)
             if url is not None:
                 site_urls.append({"site_name": _site_name, "site_url": url})
-            if url is None:
-                site_urls.append({"site_name": _site_name, "site_url": ""})
 
         return site_urls
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -406,7 +406,8 @@ class BaseDataContext(object):
         for _site_name, site_config in sites.items():
             site_builder = self._load_site_builder_from_site_config(site_config)
             url = site_builder.get_resource_url(resource_identifier=resource_identifier)
-            site_urls.append({"site_name": _site_name, "site_url": url})
+            if url is not None:
+                site_urls.append({"site_name": _site_name, "site_url": url})
 
         return site_urls
 

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -33,7 +33,7 @@ class ExpectationsStore(Store):
         super().__init__(store_backend=store_backend, runtime_environment=runtime_environment)
 
     def remove_key(self, key):
-        return super().store_backend.remove_key(key)
+        return self.store_backend.remove_key(key)
 
     def serialize(self, key, value):
         return self._expectationSuiteSchema.dumps(value, indent=2, sort_keys=True)

--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -143,7 +143,7 @@ class HtmlSiteStore(object):
         ].set(key.resource_identifier.to_tuple(), serialized_value,
               content_encoding='utf-8', content_type='text/html; charset=utf-8')
 
-    def get_url_for_resource(self, resource_identifier=None):
+    def get_url_for_resource(self, only_if_exists=True, resource_identifier=None):
         """
         Return the URL of the HTML document that renders a resource
         (e.g., an expectation suite or a validation result).

--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -143,7 +143,7 @@ class HtmlSiteStore(object):
         ].set(key.resource_identifier.to_tuple(), serialized_value,
               content_encoding='utf-8', content_type='text/html; charset=utf-8')
 
-    def get_url_for_resource(self, only_if_exists=True, resource_identifier=None):
+    def get_url_for_resource(self, resource_identifier=None, only_if_exists=True):
         """
         Return the URL of the HTML document that renders a resource
         (e.g., an expectation suite or a validation result).

--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -166,6 +166,13 @@ class HtmlSiteStore(object):
             # this method does not support getting the URL of static assets
             raise ValueError("Cannot get URL for resource {0:s}".format(str(resource_identifier)))
 
+        if store_backend is None:
+            return None
+        if only_if_exists:
+            if store_backend.has_key(key):
+                return store_backend.get_url_for_key(key)
+            else:
+                return None
         return store_backend.get_url_for_key(key)
 
     def _validate_key(self, key):

--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -166,7 +166,9 @@ class HtmlSiteStore(object):
             # this method does not support getting the URL of static assets
             raise ValueError("Cannot get URL for resource {0:s}".format(str(resource_identifier)))
 
-        return store_backend.get_url_for_key(key) if store_backend is not None and only_if_exists and store_backend.has_key(key) else None
+        if only_if_exists:
+            return store_backend.get_url_for_key(key) if store_backend.has_key(key) else None
+        return store_backend.get_url_for_key(key)
 
     def _validate_key(self, key):
         if not isinstance(key, SiteSectionIdentifier):

--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -166,14 +166,7 @@ class HtmlSiteStore(object):
             # this method does not support getting the URL of static assets
             raise ValueError("Cannot get URL for resource {0:s}".format(str(resource_identifier)))
 
-        if store_backend is None:
-            return None
-        if only_if_exists:
-            if store_backend.has_key(key):
-                return store_backend.get_url_for_key(key)
-            else:
-                return None
-        return store_backend.get_url_for_key(key)
+        return store_backend.get_url_for_key(key) if store_backend is not None and only_if_exists and store_backend.has_key(key) else None
 
     def _validate_key(self, key):
         if not isinstance(key, SiteSectionIdentifier):

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -91,4 +91,6 @@ class Store(object):
         return [self.tuple_to_key(key) for key in self._store_backend.list_keys()]
 
     def has_key(self, key):
+         if self._use_fixed_length_key:
+            return self._store_backend.has_key(key.to_fixed_length_tuple()) 
         return self._store_backend.has_key(key.to_tuple())

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -91,6 +91,6 @@ class Store(object):
         return [self.tuple_to_key(key) for key in self._store_backend.list_keys()]
 
     def has_key(self, key):
-         if self._use_fixed_length_key:
+        if self._use_fixed_length_key:
             return self._store_backend.has_key(key.to_fixed_length_tuple()) 
         return self._store_backend.has_key(key.to_tuple())

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -257,7 +257,23 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
                     key_list.append(key)
 
         return key_list
+   
     
+    def crmdir(self, mroot, curpath):
+        try:
+            while not os.listdir(curpath) and os.path.exists(curpath):
+                d2=curpath
+                f2=os.path.dirname(d2)
+                if os.path.isdir(curpath):
+                    shutil.rmtree(curpath)
+                else:
+                    os.remove(curpath)
+                curpath=f2
+                self.crmdir(mroot,curpath)
+        except (NotADirectoryError, FileNotFoundError):
+            pass
+
+
     def remove_key(self, key):
         if not isinstance(key, tuple):
             key = key.to_tuple()
@@ -268,7 +284,9 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         )
         path, filename = os.path.split(filepath)
         if os.path.exists(filepath):
-            if os.remove(filepath):
+            d_path = os.path.dirname(filepath)
+            os.remove(filepath)
+            self.crmdir(self.full_base_directory, d_path)
                 return True
         return False
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -259,7 +259,10 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         return key_list
    
     
-    def crmdir(self, mroot, curpath):
+    def hsrrmdir(self, mroot, curpath):
+        """
+        recursively remove curpath dir until mroot
+        """
         try:
             while not os.listdir(curpath) and os.path.exists(curpath):
                 d2=curpath
@@ -270,7 +273,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
                     if os.path.isdir(curpath):
                         shutil.rmtree(curpath)
                 curpath=f2
-                self.crmdir(mroot,curpath)
+                self.hsrrmdir(mroot,curpath)
         except (NotADirectoryError, FileNotFoundError):
             pass
 
@@ -287,7 +290,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         if os.path.exists(filepath):
             d_path = os.path.dirname(filepath)
             os.remove(filepath)
-            self.crmdir(self.full_base_directory, d_path)
+            self.hsrrmdir(self.full_base_directory, d_path)
                 return True
         return False
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -259,9 +259,9 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         return key_list
    
     
-    def hsrrmdir(self, mroot, curpath):
+    def rrmdir(self, mroot, curpath):
         """
-        recursively remove curpath dir until mroot
+        recursively removes empty dirs between curpath and mroot inclusive
         """
         try:
             while not os.listdir(curpath) and os.path.exists(curpath):
@@ -273,7 +273,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
                     if os.path.isdir(curpath):
                         shutil.rmtree(curpath)
                 curpath=f2
-                self.hsrrmdir(mroot,curpath)
+                self.rrmdir(mroot,curpath)
         except (NotADirectoryError, FileNotFoundError):
             pass
 
@@ -290,7 +290,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         if os.path.exists(filepath):
             d_path = os.path.dirname(filepath)
             os.remove(filepath)
-            self.hsrrmdir(self.full_base_directory, d_path)
+            self.rrmdir(self.full_base_directory, d_path)
                 return True
         return False
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -264,7 +264,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         recursively removes empty dirs between curpath and mroot inclusive
         """
         try:
-            while not os.listdir(curpath) and os.path.exists(curpath):
+            while not os.listdir(curpath) and os.path.exists(curpath) and mroot!=curpath:
                 d2=curpath
                 f2=os.path.dirname(d2)
                 if os.path.isfile(curpath):
@@ -273,7 +273,6 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
                     if os.path.isdir(curpath):
                         shutil.rmtree(curpath)
                 curpath=f2
-                self.rrmdir(mroot,curpath)
         except (NotADirectoryError, FileNotFoundError):
             pass
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -265,13 +265,9 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         """
         try:
             while not os.listdir(curpath) and os.path.exists(curpath) and mroot!=curpath:
-                d2=curpath
-                f2=os.path.dirname(d2)
-                if os.path.isfile(curpath):
-                    os.remove(curpath)
-                else: 
-                    if os.path.isdir(curpath):
-                        shutil.rmtree(curpath)
+                f2=os.path.dirname(curpath)
+                if os.path.isdir(curpath):
+                    shutil.rmdir(curpath)
                 curpath=f2
         except (NotADirectoryError, FileNotFoundError):
             pass

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -264,10 +264,11 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
             while not os.listdir(curpath) and os.path.exists(curpath):
                 d2=curpath
                 f2=os.path.dirname(d2)
-                if os.path.isdir(curpath):
-                    shutil.rmtree(curpath)
-                else:
+                if os.path.isfile(curpath):
                     os.remove(curpath)
+                else: 
+                    if os.path.isdir(curpath):
+                        shutil.rmtree(curpath)
                 curpath=f2
                 self.crmdir(mroot,curpath)
         except (NotADirectoryError, FileNotFoundError):

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -290,7 +290,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
             d_path = os.path.dirname(filepath)
             os.remove(filepath)
             self.rrmdir(self.full_base_directory, d_path)
-                return True
+            return True
         return False
 
     def get_url_for_key(self, key, protocol=None):

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -268,7 +268,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         )
         path, filename = os.path.split(filepath)
         if os.path.exists(filepath):
-            if shutil.rmtree(self.full_base_directory):
+            if os.remove(filepath):
                 return True
         return False
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -266,8 +266,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         try:
             while not os.listdir(curpath) and os.path.exists(curpath) and mroot!=curpath:
                 f2=os.path.dirname(curpath)
-                if os.path.isdir(curpath):
-                    shutil.rmdir(curpath)
+                os.rmdir(curpath)
                 curpath=f2
         except (NotADirectoryError, FileNotFoundError):
             pass

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -239,7 +239,7 @@ class SiteBuilder(object):
         index_page_resource_identifier_tuple = self.site_index_builder.build()
         return self.get_resource_url(), index_page_resource_identifier_tuple[1]
 
-    def get_resource_url(self, resource_identifier=None):
+    def get_resource_url(self, resource_identifier=None, only_if_exists=True):
         """
         Return the URL of the HTML document that renders a resource
         (e.g., an expectation suite or a validation result).
@@ -250,7 +250,7 @@ class SiteBuilder(object):
         :return: URL (string)
         """
 
-        return self.target_store.get_url_for_resource(resource_identifier=resource_identifier)
+        return self.target_store.get_url_for_resource(resource_identifier=resource_identifier, only_if_exists=only_if_exists)
 
 
 class DefaultSiteSectionBuilder(object):

--- a/tests/cli/test_docs.py
+++ b/tests/cli/test_docs.py
@@ -42,7 +42,7 @@ def test_docs_build_view(
     context = DataContext(root_dir)
     obs_urls = context.get_docs_sites_urls()
 
-    assert len(obs_urls) == 1
+    assert len(obs_urls) == 2
     assert (
         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]["site_url"]
     )
@@ -76,7 +76,7 @@ def test_docs_build_no_view(
     context = DataContext(root_dir)
     obs_urls = context.get_docs_sites_urls()
 
-    assert len(obs_urls) == 1
+    assert len(obs_urls) == 2
     assert (
         "great_expectations/uncommitted/data_docs/local_site/index.html" in obs_urls[0]["site_url"]
     )

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -428,21 +428,22 @@ def test_suite_demo_multiple_datasources_with_generator_without_suite_name_argum
         catch_exceptions=False,
     )
     stdout = result.stdout
-
     assert result.exit_code == 0
     assert (
         """Select a datasource
-    1. random
-    2. titanic"""
+    1. mydatasource
+    2. random
+    3. titanic"""
         in stdout
     )
     assert (
         """Which data would you like to use?
-    1. f1 (file)
-    2. f2 (file)"""
+    1. random (directory)
+    2. titanic (directory)"""
         in stdout
     )
-    assert "Name the new expectation suite [f1.warning]" in stdout
+    
+    assert "Name the new expectation suite [random.warning]" in stdout
     assert (
         "Great Expectations will choose a couple of columns and generate expectations"
         in stdout
@@ -454,7 +455,7 @@ def test_suite_demo_multiple_datasources_with_generator_without_suite_name_argum
 
     obs_urls = context.get_docs_sites_urls()
 
-    assert len(obs_urls) == 1
+    assert len(obs_urls) == 2
     assert (
         "great_expectations/uncommitted/data_docs/local_site/index.html"
         in obs_urls[0]["site_url"]
@@ -468,7 +469,7 @@ def test_suite_demo_multiple_datasources_with_generator_without_suite_name_argum
     expected_suite_path = os.path.join(root_dir, "expectations", "my_new_suite.json")
     assert os.path.isfile(expected_suite_path)
 
-    assert mock_webbrowser.call_count == 1
+    assert mock_webbrowser.call_count == 2
     assert mock_subprocess.call_count == 0
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
@@ -517,7 +518,7 @@ def test_suite_demo_multiple_datasources_with_generator_with_suite_name_argument
 
     obs_urls = context.get_docs_sites_urls()
 
-    assert len(obs_urls) == 1
+    assert len(obs_urls) == 2 
     assert (
         "great_expectations/uncommitted/data_docs/local_site/index.html"
         in obs_urls[0]["site_url"]
@@ -531,7 +532,7 @@ def test_suite_demo_multiple_datasources_with_generator_with_suite_name_argument
     expected_suite_path = os.path.join(root_dir, "expectations", "foo_suite.json")
     assert os.path.isfile(expected_suite_path)
 
-    assert mock_webbrowser.call_count == 1
+    assert mock_webbrowser.call_count == 2
     assert mock_subprocess.call_count == 0
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
@@ -713,7 +714,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args_
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 1
+    assert mock_webbrowser.call_count == 2
     assert mock_subprocess.call_count == 0
     mock_webbrowser.reset_mock()
     mock_subprocess.reset_mock()
@@ -785,7 +786,7 @@ def test_suite_edit_multiple_datasources_with_generator_with_no_additional_args_
         input="2\n1\n1\n\n",
         catch_exceptions=False,
     )
-    assert mock_webbrowser.call_count == 1
+    assert mock_webbrowser.call_count == 2
     assert mock_subprocess.call_count == 0
     mock_subprocess.reset_mock()
     mock_webbrowser.reset_mock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -742,10 +742,10 @@ def site_builder_data_context_with_html_store_titanic_random(tmp_path_factory, f
         os.path.join(filesystem_csv_3, "f2.csv"),
         str(os.path.join(project_dir, "data/random/f2.csv"))
     )
-
+    ge.data_context.DataContext.create(project_dir)
     shutil.copy(file_relative_path(__file__, "./test_fixtures/great_expectations_site_builder.yml"),
-                str(os.path.join(project_dir, "great_expectations.yml")))
-    context = ge.data_context.DataContext(project_dir)
+                str(os.path.join(project_dir,"great_expectations", "great_expectations.yml")))
+    context = ge.data_context.DataContext(context_root_dir=os.path.join(project_dir, "great_expectations"))
 
     context.add_datasource(
         "titanic",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -745,7 +745,7 @@ def site_builder_data_context_with_html_store_titanic_random(tmp_path_factory, f
 
     shutil.copy(file_relative_path(__file__, "./test_fixtures/great_expectations_site_builder.yml"),
                 str(os.path.join(project_dir, "great_expectations.yml")))
-    context = ge.data_context.DataContext.create(project_dir)
+    context = ge.data_context.DataContext(project_dir)
 
     context.add_datasource(
         "titanic",

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -255,10 +255,12 @@ def test_data_context_expectation_suite_delete(empty_data_context):
 def test_data_context_expectation_nested_suite_delete(empty_data_context):
     assert empty_data_context.create_expectation_suite(expectation_suite_name="titanic.test.create_expectation_suite")
     expectation_suites = empty_data_context.list_expectation_suite_names()
-    assert len(expectation_suites) == 1
+    assert empty_data_context.create_expectation_suite(expectation_suite_name="titanic.test.a.create_expectation_suite")
+    expectation_suites = empty_data_context.list_expectation_suite_names()
+    assert len(expectation_suites) == 2
     empty_data_context.delete_expectation_suite(expectation_suite_name=expectation_suites[0])
     expectation_suites = empty_data_context.list_expectation_suite_names()
-    assert len(expectation_suites) == 0
+    assert len(expectation_suites) == 1
 
 def test_data_context_get_datasource_on_non_existent_one_raises_helpful_error(titanic_data_context):
     with pytest.raises(ValueError):

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -252,6 +252,14 @@ def test_data_context_expectation_suite_delete(empty_data_context):
     expectation_suites = empty_data_context.list_expectation_suite_names()
     assert len(expectation_suites) == 0
 
+def test_data_context_expectation_spchars_suite_delete(empty_data_context):
+    assert empty_data_context.create_expectation_suite(expectation_suite_name="titanic.test.create_expectation_suite")
+    expectation_suites = empty_data_context.list_expectation_suite_names()
+    assert len(expectation_suites) == 1
+    empty_data_context.delete_expectation_suite(expectation_suite_name=expectation_suites[0])
+    expectation_suites = empty_data_context.list_expectation_suite_names()
+    assert len(expectation_suites) == 0
+
 def test_data_context_get_datasource_on_non_existent_one_raises_helpful_error(titanic_data_context):
     with pytest.raises(ValueError):
         _ = titanic_data_context.get_datasource("fakey_mc_fake")

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1001,7 +1001,7 @@ def test_existing_local_data_docs_urls_returns_url_on_project_with_no_datasource
     DataContext.create(empty_directory)
     context = DataContext(os.path.join(empty_directory, DataContext.GE_DIR))
 
-    obs = context.get_docs_sites_urls()
+    obs = context.get_docs_sites_urls(only_if_exists=False)
     assert len(obs) == 1
     assert obs[0]["site_url"].endswith("great_expectations/uncommitted/data_docs/local_site/index.html")
 

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -252,7 +252,7 @@ def test_data_context_expectation_suite_delete(empty_data_context):
     expectation_suites = empty_data_context.list_expectation_suite_names()
     assert len(expectation_suites) == 0
 
-def test_data_context_expectation_spchars_suite_delete(empty_data_context):
+def test_data_context_expectation_nested_suite_delete(empty_data_context):
     assert empty_data_context.create_expectation_suite(expectation_suite_name="titanic.test.create_expectation_suite")
     expectation_suites = empty_data_context.list_expectation_suite_names()
     assert len(expectation_suites) == 1

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -32,7 +32,7 @@ def test_open_docs_with_single_local_site(mock_webbrowser, empty_data_context):
     )
     assert obs[0]["site_name"] == "local_site"
 
-    context.open_data_docs()
+    context.open_data_docs(only_if_exists=False)
     assert mock_webbrowser.call_count == 1
     call = mock_webbrowser.call_args_list[0][0][0]
     assert call.startswith("file:///")

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -146,7 +146,7 @@ def test_open_docs_with_two_local_sites_specify_open_one(
     mock_webbrowser, context_with_multiple_sites
 ):
     context = context_with_multiple_sites
-    context.open_data_docs(site_name="another_local_site")
+    context.open_data_docs(site_name="another_local_site", only_if_exists=False)
 
     assert mock_webbrowser.call_count == 1
     call = mock_webbrowser.call_args_list[0][0][0]

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -25,7 +25,7 @@ def test_open_docs_with_non_existent_site_raises_error(
 @mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_open_docs_with_single_local_site(mock_webbrowser, empty_data_context):
     context = empty_data_context
-    obs = context.get_docs_sites_urls()
+    obs = context.get_docs_sites_urls(only_if_exists=False)
     assert len(obs) == 1
     assert obs[0]["site_url"].endswith(
         "great_expectations/uncommitted/data_docs/local_site/index.html"
@@ -65,7 +65,7 @@ def context_with_multiple_sites(empty_data_context):
     }
     config.data_docs_sites = multi_sites
     context._project_config = config
-    obs = context.get_docs_sites_urls()
+    obs = context.get_docs_sites_urls(only_if_exists=False)
     assert len(obs) == 2
     assert obs[0]["site_url"].endswith(
         "great_expectations/uncommitted/data_docs/local_site/index.html"
@@ -127,7 +127,7 @@ def context_with_multiple_local_sites_and_s3_site(empty_data_context):
 @mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_open_docs_with_two_local_sites(mock_webbrowser, context_with_multiple_sites):
     context = context_with_multiple_sites
-    context.open_data_docs()
+    context.open_data_docs(only_if_exists=False)
     assert mock_webbrowser.call_count == 2
     first_call = mock_webbrowser.call_args_list[0][0][0]
     assert first_call.startswith("file:///")
@@ -183,7 +183,7 @@ def test_get_docs_sites_urls_with_two_local_sites_specify_one(
     context_with_multiple_sites,
 ):
     context = context_with_multiple_sites
-    obs = context.get_docs_sites_urls(site_name="another_local_site")
+    obs = context.get_docs_sites_urls(site_name="another_local_site", only_if_exists=False)
     assert len(obs) == 1
     assert obs[0]["site_name"] == "another_local_site"
 

--- a/tests/render/test_data_documentation_site_builder.py
+++ b/tests/render/test_data_documentation_site_builder.py
@@ -282,11 +282,24 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
                                         ValidationResultIdentifier].full_base_directory,
                                         "index.html") == html_url
 
+    team_site_config = data_docs_config['team_site']
+    team_site_builder = SiteBuilder(
+            data_context=context,
+            runtime_environment={
+                "root_directory": context.root_directory
+            },
+            **team_site_config
+        )
+    team_site_builder.clean_site()
+    obs = context.get_docs_sites_urls("team_site")
+    assert len(obs) == 0
+
+ 
     resource_dir = os.path.dirname(html_url) + "/"
     #exercise clean_site
     site_builder.clean_site()
-    assert "file://" + site_builder.site_index_builder.target_store.store_backends[\
-                                        ValidationResultIdentifier].full_base_directory == resource_dir
+    obs = context.get_docs_sites_urls()
+    assert len(obs) == 0
 
     #restore site
     context = site_builder_data_context_with_html_store_titanic_random

--- a/tests/render/test_data_documentation_site_builder.py
+++ b/tests/render/test_data_documentation_site_builder.py
@@ -143,8 +143,6 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
 
     data_docs_config = context._project_config.data_docs_sites
     local_site_config = data_docs_config['local_site']
-    # local_site_config.pop('module_name')  # This isn't necessary
-    local_site_config.pop('class_name')
 
     validations_set = set(context.stores["validations_store"].list_keys())
     assert len(validations_set) == 4
@@ -291,21 +289,19 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
             **team_site_config
         )
     team_site_builder.clean_site()
-    obs = context.get_docs_sites_urls("team_site")
+    obs = [url_dict for url_dict in context.get_docs_sites_urls(site_name="team_site") if url_dict.get("site_url")]
     assert len(obs) == 0
 
- 
-    resource_dir = os.path.dirname(html_url) + "/"
     #exercise clean_site
     site_builder.clean_site()
-    obs = context.get_docs_sites_urls()
+    obs = [url_dict for url_dict in context.get_docs_sites_urls() if url_dict.get("site_url")]
     assert len(obs) == 0
 
     #restore site
     context = site_builder_data_context_with_html_store_titanic_random
     site_builder = SiteBuilder(
-            data_context=context, 
-            runtime_environment={ 
+            data_context=context,
+            runtime_environment={
                 "root_directory": context.root_directory
             },
             **local_site_config
@@ -375,7 +371,7 @@ def test_configuration_driven_site_builder_without_how_to_buttons(site_builder_d
 
     data_docs_config = context._project_config.data_docs_sites
     local_site_config = data_docs_config['local_site']
-    local_site_config.pop('class_name')
+
     # set this flag to false in config to hide how-to buttons and related elements
     local_site_config["show_how_to_buttons"] = False
 

--- a/tests/render/test_data_documentation_site_builder.py
+++ b/tests/render/test_data_documentation_site_builder.py
@@ -145,7 +145,7 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
     local_site_config = data_docs_config['local_site']
 
     validations_set = set(context.stores["validations_store"].list_keys())
-    assert len(validations_set) == 4
+    assert len(validations_set) == 6
     assert ValidationResultIdentifier(
         expectation_suite_identifier=ExpectationSuiteIdentifier(
             expectation_suite_name=expectation_suite_name
@@ -189,15 +189,15 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
 
     # assert that how-to buttons and related elements are rendered (default behavior)
     assert_how_to_buttons(context, index_page_locator_info, index_links_dict)
-    print(json.dumps(index_page_locator_info, indent=2))
+    #print(json.dumps(index_page_locator_info, indent=2))
     assert index_page_locator_info == "file://" + context.root_directory + '/uncommitted/data_docs/local_site/index.html'
 
-    print(json.dumps(index_links_dict, indent=2))
+    #print(json.dumps(index_links_dict, indent=2))
 
     assert "site_name" in index_links_dict
 
     assert "expectations_links" in index_links_dict
-    assert len(index_links_dict["expectations_links"]) == 3
+    assert len(index_links_dict["expectations_links"]) == 5
 
     assert "validations_links" in index_links_dict
     assert len(index_links_dict["validations_links"]) == 1, \
@@ -206,7 +206,7 @@ def test_configuration_driven_site_builder(site_builder_data_context_with_html_s
     """
 
     assert "profiling_links" in index_links_dict
-    assert len(index_links_dict["profiling_links"]) == 3
+    assert len(index_links_dict["profiling_links"]) == 5
 
     # save documentation locally
     os.makedirs("./tests/render/output", exist_ok=True)

--- a/tests/test_fixtures/great_expectations_site_builder.yml
+++ b/tests/test_fixtures/great_expectations_site_builder.yml
@@ -11,7 +11,7 @@ datasources:
     batch_kwargs_generators:
       # The name default is read if no datasource or generator is specified
       mygenerator:
-        type: subdir_reader
+        class_name: SubdirReaderBatchKwargsGenerator
         base_directory: ../data
 plugins_directory: plugins/
 
@@ -38,7 +38,6 @@ stores:
       base_directory: fixtures/validations
 
   evaluation_parameter_store:
-      module_name: great_expectations.data_context.store
       class_name: EvaluationParameterStore
 
 data_docs_sites:
@@ -47,7 +46,6 @@ data_docs_sites:
   # The site includes expectation suites and profiling and validation results from uncommitted directory.
   # Local site provides the convenience of visualizing all the entities stored in JSON files as HTML.
 
-    module_name: great_expectations.render.renderer.site_builder
     class_name: SiteBuilder
     show_how_to_buttons: true
     store_backend:
@@ -56,39 +54,12 @@ data_docs_sites:
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
 
-    site_section_builders:
-      expectations:
-        class_name: DefaultSiteSectionBuilder
-        source_store_name: expectations_store
-        renderer:
-          module_name: great_expectations.render.renderer
-          class_name: ExpectationSuitePageRenderer
-
-      validations:
-        class_name: DefaultSiteSectionBuilder
-        source_store_name: validations_store
-        run_id_filter:
-          ne: profiling
-        renderer:
-          module_name: great_expectations.render.renderer
-          class_name: ValidationResultsPageRenderer
-
-      profiling:
-        class_name: DefaultSiteSectionBuilder
-        source_store_name: validations_store
-        run_id_filter:
-          eq: profiling
-        renderer:
-          module_name: great_expectations.render.renderer
-          class_name: ProfilingResultsPageRenderer
-
   team_site:
   # "team_site" is meant to support the "shared source of truth for a team" use case.
   # By default only the expectations section is enabled.
   #  Users have to configure the profiling and the validations sections (and the corresponding validations_store and validations_store attributes based on the team's decisions where these are stored (a local filesystem or S3).
   # Reach out on Slack (https://greatexpectations.io/slack>) if you would like to discuss the best way to configure a team site.
 
-    module_name: great_expectations.render.renderer.site_builder
     class_name: SiteBuilder
     show_how_to_buttons: true
     store_backend:
@@ -96,14 +67,6 @@ data_docs_sites:
       base_directory: uncommitted/data_docs/team_site/
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
-
-    site_section_builders:
-      expectations:
-        class_name: DefaultSiteSectionBuilder
-        source_store_name: expectations_store
-        renderer:
-          module_name: great_expectations.render.renderer
-          class_name: ExpectationSuitePageRenderer
 
 validation_operators:
   # Read about validation operators at: https://docs.greatexpectations.io/en/latest/guides/validation_operators.html
@@ -113,11 +76,12 @@ validation_operators:
       - name: store_validation_result
         action:
           class_name: StoreValidationResultAction
-          target_store_name: validations_store
       - name: store_evaluation_params
         action:
           class_name: StoreEvaluationParametersAction
-          target_store_name: evaluation_parameter_store
+      - name: update_data_docs
+        action:
+          class_name: UpdateDataDocsAction
       # Uncomment the notify_slack action below to send notifications during evaluation
       # - name: notify_slack
       #   action:

--- a/tests/test_fixtures/great_expectations_site_builder.yml
+++ b/tests/test_fixtures/great_expectations_site_builder.yml
@@ -31,35 +31,6 @@ stores:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/validations/
 
-  local_site_html_store:
-    module_name: great_expectations.data_context.store
-    class_name: HtmlSiteStore
-    base_directory: uncommitted/data_docs/local_site/
-
-  # These next three blocks are never used in tests.
-
-  # local_profiling_store:
-  #   module_name: great_expectations.data_context.store
-  #   class_name: FilesystemStore
-  #   store_config:
-  #     base_directory: uncommitted/profiling/
-  #     serialization_type: json
-  #     file_extension: .json
-
-  # local_workbench_site_store:
-  #   module_name: great_expectations.data_context.store
-  #   class_name: FilesystemStore
-  #   store_config:
-  #     base_directory: uncommitted/data_docs/local_site
-  #     file_extension: .html
-
-  # shared_team_site_store:
-  #   module_name: great_expectations.data_context.store
-  #   class_name: FilesystemStore
-  #   store_config:
-  #     base_directory: uncommitted/data_docs/team_site
-  #     file_extension: .html
-
   fixture_validation_results_store:
     class_name: ValidationsStore
     store_backend:
@@ -78,8 +49,10 @@ data_docs_sites:
 
     module_name: great_expectations.render.renderer.site_builder
     class_name: SiteBuilder
-    target_store_name: local_site_html_store
-
+    show_how_to_buttons: true
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: uncommitted/data_docs/local_site/
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
 
@@ -118,8 +91,9 @@ data_docs_sites:
     module_name: great_expectations.render.renderer.site_builder
     class_name: SiteBuilder
     show_how_to_buttons: true
-    target_store_name: team_site_html_store
-
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: uncommitted/data_docs/team_site/
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
 


### PR DESCRIPTION
Changes proposed in this pull request:
-tuplefilestore backend, expectationstore backend remove_key bugs fixed 
-no url is returned on empty data_docs site
-return url for resource only if key exists
-Test added for the period special char case


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
