### PR TITLE
[ENHANCEMENT] Use green checkmark in Slack msgs instead of tada

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Develop
 -----------------
+* [ENHANCEMENT] Use green checkmark in Slack msgs instead of tada 
 * [BUGFIX] Add spark_context to DatasourceConfigSchema (#1713) -- thanks @Dandandan
 
 

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -46,7 +46,7 @@ class SlackRenderer(Renderer):
             )
 
             if validation_result.success:
-                status = "Success :tada:"
+                status = "Success :white_check_mark:"
 
             summary_text = """*Batch Validation Status*: {}
 *Expectation suite name*: `{}`

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -586,7 +586,7 @@ The value of "success" is True if no critical expectation suites ("failure") fai
 
     def _build_slack_query(self, validation_operator_result: ValidationOperatorResult):
         success = validation_operator_result.success
-        status_text = "Success :tada:" if success else "Failed :x:"
+        status_text = "Success :white_check_mark:" if success else "Failed :x:"
         run_id = validation_operator_result.run_id
         run_name = run_id.run_name
         run_time = run_id.run_time.strftime("%x %X")

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -39,7 +39,7 @@ def test_SlackRenderer():
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Timestamp*: `09/24/2019 23:18:36`\n*Summary*: *0* of *0* expectations were met",
+                    "text": "*Batch Validation Status*: Success :white_check_mark:\n*Expectation suite name*: `default`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Timestamp*: `09/24/2019 23:18:36`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {"type": "divider"},
@@ -53,7 +53,7 @@ def test_SlackRenderer():
                 ],
             },
         ],
-        "text": "default: Success :tada:",
+        "text": "default: Success :white_check_mark:",
     }
 
     # We're okay with system variation in locales (OS X likes 24 hour, but not Travis)


### PR DESCRIPTION
**Changes proposed in this pull request:**
Replace the  🎉  emoji with the ✅  emoji in Slack messages coming from the GE validation action, to make them visually stand out more. I've just found it a little difficult to spot the "success" messages. I'm aware that red/green doesn't necessarily distinguish this for everyone, but I think X for failed vs checkmark for success is also a better visual distinction.

This was a simple search+replace across the codebase.

Yes, this is a total nitpick :)