### PR TITLE
[BUGFIX] Fixed bad get_batch_kwargs_generator call

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -963,7 +963,7 @@ def get_batch_kwargs(
     # if the user provided us with the batch kwargs generator name and the data asset, we have everything we need -
     # let's ask the generator to build batch kwargs for this asset - we are done.
     if batch_kwargs_generator_name is not None and data_asset_name is not None:
-        generator = datasource.get_batch_kwargs_generator(batch_kwargs_generator_name)
+        generator = data_source.get_batch_kwargs_generator(batch_kwargs_generator_name)
         batch_kwargs = generator.build_batch_kwargs(
             data_asset_name, **additional_batch_kwargs
         )

--- a/tests/cli/test_datasource.py
+++ b/tests/cli/test_datasource.py
@@ -1,0 +1,37 @@
+import os
+
+from great_expectations import DataContext
+from great_expectations.cli.datasource import get_batch_kwargs
+
+
+def test_get_batch_kwargs_for_specific_dataasset(empty_data_context, filesystem_csv):
+    project_root_dir = empty_data_context.root_directory
+    context = DataContext(project_root_dir)
+    base_directory = str(filesystem_csv)
+
+    context.add_datasource(
+        "wow_a_datasource",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+        batch_kwargs_generators={
+            "subdir_reader": {
+                "class_name": "SubdirReaderBatchKwargsGenerator",
+                "base_directory": base_directory,
+            }
+        },
+    )
+
+    batch = get_batch_kwargs(
+        context,
+        datasource_name=None,
+        batch_kwargs_generator_name=None,
+        data_asset_name="f1",
+        additional_batch_kwargs={},
+    )
+
+    expected_batch = {
+        "data_asset_name": "f1",
+        "datasource": "wow_a_datasource",
+        "path": os.path.join(filesystem_csv, "f1.csv"),
+    }
+    assert batch == expected_batch


### PR DESCRIPTION

Changes proposed in this pull request:

Hi Team,

Fixed bad `get_batch_kwargs_generator` call.

Original code was pointing at the `datasource` variable when trying to call `get_batch_kwargs_generator`. This doesn't work, because `datasource` is a `click.Group`. The correct object to call is `data_source`, from line 953.

