### PR TITLE
[FEATURE] Spark Support for expect_values_to_match_json_schema

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ develop
 -----------------
 * [ENHANCEMENT] Improved error messages for misconfigured checkpoints.
 * [BUGFIX] Fixed bug that could cause some substituted variables in DataContext config to be saved to `great_expectations.yml`
+* [FEATURE] Add support for expect_volumn_values_to_match_json_schema exception for Spark backend
 
 0.10.12
 -----------------

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -1,11 +1,13 @@
 import copy
 import inspect
+import json
 import logging
+from collections import OrderedDict
 from datetime import datetime
 from functools import reduce, wraps
 from typing import List
-from collections import OrderedDict
 
+import jsonschema
 import numpy as np
 import pandas as pd
 from dateutil.parser import parse
@@ -992,6 +994,36 @@ class SparkDFDataset(MetaSparkDFDataset):
         meta=None,
     ):
         return column.withColumn("__success", column[0].isNull())
+
+    @DocInherit
+    @MetaSparkDFDataset.column_map_expectation
+    def expect_column_values_to_match_json_schema(
+        self,
+        column,
+        json_schema,
+        mostly=None,
+        result_format=None,
+        include_config=True,
+        catch_exceptions=None,
+        meta=None,
+    ):
+        def matches_json_schema(val):
+            try:
+                val_json = json.loads(val)
+                jsonschema.validate(val_json, json_schema)
+                # jsonschema.validate raises an error if validation fails.
+                # So if we make it this far, we know that the validation succeeded.
+                return True
+            except jsonschema.ValidationError:
+                return False
+            except jsonschema.SchemaError:
+                raise
+            except:
+                raise
+
+        matches_json_schema_udf = udf(matches_json_schema, sparktypes.StringType())
+
+        return column.withColumn("__success", matches_json_schema_udf(column[0]))
 
     @DocInherit
     @DataAsset.expectation(["column", "type_", "mostly"])

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_match_json_schema.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_match_json_schema.json
@@ -5,6 +5,12 @@
       "w" : [2, 3, 4, 5, 6, 7, 8, 9, 10, null],
       "x" : ["{\"a\":1}", "{\"a\":2}", "{\"a\":3}", "{\"a\":4}", "{\"a\":5}", null, null, null, null, null]
     },
+    "schemas": {
+      "spark": {
+        "w": "IntegerType",
+        "x": "StringType"
+      }
+    },
     "tests" : [{
       "title" : "Basic positive test",
       "exact_match_out" : false,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -459,7 +459,7 @@ def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type
             # "expect_column_values_to_match_strftime_format",
             "expect_column_values_to_be_dateutil_parseable",
             "expect_column_values_to_be_json_parseable",
-            "expect_column_values_to_match_json_schema",
+            # "expect_column_values_to_match_json_schema",
             # "expect_column_mean_to_be_between",
             # "expect_column_median_to_be_between",
             # "expect_column_quantile_values_to_be_between",


### PR DESCRIPTION
Changes proposed in this pull request:

-Adding support for expect_values_to_match_json_schema exception for Spark.