### PR TITLE
[ENHANCEMENT] BasicSuiteBuilderProfiler now rounds mostly values for readability

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -13,7 +13,7 @@ develop
 * [ENHANCEMENT] Bring in custom_views_directory in DefaultJinjaView to enable custom jinja templates stored in plugins dir
 * [BUGFIX] fixed glossary links in walkthrough modal, README, CTA button, scaffold notebook
 * [BUGFIX] Improved TupleGCSStoreBackend configurability (#1398 #1399)
-
+* [ENHANCEMENT] BasicSuiteBuilderProfiler now rounds mostly values for readability
 
 0.11.2
 -----------------

--- a/great_expectations/profile/basic_suite_builder_profiler.py
+++ b/great_expectations/profile/basic_suite_builder_profiler.py
@@ -153,7 +153,9 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
         not_null_result = dataset.expect_column_values_to_not_be_null(column)
         if not not_null_result.success:
             unexpected_percent = float(not_null_result.result["unexpected_percent"])
-            mostly_value = max(0.001, (100.0 - unexpected_percent - 10) / 100.0)
+            mostly_value = round(
+                max(0.001, (100.0 - unexpected_percent - 10) / 100.0), 2
+            )
             dataset.expect_column_values_to_not_be_null(column, mostly=mostly_value)
 
     @classmethod

--- a/tests/profile/fixtures/expected_evrs_BasicSuiteBuilderProfiler_on_titanic_demo_mode.json
+++ b/tests/profile/fixtures/expected_evrs_BasicSuiteBuilderProfiler_on_titanic_demo_mode.json
@@ -739,7 +739,7 @@
       "expectation_config": {
         "kwargs": {
           "column": "Age",
-          "mostly": 0.47578065498857575,
+          "mostly": 0.48,
           "result_format": "SUMMARY"
         },
         "meta": {},

--- a/tests/profile/fixtures/expected_evrs_SuiteBuilderProfiler_on_titanic_with_configurations.json
+++ b/tests/profile/fixtures/expected_evrs_SuiteBuilderProfiler_on_titanic_with_configurations.json
@@ -515,7 +515,7 @@
         "meta": {},
         "kwargs": {
           "column": "Age",
-          "mostly": 0.47578065498857575,
+          "mostly": 0.48,
           "result_format": "SUMMARY"
         },
         "expectation_type": "expect_column_values_to_not_be_null"

--- a/tests/profile/test_basic_suite_builder_profiler.py
+++ b/tests/profile/test_basic_suite_builder_profiler.py
@@ -488,13 +488,16 @@ def test_snapshot_BasicSuiteBuilderProfiler_on_titanic_in_demo_mode():
         if "partial_unexpected_counts" in result.result:
             result.result.pop("partial_unexpected_counts")
 
-    # Version and RUN-ID will be different
+    # Version, run_id, batch id will be different
     del expected_evrs.meta["great_expectations.__version__"]
     del evrs.meta["great_expectations.__version__"]
+
     del expected_evrs.meta["run_id"]
-    del expected_evrs.meta["batch_kwargs"]["ge_batch_id"]
     del evrs.meta["run_id"]
+
+    del expected_evrs.meta["batch_kwargs"]["ge_batch_id"]
     del evrs.meta["batch_kwargs"]["ge_batch_id"]
+
     del evrs.meta["validation_time"]
 
     assert evrs == expected_evrs
@@ -607,7 +610,7 @@ def test_BasicSuiteBuilderProfiler_uses_all_columns_if_configuration_does_not_ha
                 "expectation_type": "expect_column_values_to_be_unique",
             },
             {
-                "kwargs": {"column": "nulls", "mostly": 0.4714285714285715},
+                "kwargs": {"column": "nulls", "mostly": 0.47},
                 "meta": {"BasicSuiteBuilderProfiler": {"confidence": "very low"}},
                 "expectation_type": "expect_column_values_to_not_be_null",
             },
@@ -908,7 +911,7 @@ def test_BasicSuiteBuilderProfiler_respects_included_expectations_on_pandas(
             },
             {
                 "meta": {"BasicSuiteBuilderProfiler": {"confidence": "very low"}},
-                "kwargs": {"column": "nulls", "mostly": 0.4714285714285715},
+                "kwargs": {"column": "nulls", "mostly": 0.47},
                 "expectation_type": "expect_column_values_to_not_be_null",
             },
         ],
@@ -1085,7 +1088,7 @@ def test_BasicSuiteBuilderProfiler_uses_all_expectations_if_excluded_expectation
                 "meta": {"BasicSuiteBuilderProfiler": {"confidence": "very low"}},
             },
             {
-                "kwargs": {"column": "nulls", "mostly": 0.4714285714285715},
+                "kwargs": {"column": "nulls", "mostly": 0.47},
                 "expectation_type": "expect_column_values_to_not_be_null",
                 "meta": {"BasicSuiteBuilderProfiler": {"confidence": "very low"}},
             },
@@ -1231,7 +1234,7 @@ def test_BasicSuiteBuilderProfiler_uses_all_columns_if_excluded_columns_are_fals
             {
                 "expectation_type": "expect_column_values_to_not_be_null",
                 "meta": {"BasicSuiteBuilderProfiler": {"confidence": "very low"}},
-                "kwargs": {"column": "nulls", "mostly": 0.4714285714285715},
+                "kwargs": {"column": "nulls", "mostly": 0.47},
             },
         ],
     )


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- round mostly values when scaffolding
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
