### PR TITLE
[FEATURE] [WIP] Add add_expect_column_max_to_be_within_hours expectation - feedback pls

### DIFF
--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -1,5 +1,5 @@
 import inspect
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import lru_cache, wraps
 from itertools import zip_longest
 from numbers import Number
@@ -3656,6 +3656,42 @@ class Dataset(MetaDataset):
                 column_max = str(column_max)
 
         return {"success": success, "result": {"observed_value": column_max}}
+
+    @DocInherit
+    @MetaDataset.column_aggregate_expectation
+    def expect_column_max_to_be_within_hours(self, column, hours):
+        """Expect the column max time to be within a specified number of hours to now
+
+        expect_column_max_to_be_within_hours is a \
+        :func:`column_aggregate_expectation <great_expectations.dataset.MetaDataset.column_aggregate_expectation>`.
+
+        Args:
+            column (str): \
+                The column name
+            hours (int): \
+                The minimum number of hours between now and the maximum column time.
+
+        Returns:
+            An ExpectationSuiteValidationResult
+
+            Exact fields vary depending on the values passed to :ref:`result_format <result_format>` and
+            :ref:`include_config`, :ref:`catch_exceptions`, and :ref:`meta`.
+
+        Notes:
+            * hours is inclusive, so a difference of 1 hour between now and the maximum column value \
+            with a specified hours argument of 1 will succeed.
+
+        """
+        column_max = self.get_column_max(column, False)
+
+        if column_max is None:
+            success = False
+        else:
+            dt_min = datetime.today() - timedelta(hours=hours)
+            success = column_max >= dt_min
+
+        return {"success": success, "result": {"observed_value": column_max}}
+
 
     ###
     #


### PR DESCRIPTION
I've been meaning to contribute this one for a while. It's very simple, you give it a column and an hours argument and if the maximum value in that column is within the specified number of hours before right now it passes. At tails.com this is the most valuable expectation to us, we use to it as a latency check on all our data pipelines for decoupled alerting from the jobs themselves.

I'm aware there is a lot more to add before merging, but want to make sure it is a desired contribution before I add the rest!