### PR TITLE
[BUGFIX] Use correct schema to fetch table and column metadata

### DIFF
--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -496,12 +496,12 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         else:
             try:
                 # use the schema name configured for the datasource
-                query_schema = self.engine.url.query.get("schema")
+                temp_table_schema_name = self.engine.url.query.get("schema")
             except AttributeError as err:
                 # sqlite/mssql dialects use a Connection object instead of Engine and override self.engine
                 # retrieve the schema from the Connection object i.e. self.engine
                 conn_object = self.engine
-                query_schema = conn_object.engine.url.query.get("schema")
+                temp_table_schema_name = conn_object.engine.url.query.get("schema")
 
             self._table = sa.Table(table_name, sa.MetaData(), schema=schema)
 
@@ -564,7 +564,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         if custom_sql:
             self.create_temporary_table(
-                table_name, custom_sql, schema_name=query_schema
+                table_name, custom_sql, schema_name=temp_table_schema_name
             )
 
             if self.generated_table_name is not None:

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -503,7 +503,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 conn_object = self.engine
                 query_schema = conn_object.engine.url.query.get("schema")
 
-            self._table = sa.Table(table_name, sa.MetaData(), schema=query_schema)
+            self._table = sa.Table(table_name, sa.MetaData(), schema=schema)
 
         # Get the dialect **for purposes of identifying types**
         if self.engine.dialect.name.lower() in [
@@ -583,7 +583,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         try:
             insp = reflection.Inspector.from_engine(self.engine)
-            self.columns = insp.get_columns(table_name, schema=query_schema)
+            self.columns = insp.get_columns(table_name, schema=schema)
         except KeyError:
             # we will get a KeyError for temporary tables, since
             # reflection will not find the temporary schema


### PR DESCRIPTION
Changes proposed in this pull request:
- Use schema provided via the prompt in `great_expectations suite` creation flow to get metadata about table and columns