### PR TITLE
[FEATURE] JSONSchema profiler creates basic suites

### DIFF
--- a/docs/how_to_guides/creating_and_editing_expectations/how_to_create_a_suite_from_a_json_schema_file.rst
+++ b/docs/how_to_guides/creating_and_editing_expectations/how_to_create_a_suite_from_a_json_schema_file.rst
@@ -1,0 +1,100 @@
+.. _how_to_guides__how_to_create_a_suite_from_a_json_schema_file:
+
+How to create a new Expectation Suite from a jsonschema file
+============================================================
+
+
+The ``JsonSchemaProfiler`` helps you quickly create :ref:`Expectation Suites` from jsonschema files.
+
+.. admonition:: Prerequisites: This how-to guide assumes you have already:
+
+  - :ref:`Set up a working deployment of Great Expectations <getting_started>`
+  - Have a valid jsonschema file that is has top level object of type `object`.
+
+.. warning:: This implementation does not traverse any levels of nesting.
+
+Steps
+-----
+
+1. **Set a filename and a suite name**
+
+    .. code-block:: python
+
+        jsonschema_file = "YOUR_JSON_SCHEMA_FILE.json"
+        suite_name = "YOUR_SUITE_NAME"
+
+2. **Load a DataContext**
+
+    .. code-block:: python
+
+        context = ge.data_context.DataContext()
+
+3. **Load the jsonschema file**
+
+    .. code-block:: python
+
+        with open(jsonschema_file, "r") as f:
+            schema = json.load(f)
+
+4. **Instantiate the profiler**
+
+    .. code-block:: python
+
+        profiler = JsonSchemaProfiler()
+
+5. **Create the suite**
+
+    .. code-block:: python
+
+        suite = profiler.profile(schema, suite_name)
+
+6. **Save the suite**
+
+    .. code-block:: python
+
+        context.save_expectation_suite(suite)
+
+7. **Optionally, generate Data Docs and review the results there.**
+
+    Data Docs provides a concise and useful way to review the Expectation Suite that has been created.
+
+    .. code-block:: bash
+
+        context.build_data_docs()
+
+     You can also review and update the Expectations created by the profiler to get to the Expectation Suite you want using ``great_expectations suite edit``.
+
+Additional notes
+----------------
+
+.. important::
+
+    Note that JsonSchemaProfiler generates Expectation Suites using column map expectations, which assumes a tabular data structure, because Great Expectations does not currently support nested data structures.
+
+The full example script is here:
+
+.. code-block:: python
+
+    import json
+    import great_expectations as ge
+    from great_expectations.profile.json_schema_profiler import JsonSchemaProfiler
+
+    jsonschema_file = "YOUR_JSON_SCHEMA_FILE.json"
+    suite_name = "YOUR_SUITE_NAME"
+
+    context = ge.data_context.DataContext()
+
+    with open(jsonschema_file, "r") as f:
+        raw_json = f.read()
+        schema = json.loads(raw_json)
+
+    print("Generating suite...")
+    profiler = JsonSchemaProfiler()
+    suite = profiler.profile(schema, suite_name)
+    context.save_expectation_suite(suite)
+
+Comments
+--------
+
+    .. discourse::
+        :topic_identifier: 268

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 
 Develop
 -----------------
-
+* [FEATURE] A profiler that builds suites from JSONSchema files.
 
 0.11.5
 -----------------

--- a/great_expectations/profile/base.py
+++ b/great_expectations/profile/base.py
@@ -1,11 +1,13 @@
+import abc
 import logging
 import time
 import warnings
 from enum import Enum
+from typing import Any
 
 from dateutil.parser import ParserError, parse
 
-from great_expectations.core import RunIdentifier
+from great_expectations.core import ExpectationSuite, RunIdentifier
 from great_expectations.exceptions import GreatExpectationsError
 
 from ..data_asset import DataAsset
@@ -15,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class ProfilerDataType(Enum):
+    """Useful data types for building profilers."""
+
     INT = "int"
     FLOAT = "float"
     STRING = "string"
@@ -24,6 +28,8 @@ class ProfilerDataType(Enum):
 
 
 class ProfilerCardinality(Enum):
+    """Useful cardinality categories for building profilers."""
+
     NONE = "none"
     ONE = "one"
     TWO = "two"
@@ -32,6 +38,87 @@ class ProfilerCardinality(Enum):
     MANY = "many"
     VERY_MANY = "very many"
     UNIQUE = "unique"
