### PR TITLE
Revert "[BUGFIX] remove black from requirements.txt"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
 altair>=4.0.0,<5  # package
+black>=19.10b0  # package
 Click>=7.1.2  # package
 importlib-metadata>=1.7.0 # package (included in Python 3.8 by default.)
 ipywidgets>=7.5.1  # package


### PR DESCRIPTION
Reverts great-expectations/great_expectations#1973

Note:
- black needs to be pinned for automated tests in requirements-dev-test.txt
- black needs to be included in requirements.txt but does not need to be pinned, since it is used within the Great Expectations package to lint code (e.g. checkpoints and jupyter rendering)
- If you have conflicts when developing, make sure to run tests in a separate environment from where you are running a locally modified copy of Great Expectations (so that the tests can use the pinned black, and the installed GE can use the latest black).