### PR TITLE
[ENHANCEMENT] Exclude black from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 altair>=4.0.0,<5
-black==19.10b0
 Click>=7.0
 future>=0.16
 ipywidgets>=7.4.2


### PR DESCRIPTION
Changes proposed in this pull request:
- remove black from requirements

black is a linter used for development purposes. I don't think it is necessary to install when great expectations is used in production environments.