### PR TITLE
[BUGFIX] Skip escaping substitution variables in escape_all_config_variables

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ Develop
 * [ENHANCEMENT] Data docs can now be built skipping the index page using the python API
 * [ENHANCEMENT] Speed up new suite creation flow when connecting to Databases. Issue #1670 (Thanks @armaandhull!)
 * [BUGFIX] Mask passwords in DataContext.list_datasources(). Issue #2184
+* [BUGFIX] Skip escaping substitution variables in escape_all_config_variables #2243. Issue #2196 (Thanks @
+varundunga!)
 
 
 0.13.4

--- a/docs/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.rst
+++ b/docs/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.rst
@@ -17,7 +17,7 @@ Steps
   .. admonition:: Note:
 
     - In the ``great_expectations.yml`` config file, environment variables take precedence over variables defined in a config variables YAML
-    - Environment variable substitution is also supported in the ``great_expectations.yml`` config file.
+    - Environment variable substitution is supported in both the ``great_expectations.yml`` and config variables ``config_variables.yml`` config file.
 
   If using a YAML file, save desired credentials or config values to ``great_expectations/uncommitted/config_variables.yml`` or another YAML file of your choosing:
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -61,6 +61,7 @@ from great_expectations.data_context.util import (
     file_relative_path,
     instantiate_class_from_config,
     load_class,
+    parse_substitution_variable,
     substitute_all_config_variables,
     substitute_config_variable,
 )
@@ -805,6 +806,7 @@ class BaseDataContext:
         self,
         value: Union[str, dict, list],
         dollar_sign_escape_string: str = DOLLAR_SIGN_ESCAPE_STRING,
+        skip_if_substitution_variable: bool = True,
     ) -> Union[str, dict, list]:
         """
         Replace all `$` characters with the DOLLAR_SIGN_ESCAPE_STRING
@@ -812,6 +814,7 @@ class BaseDataContext:
         Args:
             value: config variable value
             dollar_sign_escape_string: replaces instances of `$`
+            skip_if_substitution_variable: skip if the value is of the form ${MYVAR} or $MYVAR
 
         Returns:
             input value with all `$` characters replaced with the escape string
@@ -819,29 +822,47 @@ class BaseDataContext:
 
         if isinstance(value, dict) or isinstance(value, OrderedDict):
             return {
-                k: self.escape_all_config_variables(v, dollar_sign_escape_string)
+                k: self.escape_all_config_variables(
+                    v, dollar_sign_escape_string, skip_if_substitution_variable
+                )
                 for k, v in value.items()
             }
 
         elif isinstance(value, list):
             return [
-                self.escape_all_config_variables(v, dollar_sign_escape_string)
+                self.escape_all_config_variables(
+                    v, dollar_sign_escape_string, skip_if_substitution_variable
+                )
                 for v in value
             ]
-        return value.replace("$", dollar_sign_escape_string)
+        if skip_if_substitution_variable:
+            if parse_substitution_variable(value) is None:
+                return value.replace("$", dollar_sign_escape_string)
+            else:
+                return value
+        else:
+            return value.replace("$", dollar_sign_escape_string)
 
-    def save_config_variable(self, config_variable_name, value):
-        """Save config variable value
+    def save_config_variable(
+        self, config_variable_name, value, skip_if_substitution_variable: bool = True
+    ):
+        r"""Save config variable value
+        Escapes $ unless they are used in substitution variables e.g. the $ characters in ${SOME_VAR} or $SOME_VAR are not escaped
 
         Args:
             config_variable_name: name of the property
             value: the value to save for the property
+            skip_if_substitution_variable: set to False to escape $ in values in substitution variable form e.g. ${SOME_VAR} -> r"\${SOME_VAR}" or $SOME_VAR -> r"\$SOME_VAR"
 
         Returns:
             None
         """
         config_variables = self._load_config_variables_file()
