### PR TITLE
Remove incorrect doc line from PagerdutyAlertAction

### DIFF
--- a/great_expectations/validation_operators/actions.py
+++ b/great_expectations/validation_operators/actions.py
@@ -191,7 +191,6 @@ PagerdutyAlertAction sends a pagerduty event
     - name: send_pagerduty_alert_on_validation_result
     action:
       class_name: PagerdutyAlertAction
-      # put the actual webhook URL in the uncommitted/config_variables.yml file
       api_key: ${pagerduty_api_key} # Events API v2 key
       routing_key: # The 32 character Integration Key for an integration on a service or on a global ruleset.
       notify_on: failure # possible values: "all", "failure", "success"


### PR DESCRIPTION
Just spotted this doc line I accidentally left when I copied from the slack validation operator