### PR TITLE
[WIP][BUGFIX] TSQL mean on `int` columns (MSSQL)

### DIFF
--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -741,8 +741,9 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         return series
 
     def get_column_mean(self, column):
+        # column * 1.0 needed for correct calculation of avg in MSSQL
         return self.engine.execute(
-            sa.select([sa.func.avg(sa.column(column))]).select_from(self._table)
+            sa.select([sa.func.avg(sa.column(column) * 1.0)]).select_from(self._table)
         ).scalar()
 
     def get_column_unique_count(self, column):

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_mean.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_mean.py
@@ -26,7 +26,8 @@ class ColumnMean(ColumnMetricProvider):
     @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)
     def _sqlalchemy(cls, column, **kwargs):
         """SqlAlchemy Mean Implementation"""
-        return sa.func.avg(column)
+        # column * 1.0 needed for correct calculation of avg in MSSQL
+        return sa.func.avg(column * 1.0)
 
     @column_aggregate_partial(engine=SparkDFExecutionEngine)
     def _spark(cls, column, _table, _column_name, **kwargs):

--- a/tests/test_definitions/column_aggregate_expectations/expect_column_mean_to_be_between.json
+++ b/tests/test_definitions/column_aggregate_expectations/expect_column_mean_to_be_between.json
@@ -3,7 +3,7 @@
   "datasets": [{
       "data": {
         "x": [2.0, 5.0],
-        "y": [5, 5],
+        "y": [1, 2],
         "z": [0, 10],
         "n": [0, null],
         "b": [true, false]
@@ -55,12 +55,12 @@
           "exact_match_out": false,
           "in": {
             "column": "y",
-            "min_value": 5,
-            "max_value": 5
+            "min_value": 1.5,
+            "max_value": 1.5
           },
           "out": {
             "success": true,
-            "observed_value": 5
+            "observed_value": 1.5
           }
         },
         {
@@ -73,7 +73,7 @@
           },
           "out": {
             "success": false,
-            "observed_value": 5
+            "observed_value": 1.5
           }
         },
         {


### PR DESCRIPTION
Changes proposed in this pull request:
- Cast `int` columns to floats by multiplying by 1.0 for MSSQL (for both 0.12.x and 0.13 metric)
- Updated fixture for `expect_column_mean_to_be_between`
- Fixes #2126 