### PR TITLE
[BUGFIX] usage_statistics decorator now handles 'dry_run' flag

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ include_trailing_comma=1
 use_parentheses=True
 line_length=88
 known_first_party=great_expectations
-known_third_party=IPython,_pytest,altair,black,boto3,botocore,click,dateutil,freezegun,ipywidgets,jinja2,jsonschema,marshmallow,mistune,mock,moto,nbconvert,nbformat,numpy,pandas,pkg_resources,pyparsing,pytest,requests,ruamel,scipy,setuptools,sphinx,sqlalchemy,tzlocal
+known_third_party=IPython,_pytest,altair,black,boto3,botocore,click,dateutil,freezegun,importlib_metadata,ipywidgets,jinja2,jsonschema,marshmallow,mistune,mock,moto,nbconvert,nbformat,numpy,pandas,pkg_resources,pyparsing,pytest,requests,ruamel,scipy,setuptools,sphinx,sqlalchemy,tzlocal

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ include_trailing_comma=1
 use_parentheses=True
 line_length=88
 known_first_party=great_expectations
-known_third_party=IPython,_pytest,altair,black,boto3,botocore,click,dateutil,freezegun,importlib_metadata,ipywidgets,jinja2,jsonschema,marshmallow,mistune,mock,moto,nbconvert,nbformat,numpy,pandas,pkg_resources,pyparsing,pytest,requests,ruamel,scipy,setuptools,sphinx,sqlalchemy,tzlocal
+known_third_party=IPython,_pytest,altair,black,boto3,botocore,click,dateutil,freezegun,ipywidgets,jinja2,jsonschema,marshmallow,mistune,mock,moto,nbconvert,nbformat,numpy,pandas,pkg_resources,pyparsing,pytest,requests,ruamel,scipy,setuptools,sphinx,sqlalchemy,tzlocal

--- a/great_expectations/core/usage_statistics/usage_statistics.py
+++ b/great_expectations/core/usage_statistics/usage_statistics.py
@@ -244,6 +244,10 @@ def usage_statistics_enabled_method(
 
         @wraps(func)
         def usage_statistics_wrapped_method(*args, **kwargs):
+            # if a function like `build_data_docs()` is being called as a `dry_run`
+            # then we dont want to emit usage_statistics. We just return the function without sending a usage_stats message
+            if "dry_run" in kwargs and kwargs["dry_run"]:
+                return func(*args, **kwargs)
             # Set event_payload now so it can be updated below
             event_payload = {}
             message = {"event_payload": event_payload, "event": event_name}

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -156,8 +156,7 @@ def test_cli_init_on_new_project(
 """
     )
 
-    # data_context.build_docs is twice (once in dry run mode) and two events are fired
-    assert mock_emit.call_count == 10
+    assert mock_emit.call_count == 9
     assert mock_emit.call_args_list[1] == mock.call(
         {"event_payload": {}, "event": "cli.init.create", "success": True}
     )


### PR DESCRIPTION
Changes proposed in this pull request:

- When building DataDocs through the CLI (handled by the `build_docs()` function), the DataContext's `context.build_data_docs()` function is called twice. First `context.build_data_docs()` is called using the dry_run flag, which returns a structure containing the URLs of the sites that would be built, and allowing users to confirm. It is called a second time when the DataDocs are actually built. The way that `context.build_data_docs()` sends usage_statistics is by using the usage_statistics_enabled_method decorator, which is not able to distinguish a dry_run from a real one. This causes a duplicate message to be sent

- `usage_statistics_wrapped_method` decorator will check if `dry_run` is part of the **kwargs, and return undecorated function if `dry_run` is set to True
- this will allow `context.build_data_docs()` to only emit a message if the `dry_run` is False (as well as handle future functions that may need to be called more than once)
- closes #1714 
