### PR TITLE
[MAINTENANCE] fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignored_updates:
-      - match:
-          dependency_name: "isort"
+    ignore:
+      - dependency_name: "isort"


### PR DESCRIPTION
Ugh - There are two dependabots around - they original one and the newer one that is part of GH now and I used the incorrect syntax...

It's easiest to see status here: https://github.com/great-expectations/great_expectations/network/updates
