### PR TITLE
[DOCS] Fixed typo in link to Validation Actions DOC

### DIFF
--- a/docs/how_to_guides/validation/how_to_trigger_slack_notifications_as_a_validation_action.rst
+++ b/docs/how_to_guides/validation/how_to_trigger_slack_notifications_as_a_validation_action.rst
@@ -3,7 +3,7 @@
 How to trigger Slack notifications as a Validation Action
 =========================================================
 
-This guide will help you trigger Slack notifications as a :ref:`Validation Action <validation_actions>`_
+This guide will help you trigger Slack notifications as a :ref:`Validation Action <validation_actions>`
 .  It will allow you to send a Slack message including information about a Validation Result, including whether or not the Validation succeeded.
 
 .. admonition:: Prerequisites: This how-to guide assumes that you have already:


### PR DESCRIPTION

Changes proposed in this pull request:
- Fixed typo in link to Validation Action document in How To Trigger Slack Notification as Validation Action
- closes #1545

