### PR TITLE
[DOCS] Clarify where env variables substitution occurs

### DIFF
--- a/docs/reference/data_context_reference.rst
+++ b/docs/reference/data_context_reference.rst
@@ -215,10 +215,9 @@ Variable substitution enables: 1) keeping secrets out of source control & 2)
 environment-based configuration changes such as staging vs prod.
 
 When GE encounters substitution syntax (like ``my_key: ${my_value}`` or
-``my_key: $my_value``) in the config file it will attempt to replace the value
+``my_key: $my_value``) in the great_expectations.yml config file it will attempt to replace the value
 of ``my_key`` with the value from an environment variable ``my_value`` or a
-corresponding key read from the file specified using ``config_variables_file_path``.
-
+corresponding key read from the file specified using ``config_variables_file_path``, which is located in uncommitted/config_variables.yml by default. This is an example of a config_variables.yml file:
 
 
 .. code-block:: yaml
@@ -248,6 +247,8 @@ Environment Variable Substitution
 
 Environment variables will be substituted into a DataContext config with higher priority than values from the
 config variables file.
+
+**Note**: Substitution of environment variables is currently only supported in the great_expectations.yml, but not in a config variables file. See [this Discuss post](https://discuss.greatexpectations.io/t/environment-variable-substitution-is-not-working-for-me-when-connecting-ge-to-my-database/72) for an example.
 
 ****************************************************
 Default Out of Box Config File


### PR DESCRIPTION
It wasn't clear from the docs that env variables are not supported in config_variables.yml. Added a note to clarify and pointed to Eugene's example in Discuss. This is just a quick fix to clarify since this seems like a pretty big blocker to run into.

Changes proposed in this pull request:
- Add note to docs


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
