### PR TITLE
[BUGFIX] TupleS3StoreBackend: pass AWS_PROFILE to boto3.session as part of _set

### DIFF
--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -445,8 +445,8 @@ class TupleS3StoreBackend(TupleStoreBackend):
     def _set(
         self, key, value, content_encoding="utf-8", content_type="application/json"
     ):
-        import boto3
         import os
+        import boto3
         
         session = boto3.session.Session(profile_name=os.getenv('AWS_PROFILE'))
         s3 = session.resource("s3", endpoint_url=self.endpoint_url)

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -446,9 +446,10 @@ class TupleS3StoreBackend(TupleStoreBackend):
         self, key, value, content_encoding="utf-8", content_type="application/json"
     ):
         import boto3
-
-        s3 = boto3.resource("s3", endpoint_url=self.endpoint_url)
-
+        import os
+        
+        session = boto3.session.Session(profile_name=os.getenv('AWS_PROFILE'))
+        s3 = session.resource("s3", endpoint_url=self.endpoint_url)
         s3_object_key = self._build_s3_object_key(key)
 
         try:


### PR DESCRIPTION
Changes proposed in this pull request:
- fixing issue (likely bug in boto3?) when default boto3.resource('s3') (default session, really) does not pick profile from aws_profile
- this tweak fixed everything for me, and while is not very elegant, should not affect anything else

