### PR TITLE
[DOCS] will/docs/how_to/Store Expectations on Google Cloud Store

### DIFF
--- a/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
+++ b/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
@@ -67,7 +67,7 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 
 5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``.
 
-    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the S3 bucket as long as we set the ``expectations_name`` variable to ``expectations_S3_store``.
+    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_GCP_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in GCP as long as we set the ``expectations_name`` variable to ``expectations_GCP_store``.
 
     .. code-block:: bash
 

--- a/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
+++ b/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
@@ -3,7 +3,7 @@
 How to configure an Expectation store in GCP
 ============================================
 
-By default, newly profiled Expectations are stored in JSON format in the ``expectations/`` subdirectory of your ``great_expectations/`` folder.  This guide will help you configure Great Expectations to store them in a Google Cloud Platform (GCP) bucket.
+By default, newly profiled Expectations are stored in JSON format in the ``expectations/`` subdirectory of your ``great_expectations/`` folder.  This guide will help you configure Great Expectations to store them in a Google Cloud Storage (GCS) bucket.
 
 .. admonition:: Prerequisites: This how-to guide assumes that you have already:
 

--- a/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
+++ b/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
@@ -59,7 +59,7 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 
     .. code-block:: bash
 
-        gsutil cp '<OBJECT_LOCATION>' gs://'<your_GCP_bucket_name>'/
+        gsutil cp exp1.json gs://'<your_GCP_bucket_name>'/'<your_GCP_folder_name>'
 
         Operation completed over 1 objects/58.8 KiB.
 

--- a/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
+++ b/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
@@ -1,18 +1,110 @@
 .. _how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_gcs:
 
-How to configure an Expectation store in GCS
+How to configure an Expectation store in GCP
 ============================================
 
-.. admonition:: Admonition from Mr. Dickens
+By default, newly profiled Expectations are stored in JSON format in the ``expectations/`` subdirectory of your ``great_expectations/`` folder.  This guide will help you configure Great Expectations to store them in a Google Cloud Platform (GCP) bucket.
 
