### PR TITLE
[ENHANCEMENT] Allow config substitutions to be passed to DataContext

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 develop
 -----------------
+* Enhancement: A dictionary of variables can be passed to the DataContext constructor to allow override config variables
+  at runtime.
 
 0.10.11
 -----------------

--- a/docs/reference/data_context_reference.rst
+++ b/docs/reference/data_context_reference.rst
@@ -197,9 +197,16 @@ See the :ref:`validation_operators` for more information regarding configuring a
 Managing Environment and Secrets
 *****************************************
 
-In a DataContext configuration, values that should come from the runtime environment or secrets can be injected via
-a separate config file or using environment variables. Use the ``${var}`` syntax in a config file to specify a variable
-to be substituted.
+Values can be injected in a DataContext configuration file by using the
+``${var}`` syntax to specify a variable to be substituted.
+
+The injected value can come from three sources:
+
+1. A config variables file
+2. Environment variables
+3. A dictionary passed to the DataContext constructor.
+
+Each source above will override variables set in a previous source.
 
 Config Variables File
 ========================
@@ -249,6 +256,21 @@ Environment variables will be substituted into a DataContext config with higher 
 config variables file.
 
 **Note**: Substitution of environment variables is currently only supported in the great_expectations.yml, but not in a config variables file. See [this Discuss post](https://discuss.greatexpectations.io/t/environment-variable-substitution-is-not-working-for-me-when-connecting-ge-to-my-database/72) for an example.
+
+
+Passing Values To DataContext
+===============================
+
+A dictionary of values can be passed to a DataContext when it is instantiated.
+These values will override both values from the config variables file and
+from environment variables.
+
+.. code-block:: python
+
+  data_context = DataContext.create(runtime_environment={
+      'name_to_replace': 'replacement_value'
+    })
+
 
 ****************************************************
 Default Out of Box Config File

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -2050,7 +2050,11 @@ class DataContext(BaseDataContext):
                 destination_path = os.path.join(subdir_path, notebook_name)
                 shutil.copyfile(notebook, destination_path)
 
-    def __init__(self, context_root_dir=None, runtime_config_substitutions=None):
+    def __init__(
+            self,
+            context_root_dir=None,
+            runtime_config_substitutions=None
+    ):
 
         # Determine the "context root directory" - this is the parent of "great_expectations" dir
         if context_root_dir is None:

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -565,7 +565,7 @@ class BaseDataContext(object):
             try:
                 # If the user specifies the config variable path with an environment variable, we want to substitute it
                 defined_path = substitute_config_variable(
-                    config_variables_file_path, {}
+                    config_variables_file_path, dict(os.environ)
                 )
                 if not os.path.isabs(defined_path):
                     # A BaseDataContext will not have a root directory; in that case use the current directory
@@ -2050,7 +2050,7 @@ class DataContext(BaseDataContext):
                 destination_path = os.path.join(subdir_path, notebook_name)
                 shutil.copyfile(notebook, destination_path)
 
-    def __init__(self, context_root_dir=None, runtime_config_substitutions={}):
+    def __init__(self, context_root_dir=None, runtime_config_substitutions=None):
 
         # Determine the "context root directory" - this is the parent of "great_expectations" dir
         if context_root_dir is None:

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -127,8 +127,8 @@ class BaseDataContext(object):
         Args:
             context_root_dir: location to look for the ``great_expectations.yml`` file. If None, searches for the file \
             based on conventions for project subdirectories.
-            runtime_config_substitutions: a dictionary of config variables that override both those set in
-            config_variables.yml and the environment
+            runtime_config_substitutions: a dictionary of config variables that
+            override both those set in config_variables.yml and the environment
 
         Returns:
             None
@@ -595,7 +595,9 @@ class BaseDataContext(object):
             **self.runtime_config_substitutions
         }
 