-        value = self.escape_all_config_variables(value, self.DOLLAR_SIGN_ESCAPE_STRING)
+        value = self.escape_all_config_variables(
+            value,
+            self.DOLLAR_SIGN_ESCAPE_STRING,
+            skip_if_substitution_variable=skip_if_substitution_variable,
+        )
         config_variables[config_variable_name] = value
         config_variables_filepath = self.get_config().config_variables_file_path
         if not config_variables_filepath:

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -5,7 +5,10 @@ import os
 import re
 import warnings
 from collections import OrderedDict
+from typing import Optional
 from urllib.parse import urlparse
+
+import pyparsing as pp
 
 from great_expectations.data_context.types.base import (
     DataContextConfig,
@@ -212,6 +215,28 @@ def file_relative_path(dunderfile, relative_path):
     H/T https://github.com/dagster-io/dagster/blob/8a250e9619a49e8bff8e9aa7435df89c2d2ea039/python_modules/dagster/dagster/utils/__init__.py#L34
     """
     return os.path.join(os.path.dirname(dunderfile), relative_path)
+
+
+def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
+    """
+    Parse and check whether the string contains a substitution variable of the case insensitive form ${SOME_VAR} or $SOME_VAR
+    Args:
+        substitution_variable: string to be parsed
+
+    Returns:
+        string of variable name e.g. SOME_VAR or None if not parsable
+    """
+    substitution_variable_name = pp.Word(pp.alphanums + "_" + "-").setResultsName(
+        "substitution_variable_name"
+    )
+    curly_brace_parser = "${" + substitution_variable_name + "}"
+    non_curly_brace_parser = "$" + substitution_variable_name
+    both_parser = curly_brace_parser | non_curly_brace_parser
+    try:
+        parsed_substitution_variable = both_parser.parseString(substitution_variable)
+        return parsed_substitution_variable.substitution_variable_name
+    except pp.ParseException:
+        return None
 
 
 class PasswordMasker:

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -224,7 +224,7 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
         substitution_variable: string to be parsed
 
     Returns:
-        string of variable name e.g. SOME_VAR or None if not parsable
+        string of variable name e.g. SOME_VAR or None if not parsable. If there are multiple substitution variables this currently returns the first e.g. $SOME_$TRING -> $SOME_
     """
     substitution_variable_name = pp.Word(pp.alphanums + "_").setResultsName(
         "substitution_variable_name"

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -226,7 +226,7 @@ def parse_substitution_variable(substitution_variable: str) -> Optional[str]:
     Returns:
         string of variable name e.g. SOME_VAR or None if not parsable
     """
-    substitution_variable_name = pp.Word(pp.alphanums + "_" + "-").setResultsName(
+    substitution_variable_name = pp.Word(pp.alphanums + "_").setResultsName(
         "substitution_variable_name"
     )
     curly_brace_parser = "${" + substitution_variable_name + "}"

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -831,7 +831,6 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
     context.save_config_variable(
         "escaped_curly", "${SOME_VAR}", skip_if_substitution_variable=False
     )
-    context
 
     config_vars_file_contents = context._load_config_variables_file()
 

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -113,7 +113,7 @@ def test_setting_config_variables_is_visible_immediately(
         "host": "localhost",
         "port": "5432",
         "username": "postgres",
-        "password": "$pas$wor$d1$",
+        "password": "pas$wor$d1$",
         "database": "postgres",
     }
     context.save_config_variable(
@@ -152,7 +152,7 @@ def test_setting_config_variables_is_visible_immediately(
         "host": "localhost",
         "port": "5432",
         "username": "postgres",
-        "password": r"\$pas\$wor\$d1\$",
+        "password": r"pas\$wor\$d1\$",
         "database": "postgres",
     }
 
@@ -391,8 +391,8 @@ def test_escape_all_config_variables(empty_data_context_with_config_variables):
     escaped_value_str = r"pas\$word1"
     assert context.escape_all_config_variables(value=value_str) == escaped_value_str
 
-    value_str2 = "$pas$wor$d1$"
-    escaped_value_str2 = r"\$pas\$wor\$d1\$"
+    value_str2 = "pas$wor$d1$"
+    escaped_value_str2 = r"pas\$wor\$d1\$"
     assert context.escape_all_config_variables(value=value_str2) == escaped_value_str2
 
     # dict
@@ -418,7 +418,7 @@ def test_escape_all_config_variables(empty_data_context_with_config_variables):
     value_ordered_dict = OrderedDict(
         [
             ("UNCOMMITTED", "uncommitted"),
-            ("docs_test_folder", "$test$folder"),
+            ("docs_test_folder", "test$folder"),
             (
                 "test_db",
                 {
@@ -435,7 +435,7 @@ def test_escape_all_config_variables(empty_data_context_with_config_variables):
     escaped_value_ordered_dict = OrderedDict(
         [
             ("UNCOMMITTED", "uncommitted"),
-            ("docs_test_folder", r"\$test\$folder"),
+            ("docs_test_folder", r"test\$folder"),
             (
                 "test_db",
                 {
@@ -483,13 +483,258 @@ def test_escape_all_config_variables(empty_data_context_with_config_variables):
         == escaped_value_str_custom_escape_string
     )
 
-    value_str_custom_escape_string2 = "$pas$wor$d1$"
-    escaped_value_str_custom_escape_string2 = "@*&$pas@*&$wor@*&$d1@*&$"
+    value_str_custom_escape_string2 = "pas$wor$d1$"
+    escaped_value_str_custom_escape_string2 = "pas@*&$wor@*&$d1@*&$"
     assert (
         context.escape_all_config_variables(
             value=value_str_custom_escape_string2, dollar_sign_escape_string="@*&$"
         )
         == escaped_value_str_custom_escape_string2
+    )
+
+
+def test_escape_all_config_variables_skip_substitution_vars(
+    empty_data_context_with_config_variables,
+):
+    """
+    What does this test and why?
+    escape_all_config_variables(skip_if_substitution_variable=True/False) should function as documented.
+    """
+    context = empty_data_context_with_config_variables
+
+    # str
+    value_str = "$VALUE_STR"
+    escaped_value_str = r"\$VALUE_STR"
+    assert (
+        context.escape_all_config_variables(
+            value=value_str, skip_if_substitution_variable=True
+        )
+        == value_str
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=value_str, skip_if_substitution_variable=False
+        )
+        == escaped_value_str
+    )
+
+    value_str2 = "VALUE_$TR"
+    escaped_value_str2 = r"VALUE_\$TR"
+    assert (
+        context.escape_all_config_variables(
+            value=value_str2, skip_if_substitution_variable=True
+        )
+        == escaped_value_str2
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=value_str2, skip_if_substitution_variable=False
+        )
+        == escaped_value_str2
+    )
+
+    multi_value_str = "${USER}:pas$word@${HOST}:${PORT}/${DATABASE}"
+    escaped_multi_value_str = r"\${USER}:pas\$word@\${HOST}:\${PORT}/\${DATABASE}"
+    assert (
+        context.escape_all_config_variables(
+            value=multi_value_str, skip_if_substitution_variable=True
+        )
+        == multi_value_str
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=multi_value_str, skip_if_substitution_variable=False
+        )
+        == escaped_multi_value_str
+    )
+
+    multi_value_str2 = "$USER:pas$word@$HOST:${PORT}/${DATABASE}"
+    escaped_multi_value_str2 = r"\$USER:pas\$word@\$HOST:\${PORT}/\${DATABASE}"
+    assert (
+        context.escape_all_config_variables(
+            value=multi_value_str2, skip_if_substitution_variable=True
+        )
+        == multi_value_str2
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=multi_value_str2, skip_if_substitution_variable=False
+        )
+        == escaped_multi_value_str2
+    )
+
+    multi_value_str3 = "USER:pas$word@$HOST:${PORT}/${DATABASE}"
+    escaped_multi_value_str3 = r"USER:pas\$word@\$HOST:\${PORT}/\${DATABASE}"
+    assert (
+        context.escape_all_config_variables(
+            value=multi_value_str3, skip_if_substitution_variable=True
+        )
+        == escaped_multi_value_str3
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=multi_value_str3, skip_if_substitution_variable=False
+        )
+        == escaped_multi_value_str3
+    )
+
+    # dict
+    value_dict = {
+        "drivername": "postgresql",
+        "host": "${HOST}",
+        "port": "5432",
+        "username": "postgres",
+        "password": "pass$word1",
+        "database": "$postgres",
+        "sub_dict": {
+            "test_val_no_escaping": "test_val",
+            "test_val_escaping": "te$t_val",
+            "test_val_substitution": "$test_val",
+            "test_val_substitution_braces": "${test_val}",
+        },
+    }
+    escaped_value_dict = {
+        "drivername": "postgresql",
+        "host": r"\${HOST}",
+        "port": "5432",
+        "username": "postgres",
+        "password": r"pass\$word1",
+        "database": r"\$postgres",
+        "sub_dict": {
+            "test_val_no_escaping": "test_val",
+            "test_val_escaping": r"te\$t_val",
+            "test_val_substitution": r"\$test_val",
+            "test_val_substitution_braces": r"\${test_val}",
+        },
+    }
+    escaped_value_dict_skip_substitution_variables = {
+        "drivername": "postgresql",
+        "host": "${HOST}",
+        "port": "5432",
+        "username": "postgres",
+        "password": r"pass\$word1",
+        "database": "$postgres",
+        "sub_dict": {
+            "test_val_no_escaping": "test_val",
+            "test_val_escaping": r"te\$t_val",
+            "test_val_substitution": "$test_val",
+            "test_val_substitution_braces": "${test_val}",
+        },
+    }
+    assert (
+        context.escape_all_config_variables(
+            value=value_dict, skip_if_substitution_variable=False
+        )
+        == escaped_value_dict
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=value_dict, skip_if_substitution_variable=True
+        )
+        == escaped_value_dict_skip_substitution_variables
+    )
+
+    # OrderedDict
+    value_ordered_dict = OrderedDict(
+        [
+            ("UNCOMMITTED", "uncommitted"),
+            ("docs_test_folder", "test$folder"),
+            (
+                "test_db",
+                {
+                    "drivername": "$postgresql",
+                    "host": "some_host",
+                    "port": "5432",
+                    "username": "${USERNAME}",
+                    "password": "pa$sword1",
+                    "database": "postgres",
+                },
+            ),
+        ]
+    )
+    escaped_value_ordered_dict = OrderedDict(
+        [
+            ("UNCOMMITTED", "uncommitted"),
+            ("docs_test_folder", r"test\$folder"),
+            (
+                "test_db",
+                {
+                    "drivername": r"\$postgresql",
+                    "host": "some_host",
+                    "port": "5432",
+                    "username": r"\${USERNAME}",
+                    "password": r"pa\$sword1",
+                    "database": "postgres",
+                },
+            ),
+        ]
+    )
+    escaped_value_ordered_dict_skip_substitution_variables = OrderedDict(
+        [
+            ("UNCOMMITTED", "uncommitted"),
+            ("docs_test_folder", r"test\$folder"),
+            (
+                "test_db",
+                {
+                    "drivername": "$postgresql",
+                    "host": "some_host",
+                    "port": "5432",
+                    "username": "${USERNAME}",
+                    "password": r"pa\$sword1",
+                    "database": "postgres",
+                },
+            ),
+        ]
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=value_ordered_dict, skip_if_substitution_variable=False
+        )
+        == escaped_value_ordered_dict
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=value_ordered_dict, skip_if_substitution_variable=True
+        )
+        == escaped_value_ordered_dict_skip_substitution_variables
+    )
+
+    # list
+    value_list = [
+        "postgresql",
+        "localhost",
+        "5432",
+        "$postgres",
+        "pass$word1",
+        "${POSTGRES}",
+    ]
+    escaped_value_list = [
+        "postgresql",
+        "localhost",
+        "5432",
+        r"\$postgres",
+        r"pass\$word1",
+        r"\${POSTGRES}",
+    ]
+    escaped_value_list_skip_substitution_variables = [
+        "postgresql",
+        "localhost",
+        "5432",
+        "$postgres",
+        r"pass\$word1",
+        "${POSTGRES}",
+    ]
+    assert (
+        context.escape_all_config_variables(
+            value=value_list, skip_if_substitution_variable=False
+        )
+        == escaped_value_list
+    )
+    assert (
+        context.escape_all_config_variables(
+            value=value_list, skip_if_substitution_variable=True
+        )
+        == escaped_value_list_skip_substitution_variables
     )
 
 
@@ -505,30 +750,34 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
         project_root_dir=project_path,
         usage_statistics_enabled=False,
     )
-    context.save_config_variable("DB_PWD", "DB_PWD_saved_before_adding_datasource")
-    context.save_config_variable("DB_USER", "DB_USER_saved_before_adding_datasource")
-    context.save_config_variable(
-        "DB_HOST", "${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}"
-    )
-    context.save_config_variable("DB_NAME", "${DB_NAME_to_be_subbed_by_config_var}")
-    context.save_config_variable(
-        "DB_NAME_to_be_subbed_by_config_var", "DB_NAME_subbed_by_config_var"
-    )
+
+    CONFIG_VARS = {
+        "DB_HOST": "${DB_HOST_FROM_ENV_VAR}",
+        "DB_NAME": "DB_NAME",
+        "DB_USER": "DB_USER",
+        "DB_PWD": "pas$word",
+    }
+    for k, v in CONFIG_VARS.items():
+        context.save_config_variable(k, v)
 
     config_vars_file_contents = context._load_config_variables_file()
 
-    assert config_vars_file_contents == {
-        "DB_PWD": "DB_PWD_saved_before_adding_datasource",
-        "DB_USER": "DB_USER_saved_before_adding_datasource",
-        # Note Escaped $ in DB_HOST in config_variables.yml
-        "DB_HOST": r"\${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}",
-        # Note Escaped $
-        "DB_NAME": r"\${DB_NAME_to_be_subbed_by_config_var}",
-        # This will not be substituted:
-        "DB_NAME_to_be_subbed_by_config_var": "DB_NAME_subbed_by_config_var",
-        # Use the generated instance_id:
-        "instance_id": config_vars_file_contents["instance_id"],
-    }
+    # Add escaping for DB_PWD since it is not of the form ${SOMEVAR} or $SOMEVAR
+    CONFIG_VARS_WITH_ESCAPING = CONFIG_VARS.copy()
+    CONFIG_VARS_WITH_ESCAPING["DB_PWD"] = r"pas\$word"
+
+    # Ensure all config vars saved are in the config_variables.yml file
+    # and that escaping was added for "pas$word" -> "pas\$word"
+    assert all(
+        item in config_vars_file_contents.items()
+        for item in CONFIG_VARS_WITH_ESCAPING.items()
+    )
+    assert not all(
+        item in config_vars_file_contents.items() for item in CONFIG_VARS.items()
+    )
+
+    # Add env var for substitution
+    monkeypatch.setenv("DB_HOST_FROM_ENV_VAR", "DB_HOST_FROM_ENV_VAR_VALUE")
 
     datasource_config = DatasourceConfig(
         class_name="SqlAlchemyDatasource",
@@ -552,10 +801,10 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
 
     assert context.list_datasources()[0]["credentials"] == {
         "drivername": "postgresql",
-        "host": "${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}",
+        "host": "DB_HOST_FROM_ENV_VAR_VALUE",
         "port": "65432",
-        "database": "${DB_NAME_to_be_subbed_by_config_var}",
-        "username": "DB_USER_saved_before_adding_datasource",
+        "database": "DB_NAME",
+        "username": "DB_USER",
         # Note masking of "password" field
         "password": "***",
     }
@@ -570,54 +819,21 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
         "datasources"
     ]["test_datasource"]["credentials"]
 
-    assert (
-        test_datasource_credentials["host"]
-        == "${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}"
-    )
-    assert (
-        test_datasource_credentials["username"]
-        == "DB_USER_saved_before_adding_datasource"
-    )
-    assert (
-        test_datasource_credentials["password"]
-        == "DB_PWD_saved_before_adding_datasource"
-    )
-    assert (
-        test_datasource_credentials["database"]
-        == "${DB_NAME_to_be_subbed_by_config_var}"
-    )
+    assert test_datasource_credentials["host"] == "DB_HOST_FROM_ENV_VAR_VALUE"
+    assert test_datasource_credentials["username"] == "DB_USER"
+    assert test_datasource_credentials["password"] == "pas$word"
+    assert test_datasource_credentials["database"] == "DB_NAME"
 
-    # Set env variable and check again, making sure that variable in config_variables.yml is substituted correctly with an env variable.
-    monkeypatch.setenv(
-        "DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource", "DB_HOST_FROM_ENV_VAR"
+    # Ensure skip_if_substitution_variable=False works as documented
+    context.save_config_variable(
+        "escaped", "$SOME_VAR", skip_if_substitution_variable=False
     )
-    assert (
-        os.environ.get("DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource")
-        == "DB_HOST_FROM_ENV_VAR"
+    context.save_config_variable(
+        "escaped_curly", "${SOME_VAR}", skip_if_substitution_variable=False
     )
-    context_with_variables_substituted_dict = data_context_config_schema.dump(
-        context.get_config_with_variables_substituted()
-    )
+    context
 
-    test_datasource_credentials = context_with_variables_substituted_dict[
-        "datasources"
-    ]["test_datasource"]["credentials"]
+    config_vars_file_contents = context._load_config_variables_file()
 
-    # 20210108 - AJB - Env var substitution not yet supported in config_variables.yml
-    # https://discuss.greatexpectations.io/t/environment-variable-substitution-is-not-working-for-me-when-connecting-ge-to-my-database/72
-    assert (
-        test_datasource_credentials["host"]
-        == "${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}"
-    )
-    assert (
-        test_datasource_credentials["username"]
-        == "DB_USER_saved_before_adding_datasource"
-    )
-    assert (
-        test_datasource_credentials["password"]
-        == "DB_PWD_saved_before_adding_datasource"
-    )
-    assert (
-        test_datasource_credentials["database"]
-        == "${DB_NAME_to_be_subbed_by_config_var}"
-    )
+    assert config_vars_file_contents["escaped"] == r"\$SOME_VAR"
+    assert config_vars_file_contents["escaped_curly"] == r"\${SOME_VAR}"

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -510,6 +510,10 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
     context.save_config_variable(
         "DB_HOST", "${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}"
     )
+    context.save_config_variable("DB_NAME", "${DB_NAME_to_be_subbed_by_config_var}")
+    context.save_config_variable(
+        "DB_NAME_to_be_subbed_by_config_var", "DB_NAME_subbed_by_config_var"
+    )
 
     config_vars_file_contents = context._load_config_variables_file()
 
@@ -518,6 +522,11 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
         "DB_USER": "DB_USER_saved_before_adding_datasource",
         # Note Escaped $ in DB_HOST in config_variables.yml
         "DB_HOST": r"\${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}",
+        # Note Escaped $
+        "DB_NAME": r"\${DB_NAME_to_be_subbed_by_config_var}",
+        # This will not be substituted:
+        "DB_NAME_to_be_subbed_by_config_var": "DB_NAME_subbed_by_config_var",
+        # Use the generated instance_id:
         "instance_id": config_vars_file_contents["instance_id"],
     }
 
@@ -527,7 +536,7 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
             "drivername": "postgresql",
             "host": "$DB_HOST",
             "port": "65432",
-            "database": "test_database",
+            "database": "${DB_NAME}",
             "username": "${DB_USER}",
             "password": "${DB_PWD}",
         },
@@ -545,7 +554,7 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
         "drivername": "postgresql",
         "host": "${DB_HOST_FROM_ENV_VAR_saved_before_adding_datasource}",
         "port": "65432",
-        "database": "test_database",
+        "database": "${DB_NAME_to_be_subbed_by_config_var}",
         "username": "DB_USER_saved_before_adding_datasource",
         # Note masking of "password" field
         "password": "***",
@@ -572,6 +581,10 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
     assert (
         test_datasource_credentials["password"]
         == "DB_PWD_saved_before_adding_datasource"
+    )
+    assert (
+        test_datasource_credentials["database"]
+        == "${DB_NAME_to_be_subbed_by_config_var}"
     )
 
     # Set env variable and check again, making sure that variable in config_variables.yml is substituted correctly with an env variable.
@@ -603,4 +616,8 @@ def test_create_data_context_and_config_vars_in_code(tmp_path_factory, monkeypat
     assert (
         test_datasource_credentials["password"]
         == "DB_PWD_saved_before_adding_datasource"
+    )
+    assert (
+        test_datasource_credentials["database"]
+        == "${DB_NAME_to_be_subbed_by_config_var}"
     )

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -1,7 +1,10 @@
 import pytest
 
 import great_expectations.exceptions as gee
-from great_expectations.data_context.util import PasswordMasker
+from great_expectations.data_context.util import (
+    PasswordMasker,
+    parse_substitution_variable,
+)
 from great_expectations.util import load_class
 
 
@@ -227,3 +230,20 @@ def test_password_masker_mask_db_url():
     # in-memory
     assert PasswordMasker.mask_db_url("sqlite://") == "sqlite://"
     assert PasswordMasker.mask_db_url("sqlite://", use_urlparse=True) == "sqlite://"
+
+
+def test_parse_substitution_variable():
+    """
+    What does this test and why?
+    Ensure parse_substitution_variable works as expected.
+    Returns:
+
+    """
+    assert parse_substitution_variable("${SOME_VAR}") == "SOME_VAR"
+    assert parse_substitution_variable("$SOME_VAR") == "SOME_VAR"
+    assert parse_substitution_variable("SOME_STRING") is None
+    assert parse_substitution_variable("SOME_$TRING") is None
+    assert parse_substitution_variable("${some_var}") == "some_var"
+    assert parse_substitution_variable("$some_var") == "some_var"
+    assert parse_substitution_variable("some_string") is None
+    assert parse_substitution_variable("some_$tring") is None

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -247,3 +247,5 @@ def test_parse_substitution_variable():
     assert parse_substitution_variable("$some_var") == "some_var"
     assert parse_substitution_variable("some_string") is None
     assert parse_substitution_variable("some_$tring") is None
+    assert parse_substitution_variable("${SOME_$TRING}") is None
+    assert parse_substitution_variable("$SOME_$TRING") == "SOME_"


### PR DESCRIPTION
Specifically test the case where someone creates a `DataContext` in code (not a `BaseDataContext`) and adds items with `$` characters to `config_variables.yml` in code as well. 
The resulting behavior is:
1. `$` characters should be escaped in `config_variables.yml` e.g. `${SOME_VAR}` -> `\${SOME_VAR}` 
2. When reading the config (e.g. via `context.get_config_with_variables_substituted()`) the escaping should be removed
3. If the value added to `config_variables.yml` is of the form that should be substituted, it will not be substituted as env var substitution is not yet supported in `config_variables.yml`. See this discuss post: https://discuss.greatexpectations.io/t/environment-variable-substitution-is-not-working-for-me-when-connecting-ge-to-my-database/72
4. If the value added to `config_variables.yml` is of the form that should be substituted and another config variable matches the substitution name, it will not be substituted as this is not supported.

Closes #2196 