### PR TITLE
[BUGFIX] Mask passwords in DataContext.list_datasources()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Develop
 -----------------
-
+* [BUGFIX] Mask passwords in DataContext.list_datasources(). Issue #2184
 
 0.13.4
 -----------------

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -245,7 +245,7 @@ class PasswordMasker:
             return engine.url.__repr__()
         else:
             warnings.warn(
-                "SqlAlchemy is not installed, using urlparse to mask database url password which ignores **kwargs."
+                "SQLAlchemy is not installed, using urlparse to mask database url password which ignores **kwargs."
             )
 
             # oracle+cx_oracle does not parse well using urlparse, parse as oracle then swap back

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -283,6 +283,88 @@ def test_list_datasources(data_context_parameterized_expectation_suite):
         },
     ]
 
+    # Make sure passwords are masked in password or url fields
+    data_context_parameterized_expectation_suite.add_datasource(
+        "postgres_source_with_password",
+        initialize=False,
+        module_name="great_expectations.datasource",
+        class_name="SqlAlchemyDatasource",
+        credentials={
+            "drivername": "postgresql",
+            "host": "localhost",
+            "port": "65432",
+            "username": "username_str",
+            "password": "password_str",
+            "database": "database_str",
+        },
+    )
+
+    data_context_parameterized_expectation_suite.add_datasource(
+        "postgres_source_with_password_in_url",
+        initialize=False,
+        module_name="great_expectations.datasource",
+        class_name="SqlAlchemyDatasource",
+        credentials={
+            "url": "postgresql+psycopg2://username:password@host:65432/database",
+        },
+    )
+
+    datasources = data_context_parameterized_expectation_suite.list_datasources()
+
+    assert datasources == [
+        {
+            "name": "mydatasource",
+            "class_name": "PandasDatasource",
+            "module_name": "great_expectations.datasource",
+            "data_asset_type": {"class_name": "PandasDataset"},
+            "batch_kwargs_generators": {
+                "mygenerator": {
+                    "base_directory": "../data",
+                    "class_name": "SubdirReaderBatchKwargsGenerator",
+                    "reader_options": {"engine": "python", "sep": None},
+                }
+            },
+        },
+        {
+            "name": "second_pandas_source",
+            "class_name": "PandasDatasource",
+            "module_name": "great_expectations.datasource",
+            "data_asset_type": {
+                "class_name": "PandasDataset",
+                "module_name": "great_expectations.dataset",
+            },
+        },
+        {
+            "name": "postgres_source_with_password",
+            "class_name": "SqlAlchemyDatasource",
+            "module_name": "great_expectations.datasource",
+            "data_asset_type": {
+                "class_name": "SqlAlchemyDataset",
+                "module_name": "great_expectations.dataset",
+            },
+            "credentials": {
+                "drivername": "postgresql",
+                "host": "localhost",
+                "port": "65432",
+                "username": "username_str",
+                "password": "********",
+                "database": "database_str",
+            },
+        },
+        {
+            "name": "postgres_source_with_password_in_url",
+            "class_name": "SqlAlchemyDatasource",
+            "module_name": "great_expectations.datasource",
+            "data_asset_type": {
+                "class_name": "SqlAlchemyDataset",
+                "module_name": "great_expectations.dataset",
+            },
+            "credentials": {
+                "url": "postgresql+psycopg2://username:********@host:65432/database",
+            },
+        },
+    ]
+
 
 @freeze_time("09/26/2019 13:42:41")
 def test_data_context_get_validation_result(titanic_data_context):

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -347,7 +347,7 @@ def test_list_datasources(data_context_parameterized_expectation_suite):
                 "host": "localhost",
                 "port": "65432",
                 "username": "username_str",
-                "password": "********",
+                "password": "***",
                 "database": "database_str",
             },
         },
@@ -360,7 +360,7 @@ def test_list_datasources(data_context_parameterized_expectation_suite):
                 "module_name": "great_expectations.dataset",
             },
             "credentials": {
-                "url": "postgresql+psycopg2://username:********@host:65432/database",
+                "url": "postgresql+psycopg2://username:***@host:65432/database",
             },
         },
     ]

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 import great_expectations.exceptions as gee
+from great_expectations.data_context.util import PasswordMasker
 from great_expectations.util import load_class
 
 
@@ -12,3 +13,217 @@ def test_load_class_raises_error_when_module_not_found():
 def test_load_class_raises_error_when_class_not_found():
     with pytest.raises(gee.PluginClassNotFoundError):
         load_class("TotallyNotARealClass", "great_expectations.datasource")
