### PR TITLE
* [BUGFIX] Fixed bug preventing GCS Data Docs sites to cleaned

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 develop
 -----------------
 
+* [BUGFIX] Fixed bug preventing GCS Data Docs sites to cleaned
+
 0.11.1
 -----------------
 * [BUGFIX] Fixed bug that was caused by comparison between timezone aware and non-aware datetimes

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -619,7 +619,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
 
     def remove_key(self, key):
         from google.cloud import storage
-        from gcloud.exceptions import NotFound
+        from google.cloud.exceptions import NotFound
 
         gcs = storage.Client(project=self.project)
         bucket = gcs.get_bucket(self.bucket)


### PR DESCRIPTION
Changes proposed in this pull request:
* [BUGFIX] Fixed bug preventing GCS Data Docs sites to cleaned-

Previous Design Review notes:
- n/a

Testing notes

- There is no integration test covering this. This was tested manually on GCS shortly after discovery.
