### PR TITLE
[BUGFIX] Resolve Data Docs resource identifier issues

### DIFF
--- a/docs/guides/how_to_guides/validation/how_to_update_data_docs_as_a_validation_action.rst
+++ b/docs/guides/how_to_guides/validation/how_to_update_data_docs_as_a_validation_action.rst
@@ -68,7 +68,7 @@ Steps
 Additional notes
 ----------------
 
-The ``UpdateDataDocsAction`` generates an HTML file for the latest validation result and updates the index page to link to the new file, and re-renders expectation suite pages. It does not perform a full rebuild of Data Docs sites. This means that if you wish to render older Validation Results, you should run full Data Docs rebuild (via CLI's ``great_expectations docs build`` command or by calling ``context.build_data_docs()``).
+The ``UpdateDataDocsAction`` generates an HTML file for the latest validation result and updates the index page to link to the new file, and re-renders pages for the suite used for that validation. It does not perform a full rebuild of Data Docs sites. This means that if you wish to render older Validation Results, you should run full Data Docs rebuild (via CLI's ``great_expectations docs build`` command or by calling ``context.build_data_docs()``).
 
 
 Additional resources

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -386,22 +386,14 @@ class DefaultSiteSectionBuilder:
                 source_store_keys, key=lambda x: x.run_id.run_time, reverse=True
             )[: self.validation_results_limit]
 
-        expectation_suite_identifier_exists: bool = any(
-            [isinstance(ri, ExpectationSuiteIdentifier) for ri in resource_identifiers]
-        ) if resource_identifiers is not None else False
-
         for resource_key in source_store_keys:
-
-            # All expectation suites are always rendered unless resource_identifiers contains ExpectationSuiteIdentifier(s).
-            if expectation_suite_identifier_exists or (self.name != "expectations"):
-
-                # if no resource_identifiers are passed, the section
-                # builder will build
-                # a page for every keys in its source store.
-                # if the caller did pass resource_identifiers, the section builder
-                # will build pages only for the specified resources
-                if resource_identifiers and resource_key not in resource_identifiers:
-                    continue
+            # if no resource_identifiers are passed, the section
+            # builder will build
+            # a page for every keys in its source store.
+            # if the caller did pass resource_identifiers, the section builder
+            # will build pages only for the specified resources
+            if resource_identifiers and resource_key not in resource_identifiers:
+                continue
 
             if self.run_name_filter:
                 if not resource_key_passes_run_name_filter(

--- a/great_expectations/validation_operators/actions.py
+++ b/great_expectations/validation_operators/actions.py
@@ -639,7 +639,10 @@ list of sites to update:
         # build_data_docs will return the index page for the validation results, but we want to return the url for the valiation result using the code below
         data_docs_index_pages = self.data_context.build_data_docs(
             site_names=self._site_names,
-            resource_identifiers=[validation_result_suite_identifier],
+            resource_identifiers=[
+                validation_result_suite_identifier,
+                validation_result_suite_identifier.expectation_suite_identifier,
+            ],
         )
 
         # get the URL for the validation result


### PR DESCRIPTION
Changes proposed in this pull request:
- Reverts the changes to `site_builder` from PR #1990 
- Updated `UpdateDataDocs` action so that by default, it renders both the validation result for the checkpoint as well as the expectation suite tied to that validation result.

Previous Design Review notes
-The problem was that when running the `UpdateDataDocs`, we were re-rendering all of the expectation suites in the project each time, which was causing performance issues. This was unexpected, as it seemed that only resources passed into `resource_identifiers` would be re-rendered. However given the change in #1990, there was a safeguard that re-rendered all expectation_suites automatically unless an expectation_suite was specifically passed in as a resource_identifier. That PR was important for insuring that we would always have an Expectations page, but after discussing with Taylor and Eugene, we came to the realization that the original functionality here was correct - a resource_identifier should be supplied if we want a resource to be re-rendered. However, we can solve for the issue that that PR was solving for (not having an expectation suite when running checkpoints on an empty data docs site) by updating the `UpdateDataDocs` action to render the validation results and the corresponding suite.

