### PR TITLE
[ENHANCEMENT] Move black requirement

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Develop
 -----------------
 
 * [ENHANCEMENT] Update schema for anonymized expectation types to avoid large key domain
+* [ENHANCEMENT] Moved black from main requirements file to dev requirements
 * [BUGFIX] Fix bug where running checkpoint fails if GCS data docs site has a prefix (thanks @sergii-tsymbal-exa)!
 * [BUGFIX] Fix bug in deleting datasource config from config file (thanks @rxmeez)!
 * [BUGFIX] clarify inclusiveness of min/max values in string rendering

--- a/docs/contributing/contribution_checklist.rst
+++ b/docs/contributing/contribution_checklist.rst
@@ -45,7 +45,7 @@ Once your code is ready, please go through the following checklist before submit
 
 **5. Have you added a bullet with your changes under the "develop" heading in the Changelog?**
 
-    * Please add a bullet point to ``docs/changelog/changelog.rst``, in the ``develop`` section.
+    * Please add a bullet point to ``docs/changelog.rst``, in the ``develop`` section.
         * Please group in the following order: [BREAKING], [FEATURE], [ENHANCEMENT], [BUGFIX], [DOCS], [MAINTENANCE]
     * You can see the past Changelog here: :ref:`changelog`
 

--- a/requirements-dev-build.txt
+++ b/requirements-dev-build.txt
@@ -7,3 +7,4 @@ flake8==3.8.3  # lint
 isort==5.4.2  # lint
 pre-commit>=2.6.0  # lint
 pyupgrade==2.7.2  # lint
+black==19.10b0  # lint

--- a/requirements-dev-test.txt
+++ b/requirements-dev-test.txt
@@ -3,7 +3,6 @@
 # To run tests for smaller subsets of infrastructure, please look at other requirements-dev-*.txt files.
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
-black==19.10b0  # lint
 freezegun>=0.3.15  # all_tests
 pytest>=5.3.5,<6.0.0  # all_tests
 pytest-cov>=2.8.1  # all_tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
 altair>=4.0.0,<5  # package
-black==19.10b0  # package
 Click>=7.1.2  # package
 importlib-metadata>=1.7.0 # package (included in Python 3.8 by default.)
 ipywidgets>=7.5.1  # package


### PR DESCRIPTION
Changes proposed in this pull request:
- Move the pinned `black` requirement from the main requirements file to the dev requirements file. It is only need for developing, and this will prevent other projects that require Great Expectations from inheriting this pinned requirement which may cause conflicts.
- A small fix to the contributing docs. It looks like the changelog must have moved at some point.