### PR TITLE
[DOCS] Docs minor clarifications based on users' question in support

### DIFF
--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
@@ -61,7 +61,7 @@ To add an S3-backed Pandas datasource do this:
                     regex_filter: .*  # The regex filter will filter the results returned by S3 for the key and prefix to only those matching the regex
                   your_third_data_asset_name:
                     prefix: prefix_to_folder_containing_your_third_data_asset_files/ # trailing slash is important
-                    regex_filter: .*  # The regex filter will filter the results returned by S3 for the key and prefix to only those matching the regex
+                    regex_filter: .*  # The regex filter will filter the results returned by S3 for the prefix to only those matching the regex. Note: construct your regex to match the entire S3 key (including the prefix).
             module_name: great_expectations.datasource
             data_asset_type:
               class_name: PandasDataset

--- a/docs/guides/how_to_guides/validation/how_to_update_data_docs_as_a_validation_action.rst
+++ b/docs/guides/how_to_guides/validation/how_to_update_data_docs_as_a_validation_action.rst
@@ -68,7 +68,7 @@ Steps
 Additional notes
 ----------------
 
-The ``UpdateDataDocsAction`` generates an HTML file for the latest validation result and updates the index page to link to the new file. It does not perform a full rebuild of Data Docs sites. This means that every time an existing Expectation Suite is edited (or a new Expectation Suite is created), you should run full Data Docs rebuild (via CLI's ``great_expectations docs build`` command or by calling ``context.build_data_docs()``) for the current state of that Expectation Suite to be reflected in Data Docs.
+The ``UpdateDataDocsAction`` generates an HTML file for the latest validation result and updates the index page to link to the new file, and re-renders expectation suite pages. It does not perform a full rebuild of Data Docs sites. This means that if you wish to render older Validation Results, you should run full Data Docs rebuild (via CLI's ``great_expectations docs build`` command or by calling ``context.build_data_docs()``).
 
 
 Additional resources

--- a/docs/guides/how_to_guides/validation/how_to_update_data_docs_as_a_validation_action.rst
+++ b/docs/guides/how_to_guides/validation/how_to_update_data_docs_as_a_validation_action.rst
@@ -65,6 +65,12 @@ Steps
     2. Run the Checkpoint and verify that no errors are thrown. You can run the Checkpoint from the CLI as explained :ref:`here<how_to_guides__validation__how_to_run_a_checkpoint_in_terminal>` or from Python, as explained :ref:`here<how_to_guides__validation__how_to_run_a_checkpoint_in_python>`.
     3. Check your configured Data Docs sites to confirm that a new Validation Result has been added.
 
+Additional notes
+----------------
+
+The ``UpdateDataDocsAction`` generates an HTML file for the latest validation result and updates the index page to link to the new file. It does not perform a full rebuild of Data Docs sites. This means that every time an existing Expectation Suite is edited (or a new Expectation Suite is created), you should run full Data Docs rebuild (via CLI's ``great_expectations docs build`` command or by calling ``context.build_data_docs()``) for the current state of that Expectation Suite to be reflected in Data Docs.
+
+
 Additional resources
 --------------------
 


### PR DESCRIPTION
1. A clarification on regex filter for S3 batch kwargs gen 
2. A clarification in the How to update Data Docs as a Validation Action" guide 

Both were prompted by users' questions.
