### PR TITLE
[DOCS] Fixed return type in custom expectations doc example

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ develop
 -----------------
 * Removed out-of-date Airflow integration examples. This repo provides a comprehensive example of Airflow integration: `#GE Airflow Example <https://github.com/superconductive/ge_tutorials>`_
 * Bugfix suite scaffold notebook now has correct suite name in first markdown cell.
+* Bugfix: fixed an example in the custom expectations documentation article - "result" key was missing in the returned dictionary
 
 0.10.9
 -----------------

--- a/docs/reference/custom_expectations.rst
+++ b/docs/reference/custom_expectations.rst
@@ -146,21 +146,27 @@ Pay special attention to proper formatting of :ref:`result_format`.
                 if len(not_null) == 0:
                     return {
                         'success':True,
-                        'unexpected_list':unexpected_values,
-                        'unexpected_index_list':self.index[result],
+                        'result': {
+                            'unexpected_list':unexpected_values,
+                            'unexpected_index_list':self.index[result],
+                        }
                     }
 
                 percent_equaling_1 = float(sum(result))/len(not_null)
                 return {
                     "success" : percent_equaling_1 >= mostly,
-                    "unexpected_list" : unexpected_values[:20],
-                    "unexpected_index_list" : list(self.index[result==False])[:20],
+                        'result': {
+                            "unexpected_list" : unexpected_values[:20],
+                            "unexpected_index_list" : list(self.index[result==False])[:20],
+                        }
                 }
             else:
                 return {
                     "success" : len(unexpected_values) == 0,
-                    "unexpected_list" : unexpected_values[:20],
-                    "unexpected_index_list" : list(self.index[result==False])[:20],
+                        'result': {
+                            "unexpected_list" : unexpected_values[:20],
+                            "unexpected_index_list" : list(self.index[result==False])[:20],
+                        }
                 }
 
 

--- a/docs/reference/custom_expectations.rst
+++ b/docs/reference/custom_expectations.rst
@@ -145,8 +145,8 @@ Pay special attention to proper formatting of :ref:`result_format`.
                 #Prevent division-by-zero errors
                 if len(not_null) == 0:
                     return {
-                        'success':True,
-                        'result': {
+                        "success":True,
+                        "result": {
                             'unexpected_list':unexpected_values,
                             'unexpected_index_list':self.index[result],
                         }
@@ -155,18 +155,18 @@ Pay special attention to proper formatting of :ref:`result_format`.
                 percent_equaling_1 = float(sum(result))/len(not_null)
                 return {
                     "success" : percent_equaling_1 >= mostly,
-                        'result': {
-                            "unexpected_list" : unexpected_values[:20],
-                            "unexpected_index_list" : list(self.index[result==False])[:20],
+                    "result": {
+                        "unexpected_list" : unexpected_values[:20],
+                        "unexpected_index_list" : list(self.index[result==False])[:20],
                         }
                 }
             else:
                 return {
                     "success" : len(unexpected_values) == 0,
-                        'result': {
-                            "unexpected_list" : unexpected_values[:20],
-                            "unexpected_index_list" : list(self.index[result==False])[:20],
-                        }
+                    "result": {
+                        "unexpected_list" : unexpected_values[:20],
+                        "unexpected_index_list" : list(self.index[result==False])[:20],
+                    }
                 }
 
 


### PR DESCRIPTION


Changes proposed in this pull request:
- Bugfix: fixed an example in the custom expectations docs article - result key was missing in the returned dictionary


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- No design review required - this was done in an interactive session with @jcampbell 
-
-


Thank you for submitting!
