### PR TITLE
[FEATURE] Add new usage stats event for CLI init

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ develop
 * Instantiate datasources and validate config only when datasource is used (#1374) @mzjp2
 * suite delete changed from an optional argument to a required one
 * bugfix for uploading objects to GCP #1393
+* added a new usage stats event for the case when a data context is created through CLI
 
 0.10.8
 -----------------

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -100,7 +100,7 @@ def init(target_directory, view, usage_stats):
 
         try:
             context = DataContext.create(target_directory, usage_statistics_enabled=usage_stats)
-            send_usage_message(data_context=context, event="cli.init.ctx_new", success=True)
+            send_usage_message(data_context=context, event="cli.init.create", success=True)
         except DataContextError as e:
             # TODO ensure this is covered by a test
             cli_message("<red>{}</red>".format(e))

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -29,6 +29,10 @@ from great_expectations.exceptions import (
     DatasourceInitializationError,
 )
 
+from great_expectations.core.usage_statistics.usage_statistics import (
+    send_usage_message,
+)
+
 try:
     from sqlalchemy.exc import SQLAlchemyError
 except ImportError:
@@ -96,6 +100,7 @@ def init(target_directory, view, usage_stats):
 
         try:
             context = DataContext.create(target_directory, usage_statistics_enabled=usage_stats)
+            send_usage_message(data_context=context, event="cli.init.ctx_new", success=True)
         except DataContextError as e:
             # TODO ensure this is covered by a test
             cli_message("<red>{}</red>".format(e))

--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -514,7 +514,8 @@ usage_statistics_record_schema = {
                         "cli.datasource.list",
                         "cli.datasource.new",
                         "data_context.open_data_docs",
-                        "data_context.build_data_docs"
+                        "data_context.build_data_docs",
+                        "cli.init.ctx_new"
                     ],
                 },
                 "event_payload": {

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -23,7 +23,7 @@ except ImportError:
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 def test_cli_init_on_new_project(mock_emit, mock_webbrowser, caplog, tmp_path_factory, monkeypatch):
-    monkeypatch.setenv("GE_USAGE_STATS", "True")
+    monkeypatch.delenv("GE_USAGE_STATS", raising=False)  # Undo the project-wide test default
     project_dir = str(tmp_path_factory.mktemp("test_cli_init_diff"))
     os.makedirs(os.path.join(project_dir, "data"))
     data_path = os.path.join(project_dir, "data", "Titanic.csv")

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -19,7 +19,11 @@ except ImportError:
 
 
 @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-def test_cli_init_on_new_project(mock_webbrowser, caplog, tmp_path_factory):
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
+)
+def test_cli_init_on_new_project(mock_emit, mock_webbrowser, caplog, tmp_path_factory, monkeypatch):
+    monkeypatch.setenv("GE_USAGE_STATS", "True")
     project_dir = str(tmp_path_factory.mktemp("test_cli_init_diff"))
     os.makedirs(os.path.join(project_dir, "data"))
     data_path = os.path.join(project_dir, "data", "Titanic.csv")
@@ -144,6 +148,12 @@ def test_cli_init_on_new_project(mock_webbrowser, caplog, tmp_path_factory):
                         foobarbazguid.json
 """
     )
+
+    assert mock_emit.call_count == 7
+    assert mock_emit.call_args_list[1] ==\
+        mock.call(
+            {"event_payload": {}, "event": "cli.init.create", "success": True}
+        )
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Added a new usage stats event for the case when a data context is created through CLI.

Reasoning:
Knowing that a data context was created by running CLI init will help us understand the top of the activation funnel.

After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [x] Code Review

Thank you for submitting!
