### PR TITLE
Bugfix/revert sqlalchemy datasource setup in the cli

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -546,6 +546,7 @@ def _add_sqlalchemy_datasource(context, prompt_for_datasource_name=True):
             datasource = context._build_datasource_from_config(
                 datasource_name, configuration, substitute_variables=True
             )
+            print("Connection successful!")
 
             cli_message(
                 """
@@ -575,32 +576,53 @@ The credentials will be saved in uncommitted/config_variables.yml under the key 
         except DatasourceInitializationError as de:
             cli_message(msg_cannot_connect_to_database.format(str(de)))
             if not click.confirm("Enter the credentials again?", default=True):
-                context.add_datasource(
-                    datasource_name,
-                    initialize=False,
-                    module_name="great_expectations.datasource",
-                    class_name="SqlAlchemyDatasource",
-                    data_asset_type={"class_name": "SqlAlchemyDataset"},
-                    credentials="${" + datasource_name + "}",
-                )
-                # TODO this message about continuing may not be accurate
+
                 cli_message(
                     """
-Datasource {0:s} was saved to {1:s}.
-Credentials have been saved to {2:s}.
-Since we could not connect to the database, you can complete troubleshooting in the configuration files documented here:
-<blue>https://docs.greatexpectations.io/en/latest/tutorials/add-sqlalchemy-datasource.html?utm_source=cli&utm_medium=init&utm_campaign={3:s}#{4:s}</blue> .
+Here is the config that would have been added to your {0:s}:
 
-After you connect to the datasource, run great_expectations init to continue.
+{1:s}
+
+Here is the config that would have been added to your credentials.yml:
 
 """.format(
-                        datasource_name,
+                        DataContext.GE_YML,
+                        textwrap.indent(
+                            toolkit.yaml.dump({datasource_name: configuration}), "  "
+                        ),
                         DataContext.GE_YML,
                         context.get_config()["config_variables_file_path"],
                         rtd_url_ge_version,
                         selected_database.value.lower(),
                     )
                 )
+
+#                 context.add_datasource(
+#                     datasource_name,
+#                     initialize=False,
+#                     module_name="great_expectations.datasource",
+#                     class_name="SqlAlchemyDatasource",
+#                     data_asset_type={"class_name": "SqlAlchemyDataset"},
+#                     credentials="${" + datasource_name + "}",
+#                 )
+#                 # TODO this message about continuing may not be accurate
+#                 cli_message(
+#                     """
+# Datasource {0:s} was saved to {1:s}.
+# Credentials have been saved to {2:s}.
+# Since we could not connect to the database, you can complete troubleshooting in the configuration files documented here:
+# <blue>https://docs.greatexpectations.io/en/latest/tutorials/add-sqlalchemy-datasource.html?utm_source=cli&utm_medium=init&utm_campaign={3:s}#{4:s}</blue> .
+
+# After you connect to the datasource, run great_expectations init to continue.
+
+# """.format(
+#                         datasource_name,
+#                         DataContext.GE_YML,
+#                         context.get_config()["config_variables_file_path"],
+#                         rtd_url_ge_version,
+#                         selected_database.value.lower(),
+#                     )
+#                 )
                 return None
 
     return datasource_name

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -1,3 +1,4 @@
+import copy
 import enum
 import importlib
 import json
@@ -7,7 +8,6 @@ import platform
 import sys
 import textwrap
 import uuid
-import copy
 
 import click
 

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -597,7 +597,6 @@ The credentials will be saved in uncommitted/config_variables.yml under the key 
 
         except DatasourceInitializationError as de:
             cli_message(msg_cannot_connect_to_database.format(str(de)))
-            print(configuration)
             if not click.confirm("\nEnter the credentials again?", default=True):
 
                 cli_message(

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -586,7 +586,8 @@ The credentials will be saved in uncommitted/config_variables.yml under the key 
                 # TODO this message about continuing may not be accurate
                 cli_message(
                     """
-We saved datasource {0:s} in {1:s} and the credentials you entered in {2:s}.
+Datasource {0:s} was saved to {1:s}.
+Credentials have been saved to {2:s}.
 Since we could not connect to the database, you can complete troubleshooting in the configuration files documented here:
 <blue>https://docs.greatexpectations.io/en/latest/tutorials/add-sqlalchemy-datasource.html?utm_source=cli&utm_medium=init&utm_campaign={3:s}#{4:s}</blue> .
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -941,6 +941,7 @@ class BaseDataContext(object):
         # context provides. Datasources should not see unsubstituted variables in their config.
         if initialize:
             datasource = self._build_datasource_from_config(
+                name,
                 self._project_config_with_variables_substituted.datasources[name]
             )
             self._cached_datasources[name] = datasource

--- a/tests/cli/test_datasource_sqlite.py
+++ b/tests/cli/test_datasource_sqlite.py
@@ -653,7 +653,7 @@ def test_cli_datasource_with_failed_connection(
 
     assert "Cannot connect to the database." in stdout
     assert 'invalid port number: "99999"' in stdout
-    assert 'Connection successful!' in stdout
+    assert 'Great Expectations connected to your database!' in stdout
     assert not 'Credentials have been saved' in stdout
     assert len(datasources.keys()) == 0
     assert_no_logging_messages_or_tracebacks(caplog, result)
@@ -674,7 +674,7 @@ def test_cli_datasource_with_failed_connection(
 
     assert "Cannot connect to the database." in stdout
     assert 'invalid port number: "99999"' in stdout
-    assert 'Connection successful!' in stdout
+    assert 'Great Expectations connected to your database!' in stdout
     assert 'Credentials have been saved' in stdout
     assert len(datasources.keys()) == 1
     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/test_datasource_sqlite.py
+++ b/tests/cli/test_datasource_sqlite.py
@@ -628,8 +628,8 @@ def test_cli_datasource_with_failed_connection(
     stdout = result.stdout
     config = yaml.load(open(config_path, "r"))
     datasources = config["datasources"]
-    print("="*80)
-    print(stdout)
+    # print("="*80)
+    # print(stdout)
 
     assert "Cannot connect to the database." in stdout
     assert 'invalid port number: "99999"' in stdout
@@ -669,8 +669,8 @@ def test_cli_datasource_with_failed_connection(
     stdout = result.stdout
     config = yaml.load(open(config_path, "r"))
     datasources = config["datasources"]
-    # print("="*80)
-    # print(stdout)
+    print("="*80)
+    print(stdout)
 
     assert "Cannot connect to the database." in stdout
     assert 'invalid port number: "99999"' in stdout

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -159,10 +159,12 @@ def test_cli_init_connection_string_non_working_db_connection_instructs_user_and
     result = runner.invoke(
         cli,
         ["init"],
-        input="\n\n2\n6\nmy_db\nsqlite:////not_a_real.db\n\nn\n",
+        input="\n\n2\n6\nmy_db\nsqlite:////not_a_real.db\nn\n",
         catch_exceptions=False,
     )
     stdout = result.output
+    # print(stdout)
+
     assert mock_webbrowser.call_count == 0
 
     assert "Always know what to expect from your data" in stdout
@@ -184,25 +186,14 @@ def test_cli_init_connection_string_non_working_db_connection_instructs_user_and
     assert os.path.isdir(ge_dir)
     config_path = os.path.join(ge_dir, DataContext.GE_YML)
     assert os.path.isfile(config_path)
-
     config = yaml.load(open(config_path, "r"))
-    assert config["datasources"] == {
-        "my_db": {
-            "data_asset_type": {
-                "module_name": None,
-                "class_name": "SqlAlchemyDataset",
-            },
-            "credentials": "${my_db}",
-            "class_name": "SqlAlchemyDatasource",
-            "module_name": "great_expectations.datasource",
-        }
-    }
-
-    config_path = os.path.join(
+    assert config["datasources"] == {}
+    
+    uncommitted_config_path = os.path.join(
         ge_dir, DataContext.GE_UNCOMMITTED_DIR, "config_variables.yml"
     )
-    config = yaml.load(open(config_path, "r"))
-    assert config["my_db"] == {"url": "sqlite:////not_a_real.db"}
+    uncommitted_config = yaml.load(open(uncommitted_config_path, "r"))
+    assert not "my_db" in uncommitted_config
 
     obs_tree = gen_directory_tree_str(os.path.join(root_dir, "great_expectations"))
     assert (


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Fixes a bug where `great_expectations init` and `great_expectations datasource new` said they were attempting to connect to a database, but would not attempt to connect until later.
- Changes the behavior of `great_expectations init` and `great_expectations datasource new` so that they do not write failing datasource configurations to `great_expectations.yml` and `config_variables.yml`.
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Notes for design review:
- https://www.loom.com/share/1e256b22f35c40f0b77bd06227148873

Previous Design Review notes:

-
-


Thank you for submitting!