-        return DataContextConfig(**substitute_all_config_variables(config, substitutions))
+        return DataContextConfig(
+            **substitute_all_config_variables(config, substitutions)
+        )
 
     def save_config_variable(self, config_variable_name, value):
         """Save config variable value
@@ -1898,8 +1900,8 @@ class DataContext(BaseDataContext):
 
         Args:
             project_root_dir: path to the root directory in which to create a new great_expectations directory
-            runtime_config_substitutions: a dictionary of config variables that override both those set in
-            config_variables.yml and the environment
+            runtime_config_substitutions: a dictionary of config variables that
+            override both those set in config_variables.yml and the environment
 
         Returns:
             DataContext
@@ -1943,7 +1945,9 @@ class DataContext(BaseDataContext):
         else:
             cls.write_config_variables_template_to_disk(uncommitted_dir)
 
-        return cls(ge_dir, runtime_config_substitutions=runtime_config_substitutions)
+        return cls(
+            ge_dir, runtime_config_substitutions=runtime_config_substitutions
+        )
 
     @classmethod
     def all_uncommitted_directories_exist(cls, ge_dir):

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -117,7 +117,11 @@ class BaseDataContext(object):
         return True
 
     @usage_statistics_enabled_method(event_name="data_context.__init__",)
-    def __init__(self, project_config, context_root_dir=None, runtime_config_substitutions={}):
+    def __init__(
+            self,
+            project_config,
+            context_root_dir=None,
+            runtime_config_substitutions=None):
         """DataContext constructor
 
         Args:
@@ -139,7 +143,7 @@ class BaseDataContext(object):
             self._context_root_directory = os.path.abspath(context_root_dir)
         else:
             self._context_root_directory = context_root_dir
-        self.runtime_config_substitutions = runtime_config_substitutions
+        self.runtime_config_substitutions = runtime_config_substitutions or {}
 
         # Init plugin support
         if self.plugins_directory is not None:
@@ -1881,7 +1885,11 @@ class DataContext(BaseDataContext):
     """
 
     @classmethod
-    def create(cls, project_root_dir=None, usage_statistics_enabled=True, runtime_config_substitutions={}):
+    def create(
+            cls,
+            project_root_dir=None,
+            usage_statistics_enabled=True,
+            runtime_config_substitutions=None):
         """
         Build a new great_expectations directory and DataContext object in the provided project_root_dir.
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -117,12 +117,14 @@ class BaseDataContext(object):
         return True
 
     @usage_statistics_enabled_method(event_name="data_context.__init__",)
-    def __init__(self, project_config, context_root_dir=None):
+    def __init__(self, project_config, context_root_dir=None, runtime_config_substitutions={}):
         """DataContext constructor
 
         Args:
             context_root_dir: location to look for the ``great_expectations.yml`` file. If None, searches for the file \
             based on conventions for project subdirectories.
+            runtime_config_substitutions: a dictionary of config variables that override both those set in
+            config_variables.yml and the environment
 
         Returns:
             None
@@ -137,6 +139,7 @@ class BaseDataContext(object):
             self._context_root_directory = os.path.abspath(context_root_dir)
         else:
             self._context_root_directory = context_root_dir
+        self.runtime_config_substitutions = runtime_config_substitutions
 
         # Init plugin support
         if self.plugins_directory is not None:
@@ -578,14 +581,17 @@ class BaseDataContext(object):
             return {}
 
     def get_config_with_variables_substituted(self, config=None):
+
         if not config:
             config = self._project_config
 
-        return DataContextConfig(
-            **substitute_all_config_variables(
-                config, self._load_config_variables_file()
-            )
-        )
+        substitutions = {
+            **dict(self._load_config_variables_file()),
+            **dict(os.environ),
+            **self.runtime_config_substitutions
+        }
+
+        return DataContextConfig(**substitute_all_config_variables(config, substitutions))
 
     def save_config_variable(self, config_variable_name, value):
         """Save config variable value
@@ -1875,7 +1881,7 @@ class DataContext(BaseDataContext):
     """
 
     @classmethod
-    def create(cls, project_root_dir=None, usage_statistics_enabled=True):
+    def create(cls, project_root_dir=None, usage_statistics_enabled=True, runtime_config_substitutions={}):
         """
         Build a new great_expectations directory and DataContext object in the provided project_root_dir.
 
@@ -1884,6 +1890,8 @@ class DataContext(BaseDataContext):
 
         Args:
             project_root_dir: path to the root directory in which to create a new great_expectations directory
+            runtime_config_substitutions: a dictionary of config variables that override both those set in
+            config_variables.yml and the environment
 
         Returns:
             DataContext
