### PR TITLE
[ENHANCEMENT] Improved data docs performance by changing instantiation of Jinja environment

### DIFF
--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -57,6 +57,41 @@ class DefaultJinjaView:
         self.custom_styles_directory = custom_styles_directory
         self.custom_views_directory = custom_views_directory
 
+        templates_loader = PackageLoader("great_expectations", "render/view/templates")
+        styles_loader = PackageLoader("great_expectations", "render/view/static/styles")
+
+        loaders = [templates_loader, styles_loader]
+        if self.custom_styles_directory:
+            loaders.append(FileSystemLoader(self.custom_styles_directory))
+        if self.custom_views_directory:
+            loaders.append(FileSystemLoader(self.custom_views_directory))
+
+        self.env = Environment(
+            loader=ChoiceLoader(loaders),
+            autoescape=select_autoescape(["html", "xml"]),
+            extensions=["jinja2.ext.do"],
+        )
+
+        self.env.filters["render_string_template"] = self.render_string_template
+        self.env.filters[
+            "render_styling_from_string_template"
+        ] = self.render_styling_from_string_template
+        self.env.filters["render_styling"] = self.render_styling
+        self.env.filters["render_content_block"] = self.render_content_block
+        self.env.filters["render_markdown"] = self.render_markdown
+        self.env.filters[
+            "get_html_escaped_json_string_from_dict"
+        ] = self.get_html_escaped_json_string_from_dict
+        self.env.filters["generate_html_element_uuid"] = self.generate_html_element_uuid
+        self.env.filters[
+            "attributes_dict_to_html_string"
+        ] = self.attributes_dict_to_html_string
+        self.env.filters[
+            "render_bootstrap_table_data"
+        ] = self.render_bootstrap_table_data
+        self.env.globals["ge_version"] = ge_version
+        self.env.filters["add_data_context_id_to_url"] = self.add_data_context_id_to_url
+
     def render(self, document, template=None, **kwargs):
         self._validate_document(document)
 
@@ -72,40 +107,7 @@ class DefaultJinjaView:
         if template is None:
             return NoOpTemplate
 
-        templates_loader = PackageLoader("great_expectations", "render/view/templates")
-        styles_loader = PackageLoader("great_expectations", "render/view/static/styles")
-
-        loaders = [templates_loader, styles_loader]
-
-        if self.custom_styles_directory:
-            loaders.append(FileSystemLoader(self.custom_styles_directory))
-        if self.custom_views_directory:
-            loaders.append(FileSystemLoader(self.custom_views_directory))
-
-        env = Environment(
-            loader=ChoiceLoader(loaders),
-            autoescape=select_autoescape(["html", "xml"]),
-            extensions=["jinja2.ext.do"],
-        )
-        env.filters["render_string_template"] = self.render_string_template
-        env.filters[
-            "render_styling_from_string_template"
-        ] = self.render_styling_from_string_template
-        env.filters["render_styling"] = self.render_styling
-        env.filters["render_content_block"] = self.render_content_block
-        env.filters["render_markdown"] = self.render_markdown
-        env.filters[
-            "get_html_escaped_json_string_from_dict"
-        ] = self.get_html_escaped_json_string_from_dict
-        env.filters["generate_html_element_uuid"] = self.generate_html_element_uuid
-        env.filters[
-            "attributes_dict_to_html_string"
-        ] = self.attributes_dict_to_html_string
-        env.filters["render_bootstrap_table_data"] = self.render_bootstrap_table_data
-        env.globals["ge_version"] = ge_version
-        env.filters["add_data_context_id_to_url"] = self.add_data_context_id_to_url
-
-        template = env.get_template(template)
+        template = self.env.get_template(template)
         template.globals["now"] = lambda: datetime.datetime.now(datetime.timezone.utc)
 
         return template


### PR DESCRIPTION
Changes proposed in this pull request:
- Previously, we instantiated a new Jinja environment every time we called DefaultJinjaView._get_template(). This meant that we could be doing this thousands of times (once for every template in Data Docs, which is a lot).
- This PR moves that instantiation into the `__init__` for the class so that we only instantiate the environment once per object. This leads to some pretty drastic performance improvements.

Previous Design Review notes:
- @roblim and I went through the code here which is how we came up with this solution. It might be possible to move this instantiation further up the chain, but for now this has major improvement gains with relatively minimal code changes.

