### PR TITLE
[BUGFIX] Updated sort to correctly return partial unexpected results when expect_column_values_to_be_of_type has more than one unexpected type

### DIFF
--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -1155,7 +1155,7 @@ class DataAsset:
                         Counter(unexpected_list).most_common(
                             result_format["partial_unexpected_count"]
                         ),
-                        key=lambda x: (-x[1], x[0]),
+                        key=lambda x: (-x[1], str(x[0])),
                     )
                 ]
             except TypeError:


### PR DESCRIPTION
Resolves #1994 

Changes proposed in this pull request:
- When using `expect_column_values_to_be_of_type", if there was more than one kind of unexpected type, we run into an error with `sorted` - we sort based on frequency of value firstly and then by the value itself secondarily, and we are unable to sort values of mixed types. I updated this so that instead of secondarily sorting by the value itself, we sort by `str(value)`.

Previous Design Review notes:
- @anthonyburdi and I discussed changing the error message, but given that I was able to fix the actual cause for the error, and given that the error is not specific to this expectation, but will arise for any TypeError, I decided to leave the error message the same for now, until a more obvious reason comes along (I'm not sure what might trigger it now).

Thank you for submitting!
