### PR TITLE
[BUGFIX] Fix: change the new usage stats event name in the schema

### DIFF
--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -515,7 +515,7 @@ usage_statistics_record_schema = {
                         "cli.datasource.new",
                         "data_context.open_data_docs",
                         "data_context.build_data_docs",
-                        "cli.init.ctx_new"
+                        "cli.init.create"
                     ],
                 },
                 "event_payload": {


### PR DESCRIPTION
Changes proposed in this pull request:
- When we added a new usage stats event "cli.init.create", we changed its name in the last minute and forgot to update it in the schema. This PR fixes that. A remaining known issue is that our test did not catch this bug, because it was mocking out the "emit" method. @jcampbell and I discussed this - no action for now.


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
