### PR TITLE
[BUGFIX] Update datasource config schema with spark_config

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -256,6 +256,9 @@ class DatasourceConfigSchema(Schema):
 
     credentials = fields.Raw(allow_none=True)
     spark_context = fields.Raw(allow_none=True)
+    spark_config = fields.Dict(
+        keys=fields.Str(), values=fields.Str(), allow_none=True
+    )
 
     @validates_schema
     def validate_schema(self, data, **kwargs):


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `spark_config` to base `DatasourceConfigSchema` to allow setting Spark env variables when defining a Spark datasource

Notes
* Currently, setting either `spark_config` or `spark_context` doesn't seem to have the effect of configuring the spark context
* The documentation seems to be a little ambiguous 
  * [This page](https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.html) notes a `spark_config` mapping in the datasource definition; 
  * [this other page](https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_datasources/how_to_configure_a_self_managed_spark_datasource.html) specifies a similar-seeming `spark_context` mapping.
* The `DatasourceConfigSchema` currently allows for a nullable `spark_context` with type `Raw`, which means any `spark_config` values in the config seem to be discarded during serialization. 
* Yet, the `SparkDFDatasource` requires a `spark_config` dictionary ([code](https://github.com/great-expectations/great_expectations/blob/6fd1ba3e2683ee2ef55e91a940d948e8a559e756/great_expectations/datasource/sparkdf_datasource.py#L104-L112)), which is drawn from the datasource config.

I went with the simplest solution here, which is just to add `spark_config` to the schema definition (right alongside the existing `spark_context`). But I'm not totally sure what the _intent_ of these two parameters are, so there may be a better, more consistent solution. Depending on the final decision here, we may also want to update the documentation.

More context and discussion...
* original discussion: https://greatexpectationstalk.slack.com/archives/CUTCNHN82/p1606928521489200
* issue opened by @EricSteg: https://github.com/great-expectations/great_expectations/issues/2104