### PR TITLE
[BUGFIX][ENHANCEMENT] Stop using utm_medium to set paths; enable custom jinja templates

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 develop
 -----------------
+* [BUGFIX] Use renderer_type to set paths in jinja templates instead of utm_medium since utm_medium is optional
+* [ENHANCEMENT] Bring in custom_views_directory in DefaultJinjaView to enable custom jinja templates stored in plugins dir
 
 0.11.2
 -----------------

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -131,6 +131,15 @@ class SiteBuilder(object):
                 plugins_directory, "custom_data_docs", "styles"
             )
 
+        # set custom_views_directory if present
+        custom_views_directory = None
+        if plugins_directory and os.path.isdir(
+            os.path.join(plugins_directory, "custom_data_docs", "views")
+        ):
+            custom_views_directory = os.path.join(
+                plugins_directory, "custom_data_docs", "views"
+            )
+
         if site_index_builder is None:
             site_index_builder = {"class_name": "DefaultSiteIndexBuilder"}
 
@@ -195,6 +204,7 @@ class SiteBuilder(object):
                     "data_context": data_context,
                     "target_store": self.target_store,
                     "custom_styles_directory": custom_styles_directory,
+                    "custom_views_directory": custom_views_directory,
                     "data_context_id": self.data_context_id,
                     "show_how_to_buttons": self.show_how_to_buttons,
                 },
