### PR TITLE
[BUG] Fixing broken link to GE docs in Slack message

### DIFF
--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -113,7 +113,7 @@ class SlackRenderer(Renderer):
         if custom_blocks:
             query["blocks"].append(custom_blocks)
 
-        documentation_url = "https://docs.greatexpectations.io/en/latest/tutorials/getting_started/set_up_data_docs.html#_getting_started__set_up_data_docs"
+        documentation_url = "https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html"
         footer_section = {
             "type": "context",
             "elements": [

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -48,7 +48,7 @@ def test_SlackRenderer():
                 "elements": [
                     {
                         "type": "mrkdwn",
-                        "text": "Learn how to review validation results in Data Docs: https://docs.greatexpectations.io/en/latest/tutorials/getting_started/set_up_data_docs.html#_getting_started__set_up_data_docs",
+                        "text": "Learn how to review validation results in Data Docs: https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html",
                     }
                 ],
             },


### PR DESCRIPTION
Flagged by a user (I couldn't find a PR), the link to the GE docs in the Slack notification was broken after moving the tutorial around.