### PR TITLE
[MAINTENANCE] Unpin black in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
 altair>=4.0.0,<5  # package
-black==19.10b0  # package
+black>=19.10b0  # package
 Click>=7.1.2  # package
 importlib-metadata>=1.7.0 # package (included in Python 3.8 by default.)
 ipywidgets>=7.5.1  # package


### PR DESCRIPTION
Related #1600 #1897 

I'm not removing black from the requirements, but I'm allowing for the most recent version (`20.8*`), which passes the tests in `test_ge_utils.py`. I'm leaving the dev requirements pinned.