### PR TITLE
Bugfix/validator.get default expectations args

### DIFF
--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -103,7 +103,6 @@ class Validator:
         }
         self._validator_config = {}
 
-
         # This special state variable tracks whether a validation run is going on, which will disable
         # saving expectation config objects
         self._active_validation = False

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -96,6 +96,13 @@ class Validator:
             expectation_suite=expectation_suite,
             expectation_suite_name=expectation_suite_name,
         )
+        self._default_expectation_args = {
+            "include_config": True,
+            "catch_exceptions": False,
+            "result_format": "BASIC",
+        }
+        self._validator_config = {}
+
 
         # This special state variable tracks whether a validation run is going on, which will disable
         # saving expectation config objects
@@ -654,12 +661,12 @@ class Validator:
         See also:
             set_default_expectation_arguments
         """
-        return self.execution_engine.default_expectation_args
+        return self._default_expectation_args
 
     @property
     def default_expectation_args(self):
         """A getter for default Expectation arguments"""
-        return self.execution_engine.default_expectation_args
+        return self._default_expectation_args
 
     def set_default_expectation_argument(self, argument, value):
         """
@@ -675,9 +682,8 @@ class Validator:
         See also:
             get_default_expectation_arguments
         """
-        # !!! Maybe add a validation check here?
 
-        self.default_expectation_args[argument] = value
+        self._default_expectation_args[argument] = value
 
     def get_expectations_config(
         self,

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -280,3 +280,48 @@ def test_graph_validate_with_runtime_config(basic_datasource):
             exception_info=None,
         )
     ]
+    
+def test_validator_default_expectation_args(basic_datasource):
+    df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10], "b": [1, 2, 3, 4, 5, None]})
+    expectationConfiguration = ExpectationConfiguration(
+        expectation_type="expect_column_value_z_scores_to_be_less_than",
+        kwargs={"column": "b", "mostly": 0.9, "threshold": 4, "double_sided": True,},
+    )
+
+    batch = basic_datasource.get_single_batch_from_batch_request(
+        BatchRequest(
+            **{
+                "datasource_name": "my_datasource",
+                "data_connector_name": "test_runtime_data_connector",
+                "batch_data": df,
+                "partition_request": PartitionRequest(
+                    **{
+                        "partition_identifiers": {
+                            "pipeline_stage_name": 0,
+                            "run_id": 0,
+                            "custom_key_0": 0,
+                        }
+                    }
+                ),
+            }
+        )
+    )
+
+    my_validator = Validator(
+        execution_engine=PandasExecutionEngine(), batches=[batch]
+    )
+
+    print(my_validator.get_default_expectation_arguments())
+
+def test_validator_default_expectation_args(data_context_with_sql_datasource_for_testing_get_batch):
+    context = data_context_with_sql_datasource_for_testing_get_batch
+
+    my_validator = context.get_validator(
+        datasource_name= "my_sqlite_db",
+        data_connector_name= "daily",
+        data_asset_name= "table_partitioned_by_date_column__A",
+        partition_identifiers= {"date": "2020-01-15"},
+        create_expectation_suite_with_name="test_suite",
+    )
+
+    print(my_validator.get_default_expectation_arguments())

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -281,6 +281,7 @@ def test_graph_validate_with_runtime_config(basic_datasource):
         )
     ]
 
+
 def test_validator_default_expectation_args__pandas(basic_datasource):
     df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10], "b": [1, 2, 3, 4, 5, None]})
     expectationConfiguration = ExpectationConfiguration(
@@ -307,20 +308,21 @@ def test_validator_default_expectation_args__pandas(basic_datasource):
         )
     )
 
-    my_validator = Validator(
-        execution_engine=PandasExecutionEngine(), batches=[batch]
-    )
+    my_validator = Validator(execution_engine=PandasExecutionEngine(), batches=[batch])
 
     print(my_validator.get_default_expectation_arguments())
 
-def test_validator_default_expectation_args__sql(data_context_with_sql_datasource_for_testing_get_batch):
+
+def test_validator_default_expectation_args__sql(
+    data_context_with_sql_datasource_for_testing_get_batch,
+):
     context = data_context_with_sql_datasource_for_testing_get_batch
 
     my_validator = context.get_validator(
-        datasource_name= "my_sqlite_db",
-        data_connector_name= "daily",
-        data_asset_name= "table_partitioned_by_date_column__A",
-        partition_identifiers= {"date": "2020-01-15"},
+        datasource_name="my_sqlite_db",
+        data_connector_name="daily",
+        data_asset_name="table_partitioned_by_date_column__A",
+        partition_identifiers={"date": "2020-01-15"},
         create_expectation_suite_with_name="test_suite",
     )
 

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -280,8 +280,8 @@ def test_graph_validate_with_runtime_config(basic_datasource):
             exception_info=None,
         )
     ]
-    
-def test_validator_default_expectation_args(basic_datasource):
+
+def test_validator_default_expectation_args__pandas(basic_datasource):
     df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10], "b": [1, 2, 3, 4, 5, None]})
     expectationConfiguration = ExpectationConfiguration(
         expectation_type="expect_column_value_z_scores_to_be_less_than",
@@ -313,7 +313,7 @@ def test_validator_default_expectation_args(basic_datasource):
 
     print(my_validator.get_default_expectation_arguments())
 
-def test_validator_default_expectation_args(data_context_with_sql_datasource_for_testing_get_batch):
+def test_validator_default_expectation_args__sql(data_context_with_sql_datasource_for_testing_get_batch):
     context = data_context_with_sql_datasource_for_testing_get_batch
 
     my_validator = context.get_validator(


### PR DESCRIPTION
Changes proposed in this pull request:
- Implement `Validator.default_expectation_arguments` and related methods, with basic smoke tests.
- Also adds `_validator_config` (used, but untested).