### PR TITLE
[BUGFIX] Fix ExpectationSuiteIdentifier repr error when suite name is None

### DIFF
--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -59,7 +59,7 @@ class BatchIdentifier(DataContextKey):
 
     @property
     def batch_identifier(self):
-        return self._batch_identifier or "__none__"
+        return self._batch_identifier
 
     def to_tuple(self):
         return self.batch_identifier,

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -10,8 +10,12 @@ logger = logging.getLogger(__name__)
 
 
 class ExpectationSuiteIdentifier(DataContextKey):
-    def __init__(self, expectation_suite_name):
+    def __init__(self, expectation_suite_name: str):
         super(ExpectationSuiteIdentifier, self).__init__()
+        if not isinstance(expectation_suite_name, str):
+            raise InvalidDataContextKeyError(
+                f"expectation_suite_name must be a string, not {type(expectation_suite_name).__name__}"
+            )
         self._expectation_suite_name = expectation_suite_name
 
     @property
@@ -19,8 +23,6 @@ class ExpectationSuiteIdentifier(DataContextKey):
         return self._expectation_suite_name
 
     def to_tuple(self):
-        if self._expectation_suite_name is None:
-            return None,
         return tuple(self.expectation_suite_name.split("."))
 
     def to_fixed_length_tuple(self):
@@ -35,8 +37,6 @@ class ExpectationSuiteIdentifier(DataContextKey):
         return cls(expectation_suite_name=tuple_[0])
 
     def __repr__(self):
-        if self._expectation_suite_name is None:
-            return self.__class__.__name__ + "::__none__"
         return self.__class__.__name__ + "::" + self._expectation_suite_name
 
 class ExpectationSuiteIdentifierSchema(Schema):

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -19,6 +19,8 @@ class ExpectationSuiteIdentifier(DataContextKey):
         return self._expectation_suite_name
 
     def to_tuple(self):
+        if self._expectation_suite_name is None:
+            return None,
         return tuple(self.expectation_suite_name.split("."))
 
     def to_fixed_length_tuple(self):
@@ -32,6 +34,10 @@ class ExpectationSuiteIdentifier(DataContextKey):
     def from_fixed_length_tuple(cls, tuple_):
         return cls(expectation_suite_name=tuple_[0])
 
+    def __repr__(self):
+        if self._expectation_suite_name is None:
+            return self.__class__.__name__ + "::__none__"
+        return self.__class__.__name__ + "::" + self._expectation_suite_name
 
 class ExpectationSuiteIdentifierSchema(Schema):
     expectation_suite_name = fields.Str()
@@ -53,7 +59,7 @@ class BatchIdentifier(DataContextKey):
 
     @property
     def batch_identifier(self):
-        return self._batch_identifier
+        return self._batch_identifier or "__none__"
 
     def to_tuple(self):
         return self.batch_identifier,

--- a/tests/data_context/test_data_context_resource_identifiers.py
+++ b/tests/data_context/test_data_context_resource_identifiers.py
@@ -1,6 +1,24 @@
+import pytest
+
 from great_expectations.data_context.types.resource_identifiers import (
+    ExpectationSuiteIdentifier,
     ValidationResultIdentifier
 )
+from great_expectations.exceptions import InvalidDataContextKeyError
+
+
+def test_expectation_suite_identifier_to_tuple():
+    identifier = ExpectationSuiteIdentifier("test.identifier.name")
+    assert identifier.to_tuple() == ("test", "identifier", "name")
+    assert identifier.to_fixed_length_tuple() == ("test.identifier.name",)
+
+    with pytest.raises(InvalidDataContextKeyError) as exc:
+        _ = ExpectationSuiteIdentifier(None)
+    assert "must be a string, not NoneType" in str(exc.value)
+
+    with pytest.raises(InvalidDataContextKeyError) as exc:
+        _ = ExpectationSuiteIdentifier(1)
+    assert "must be a string, not int" in str(exc.value)
 
 
 def test_ValidationResultIdentifier_to_tuple(expectation_suite_identifier):


### PR DESCRIPTION
Changes proposed in this pull request:
- Provide repr for expectation suite identifier consistent with "None" as suite name
- Check for none in expectation suite name before trying to split


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For nontrivial changes, we will conduct both a design review and a code review. Please tag a core team member for code review, or leave blank and we will find someone for you!

- [ ] Design Review (@jcampbell)
- [ ] Code Review

Thank you for submitting!
