### PR TITLE
[ENHANCEMENT] Use colorama init to support terminal color on Windows

### DIFF
--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -14,6 +14,14 @@ from great_expectations.cli.store import store
 from great_expectations.cli.suite import suite
 from great_expectations.cli.validation_operator import validation_operator
 
+try:
+    from colorama import init as init_colorama
+
+    init_colorama()
+except ImportError:
+    pass
+
+
 # TODO: consider using a specified-order supporting class for help (but wasn't working with python 2)
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Use colorama init to support terminal color on Windows
