### PR TITLE
[MAINTENANCE] remove the obsolete TODO comments

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -1195,7 +1195,6 @@ We could not determine the format of the file. What is it?
                     batch = datasource.get_batch(batch_kwargs=batch_kwargs)
                     break
         else:
-            # TODO: read the file and confirm with user that we read it correctly (headers, columns, etc.)
             try:
                 batch_kwargs["reader_method"] = reader_method
                 if isinstance(datasource, SparkDFDatasource) and reader_method == "csv":


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comments. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- MAINTENANCE Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
great_expectations/cli/datasource.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: https://github.com/great-expectations/great_expectations/commit/8ad46babfeaeef7482aa8e7f42260ba0559a5d49.