### PR TITLE
[BUGFIX] Fix `TypeError: unhashable type` error in Data Docs rendering

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Develop
 * [BUGFIX] Fix bug preventing the use of get_available_partition_ids in s3 generator
 * [BUGFIX] SuiteEditNotebookRenderer no longer break GCS and S3 data paths
 * [BUGFIX] TupleGCSStoreBackend: remove duplicate prefix for urls (thanks @azban)!
+* [BUGFIX] Fix `TypeError: unhashable type` error in Data Docs rendering
 
 0.12.0
 -----------------

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -156,13 +156,13 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
             sampled_values_set = set()
             for unexpected_value in result.get("partial_unexpected_list"):
                 if unexpected_value:
-                    string_unexpected_value = unexpected_value
+                    string_unexpected_value = str(unexpected_value)
                 elif unexpected_value == "":
                     string_unexpected_value = "EMPTY"
                 else:
                     string_unexpected_value = "null"
                 if string_unexpected_value not in sampled_values_set:
-                    table_rows.append([string_unexpected_value])
+                    table_rows.append([unexpected_value])
                     sampled_values_set.add(string_unexpected_value)
 
         unexpected_table_content_block = RenderedTableContent(


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- re: https://github.com/great-expectations/great_expectations/issues/1841
- Fix `TypeError: unhashable type` error in Data Docs rendering
- Exception occurred when rendering unexpected value lists and an element was an unhashable type (e.g. dict) - from checking for set membership
- Coerce unexpected value to string for set membership checking, but use actual unexpected value for Data Docs
