### PR TITLE
[DOCS] WIP: First version of shuffling tutorials around

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -18,6 +18,7 @@ These tutorials will teach you everything you need to know to get up and running
    :maxdepth: 2
 
    /tutorials/quick_start
+   /tutorials/exploring_ge_notebook
    /tutorials/getting_started
    /tutorials/contributing
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -18,8 +18,9 @@ These tutorials will teach you everything you need to know to get up and running
    :maxdepth: 2
 
    /tutorials/quick_start
-   /tutorials/exploring_ge_notebook
+   /tutorials/exploring_expectations
    /tutorials/getting_started
+   /tutorials/customize_your_deployment
    /tutorials/contributing
 
 

--- a/docs/tutorials/customize_your_deployment.rst
+++ b/docs/tutorials/customize_your_deployment.rst
@@ -3,9 +3,8 @@
 Customize your deployment
 =========================
 
-At this point, you have your first, working deployment of Great Expectations. You've also been introduced to the foundational concepts in the library: :ref:`Data Contexts`, :ref:`Datasources`, :ref:`Expectations`, :ref:`Profilers`, :ref:`Data Docs`, :ref:`Validation`, and :ref:`Checkpoints`.
+At this point, we assume you have your first working deployment of Great Expectations using a Data Context.
 
-Congratulations! You're off to a very good start.
 
 The next step is to customize your deployment by upgrading specific components of your deployment. Data Contexts make this modular, so that you can add or swap out one component at a time. Most of these changes are quick, incremental steps---so you can upgrade from a basic demo deployment to a full production deployment at your own pace and be confident that your Data Context will continue to work at every step along the way.
 

--- a/docs/tutorials/exploring_expectations.rst
+++ b/docs/tutorials/exploring_expectations.rst
@@ -1,0 +1,1 @@
+Placeholder for :ref:`how_to_guides__creating_and_editing_expectations__how_to_quickly_explore_data_using_expectations_in_a_notebook`

--- a/docs/tutorials/exploring_expectations.rst
+++ b/docs/tutorials/exploring_expectations.rst
@@ -1,1 +1,7 @@
+.. _exploring_expectations:
+
+#########
+Exploring Expectations In A Notebook
+#########
+
 Placeholder for :ref:`how_to_guides__creating_and_editing_expectations__how_to_quickly_explore_data_using_expectations_in_a_notebook`

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -1,10 +1,16 @@
 .. _getting_started:
 
 ###############
-Getting started
+GE 101: Getting started
 ###############
 
-Welcome to Great Expectations! This tutorial will help you set up your first deployment of Great Expectactions. We'll also introduce important concepts, with links to detailed material you can dig into later.
+Welcome to Great Expectations! This tutorial will help you set up your first deployment of Great Expectactions. We'll also introduce important concepts, with links to detailed material you can dig into later. After completing this tutorial, you will know how to
+
+- Initialize a Data Context to manage your project configuration
+- Set up a Datasource to connect Great Expectations to sample data
+- Create your first Expectations
+- Validate data with those Expectations
+- View the validation output in Data Docs
 
 Please follow these steps to get started:
 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -1,10 +1,10 @@
 .. _getting_started:
 
 ###############
-GE 101: Getting started
+Getting started with Great Expectations
 ###############
 
-Welcome to Great Expectations! This tutorial will help you set up your first deployment of Great Expectactions. We'll also introduce important concepts, with links to detailed material you can dig into later. After completing this tutorial, you will know how to
+Welcome to Great Expectations! This tutorial will help you set up your first local deployment of Great Expectactions. We'll also introduce important concepts, with links to detailed material you can dig into later. After completing this tutorial, you will know how to
 
 - Initialize a Data Context to manage your project configuration
 - Set up a Datasource to connect Great Expectations to sample data
@@ -104,42 +104,11 @@ Please follow these steps to get started:
          <strong class="fa-stack-1x">
             5
          </strong>
-      </span> Set up your first Checkpoint</h2>
+      </span> Validate your data</h2>
    </embed>
 
 .. container:: custom-indented-paragraph
 
    In normal usage, the best way to validate data is with a :ref:`Checkpoint`. Checkpoints simplify deployment, by pre-specifying the data and Expectations that to validate at any given point in your data infrastructure, along with follow-up actions to trigger based on the results of validation.
 
