### PR TITLE
[BUGFIX] "data_asset.validate" events with "data_asset_name" key in the batch kwargs were failing schema validation

### DIFF
--- a/great_expectations/core/usage_statistics/anonymizers/batch_kwargs_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/batch_kwargs_anonymizer.py
@@ -22,6 +22,7 @@ class BatchKwargsAnonymizer(Anonymizer):
             "offset",
             "snowflake_transient_table",
             "bigquery_temp_table",
+            "data_asset_name",
         ]
 
     def anonymize_batch_kwargs(self, batch_kwargs):

--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -238,7 +238,6 @@ anonymized_batch_schema = {
                     "maxItems": 1000,
                     "items": {
                         "oneOf": [
-                            {"$ref": "#/definitions/anonymized_string"},
                             {"type": "string", "maxLength": 256},
                         ]
                     },

--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -236,11 +236,7 @@ anonymized_batch_schema = {
                 "anonymized_batch_kwarg_keys": {
                     "type": "array",
                     "maxItems": 1000,
-                    "items": {
-                        "oneOf": [
-                            {"type": "string", "maxLength": 256},
-                        ]
-                    },
+                    "items": {"oneOf": [{"type": "string", "maxLength": 256},]},
                 },
                 "anonymized_expectation_suite_name": {
                     "$ref": "#/definitions/anonymized_string"


### PR DESCRIPTION
### Changes proposed in this pull request:
- Bug description:
anonymized_batch_schema allowed both string and anonymized_string to be in anonymized_batch_kwarg_keys. When we added "data_asset_name" key to batch kwargs, we forgot to add it to the list of recognized keys. The anonymizer started interpreting it as a custom key that must be anonymized. All "data_asset.validate" events with this key in batch kwargs started failing in schema validation. 

Fixes:
1. Added data_asset_name as a recognized batch kwargs key
2. Fix: anomymized_batch schema specified both string and anonymizdd string as acceptable - this confuses validation when an anonymized string is present



Previous Design Review notes:
-
-
-


Thank you for submitting!