-    "Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show."
+.. admonition:: Prerequisites: This how-to guide assumes that you have already:
+
+    - Configured a :ref:`Data Context <tutorials__getting_started__initialize_a_data_context>`.
+    - Configured an :ref:`Expectations Suite <tutorials__getting_started__create_your_first_expectations>`.
+    - Configured a GCP `service account <https://cloud.google.com/iam/docs/service-accounts>`_ with credentials that can access the appropriate GCP resources, which include Storage Objects.
+    - Identified the GCP project, bucket, and prefix where Expectations will be stored.
+
+1. **Configure local environment with appropriate authentication credentials to connect to the** `Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_ **where Expectations will be stored**.
+
+2. **Identify your Data Context Expectations Store**
+
+    In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
 
-This guide is a stub. We all know that it will be useful, but no one has made time to write it yet.
+    .. code-block:: yaml
+
+        expectations_store_name: expectations_store
+
+        stores:
+            expectations_store:
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: expectations/
+
+
+3. **Update your configuration file to include a new store for Expectations on GCP.**
+
+    In our case, the name is set to ``expectations_GCP_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to the GCP project, ``bucket`` will be set to the address of your GCP bucket, and ``prefix`` will be set to the folder where Expectation files will be located.
+
+
+.. warning::
+
+    If you are also storing :ref:`Validations in GCP, <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_gcs>` please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+    .. code-block:: yaml
+
+        expectations_store_name: expectations_GCP_store
+        stores:
+            expectations_GCP_store:
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleGCSStoreBackend
+                    project: '<your_GCP_project_name>'
+                    bucket: '<your_GCP_bucket_name>'
+                    prefix: '<your_GCP_folder_name>'
+
+
+4. **Copy existing Expectation JSON files to the GCP bucket**. (This step is optional).
+
+    One way to copy Expectations into GCP is by using the `gsutil cp` command, which is part of the Google Cloud SDK. The command will copy one Expectation, ``exp1`` from a local folder to the GCP bucket.   Information on other options, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+
+    .. code-block:: bash
+
+        gsutil cp '<OBJECT_LOCATION>' gs://'<your_GCP_bucket_name>'/
+
+        Operation completed over 1 objects/58.8 KiB.
+
+
+
+5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``.
+
+    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the S3 bucket as long as we set the ``expectations_name`` variable to ``expectations_S3_store``.
+
+    .. code-block:: bash
+
+        great_expectations store list
+
+        - name: expectations_store
+        class_name: ExpectationsStore
+        store_backend:
+            class_name: TupleFilesystemStoreBackend
+            base_directory: expectations/
+
+        - name: expectations_GCP_store
+        class_name: ExpectationsStore
+        store_backend:
+            class_name: TupleGCSStoreBackend
+            project: '<your_GCP_project_name>'
+            bucket: '<your_GCP_bucket_name>'
+            prefix: '<your_GCP_folder_name>'
+
+
+6. **Confirm that Expectations can be accessed from GCP by running** ``great_expectations suite list``.
+
+    If you followed Step 4, The output should include the Expectation we copied to GCP: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no expectations were found.
+
+    .. code-block:: bash
+
+        great_expectations suite list
+
+        1 Expectation Suite found:
+         - exp1
+
+
+Additional resources
+--------------------
 
 If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.
 
-If you want to be a real hero, we'd welcome a pull request. Please see :ref:`the Contributing tutorial <tutorials__contributing>` and :ref:`How to write a how to guide` to get started.
 
 .. discourse::
     :topic_identifier: 180

--- a/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
+++ b/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
@@ -1,6 +1,6 @@
 .. _how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_gcs:
 
-How to configure an Expectation store in GCP
+How to configure an Expectation store in GCS
 ============================================
 
 By default, newly profiled Expectations are stored in JSON format in the ``expectations/`` subdirectory of your ``great_expectations/`` folder.  This guide will help you configure Great Expectations to store them in a Google Cloud Storage (GCS) bucket.
@@ -9,14 +9,22 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 
     - Configured a :ref:`Data Context <tutorials__getting_started__initialize_a_data_context>`.
     - Configured an :ref:`Expectations Suite <tutorials__getting_started__create_your_first_expectations>`.
-    - Configured a GCP `service account <https://cloud.google.com/iam/docs/service-accounts>`_ with credentials that can access the appropriate GCP resources, which include Storage Objects.
-    - Identified the GCP project, bucket, and prefix where Expectations will be stored.
+    - Configured a Google Cloud Platform (GCP) `service account <https://cloud.google.com/iam/docs/service-accounts>`_ with credentials that can access the appropriate GCP resources, which include Storage Objects.
+    - Identified the GCP project, GCS bucket, and prefix where Expectations will be stored.
 
-1. **Configure local environment with appropriate authentication credentials to connect to the** `Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_ **where Expectations will be stored**.
+1. **Configure your GCP credentials**
+
+    Check that your environment is configured with the appropriate authentication credentials needed to connect to the GCS bucket where Expectations will be stored.
+
+    The Google Cloud Platform documentation describes how to verify your `authentication for the Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_, which includes:
+
+        1. Creating a Google Cloud Platform (GCP) service account,
+        2. Setting the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable,
+        3. Verifying authentication by running a simple `Google Cloud Storage client <https://cloud.google.com/storage/docs/reference/libraries>`_ library script.
 
 2. **Identify your Data Context Expectations Store**
 
-    In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+    In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
 
     .. code-block:: yaml
@@ -31,35 +39,35 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
                     base_directory: expectations/
 
 
-3. **Update your configuration file to include a new store for Expectations on GCP.**
+3. **Update your configuration file to include a new store for Expectations on GCS**
 
-    In our case, the name is set to ``expectations_GCP_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to the GCP project, ``bucket`` will be set to the address of your GCP bucket, and ``prefix`` will be set to the folder where Expectation files will be located.
+    In our case, the name is set to ``expectations_GCS_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to your GCP project, ``bucket`` will be set to the address of your GCS bucket, and ``prefix`` will be set to the folder on GCS where Expectation files will be located.
 
 
 .. warning::
 
