### PR TITLE
Add _batch_parameters as DataFrame recognized attribute

### DIFF
--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -335,6 +335,7 @@ class PandasDataset(MetaPandasDataset, pd.DataFrame):
     _internal_names = pd.DataFrame._internal_names + [
         "_batch_kwargs",
         "_batch_markers",
+        "_batch_parameters",
         "_batch_id",
         "_expectation_suite",
         "_config",


### PR DESCRIPTION
- Inform Pandas of use of _batch_parameters as an internal attribute.