+
+
+class ProfilerTypeMapping:
+    """Useful backend type mapping for building profilers."""
+
+    # Future support possibility: JSON (RECORD)
+    # Future support possibility: BINARY (BYTES)
+    INT_TYPE_NAMES = {
+        "INTEGER",
+        "integer",
+        "int",
+        "INT",
+        "TINYINT",
+        "BYTEINT",
+        "SMALLINT",
+        "BIGINT",
+        "IntegerType",
+        "LongType",
+        "DECIMAL",
+    }
+    FLOAT_TYPE_NAMES = {
+        "FLOAT",
+        "FLOAT4",
+        "FLOAT8",
+        "DOUBLE_PRECISION",
+        "NUMERIC",
+        "FloatType",
+        "DoubleType",
+        "float",
+        "number",
+    }
+    STRING_TYPE_NAMES = {
+        "CHAR",
+        "VARCHAR",
+        "TEXT",
+        "STRING",
+        "StringType",
+        "string",
+        "str",
+    }
+    BOOLEAN_TYPE_NAMES = {"BOOLEAN", "boolean", "BOOL", "bool", "BooleanType"}
+    DATETIME_TYPE_NAMES = {
+        "DATETIME",
+        "DATE",
+        "TIME",
+        "TIMESTAMP",
+        "DateType",
+        "TimestampType",
+        "datetime64",
+        "Timestamp",
+    }
+
+
+class Profiler(object, metaclass=abc.ABCMeta):
+    """
+    Profilers creates suites from various sources of truth.
+
+    These sources of truth can be data or non-data sources such as DDLs.
+
+    When implementing a Profiler ensure that you:
+    - Implement a . _profile() method
+    - Optionally implement .validate() method that verifies you are running on the right
+     kind of object. You should raise an appropriate Exception if the object is not valid.
+    """
+
+    def __init__(self, configuration: dict = None):
+        self.configuration = configuration
+
+    def validate(self, item_to_validate: Any) -> None:
+        pass
+
+    def profile(self, item_to_profile: Any, suite_name: str = None) -> ExpectationSuite:
+        self.validate(item_to_profile)
+        expectation_suite = self._profile(item_to_profile, suite_name=suite_name)
+        return expectation_suite
+
+    @abc.abstractmethod
+    def _profile(
+        self, item_to_profile: Any, suite_name: str = None
+    ) -> ExpectationSuite:
+        pass
 
 
 class DataAssetProfiler(object):

--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -4,6 +4,7 @@ from great_expectations.profile.base import (
     DatasetProfiler,
     ProfilerCardinality,
     ProfilerDataType,
+    ProfilerTypeMapping,
 )
 
 try:
@@ -19,50 +20,15 @@ class BasicDatasetProfilerBase(DatasetProfiler):
     that is used by the dataset profiler classes that extend this class.
     """
 
-    # Future support possibility: JSON (RECORD)
-    # Future support possibility: BINARY (BYTES)
-    INT_TYPE_NAMES = {
-        "INTEGER",
-        "int",
-        "INT",
-        "TINYINT",
-        "BYTEINT",
-        "SMALLINT",
-        "BIGINT",
-        "IntegerType",
-        "LongType",
-        "DECIMAL",
-    }
-    FLOAT_TYPE_NAMES = {
-        "FLOAT",
-        "FLOAT4",
-        "FLOAT8",
-        "DOUBLE_PRECISION",
-        "NUMERIC",
-        "FloatType",
-        "DoubleType",
-        "float",
-    }
-    STRING_TYPE_NAMES = {
-        "CHAR",
-        "VARCHAR",
-        "TEXT",
-        "STRING",
-        "StringType",
-        "string",
-        "str",
-    }
-    BOOLEAN_TYPE_NAMES = {"BOOLEAN", "BOOL", "bool", "BooleanType"}
-    DATETIME_TYPE_NAMES = {
-        "DATETIME",
-        "DATE",
-        "TIME",
-        "TIMESTAMP",
-        "DateType",
-        "TimestampType",
-        "datetime64",
-        "Timestamp",
-    }
+    # Deprecation Warning. If you are reading this code you are likely building
+    # your own profiler. We are moving toward a profiler toolkit to simplify
+    # building custom profilers. These mappings now exist in ProfilerTypeMapping
+    # and will be deprecated in the future.
+    INT_TYPE_NAMES = ProfilerTypeMapping.INT_TYPE_NAMES
+    FLOAT_TYPE_NAMES = ProfilerTypeMapping.FLOAT_TYPE_NAMES
+    STRING_TYPE_NAMES = ProfilerTypeMapping.STRING_TYPE_NAMES
+    BOOLEAN_TYPE_NAMES = ProfilerTypeMapping.BOOLEAN_TYPE_NAMES
+    DATETIME_TYPE_NAMES = ProfilerTypeMapping.DATETIME_TYPE_NAMES
 
     @classmethod
     def _get_column_type(cls, df, column):
@@ -71,27 +37,27 @@ class BasicDatasetProfilerBase(DatasetProfiler):
         df.set_config_value("interactive_evaluation", True)
         try:
             if df.expect_column_values_to_be_in_type_list(
-                column, type_list=sorted(list(cls.INT_TYPE_NAMES))
+                column, type_list=sorted(list(ProfilerTypeMapping.INT_TYPE_NAMES))
             ).success:
                 type_ = ProfilerDataType.INT
 
             elif df.expect_column_values_to_be_in_type_list(
-                column, type_list=sorted(list(cls.FLOAT_TYPE_NAMES))
+                column, type_list=sorted(list(ProfilerTypeMapping.FLOAT_TYPE_NAMES))
             ).success:
                 type_ = ProfilerDataType.FLOAT
 
             elif df.expect_column_values_to_be_in_type_list(
-                column, type_list=sorted(list(cls.STRING_TYPE_NAMES))
+                column, type_list=sorted(list(ProfilerTypeMapping.STRING_TYPE_NAMES))
             ).success:
                 type_ = ProfilerDataType.STRING
 
             elif df.expect_column_values_to_be_in_type_list(
-                column, type_list=sorted(list(cls.BOOLEAN_TYPE_NAMES))
+                column, type_list=sorted(list(ProfilerTypeMapping.BOOLEAN_TYPE_NAMES))
             ).success:
                 type_ = ProfilerDataType.BOOLEAN
 
             elif df.expect_column_values_to_be_in_type_list(
-                column, type_list=sorted(list(cls.DATETIME_TYPE_NAMES))
+                column, type_list=sorted(list(ProfilerTypeMapping.DATETIME_TYPE_NAMES))
             ).success:
                 type_ = ProfilerDataType.DATETIME
 

--- a/great_expectations/profile/basic_suite_builder_profiler.py
+++ b/great_expectations/profile/basic_suite_builder_profiler.py
@@ -462,7 +462,7 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
                     ProfilerCardinality.UNIQUE,
                 ]:
                     # TODO we will want to finesse the number and types of
-                    #  expectations created here. The simple version is blacklisting
+                    #  expectations created here. The simple version is deny/allow list
                     #  and the more complex version is desired per column type and
                     #  cardinality. This deserves more thought on configuration.
                     dataset.expect_column_values_to_be_unique(column)

--- a/great_expectations/profile/json_schema_profiler.py
+++ b/great_expectations/profile/json_schema_profiler.py
@@ -1,0 +1,249 @@
+import logging
+from enum import Enum
+from typing import Any, Dict, Optional
+
+import jsonschema
+
+from great_expectations.core import (
+    ExpectationConfiguration,
+    ExpectationKwargs,
+    ExpectationSuite,
+)
+from great_expectations.profile.base import Profiler, ProfilerTypeMapping
+
+logger = logging.getLogger(__name__)
+
+
+class JsonSchemaTypes(Enum):
+    STRING = "string"
+    INTEGER = "integer"
+    NUMBER = "number"
+    ARRAY = "array"
+    NULL = "null"
+    BOOLEAN = "boolean"
+    OBJECT = "object"
+    ENUM = "enum"
+
+
+class JsonSchemaProfiler(Profiler):
+    """
+    This profiler creates Expectation Suites from JSONSchema artifacts.
+
+    JSON Schema is a vocabulary that allows you to annotate and validate JSON
+    documents. https://json-schema.org
+
+    Basic suites can be created from these specifications.
+
+    Note that there is not yet a notion of nested data types in Great
+    Expectations so suites generated use column map expectations.
+
+    Also note that this implementation does not traverse nested schemas and
+    requires a top level object of type `object`.
+    """
+
+    PROFILER_TYPE_LIST_BY_JSON_SCHEMA_TYPE = {
+        JsonSchemaTypes.STRING.value: ProfilerTypeMapping.STRING_TYPE_NAMES,
+        JsonSchemaTypes.INTEGER.value: ProfilerTypeMapping.INT_TYPE_NAMES,
+        JsonSchemaTypes.NUMBER.value: ProfilerTypeMapping.FLOAT_TYPE_NAMES,
+        JsonSchemaTypes.BOOLEAN.value: ProfilerTypeMapping.BOOLEAN_TYPE_NAMES,
+    }
+
+    def validate(self, schema: dict) -> bool:
+        if not isinstance(schema, dict):
+            raise TypeError(
+                f"This profiler requires a schema of type dict and was passed a {type(schema)}"
+            )
+        if "type" not in schema.keys():
+            raise KeyError(
+                f"This profiler requires a json schema with a top level `type` key"
+            )
+        if schema["type"] != JsonSchemaTypes.OBJECT.value:
+            raise TypeError(
+                f"This profiler requires a json schema with a top level `type` of `object`"
+            )
+        validator = jsonschema.validators.validator_for(schema)
+        validator.check_schema(schema)
+        return True
+
+    def _profile(self, schema: dict, suite_name: str = None) -> ExpectationSuite:
+        if not suite_name:
+            raise ValueError("Please provide a suite name when using this profiler.")
+        expectations = []
+        # TODO add recursion to allow creation of suites for nested schema files
+        if schema["type"] == JsonSchemaTypes.OBJECT.value:
+            for key, details in schema["properties"].items():
+                expectations.append(self._create_existence_expectation(key, details))
+
+                type_expectation = self._create_type_expectation(key, details)
+                if type_expectation:
+                    expectations.append(type_expectation)
+
+                range_expectation = self._create_range_expectation(key, details)
+                if range_expectation:
+                    expectations.append(range_expectation)
+
+                boolean_expectation = self._create_boolean_expectation(key, details)
+                if boolean_expectation:
+                    expectations.append(boolean_expectation)
+
+                set_expectation = self._create_set_expectation(key, details)
+                if set_expectation:
+                    expectations.append(set_expectation)
+
+                string_len_expectation = self._create_string_length_expectation(
+                    key, details
+                )
+                if string_len_expectation:
+                    expectations.append(string_len_expectation)
+        description = schema.get("description", None)
+        meta = None
+        if description:
+            meta = {
+                "notes": {
+                    "format": "markdown",
+                    "content": [f"### Description:\n{description}"],
+                }
+            }
+        suite = ExpectationSuite(suite_name, expectations=expectations, meta=meta)
+        suite.add_citation(
+            comment=f"This suite was built by the {self.__class__.__name__}",
+        )
+        return suite
+
+    def _create_existence_expectation(
+        self, key: str, details: dict
+    ) -> ExpectationConfiguration:
+        kwargs = ExpectationKwargs(column=key)
+        description = details.get("description", None)
+        meta = None
+        if description:
+            meta = {
+                "notes": {
+                    "format": "markdown",
+                    "content": [f"### Description:\n{description}"],
+                }
+            }
+        return ExpectationConfiguration("expect_column_to_exist", kwargs, meta=meta)
+
+    def _create_type_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        type_ = details.get("type", None)
+        if type_ is None:
+            return None
+
+        type_list = self.PROFILER_TYPE_LIST_BY_JSON_SCHEMA_TYPE[type_]
+        kwargs = ExpectationKwargs(column=key, type_list=type_list)
+        return ExpectationConfiguration(
+            "expect_column_values_to_be_in_type_list", kwargs
+        )
+
+    def _create_boolean_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        """https://json-schema.org/understanding-json-schema/reference/boolean.html"""
+        type_ = details.get("type", None)
+        if type_ != JsonSchemaTypes.BOOLEAN.value:
+            return None
+
+        # TODO map JSONSchema types to which type backend? Pandas? Should this value set be parameterized per back end?
+        kwargs = ExpectationKwargs(column=key, value_set=[True, False])
+        return ExpectationConfiguration("expect_column_values_to_be_in_set", kwargs)
+
+    def _create_range_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        """https://json-schema.org/understanding-json-schema/reference/numeric.html#range"""
+        type_ = details.get("type", None)
+        if type_ not in [JsonSchemaTypes.INTEGER.value, JsonSchemaTypes.NUMBER.value]:
+            return None
+
+        minimum = details.get("minimum", None)
+        maximum = details.get("maximum", None)
+        exclusive_minimum = details.get("exclusiveMinimum", None)
+        exclusive_maximum = details.get("exclusiveMaximum", None)
+
+        if (
+            minimum is None
+            and maximum is None
+            and exclusive_minimum is None
+            and exclusive_maximum is None
+        ):
+            return None
+
+        kwargs: Dict[str, Any] = {"column": key}
+        if minimum is not None:
+            kwargs["min_value"] = minimum
+        if maximum is not None:
+            kwargs["max_value"] = maximum
+        if exclusive_minimum is not None:
+            kwargs["min_value"] = exclusive_minimum
+            kwargs["strict_min"] = True
+        if exclusive_maximum is not None:
+            kwargs["max_value"] = exclusive_maximum
+            kwargs["strict_max"] = True
+
+        return ExpectationConfiguration(
+            "expect_column_values_to_be_between", ExpectationKwargs(kwargs)
+        )
+
+    def _create_string_length_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        """https://json-schema.org/understanding-json-schema/reference/string.html#length"""
+        type_ = details.get("type", None)
+        minimum = details.get("minLength", None)
+        maximum = details.get("maxLength", None)
+
+        if type_ != JsonSchemaTypes.STRING.value:
+            return None
+        if minimum is None and maximum is None:
+            return None
+
+        kwargs = {
+            "column": key,
+        }
+        if minimum == maximum:
+            kwargs["value"] = minimum
+            return ExpectationConfiguration(
+                "expect_column_value_lengths_to_equal", ExpectationKwargs(kwargs)
+            )
+        if minimum is not None:
+            kwargs["min_value"] = minimum
+        if maximum is not None:
+            kwargs["max_value"] = maximum
+
+        return ExpectationConfiguration(
+            "expect_column_value_lengths_to_be_between", ExpectationKwargs(kwargs)
+        )
+
+    def _create_set_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        """https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values"""
+        if JsonSchemaTypes.ENUM.value not in details.keys():
+            return None
+        enum = details.get("enum", None)
+        if not isinstance(enum, list):
+            return None
+
+        kwargs = ExpectationKwargs(column=key, value_set=enum)
+        return ExpectationConfiguration("expect_column_values_to_be_in_set", kwargs)
+
+    def _create_regex_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        # TODO https://json-schema.org/understanding-json-schema/reference/regular_expressions.html
+        raise NotImplementedError("regex are not yet implemented.")
+
+    def _create_string_format_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        # TODO https://json-schema.org/understanding-json-schema/reference/string.html#format
+        raise NotImplementedError("string format are not yet implemented.")
+
+    def _create_array_expectation(
+        self, key: str, details: dict
+    ) -> Optional[ExpectationConfiguration]:
+        # TODO Non tabular - how do we validate these? https://json-schema.org/understanding-json-schema/reference/array.html
+        raise NotImplementedError("arrays are not yet implemented.")