@@ -217,6 +227,7 @@ class SiteBuilder(object):
             runtime_environment={
                 "data_context": data_context,
                 "custom_styles_directory": custom_styles_directory,
+                "custom_views_directory": custom_views_directory,
                 "show_how_to_buttons": self.show_how_to_buttons,
                 "target_store": self.target_store,
                 "site_name": self.site_name,
@@ -293,6 +304,7 @@ class DefaultSiteSectionBuilder(object):
         target_store,
         source_store_name,
         custom_styles_directory=None,
+        custom_views_directory=None,
         show_how_to_buttons=True,
         run_name_filter=None,
         validation_results_limit=None,
@@ -338,7 +350,10 @@ class DefaultSiteSectionBuilder(object):
         module_name = view.get("module_name") or module_name
         self.view_class = instantiate_class_from_config(
             config=view,
-            runtime_environment={"custom_styles_directory": custom_styles_directory},
+            runtime_environment={
+                "custom_styles_directory": custom_styles_directory,
+                "custom_views_directory": custom_views_directory,
+            },
             config_defaults={"module_name": module_name},
         )
         if not self.view_class:
@@ -458,6 +473,7 @@ class DefaultSiteIndexBuilder(object):
         data_context,
         target_store,
         custom_styles_directory=None,
+        custom_views_directory=None,
         show_how_to_buttons=True,
         validation_results_limit=None,
         renderer=None,
@@ -505,7 +521,10 @@ class DefaultSiteIndexBuilder(object):
         module_name = view.get("module_name") or module_name
         self.view_class = instantiate_class_from_config(
             config=view,
-            runtime_environment={"custom_styles_directory": custom_styles_directory},
+            runtime_environment={
+                "custom_styles_directory": custom_styles_directory,
+                "custom_views_directory": custom_views_directory,
+            },
             config_defaults={"module_name": module_name},
         )
         if not self.view_class:

--- a/great_expectations/render/view/static/styles/data_docs_default_styles.css
+++ b/great_expectations/render/view/static/styles/data_docs_default_styles.css
@@ -1,8 +1,8 @@
-{% if utm_medium == "validation-results-page" or utm_medium == "profiling-results-page" %}
+{% if "ValidationResults" in renderer_type or "ProfilingResults" in renderer_type %}
   {% set static_fonts_dir = "../../../../../static/fonts/" -%}
-{% elif utm_medium == "expectation-suite-page" %}
+{% elif "ExpectationSuite" in renderer_type %}
   {% set static_fonts_dir = "../../../../static/fonts/" -%}
-{% elif utm_medium == "index-page" %}
+{% elif "SiteIndex" in renderer_type %}
   {% set static_fonts_dir = "./static/fonts/" -%}
 {% endif %}
 

--- a/great_expectations/render/view/templates/carousel_modal.j2
+++ b/great_expectations/render/view/templates/carousel_modal.j2
@@ -4,6 +4,14 @@
 
 {% set glossary_url = "http://docs.greatexpectations.io/en/latest/expectation_glossary.html?utm_source=walkthrough&utm_medium=glossary" %}
 
+{% if "ValidationResults" in renderer_type or "ProfilingResults" in renderer_type %}
+  {% set static_images_dir = ((expectation_suite_name_dot_count + 3) * "../") + "static/images/" -%}
+{% elif "ExpectationSuite" in renderer_type %}
+  {% set static_images_dir = ((expectation_suite_name_dot_count + 1) * "../") + "static/images/" -%}
+{% elif "SiteIndex" in renderer_type %}
+  {% set static_images_dir = "./static/images/" -%}
+{% endif %}
+
 {% if renderer_type in ["ValidationResultsPageRenderer", "ProfilingResultsPageRenderer"] %}
   {% set static_images_dir = ((expectation_suite_name_dot_count + 3) * "../") + "static/images/" -%}
 {% elif renderer_type == "ExpectationSuitePageRenderer" %}

--- a/great_expectations/render/view/templates/edit_expectations_instructions_modal.j2
+++ b/great_expectations/render/view/templates/edit_expectations_instructions_modal.j2
@@ -5,11 +5,11 @@
 {% set edit_suite_command = "great_expectations suite edit " + expectation_suite_name  %}
 
 {# TODO move this logic into a testable method on DefaultJinjaView #}
-{% if utm_medium == "validation-results-page" or utm_medium == "profiling-results-page" %}
+{% if "ValidationResults" in renderer_type or "ProfilingResults" in renderer_type %}
   {% set static_images_dir = ((expectation_suite_name_dot_count + 3) * "../") + "static/images/" -%}
-{% elif utm_medium == "expectation-suite-page" %}
+{% elif "ExpectationSuite" in renderer_type %}
   {% set static_images_dir = ((expectation_suite_name_dot_count + 1) * "../") + "static/images/" -%}
-{% elif utm_medium == "index-page" %}
+{% elif "SiteIndex" in renderer_type %}
   {% set static_images_dir = "./static/images/" -%}
 {% endif %}
 

--- a/great_expectations/render/view/templates/favicon.j2
+++ b/great_expectations/render/view/templates/favicon.j2
@@ -2,11 +2,11 @@
   {% set expectation_suite_name_dot_count = expectation_suite_name.count(".") -%}
 {% endif %}
 
-{% if utm_medium == "validation-results-page" or utm_medium == "profiling-results-page" %}
+{% if "ValidationResults" in renderer_type or "ProfilingResults" in renderer_type %}
   {% set static_images_dir = ((expectation_suite_name_dot_count + 3) * "../") + "static/images/" -%}
-{% elif utm_medium == "expectation-suite-page" %}
+{% elif "ExpectationSuite" in renderer_type %}
   {% set static_images_dir = ((expectation_suite_name_dot_count + 1) * "../") + "static/images/" -%}
-{% elif utm_medium == "index-page" %}
+{% elif "SiteIndex" in renderer_type %}
   {% set static_images_dir = "./static/images/" -%}
 {% endif %}
 

--- a/great_expectations/render/view/templates/js_script_imports.j2
+++ b/great_expectations/render/view/templates/js_script_imports.j2
@@ -1,8 +1,8 @@
-{% if utm_medium == "validation-results-page" or utm_medium == "profiling-results-page" %}
+{% if "ValidationResults" in renderer_type or "ProfilingResults" in renderer_type %}
   {% set static_scripts_dir = "../../../../../static/scripts/" -%}
-{% elif utm_medium == "expectation-suite-page" %}
+{% elif "ExpectationSuite" in renderer_type %}
   {% set static_scripts_dir = "../../../../static/scripts/" -%}
-{% elif utm_medium == "index-page" %}
+{% elif "SiteIndex" in renderer_type %}
   {% set static_scripts_dir = "./static/scripts/" -%}
 {% endif %}
 

--- a/great_expectations/render/view/templates/top_navbar.j2
+++ b/great_expectations/render/view/templates/top_navbar.j2
@@ -2,13 +2,13 @@
   {% set expectation_suite_name_dot_count = expectation_suite_name.count(".") -%}
 {% endif %}
 
-{% if utm_medium == "validation-results-page" or utm_medium == "profiling-results-page" %}
+{% if "ValidationResults" in renderer_type or "ProfilingResults" in renderer_type %}
   {% set home_url =  ((expectation_suite_name_dot_count + 4) * "../") + "index.html" -%}
   {% set static_images_dir = ((expectation_suite_name_dot_count + 4) * "../") + "static/images/" -%}
-{% elif utm_medium == "expectation-suite-page" %}
+{% elif "ExpectationSuite" in renderer_type %}
   {% set home_url = ((expectation_suite_name_dot_count + 1) * "../") + "index.html" -%}
   {% set static_images_dir = ((expectation_suite_name_dot_count + 1) * "../") + "static/images/" -%}
-{% elif utm_medium == "index-page" %}
+{% elif "SiteIndex" in renderer_type %}
   {% set home_url = "#" -%}
 {% endif %}
 

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -8,12 +8,6 @@ from string import Template as pTemplate
 from uuid import uuid4
 
 import mistune
-from great_expectations import __version__ as ge_version
-from great_expectations.render.types import (
-    RenderedComponentContent,
-    RenderedContent,
-    RenderedDocumentContent,
-)
 from jinja2 import (
     ChoiceLoader,
     Environment,
@@ -21,6 +15,13 @@ from jinja2 import (
     PackageLoader,
     contextfilter,
     select_autoescape,
+)
+
+from great_expectations import __version__ as ge_version
+from great_expectations.render.types import (
+    RenderedComponentContent,
+    RenderedContent,
+    RenderedDocumentContent,
 )
 
 

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -8,6 +8,12 @@ from string import Template as pTemplate
 from uuid import uuid4
 
 import mistune
+from great_expectations import __version__ as ge_version
+from great_expectations.render.types import (
+    RenderedComponentContent,
+    RenderedContent,
+    RenderedDocumentContent,
+)
 from jinja2 import (
     ChoiceLoader,
     Environment,
@@ -15,13 +21,6 @@ from jinja2 import (
     PackageLoader,
     contextfilter,
     select_autoescape,
-)
-
-from great_expectations import __version__ as ge_version
-from great_expectations.render.types import (
-    RenderedComponentContent,
-    RenderedContent,
-    RenderedDocumentContent,
 )
 
 
@@ -55,8 +54,9 @@ class DefaultJinjaView(object):
 
     _template = NoOpTemplate
 
-    def __init__(self, custom_styles_directory=None):
+    def __init__(self, custom_styles_directory=None, custom_views_directory=None):
         self.custom_styles_directory = custom_styles_directory
+        self.custom_views_directory = custom_views_directory
 
     def render(self, document, template=None, **kwargs):
         self._validate_document(document)
@@ -80,6 +80,8 @@ class DefaultJinjaView(object):
 
         if self.custom_styles_directory:
             loaders.append(FileSystemLoader(self.custom_styles_directory))
+        if self.custom_views_directory:
+            loaders.append(FileSystemLoader(self.custom_views_directory))
 
         env = Environment(
             loader=ChoiceLoader(loaders),


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
* [BUGFIX] Use renderer_type to set paths in jinja templates instead of utm_medium since utm_medium is optional
* [ENHANCEMENT] Bring in custom_views_directory in DefaultJinjaView to enable custom jinja templates stored in plugins dir


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
