### PR TITLE
Remove stray print

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -340,7 +340,6 @@ class SqlAlchemyBatchData(object):
             sa.select([sa.func.count()]).select_from(self._selectable)
         )
         rows = result_object.fetchall()
-        print(rows)
 
         return rows[0][0]
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Drops a stray print statement

When running `test_yaml_config`, we were getting nuisance output. (Search for "9172565" in the code block.)

```
Attempting to instantiate class from config…
	Instantiating as a Datasource, since class_name is SimpleSqlalchemyDatasource
	Successfully instantiated SimpleSqlalchemyDatasource

Execution engine: SqlAlchemyExecutionEngine
Data connectors:
	whole_table : InferredAssetSqlDataConnector

	Available data_asset_names (3 of 4):
		case_ids (1 of 1): [{}]
		collisions (1 of 1): [{}]
		parties (1 of 1): [{}]

	Unmatched data_references (0 of 0): []

	Choosing an example data reference…
		Reference chosen: {}

		Fetching batch data…
[(9172565,)]

		Showing 5 rows
   case_id db_year
0  0081715    2020
1  0726202    2020
2  3493128    2020
3  3495044    2020
4  3503560    2020
```