### PR TITLE
[DOCS] Proposal: new deployment patterns section

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -12,7 +12,9 @@ the thinking behind the tools.
 
    /reference/glossary_of_expectations
    /reference/core_concepts
+   /reference/deployment_patterns
    /reference/supporting_resources
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/reference/deployment_patterns.rst
+++ b/docs/reference/deployment_patterns.rst
@@ -1,0 +1,14 @@
+.. _reference__deployment_patterns:
+
+
+#############
+Deployment patterns
+#############
+
+This section contains several guides on patterns for deploying Great Expectations in specific environments.
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   /reference/deployment_patterns/*

--- a/docs/reference/deployment_patterns/deployment_airflow.rst
+++ b/docs/reference/deployment_patterns/deployment_airflow.rst
@@ -1,0 +1,7 @@
+.. _deployment_airflow:
+
+
+############
+Deploying Great Expectations with Airflow
+############
+

--- a/docs/reference/deployment_patterns/deployment_hosted_environments.rst
+++ b/docs/reference/deployment_patterns/deployment_hosted_environments.rst
@@ -1,0 +1,7 @@
+.. _deployment_airflow:
+
+
+############
+Deploying Great Expectations in a hosted environment without file system or CLI
+############
+

--- a/docs/reference/deployment_patterns/ge_on_teams.rst
+++ b/docs/reference/deployment_patterns/ge_on_teams.rst
@@ -1,7 +1,7 @@
 .. _using_ge_on_teams:
 
 #################################
-Using Great Expectations on Teams
+Collaborating With Great Expectations As a Team
 #################################
 
 Now that you've enjoyed single player mode, let's bring Great Expectations to


### PR DESCRIPTION
Changes proposed in this pull request:

Added a new section "Deployment Patterns" under "Reference" to capture docs for things like Airflow, "serverless" deploys, etc. Discussed this with Abe and we found that these aren't how-tos or tutorials but closer to explanations of how to think about the problem, with some links to the how-tos, so the reference section made sense. 
I also moved the "GE on teams" section in there from spare parts, since at least to me I think it fits the description of a "pattern". 

**Question for the reviewer:** Does this structure make sense? Another suggestion for the title would be "Deployment Patterns and Best Practices".



**THIS IS UNTESTED** since docs rendering is currently broken. Just wanted to get feedback on the layout.