@@ -1927,7 +1935,7 @@ class DataContext(BaseDataContext):
         else:
             cls.write_config_variables_template_to_disk(uncommitted_dir)
 
-        return cls(ge_dir)
+        return cls(ge_dir, runtime_config_substitutions=runtime_config_substitutions)
 
     @classmethod
     def all_uncommitted_directories_exist(cls, ge_dir):
@@ -2030,7 +2038,7 @@ class DataContext(BaseDataContext):
                 destination_path = os.path.join(subdir_path, notebook_name)
                 shutil.copyfile(notebook, destination_path)
 
-    def __init__(self, context_root_dir=None):
+    def __init__(self, context_root_dir=None, runtime_config_substitutions={}):
 
         # Determine the "context root directory" - this is the parent of "great_expectations" dir
         if context_root_dir is None:
@@ -2040,7 +2048,11 @@ class DataContext(BaseDataContext):
 
         project_config = self._load_project_config()
         project_config_dict = dataContextConfigSchema.dump(project_config)
-        super(DataContext, self).__init__(project_config, context_root_directory)
+        super(DataContext, self).__init__(
+            project_config,
+            context_root_directory,
+            runtime_config_substitutions
+        )
 
         # save project config if data_context_id auto-generated or global config values applied
         if (

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -144,9 +144,7 @@ def substitute_config_variable(template_str, config_variables_dict):
         return template_str
 
     if match:
-        config_variable_value = os.getenv(match.group(1))
-        if not config_variable_value:
-            config_variable_value = config_variables_dict.get(match.group(1))
+        config_variable_value = config_variables_dict.get(match.group(1))
 
         if config_variable_value:
             if match.start() == 0 and match.end() == len(template_str):

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -31,28 +31,25 @@ def data_context_with_variables_in_config(tmp_path_factory):
 
 
 def create_data_context_files(
-        context_path,
-        asset_config_path,
-        with_config_variables_file):
+    context_path, asset_config_path, with_config_variables_file
+):
     if with_config_variables_file:
         os.makedirs(context_path, exist_ok=True)
         os.makedirs(os.path.join(context_path, "uncommitted"), exist_ok=True)
         copy_relative_path(
             "../test_fixtures/config_variables.yml",
-            str(
-                os.path.join(context_path, "uncommitted/config_variables.yml")
-            ),
+            str(os.path.join(context_path, "uncommitted/config_variables.yml")),
         )
         copy_relative_path(
             "../test_fixtures/great_expectations_basic_with_variables.yml",
-            str(os.path.join(context_path, "great_expectations.yml"))
+            str(os.path.join(context_path, "great_expectations.yml")),
         )
     else:
         os.makedirs(context_path, exist_ok=True)
         copy_relative_path(
             "../test_fixtures/"
             "great_expectations_basic_without_config_variables_filepath.yml",
-            str(os.path.join(context_path, "great_expectations.yml"))
+            str(os.path.join(context_path, "great_expectations.yml")),
         )
     create_common_data_context_files(context_path, asset_config_path)
 
