### PR TITLE
[BUGFIX] Building data docs no longer crashes when a data asset name is an integer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Develop
 * [DOCS] Fixed several broken links and glossary organization (thanks @JavierMonton and @sbrugman)!
 * [DOCS] Deploying Great Expectations with Google Cloud Composer (Hosted Airflow)
 * [ENHANCEMENT] BaseProfiler type mapping expanded to include more pandas and numpy dtypes
+* [BUGFIX] Building data docs no longer crashes when a data asset name is an integer #1913
 
 
 0.12.1

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -205,12 +205,12 @@ class ValidationResultsPageRenderer(Renderer):
         if run_name_as_time != run_time_datetime and run_name_as_time != "__none__":
             include_run_name = True
 
-        page_title = "Validations / " + expectation_suite_name
+        page_title = "Validations / " + str(expectation_suite_name)
         if data_asset_name:
-            page_title += " / " + data_asset_name
+            page_title += " / " + str(data_asset_name)
         if include_run_name:
-            page_title += " / " + run_name
-        page_title += " / " + run_time
+            page_title += " / " + str(run_name)
+        page_title += " / " + str(run_time)
 
         return RenderedDocumentContent(
             **{
@@ -230,7 +230,7 @@ class ValidationResultsPageRenderer(Renderer):
         expectation_suite_path_components = (
             [".." for _ in range(len(expectation_suite_name.split(".")) + 3)]
             + ["expectations"]
-            + expectation_suite_name.split(".")
+            + str(expectation_suite_name).split(".")
         )
         expectation_suite_path = (
             os.path.join(*expectation_suite_path_components) + ".html"
@@ -546,7 +546,7 @@ class ExpectationSuitePageRenderer(Renderer):
         return RenderedDocumentContent(
             **{
                 "renderer_type": "ExpectationSuitePageRenderer",
-                "page_title": "Expectations / " + expectation_suite_name,
+                "page_title": "Expectations / " + str(expectation_suite_name),
                 "expectation_suite_name": expectation_suite_name,
                 "utm_medium": "expectation-suite-page",
                 "sections": sections,
@@ -820,12 +820,12 @@ class ProfilingResultsPageRenderer(Renderer):
         if run_name_as_time != run_time_datetime and run_name_as_time != "__none__":
             include_run_name = True
 
-        page_title = "Profiling Results / " + expectation_suite_name
+        page_title = "Profiling Results / " + str(expectation_suite_name)
         if data_asset_name:
-            page_title += " / " + data_asset_name
+            page_title += " / " + str(data_asset_name)
         if include_run_name:
-            page_title += " / " + run_name
-        page_title += " / " + run_time
+            page_title += " / " + str(run_name)
+        page_title += " / " + str(run_time)
 
         return RenderedDocumentContent(
             **{

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -446,6 +446,13 @@ class DefaultSiteSectionBuilder:
                     data_context_id=self.data_context_id,
                     show_how_to_buttons=self.show_how_to_buttons,
                 )
+
+                self.target_store.set(
+                    SiteSectionIdentifier(
+                        site_section_name=self.name, resource_identifier=resource_key,
+                    ),
+                    viewable_content,
+                )
             except Exception as e:
                 exception_message = f"""\
 An unexpected Exception occurred during data docs rendering.  Because of this error, certain parts of data docs will \
@@ -458,13 +465,6 @@ diagnose and repair the underlying issue.  Detailed information follows:
                     f'Traceback: "{exception_traceback}".'
                 )
                 logger.error(exception_message, e, exc_info=True)
-
-            self.target_store.set(
-                SiteSectionIdentifier(
-                    site_section_name=self.name, resource_identifier=resource_key,
-                ),
-                viewable_content,
-            )
 
 
 class DefaultSiteIndexBuilder:


### PR DESCRIPTION

Changes proposed in this pull request:
- Fixes #1913
-
-


