### PR TITLE
[BUGFIX] sqlalchemy_dataset bug

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 Develop
 -----------------
-
+* [BUGFIX] Fix Local variable 'query_schema' might be referenced before assignment bug in sqlalchemy_dataset.py
 
 0.13.5
 -----------------

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -564,7 +564,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         if custom_sql:
             self.create_temporary_table(
-                table_name, custom_sql, schema_name=query_schema
+                table_name, custom_sql, schema_name=schema
             )
 
             if self.generated_table_name is not None:
@@ -583,7 +583,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         try:
             insp = reflection.Inspector.from_engine(self.engine)
-            self.columns = insp.get_columns(table_name, schema=query_schema)
+            self.columns = insp.get_columns(table_name, schema=schema)
         except KeyError:
             # we will get a KeyError for temporary tables, since
             # reflection will not find the temporary schema

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -493,6 +493,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         if self.engine.dialect.name.lower() == "bigquery":
             # In BigQuery the table name is already qualified with its schema name
             self._table = sa.Table(table_name, sa.MetaData(), schema=None)
+            query_schema = None
         else:
             try:
                 # use the schema name configured for the datasource
@@ -564,7 +565,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         if custom_sql:
             self.create_temporary_table(
-                table_name, custom_sql, schema_name=schema
+                table_name, custom_sql, schema_name=query_schema
             )
 
             if self.generated_table_name is not None:
@@ -583,7 +584,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         try:
             insp = reflection.Inspector.from_engine(self.engine)
-            self.columns = insp.get_columns(table_name, schema=schema)
+            self.columns = insp.get_columns(table_name, schema=query_schema)
         except KeyError:
             # we will get a KeyError for temporary tables, since
             # reflection will not find the temporary schema


### PR DESCRIPTION
After the release of Great Expectations version 0.13.5

We encountered the following issue :

```
[2021-01-20 11:39:00,429] {{taskinstance.py:1145}} ERROR - local variable 'query_schema' referenced before assignment
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 983, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/opt/airflow/src/datahub/operators/expectations/great_expectations_operator.py", line 52, in execute
    self._run_validation(context)
  File "/opt/airflow/src/datahub/operators/expectations/great_expectations_operator.py", line 59, in _run_validation
    batches_to_validate = [self._create_batch(data_context)]
  File "/opt/airflow/src/datahub/operators/expectations/great_expectations_operator.py", line 85, in _create_batch
    batch = context.get_batch(batch_kwargs, suite, data_asset_type=self._get_data_asset_type())
  File "/home/airflow/.local/lib/python3.7/site-packages/great_expectations/data_context/data_context.py", line 1354, in get_batch
    batch_parameters=batch_parameters,
  File "/home/airflow/.local/lib/python3.7/site-packages/great_expectations/data_context/data_context.py", line 1081, in _get_batch_v2
    return validator.get_dataset()
  File "/home/airflow/.local/lib/python3.7/site-packages/great_expectations/validator/validator.py", line 1392, in get_dataset
    **self.batch.batch_kwargs.get("dataset_options", {}),
  File "/home/airflow/.local/lib/python3.7/site-packages/great_expectations/dataset/sqlalchemy_dataset.py", line 567, in __init__
    table_name, custom_sql, schema_name=query_schema
UnboundLocalError: local variable 'query_schema' referenced before assignment
```

Changes proposed in this pull request:
- Fix `Local variable 'query_schema' might be referenced before assignment` in sqlalchemy_dataset
