### PR TITLE
[MAINTENANCE] Exclude docs-only changes from PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,11 @@
 trigger:
   - main
 
+pr:
+  paths:
+    exclude:
+      - docs/*
+
 resources:
   containers:
   - container: postgres


### PR DESCRIPTION
Changes proposed in this pull request:
- Do not trigger CI builds on docs-only PRs
