### PR TITLE
[BUGFIX] Fixed a divided by zero error for checkpoints on empty expectation suites

### DIFF
--- a/great_expectations/cli/checkpoint.py
+++ b/great_expectations/cli/checkpoint.py
@@ -124,7 +124,9 @@ from great_expectations.core.usage_statistics.usage_statistics import send_usage
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import DataContextError
 from great_expectations.util import lint_code
-from great_expectations.validation_operators.types.validation_operator_result import ValidationOperatorResult
+from great_expectations.validation_operators.types.validation_operator_result import (
+    ValidationOperatorResult,
+)
 
 try:
     from sqlalchemy.exc import SQLAlchemyError
@@ -319,22 +321,28 @@ def checkpoint_run(checkpoint, directory):
     sys.exit(0)
 
 
-def print_validation_operator_results_details(results: ValidationOperatorResult) -> None:
+def print_validation_operator_results_details(
+    results: ValidationOperatorResult,
+) -> None:
     max_suite_display_width = 40
-    toolkit.cli_message(f"""
-{'Suite Name'.ljust(max_suite_display_width)}     Status     Expectations met""")
+    toolkit.cli_message(
+        f"""
+{'Suite Name'.ljust(max_suite_display_width)}     Status     Expectations met"""
+    )
     for id, result in results.run_results.items():
-        vr = result['validation_result']
+        vr = result["validation_result"]
         stats = vr.statistics
-        passed = stats['successful_expectations']
-        evaluated = stats['evaluated_expectations']
-        percentage_slug = f"{round(passed / evaluated * 100, 2)} %"
+        passed = stats["successful_expectations"]
+        evaluated = stats["evaluated_expectations"]
+        percentage_slug = (
+            f"{round(passed / evaluated * 100, 2) if evaluated > 0 else 0} %"
+        )
         stats_slug = f"{passed} of {evaluated} ({percentage_slug})"
         if vr.success:
             status_slug = "<green>✔ Passed</green>"
         else:
             status_slug = "<red>✖ Failed</red>"
-        suite_name = str(vr.meta['expectation_suite_name'])
+        suite_name = str(vr.meta["expectation_suite_name"])
         if len(suite_name) > max_suite_display_width:
             suite_name = suite_name[0:max_suite_display_width]
             suite_name = suite_name[:-1] + "…"

--- a/great_expectations/cli/checkpoint.py
+++ b/great_expectations/cli/checkpoint.py
@@ -335,7 +335,7 @@ def print_validation_operator_results_details(
         passed = stats["successful_expectations"]
         evaluated = stats["evaluated_expectations"]
         percentage_slug = (
-            f"{round(passed / evaluated * 100, 2) if evaluated > 0 else 0} %"
+            f"{round(passed / evaluated * 100, 2) if evaluated > 0 else 100} %"
         )
         stats_slug = f"{passed} of {evaluated} ({percentage_slug})"
         if vr.success:


### PR DESCRIPTION
Changes proposed in this pull request:
- Running a checkpoint on an empty expectation suite was causing a divided by zero error. Added an if statement to prevent this.