### PR TITLE
[DOCS] Fix doc create and editing exptations

### DIFF
--- a/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_parameterized_expectations_super_fast.rst
+++ b/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_parameterized_expectations_super_fast.rst
@@ -6,12 +6,12 @@ This guide will walk you through the process of creating Parameterized Expectati
 .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
   - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
-  
-A Parameterized Expectation is a great new capability unlocked by new Modular Expectations. Now that Expectations are structured in class form, 
-it is easier than every before to inherit fromthese classes and build similar Expectations that are adapted to your own needs. 
+
+A Parameterized Expectation is a great new capability unlocked by new Modular Expectations. Now that Expectations are structured in class form,
+it is easier than every before to inherit fromthese classes and build similar Expectations that are adapted to your own needs.
 
 Steps
-_____
+-----
 1. Select an Expectation to inherit from
 ########################################
 
@@ -24,7 +24,7 @@ _____
 As can be seen in the implementation below, we have chosen to keep our default minimum value at 0, given that we are validating that all our values are positive. Setting the upper bound to ``None`` means that no upper bound will be checked -- effectively setting the threshold at ∞ and allowing any positive value.
 
 Notice that we do not need to set ``default_kwarg_values`` for all kwargs: it is sufficient to set them only for ones for which we would like to set a default value. To keep our implementation simple, we do not override the ``metric_dependencies`` or ``success_keys``.
-  
+
 .. code-block:: python
 
    class ExpectColumnMeanToBePositive(ExpectColumnMeanToBeBetween):

--- a/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_dynamically_load_evaluation_parameters_from_a_database.rst
+++ b/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_dynamically_load_evaluation_parameters_from_a_database.rst
@@ -30,7 +30,7 @@ Steps
 
     By default, query results will be returned as a list. If instead you need a scalar for your expectation, you can specify the return_type
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
       my_query_store:
         class_name: SqlAlchemyQueryStore


### PR DESCRIPTION
Changes proposed in this pull request:
- fix table of content for `Guides > `How-to Guides` > `Creating and editing expectations`
    - Original
    ![image](https://user-images.githubusercontent.com/5144808/100962890-3bb85200-3560-11eb-97ac-30f3ad019d05.png)
    - Fixed
    ![image](https://user-images.githubusercontent.com/5144808/100962898-41159c80-3560-11eb-828c-558cc97d4d11.png)

- fix code-block indentation for `Guides > `How-to Guides` > `Creating and editing expectations` > `How to dynamically load evaluation parameters from a database`
    - Original
    ![image](https://user-images.githubusercontent.com/5144808/100962934-57235d00-3560-11eb-9405-a1ca191749d5.png)

    - Fixed
    ![image](https://user-images.githubusercontent.com/5144808/100962941-5be81100-3560-11eb-89a7-19cc4d39e00e.png)
