### PR TITLE
[FEATURE] Enable passing boto3 options to TupleS3StoreBackend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-

--- a/docs/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_s3.rst
+++ b/docs/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_s3.rst
@@ -56,6 +56,7 @@ Steps
                     class_name: TupleS3StoreBackend
                     bucket: '<your_s3_bucket_name>'
                     prefix: '<your_s3_bucket_folder_name>'
+                    boto3_options: {}
 
 
 4. **Copy existing Validation results to the S3 bucket**. (This step is optional).
@@ -91,6 +92,7 @@ Steps
             class_name: TupleS3StoreBackend
             bucket: '<your_s3_bucket_name>'
             prefix: '<your_s3_bucket_folder_name>'
+            boto3_options: {}
 
 
 

--- a/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.rst
+++ b/docs/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.rst
@@ -55,6 +55,7 @@ Steps
                     class_name: TupleS3StoreBackend
                     bucket: '<your_s3_bucket_name>'
                     prefix: '<your_s3_bucket_folder_name>'
+                    boto3_options: {}
 
 
 4. **Copy existing Expectation JSON files to the S3 bucket**. (This step is optional).
@@ -89,6 +90,7 @@ Steps
             class_name: TupleS3StoreBackend
             bucket: '<your_s3_bucket_name>'
             prefix: '<your_s3_bucket_folder_name>'
+            boto3_options: {}
 
 
 6. **Confirm that Expectations can be accessed from Amazon S3 by running** ``great_expectations suite list``.

--- a/docs/how_to_guides/spare_parts/data_context_reference.rst
+++ b/docs/how_to_guides/spare_parts/data_context_reference.rst
@@ -176,12 +176,14 @@ providing the bucket/prefix combination:
           base_directory: expectations/
           bucket: ge.my_org.com
           prefix:
+          boto3_options: {}
       validations_store:
         class_name: ValidationsStore
         store_backend:
           class_name: TupleS3StoreBackend
           bucket: ge.my_org.com
           prefix: common_validations
+          boto3_options: {}
       evaluation_parameter_store:
         class_name: EvaluationParameterStore
 

--- a/docs/how_to_guides/spare_parts/data_docs_reference.rst
+++ b/docs/how_to_guides/spare_parts/data_docs_reference.rst
@@ -116,6 +116,7 @@ will automatically save the resulting site to that bucket.
     class_name: TupleS3StoreBackend
     bucket: data-docs.my_org.org
     prefix:
+    boto3_options: {}
 
 See the tutorial on :ref:`publishing data docs to S3 <publishing_data_docs_to_s3>` for more information.
 

--- a/docs/how_to_guides/validation/spare_parts/how_to_validate_data.rst
+++ b/docs/how_to_guides/validation/spare_parts/how_to_validate_data.rst
@@ -270,6 +270,7 @@ as ``s3`` or ``gcs``, edit the stores section of the DataContext configuration o
           class_name: TupleS3StoreBackend
           bucket: my_bucket
           prefix: my_prefix
+          boto3_options: {}
 
 Removing the store_validation_result action from the ``action_list_operator`` configuration will disable automatically storing ``validation_result`` objects.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -14,6 +14,7 @@ Develop
 * [BUGFIX] Fix issue where allow_updates was set for StoreBackend that did not support it
 * [BUGFIX] Fix issue where GlobReaderBatchKwargsGenerator failed with relative base_directory
 * [MAINTENANCE] Install GitHub Dependabot
+* [FEATURE] Add possibility to pass boto3 configuration to TupleS3StoreBackend
 
 0.11.7
 -----------------

--- a/great_expectations/cli/checkpoint.py
+++ b/great_expectations/cli/checkpoint.py
@@ -108,9 +108,9 @@ datasources paired with one or more Expectation Suites each.
     id: checkpoint_kedro
     title: Checkpoint - Kedro
     icon:
-    short_description: 
-    description: 
-    how_to_guide_url: 
+    short_description:
+    description:
+    how_to_guide_url:
     maturity: Experimental
     maturity_details:
         api_stability: Unknown (implemented by Kedro team)
@@ -123,9 +123,9 @@ datasources paired with one or more Expectation Suites each.
     id: checkpoint_prefect
     title: Checkpoint - Prefect
     icon:
-    short_description: 
-    description: 
-    how_to_guide_url: 
+    short_description:
+    description:
+    how_to_guide_url:
     maturity: Experimental
     maturity_details:
         api_stability: Unknown (implemented by Prefect team)
@@ -138,9 +138,9 @@ datasources paired with one or more Expectation Suites each.
     id: checkpoint_dbt
     title: Checkpoint - DBT
     icon:
-    short_description: 
-    description: 
-    how_to_guide_url: 
+    short_description:
+    description:
+    how_to_guide_url:
     maturity: Beta
     maturity_details:
         api_stability: Mostly Stable (SQLAlchemy)

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -96,9 +96,9 @@ class BaseDataContext(object):
     id: os_linux
     title: OS - Linux
     icon:
-    short_description: 
-    description: 
-    how_to_guide_url: 
+    short_description:
+    description:
+    how_to_guide_url:
     maturity: Production
     maturity_details:
         api_stability: N/A
@@ -111,9 +111,9 @@ class BaseDataContext(object):
     id: os_macos
     title: OS - MacOS
     icon:
-    short_description: 
-    description: 
-    how_to_guide_url: 
+    short_description:
+    description:
+    how_to_guide_url:
     maturity: Production
     maturity_details:
         api_stability: N/A
@@ -126,9 +126,9 @@ class BaseDataContext(object):
     id: os_windows
     title: OS - Windows
     icon:
-    short_description: 
-    description: 
-    how_to_guide_url: 
+    short_description:
+    description:
+    how_to_guide_url:
     maturity: Beta
     maturity_details:
         api_stability: N/A


### PR DESCRIPTION
**Changes proposed in this pull request:**
- optional boto3_options (dictionary) section when configuring TupleS3BackendStore.

After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
