### PR TITLE
[ENHANCEMENT] Serialize PySpark DataFrame by converting to dictionary

### DIFF
--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -16,7 +16,6 @@ from great_expectations.types import SerializableDictDot
 # https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
 
 
-
 logger = logging.getLogger(__name__)
 
 try:

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -1,24 +1,23 @@
+import datetime
+import decimal
 import logging
 import sys
 from collections.abc import Mapping
 
-# Updated from the stack overflow version below to concatenate lists
-# https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
-from decimal import Context
-
+import numpy as np
+import pandas as pd
 from IPython import get_ipython
 
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.types import SerializableDictDot
 
+# Updated from the stack overflow version below to concatenate lists
+# https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
+
+
+
 logger = logging.getLogger(__name__)
-
-import datetime
-import decimal
-
-import numpy as np
-import pandas as pd
 
 try:
     import pyspark
@@ -278,4 +277,4 @@ def ensure_json_serializable(data):
 
 
 def requires_lossy_conversion(d):
-    return d - Context(prec=sys.float_info.dig).create_decimal(d) != 0
+    return d - decimal.Context(prec=sys.float_info.dig).create_decimal(d) != 0

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from collections.abc import Mapping
 
+
 # Updated from the stack overflow version below to concatenate lists
 # https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
 from decimal import Context
@@ -13,6 +14,20 @@ from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.types import SerializableDictDot
 
 logger = logging.getLogger(__name__)
+
+import datetime
+import decimal
+
+import numpy as np
+import pandas as pd
+
+try:
+    import pyspark
+except ImportError:
+    pyspark = None
+    logger.debug(
+        "Unable to load pyspark; install optional spark dependency if you will be working with Spark dataframes"
+    )
 
 
 def nested_update(d, u):
@@ -56,20 +71,6 @@ def convert_to_json_serializable(data):
     Warning:
         test_obj may also be converted in place.
     """
-    import datetime
-    import decimal
-    import sys
-
-    import numpy as np
-    import pandas as pd
-
-    try:
-        import pyspark
-    except ImportError:
-        pyspark = None
-        logger.debug(
-            "Unable to load pyspark and pyspark.sql; install optional spark dependency for support."
-        )
 
     # If it's one of our types, we use our own conversion; this can move to full schema
     # once nesting goes all the way down
@@ -182,19 +183,6 @@ def ensure_json_serializable(data):
     Warning:
         test_obj may also be converted in place.
     """
-    import datetime
-    import decimal
-
-    import numpy as np
-    import pandas as pd
-
-    try:
-        import pyspark
-    except ImportError:
-        pyspark = None
-        logger.debug(
-            "Unable to load pyspark and pyspark.sql; install optional spark dependency for support."
-        )
 
     if isinstance(data, SerializableDictDot):
         return

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -2,7 +2,6 @@ import logging
 import sys
 from collections.abc import Mapping
 
-
 # Updated from the stack overflow version below to concatenate lists
 # https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
 from decimal import Context

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -151,7 +151,9 @@ def convert_to_json_serializable(data):
     elif pyspark and isinstance(data, pyspark.sql.DataFrame):
         # using StackOverflow suggestion for converting pyspark df into dictionary
         # https://stackoverflow.com/questions/43679880/pyspark-dataframe-to-dictionary-columns-as-keys-and-list-of-column-values-ad-di
-        return convert_to_json_serializable(dict(zip(data.schema.names, zip(*data.collect()))))
+        return convert_to_json_serializable(
+            dict(zip(data.schema.names, zip(*data.collect())))
+        )
 
     elif isinstance(data, decimal.Decimal):
         if requires_lossy_conversion(data):
@@ -268,7 +270,9 @@ def ensure_json_serializable(data):
     elif pyspark and isinstance(data, pyspark.sql.DataFrame):
         # using StackOverflow suggestion for converting pyspark df into dictionary
         # https://stackoverflow.com/questions/43679880/pyspark-dataframe-to-dictionary-columns-as-keys-and-list-of-column-values-ad-di
-        return ensure_json_serializable(dict(zip(data.schema.names, zip(*data.collect()))))
+        return ensure_json_serializable(
+            dict(zip(data.schema.names, zip(*data.collect())))
+        )
 
     elif isinstance(data, pd.DataFrame):
         return ensure_json_serializable(data.to_dict(orient="records"))

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -51,6 +51,7 @@ def test_lossy_conversion():
 # TODO add unittests for convert_to_json_serializable() and ensure_json_serializable()
 def test_serialization_of_spark_df(spark_session):
     import pandas as pd
+
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     sdf = spark_session.createDataFrame(df)
-    assert convert_to_json_serializable(sdf) == {'a': (1, 2, 3), 'b': (4, 5, 6)}
+    assert convert_to_json_serializable(sdf) == {"a": (1, 2, 3), "b": (4, 5, 6)}

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -52,6 +52,10 @@ def test_lossy_conversion():
 def test_serialization_of_spark_df(spark_session):
     import pandas as pd
 
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    sdf = spark_session.createDataFrame(df)
+    assert convert_to_json_serializable(sdf) == {"a": [1, 2, 3]}
+
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     sdf = spark_session.createDataFrame(df)
     assert convert_to_json_serializable(sdf) == {"a": [1, 2, 3], "b": [4, 5, 6]}

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -46,3 +46,11 @@ def test_lossy_conversion():
 
     d = Decimal("0.1")
     assert not requires_lossy_conversion(d)
+
+
+# TODO add unittests for convert_to_json_serializable() and ensure_json_serializable()
+def test_serialization_of_spark_df(spark_session):
+    import pandas as pd
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    sdf = spark_session.createDataFrame(df)
+    assert convert_to_json_serializable(sdf) == {'a': (1, 2, 3), 'b': (4, 5, 6)}

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -54,4 +54,4 @@ def test_serialization_of_spark_df(spark_session):
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     sdf = spark_session.createDataFrame(df)
-    assert convert_to_json_serializable(sdf) == {"a": (1, 2, 3), "b": (4, 5, 6)}
+    assert convert_to_json_serializable(sdf) == {"a": [1, 2, 3], "b": [4, 5, 6]}


### PR DESCRIPTION
Changes proposed in this pull request:
- added code to `convert_to_json_serializable()` and `ensure_json_serializable()` to handle pyspark DFs
- added single test (draft only)
