### PR TITLE
[BUGFIX] Slack messages occasionally give `NoneType` not iterable error.  

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@
 Changelog
 #########
 
+Develop
+-----------------
+
+
 0.13.2
 -----------------
 * [ENHANCEMENT] Support avro format in Spark datasource (thanks @ryanaustincarlson!) #2122

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -116,10 +116,6 @@ class SlackRenderer(Renderer):
                 }
                 query["blocks"].append(dataset_element)
 
-        custom_blocks = self._custom_blocks(evr=validation_result)
-        if custom_blocks:
-            query["blocks"].append(custom_blocks)
-
         documentation_url = "https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html"
         footer_section = {
             "type": "context",
@@ -136,30 +132,38 @@ class SlackRenderer(Renderer):
         query["blocks"].append(footer_section)
         return query
 
-    def _custom_blocks(self, evr):
-        return None
-
     def _get_report_element(self, docs_link):
         report_element = None
-        if docs_link is None:
+        if docs_link:
+            try:
+                if "file://" in docs_link:
+                    # handle special case since Slack does not render these links
+                    report_element = {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*DataDocs* can be found here: `{docs_link}` \n (Please copy and paste link into a browser to view)\n",
+                        },
+                    }
+                else:
+                    report_element = {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*DataDocs* can be found here: <{docs_link}|{docs_link}>",
+                        },
+                    }
+            except:
+                logger.warning(
+                    f"""SlackRenderer had a problem with generating the docs link.
+                        link used to generate the docs link is: {docs_link} and is of type: {type(docs_link)}
+                    """
+                )
+                return
+
+        else:
             logger.warning(
                 "No docs link found. Skipping data docs link in Slack message."
             )
-        elif "file://" in docs_link:
-            # handle special case since Slack does not render these links
-            report_element = {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*DataDocs* can be found here: `{docs_link}` \n (Please copy and paste link into a browser to view)\n",
-                },
-            }
-        else:
-            report_element = {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*DataDocs* can be found here: <{docs_link}|{docs_link}>",
-                },
-            }
+
         return report_element

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -140,11 +140,12 @@ class SlackRenderer(Renderer):
         return None
 
     def _get_report_element(self, docs_link):
+        report_element = None
         if docs_link is None:
-            logger.warn("No docs link found. Skipping data docs link in slack message.")
-            return
-
-        if "file://" in docs_link:
+            logger.warning(
+                "No docs link found. Skipping data docs link in Slack message."
+            )
+        elif "file://" in docs_link:
             # handle special case since Slack does not render these links
             report_element = {
                 "type": "section",

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -153,17 +153,15 @@ class SlackRenderer(Renderer):
                             "text": f"*DataDocs* can be found here: <{docs_link}|{docs_link}>",
                         },
                     }
-            except:
+            except Exception as e:
                 logger.warning(
                     f"""SlackRenderer had a problem with generating the docs link.
-                        link used to generate the docs link is: {docs_link} and is of type: {type(docs_link)}
-                    """
+                    link used to generate the docs link is: {docs_link} and is of type: {type(docs_link)}.
+                    Error: {e}"""
                 )
                 return
-
         else:
             logger.warning(
                 "No docs link found. Skipping data docs link in Slack message."
             )
-
         return report_element

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -1,11 +1,7 @@
-# from freezegun import freeze_time
-import pytest
-
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
 from great_expectations.render.renderer import SlackRenderer
-from tests.test_utils import modify_locale
 
 
 def test_SlackRenderer_validation_results_with_datadocs():

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -130,3 +130,15 @@ def test_SlackRenderer_validation_results_with_datadocs():
     }
 
     assert rendered_output == expected_output
+
+
+def test_SlackRenderer_get_report_element():
+    slack_renderer = SlackRenderer()
+
+    # these should all be caught
+    assert slack_renderer._get_report_element(docs_link=None) == None
+    assert slack_renderer._get_report_element(docs_link=1) == None
+    assert slack_renderer._get_report_element(docs_link=slack_renderer) == None
+
+    # this should work
+    assert slack_renderer._get_report_element(docs_link="i_should_work") is not None

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -136,9 +136,9 @@ def test_SlackRenderer_get_report_element():
     slack_renderer = SlackRenderer()
 
     # these should all be caught
-    assert slack_renderer._get_report_element(docs_link=None) == None
-    assert slack_renderer._get_report_element(docs_link=1) == None
-    assert slack_renderer._get_report_element(docs_link=slack_renderer) == None
+    assert slack_renderer._get_report_element(docs_link=None) is None
+    assert slack_renderer._get_report_element(docs_link=1) is None
+    assert slack_renderer._get_report_element(docs_link=slack_renderer) is None
 
     # this should work
     assert slack_renderer._get_report_element(docs_link="i_should_work") is not None


### PR DESCRIPTION
Changes proposed in this pull request:
- Added logic to better-handle exceptions when Slack report element is generated
- Since this is a sporadic error, added more-informative log messages for future debugging (if need be)
- Closes #2062 
