### PR TITLE
[ENHANCEMENT] Data docs can now be built skipping the index page using the python API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Develop
 -----------------
-
+* [ENHANCEMENT] Data docs can now be built skipping the index page using the python API
 
 0.13.4
 -----------------

--- a/great_expectations/cli/docs.py
+++ b/great_expectations/cli/docs.py
@@ -145,7 +145,7 @@ def build_docs(context, site_name=None, view=True, assume_yes=False):
         toolkit.confirm_proceed_or_exit()
 
     cli_message("\nBuilding Data Docs...\n")
-    index_page_locator_infos = context.build_data_docs(site_names=site_names)
+    context.build_data_docs(site_names=site_names)
 
     cli_message("Done building Data Docs")
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -2130,7 +2130,11 @@ class BaseDataContext:
 
     @usage_statistics_enabled_method(event_name="data_context.build_data_docs")
     def build_data_docs(
-        self, site_names=None, resource_identifiers=None, dry_run=False
+        self,
+        site_names=None,
+        resource_identifiers=None,
+        dry_run=False,
+        build_index: bool = True,
     ):
         """
         Build Data Docs for your project.
@@ -2153,6 +2157,8 @@ class BaseDataContext:
                             these sites. The motivation for adding this flag was to allow
                             the CLI to display the the URLs before building and to let users
                             confirm.
+
+        :param build_index: a flag if False, skips building the index page
 
         Returns:
             A dictionary with the names of the updated data documentation sites as keys and the the location info
@@ -2195,7 +2201,7 @@ class BaseDataContext:
                         ] = site_builder.get_resource_url(only_if_exists=False)
                     else:
                         index_page_resource_identifier_tuple = site_builder.build(
-                            resource_identifiers
+                            resource_identifiers, build_index=build_index
                         )
                         if index_page_resource_identifier_tuple:
                             index_page_locator_infos[

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -269,7 +269,7 @@ class SiteBuilder:
     def clean_site(self):
         self.target_store.clean_site()
 
-    def build(self, resource_identifiers=None):
+    def build(self, resource_identifiers=None, build_index: bool = True):
         """
 
         :param resource_identifiers: a list of resource identifiers
@@ -280,6 +280,9 @@ class SiteBuilder:
                             This supports incremental build of data docs sites
                             (e.g., when a new validation result is created)
                             and avoids full rebuild.
+
+        :param build_index: a flag if False, skips building the index page
+
         :return:
         """
 
@@ -289,10 +292,12 @@ class SiteBuilder:
         for site_section, site_section_builder in self.site_section_builders.items():
             site_section_builder.build(resource_identifiers=resource_identifiers)
 
-        index_page_resource_identifier_tuple = self.site_index_builder.build()
+        index_page_url, index_links_dict = self.site_index_builder.build(
+            build_index=build_index
+        )
         return (
             self.get_resource_url(only_if_exists=False),
-            index_page_resource_identifier_tuple[1],
+            index_links_dict,
         )
 
     def get_resource_url(self, resource_identifier=None, only_if_exists=True):
@@ -684,15 +689,19 @@ class DefaultSiteIndexBuilder:
         return results
 
     # TODO: deprecate dual batch api support
-    def build(self, skip_and_clean_missing=True):
+    def build(self, skip_and_clean_missing=True, build_index: bool = True):
         """
         :param skip_and_clean_missing: if True, target html store keys without corresponding source store keys will
         be skipped and removed from the target store
+        :param build_index: a flag if False, skips building the index page
         :return: tuple(index_page_url, index_links_dict)
         """
 
         # Loop over sections in the HtmlStore
         logger.debug("DefaultSiteIndexBuilder.build")
+        if not build_index:
+            logger.debug("Skipping index rendering")
+            return None, None
 
         index_links_dict = OrderedDict()
         index_links_dict["site_name"] = self.site_name
@@ -701,6 +710,7 @@ class DefaultSiteIndexBuilder:
             index_links_dict["cta_object"] = self.get_calls_to_action()
 
         if (
+            # TODO why is this duplicated?
             self.site_section_builders_config.get("expectations", "None")
             and self.site_section_builders_config.get("expectations", "None")
             not in FALSEY_YAML_STRINGS
@@ -736,6 +746,7 @@ class DefaultSiteIndexBuilder:
 
         validation_and_profiling_result_site_keys = []
         if (
+            # TODO why is this duplicated?
             self.site_section_builders_config.get("validations", "None")
             and self.site_section_builders_config.get("validations", "None")
             not in FALSEY_YAML_STRINGS
@@ -745,6 +756,7 @@ class DefaultSiteIndexBuilder:
         ):
             source_store = (
                 "validations"
+                # TODO why is this duplicated?
                 if self.site_section_builders_config.get("validations", "None")
                 and self.site_section_builders_config.get("validations", "None")
                 not in FALSEY_YAML_STRINGS
@@ -776,6 +788,7 @@ class DefaultSiteIndexBuilder:
                 validation_and_profiling_result_site_keys = cleaned_keys
 
         if (
+            # TODO why is this duplicated?
             self.site_section_builders_config.get("profiling", "None")
             and self.site_section_builders_config.get("profiling", "None")
             not in FALSEY_YAML_STRINGS
@@ -822,6 +835,7 @@ class DefaultSiteIndexBuilder:
                     logger.warning(error_msg)
 
         if (
+            # TODO why is this duplicated?
             self.site_section_builders_config.get("validations", "None")
             and self.site_section_builders_config.get("validations", "None")
             not in FALSEY_YAML_STRINGS

--- a/great_expectations/validation_operators/actions.py
+++ b/great_expectations/validation_operators/actions.py
@@ -653,7 +653,7 @@ class UpdateDataDocsAction(ValidationAction):
             )
 
         # build_data_docs will return the index page for the validation results, but we want to return the url for the valiation result using the code below
-        data_docs_index_pages = self.data_context.build_data_docs(
+        self.data_context.build_data_docs(
             site_names=self._site_names,
             resource_identifiers=[
                 validation_result_suite_identifier,


### PR DESCRIPTION
Changes proposed in this pull request:

Situations can arise where for various reasons building the index page takes quite some time relative to building individual pages. When a checkpoint with many many validations is being run this accumulates into lots of overhead. In these situations a desirable feature is to build the index only once after all validations have been run. This PR implements an override to skip the index page if desired.

Previous Design Review notes:
- Design review in conversation with @eugmandel
