### PR TITLE
[FEATURE] Add support for nested columns in PySpark expectations

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Develop
 -----------------
+* [FEATURE] Add support for nested columns in the PySpark expectations
 * [BREAKING] This release includes a breaking change that *only* affects users who directly call `add_expectation`, `remove_expectation`, or `find_expectations`. (Most users do not use these APIs but add Expectations by stating them directly on Datasets). Those methods have been updated to take an ExpectationConfiguration object and `match_type` object. The change provides more flexibility in determining which expectations should be modified and allows us provide substantially improved support for two major features that we have frequently heard requested: conditional Expectations and more flexible multi-column custom expectations. See :ref:`expectation_suite_operations`_ and :ref:`migrating_versions`_ for more information.
 * [FEATURE] Expectations now define “domain,” “success,” and “runtime” kwargs to allow them to determine expectation equivalence for updating expectations. Fixes column pair expectation update logic.
 * [ENHANCEMENT] Include datetime and bool column types in descriptive documentation results

--- a/tests/spark/test_spark_expectations.py
+++ b/tests/spark/test_spark_expectations.py
@@ -1,0 +1,107 @@
+import pytest
+
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType
+from pyspark.sql.utils import AnalysisException
+from great_expectations.dataset import SparkDFDataset
+
+
+@pytest.fixture
+def test_dataframe(spark_session):
+    schema = StructType([
+        StructField("name", StringType(), True),
+        StructField("age", IntegerType(), True),
+        StructField("address", StructType([
+            StructField("street", StringType(), True),
+            StructField("city", StringType(), True),
+            StructField("house_number", IntegerType(), True)
+        ]), False),
+        StructField("name_duplicate", StringType(), True),
+        StructField("non.nested", StringType(), True)
+    ])
+    l = [
+        ("Alice", 1, ("Street 1", "Alabama", 10), "Alice", "a"),
+        ("Bob", 2, ("Street 2", "Brooklyn", 11), "Bob", "b"),
+        ("Charlie", 3, ("Street 3", "Alabama", 12), "Charlie", "c"),
+    ]
+
+    rdd = spark_session.sparkContext.parallelize(l)
+
+    df = spark_session.createDataFrame(rdd, schema)
+    return SparkDFDataset(df, persist=True)
+
+
+def test_expect_column_values_to_be_of_type(spark_session, test_dataframe):
+    """
+    data asset expectation
+    """
+    assert test_dataframe.expect_column_values_to_be_of_type("address.street", "StringType").success
+    assert test_dataframe.expect_column_values_to_be_of_type("non.nested", "StringType", non_nested=True).success
+    assert test_dataframe.expect_column_values_to_be_of_type("name", "StringType").success
+    with pytest.raises(AnalysisException):
+        test_dataframe.expect_column_values_to_be_of_type("non.nested", "StringType")
+
+
+def test_expect_column_pair_values_to_be_equal(spark_session, test_dataframe):
+    """
+    column_pair_map_expectation
+    """
+    assert test_dataframe.expect_column_pair_values_to_be_equal("name", "name_duplicate").success
+    assert not test_dataframe.expect_column_pair_values_to_be_equal("name", "address.street").success
+    assert not test_dataframe.expect_column_pair_values_to_be_equal("name", "non.nested", non_nested_B=True).success
+    with pytest.raises(AnalysisException):
+        test_dataframe.expect_column_pair_values_to_be_equal("name", "non.nested")
+
+
+def test_expect_column_pair_values_A_to_be_greater_than_B(spark_session, test_dataframe):
+    """
+    column_pair_map_expectation
+    """
+    assert test_dataframe.expect_column_pair_values_A_to_be_greater_than_B("address.house_number", "age").success
+    assert test_dataframe.expect_column_pair_values_A_to_be_greater_than_B("age", "age", or_equal=True).success
+
+
+def test_expect_multicolumn_values_to_be_unique(spark_session, test_dataframe):
+    """
+    multicolumn_map_expectation
+    """
+    assert test_dataframe.expect_multicolumn_values_to_be_unique(["name", "age"]).success
+    assert test_dataframe.expect_multicolumn_values_to_be_unique(["address.street", "name"]).success
+    assert test_dataframe.expect_multicolumn_values_to_be_unique(["address.street", "non.nested"],
+                                                                 non_nested_column_list=["non.nested"]).success
+    with pytest.raises(AnalysisException):
+        test_dataframe.expect_multicolumn_values_to_be_unique(["address.street", "non.nested"])
+
+
+def test_expect_column_values_to_be_unique(spark_session, test_dataframe):
+    """
+    column_map_expectation
+    """
+    assert test_dataframe.expect_column_values_to_be_unique("name").success
+    assert not test_dataframe.expect_column_values_to_be_unique("address.city").success
+    assert test_dataframe.expect_column_values_to_be_unique("non.nested", non_nested=True).success
+    with pytest.raises(AnalysisException):
+        test_dataframe.expect_column_values_to_be_unique("non.nested")
+
+
+def test_expect_column_value_lengths_to_be_between(spark_session, test_dataframe):
+    """
+    column_map_expectation
+    """
+    assert test_dataframe.expect_column_value_lengths_to_be_between("name", 3, 7).success
+    assert test_dataframe.expect_column_value_lengths_to_be_between("address.street", 1, 10).success
+
+
+def test_expect_column_value_lengths_to_equal(spark_session, test_dataframe):
+    """
+    column_map_expectation
+    """
+    assert test_dataframe.expect_column_value_lengths_to_equal("age", 1).success
+    assert test_dataframe.expect_column_value_lengths_to_equal("address.street", 8).success
+
+
+# TODO: Get tests working for expect_column_values_to_be_in_type_list
+# def test_expect_column_values_to_be_in_type_list(spark_session, test_dataframe):
+#     """
+#     data asset expectation
+#     """
+#     assert test_dataframe.expect_column_values_to_be_in_type_list("age", ["StringType", "IntegerType"]).success


### PR DESCRIPTION
Hello, 

We are currently using Great Expectations for Parquet data and running the expectations with PySpark. We noticed that there is currently no support for nested columns. This PR aims to resolve this.

DataFrames like the following should now be supported:
```
|-- name: string (nullable = true)
|-- age: integer (nullable = true)
|-- address: struct (nullable = false)
|    |-- street: string (nullable = true)
|    |-- city: string (nullable = true)
|    |-- house_number: integer (nullable = true)
|-- name_duplicate: string (nullable = true)
|-- non.nested: string (nullable = true)
```

Non-nested columns with dot notation (like `non.nested`) are also supported.

Changes proposed in this pull request:
- Adding support for nested columns in PySpark expectations. 
- Support non-nested columns that do have dot notation
