### PR TITLE
[BUGFIX] instantiation of ExpectationSuite always adds ge version metadata to prevent datadocs from crashing

### DIFF
--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -657,6 +657,8 @@ class ExpectationSuite(object):
         self.data_asset_type = data_asset_type
         if meta is None:
             meta = {"great_expectations.__version__": ge_version}
+        if not "great_expectations.__version__" in meta.keys():
+            meta["great_expectations.__version__"] = ge_version
         # We require meta information to be serializable, but do not convert until necessary
         ensure_json_serializable(meta)
         self.meta = meta

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -267,6 +267,21 @@ def test_expectation_suite_deepcopy(baseline_suite):
     assert baseline_suite.expectations[0].meta["notes"] == "This is an expectation."
 
 
+def test_suite_without_metadata_includes_ge_version_metadata_if_none_is_provided():
+    suite = ExpectationSuite("foo")
+    assert "great_expectations.__version__" in suite.meta.keys()
+
+
+def test_suite_does_not_overwrite_existing_version_metadata():
+    suite = ExpectationSuite("foo", meta={"great_expectations.__version__": "0.0.0"})
+    assert "great_expectations.__version__" in suite.meta.keys()
+    assert suite.meta["great_expectations.__version__"] == "0.0.0"
+
+
+def test_suite_with_metadata_includes_ge_version_metadata(baseline_suite):
+    assert "great_expectations.__version__" in baseline_suite.meta.keys()
+
+
 def test_add_citation(baseline_suite):
     assert (
         "citations" not in baseline_suite.meta

--- a/tests/data_asset/test_data_asset_internals.py
+++ b/tests/data_asset/test_data_asset_internals.py
@@ -273,24 +273,24 @@ def test_meta_version_warning():
     asset = ge.data_asset.DataAsset()
 
     with pytest.warns(UserWarning) as w:
-        out = asset.validate(
-            expectation_suite=ExpectationSuite(
-                expectations=[], expectation_suite_name="test", meta={}
-            )
-        )
+        suite = ExpectationSuite(expectations=[], expectation_suite_name="test")
+        # mangle the metadata
+        suite.meta = {"foo": "bar"}
+        out = asset.validate(expectation_suite=suite)
     assert (
         w[0].message.args[0]
         == "WARNING: No great_expectations version found in configuration object."
     )
 
     with pytest.warns(UserWarning) as w:
-        out = asset.validate(
-            expectation_suite=ExpectationSuite(
-                expectations=[],
-                expectation_suite_name="test",
-                meta={"great_expectations.__version__": "0.0.0"},
-            )
+        suite = ExpectationSuite(
+            expectations=[],
+            expectation_suite_name="test",
+            meta={"great_expectations.__version__": "0.0.0"},
         )
+        # mangle the metadata
+        suite.meta = {"great_expectations.__version__": "0.0.0"}
+        out = asset.validate(expectation_suite=suite)
     assert (
         w[0].message.args[0]
         == "WARNING: This configuration object was built using version 0.0.0 of great_expectations, but is currently "


### PR DESCRIPTION
Changes proposed in this pull request:
- instantiation of ExpectationSuite always adds ge version metadata to prevent datadocs from crashing. Fixes #1637 

Previous Design Review notes:
- n/a
