### PR TITLE
[DOCS] Add how-to guides for configuring MySQL and MSSQL Datasources

### DIFF
--- a/docs/contributing/miscellaneous.rst
+++ b/docs/contributing/miscellaneous.rst
@@ -55,7 +55,7 @@ GE core team members use this checklist to ship releases.
 7. After successful checks, get it approved and merged.
 8. Update your local branches and switch to main: ``git fetch --all; git checkout main; git pull``.
 9. Merge the now-updated ``develop`` branch into ``main`` and trigger the release: ``git merge origin/develop; git push``
-10. Wait for all the build to complete. It should include 4 test jobs and a deploy job, which handles the actual publishing of code to pypi. You can watch the progress of these builds on Azure.
+10. Wait for all the builds to complete. The builds should include several test jobs and a deploy job, which handles the actual publishing of code to pypi. You can watch the progress of these builds on Azure.
 11. Check `PyPI <https://pypi.org/project/great-expectations/#history>`__ for the new release
 12. Create an annotated git tag:
 

--- a/docs/how_to_guides/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file.rst
+++ b/docs/how_to_guides/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file.rst
@@ -3,15 +3,7 @@
 How to instantiate a Data Context without a yml file
 ====================================================
 
-.. admonition:: Admonition from Mr. Dickens
-
-    "Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show."
-
-This guide is a stub. We all know that it will be useful, but no one has made time to write it yet.
-
-If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.
-
-If you want to be a real hero, we'd welcome a pull request. Please see :ref:`the Contributing tutorial <tutorials__contributing>` and :ref:`How to write a how to guide` to get started.
+To instantiate a Data Context without a yml file, please see the guide on :ref:`how to instantiate a Data Context on an EMR Spark Cluster <how_to_instantiate_a_data_context_on_an_emr_spark_cluster>`, and choose an alternate Datasource as appropriate for your configuration.
 
 .. discourse::
     :topic_identifier: 163

--- a/docs/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
+++ b/docs/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
@@ -1,0 +1,119 @@
+.. _how_to_guides__configuring_datasources__how_to_configure_a_mssql_datasource:
+
+
+#######################################
+How to configure a MSSQL Datasource
+#######################################
+
+This guide shows how to connect to a MSSQL Datasource. Great Expectations uses SqlAlchemy to connect to MSSQL, and relies further on the PyODBC driver.
+
+.. admonition:: Prerequisites: This how-to guide assumes you have already:
+
+  - :ref:`Set up a working deployment of Great Expectations <getting_started>`
+  - Obtained database credentials for MSSQL, including username, password, hostname, and database.
+
+Steps
+-----
+
+# **Install the required ODBC drivers**
+
+    Follow guides from Microsoft according to your operating system. We have included additional links to relevant resources for connecting to MSSQL databases in the Additional Information section below.
+
+    * `Installing Microsoft ODBC driver for MacOS <https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos>`__
+    * `Installing Microsoft ODBC driver for Linux <https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server>`__
+
+#. **Install the required python modules**
+
+    If you have not already done so, install required modules for connecting to mysql.
+
+    .. code-block:: bash
+
+        pip install sqlalchemy
+        pip install pyodbc
+
+
+#. **Run datasource new**
+
+    From the command line, run:
+
+    .. code-block:: bash
+
+        great_expectations datasource new
+
+
+#. **Choose "Relational database (SQL)"**
+
+    .. code-block:: bash
+
+        What data would you like Great Expectations to connect to?
+            1. Files on a filesystem (for processing with Pandas or Spark)
+            2. Relational database (SQL)
+        : 2
+
+#. **Choose 'other' and provide a connection string**
+
+    .. code-block:: bash
+
+        Which database backend are you using?
+            1. MySQL
+            2. Postgres
+            3. Redshift
+            4. Snowflake
+            5. BigQuery
+            6. other - Do you have a working SQLAlchemy connection string?
+        : 6
+
+#. **Give your Datasource a name**
+
+    When prompted, provide a custom name for your Snowflake data source, or hit Enter to accept the default.
+
+    .. code-block:: bash
+
+        Give your new Datasource a short name.
+         [my_database]: mssql_db
+
+#. **Enter connection information**
+
+    When prompted, enter a connection string to use to connect to your datasource. Note that we add a query parameter to our connection string to specify the driver: ``driver=ODBC Driver 17 for SQL Server``
+
+    .. code-block:: bash
+
+        Next, we will configure database credentials and store them in the `my_database` section
+        of this config file: great_expectations/uncommitted/config_variables.yml:
+
+        What is the url/connection string for the sqlalchemy connection?
+        (reference: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls)
+        : mssql+pyodbc://<<username>>:<<password>>@<<host>>:<<port>>/<<database>>?driver=ODBC Driver 17 for SQL Server&charset=utf&autocommit=true
+
+#. **Save your new configuration**
+
+    .. code-block:: bash
+
+        Great Expectations will now add a new Datasource 'mssql_db' to your deployment, by adding this entry to your great_expectations.yml:
+
+          mssql_db:
+            credentials: ${my_database}
+            data_asset_type:
+              class_name: SqlAlchemyDataset
+              module_name: great_expectations.dataset
+            class_name: SqlAlchemyDatasource
+            module_name: great_expectations.datasource
+
+        The credentials will be saved in uncommitted/config_variables.yml under the key 'mssql_db'
+
+
+
+
+Additional notes
+----------------
+
+The following blog post provides a useful overview of using SqlAlchemy to connect to MSSQL.
+
+* https://medium.com/@anushkamehra16/connecting-to-sql-database-using-sqlalchemy-in-python-2be2cf883f85
+
+
+Comments
+--------
+
+.. discourse::
+   :topic_identifier: 295

