### PR TITLE
[MAINTENANCE] Temporarily pin pip version to latest before 20.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - bash: pip install  pandas
@@ -142,7 +142,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - script: |
@@ -199,7 +199,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - script: |
@@ -233,7 +233,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - script: |
@@ -274,7 +274,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - script: |
@@ -310,7 +310,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - script: |


### PR DESCRIPTION
Our dependencies need to be updated to be compatible with the new pip resolver in pip v20.3 https://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html

Changes proposed in this pull request:
- pin pip to 20.2.4
