### PR TITLE
[BUGFIX] Allow for pandas reader option inference

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Develop
 -----------------
 
 * [ENHANCEMENT] Update schema for anonymized expectation types to avoid large key domain
+* [BUGFIX] Allow for pandas reader option inference with parquet and Excel (thanks @dlachasse)!
 * [BUGFIX] Fix bug where running checkpoint fails if GCS data docs site has a prefix (thanks @sergii-tsymbal-exa)!
 * [BUGFIX] Fix bug in deleting datasource config from config file (thanks @rxmeez)!
 * [BUGFIX] clarify inclusiveness of min/max values in string rendering

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import uuid
+from collections import Callable
 from functools import partial
 from io import BytesIO
 
@@ -214,7 +215,7 @@ class PandasDatasource(Datasource):
             s3_object = s3.get_object(Bucket=url.bucket, Key=url.key)
             reader_fn = self._get_reader_fn(reader_method, url.key)
             default_reader_options = self._infer_default_options(
-                reader_method, reader_options
+                reader_fn, reader_options
             )
             if not reader_options.get("encoding") and default_reader_options.get(
                 "encoding"
@@ -275,7 +276,7 @@ class PandasDatasource(Datasource):
             "Unable to determine reader method from path: %s" % path, {"path": path}
         )
 
-    def _infer_default_options(self, reader_method: str, reader_options: dict) -> dict:
+    def _infer_default_options(self, reader_fn: Callable, reader_options: dict) -> dict:
         """
         Allows reader options to be customized based on file context before loading to a DataFrame
 
@@ -286,9 +287,9 @@ class PandasDatasource(Datasource):
         Returns:
             dict: A copy of the reader options post-inference
         """
-        if reader_method == "read_parquet":
+        if reader_fn.__name__ == "read_parquet":
             return {}
-        if reader_method == "read_excel":
+        if reader_fn.__name__ == "read_excel":
             return {}
         else:
             return {"encoding": "utf-8"}

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -222,8 +222,6 @@ class PandasDatasource(Datasource):
                 reader_options["encoding"] = s3_object.get(
                     "ContentEncoding", default_reader_options.get("encoding")
                 )
-            if not reader_options.get("encoding"):
-                reader_options["encoding"] = s3_object.get("ContentEncoding", "utf-8")
             df = reader_fn(BytesIO(s3_object["Body"].read()), **reader_options)
 
         elif "dataset" in batch_kwargs and isinstance(

--- a/tests/datasource/test_pandas_datasource.py
+++ b/tests/datasource/test_pandas_datasource.py
@@ -1,8 +1,11 @@
 import os
 import shutil
+from tempfile import mkstemp
 
+import boto3
 import pandas as pd
 import pytest
+from moto import mock_s3
 from ruamel.yaml import YAML
 
 from great_expectations.core import ExpectationSuite
@@ -271,6 +274,49 @@ def test_pandas_source_read_csv(
         expectation_suite_name="unicode",
     )
     assert "😁" in list(batch["Μ"])
+
+
+@mock_s3
+def test_s3_pandas_source_read_parquet(
+    data_context_parameterized_expectation_suite, tmp_path_factory
+):
+    test_bucket = "test-bucket"
+    # set up dummy bucket
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket=test_bucket)
+
+    df1 = pd.DataFrame({"col_1": [1, 2, 3, 4, 5], "col_2": ["a", "b", "c", "d", "e"]})
+    _, tmp = mkstemp(suffix=".parquet")
+    with open(tmp, "wb") as fp:
+        df1.to_parquet(fp)
+
+    with open(tmp, "rb") as fp:
+        s3.upload_fileobj(fp, test_bucket, "test_data.parquet")
+
+    data_context_parameterized_expectation_suite.add_datasource(
+        "parquet_source",
+        module_name="great_expectations.datasource",
+        class_name="PandasDatasource",
+        batch_kwargs_generators={
+            "s3_reader": {
+                "class_name": "S3GlobReaderBatchKwargsGenerator",
+                "bucket": test_bucket,
+                "assets": {"test_data": {"prefix": "", "regex_filter": r".*parquet",},},
+            }
+        },
+    )
+
+    data_context_parameterized_expectation_suite.create_expectation_suite(
+        expectation_suite_name="test_parquet"
+    )
+    batch = data_context_parameterized_expectation_suite.get_batch(
+        data_context_parameterized_expectation_suite.build_batch_kwargs(
+            "parquet_source", "s3_reader", "test_data",
+        ),
+        "test_parquet",
+    )
+    assert batch["col_1"][4] == 5
+    assert batch["col_2"][0] == "a"
 
 
 def test_invalid_reader_pandas_datasource(tmp_path_factory):

--- a/tests/datasource/test_pandas_datasource.py
+++ b/tests/datasource/test_pandas_datasource.py
@@ -302,6 +302,7 @@ def test_s3_pandas_source_read_parquet(
                 "class_name": "S3GlobReaderBatchKwargsGenerator",
                 "bucket": test_bucket,
                 "assets": {"test_data": {"prefix": "", "regex_filter": r".*parquet",},},
+                "reader_options": {"columns": ["col_1"]},
             }
         },
     )
@@ -315,8 +316,8 @@ def test_s3_pandas_source_read_parquet(
         ),
         "test_parquet",
     )
+    assert batch.columns == ["col_1"]
     assert batch["col_1"][4] == 5
-    assert batch["col_2"][0] == "a"
 
 
 def test_invalid_reader_pandas_datasource(tmp_path_factory):


### PR DESCRIPTION
There are some special cases where default options need to be handled differently. This allows for specific filetypes to address the default options applied before contents are read into a DataFrame. This currently only handles parquet format, but includes a conditional that will act as an easy entrypoint for other reader functions. A regression test has been included to illustrate expected behavior. 

Closes https://github.com/great-expectations/great_expectations/issues/1843.

Changes proposed in this pull request:
- Allow for `PandasDatasource` assets to infer special options based on Pandas reader_fn

