### PR TITLE
[BUGFIX] add missing markdown_content_block_container

### DIFF
--- a/great_expectations/render/view/templates/markdown_content_block_container.j2
+++ b/great_expectations/render/view/templates/markdown_content_block_container.j2
@@ -1,0 +1,13 @@
+{% include 'markdown_content_block_header.j2' %}
+
+{% if "styling" in content_block -%}
+    {% set content_block_styling = content_block["styling"] | render_styling -%}
+{% else -%}
+    {% set content_block_styling = "" -%}
+{% endif -%}
+
+<div id="{{ content_block_id }}-container" {{ content_block_body_styling | replace("{{section_id}}", section_id) | replace("{{content_block_id}}", content_block_id) }}>
+  {% for el in content_block["content_blocks"] %}
+    {{ el | render_content_block }}
+  {% endfor %}
+</div>


### PR DESCRIPTION
Changes proposed in this pull request:
- Add missing template to markdown renderer for markdown_content_block_container
This issue was discovered by prefect team: https://github.com/PrefectHQ/prefect/discussions/3558#discussioncomment-132863