--- a/great_expectations/render/renderer/other_section_renderer.py
+++ b/great_expectations/render/renderer/other_section_renderer.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import Counter, defaultdict
 
-from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
+from great_expectations.profile.base import ProfilerTypeMapping
 from great_expectations.render.types import (
     CollapseContent,
     RenderedBulletListContent,
@@ -336,15 +336,15 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
             else:  # assuming expect_column_values_to_be_of_type
                 expected_types = set([evr.expectation_config.kwargs["type_"]])
 
-            if expected_types.issubset(BasicDatasetProfiler.INT_TYPE_NAMES):
+            if expected_types.issubset(ProfilerTypeMapping.INT_TYPE_NAMES):
                 column_types[column] = "int"
-            elif expected_types.issubset(BasicDatasetProfiler.FLOAT_TYPE_NAMES):
+            elif expected_types.issubset(ProfilerTypeMapping.FLOAT_TYPE_NAMES):
                 column_types[column] = "float"
-            elif expected_types.issubset(BasicDatasetProfiler.STRING_TYPE_NAMES):
+            elif expected_types.issubset(ProfilerTypeMapping.STRING_TYPE_NAMES):
                 column_types[column] = "string"
-            elif expected_types.issubset(BasicDatasetProfiler.DATETIME_TYPE_NAMES):
+            elif expected_types.issubset(ProfilerTypeMapping.DATETIME_TYPE_NAMES):
                 column_types[column] = "datetime"
-            elif expected_types.issubset(BasicDatasetProfiler.BOOLEAN_TYPE_NAMES):
+            elif expected_types.issubset(ProfilerTypeMapping.BOOLEAN_TYPE_NAMES):
                 column_types[column] = "bool"
             else:
                 warnings.warn(

--- a/tests/profile/test_jsonschema_profiler.py
+++ b/tests/profile/test_jsonschema_profiler.py
@@ -1,0 +1,808 @@
+import jsonschema
+import pytest
+
+from great_expectations.core import ExpectationSuite
+from great_expectations.profile.base import ProfilerTypeMapping
+from great_expectations.profile.json_schema_profiler import JsonSchemaProfiler
+
+
+@pytest.fixture
+def simple_schema():
+    return {
+        "$id": "https://example.com/address.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"first_name": {"type": "string"}, "age": {"type": "integer"},},
+    }
+
+
+@pytest.fixture
+def complex_flat_schema():
+    """This includes some descriptions."""
+    return {
+        "$id": "https://example.com/address.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "An address",
+        "type": "object",
+        "properties": {
+            "post-office-box": {"type": "string"},
+            "street-name": {"type": "string"},
+            "street-number": {
+                "type": "integer",
+                "description": "Only the address number.",
+            },
+            "locality": {"type": "string"},
+            "region": {"type": "string"},
+            "postal-code": {"type": "string"},
+            "country-name": {"type": "string"},
+        },
+        "required": ["locality", "region", "country-name"],
+    }
+
+
+@pytest.fixture
+def boolean_types_schema():
+    return {
+        "$id": "https://example.com/address.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"active": {"type": "boolean"}},
+    }
+
+
+@pytest.fixture
+def enum_types_schema():
+    return {
+        "$id": "https://example.com/address.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"shirt-size": {"enum": ["XS", "S", "M", "XL", "XXL"]}},
+    }
+
+
+@pytest.fixture
+def string_lengths_schema():
+    """
+    This fixture has various combinations string lengths.
+    https://json-schema.org/understanding-json-schema/reference/string.html#length
+    """
+    return {
+        "$id": "https://example.com/address.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "comments-no-constraints": {"type": "string"},
+            "state-abbreviation-equal-min-max": {
+                "type": "string",
+                "minLength": 2,
+                "maxLength": 2,
+            },
+            "ICD10-code-3-7": {"type": "string", "minLength": 3, "maxLength": 7},
+            "name-no-max": {"type": "string", "minLength": 1},
+            "password-max-33": {"type": "string", "maxLength": 33},
+        },
+    }
+
+
+@pytest.fixture
+def integer_ranges_schema():
+    """
+    This fixture has various combinations of integer ranges.
+    https://json-schema.org/understanding-json-schema/reference/numeric.html#range
+    """
+    return {
+        "$id": "https://example.com/address.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "An address similar to http://microformats.org/wiki/h-card",
+        "type": "object",
+        "properties": {
+            "favorite-number": {"type": "integer"},
+            "age-0-130": {"type": "integer", "minimum": 0, "maximum": 130},
+            "wheel-count-0-plus": {"type": "integer", "minimum": 0},
+            "rpm-max-7000": {"type": "integer", "maximum": 7000},
+            "lake-depth-max-minus-100": {"type": "integer", "maximum": -100},
+            "floor-exclusive-min-0": {"type": "integer", "exclusiveMinimum": 0},
+            "floor-exclusive-max-100": {"type": "integer", "exclusiveMaximum": 100},
+            "gear-exclusive-0-6": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "exclusiveMaximum": 6,
+            },
+        },
+    }
+
+
+@pytest.fixture
+def number_ranges_schema():
+    """
+    This fixture has various combinations of number ranges.
+    https://json-schema.org/understanding-json-schema/reference/numeric.html#range
+    """
+    return {
+        "$id": "https://example.com/address.schema.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "An address similar to http://microformats.org/wiki/h-card",
+        "type": "object",
+        "properties": {
+            "favorite-number": {"type": "number"},
+            "age-0-130": {"type": "number", "minimum": 0.5, "maximum": 130.5},
+            "wheel-count-0-plus": {"type": "number", "minimum": 0.5},
+            "rpm-max-7000": {"type": "number", "maximum": 7000.5},
+            "lake-depth-max-minus-100": {"type": "number", "maximum": -100.5},
+            "floor-exclusive-min-0": {"type": "number", "exclusiveMinimum": 0.5},
+            "floor-exclusive-max-100": {"type": "number", "exclusiveMaximum": 100.5},
+            "gear-exclusive-0-6": {
+                "type": "number",
+                "exclusiveMinimum": 0.5,
+                "exclusiveMaximum": 6.5,
+            },
+        },
+    }
+
+
+def test_instantiable():
+    profiler = JsonSchemaProfiler()
+    assert isinstance(profiler, JsonSchemaProfiler)
+
+
+def test_validate_returns_true_on_valid_schema(simple_schema):
+    profiler = JsonSchemaProfiler()
+    assert profiler.validate(simple_schema) is True
+
+
+def test_profile_raises_errors_on_bad_inputs():
+    profiler = JsonSchemaProfiler()
+    for bad in [1, 1.1, None, "junk"]:
+        with pytest.raises(TypeError):
+            profiler.profile(bad, "foo")
+
+
+def test_profile_raises_error_on_missing_suite_name(simple_schema):
+    profiler = JsonSchemaProfiler()
+    with pytest.raises(ValueError) as e:
+        profiler.profile(simple_schema, suite_name=None)
+    message = str(e.value)
+    assert "provide a suite name" in message
+
+
+def test_profile_raises_error_on_schema_missing_top_level_type_key():
+    profiler = JsonSchemaProfiler()
+    schema = {"a_schema": "missing_type"}
+    with pytest.raises(KeyError) as e:
+        profiler.profile(schema, "suite")
+    message = str(e.value)
+    assert "This profiler requires a json schema with a top level `type` key" in message
+
+
+def test_profile_raises_error_on_schema_with_top_level_type_other_than_object():
+    profiler = JsonSchemaProfiler()
+    schema = {"type": "array"}
+    with pytest.raises(TypeError) as e:
+        profiler.profile(schema, "suite")
+    message = str(e.value)
+    assert (
+        "This profiler requires a json schema with a top level `type` of `object`"
+        in message
+    )
+
+
+def test_profile_enum_with_bad_input_raises_schema_error(enum_types_schema):
+    profiler = JsonSchemaProfiler()
+    # mangle the enum list
+    enum_types_schema["properties"]["shirt-size"]["enum"] = "foo"
+    with pytest.raises(jsonschema.SchemaError):
+        profiler.profile(enum_types_schema, "enums")
+
+
+def test_profile_simple_schema(simple_schema):
+    profiler = JsonSchemaProfiler()
+    obs = profiler.profile(simple_schema, "simple_suite")
+    assert isinstance(obs, ExpectationSuite)
+    assert obs.expectation_suite_name == "simple_suite"
+    assert [e.to_json_dict() for e in obs.expectations] == [
+        {
+            "kwargs": {"column": "first_name"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "first_name",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "age"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "age",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+    ]
+
+
+def test_profile_boolean_schema(boolean_types_schema):
+    profiler = JsonSchemaProfiler()
+    obs = profiler.profile(boolean_types_schema, "bools")
+    assert isinstance(obs, ExpectationSuite)
+    assert obs.expectation_suite_name == "bools"
+    assert [e.to_json_dict() for e in obs.expectations] == [
+        {
+            "meta": {},
+            "kwargs": {"column": "active"},
+            "expectation_type": "expect_column_to_exist",
+        },
+        {
+            "meta": {},
+            "kwargs": {
+                "column": "active",
+                "type_list": list(ProfilerTypeMapping.BOOLEAN_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+        },
+        {
+            "meta": {},
+            "kwargs": {"column": "active", "value_set": [True, False]},
+            "expectation_type": "expect_column_values_to_be_in_set",
+        },
+    ]
+
+
+def test_profile_enum_schema(enum_types_schema):
+    profiler = JsonSchemaProfiler()
+    obs = profiler.profile(enum_types_schema, "enums")
+    assert isinstance(obs, ExpectationSuite)
+    assert obs.expectation_suite_name == "enums"
+    assert [e.to_json_dict() for e in obs.expectations] == [
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "shirt-size"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_set",
+            "kwargs": {
+                "column": "shirt-size",
+                "value_set": ["XS", "S", "M", "XL", "XXL"],
+            },
+        },
+    ]
+
+
+def test_profile_string_lengths_schema(string_lengths_schema):
+    profiler = JsonSchemaProfiler()
+    obs = profiler.profile(string_lengths_schema, "lengths")
+    assert isinstance(obs, ExpectationSuite)
+    assert obs.expectation_suite_name == "lengths"
+    assert [e.to_json_dict() for e in obs.expectations] == [
+        {
+            "kwargs": {"column": "comments-no-constraints"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "comments-no-constraints",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "state-abbreviation-equal-min-max"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "state-abbreviation-equal-min-max",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "state-abbreviation-equal-min-max", "value": 2},
+            "expectation_type": "expect_column_value_lengths_to_equal",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "ICD10-code-3-7"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "ICD10-code-3-7",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "ICD10-code-3-7", "min_value": 3, "max_value": 7},
+            "expectation_type": "expect_column_value_lengths_to_be_between",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "name-no-max"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "name-no-max",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "name-no-max", "min_value": 1},
+            "expectation_type": "expect_column_value_lengths_to_be_between",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "password-max-33"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "password-max-33",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {"column": "password-max-33", "max_value": 33},
+            "expectation_type": "expect_column_value_lengths_to_be_between",
+            "meta": {},
+        },
+    ]
+
+
+def test_profile_integer_ranges_schema(integer_ranges_schema):
+    profiler = JsonSchemaProfiler()
+    obs = profiler.profile(integer_ranges_schema, "integer_ranges")
+    assert isinstance(obs, ExpectationSuite)
+    assert obs.expectation_suite_name == "integer_ranges"
+
+    assert [e.to_json_dict() for e in obs.expectations] == [
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "favorite-number"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "favorite-number",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "age-0-130"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "age-0-130",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "age-0-130", "min_value": 0, "max_value": 130},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "wheel-count-0-plus"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "wheel-count-0-plus",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "wheel-count-0-plus", "min_value": 0},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "rpm-max-7000"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "rpm-max-7000",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "rpm-max-7000", "max_value": 7000},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "lake-depth-max-minus-100"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "lake-depth-max-minus-100",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "lake-depth-max-minus-100", "max_value": -100},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "floor-exclusive-min-0"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "floor-exclusive-min-0",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {
+                "column": "floor-exclusive-min-0",
+                "min_value": 0,
+                "strict_min": True,
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "floor-exclusive-max-100"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "floor-exclusive-max-100",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {
+                "column": "floor-exclusive-max-100",
+                "max_value": 100,
+                "strict_max": True,
+            },
+        },
+        {
+            "kwargs": {"column": "gear-exclusive-0-6"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "gear-exclusive-0-6",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "gear-exclusive-0-6",
+                "min_value": 0,
+                "strict_min": True,
+                "max_value": 6,
+                "strict_max": True,
+            },
+            "expectation_type": "expect_column_values_to_be_between",
+            "meta": {},
+        },
+    ]
+
+
+def test_profile_number_ranges_schema(number_ranges_schema):
+    profiler = JsonSchemaProfiler()
+    obs = profiler.profile(number_ranges_schema, "number_ranges")
+    assert isinstance(obs, ExpectationSuite)
+    assert obs.expectation_suite_name == "number_ranges"
+
+    assert [e.to_json_dict() for e in obs.expectations] == [
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "favorite-number"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "favorite-number",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "age-0-130"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "age-0-130",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "age-0-130", "min_value": 0.5, "max_value": 130.5},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "wheel-count-0-plus"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "wheel-count-0-plus",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "wheel-count-0-plus", "min_value": 0.5},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "rpm-max-7000"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "rpm-max-7000",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "rpm-max-7000", "max_value": 7000.5},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "lake-depth-max-minus-100"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "lake-depth-max-minus-100",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {"column": "lake-depth-max-minus-100", "max_value": -100.5},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "floor-exclusive-min-0"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "floor-exclusive-min-0",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {
+                "column": "floor-exclusive-min-0",
+                "min_value": 0.5,
+                "strict_min": True,
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "floor-exclusive-max-100"},
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "floor-exclusive-max-100",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+        },
+        {
+            "meta": {},
+            "expectation_type": "expect_column_values_to_be_between",
+            "kwargs": {
+                "column": "floor-exclusive-max-100",
+                "max_value": 100.5,
+                "strict_max": True,
+            },
+        },
+        {
+            "kwargs": {"column": "gear-exclusive-0-6"},
+            "expectation_type": "expect_column_to_exist",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "gear-exclusive-0-6",
+                "type_list": list(ProfilerTypeMapping.FLOAT_TYPE_NAMES),
+            },
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "meta": {},
+        },
+        {
+            "kwargs": {
+                "column": "gear-exclusive-0-6",
+                "min_value": 0.5,
+                "strict_min": True,
+                "max_value": 6.5,
+                "strict_max": True,
+            },
+            "expectation_type": "expect_column_values_to_be_between",
+            "meta": {},
+        },
+    ]
+
+
+def test_has_profile_create_expectations_from_complex_schema(complex_flat_schema):
+    profiler = JsonSchemaProfiler()
+    obs = profiler.profile(complex_flat_schema, "complex")
+    assert isinstance(obs, ExpectationSuite)
+    assert obs.expectation_suite_name == "complex"
+    assert obs.meta["notes"] == {
+        "format": "markdown",
+        "content": ["### Description:\nAn address"],
+    }
+
+    assert [e.to_json_dict() for e in obs.expectations] == [
+        {
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "post-office-box"},
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "post-office-box",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "street-name"},
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "street-name",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "street-number"},
+            "meta": {
+                "notes": {
+                    "format": "markdown",
+                    "content": ["### Description:\nOnly the address number."],
+                }
+            },
+        },
+        {
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "street-number",
+                "type_list": list(ProfilerTypeMapping.INT_TYPE_NAMES),
+            },
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "locality"},
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "locality",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "region"},
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "region",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "postal-code"},
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "postal-code",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_to_exist",
+            "kwargs": {"column": "country-name"},
+            "meta": {},
+        },
+        {
+            "expectation_type": "expect_column_values_to_be_in_type_list",
+            "kwargs": {
+                "column": "country-name",
+                "type_list": list(ProfilerTypeMapping.STRING_TYPE_NAMES),
+            },
+            "meta": {},
+        },
+    ]

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -5,9 +5,14 @@ import pytest
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.dataset.pandas_dataset import PandasDataset
 from great_expectations.datasource import PandasDatasource
