### PR TITLE
[DOCS] How to host and share data docs on azure blob storage, getting_started docs edits

### DIFF
--- a/docs/how_to_guides/configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.rst
+++ b/docs/how_to_guides/configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.rst
@@ -3,16 +3,9 @@
 How to host and share Data Docs on Azure Blob Storage
 =====================================================
 
-.. admonition:: Admonition from Mr. Dickens
+Unfortunately, this feature has not been implemented yet.  If you would like to help contribute to Great Expectations,  please start with our :ref:`contributing` guide and don’t be shy with questions!
 
-    "Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show."
-
-
-This guide is a stub. We all know that it will be useful, but no one has made time to write it yet.
-
-If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.
-
-If you want to be a real hero, we'd welcome a pull request. Please see :ref:`the Contributing tutorial <tutorials__contributing>` and :ref:`How to write a how to guide` to get started.
+Also, please reach out to us on `slack <greatexpectations.io/slack>`_ if you would like to learn more, or have any questions.
 
 .. discourse::
    :topic_identifier: 231

--- a/docs/tutorials/getting_started/create_your_first_expectations.rst
+++ b/docs/tutorials/getting_started/create_your_first_expectations.rst
@@ -61,9 +61,9 @@ A first look at real Expectations
 
 The newly profiled Expectations are stored in an :ref:`Expectation Suite`.
 
-For now, they're stored in a JSON file in a subdirectory subdirectory of your ``great_expectations/`` folder. You can also configure Great Expectations to store Expectations to other locations, like S3, postgresql, etc. We'll come back to these options in the last step of the tutorial.
+For now, they're stored in a JSON file in a subdirectory of your ``great_expectations/`` folder. You can also configure Great Expectations to store Expectations to other locations, like S3, postgresql, etc. We'll come back to these options in the last step of the tutorial.
 
-If you open up the suite in ``great_expectations/expectations/something-something.json`` in a text editor, you'll see:
+If you open up the suite in ``great_expectations/expectations/npidata_pfile_20200511-20200517/warning.json`` in a text editor, you'll see:
 
 .. code-block:: JSON
 

--- a/docs/tutorials/getting_started/initialize_a_data_context.rst
+++ b/docs/tutorials/getting_started/initialize_a_data_context.rst
@@ -60,7 +60,7 @@ To download the NPI data using wget, please run:
 
 .. code-block:: bash
 
-    wget https://superconductive-public.s3.amazonaws.com/data/npi/weekly/npidata_pfile_20200511-20200517.csv.gz -O my_data
+    wget https://superconductive-public.s3.amazonaws.com/data/npi/weekly/npidata_pfile_20200511-20200517.csv.gz -P my_data
 
 Alternatively, you can use curl:
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Update: How to host and share data docs on azure blob storage
- Minor edits to getting_started docs