@@ -65,8 +62,9 @@ def create_common_data_context_files(context_path, asset_config_path):
     copy_relative_path(
         "../test_fixtures/"
         "expectation_suites/parameterized_expectation_suite_fixture.json",
-        os.path.join(asset_config_path,
-                     "mydatasource/mygenerator/my_dag_node/default.json"),
+        os.path.join(
+            asset_config_path, "mydatasource/mygenerator/my_dag_node/default.json"
+        ),
     )
     os.makedirs(os.path.join(context_path, "plugins"), exist_ok=True)
     copy_relative_path(
@@ -75,8 +73,7 @@ def create_common_data_context_files(context_path, asset_config_path):
     )
     copy_relative_path(
         "../test_fixtures/custom_sqlalchemy_dataset.py",
-        str(os.path.join(context_path, "plugins",
-                         "custom_sqlalchemy_dataset.py")),
+        str(os.path.join(context_path, "plugins", "custom_sqlalchemy_dataset.py")),
     )
     copy_relative_path(
         "../test_fixtures/custom_sparkdf_dataset.py",

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -50,7 +50,7 @@ def create_data_context_files(
     else:
         os.makedirs(context_path, exist_ok=True)
         copy_relative_path(
-            "../test_fixtures/"  
+            "../test_fixtures/"
             "great_expectations_basic_without_config_variables_filepath.yml",
             str(os.path.join(context_path, "great_expectations.yml"))
         )

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -39,7 +39,9 @@ def create_data_context_files(
         os.makedirs(os.path.join(context_path, "uncommitted"), exist_ok=True)
         copy_relative_path(
             "../test_fixtures/config_variables.yml",
-            str(os.path.join(context_path, "uncommitted/config_variables.yml")),
+            str(
+                os.path.join(context_path, "uncommitted/config_variables.yml")
+            ),
         )
         copy_relative_path(
             "../test_fixtures/great_expectations_basic_with_variables.yml",

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -50,7 +50,8 @@ def create_data_context_files(
     else:
         os.makedirs(context_path, exist_ok=True)
         copy_relative_path(
-            "../test_fixtures/great_expectations_basic_without_config_variables_filepath.yml",
+            "../test_fixtures/"  
+            "great_expectations_basic_without_config_variables_filepath.yml",
             str(os.path.join(context_path, "great_expectations.yml"))
         )
     create_common_data_context_files(context_path, asset_config_path)
@@ -62,7 +63,8 @@ def create_common_data_context_files(context_path, asset_config_path):
         exist_ok=True,
     )
     copy_relative_path(
-        "../test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json",
+        "../test_fixtures/"
+        "expectation_suites/parameterized_expectation_suite_fixture.json",
         os.path.join(asset_config_path,
                      "mydatasource/mygenerator/my_dag_node/default.json"),
     )

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -30,7 +30,10 @@ def data_context_with_variables_in_config(tmp_path_factory):
     return ge.data_context.DataContext(context_path)
 
 
-def create_data_context_files(context_path, asset_config_path, with_config_variables_file):
+def create_data_context_files(
+        context_path,
+        asset_config_path,
+        with_config_variables_file):
     if with_config_variables_file:
         os.makedirs(context_path, exist_ok=True)
         os.makedirs(os.path.join(context_path, "uncommitted"), exist_ok=True)
@@ -58,7 +61,8 @@ def create_common_data_context_files(context_path, asset_config_path):
     )
     copy_relative_path(
         "../test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json",
-        os.path.join(asset_config_path, "mydatasource/mygenerator/my_dag_node/default.json"),
+        os.path.join(asset_config_path,
+                     "mydatasource/mygenerator/my_dag_node/default.json"),
     )
     os.makedirs(os.path.join(context_path, "plugins"), exist_ok=True)
     copy_relative_path(
@@ -67,7 +71,8 @@ def create_common_data_context_files(context_path, asset_config_path):
     )
     copy_relative_path(
         "../test_fixtures/custom_sqlalchemy_dataset.py",
-        str(os.path.join(context_path, "plugins", "custom_sqlalchemy_dataset.py")),
+        str(os.path.join(context_path, "plugins",
+                         "custom_sqlalchemy_dataset.py")),
     )
     copy_relative_path(
         "../test_fixtures/custom_sparkdf_dataset.py",

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -12,40 +12,9 @@ def data_context_without_config_variables_filepath_configured(tmp_path_factory):
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, "great_expectations")
     asset_config_path = os.path.join(context_path, "expectations")
-    os.makedirs(
-        os.path.join(asset_config_path, "mydatasource/mygenerator/my_dag_node"),
-        exist_ok=True,
-    )
-    shutil.copy(
-        file_relative_path(
-            __file__,
-            "../test_fixtures/great_expectations_basic_without_config_variables_filepath.yml",
-        ),
-        str(os.path.join(context_path, "great_expectations.yml")),
-    )
-    shutil.copy(
-        file_relative_path(
-            __file__,
-            "../test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json",
-        ),
-        os.path.join(
-            asset_config_path, "mydatasource/mygenerator/my_dag_node/default.json"
-        ),
-    )
 
-    os.makedirs(os.path.join(context_path, "plugins"))
-    shutil.copy(
-        file_relative_path(__file__, "../test_fixtures/custom_pandas_dataset.py"),
-        str(os.path.join(context_path, "plugins", "custom_pandas_dataset.py")),
-    )
-    shutil.copy(
-        file_relative_path(__file__, "../test_fixtures/custom_sqlalchemy_dataset.py"),
-        str(os.path.join(context_path, "plugins", "custom_sqlalchemy_dataset.py")),
-    )
-    shutil.copy(
-        file_relative_path(__file__, "../test_fixtures/custom_sparkdf_dataset.py"),
-        str(os.path.join(context_path, "plugins", "custom_sparkdf_dataset.py")),
-    )
+    create_data_context_files(context_path, asset_config_path, False)
+
     return ge.data_context.DataContext(context_path)
 
 
@@ -55,42 +24,56 @@ def data_context_with_variables_in_config(tmp_path_factory):
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, "great_expectations")
     asset_config_path = os.path.join(context_path, "expectations")
+
+    create_data_context_files(context_path, asset_config_path, True)
+
+    return ge.data_context.DataContext(context_path)
+
+
+def create_data_context_files(context_path, asset_config_path, with_config_variables_file):
+    if with_config_variables_file:
+        os.makedirs(context_path, exist_ok=True)
+        os.makedirs(os.path.join(context_path, "uncommitted"), exist_ok=True)
+        copy_relative_path(
+            "../test_fixtures/config_variables.yml",
+            str(os.path.join(context_path, "uncommitted/config_variables.yml")),
+        )
+        copy_relative_path(
+            "../test_fixtures/great_expectations_basic_with_variables.yml",
+            str(os.path.join(context_path, "great_expectations.yml"))
+        )
+    else:
+        os.makedirs(context_path, exist_ok=True)
+        copy_relative_path(
+            "../test_fixtures/great_expectations_basic_without_config_variables_filepath.yml",
+            str(os.path.join(context_path, "great_expectations.yml"))
+        )
+    create_common_data_context_files(context_path, asset_config_path)
+
+
+def create_common_data_context_files(context_path, asset_config_path):
     os.makedirs(
         os.path.join(asset_config_path, "mydatasource/mygenerator/my_dag_node"),
         exist_ok=True,
     )
-    os.makedirs(os.path.join(context_path, "uncommitted"), exist_ok=True)
-    shutil.copy(
-        file_relative_path(
-            __file__, "../test_fixtures/great_expectations_basic_with_variables.yml"
-        ),
-        str(os.path.join(context_path, "great_expectations.yml")),
+    copy_relative_path(
+        "../test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json",
+        os.path.join(asset_config_path, "mydatasource/mygenerator/my_dag_node/default.json"),
     )
-    shutil.copy(
-        file_relative_path(__file__, "../test_fixtures/config_variables.yml"),
-        str(os.path.join(context_path, "uncommitted/config_variables.yml")),
-    )
-    shutil.copy(
-        file_relative_path(
-            __file__,
-            "../test_fixtures/expectation_suites/parameterized_expectation_suite_fixture.json",
-        ),
-        os.path.join(
-            asset_config_path, "mydatasource/mygenerator/my_dag_node/default.json"
-        ),
-    )
-
     os.makedirs(os.path.join(context_path, "plugins"), exist_ok=True)
-    shutil.copy(
-        file_relative_path(__file__, "../test_fixtures/custom_pandas_dataset.py"),
+    copy_relative_path(
+        "../test_fixtures/custom_pandas_dataset.py",
         str(os.path.join(context_path, "plugins", "custom_pandas_dataset.py")),
     )
-    shutil.copy(
-        file_relative_path(__file__, "../test_fixtures/custom_sqlalchemy_dataset.py"),
+    copy_relative_path(
+        "../test_fixtures/custom_sqlalchemy_dataset.py",
         str(os.path.join(context_path, "plugins", "custom_sqlalchemy_dataset.py")),
     )
-    shutil.copy(
-        file_relative_path(__file__, "../test_fixtures/custom_sparkdf_dataset.py"),
+    copy_relative_path(
+        "../test_fixtures/custom_sparkdf_dataset.py",
         str(os.path.join(context_path, "plugins", "custom_sparkdf_dataset.py")),
     )
-    return ge.data_context.DataContext(context_path)
+
+
+def copy_relative_path(relative_src, dest):
+    shutil.copy(file_relative_path(__file__, relative_src), dest)

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -98,13 +98,12 @@ def test_setting_config_variables_is_visible_immediately(
         del os.environ["replace_me_2"]
 
 
-def test_runtime_config_substitutions_are_used_preferentially(
-        tmp_path_factory):
-    value_from_environment = 'from_environment'
+def test_runtime_environment_are_used_preferentially(tmp_path_factory):
+    value_from_environment = "from_environment"
     os.environ["replace_me"] = value_from_environment
 
-    value_from_runtime_override = 'runtime_var'
-    runtime_config_substitutions = {'replace_me': value_from_runtime_override}
+    value_from_runtime_override = "runtime_var"
+    runtime_environment = {"replace_me": value_from_runtime_override}
 
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, "great_expectations")
@@ -112,17 +111,23 @@ def test_runtime_config_substitutions_are_used_preferentially(
     create_data_context_files(context_path, asset_config_path, True)
 
     data_context = ge.data_context.DataContext(
-        context_path,
-        runtime_config_substitutions=runtime_config_substitutions)
+        context_path, runtime_environment=runtime_environment
+    )
     config = data_context.get_config_with_variables_substituted()
 
     try:
-        assert (config.datasources["mydatasource"]["batch_kwargs_generators"][
-                    "mygenerator"]["reader_options"][
-                    "test_variable_sub1"] == value_from_runtime_override)
-        assert (config.datasources["mydatasource"]["batch_kwargs_generators"][
-                    "mygenerator"]["reader_options"][
-                    "test_variable_sub2"] == value_from_runtime_override)
+        assert (
+            config.datasources["mydatasource"]["batch_kwargs_generators"][
+                "mygenerator"
+            ]["reader_options"]["test_variable_sub1"]
+            == value_from_runtime_override
+        )
+        assert (
+            config.datasources["mydatasource"]["batch_kwargs_generators"][
+                "mygenerator"
+            ]["reader_options"]["test_variable_sub2"]
+            == value_from_runtime_override
+        )
     except Exception:
         raise
     finally:

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -98,31 +98,12 @@ def test_setting_config_variables_is_visible_immediately(
         del os.environ["replace_me_2"]
 
 
-def test_env_variable_overrides_config_file_variable(tmp_path_factory):
-    value_from_environment = 'from_environment'
-    os.environ["replace_me"] = value_from_environment
-
-    project_path = str(tmp_path_factory.mktemp("data_context"))
-    context_path = os.path.join(project_path, "great_expectations")
-    asset_config_path = os.path.join(context_path, "expectations")
-
-    create_data_context_files(context_path, asset_config_path, True)
-
-    data_context = ge.data_context.DataContext(context_path)
-    config = data_context.get_config_with_variables_substituted()
-
-    assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
-                "test_variable_sub1"] == value_from_environment)
-
-
 def test_runtime_config_substitutions_are_used_preferentially(tmp_path_factory):
     value_from_environment = 'from_environment'
     os.environ["replace_me"] = value_from_environment
 
     value_from_runtime_override = 'runtime_var'
-    runtime_config_substitutions = {
-        'replace_me': value_from_runtime_override,
-    }
+    runtime_config_substitutions = {'replace_me': value_from_runtime_override}
 
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, "great_expectations")
@@ -132,8 +113,15 @@ def test_runtime_config_substitutions_are_used_preferentially(tmp_path_factory):
     data_context = ge.data_context.DataContext(context_path, runtime_config_substitutions=runtime_config_substitutions)
     config = data_context.get_config_with_variables_substituted()
 
-    assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
-                "test_variable_sub1"] == value_from_runtime_override)
+    try:
+        assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
+                    "test_variable_sub1"] == value_from_runtime_override)
+        assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
+                    "test_variable_sub2"] == value_from_runtime_override)
+    except Exception:
+        raise
+    finally:
+        del os.environ["replace_me"]
 
 
 def test_substitute_config_variable():

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -98,7 +98,8 @@ def test_setting_config_variables_is_visible_immediately(
         del os.environ["replace_me_2"]
 
 
-def test_runtime_config_substitutions_are_used_preferentially(tmp_path_factory):
+def test_runtime_config_substitutions_are_used_preferentially(
+        tmp_path_factory):
     value_from_environment = 'from_environment'
     os.environ["replace_me"] = value_from_environment
 

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -1,8 +1,10 @@
 import os
 
 import pytest
+import great_expectations as ge
 from great_expectations.data_context.util import substitute_config_variable
 from great_expectations.exceptions import InvalidConfigError, MissingConfigVariableError
+from tests.data_context.conftest import create_data_context_files
 
 
 def test_config_variables_on_context_without_config_variables_filepath_configured(
@@ -94,6 +96,44 @@ def test_setting_config_variables_is_visible_immediately(
         raise
     finally:
         del os.environ["replace_me_2"]
+
+
+def test_env_variable_overrides_config_file_variable(tmp_path_factory):
+    value_from_environment = 'from_environment'
+    os.environ["replace_me"] = value_from_environment
+
+    project_path = str(tmp_path_factory.mktemp("data_context"))
+    context_path = os.path.join(project_path, "great_expectations")
+    asset_config_path = os.path.join(context_path, "expectations")
+
+    create_data_context_files(context_path, asset_config_path, True)
+
+    data_context = ge.data_context.DataContext(context_path)
+    config = data_context.get_config_with_variables_substituted()
+
+    assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
+                "test_variable_sub1"] == value_from_environment)
+
+
+def test_runtime_config_substitutions_are_used_preferentially(tmp_path_factory):
+    value_from_environment = 'from_environment'
+    os.environ["replace_me"] = value_from_environment
+
+    value_from_runtime_override = 'runtime_var'
+    runtime_config_substitutions = {
+        'replace_me': value_from_runtime_override,
+    }
+
+    project_path = str(tmp_path_factory.mktemp("data_context"))
+    context_path = os.path.join(project_path, "great_expectations")
+    asset_config_path = os.path.join(context_path, "expectations")
+    create_data_context_files(context_path, asset_config_path, True)
+
+    data_context = ge.data_context.DataContext(context_path, runtime_config_substitutions=runtime_config_substitutions)
+    config = data_context.get_config_with_variables_substituted()
+
+    assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
+                "test_variable_sub1"] == value_from_runtime_override)
 
 
 def test_substitute_config_variable():

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -110,13 +110,17 @@ def test_runtime_config_substitutions_are_used_preferentially(tmp_path_factory):
     asset_config_path = os.path.join(context_path, "expectations")
     create_data_context_files(context_path, asset_config_path, True)
 
