### PR TITLE
[BUGFIX] Support calling head() on empty SqlAlchemyDataset

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Develop
 -----------------
 * [FEATURE] Add support for expect_column_values_to_match_regex_list exception for Spark backend
+* [BUGFIX] fixed issue where calling head() on a SqlAlchemyDataset would fail if the underlying table is empty
 
 0.11.4
 -----------------

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -467,6 +467,8 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 )
 
             df = pd.read_sql(head_sql_str, con=self.engine)
+        except StopIteration:
+            df = pd.DataFrame(columns=self.get_table_columns())
 
         return PandasDataset(
             df,

--- a/tests/dataset/test_dataset_legacy.py
+++ b/tests/dataset/test_dataset_legacy.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import pytest
+
 from great_expectations.dataset import PandasDataset
 from tests.test_utils import get_dataset
 

--- a/tests/dataset/test_dataset_legacy.py
+++ b/tests/dataset/test_dataset_legacy.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 
 import pytest
-
 from great_expectations.dataset import PandasDataset
 from tests.test_utils import get_dataset
 
@@ -51,4 +50,13 @@ def test_head(test_backend):
     head = dataset.head(1)
     assert isinstance(head, PandasDataset)
     assert len(head) == 1
+    assert list(head.columns) == ["a"]
+
+    # We also needed special handling for empty tables in SqlalchemyDataset
+    dataset = get_dataset(
+        test_backend, {"a": []}, schemas=schemas.get(test_backend), caching=True
+    )
+    head = dataset.head(1)
+    assert isinstance(head, PandasDataset)
+    assert len(head) == 0
     assert list(head.columns) == ["a"]


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix an issue where calling head() on an empty table attached to SqlAlchemyDataset raised StopIteration exception

Design Review Notes:
- This fix comes from a slack support request!

Thank you for submitting!