+
+
+def test_password_masker_mask_db_url():
+    """
+    What does this test and why?
+    The PasswordMasker.mask_db_url() should mask passwords consistently in database urls.
+    This test uses database url examples from
+    https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
+    """
+    # PostgreSQL
+    # default
+    assert (
+        PasswordMasker.mask_db_url(
+            "postgresql://scott:tiger@localhost:65432/mydatabase"
+        )
+        == "postgresql://scott:***@localhost:65432/mydatabase"
+    )
+    assert (
+        PasswordMasker.mask_db_url(
+            "postgresql://scott:tiger@localhost:65432/mydatabase", use_urlparse=True
+        )
+        == "postgresql://scott:***@localhost:65432/mydatabase"
+    )
+    # missing port number, using urlparse
+    assert (
+        PasswordMasker.mask_db_url(
+            "postgresql://scott:tiger@localhost/mydatabase", use_urlparse=True
+        )
+        == "postgresql://scott:***@localhost/mydatabase"
+    )
+
+    # psycopg2
+    assert (
+        PasswordMasker.mask_db_url(
+            "postgresql+psycopg2://scott:tiger@localhost:65432/mydatabase"
+        )
+        == "postgresql+psycopg2://scott:***@localhost:65432/mydatabase"
+    )
+    assert (
+        PasswordMasker.mask_db_url(
+            "postgresql+psycopg2://scott:tiger@localhost:65432/mydatabase",
+            use_urlparse=True,
+        )
+        == "postgresql+psycopg2://scott:***@localhost:65432/mydatabase"
+    )
+
+    # pg8000 (if installed in test environment)
+    try:
+        assert (
+            PasswordMasker.mask_db_url(
+                "postgresql+pg8000://scott:tiger@localhost:65432/mydatabase"
+            )
+            == "postgresql+pg8000://scott:***@localhost:65432/mydatabase"
+        )
+    except ModuleNotFoundError:
+        pass
+    assert (
+        PasswordMasker.mask_db_url(
+            "postgresql+pg8000://scott:tiger@localhost:65432/mydatabase",
+            use_urlparse=True,
+        )
+        == "postgresql+pg8000://scott:***@localhost:65432/mydatabase"
+    )
+
+    # MySQL
+    # default (if installed in test environment)
+    try:
+        assert (
+            PasswordMasker.mask_db_url("mysql://scott:tiger@localhost:65432/foo")
+            == "mysql://scott:***@localhost:65432/foo"
+        )
+    except ModuleNotFoundError:
+        pass
+
+    assert (
+        PasswordMasker.mask_db_url(
+            "mysql://scott:tiger@localhost:65432/foo", use_urlparse=True
+        )
+        == "mysql://scott:***@localhost:65432/foo"
+    )
+
+    # mysqlclient (a maintained fork of MySQL-Python) (if installed in test environment)
+    try:
+        assert (
+            PasswordMasker.mask_db_url(
+                "mysql+mysqldb://scott:tiger@localhost:65432/foo"
+            )
+            == "mysql+mysqldb://scott:***@localhost:65432/foo"
+        )
+    except ModuleNotFoundError:
+        pass
+    assert (
+        PasswordMasker.mask_db_url(
+            "mysql+mysqldb://scott:tiger@localhost:65432/foo", use_urlparse=True
+        )
+        == "mysql+mysqldb://scott:***@localhost:65432/foo"
+    )
+
+    # PyMySQL
+    assert (
+        PasswordMasker.mask_db_url("mysql+pymysql://scott:tiger@localhost:65432/foo")
+        == "mysql+pymysql://scott:***@localhost:65432/foo"
+    )
+    assert (
+        PasswordMasker.mask_db_url(
+            "mysql+pymysql://scott:tiger@localhost:65432/foo", use_urlparse=True
+        )
+        == "mysql+pymysql://scott:***@localhost:65432/foo"
+    )
+
+    # Oracle (if installed in test environment)
+    try:
+        assert (
+            PasswordMasker.mask_db_url("oracle://scott:tiger@127.0.0.1:1521/sidname")
+            == "oracle://scott:***@127.0.0.1:1521/sidname"
+        )
+    except ModuleNotFoundError:
+        pass
+
+    assert (
+        PasswordMasker.mask_db_url(
+            "oracle://scott:tiger@127.0.0.1:1521/sidname", use_urlparse=True
+        )
+        == "oracle://scott:***@127.0.0.1:1521/sidname"
+    )
+
+    try:
+        assert (
+            PasswordMasker.mask_db_url("oracle+cx_oracle://scott:tiger@tnsname")
+            == "oracle+cx_oracle://scott:***@tnsname"
+        )
+    except ModuleNotFoundError:
+        pass
+    assert (
+        PasswordMasker.mask_db_url(
+            "oracle+cx_oracle://scott:tiger@tnsname", use_urlparse=True
+        )
+        == "oracle+cx_oracle://scott:***@tnsname"
+    )
+
+    # Microsoft SQL Server
+    # pyodbc
+    assert (
+        PasswordMasker.mask_db_url("mssql+pyodbc://scott:tiger@mydsn")
+        == "mssql+pyodbc://scott:***@mydsn"
+    )
+    assert (
+        PasswordMasker.mask_db_url(
+            "mssql+pyodbc://scott:tiger@mydsn", use_urlparse=True
+        )
+        == "mssql+pyodbc://scott:***@mydsn"
+    )
+
+    # pymssql (if installed in test environment)
+    try:
+        assert (
+            PasswordMasker.mask_db_url(
+                "mssql+pymssql://scott:tiger@hostname:12345/dbname"
+            )
+            == "mssql+pymssql://scott:***@hostname:12345/dbname"
+        )
+    except ModuleNotFoundError:
+        pass
+    assert (
+        PasswordMasker.mask_db_url(
+            "mssql+pymssql://scott:tiger@hostname:12345/dbname", use_urlparse=True
+        )
+        == "mssql+pymssql://scott:***@hostname:12345/dbname"
+    )
+
+    # SQLite
+    # relative path
+    assert PasswordMasker.mask_db_url("sqlite:///foo.db") == "sqlite:///foo.db"
+    assert (
+        PasswordMasker.mask_db_url("sqlite:///foo.db", use_urlparse=True)
+        == "sqlite:///foo.db"
+    )
+
+    # absolute path
+    # Unix/Mac - 4 initial slashes in total
+    assert (
+        PasswordMasker.mask_db_url("sqlite:////absolute/path/to/foo.db")
+        == "sqlite:////absolute/path/to/foo.db"
+    )
+    assert (
+        PasswordMasker.mask_db_url(
+            "sqlite:////absolute/path/to/foo.db", use_urlparse=True
+        )
+        == "sqlite:////absolute/path/to/foo.db"
+    )
+
+    # Windows
+    assert (
+        PasswordMasker.mask_db_url("sqlite:///C:\\path\\to\\foo.db")
+        == "sqlite:///C:\\path\\to\\foo.db"
+    )
+    assert (
+        PasswordMasker.mask_db_url("sqlite:///C:\\path\\to\\foo.db", use_urlparse=True)
+        == "sqlite:///C:\\path\\to\\foo.db"
+    )
+
+    # Windows alternative using raw string
+    assert (
+        PasswordMasker.mask_db_url(r"sqlite:///C:\path\to\foo.db")
+        == r"sqlite:///C:\path\to\foo.db"
+    )
+    assert (
+        PasswordMasker.mask_db_url(r"sqlite:///C:\path\to\foo.db", use_urlparse=True)
+        == r"sqlite:///C:\path\to\foo.db"
+    )
+
+    # in-memory
+    assert PasswordMasker.mask_db_url("sqlite://") == "sqlite://"
+    assert PasswordMasker.mask_db_url("sqlite://", use_urlparse=True) == "sqlite://"

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -18,7 +18,7 @@ def test_load_class_raises_error_when_class_not_found():
 def test_password_masker_mask_db_url():
     """
     What does this test and why?
-    The PasswordMasker.mask_db_url() should mask passwords consistently in database urls.
+    The PasswordMasker.mask_db_url() should mask passwords consistently in database urls. The output of mask_db_url should be the same whether user_urlparse is set to True or False.
     This test uses database url examples from
     https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls
     """


### PR DESCRIPTION
Changes proposed in this pull request:
- Mask passwords with a string of asterisks before returning from `DataContext.list_datasources()`
- Created `PasswordMasker` util class. Created as a class to encapsulate password masking in one place, e.g. keep together the `MASKED_PASSWORD_STRING` and the mask_db_url method. 
- Added tests for all common url cases from https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls

Previous Design Review notes:
- Suggested fix is to parse datasources and substitute passwords in both "credentials"/"password" or "url" fields.
- Closes #2184 