### PR TITLE
[DOCS] fix a description that may be misleading

### DIFF
--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -62,7 +62,7 @@ class SiteBuilder(object):
                 class_name: DefaultSiteIndexBuilder
 
             # Verbose version:
-            # index_builder:
+            # site_index_builder:
             #     module_name: great_expectations.render.builder
             #     class_name: DefaultSiteIndexBuilder
             #     renderer:


### PR DESCRIPTION
fix example in description docs of SiteBuilder class  by replacing index_builder with site_index_builder
