### PR TITLE
[DOCS] add a conda example to creating virtualenvs

### DIFF
--- a/docs/contributing/setting_up_your_dev_environment.rst
+++ b/docs/contributing/setting_up_your_dev_environment.rst
@@ -51,7 +51,8 @@ Install python dependencies
 **5. Create a new virtual environment**
 
     * Make a new virtual environment (e.g. using virtualenv or conda), name it "great_expectations_dev" or similar.
-    * Ex: ``python3 -m venv <path_to_environments_folder>/great_expectations_dev`` and then ``<source path_to_environments_folder>/great_expectations_dev/bin/activate``
+    * Ex virtualenv: ``python3 -m venv <path_to_environments_folder>/great_expectations_dev`` and then ``<source path_to_environments_folder>/great_expectations_dev/bin/activate``
+    * Ex conda: ``conda create --name great_expectations_dev`` and then ``conda activate great_expectations_dev``
     * This is not required, but highly recommended.
 
 **6. Install dependencies from requirements-dev.txt**


### PR DESCRIPTION
I happened to notice while following our instructions to test out the black conflict issues that we give an example for virtualenv but not for python in the `Setting up your dev environment` doc. Thought it might be nice to show both.