### PR TITLE
* DataContext.get_checkpoint now returns a Checkpoint

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -116,9 +116,8 @@ class Checkpoint:
 
                 self._substituted_config = substituted_config
             else:
-                template_config = self.data_context.get_checkpoint(
-                    name=template_name, return_config=True
-                )
+                checkpoint = self.data_context.get_checkpoint(name=template_name)
+                template_config = checkpoint.config
 
                 if template_config.config_version != config.config_version:
                     raise CheckpointError(

--- a/great_expectations/cli/checkpoint.py
+++ b/great_expectations/cli/checkpoint.py
@@ -6,6 +6,7 @@ import click
 from ruamel.yaml import YAML
 
 from great_expectations import DataContext
+from great_expectations.checkpoint import Checkpoint
 from great_expectations.cli import toolkit
 from great_expectations.cli.mark import Mark as mark
 from great_expectations.cli.util import cli_message, cli_message_list
@@ -291,11 +292,10 @@ def checkpoint_run(checkpoint, directory):
     context = toolkit.load_data_context_with_error_handling(directory)
     usage_event = "cli.checkpoint.run"
 
-    checkpoint = toolkit.load_checkpoint(
+    checkpoint: Checkpoint = toolkit.load_checkpoint(
         context,
         checkpoint,
         usage_event,
-        return_config=False,
     )
 
     try:

--- a/great_expectations/cli/checkpoint_script_template.py
+++ b/great_expectations/cli/checkpoint_script_template.py
@@ -42,10 +42,8 @@ for batch in checkpoint.batches:
 
 # run the validation operator
 results = context.run_validation_operator(
-    checkpoint["validation_operator_name"],
+    checkpoint.validation_operator_name,
     assets_to_validate=batches_to_validate,
-    # TODO prepare for new RunID - checkpoint name and timestamp
-    # run_id=RunID(checkpoint)
 )
 
 # take action based on results

--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -17,14 +17,12 @@ from great_expectations.cli.datasource import get_batch_kwargs
 from great_expectations.cli.docs import build_docs
 from great_expectations.cli.upgrade_helpers import GE_UPGRADE_HELPER_VERSION_MAP
 from great_expectations.cli.util import cli_colorize_string, cli_message
+from great_expectations.core.batch import Batch
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.id_dict import BatchKwargs
 from great_expectations.core.usage_statistics.usage_statistics import send_usage_message
 from great_expectations.data_asset import DataAsset
-from great_expectations.data_context.types.base import (
-    MINIMUM_SUPPORTED_CONFIG_VERSION,
-    CheckpointConfig,
-)
+from great_expectations.data_context.types.base import MINIMUM_SUPPORTED_CONFIG_VERSION
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,
@@ -299,10 +297,10 @@ def load_batch(
     context: DataContext,
     suite: Union[str, ExpectationSuite],
     batch_kwargs: Union[dict, BatchKwargs],
-) -> DataAsset:
-    batch: DataAsset = context.get_batch(batch_kwargs, suite)
-    assert isinstance(
-        batch, DataAsset
+) -> Union[Batch, DataAsset]:
+    batch: Union[Batch, DataAsset] = context.get_batch(batch_kwargs, suite)
+    assert isinstance(batch, DataAsset) or isinstance(
+        batch, Batch
     ), "Batch failed to load. Please check your batch_kwargs"
     return batch
 
@@ -345,14 +343,13 @@ def load_checkpoint(
     context: DataContext,
     checkpoint_name: str,
     usage_event: str,
-    return_config: bool = True,
-) -> Union[CheckpointConfig, Checkpoint, LegacyCheckpoint]:
+) -> Union[Checkpoint, LegacyCheckpoint]:
     """Load a checkpoint or raise helpful errors."""
     try:
-        checkpoint_config = context.get_checkpoint(
-            checkpoint_name, return_config=return_config
+        checkpoint: Union[Checkpoint, LegacyCheckpoint] = context.get_checkpoint(
+            checkpoint_name
         )
-        return checkpoint_config
+        return checkpoint
     except (
         ge_exceptions.CheckpointNotFoundError,
         ge_exceptions.InvalidCheckpointConfigError,

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -2754,9 +2754,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         self.checkpoint_store.set(key=key, value=checkpoint_config)
         return new_checkpoint
 
-    def get_checkpoint(
-        self, name: str, return_config: bool = True
-    ) -> Union[CheckpointConfig, Checkpoint, LegacyCheckpoint]:
+    def get_checkpoint(self, name: str) -> Union[Checkpoint, LegacyCheckpoint]:
         key: ConfigurationIdentifier = ConfigurationIdentifier(
             configuration_key=name,
         )
@@ -2795,9 +2793,6 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
                 raise ge_exceptions.CheckpointError(
                     message="Attempt to instantiate LegacyCheckpoint with insufficient and/or incorrect arguments."
                 )
-
-        if return_config:
-            return checkpoint_config
 
         config: dict = checkpoint_config.to_json_dict()
         config.update({"name": name})
@@ -2852,7 +2847,6 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
 
         checkpoint: Union[Checkpoint, LegacyCheckpoint] = self.get_checkpoint(
             name=checkpoint_name,
-            return_config=False,
         )
 
         return checkpoint.run(

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -942,7 +942,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
         configuration_key=checkpoint_config.name
     )
     context.checkpoint_store.set(key=checkpoint_config_key, value=checkpoint_config)
-    checkpoint = context.get_checkpoint(checkpoint_config.name, return_config=False)
+    checkpoint = context.get_checkpoint(checkpoint_config.name)
 
     with pytest.raises(
         ge_exceptions.DataContextError, match=r"expectation_suite .* not found"


### PR DESCRIPTION
Changes proposed in this pull request:

This PR removes the return_config parameter to make DataContext.get_checkpoint() do what it says by returning a Checkpoint.
CheckpointConfigs are easy to access from the Checkpoint.config property.