### PR TITLE
[BUGFIX] Handle case when unexpected_count list element is str

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 Develop
 -----------------
 * [BUGFIX] Add spark_context to DatasourceConfigSchema (#1713) -- thanks @Dandandan
+* [BUGFIX] Handle case when unexpected_count list element is str
+* [DOCS] New how-to guide: How to instantiate a Data Context on an EMR Spark cluster
 
 
 0.11.8

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -1239,9 +1239,12 @@ class DataAsset(object):
                     )
                 ]
             except TypeError:
-                partial_unexpected_counts = [
-                    "partial_exception_counts requires a hashable type"
-                ]
+                partial_unexpected_counts = []
+                if "details" not in return_obj["result"]:
+                    return_obj["result"]["details"] = {}
+                return_obj["result"]["details"][
+                    "partial_unexpected_counts_error"
+                ] = "partial_unexpected_counts requested, but requires a hashable type"
             finally:
                 return_obj["result"].update(
                     {

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -126,6 +126,9 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
             for unexpected_count in result.get("partial_unexpected_counts"):
                 if not isinstance(unexpected_count, dict):
                     # handles case: "partial_exception_counts requires a hashable type"
+                    # this case is also now deprecated (because the error is moved to an errors key
+                    # the error also *should have* been updated to "partial_unexpected_counts ..." long ago.
+                    # NOTE: JPC 20200724 - Consequently, this codepath should be removed by approximately Q1 2021
                     continue
                 elif unexpected_count.get("value"):
                     table_rows.append(

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -124,7 +124,10 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
         if result.get("partial_unexpected_counts"):
             header_row = ["Unexpected Value", "Count"]
             for unexpected_count in result.get("partial_unexpected_counts"):
-                if unexpected_count.get("value"):
+                if not isinstance(unexpected_count, dict):
+                    # handles case: "partial_exception_counts requires a hashable type"
+                    continue
+                elif unexpected_count.get("value"):
                     table_rows.append(
                         [unexpected_count.get("value"), unexpected_count.get("count")]
                     )


### PR DESCRIPTION
Changes proposed in this pull request:
- Addresses Data Docs rendering bug that occurs when EVR "partial_unexpected_counts" list element is a string ("partial_exception_counts requires a hashable type")


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- https://app.asana.com/0/1173104298028991/1184441060894025/f


Thank you for submitting!
