### PR TITLE
[BUGFIX] * bugfix for uploading objects to GCP #1393

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ develop
 * Bugfix and refactor for `datasource delete` CLI command (#1386) @mzjp2
 * Instantiate datasources and validate config only when datasource is used (#1374) @mzjp2
 * suite delete changed from an optional argument to a required one
+* bugfix for uploading objects to GCP #1393
 
 0.10.8
 -----------------

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -469,8 +469,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         bucket = gcs.get_bucket(self.bucket)
         blob = bucket.blob(gcs_object_key)
         if isinstance(value, str):
-            blob.upload_from_string(value.encode(content_encoding), content_encoding=content_encoding,
-                                    content_type=content_type)
+            blob.upload_from_string(value.encode(content_encoding), content_type=content_type)
         else:
             blob.upload_from_string(value, content_type=content_type)
         return gcs_object_key


### PR DESCRIPTION
Changes proposed in this pull request:
- bugfix for uploading objects to GCP #1393 to bring the upload call within the current api: https://googleapis.dev/python/storage/latest/_modules/google/cloud/storage/blob.html#Blob.upload_from_string


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [n/a] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
