### PR TITLE
[ENHANCEMENT] Add an 'allow_extra' argument to ignore additional colu…

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,8 @@ Changelog
 Develop
 -----------------
 * [BUGFIX] Add pagination to TupleS3StoreBackend.list_keys() #2169 issue #2164
-*  [BUGFIX] Fix black conflict, upgrade black, make import optional #2183
+* [BUGFIX] Fix black conflict, upgrade black, make import optional #2183
+* [ENHANCEMENT] Add an 'allow_extra' argument to ignore additional columns in expect_table_columns_to_match_ordered_list
 
 0.13.3
 -----------------

--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -523,6 +523,7 @@ class Dataset(MetaDataset):
     def expect_table_columns_to_match_ordered_list(
         self,
         column_list,
+        allow_extra: Optional[bool] = False,
         result_format=None,
         include_config=True,
         catch_exceptions=None,
@@ -537,6 +538,9 @@ class Dataset(MetaDataset):
         Args:
             column_list (list of str): \
                 The column names, in the correct order.
+            allow_extra (boolean or None): \
+                If True, tables will still pass validation if they have additional columns, as long as the list matches \
+                beginning at index 0 (ie column 1 of the table).
 
         Other Parameters:
             result_format (str or None): \
@@ -560,7 +564,9 @@ class Dataset(MetaDataset):
 
         """
         columns = self.get_table_columns()
-        if column_list is None or list(columns) == list(column_list):
+
+        if column_list is None or list(columns) == list(column_list) or (allow_extra and list(columns)[:len(column_list)] == list(
+            column_list)):
             return {"success": True, "result": {"observed_value": list(columns)}}
         else:
             # In the case of differing column lengths between the defined expectation and the observed column set, the
@@ -4659,7 +4665,7 @@ class Dataset(MetaDataset):
 
         For example::
 
-            A B C            
+            A B C
             1 1 2 Fail
             1 2 3 Pass
             8 2 7 Pass
@@ -4711,7 +4717,7 @@ class Dataset(MetaDataset):
         Note that all instances of any duplicates are considered failed
 
         For example::
-        
+
             A B C
             1 1 2 Fail
             1 2 3 Pass

--- a/great_expectations/expectations/util.py
+++ b/great_expectations/expectations/util.py
@@ -517,6 +517,7 @@ legacy_method_parameters = {
     ),
     "expect_table_columns_to_match_ordered_list": (
         "column_list",
+        "exact_match",
         "result_format",
         "include_config",
         "catch_exceptions",

--- a/tests/test_definitions/other_expectations/expect_table_columns_to_match_ordered_list_test_set.json
+++ b/tests/test_definitions/other_expectations/expect_table_columns_to_match_ordered_list_test_set.json
@@ -24,6 +24,16 @@
         "success":true
       }
     },{
+      "title": "positive_test_additional_columns_allowed",
+      "exact_match_out": false,
+      "in":{
+        "column_list": ["c1", "c2"],
+        "allow_extra": true
+      },
+      "out":{
+        "success":true
+      }
+    },{
       "title": "negative_test_column_is_missing",
       "exact_match_out": false,
       "in":{


### PR DESCRIPTION
…mns in expect_table_columns_to_match_ordered_list

Adds an optional argument to expect_table_columns_to_match_ordered_list, which allows the target table to have additional columns to those speicified in the expectation list.

If this is set to True, the expectation will pass validation if the first n columns of the table (where n is the length of the provided list) passes the validation.


Changes proposed in this pull request:
- Adds 'allow_extra' to ignore additional columns for expect_table_columns_to_match_ordered_list

Previous Design Review notes:
- Slack: https://greatexpectationstalk.slack.com/archives/CUTCNHN82/p1607956485121300
- Discuss: https://discuss.greatexpectations.io/t/can-i-validate-a-list-of-predefined-columns-and-ignore-the-rest/563/2