--- a/docs/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
+++ b/docs/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
@@ -1,0 +1,112 @@
+.. _how_to_guides__configuring_datasources__how_to_configure_a_mysql_datasource:
+
+
+#######################################
+How to configure a MySQL Datasource
+#######################################
+
+This guide shows how to connect to a MySql Datasource. Great Expectations uses SqlAlchemy to connect to MySQL.
+
+.. admonition:: Prerequisites: This how-to guide assumes you have already:
+
+  - :ref:`Set up a working deployment of Great Expectations <getting_started>`
+  - Obtained database credentials for mysql, including username, password, hostname, and database.
+
+Steps
+-----
+
+#. **Install the required modules**
+
+    If you have not already done so, install required modules for connecting to mysql.
+
+    .. code-block:: bash
+
+        pip install sqlalchemy
+        pip install PyMySQL
+
+
+#. **Run datasource new**
+
+    From the command line, run:
+
+    .. code-block:: bash
+
+        great_expectations datasource new
+
+
+#. **Choose "Relational database (SQL)"**
+
+    .. code-block:: bash
+
+        What data would you like Great Expectations to connect to?
+            1. Files on a filesystem (for processing with Pandas or Spark)
+            2. Relational database (SQL)
+        : 2
+
+#. **Choose MySQL**
+
+    .. code-block:: bash
+
+        Which database backend are you using?
+            1. MySQL
+            2. Postgres
+            3. Redshift
+            4. Snowflake
+            5. BigQuery
+            6. other - Do you have a working SQLAlchemy connection string?
+        : 1
+
+#. **Give your Datasource a name**
+
+    When prompted, provide a custom name for your Snowflake data source, or hit Enter to accept the default.
+
+    .. code-block:: bash
+
+        Give your new Datasource a short name.
+         [my_mysql_db]:
+
+#. **Enter connection information**
+
+    When prompted, provide a custom name for your new Datasource, or hit Enter to accept the default.
+
+    .. code-block:: bash
+
+        Next, we will configure database credentials and store them in the `my_mysql_db` section
+        of this config file: great_expectations/uncommitted/config_variables.yml:
+
+        What is the host for the MySQL connection? [localhost]:
+        What is the port for the MySQL connection? [3306]:
+        What is the username for the MySQL connection? []: root
+        What is the password for the MySQL connection?:
+        What is the database name for the MySQL connection? []: test_ci
+        Attempting to connect to your database. This may take a moment...
+
+
+#. **Save your new configuration**
+
+    .. code-block:: bash
+
+        Great Expectations will now add a new Datasource 'my_mysql_db' to your deployment, by adding this entry to your great_expectations.yml:
+
+          my_mysql_db:
+            credentials: ${my_mysql_db}
+            data_asset_type:
+              class_name: SqlAlchemyDataset
+              module_name: great_expectations.dataset
+            class_name: SqlAlchemyDatasource
+            module_name: great_expectations.datasource
+
+        The credentials will be saved in uncommitted/config_variables.yml under the key 'my_mysql_db'
+
+
+Additional notes
+----------------
+
+* The default configuration of the most recent MySQL releases does not support some GROUP_BY operations used in Great Expectations. To use the full range of statistical Expectations, you need to disable the ``ONLY_FULL_GROUP_BY`` ``sql_mode`` setting. Please see the following article for more information https://stackoverflow.com/questions/36829911/how-to-resolve-order-by-clause-is-not-in-select-list-caused-mysql-5-7-with-sel).
+
+
+Comments
+--------
+
+.. discourse::
+   :topic_identifier: 294

--- a/docs/how_to_guides/configuring_datasources/how_to_configure_an_emr_spark_datasource.rst
+++ b/docs/how_to_guides/configuring_datasources/how_to_configure_an_emr_spark_datasource.rst
@@ -3,16 +3,7 @@
 How to configure an EMR Spark Datasource
 ========================================
 
-.. admonition:: Admonition from Mr. Dickens
-
-    "Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show."
-
-
-This guide is a stub. We all know that it will be useful, but no one has made time to write it yet.
-
-If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.
-
-If you want to be a real hero, we'd welcome a pull request. Please see :ref:`the Contributing tutorial <tutorials__contributing>` and :ref:`How to write a how to guide` to get started.
+In most cases, using spark on EMR is easiest to configure using a dyanmic DataContext configuration in your notebook. Please see the guide on :ref:`how to instantiate a Data Context on an EMR Spark Cluster for details! <how_to_instantiate_a_data_context_on_an_emr_spark_cluster>`.
 
 .. discourse::
     :topic_identifier: 172

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Develop
 -----------------
-
+[DOCS] Add how-to guides for configuring MySQL and MSSQL Datasources
 
 0.11.9
 -----------------


### PR DESCRIPTION
Changes proposed in this pull request:
- Add how-to guides for configuring MySQL and MSSQL Datasources


Previous Design Review notes:
- Guides built in conjunction with @alexsherstinsky based on his recent work adding support for these backends!