### PR TITLE
[BUGFIX] Replace unneeded and potentially large runtime batch_data DataFrame w…

### DIFF
--- a/great_expectations/datasource/types/batch_spec.py
+++ b/great_expectations/datasource/types/batch_spec.py
@@ -102,3 +102,7 @@ class RuntimeDataBatchSpec(BatchSpec):
     @property
     def batch_data(self):
         return self.get("batch_data")
+
+    @batch_data.setter
+    def batch_data(self, batch_data):
+        self["batch_data"] = batch_data

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import random
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 
 import pandas as pd
 from ruamel.yaml.compat import StringIO
@@ -118,6 +118,7 @@ Notes:
         if isinstance(batch_spec, RuntimeDataBatchSpec):
             # batch_data != None is already checked when RuntimeDataBatchSpec is instantiated
             batch_data = batch_spec.batch_data
+            batch_spec.batch_data = "PandasDataFrame"
 
         elif isinstance(batch_spec, PathBatchSpec):
             reader_method: str = batch_spec.get("reader_method")

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -201,7 +201,9 @@ class SparkDFExecutionEngine(ExecutionEngine):
         )
 
         if isinstance(batch_spec, RuntimeDataBatchSpec):
+            # batch_data != None is already checked when RuntimeDataBatchSpec is instantiated
             batch_data = batch_spec.batch_data
+            batch_spec.batch_data = "SparkDataFrame"
         elif isinstance(batch_spec, (PathBatchSpec, S3BatchSpec)):
             reader_method: str = batch_spec.get("reader_method")
             reader_options: dict = batch_spec.get("reader_options") or {}


### PR DESCRIPTION
### Scope
* Large `batch_data` Pandas or Spark DataFrame breaks serialization of validation results (including due to an impossible serialization of Thread objects in the case of Spark).

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