-    If you are also storing :ref:`Validations in GCP, <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_gcs>` please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+    If you are also storing :ref:`Validations in GCS, <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_gcs>` please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
 
     .. code-block:: yaml
 
-        expectations_store_name: expectations_GCP_store
+        expectations_store_name: expectations_GCS_store
         stores:
-            expectations_GCP_store:
+            expectations_GCS_store:
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleGCSStoreBackend
                     project: '<your_GCP_project_name>'
-                    bucket: '<your_GCP_bucket_name>'
-                    prefix: '<your_GCP_folder_name>'
+                    bucket: '<your_GCS_bucket_name>'
+                    prefix: '<your_GCS_folder_name>'
 
 
-4. **Copy existing Expectation JSON files to the GCP bucket**. (This step is optional).
+4. **Copy existing Expectation JSON files to the GCS bucket**. (This step is optional).
 
-    One way to copy Expectations into GCP is by using the `gsutil cp` command, which is part of the Google Cloud SDK. The command will copy one Expectation, ``exp1`` from a local folder to the GCP bucket.   Information on other options, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+    One way to copy Expectations into GCS is by using the ``gsutil cp`` command, which is part of the Google Cloud SDK. The following example will copy one Expectation, ``exp1`` from a local folder to the GCS bucket.   Information on other options, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
 
     .. code-block:: bash
 
-        gsutil cp exp1.json gs://'<your_GCP_bucket_name>'/'<your_GCP_folder_name>'
+        gsutil cp exp1.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
 
         Operation completed over 1 objects/58.8 KiB.
 
@@ -67,7 +75,7 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 
 5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``.
 
-    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_GCP_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in GCP as long as we set the ``expectations_name`` variable to ``expectations_GCP_store``.
+    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_GCS_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in GCS as long as we set the ``expectations_name`` variable to ``expectations_GCS_store``, and the config for ``expectations_store`` can be removed if you would like.
 
     .. code-block:: bash
 
@@ -79,18 +87,18 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
             class_name: TupleFilesystemStoreBackend
             base_directory: expectations/
 
-        - name: expectations_GCP_store
+        - name: expectations_GCS_store
         class_name: ExpectationsStore
         store_backend:
             class_name: TupleGCSStoreBackend
             project: '<your_GCP_project_name>'
-            bucket: '<your_GCP_bucket_name>'
-            prefix: '<your_GCP_folder_name>'
+            bucket: '<your_GCS_bucket_name>'
+            prefix: '<your_GCS_folder_name>'
 
 
-6. **Confirm that Expectations can be accessed from GCP by running** ``great_expectations suite list``.
+6. **Confirm that Expectations can be accessed from GCS by running** ``great_expectations suite list``.
 
-    If you followed Step 4, The output should include the Expectation we copied to GCP: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no expectations were found.
+    If you followed Step 4, the output should include the Expectation we copied to GCS: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no Expectations were found.
 
     .. code-block:: bash
 
@@ -102,9 +110,6 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 
 Additional resources
 --------------------
-
-If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.
-
 
 .. discourse::
     :topic_identifier: 180

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ altair>=4.0.0,<5
 black==19.10b0
 Click>=7.0
 future>=0.16
-google-cloud-storage>=1.28.0
 ipywidgets>=7.4.2
 jinja2>=2.10
 jsonschema>=2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ altair>=4.0.0,<5
 black==19.10b0
 Click>=7.0
 future>=0.16
+google-cloud-storage>=1.28.0
 ipywidgets>=7.4.2
 jinja2>=2.10
 jsonschema>=2.5.1

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ config = {
         "spark": ["pyspark>=2.3.2"],
         "sqlalchemy": ["sqlalchemy>=1.2"],
         "airflow": ["apache-airflow[s3]>=1.9.0", "boto3>=1.7.3"],
+        "gcp": ["google-cloud-storage>=1.28.0"],
     },
     "packages": find_packages(exclude=["docs*", "tests*", "examples*"]),
     "entry_points": {


### PR DESCRIPTION
Changes proposed in this pull request:
- Documentation on how to store Expectations on Google Cloud Store
- Adding `google-cloud-storage>=1.28.0` to requirements.txt