-   Follow these instructions to :ref:`set up your first Checkpoint`.
-
-.. raw:: html
-
-   <embed>
-      <h2><span class="fa-stack">
-         <span class="fa fa-circle-o fa-stack-2x"></span>
-         <strong class="fa-stack-1x">
-            6
-         </strong>
-      </span> Customize your deployment</h2>
-   </embed>
-
-.. container:: custom-indented-paragraph
-
-   By this point, you'll have your first, working deployment of Great Expectations. The next step is to :ref:`tutorials__getting_started__customize_your_deployment`.
-   
-   Data Contexts make this modular, so that you can add or swap out one component at a time. Most of these changes are quick, incremental steps---so you can upgrade from a basic demo deployment to a full production deployment at your own pace, and be confident that your Data Context will continue to work at every step along the way.
-   
------
-
-Table of contents for Getting Started:
-
-.. toctree::
-   :maxdepth: 1
-
-   /tutorials/getting_started/initialize_a_data_context
-   /tutorials/getting_started/connect_to_data
-   /tutorials/getting_started/create_your_first_expectations
-   /tutorials/getting_started/set_up_data_docs
-   /tutorials/getting_started/set_up_your_first_checkpoint
-   /tutorials/getting_started/customize_your_deployment
+   Follow these instructions to :ref:`set up your first Checkpoint<_tutorials__getting_started__set_up_your_first_checkpoint>`.

--- a/docs/tutorials/getting_started/connect_to_data.rst
+++ b/docs/tutorials/getting_started/connect_to_data.rst
@@ -3,9 +3,9 @@
 Connect to data
 ===============
 
-Once you have a DataContext, you'll want to connect to data.  In Great Expectations, :ref:`Datasources` simplify connections, by managing configuration and providing a consistent, cross-platform API for referencing data.
+Once you have a DataContext initialized, you'll want to connect to data.  In Great Expectations, :ref:`Datasources` simplify connections, by managing configuration and providing a consistent, cross-platform API for referencing data.
 
-Let's configure your first Datasource, by following the next steps in the CLI init flow:
+Let's configure your first Datasource, by following the next steps in the CLI ``init`` flow. Note that these next steps match what happens when you run ``great_expectations datasource new``.
     
 .. code-block:: bash
     
@@ -14,87 +14,40 @@ Let's configure your first Datasource, by following the next steps in the CLI in
     What data would you like Great Expectations to connect to?
         1. Files on a filesystem (for processing with Pandas or Spark)
         2. Relational database (SQL)
-    : 1
+    : 2
     
     What are you processing your files with?
-        1. Pandas
-        2. PySpark
-    : 1
-    
-    Enter the path (relative or absolute) of the root directory where the data files are stored.
-    : my_data
-    
+        1. TODO
+        2. TODO
+    : 5
+
     Give your new Datasource a short name.
-     [my_data__dir]: 
+     [my_postgres_db]:
     
-    Great Expectations will now add a new Datasource 'my_data__dir' to your deployment,
-    by adding this entry to your great_expectations.yml:
+    Great Expectations will now add a new Datasource 'my_postgres_db' to your deployment, by adding this entry to your great_expectations.yml:
     
-      my_data__dir:
+      my_postgres_db:
+        credentials: ${my_postgres_db}
+        module_name: great_expectations.datasource
         data_asset_type:
-          class_name: PandasDataset
+          class_name: SqlAlchemyDataset
           module_name: great_expectations.dataset
-        batch_kwargs_generators:
-          subdir_reader:
-            class_name: SubdirReaderBatchKwargsGenerator
-            base_directory: ../my_data
-        class_name: PandasDatasource
-    
-    
-    Would you like to proceed? [Y/n]: 
+        class_name: SqlAlchemyDatasource
 
-That's it! You just configured your first Datasource!
+    Would you like to proceed? [Y/n]: n
 
