### PR TITLE
[BUGFIX]Pin the version of xlrd since 2.0.0 dropped support for xlsx files

### DIFF
--- a/requirements-dev-util.txt
+++ b/requirements-dev-util.txt
@@ -8,6 +8,6 @@ feather-format>=0.4.1  # all_tests
 google-cloud-storage>=1.28.0  # all_tests
 moto[ec2]>=1.3.7  # all_tests
 pyarrow>=0.12.0,<=1.0.0  # all_tests
-xlrd>=1.1.0  # all_tests
+xlrd>=1.1.0,<2.0.0  # all_tests
 s3fs>=0.5.1 # all_tests
 flask>=1.0.0 # for s3 test only


### PR DESCRIPTION
### Changes proposed in this pull request:
- pinning the version of xlrd since 2.0.0 dropped support for xlsx files
-
-


### Previous Design Review notes:
- N/A
-
-


Thank you for submitting!
