### PR TITLE
[DOCS] How-to guide for custom notifications

### DIFF
--- a/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
+++ b/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
@@ -3,7 +3,7 @@
 How to implement custom notifications
 =====================================
 
-If you would like to implement custom notifications that include a link to Data Docs, you can access the Data Docs URL for the respective validation results page from your Data Context after a validation run following the steps below. This will works to get the URLs for any type of Data Docs site setup, e.g. S3 or local setup.
+If you would like to implement custom notifications that include a link to Data Docs, you can access the Data Docs URL for the respective validation results page from your Data Context after a validation run following the steps below. This will work to get the URLs for any type of Data Docs site setup, e.g. S3 or local setup.
 
 .. admonition:: Prerequisites: This how-to guide assumes you have already:
 

--- a/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
+++ b/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
@@ -37,7 +37,7 @@ If you would like to implement custom notifications that include a link to Data 
         validation_ids = [res for res in results['run_results']]
         validation_id = validation_ids[0]
 
-3. Finally, use the ``validation_id`` as an argument to the Data Context's ``get_docs_sites_urls()`` method, and get the right element from the resulting list:
+3. Finally, use the ``validation_id`` as an argument to the Data Context's ``get_docs_sites_urls()`` method, and get the right element from the resulting list to access its ``site_url``:
 
     .. code-block:: python
 

--- a/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
+++ b/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
@@ -3,16 +3,17 @@
 How to implement custom notifications
 =====================================
 
-.. admonition:: Admonition from Mr. Dickens
+If you would like to implement custom notifications that include a link to Data Docs, you can access the Data Docs URL from your Data Context after a validation run following the steps below.
 
-    "Whether I shall turn out to be the hero of my own life, or whether that station will be held by anybody else, these pages must show."
+.. admonition:: Prerequisites: This how-to guide assumes you have already:
 
+  - :ref:`Set up a working deployment of Great Expectations <getting_started>`
 
-This guide is a stub. We all know that it will be useful, but no one has made time to write it yet.
+First, this is the standard boilerplate to load a Data Context and run validation on a Batch:
 
-If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.
+    .. code-block:: python
 
-If you want to be a real hero, we'd welcome a pull request. Please see :ref:`the Contributing tutorial <tutorials__contributing>` and :ref:`How to write a how to guide` to get started.
+        context.expect_table_row_count_to_be_between(min_value=1000, max_value=4000)
 
 .. discourse::
     :topic_identifier: 222

--- a/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
+++ b/docs/guides/how_to_guides/validation/how_to_implement_custom_notifications.rst
@@ -3,17 +3,55 @@
 How to implement custom notifications
 =====================================
 
-If you would like to implement custom notifications that include a link to Data Docs, you can access the Data Docs URL from your Data Context after a validation run following the steps below.
+If you would like to implement custom notifications that include a link to Data Docs, you can access the Data Docs URL for the respective validation results page from your Data Context after a validation run following the steps below. This will works to get the URLs for any type of Data Docs site setup, e.g. S3 or local setup.
 
 .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
-  - :ref:`Set up a working deployment of Great Expectations <getting_started>`
+  - :ref:`Set up a working deployment of Great Expectations <tutorial_getting_started>`
+  - :ref:`Created an Expectation Suite to use for validation <tutorial_create_expectations>`
 
-First, this is the standard boilerplate to load a Data Context and run validation on a Batch:
+1. First, this is the standard boilerplate to load a Data Context and run validation on a Batch:
 
     .. code-block:: python
 
-        context.expect_table_row_count_to_be_between(min_value=1000, max_value=4000)
+        import great_expectations as ge
+
+        # Load the Data Context
+        context = ge.data_context.DataContext()
+
+        # The batch_kwargs will differ depending on the type of Datasource,
+        # see the docs for help
+        batch_kwargs = {'table': 'my_table', 'datasource': 'my_datasource'}
+        batch = context.get_batch(batch_kwargs, 'my_suite')
+
+        # Run validation on your Batch
+        results = context.run_validation_operator(
+            "action_list_operator",
+            assets_to_validate=[batch],
+            run_id='my_run_id')
+
+2. Next, get the list of IDs of the validation results. ``results`` is a list that might have multiple elements if you validate multiple Batches, so we'll have to iterate over it. In this example, we'll just grab the only element:
+
+    .. code-block:: python
+
+        validation_ids = [res for res in results['run_results']]
+        validation_id = validation_ids[0]
+
+3. Finally, use the ``validation_id`` as an argument to the Data Context's ``get_docs_sites_urls()`` method, and get the right element from the resulting list:
+
+    .. code-block:: python
+
+        url_dicts = context.get_docs_sites_urls(resource_identifier=validation_id)
+        # The method returns a list of dictionaries like so:
+        # [{'site_name': 'local_site',
+        #  'site_url': 'file://validations/my_suite/my_run_id/20200811T181225.859901Z/123456.html'}]
+
+        # The list will have multiple elements if you have multiple sites set up, e.g.
+        # S3 and a local site. In this example, we'll just grab the only element again:
+        validation_site_url = url_dicts[0]['site_url']
+
+4. You can now include ``validation_site_url`` as a link in your custom notifications, e.g. in an email,  which will allow users to jump straight to the relevant validation results page.
+
 
 .. discourse::
     :topic_identifier: 222


### PR DESCRIPTION
As discussed with Eugene, I added content for the how-to guide for custom notifications. I believe this is only the first part really if the intent of the guide is to add something about validation operators, but I think this is a good start and in the right place for users to find info about how to get a link to data docs basically.

Thank you for submitting!
