### PR TITLE
[BUGFIX] Fixed a bug in the error printing logic in several exception handling blocks in the Data Docs rendering

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ Changelog
 Develop
 -----------------
 * [ENHANCEMENT] Add support for connection_string and url in configuring DatabaseStoreBackend, bringing parity to other SQL-based objects. In the rare case of user code that instantiates a DatabaseStoreBackend without using the Great Expectations config architecture, users should ensure they are providing kwargs to init, because the init signature order has changed.
+* [BUGFIX] Fixed a bug in the error printing logic in several exception handling blocks in the Data Docs rendering. This will make it easier for users to submit error messages in case of an error in rendering.
+* [ENHANCEMENT] Improved exception handling in the Slack notifications rendering logic
+* [DOCS] Miscellaneous doc improvements
 
 
 0.13.2

--- a/great_expectations/render/renderer/column_section_renderer.py
+++ b/great_expectations/render/renderer/column_section_renderer.py
@@ -122,7 +122,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                 """
                 exception_traceback = traceback.format_exc()
                 exception_message += f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
-                logger.error(exception_message, e, exc_info=True)
+                logger.error(exception_message)
 
         # NOTE : Some render* functions return None so we filter them out
         populated_content_blocks = list(filter(None, content_blocks))

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -87,7 +87,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                             data_docs_exception_message
                             + f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
                         )
-                        logger.error(exception_message, e, exc_info=True)
+                        logger.error(exception_message)
 
                         if isinstance(obj_, ExpectationValidationResult):
                             content_block_fn = cls._get_content_block_fn(
@@ -201,7 +201,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                         data_docs_exception_message
                         + f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
                     )
-                    logger.error(exception_message, e, exc_info=True)
+                    logger.error(exception_message)
 
                     if isinstance(render_object, ExpectationValidationResult):
                         content_block_fn = cls._get_content_block_fn(

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -112,7 +112,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                     data_docs_exception_message
                     + f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
                 )
-                logger.error(exception_message, e, exc_info=True)
+                logger.error(exception_message)
             try:
                 unexpected_table_renderer = get_renderer_impl(
                     object_name=expectation_type,
@@ -129,7 +129,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                     data_docs_exception_message
                     + f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
                 )
-                logger.error(exception_message, e, exc_info=True)
+                logger.error(exception_message)
             try:
                 observed_value_renderer = get_renderer_impl(
                     object_name=expectation_type,
@@ -146,7 +146,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                     data_docs_exception_message
                     + f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
                 )
-                logger.error(exception_message, e, exc_info=True)
+                logger.error(exception_message)
 
             # If the expectation has some unexpected values...:
             if unexpected_statement:

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -464,7 +464,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                     f'{type(e).__name__}: "{str(e)}".  '
                     f'Traceback: "{exception_traceback}".'
                 )
-                logger.error(exception_message, e, exc_info=True)
+                logger.error(exception_message)
 
 
 class DefaultSiteIndexBuilder:
@@ -879,6 +879,8 @@ class DefaultSiteIndexBuilder:
 
         try:
             rendered_content = self.renderer_class.render(index_links_dict)
+            raise Exception("BBBBB")
+
             viewable_content = self.view_class.render(
                 rendered_content,
                 data_context_id=self.data_context_id,
@@ -894,7 +896,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
             exception_message += (
                 f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
             )
-            logger.error(exception_message, e, exc_info=True)
+            logger.error(exception_message)
 
         return (self.target_store.write_index_page(viewable_content), index_links_dict)
 

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -879,8 +879,6 @@ class DefaultSiteIndexBuilder:
 
         try:
             rendered_content = self.renderer_class.render(index_links_dict)
-            raise Exception("BBBBB")
-
             viewable_content = self.view_class.render(
                 rendered_content,
                 data_context_id=self.data_context_id,

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -461,4 +461,4 @@ diagnose and repair the underlying issue.  Detailed information follows:
             exception_message += (
                 f'{type(e).__name__}: "{str(e)}".  Traceback: "{exception_traceback}".'
             )
-            logger.error(exception_message, e, exc_info=True)
+            logger.error(exception_message)


### PR DESCRIPTION
### Changes proposed in this pull request:
- Fixed a bug in the error printing logic in several exception handling blocks in the Data Docs rendering. We passed both the message and the exception when  calling logger.error - it did not conform to the method signature and caused errors. Fixing this logic is important, since it helps users report their errors to us with sufficient context.


### Previous Design Review notes:
- N/A
