### PR TITLE
Remove column starting with "__eval_col_" in expect_table_columns_to_…

### DIFF
--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -611,7 +611,12 @@ class Dataset(MetaDataset):
 
         """
         column_set = set(column_set) if column_set is not None else set()
-        dataset_columns_list = self.get_table_columns()
+
+        # Remove spark eval_col "__eval_col_" from dataset_columns_list TODO: Fix this hack
+        dataset_columns_list = [
+            c for c in self.get_table_columns() if not c.startswith("__eval_col_")
+        ]
+
         dataset_columns_set = set(dataset_columns_list)
 
         if (


### PR DESCRIPTION
…match_set

PR is a draft because: this has not yet been replicated locally with spark, nor has it been tested to see if it works, and I'm hoping there is a better fix. This is for #2017 

I'm also concerned that this test currently does not fail, even though it sets both exact_match_out and exact_match to true (meaning there should not be any extraneous columns) :
https://github.com/great-expectations/great_expectations/blob/6e19808d6ce3ed6e1a2ce9f6746c26d71167bb3a/tests/test_definitions/other_expectations/expect_table_columns_to_match_set_test_set.json#L17-L30