### PR TITLE
[MAINTENANCE] Fix pinned black dep requirement

### DIFF
--- a/requirements-dev-test.txt
+++ b/requirements-dev-test.txt
@@ -3,7 +3,7 @@
 # To run tests for smaller subsets of infrastructure, please look at other requirements-dev-*.txt files.
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
-black==19.10b0  # lint
+black>=19.10b0  # lint
 freezegun>=0.3.15  # all_tests
 pytest>=5.3.5,<6.0.0  # all_tests
 pytest-cov>=2.8.1  # all_tests


### PR DESCRIPTION
This PR fixes a problem I ran into when starting to work on this project this afternoon.

Two `requirements*.txt` files are inconsistent - the normal one allows higher versions of `black` whereas the dev dependency pins it to a specific version.

```shell
$ grep black requirements*.txt
requirements.txt:black>=19.10b0  # package
requirements-dev-test.txt:black==19.10b0  # lint
```

By having them both be `>=` you can avoid a dependency incompatibility