### PR TITLE
[BUGFIX] Escape $ characters in configuration, support multiple substitutions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Develop
 -----------------
+* [BUGFIX] Escape $ characters in configuration, support multiple substitutions #2015
 
 0.12.6
 -----------------

--- a/docs/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.rst
+++ b/docs/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.rst
@@ -33,6 +33,12 @@ Steps
       password: ${MY_DB_PW}
       database: postgres
 
+  .. admonition:: Note:
+
+    - If you wish to store values that include the dollar sign character ``$``, please escape them using a backslash ``\`` so substitution is not attempted. For example in the above example for postgres credentials you could set ``password: pa\$sword`` if your password is ``pa$sword``. Say that 5 times fast, and also please choose a more secure password!
+    - When you save values via the CLI, they are automatically escaped if they contain the ``$`` character.
+    - You can also have multiple substitutions for the same item, e.g. ``database_string: ${USER}:${PASSWORD}@${HOST}:${PORT}/${DATABASE}``
+
   If using environment variables, set values by entering ``export ENV_VAR_NAME=env_var_value`` in the terminal or adding the commands to your ``~/.bashrc`` file:
 
   .. code-block:: bash
@@ -53,7 +59,7 @@ Steps
 
     config_variables_file_path: uncommitted/config_variables.yml
 
