### PR TITLE
[BUGFIX] Deletes datasource config from config file

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Develop
 -----------------
 * [DOCS] Add notes on transient table creation to Snowflake guide (thanks @verhey)!
+* [BUGFIX] Fix bug in deleting datasource config from config file (thanks @rxmeez)!
 
 
 0.12.1

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -112,15 +112,17 @@ def delete_datasource(directory, datasource):
     except ValueError:
         cli_message(
             "<red>{}</red>".format(
-                "Datasource {} could not be found".format(datasource)
+                "Datasource {} could not be found.".format(datasource)
             )
         )
         sys.exit(1)
-    else:
+    try:
+        context.get_datasource(datasource)
+    except ValueError:
         cli_message("<green>{}</green>".format("Datasource deleted successfully."))
-
-    if context.get_datasource(datasource) is None:
-        cli_message("<red>{}</red>".format("Datasource not deleted"))
+        sys.exit(1)
+    else:
+        cli_message("<red>{}</red>".format("Datasource not deleted."))
         sys.exit(1)
 
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -764,9 +764,11 @@ class BaseDataContext(object):
         else:
             datasource = self.get_datasource(datasource_name)
             if datasource:
-                # remove key until we have a delete method on project_config
-                # self._project_config_with_variables_substituted.datasources[datasource_name].remove()
-                # del self._project_config["datasources"][datasource_name]
+                # delete datasources project config
+                del self._project_config_with_variables_substituted.datasources[
+                    datasource_name
+                ]
+                del self._project_config.datasources[datasource_name]
                 del self._cached_datasources[datasource_name]
             else:
                 raise ValueError("Datasource {} not found".format(datasource_name))
@@ -2347,6 +2349,14 @@ class DataContext(BaseDataContext):
         self._save_project_config()
 
         return new_datasource
+
+    def delete_datasource(self, name, **kwargs):
+        logger.debug("Starting DataContext.delete_datasource for datasource %s" % name)
+
+        delete_datasource = super().delete_datasource(name, **kwargs)
+        self._save_project_config()
+
+        return delete_datasource
 
     @classmethod
     def find_context_root_dir(cls):


### PR DESCRIPTION
Issue #1880 

Changes proposed in this pull request:

- Deletes datasource and saves the project_config after deletion.
- After deletion it would check again to retrieve that datasource using get_datasource if successful it would write to terminal "Datasource not deleted." otherwise it's deleted the datasource.