-Before continuing, let's stop and unpack what just happened, and why.
-
-Why Datasources?
-----------------
-
-*Validation* is the core operation in Great Expectations: "Validate X data against Y Expectations."
-
-Although the concept of data validation is simple, carrying it out can require complex engineering. This is because your Expectations and data might be stored in different places, and the computational resources for validation might live somewhere else entirely. The engineering cost of building the necessary connectors for validation has been one of the major things preventing data teams from testing their data.
-
-Datasources solve this problem, by conceptually separating *what* you want to validate from *how* you want to validate it. Datasources give you full control over the process of bringing data and Expectations together, then abstract away that underlying complexity when you validate X data against Y Expectations.
-
-.. figure:: ../../images/datasource-conceptual-diagram.png
-    :width: 400px
-    :class: with-shadow float-right
-
-We call the layer that handles the actual computation an :ref:`Execution Engine <reference__core_concepts__validation__execution_engines>`. Currently, Great Expectations supports three Execution Engines: pandas, sqlalchemy, and pyspark. We plan to extend the library to support others in the future.
-
-The layer that handles connecting to data is called a :ref:`Batch Kwargs Generator <reference__core_concepts__batch_kwargs_generators>`. Not all Batch Kwarg Generators can be used with all Execution Engines. It's also possible to configure a Datasource without a Batch Kwargs Generator if you want to pass data in directly. However, Batch Kwarg Generators are required to get the most out of Great Expectations' :ref:`Data Docs` and :ref:`Profilers`.
-
-You can read more about the inner workings of Datasources, Execution Engines, and Batch Kwargs Generators :ref:`here <Validation>`.
-
-.. attention::
-
-    We plan to upgrade this configuration API with better names and more conceptual clarity prior to Great Expectations' 1.0 release. If at all possible, we will make those changes in a non-breaking way. If you have ideas, concerns or questions about this planned improvement, please join the public discussion `here <https://discuss.greatexpectations.io/t/conceptual-mismatches-in-datasource-internals/134>`__.
-
+That's it, you just configured your first Datasource! Before continuing, let's stop and unpack what just happened.
 
 Configuring Datasources
 -----------------------
 
-When you completed those last few steps in ``great_expectations init``, you told Great Expectations that
+When you completed those last few steps, you told Great Expectations that
 
-1. You want to create a new Datasource called ``my_data__dir``.
-2. You want to use Pandas as your :ref:`Execution Engine <Execution Engines>`, hence ``data_asset_type.class_name = PandasDataset``.
-3. You want to create a BatchKwarg Generator called ``subdir_reader`` using the class ``SubdirReaderBatchKwargsGenerator``.
-4. This particular Generator connects to data in files within a local directory, specified here as ``../my_data``.
+1. You want to create a new Datasource called ``my_postgres_db``.
+2. The Datasource is of the type ``SqlAlchemyDatasource``
+3. The credentials to connect to the database are stored in a variable called ``my_postgres_db`` which, by default, is located in the ``great_expectations/uncommitted/config_variables.py`` file.
 
-Based on that information, the CLI added the following entry into your ``great_expectations.yml`` file, under the ``datasources`` header:
-
-.. code-block:: yaml
-
-    my_data__dir:
-      data_asset_type:
-        class_name: PandasDataset
-        module_name: great_expectations.dataset
-      batch_kwargs_generators:
-        subdir_reader:
-          class_name: SubdirReaderBatchKwargsGenerator
-          base_directory: ../my_data
-      class_name: PandasDatasource
-
+Based on that information, the CLI added an entry into your ``great_expectations.yml`` file, under the ``datasources`` header.
 
 In the future, you can modify or delete your configuration by editing your ``great_expectations.yml`` file directly. For instructions on how to configure various Datasources, check out :ref:`How-to guides for configuring Datasources <how_to_guides__configuring_datasources>`.
 

--- a/docs/tutorials/getting_started/create_your_first_expectations.rst
+++ b/docs/tutorials/getting_started/create_your_first_expectations.rst
@@ -3,13 +3,11 @@
 Create your first Expectations
 ==============================
 
-:ref:`Expectations` are the workhorse abstraction in Great Expectations.
+:ref:`Expectations` are the key concept in Great Expectations for asserting what you *expect* from your data.
 
-Each Expectation is a declarative, machine-verifiable assertion about the expected format, content, or behavior of your data. Great Expectations comes with :ref:`dozens of built-in Expectations <Glossary of Expectations>`, and it's easy to :ref:`develop your own custom Expectations <how_to_guides__creating_and_editing_expectations__how_to_create_custom_expectations>`, too.
+Each Expectation is a declarative, machine-verifiable assertion about the expected format, content, or behavior of your data. Great Expectations comes with :ref:`dozens of built-in Expectations <Glossary of Expectations>`, and it's possible to :ref:`develop your own custom Expectations <how_to_guides__creating_and_editing_expectations__how_to_create_custom_expectations>`, too.
 