-3. Replace credentials or other values in your ``great_expectations.yml`` with ${}-wrapped variable names (i.e. ``${ENVIRONMENT_VARIABLE}`` or ``${YAML_KEY}``).
+3. Replace credentials or other values in your ``great_expectations.yml`` with ``${}``-wrapped variable names (i.e. ``${ENVIRONMENT_VARIABLE}`` or ``${YAML_KEY}``).
 
   .. code-block:: yaml
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -740,6 +740,8 @@ class BaseDataContext:
             None
         """
         config_variables = self._load_config_variables_file()
+        # Escape $ if value is a str
+        value = value.replace("$", "$--") if isinstance(value, str) else value
         config_variables[config_variable_name] = value
         config_variables_filepath = self.get_config().config_variables_file_path
         if not config_variables_filepath:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1958,6 +1958,7 @@ def empty_data_context(tmp_path_factory):
 @pytest.fixture
 def empty_data_context_with_config_variables(monkeypatch, empty_data_context):
     monkeypatch.setenv("FOO", "BAR")
+    monkeypatch.setenv("REPLACE_ME_ESCAPED_ENV", "ive_been_$--replaced")
     root_dir = empty_data_context.root_directory
     ge_config_path = file_relative_path(
         __file__, "./test_fixtures/great_expectations_basic_with_variables.yml",

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -27,6 +27,7 @@ def data_context_without_config_variables_filepath_configured(tmp_path_factory):
 @pytest.fixture()
 def data_context_with_variables_in_config(tmp_path_factory, monkeypatch):
     monkeypatch.setenv("FOO", "BAR")
+    monkeypatch.setenv("REPLACE_ME_ESCAPED_ENV", "ive_been_$--replaced")
     # This data_context is *manually* created to have the config we want, vs created with DataContext.create
     project_path = str(tmp_path_factory.mktemp("data_context"))
     context_path = os.path.join(project_path, "great_expectations")

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -116,7 +116,7 @@ def test_setting_config_variables_is_visible_immediately(
     config_variables_with_escaped_vars = context._load_config_variables_file()
     assert (
         config_variables_with_escaped_vars["escaped_password"]
-        == "this_is_$--mypassword_escape_the_$--signs"
+        == r"this_is_\$mypassword_escape_the_\$signs"
     )
     # Ensure that when reading the escaped config variable, the escaping should be removed
     assert (
@@ -188,6 +188,7 @@ def test_substituted_config_variables_not_written_to_file(tmp_path_factory):
 
 def test_runtime_environment_are_used_preferentially(tmp_path_factory, monkeypatch):
     monkeypatch.setenv("FOO", "BAR")
+    monkeypatch.setenv("REPLACE_ME_ESCAPED_ENV", r"ive_been_\$replaced")
     value_from_environment = "from_environment"
     os.environ["replace_me"] = value_from_environment
 
@@ -290,14 +291,14 @@ See https://great-expectations.readthedocs.io/en/latest/reference/data_context_r
 
     # Escaped `$` (don't substitute, but return un-escaped string)
     assert (
-        substitute_config_variable("abc$--{arg0}$--aRg3", config_variables_dict)
+        substitute_config_variable(r"abc\${arg0}\$aRg3", config_variables_dict)
         == "abc${arg0}$aRg3"
     )
 
     # Multiple configurations together
     assert (
         substitute_config_variable(
-            "prefix$ARG4.$arg0/$aRg3:${ARG4}/$--dontsub${arg0}:${aRg3}.suffix",
+            r"prefix$ARG4.$arg0/$aRg3:${ARG4}/\$dontsub${arg0}:${aRg3}.suffix",
             config_variables_dict,
         )
         == "prefixval_of_ARG_4.val_of_arg_0/val_of_aRg_3:val_of_ARG_4/$dontsubval_of_arg_0:val_of_aRg_3.suffix"
@@ -308,7 +309,7 @@ def test_substitute_env_var_in_config_variable_file(
     monkeypatch, empty_data_context_with_config_variables
 ):
     monkeypatch.setenv("FOO", "correct_val_of_replace_me")
-    monkeypatch.setenv("REPLACE_ME_ESCAPED_ENV", "ive_been_$--replaced")
+    monkeypatch.setenv("REPLACE_ME_ESCAPED_ENV", r"ive_been_\$replaced")
     context = empty_data_context_with_config_variables
     context_config = context.get_config_with_variables_substituted()
     my_generator = context_config["datasources"]["mydatasource"][

--- a/tests/test_fixtures/config_variables.yml
+++ b/tests/test_fixtures/config_variables.yml
@@ -6,4 +6,4 @@ replace_me_2:
 arg1:
   v1: 2
 REPLACE_ME_FROM_ESCAPED_ENV: ${REPLACE_ME_ESCAPED_ENV}
-escaped_password_already_in_config_yml: correct_hor$--e_battery_$--taple
+escaped_password_already_in_config_yml: correct_hor\$e_battery_\$taple

--- a/tests/test_fixtures/config_variables.yml
+++ b/tests/test_fixtures/config_variables.yml
@@ -5,7 +5,5 @@ replace_me_2:
   inner_env_sub: ${FOO}
 arg1:
   v1: 2
-DO_REPLACE_ME: ive_been_replaced
-DO_REPLACE_ME_ENV: ive_been_replaced
-AND_ME: and_me_replaced
-Also_Me: also_me_replaced
+REPLACE_ME_FROM_ESCAPED_ENV: ${REPLACE_ME_ESCAPED_ENV}
+escaped_password_already_in_config_yml: correct_hor$--e_battery_$--taple

--- a/tests/test_fixtures/config_variables.yml
+++ b/tests/test_fixtures/config_variables.yml
@@ -5,3 +5,7 @@ replace_me_2:
   inner_env_sub: ${FOO}
 arg1:
   v1: 2
+DO_REPLACE_ME: ive_been_replaced
+DO_REPLACE_ME_ENV: ive_been_replaced
+AND_ME: and_me_replaced
+Also_Me: also_me_replaced

--- a/tests/test_fixtures/great_expectations_basic_with_variables.yml
+++ b/tests/test_fixtures/great_expectations_basic_with_variables.yml
@@ -13,11 +13,11 @@ datasources:
       mygenerator:
         class_name: SubdirReaderBatchKwargsGenerator
         base_directory: ../data
-        test_variable_escaped: dont$--replace$--me$--please$$$$--thanks${REPLACE_ME_FROM_ESCAPED_ENV}
+        test_variable_escaped: dont\$replace\$me\$please\$\$\$\$thanks${REPLACE_ME_FROM_ESCAPED_ENV}
         reader_options:
           sep:
           engine: python
-          password: dont$--replaceme
+          password: dont\$replaceme
           test_variable_sub1: ${replace_me}
           test_variable_sub2: $replace_me
           test_variable_sub3: ${replace_me_1}

--- a/tests/test_fixtures/great_expectations_basic_with_variables.yml
+++ b/tests/test_fixtures/great_expectations_basic_with_variables.yml
@@ -13,15 +13,18 @@ datasources:
       mygenerator:
         class_name: SubdirReaderBatchKwargsGenerator
         base_directory: ../data
-        password: dont$replace$me$please$$$$thanks
+        password: dont$--replace$--me$--please$$$$--thanks$DO_REPLACE_ME_ENV
         reader_options:
           sep:
           engine: python
-          password: dont$replaceme
+          password: dont$--replaceme
           test_variable_sub1: ${replace_me}
           test_variable_sub2: $replace_me
           test_variable_sub3: ${replace_me_1}
           test_variable_sub4: ${replace_me_2}
+          test_variable_sub5: hello$DO_REPLACE_ME/not_me
+          test_variable_sub6: hello$DO_REPLACE_ME_ENV/not_me
+          test_variable_sub7: hello$DO_REPLACE_ME_ENV$AND_ME${Also_Me}/not_me
 
 
 config_variables_file_path: uncommitted/config_variables.yml

--- a/tests/test_fixtures/great_expectations_basic_with_variables.yml
+++ b/tests/test_fixtures/great_expectations_basic_with_variables.yml
@@ -13,7 +13,7 @@ datasources:
       mygenerator:
         class_name: SubdirReaderBatchKwargsGenerator
         base_directory: ../data
-        password: dont$--replace$--me$--please$$$$--thanks$DO_REPLACE_ME_ENV
+        test_variable_escaped: dont$--replace$--me$--please$$$$--thanks${REPLACE_ME_FROM_ESCAPED_ENV}
         reader_options:
           sep:
           engine: python
@@ -22,10 +22,8 @@ datasources:
           test_variable_sub2: $replace_me
           test_variable_sub3: ${replace_me_1}
           test_variable_sub4: ${replace_me_2}
-          test_variable_sub5: hello$DO_REPLACE_ME/not_me
-          test_variable_sub6: hello$DO_REPLACE_ME_ENV/not_me
-          test_variable_sub7: hello$DO_REPLACE_ME_ENV$AND_ME${Also_Me}/not_me
-
+          test_escaped_env_var_from_config: prefix$REPLACE_ME_FROM_ESCAPED_ENV/suffix
+          test_escaped_manually_entered_value_from_config: $escaped_password_already_in_config_yml
 
 config_variables_file_path: uncommitted/config_variables.yml
 expectations_store_name: expectations_store


### PR DESCRIPTION
This PR reverts PR #1949 and instead adds escaping for the `$` character via `\` to configuration substitution. For example, you can now set `password: pa\$sword` if your password is `pa$sword`. Additionally, it adds support for multiple substitutions in the same item, e.g. `database_string: ${USER}:${PASSWORD}@${HOST}:${PORT}/${DATABASE}`. It also adds escaping when saving items, e.g. via the CLI.

Closes #2005 
