### PR TITLE
[BUGFIX] SuiteEditNotebookRenderer no longer break GCS and S3 data paths

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Develop
 -----------------
-
+* [BUGFIX] SuiteEditNotebookRenderer no longer break GCS and S3 data paths
 
 
 0.12.0

--- a/great_expectations/render/renderer/suite_edit_notebook_renderer.py
+++ b/great_expectations/render/renderer/suite_edit_notebook_renderer.py
@@ -338,6 +338,8 @@ class SuiteEditNotebookRenderer(Renderer):
             batch_kwargs = dict(batch_kwargs)
         if batch_kwargs and "path" in batch_kwargs.keys():
             base_dir = batch_kwargs["path"]
+            if base_dir[0:5] in ["s3://", "gs://"]:
+                return batch_kwargs
             if not os.path.isabs(base_dir):
                 batch_kwargs["path"] = os.path.join("..", "..", base_dir)
 

--- a/tests/render/renderer/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/test_suite_edit_notebook_renderer.py
@@ -858,6 +858,27 @@ def test_render_with_batch_kwargs_overrides_batch_kwargs_in_citations(
     assert obs == expected
 
 
+def test_render_path_fixes_relative_paths():
+    batch_kwargs = {"path": "data.csv"}
+    notebook_renderer = SuiteEditNotebookRenderer()
+    expected = {"path": "../../data.csv"}
+    assert notebook_renderer._fix_path_in_batch_kwargs(batch_kwargs) == expected
+
+
+def test_render_path_ignores_gcs_urls():
+    batch_kwargs = {"path": "gs://a-bucket/data.csv"}
+    notebook_renderer = SuiteEditNotebookRenderer()
+    expected = {"path": "gs://a-bucket/data.csv"}
+    assert notebook_renderer._fix_path_in_batch_kwargs(batch_kwargs) == expected
+
+
+def test_render_path_ignores_s3_urls():
+    batch_kwargs = {"path": "s3://a-bucket/data.csv"}
+    notebook_renderer = SuiteEditNotebookRenderer()
+    expected = {"path": "s3://a-bucket/data.csv"}
+    assert notebook_renderer._fix_path_in_batch_kwargs(batch_kwargs) == expected
+
+
 def test_render_with_no_batch_kwargs_multiple_batch_kwarg_citations(
     suite_with_multiple_citations, empty_data_context
 ):


### PR DESCRIPTION
Changes proposed in this pull request:
- bugfix in suite edit notebook renderer

Previous Design Review notes:
- Pairing with @anthonyburdi on this!

Thank you for submitting!
