### PR TITLE
[DOCS] Fix how_to_validate_data docs

### DIFF
--- a/docs/how_to_guides/validation/spare_parts/how_to_validate_data.rst
+++ b/docs/how_to_guides/validation/spare_parts/how_to_validate_data.rst
@@ -267,7 +267,7 @@ as ``s3`` or ``gcs``, edit the stores section of the DataContext configuration o
       validations_store:
         class_name: ValidationsStore
         store_backend:
-          class_name: TupleS3Backend
+          class_name: TupleS3StoreBackend
           bucket: my_bucket
           prefix: my_prefix
 


### PR DESCRIPTION
`TupleS3Backend` does not exist. It is called `TupleS3StoreBackend`.