-.. admonition:: Admonition from Mr. Dickens.
-
-    "Take nothing on its looks; take everything on evidence. There's no better rule."
+Remember that in the example data, we wanted to ensure that the ``passenger_count`` column always ranges between the numbers 1 and 6. Let's go ahead and create an Expectation suite to
 
 The CLI will help you create your first Expectations. You can accept the defaults by typing [Enter] twice:
 

--- a/docs/tutorials/getting_started/initialize_a_data_context.rst
+++ b/docs/tutorials/getting_started/initialize_a_data_context.rst
@@ -3,7 +3,7 @@
 Initialize a Data Context
 ===============================================
 
-In Great Expectations, your :ref:`Data Context` manages boilerplate configuration. Using a Data Context is almost always the fastest way to get up and running, even though some teams don't need every component of a Data Context.
+In Great Expectations, your :ref:`Data Context` manages your project configuration. In this tutorial, we will show you how to initialize a Data Context in a file system using the Great Expectations command line interface (CLI). In some cases, you might want to initialize a Data Context purely in code. This is not covered in the tutorial, but please see :ref:`the how-to guide on configuring a Data Context without a yml file <how_to_guides__configuring_data_contexts__how_to_instantiate_a_data_context_without_a_yml_file>` for instructions.
 
 
 Install Great Expectations
@@ -20,68 +20,19 @@ or git, you may want to check out the :ref:`supporting_resources` section before
    <br/>
    <br/>
 
-.. code-block:: bash
+If you intend to contribute to Great Expectations and want to install from a git branch or a fork, check out :ref:`contributing_setting_up_your_dev_environment` in the contributor documentation.
 
-    pip install great_expectations
-
-To install from a git branch, use the following command (replace ``develop`` below with the name of the branch you want to use):
-
-.. code-block:: bash
-
-    git clone https://github.com/great-expectations/great_expectations.git
-    cd great_expectations/
-    git checkout develop
-    pip install -e .
-
-To install from a git fork, use the following command (replace ``great-expectations`` below with the name of the fork, which is usually your github username):
-
-.. code-block:: bash
-
-    pip install -e .
-    git clone https://github.com/great-expectations/great_expectations.git
-    pip install great_expectations/
-
-If you intend to develop within the Great Expectations (e.g. to contribute back to the project), check out :ref:`contributing_setting_up_your_dev_environment` in the contributor documentation.
-
-Download example data
+About the example data
 ---------------------
 
-For this tutorial, we will use a simplified version of the National Provider Identifier (NPI) database. It's a public dataset released by the `Centers of Medicare and Medicaid Services <https://www.cms.gov/Regulations-and-Guidance/Administrative-Simplification/NationalProvIdentStand/DataDissemination>`_, intended as an authoritative list of health care providers in the United States. NPI data is famously messy---a great place to see the value of data testing and documentation in action.
-
-To avoid confusion during the tutorial, we recommend you set up the following directory structure before you download the data:
-
-.. code-block:: bash
-
-   mkdir example_project
-   mkdir example_project/my_data
-   cd example_project
-
-To download the NPI data using wget, please run:
-
-.. code-block:: bash
-
-    wget https://superconductive-public.s3.amazonaws.com/data/npi/weekly/npidata_pfile_20200511-20200517.csv.gz -P my_data
-
-Alternatively, you can use curl:
-
-.. code-block:: bash
-
-    curl https://superconductive-public.s3.amazonaws.com/data/npi/weekly/npidata_pfile_20200511-20200517.csv.gz -o my_data/npidata_pfile_20200511-20200517.csv.gz
-
-Finally, to unzip the data, please run:
-
-.. code-block:: bash
-
-    gunzip my_data/npidata_pfile_20200511-20200517.csv.gz
-
-Once unzipped, the data should be 22MB on disk.
+For this tutorial, we will use a simplified version of the ... (TODO, describe taxi data)
 
 Run ``great_expectations init``
 -----------------------------------------------
 
 When you installed Great Expectations, you also installed the Great Expectations :ref:`command line interface (CLI) <command_line>`. It provides helpful utilities for deploying and configuring DataContexts, plus a few other convenience methods.
 
-To initialize your Great Expectations deployment for the project, run this command in the terminal from the ``example_dickens_data_project/`` directory.
+To initialize your Great Expectations Data Context for the project, run this command in the terminal from the ``ge_tutorial/`` directory.
 
 .. code-block:: bash
 
