### PR TITLE
[BUGFIX] fix site_names functionality and add site_names param to get_docs_sites_urls

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Develop
 * [BUGFIX] Query batch kwargs support for Athena backend (issue 1964)
 
 * [BUGFIX] Skip config substitution if key is "password"
+* [BUGFIX] fix site_names functionality and add site_names param to get_docs_sites_urls
 
 0.12.4
 -----------------

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -510,6 +510,7 @@ class BaseDataContext:
         resource_identifier=None,
         site_name: Optional[str] = None,
         only_if_exists=True,
+        site_names: Optional[List[str]] = None,
     ) -> List[Dict[str, str]]:
         """
         Get URLs for a resource for all data docs sites.
@@ -524,12 +525,24 @@ class BaseDataContext:
                 the URLs of the index page.
             site_name: Optionally specify which site to open. If not specified,
                 return all urls in the project.
+            site_names: Optionally specify which sites are active. Sites not in
+                this list are not processed, even if specified in site_name.
 
         Returns:
             list: a list of URLs. Each item is the URL for the resource for a
                 data docs site
         """
-        sites = self._project_config_with_variables_substituted.data_docs_sites
+        unfiltered_sites = (
+            self._project_config_with_variables_substituted.data_docs_sites
+        )
+
+        # Filter out sites that are not in site_names
+        sites = (
+            {k: v for k, v in unfiltered_sites.items() if k in site_names}
+            if site_names
+            else unfiltered_sites
+        )
+
         if not sites:
             logger.debug("Found no data_docs_sites.")
             return []
@@ -1548,7 +1561,7 @@ class BaseDataContext:
             for site_name, site_config in sites.items():
                 logger.debug("Building Data Docs Site %s" % site_name,)
 
-                if (site_names and site_name in site_names) or not site_names:
+                if (site_names and (site_name in site_names)) or not site_names:
                     complete_site_config = site_config
                     module_name = "great_expectations.render.renderer.site_builder"
                     site_builder = instantiate_class_from_config(

--- a/great_expectations/validation_operators/actions.py
+++ b/great_expectations/validation_operators/actions.py
@@ -38,7 +38,7 @@ class ValidationAction:
         validation_result_suite,
         validation_result_suite_identifier,
         data_asset,
-        **kwargs
+        **kwargs,
     ):
         """
 
@@ -52,7 +52,7 @@ class ValidationAction:
             validation_result_suite,
             validation_result_suite_identifier,
             data_asset,
-            **kwargs
+            **kwargs,
         )
 
     def _run(
@@ -211,9 +211,7 @@ PagerdutyAlertAction sends a pagerduty event
         """
         super().__init__(data_context)
         if not pypd:
-            raise DataContextError(
-                "ModuleNotFoundError: No module named 'pypd'"
-            )
+            raise DataContextError("ModuleNotFoundError: No module named 'pypd'")
         self.api_key = api_key
         assert api_key, "No Pagerduty api_key found in action config."
         self.routing_key = routing_key
@@ -254,16 +252,18 @@ PagerdutyAlertAction sends a pagerduty event
                 "expectation_suite_name", "__no_expectation_suite_name__"
             )
             pypd.api_key = self.api_key
-            pypd.EventV2.create(data={
-                "routing_key": self.routing_key,
-                "dedup_key": expectation_suite_name,
-                "event_action": "trigger",
-                "payload": {
-                    "summary": f"Great Expectations suite check {expectation_suite_name} has failed",
-                    "severity": "critical",
-                    "source": "Great Expectations",
+            pypd.EventV2.create(
+                data={
+                    "routing_key": self.routing_key,
+                    "dedup_key": expectation_suite_name,
+                    "event_action": "trigger",
+                    "payload": {
+                        "summary": f"Great Expectations suite check {expectation_suite_name} has failed",
+                        "severity": "critical",
+                        "source": "Great Expectations",
+                    },
                 }
-            })
+            )
 
             return {"pagerduty_alert_result": "success"}
         return {"pagerduty_alert_result": "none sent"}
@@ -538,7 +538,8 @@ list of sites to update:
 
         # get the URL for the validation result
         docs_site_urls_list = self.data_context.get_docs_sites_urls(
-            resource_identifier=validation_result_suite_identifier
+            resource_identifier=validation_result_suite_identifier,
+            site_names=self._site_names,
         )
         # process payload
         data_docs_validation_results = {}


### PR DESCRIPTION
Changes proposed in this pull request:
- Make the site_names functionality work as intended (skip handling of data docs sites not listed in site_names)
- Don't try to connect to sites that are not listed in site_names
- Some formatting changes from black in actions.py

Previous Design Review notes:
- Closes #1991 

