### PR TITLE
[Draft - Enhancement] - enable using Minio for S3 backend

### DIFF
--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -383,6 +383,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
         platform_specific_separator=False,
         fixed_length_key=False,
         base_public_path=None,
+        endpoint_url=None,
     ):
         super().__init__(
             filepath_template=filepath_template,
@@ -392,6 +393,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
             platform_specific_separator=platform_specific_separator,
             fixed_length_key=fixed_length_key,
             base_public_path=base_public_path,
+       
         )
         self.bucket = bucket
         if prefix:
@@ -402,7 +404,8 @@ class TupleS3StoreBackend(TupleStoreBackend):
             # whether the rest of the key is built with platform-specific separators or not
             prefix = prefix.strip("/")
         self.prefix = prefix
-
+        self.endpoint_url = endpoint_url
+        
     def _build_s3_object_key(self, key):
         if self.platform_specific_separator:
             if self.prefix:
@@ -423,7 +426,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
     def _get(self, key):
         import boto3
 
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", endpoint_url=self.endpoint_url)
 
         s3_object_key = self._build_s3_object_key(key)
 
@@ -445,7 +448,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
     ):
         import boto3
 
-        s3 = boto3.resource("s3")
+        s3 = boto3.resource("s3", endpoint_url=self.endpoint_url)
 
         s3_object_key = self._build_s3_object_key(key)
 
@@ -468,7 +471,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
     def _move(self, source_key, dest_key, **kwargs):
         import boto3
 
-        s3 = boto3.resource("s3")
+        s3 = boto3.resource("s3", endpoint_url=self.endpoint_url)
 
         source_filepath = self._convert_key_to_filepath(source_key)
         if not source_filepath.startswith(self.prefix):
@@ -488,7 +491,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
 
         import boto3
 
-        s3 = boto3.client("s3")
+        s3 = boto3.client("s3", endpoint_url=self.endpoint_url)
 
         if self.prefix:
             s3_objects = s3.list_objects_v2(Bucket=self.bucket, Prefix=self.prefix)
@@ -534,7 +537,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
     def get_url_for_key(self, key, protocol=None):
         import boto3
 
-        location = boto3.client("s3").get_bucket_location(Bucket=self.bucket)[
+        location = boto3.client("s3", endpoint_url=self.endpoint_url).get_bucket_location(Bucket=self.bucket)[
             "LocationConstraint"
         ]
         if location is None:
@@ -543,7 +546,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
             location = "s3-" + location
         s3_key = self._convert_key_to_filepath(key)
 
-        location = boto3.client("s3").get_bucket_location(Bucket=self.bucket)[
+        location = boto3.client("s3", endpoint_url=self.endpoint_url).get_bucket_location(Bucket=self.bucket)[
             "LocationConstraint"
         ]
         if location is None:
@@ -580,7 +583,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
         if not isinstance(key, tuple):
             key = key.to_tuple()
 
-        s3 = boto3.resource("s3")
+        s3 = boto3.resource("s3", endpoint_url=self.endpoint_url)
         s3_object_key = self._build_s3_object_key(key)
         s3.Object(self.bucket, s3_object_key).delete()
         if s3_object_key:


### PR DESCRIPTION

Minio is a S3 API Compatible storage, to use it, we need to add an endpoint_url instead of the default s3 URL. So far I am able to run a checkpoint by adding endpoint_url argument.

We probably need to have some test(not sure what is the easiest way to do that, would love to have some help)


Related issue #1692 
![image](https://user-images.githubusercontent.com/18221871/95216963-433fd100-0825-11eb-8c9a-129706043d82.png)
![image](https://user-images.githubusercontent.com/18221871/95217010-4f2b9300-0825-11eb-8ae8-cb2e084b6881.png)


