### PR TITLE
[ENHANCEMENT] Show data asset name in Slack message

### DIFF
--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -37,6 +37,20 @@ class SlackRenderer(Renderer):
                 "expectation_suite_name", "__no_expectation_suite_name__"
             )
 
+            datasource_name = validation_result.meta["data_asset_name"]["datasource"]
+            generator_name = validation_result.meta["data_asset_name"]["generator"]
+            generator_asset_name = validation_result.meta["data_asset_name"][
+                "generator_asset"
+            ]
+            data_asset_name_list = []
+            if datasource_name:
+                data_asset_name_list.append(datasource_name)
+            if generator_name:
+                data_asset_name_list.append(generator_name)
+            if generator_asset_name:
+                data_asset_name_list.append(generator_asset_name)
+            data_asset_name = "/".join(data_asset_name_list)
+
             n_checks_succeeded = validation_result.statistics["successful_expectations"]
             n_checks = validation_result.statistics["evaluated_expectations"]
             run_id = validation_result.meta.get("run_id", "__no_run_id__")
@@ -52,10 +66,16 @@ class SlackRenderer(Renderer):
 
             summary_text = """*Batch Validation Status*: {}
 *Expectation suite name*: `{}`
+*Data asset name*: `{}`
 *Run ID*: `{}`
 *Batch ID*: `{}`
 *Summary*: {}""".format(
-                status, expectation_suite_name, run_id, batch_id, check_details_text,
+                status,
+                expectation_suite_name,
+                data_asset_name,
+                run_id,
+                batch_id,
+                check_details_text,
             )
             query["blocks"][0]["text"]["text"] = summary_text
             # this abbreviated root level "text" will show up in the notification and not the message

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -37,19 +37,24 @@ class SlackRenderer(Renderer):
                 "expectation_suite_name", "__no_expectation_suite_name__"
             )
 
-            datasource_name = validation_result.meta["data_asset_name"]["datasource"]
-            generator_name = validation_result.meta["data_asset_name"]["generator"]
-            generator_asset_name = validation_result.meta["data_asset_name"][
-                "generator_asset"
-            ]
-            data_asset_name_list = []
-            if datasource_name:
-                data_asset_name_list.append(datasource_name)
-            if generator_name:
-                data_asset_name_list.append(generator_name)
-            if generator_asset_name:
-                data_asset_name_list.append(generator_asset_name)
-            data_asset_name = "/".join(data_asset_name_list)
+            if "data_asset_name" in validation_result.meta:
+                datasource_name = validation_result.meta["data_asset_name"][
+                    "datasource"
+                ]
+                generator_name = validation_result.meta["data_asset_name"]["generator"]
+                generator_asset_name = validation_result.meta["data_asset_name"][
+                    "generator_asset"
+                ]
+                data_asset_name_list = []
+                if datasource_name:
+                    data_asset_name_list.append(datasource_name)
+                if generator_name:
+                    data_asset_name_list.append(generator_name)
+                if generator_asset_name:
+                    data_asset_name_list.append(generator_asset_name)
+                data_asset_name = "/".join(data_asset_name_list)
+            else:
+                data_asset_name = "__no_data_asset_name__"
 
             n_checks_succeeded = validation_result.statistics["successful_expectations"]
             n_checks = validation_result.statistics["evaluated_expectations"]

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -37,22 +37,10 @@ class SlackRenderer(Renderer):
                 "expectation_suite_name", "__no_expectation_suite_name__"
             )
 
-            if "data_asset_name" in validation_result.meta:
-                datasource_name = validation_result.meta["data_asset_name"][
-                    "datasource"
-                ]
-                generator_name = validation_result.meta["data_asset_name"]["generator"]
-                generator_asset_name = validation_result.meta["data_asset_name"][
-                    "generator_asset"
-                ]
-                data_asset_name_list = []
-                if datasource_name:
-                    data_asset_name_list.append(datasource_name)
-                if generator_name:
-                    data_asset_name_list.append(generator_name)
-                if generator_asset_name:
-                    data_asset_name_list.append(generator_asset_name)
-                data_asset_name = "/".join(data_asset_name_list)
+            if "batch_kwargs" in validation_result.meta:
+                data_asset_name = validation_result.meta["batch_kwargs"].get(
+                    "data_asset_name", "__no_data_asset_name__"
+                )
             else:
                 data_asset_name = "__no_data_asset_name__"
 

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -38,7 +38,7 @@ def test_SlackRenderer_validation_results_with_datadocs():
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {"type": "divider"},
@@ -68,7 +68,7 @@ def test_SlackRenderer_validation_results_with_datadocs():
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {
@@ -105,7 +105,7 @@ def test_SlackRenderer_validation_results_with_datadocs():
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -20,6 +20,7 @@ def test_SlackRenderer_validation_results_with_datadocs():
         },
         meta={
             "great_expectations_version": "v0.8.0__develop",
+            "batch_kwargs": {"data_asset_name": "x/y/z"},
             "data_asset_name": {
                 "datasource": "x",
                 "generator": "y",
@@ -38,7 +39,7 @@ def test_SlackRenderer_validation_results_with_datadocs():
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `data_asset_name=x/y/z`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {"type": "divider"},
@@ -54,6 +55,8 @@ def test_SlackRenderer_validation_results_with_datadocs():
         ],
         "text": "default: Success :tada:",
     }
+    print(rendered_output)
+    print(expected_output)
     assert rendered_output == expected_output
 
     data_docs_pages = {"local_site": "file:///localsite/index.html"}
@@ -68,7 +71,7 @@ def test_SlackRenderer_validation_results_with_datadocs():
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `data_asset_name=x/y/z`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {
@@ -105,7 +108,7 @@ def test_SlackRenderer_validation_results_with_datadocs():
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `None`\n*Summary*: *0* of *0* expectations were met",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `data_asset_name=x/y/z`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {


### PR DESCRIPTION
Changes proposed in this pull request:
- Show data asset name in Slack message
- Modify the Slack renderer test based on the updated Slack message

Relevant issue: https://github.com/great-expectations/great_expectations/issues/1805