### PR TITLE
[DOCS] add link to youtube video on in-code contexts

### DIFF
--- a/docs/guides/how_to_guides/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file.rst
+++ b/docs/guides/how_to_guides/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file.rst
@@ -9,6 +9,10 @@ This guide will help you instantiate a Data Context without a yml file, aka conf
 
     - :ref:`Followed the Getting Started tutorial and have a basic familiarity with the Great Expectations configuration<tutorials__getting_started>`.
 
+.. note::
+
+    See also our companion video for this guide: `Data Contexts In Code <https://youtu.be/4VMOYpjHNhM>`_.
+
 Steps
 -----
 


### PR DESCRIPTION
Add link to youtube video on in-code contexts via note at top of "How to instantiate a Data Context without a yml file" doc.