@@ -119,7 +70,7 @@ You should see this:
 
 Let's pause there for a moment.
 
-Once you finish going through ``init``, your ``great_expectations/`` directory will contains all of the important components of a Great Expectations deployment, in miniature:
+As you can see, the ``init`` command creates a subdirectory called ``great_expectations/`` within your ``ge_tutorial/` directory. This directory will contain all of the important components of a Great Expectations deployment:
 
 
 * ``great_expectations.yml`` will contain the main configuration your deployment.
@@ -132,4 +83,4 @@ Once you finish going through ``init``, your ``great_expectations/`` directory w
   * ``uncommitted/documentation``, which will contains :ref:`Data Docs` generated from Expectations, Validation Results, and other metadata.
   * ``uncommitted/validations``, which will hold :ref:`Validation Results` generated by Great Expectations.
 
-Back in your terminal, go ahead and hit ``Enter`` to proceed.
+Back in your terminal, go ahead and hit ``Enter`` to proceed to the next step to set up a Datasource.

--- a/docs/tutorials/getting_started/set_up_your_first_checkpoint.rst
+++ b/docs/tutorials/getting_started/set_up_your_first_checkpoint.rst
@@ -1,9 +1,9 @@
 .. _tutorials__getting_started__set_up_your_first_checkpoint:
 
-Set up your first Checkpoint
+Validate your data
 ============================
 
-As we said earlier, validation the core operation of Great Expectations: “Validate X data against Y Expectations.”
+As we said earlier, validation is the core operation of Great Expectations: “Validate X data against Y Expectations.”
 
 In normal usage, the best way to validate data is with a :ref:`Checkpoint`. Checkpoints bring :ref:`Batches` of data together with corresponding :ref:`Expectation Suites` for validation. Configuring Checkpoints simplifies deployment, by pre-specifying the "X"s and "Y"s that you want to validate at any given point in your data infrastructure.
 
@@ -57,40 +57,6 @@ Our newly configured Checkpoint knows how to load ``npidata_pfile_20200511-20200
 
 You don't need to worry much about the details of Validation Operators for now. They orchestrate the actual work of validating data and processing the results. After executing validation, the Validation Operator can kick off additional workflows through :ref:`Validation Actions`.
 
-You can see the configuration for ``action_list_operator`` in your ``great_expectations.yml`` file. With comments removed, it looks like this:
-
-.. code-block:: yaml
-
-    action_list_operator:
-      class_name: ActionListValidationOperator
-      action_list:
-      - name: store_validation_result
-        action:
-          class_name: StoreValidationResultAction
-      - name: store_evaluation_params
-        action:
-          class_name: StoreEvaluationParametersAction
-      - name: update_data_docs
-        action:
-          class_name: UpdateDataDocsAction
-      # - name: send_slack_notification_on_validation_result
-      #   action:
-      #     class_name: SlackNotificationAction
-      #     # put the actual webhook URL in the uncommitted/config_variables.yml file
-      #     slack_webhook: ${validation_notification_slack_webhook}
-      #     notify_on: all # possible values: "all", "failure", "success"
-      #     renderer:
-      #       module_name: great_expectations.render.renderer.slack_renderer
-      #       class_name: SlackRenderer
-
-You can see that the ``action_list`` for your validation Operator contains three Validation Actions. After each run using this operator...
-
-1. ``store_validation_result`` : store the :ref:`Validation Results`.
-2. ``store_evaluation_params`` : store :ref:`Evaluation Parameters`.
-3. ``update_data_docs`` : update your :ref:`Data Docs`.
-
-A fourth action, ``send_slack_notification_on_validation_result``, will trigger a notification in Slack. It's currently commented out. See :ref:`How to trigger Slack notifications as a Validation Action` to configure it.
-
 For more examples of post-validation actions, please see the :ref:`How-to section for Validation <how_to_guides__validation>`.
 
 How to run Checkpoints
@@ -102,10 +68,21 @@ Checkpoints can be run like applications from the command line or cron:
 
     great_expectations checkpoint run my_checkpoint
 
-You can also generate Checkpoint scripts that you can edit and run using python, or within data orchestration tools like airflow.
+You can also generate Checkpoint scripts that you can edit and run using python, or within data orchestration tools like Airflow. For example, see the How to Run a Checkpoint in Airflow how-to guide.
 
 .. code-block:: bash
 
     great_expectations checkpoint script my_checkpoint
 
-Now that you know how to configure Checkpoints, let's proceed to the last step of the tutorial: :ref:`Customize your deployment`.
+Once the Checkpoint is run, you can head back to your Data Docs to see the results of the latest Validation run with your Checkpoint.
+
+
+Congratulations! Where to go from here?
+----------------------
+
+At this point, you have your first, working local deployment of Great Expectations. This is the end of the Getting Started tutorial!
+
+You've also been introduced to the foundational concepts in the library: :ref:`Data Contexts`, :ref:`Datasources`, :ref:`Expectations`, :ref:`Profilers`, :ref:`Data Docs`, :ref:`Validation`, and :ref:`Checkpoints`.
+
+Data Contexts make this modular, so that you can add or swap out one component at a time. Most of these changes are quick, incremental steps---so you can upgrade from a basic demo deployment to a full production deployment at your own pace, and be confident that your Data Context will continue to work at every step along the way. The next step is to :ref:`tutorials__getting_started__customize_your_deployment`.
+

--- a/docs/tutorials/quick_start.rst
+++ b/docs/tutorials/quick_start.rst
@@ -1,3 +1,5 @@
+.. _quick_start:
+
 ###########
 Quick start
 ###########

--- a/docs/tutorials/quick_start.rst
+++ b/docs/tutorials/quick_start.rst
@@ -14,16 +14,45 @@ Off we go! Install Great Expectations:
 
     pip install great_expectations
 
-You can quickly try out Great Expectations using this guide: :ref:`how_to_guides__creating_and_editing_expectations__how_to_quickly_explore_data_using_expectations_in_a_notebook`.
+This is it! From here, you have two options to get started with Great Expectations:
 
-    .. figure:: ../images/interactive_mostly.gif
+.. raw:: html
 
-To unlock more of the power of Great Expectations, you'll also need to configure a Data Context. From the root of the directory where you want to deploy Great Expectations:
+   <embed>
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css">
+      <style>
+         .custom-indented-paragraph {
+            margin-left: 70px;
+         }
+      </style>
+   </embed>
 
-.. code-block:: bash
+.. raw:: html
 
-    great_expectations init
+   <embed>
+      <h2><span class="fa-stack">
+         <span class="fa fa-circle-o fa-stack-2x"></span>
+         <strong class="fa-stack-1x">
+            1
+         </strong>
+      </span> Explore Expectations in a notebook</h2>
+   </embed>
 
-The CLI will guide you through all the steps to set up a basic deployment of Great Expectations.
+.. container:: custom-indented-paragraph
 
-After that, if you want to understand what just happened, check out :ref:`Getting started`. Alternatively, you can :ref:`Customize your deployment <tutorials__getting_started__customize_your_deployment>`.
+   You can quickly try out Great Expectations in a Jupter notebook to explore building your first set of Expectations. Follow this guide: :ref:`how_to_guides__creating_and_editing_expectations__how_to_quickly_explore_data_using_expectations_in_a_notebook`.
+
+.. raw:: html
+
+   <embed>
+      <h2><span class="fa-stack">
+         <span class="fa fa-circle-o fa-stack-2x"></span>
+         <strong class="fa-stack-1x">
+            2
+         </strong>
+      </span> Set up a local deployment of Great Expectations</h2>
+   </embed>
+
+.. container:: custom-indented-paragraph
+
+   To unlock more of the power of Great Expectations, you'll also need to configure a Data Context. Check out the :ref:`getting_started` tutorial for instructions on how to set up your first local deployment of Great Expectations using a sample data set.


### PR DESCRIPTION
This will probably be a fairly big PR, so I want to do this in steps. The ultimate goal is to tweak the Tutorials section to match the flow of the GE 101 webinar. In order to do this, I've
- added a new tutorial for the "exploring expectations" page (currently just a placeholder page before I move the file over)
- moved the "customize your deployment" section to a top-level page under tutorials
- started changing a little bit of the language of the "Getting started" tutorial and started cutting out some paragraphs

TODO if the structure looks good: start actually populating the content and cleaning it all up. 

Open question: Not sure where to go with the quick start page since it's just the install now, since the init is on the tutorial. Should I move init back to quick start, too? (It was basically duplicated on the getting started, so I removed it)
