### PR TITLE
[ENHANCEMENT]A notebook that demonstrates how to create an Expectation Suite without sample data

### DIFF
--- a/examples/notebooks/create_expectation_suite_without_sample_data.ipynb
+++ b/examples/notebooks/create_expectation_suite_without_sample_data.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create an Expectation Suite without a sample batch of data\n",
+    "\n",
+    "#### This notebook demonstrates how to create an Expectation Suote without a sample of batch of data.\n",
+    "#### This is useful when you do not have sample data or when you know exactly what should be expected of your data and you want the suite authoring process to go faster by skipping the validation step.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import great_expectations as ge\n",
+    "import great_expectations.jupyter_ux\n",
+    "from great_expectations.core.expectation_configuration import ExpectationConfiguration\n",
+    "from great_expectations.data_context.types.resource_identifiers import ExpectationSuiteIdentifier\n",
+    "from great_expectations.exceptions import DataContextError\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Get a DataContext\n",
+    "\n",
+    "\n",
+    "#### The following line instantiates a DataContext object from the great_expectations.yml.\n",
+    "\n",
+    "#### If you do not have a config file (e.g., you are using Great Expectations in Databricks, AWS EMR Spark), you should replace the following cell with the code that builds configuration and instantiated a DataContext, as explained in this how-to guide: https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file.html\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context = ge.data_context.DataContext()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Get an existing Expectation Suite (by name) or create a new one"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expectation_suite_name = \"my_new_expectation_suite\" # TODO: replace with a name for your new suite\n",
+    "\n",
+    "try:\n",
+    "    suite = context.get_expectation_suite(expectation_suite_name)\n",
+    "except DataContextError:\n",
+    "    suite = context.create_expectation_suite(expectation_suite_name)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Add Expectations to the suite\n",
+    "\n",
+    "#### You are adding Expectations' configuration to the suite. Since there is no sample batch of data, no validation happens during this process. Consult the Expectation Glossary for the types of Expectations that can be added and their arguments: https://docs.greatexpectations.io/en/latest/reference/glossary_of_expectations.html\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create an Expectation\n",
+    "\n",
+    "expectation_config = ExpectationConfiguration(\n",
+    "    expectation_type=\"expect_table_columns_to_match_ordered_list\", # this is the name of the expectation type you are adding\n",
+    "    # These are the arguments of the expectation\n",
+    "    # The keys allowed in the dictionary are Parameters and Keyword Arguments of this Expectation Type\n",
+    "    kwargs={\n",
+    "        \"column_list\": [\"account_id\", \"user_id\", \"transaction_id\", \"transaction_type\", \"transaction_amt_usd\"]\n",
+    "    }, \n",
+    "    # This is how you can optionally add a comment about this expectation. \n",
+    "    # It will be rendered in Data Docs (see this guide for details: https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_docs/how_to_add_comments_to_expectations_and_display_them_in_data_docs.html)\n",
+    "    meta={ \n",
+    "        \"notes\": {\n",
+    "            \"format\": \"markdown\",\n",
+    "            \"content\": \"Some clever comment about this expectation. **Markdown** `Supported`\"\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# add the Expectation to the suite\n",
+    "\n",
+    "suite.add_expectation(expectation_config)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# just another example\n",
+    "\n",
+    "expectation_config = ExpectationConfiguration(\n",
+    "    expectation_type=\"expect_column_values_to_be_in_set\", \n",
+    "    kwargs={\n",
+    "        \"column\": \"transaction_type\",\n",
+    "        \"value_set\": [\"purchase\", \"refund\", \"upgrade\"]\n",
+    "    }, \n",
+    "    meta={\n",
+    "        \"notes\": {\n",
+    "            \"format\": \"markdown\",\n",
+    "            \"content\": \"Some clever comment about this expectation. **Markdown** `Supported`\"\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "suite.add_expectation(expectation_config)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Save the Expectation Suite"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context.save_expectation_suite(suite, expectation_suite_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Review the Expectation Suite in Data Docs (optional)\n",
+    "\n",
+    "#### Add the HTML view of the new Expectation Suite to Data Docs. It makes it easier to review the suite. \n",
+    "\n",
+    "#### Note: building a Data Docs view of the suite is also a good test. When you add Expectations's configurations to a suite the way shown in this notebook, there is no validation of the arguments that you are providing. Building Data Docs is an opportunity to catch if you forgot a required argument or provided a bad value.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "suite_identifier = ExpectationSuiteIdentifier(expectation_suite_name=expectation_suite_name)\n",
+    "context.build_data_docs(resource_identifiers=[suite_identifier])\n",
+    "context.open_data_docs(suite_identifier)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
### Changes proposed in this pull request:
- Add a notebook that demonstrates how to create an Expectation Suite without sample data to the example directory

### Previous Design Review notes:
- This is in response to user questions. We discussed this approach in a conversation with James and Sam on Dec 15.
- Here is a video to make the review easier: https://www.loom.com/share/4eb133fadf6e427984e531573b661e29