-    data_context = ge.data_context.DataContext(context_path, runtime_config_substitutions=runtime_config_substitutions)
+    data_context = ge.data_context.DataContext(
+        context_path,
+        runtime_config_substitutions=runtime_config_substitutions)
     config = data_context.get_config_with_variables_substituted()
 
     try:
-        assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
+        assert (config.datasources["mydatasource"]["batch_kwargs_generators"][
+                    "mygenerator"]["reader_options"][
                     "test_variable_sub1"] == value_from_runtime_override)
-        assert (config.datasources["mydatasource"]["batch_kwargs_generators"]["mygenerator"]["reader_options"][
+        assert (config.datasources["mydatasource"]["batch_kwargs_generators"][
+                    "mygenerator"]["reader_options"][
                     "test_variable_sub2"] == value_from_runtime_override)
     except Exception:
         raise


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow a dictionary of config variable substitutions to be passed to the DataContext constructor (`runtime_config_substitutions`). 
- `runtime_config_substitutions` will be used preferentially.  It overrides variables set in config_variables.yml and in the environment.

I have two concrete use cases for this functionality:

* First, I want to be able to specify different slack webhook depending on which validation I'm running, but I don't want to create a bunch of different validation_action configs.
* Second, I'm running expectations on DataBricks and I want to be able to use their secret management. With this, I can pass in a data source config like this:

```python
datasource_config={
  'redshiftCredentials': {
    'password': dbutils.secrets.get('my_scope', 'my_password'),
    'username': dbutils.secrets.get('my_scope', 'my_password'),
    'host' :....
    #... etc ...
  }
}
    
context = DataContext('./great_expectations', runtime_config_substitutions=datasource_config)
```

**Notes:**
* I'm putting up this PR with some tests that fail locally. I think it is specific to my environment but I will fix them if they are real failures
* Please let me know if there are more tests I should add/modify. I couldn't find any that needed to be changed
* Also I've very open to feedback on the name `runtime_config_substitutions`
* If this feature will be approved I can add documentation