### PR TITLE
[BUGFIX] Fix issue where data docs could remove trailing zeros from values when low precision was requested

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -17,6 +17,7 @@ develop
 * [BUGFIX] Fixed bug preventing GCS Data Docs sites to cleaned
 * [BUGFIX] Correct doc link in checkpoint yml
 * [BUGFIX] Fix S3 Batch Kwargs Generator incorrect migration to new build_batch_kwargs API
+* [BUGFIX] Fix issue where data docs could remove trailing zeros from values when low precision was requested
 
 0.11.1
 -----------------

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -52,8 +52,9 @@ def num_to_str(f, precision=DEFAULT_PRECISION, use_locale=False, no_scientific=F
         # result = '≈' + result
         #  ≈  # \u2248
         result = "≈" + result
-    if "e" not in result and "E" not in result:
-        result = result.rstrip("0").rstrip(locale.localeconv().get("decimal_point"))
+    decimal_char = locale.localeconv().get("decimal_point")
+    if "e" not in result and "E" not in result and decimal_char in result:
+        result = result.rstrip("0").rstrip(decimal_char)
     return result
 
 

--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -41,3 +41,7 @@ def test_num_to_str():
     assert num_to_str(f, precision=10, no_scientific=True) == "100"
     assert num_to_str(f, precision=10) == "100"
     assert num_to_str(f, precision=10, use_locale=True) == "100"
+
+    f = 1000  # If we have a number longer than our precision, we should still be able to correctly format
+    assert num_to_str(f, precision=4) == "1000"
+    assert num_to_str(f) == "1000"


### PR DESCRIPTION
Changes proposed in this pull request:
- This fixes an issue where low-precision representation of integers ending with zero could be erroneously truncated.