### PR TITLE
[ENHANCEMENT] Data Docs now displays row and column count in the more info section of Validation Result pages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,8 @@ Changelog
 Develop
 -----------------
 * [BUGFIX] Query batch kwargs support for Athena backend (issue 1964)
-
 * [BUGFIX] Skip config substitution if key is "password"
+* [ENHANCEMENT] Data Docs now displays row count and column count in the more info section of Validation Result pages
 
 0.12.4
 -----------------

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -66,6 +66,7 @@ class DataAsset:
         )
         batch_parameters = kwargs.pop("batch_parameters", {})
         batch_markers = kwargs.pop("batch_markers", {})
+        batch_shape = kwargs.pop("batch_shape", {})
 
         if "autoinspect_func" in kwargs:
             warnings.warn(
@@ -81,6 +82,7 @@ class DataAsset:
         self._data_context = data_context
         self._batch_kwargs = BatchKwargs(batch_kwargs)
         self._batch_markers = batch_markers
+        self._batch_shape = batch_shape
         self._batch_parameters = batch_parameters
 
         # This special state variable tracks whether a validation run is going on, which will disable
@@ -457,6 +459,10 @@ class DataAsset:
     @property
     def batch_markers(self):
         return self._batch_markers
+
+    @property
+    def batch_shape(self):
+        return self._batch_shape
 
     @property
     def batch_parameters(self):
@@ -995,6 +1001,7 @@ class DataAsset:
                     "batch_markers": self.batch_markers,
                     "batch_parameters": self.batch_parameters,
                     "validation_time": validation_time,
+                    "batch_shape": self.batch_shape,
                 },
             )
 

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -380,6 +380,7 @@ Notes:
         "_batch_kwargs",
         "_batch_markers",
         "_batch_parameters",
+        "_batch_shape",
         "_batch_id",
         "_expectation_suite",
         "_config",
@@ -417,6 +418,10 @@ Notes:
         self.discard_subset_failing_expectations = kwargs.get(
             "discard_subset_failing_expectations", False
         )
+        self._batch_shape = {
+            "row_count": self.get_row_count(),
+            "column_count": self.get_column_count(),
+        }
 
     def _apply_row_condition(self, row_condition, condition_parser):
         if condition_parser not in ["python", "pandas"]:

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -603,6 +603,10 @@ This class holds an attribute `spark_df` which is a spark.sql.DataFrame.
         self._persist = kwargs.pop("persist", True)
         if self._persist:
             self.spark_df.persist()
+        self._batch_shape = {
+            "row_count": self.get_row_count(),
+            "column_count": self.get_column_count(),
+        }
         super().__init__(*args, **kwargs)
 
     def head(self, n=5):

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -576,6 +576,10 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         if len(self.columns) == 0:
             self.columns = self.column_reflection_fallback()
 
+        self._batch_shape = {
+            "row_count": self.get_row_count(),
+            "column_count": self.get_column_count(),
+        }
         # Only call super once connection is established and table_name and columns known to allow autoinspection
         super().__init__(*args, **kwargs)
 

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -121,6 +121,14 @@ class ValidationResultsPageRenderer(Renderer):
             self._render_validation_info(validation_results=validation_results)
         ]
 
+        if validation_results["meta"].get("batch_shape"):
+            collapse_content_blocks.append(
+                self._render_nested_table_from_dict(
+                    input_dict=validation_results["meta"].get("batch_shape"),
+                    header="Batch Shape",
+                )
+            )
+
         if validation_results["meta"].get("batch_markers"):
             collapse_content_blocks.append(
                 self._render_nested_table_from_dict(

--- a/tests/profile/fixtures/expected_evrs_BasicSuiteBuilderProfiler_on_titanic_demo_mode.json
+++ b/tests/profile/fixtures/expected_evrs_BasicSuiteBuilderProfiler_on_titanic_demo_mode.json
@@ -7,7 +7,8 @@
       "ge_batch_id": "29669d54-7b8f-11ea-9d75-acde48001122"
     },
     "batch_markers": {},
-    "batch_parameters": {}
+    "batch_parameters": {},
+    "batch_shape": {"row_count": 1313, "column_count": 7}
   },
   "statistics": {
     "evaluated_expectations": 32,

--- a/tests/profile/fixtures/expected_evrs_SuiteBuilderProfiler_on_titanic_with_configurations.json
+++ b/tests/profile/fixtures/expected_evrs_SuiteBuilderProfiler_on_titanic_with_configurations.json
@@ -7,7 +7,8 @@
       "ge_batch_id": "3888859e-7b90-11ea-b685-acde48001122"
     },
     "batch_markers": {},
-    "batch_parameters": {}
+    "batch_parameters": {},
+    "batch_shape": {"row_count": 1313,"column_count": 7}
   },
   "statistics": {
     "evaluated_expectations": 22,

--- a/tests/profile/test_basic_suite_builder_profiler.py
+++ b/tests/profile/test_basic_suite_builder_profiler.py
@@ -342,6 +342,7 @@ def test_BasicSuiteBuilderProfiler_with_context(filesystem_csv_data_context):
         "batch_kwargs",
         "batch_markers",
         "batch_parameters",
+        "batch_shape",
         "expectation_suite_name",
         "great_expectations_version",
         "run_id",

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -265,6 +265,7 @@ def test_BasicDatasetProfiler_with_context(filesystem_csv_data_context):
         "batch_kwargs",
         "batch_markers",
         "batch_parameters",
+        "batch_shape",
         "expectation_suite_name",
         "great_expectations_version",
         "run_id",

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -789,6 +789,7 @@ def test_validate():
             "batch_kwargs": {"ge_batch_id": "1234"},
             "batch_markers": {},
             "batch_parameters": {},
+            "batch_shape": {"column_count": 7, "row_count": 1313},
         },
         results=[
             ExpectationValidationResult(

--- a/tests/test_sets/titanic_expected_data_asset_validate_results.json
+++ b/tests/test_sets/titanic_expected_data_asset_validate_results.json
@@ -233,6 +233,7 @@
       "ge_batch_id": "1234"
     },
     "batch_markers": {},
+    "batch_shape": {"column_count": 7, "row_count": 1313},
     "batch_parameters": {},
     "validation_time": "19551105T000000.000000Z"
   }

--- a/tests/test_sets/titanic_expected_data_asset_validate_results_with_exceptions.json
+++ b/tests/test_sets/titanic_expected_data_asset_validate_results_with_exceptions.json
@@ -10,6 +10,7 @@
     },
     "batch_markers": {},
     "batch_parameters": {},
+    "batch_shape": {"column_count": 7, "row_count": 1313},
     "validation_time": "19551105T000000.000000Z"
   },
   "results": [


### PR DESCRIPTION
## Background

> Hey when I look at these nice shiny data docs pages I have no idea how big the data sets were that were validated! Was it a tiny sample file that got ingested, or was it the entire prod table?

## Changes proposed in this pull request:

[ENHANCEMENT] Data Docs now displays row count and column count in the more info section of Validation Result pages

## Previous Design Review notes:
- client request

## Screenshot
 
<img width="738" alt="Data_documentation_compiled_by_Great_Expectations" src="https://user-images.githubusercontent.com/928247/96194577-e1a7f280-0f07-11eb-90c6-9052459c312e.png">
