### PR TITLE
[BUGFIX] Pass manually_initialize_store_backend_id to database store backends

### DIFF
--- a/great_expectations/data_context/store/database_store_backend.py
+++ b/great_expectations/data_context/store/database_store_backend.py
@@ -43,11 +43,13 @@ class DatabaseStoreBackend(StoreBackend):
         engine=None,
         store_name=None,
         suppress_store_backend_id=False,
+        manually_initialize_store_backend_id: str = "",
         **kwargs,
     ):
         super().__init__(
             fixed_length_key=fixed_length_key,
             suppress_store_backend_id=suppress_store_backend_id,
+            manually_initialize_store_backend_id=manually_initialize_store_backend_id,
             store_name=store_name,
         )
         if not sa:

--- a/tests/data_context/store/test_database_store_backend.py
+++ b/tests/data_context/store/test_database_store_backend.py
@@ -5,6 +5,7 @@ import pytest
 
 import tests.test_utils as test_utils
 from great_expectations.data_context.store import DatabaseStoreBackend
+from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.exceptions import StoreBackendError
 
 
@@ -148,6 +149,8 @@ def test_database_store_backend_id_initialization(caplog, sa, test_backends):
     and persisted. The store_backend_id should be a valid UUIDv4
     If a new store_backend_id cannot be persisted, use an ephemeral store_backend_id.
     Persistence should be in a .ge_store_id file for for filesystem and blob-stores.
+    If an existing data_context_id is available in the great_expectations.yml, use this as the expectation_store id.
+    If a store_backend_id is provided via manually_initialize_store_backend_id, make sure it is retrievable.
 
     Note: StoreBackend & TupleStoreBackend are abstract classes, so we will test the
     concrete classes that inherit from them.
@@ -174,3 +177,36 @@ def test_database_store_backend_id_initialization(caplog, sa, test_backends):
     assert store_backend.store_backend_id is not None
     # Check that store_backend_id is a valid UUID
     assert test_utils.validate_uuid4(store_backend.store_backend_id)
+
+    # Test that expectations store can be created with specified store_backend_id
+
+    expectations_store_with_database_backend = instantiate_class_from_config(
+        config={
+            "class_name": "ExpectationsStore",
+            "store_backend": {
+                "class_name": "DatabaseStoreBackend",
+                "credentials": {
+                    "drivername": "postgresql",
+                    "username": "postgres",
+                    "password": "",
+                    "host": "localhost",
+                    "port": "5432",
+                    "database": "test_ci",
+                },
+                "manually_initialize_store_backend_id": "00000000-0000-0000-0000-000000aaaaaa",
+                "table_name": "ge_expectations_store",
+                "key_columns": {"expectation_suite_name"},
+            },
+            # "name": "postgres_expectations_store",
+        },
+        runtime_environment=None,
+        config_defaults={
+            "module_name": "great_expectations.data_context.store",
+            "store_name": "postgres_expectations_store",
+        },
+    )
+
+    assert (
+        expectations_store_with_database_backend.store_backend_id
+        == "00000000-0000-0000-0000-000000aaaaaa"
+    )


### PR DESCRIPTION
Changes proposed in this pull request:
- Pass manually_initialize_store_backend_id to database store backends
- This mirrors functionality for other store backends

Closes #2181 