-from great_expectations.profile.base import DatasetProfiler
+from great_expectations.profile.base import DatasetProfiler, Profiler
 from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
 from great_expectations.profile.columns_exist import ColumnsExistProfiler
+
+
+def test_base_class_not_instantiable_due_to_abstract_methods():
+    with pytest.raises(TypeError):
+        Profiler()
 
 
 def test_DataSetProfiler_methods():


### PR DESCRIPTION
Changes proposed in this pull request:
- JSONSchema profiler that creates rudimentary suites. No intention of nested data is intended. Data to be validated are assumed to be in a tabular format.
- A new base class `NonDataProfiler`
- A new howto guide!

**Previous Design Review notes:**

**Design review notes from team meeting 6/23/2020**

- [x] Remove workarounds after #1638 is merged.
- [x] Schema is a tricky name that may imply less than is here
- [x] migrate to instance methods vs class methods
- [x] support sub-classing as much as possible
- [x] differentiate as abstract methods vs NotImplemented errors
    - [x] Base classes never raise NotImplementedErrors
    - [x] Child classes may raise NotImplementedErrors for technical reasons
        with good messages
    - [x] Child may override super method then additional checks
        - [x] example: validate()
- [x] 2020/06/26 additional pairing design review discussion about profiler mapping and deprecation warnings.
