### PR TITLE
[DOCS] Removing extra text at end of Slack Validation how-to-guide

### DIFF
--- a/docs/how_to_guides/validation/how_to_trigger_slack_notifications_as_a_validation_action.rst
+++ b/docs/how_to_guides/validation/how_to_trigger_slack_notifications_as_a_validation_action.rst
@@ -55,9 +55,5 @@ Additional resources
 
 - Instructions on how to set up a Slack app with webhook can be found in the documentation for the `Slack API <https://api.slack.com/messaging/webhooks#>`_
 
-If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.
-
-If you want to be a real hero, we'd welcome a pull request. Please see :ref:`the Contributing tutorial <tutorials__contributing>` and :ref:`How to write a how to guide` to get started.
-
 .. discourse::
     :topic_identifier: 228


### PR DESCRIPTION
Changes proposed in this pull request:
- Removing extra text at end of DOC that describes how to contribute to DOC (which is complete)
