### PR TITLE
[BUGFIX] duplicate s3 approach _build_gcs_object_key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Develop
 
 * [BUGFIX] Change default prefix for TupleStoreBackend (issue 1907)
 * [ENHANCEMENT] Add spark support for expect_compound_columns_to_be_unique(Thanks @tscottcoombes1)!
+* [BUGFIX] Duplicate s3 approach for GCS for building object keys
 
 0.12.3
 -----------------

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -647,11 +647,28 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         self.project = project
         self._public_urls = public_urls
 
+    def _build_gcs_object_key(self, key):
+        if self.platform_specific_separator:
+            if self.prefix:
+                gcs_object_key = os.path.join(
+                    self.prefix, self._convert_key_to_filepath(key)
+                )
+            else:
+                gcs_object_key = self._convert_key_to_filepath(key)
+        else:
+            if self.prefix:
+                gcs_object_key = "/".join(
+                    (self.prefix, self._convert_key_to_filepath(key))
+                )
+            else:
+                gcs_object_key = self._convert_key_to_filepath(key)
+        return gcs_object_key
+
     def _move(self, source_key, dest_key, **kwargs):
         pass
 
     def _get(self, key):
-        gcs_object_key = os.path.join(self.prefix, self._convert_key_to_filepath(key))
+        gcs_object_key = self._build_gcs_object_key(key)
 
         from google.cloud import storage
 
@@ -668,7 +685,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
     def _set(
         self, key, value, content_encoding="utf-8", content_type="application/json"
     ):
-        gcs_object_key = os.path.join(self.prefix, self._convert_key_to_filepath(key))
+        gcs_object_key = self._build_gcs_object_key(key)
 
         from google.cloud import storage
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Recreate key creation for s3 in TupleGCSStoreBackend. Closes Issue #1951 and #1886 
