### PR TITLE
[FEATURE] Modular Expectations API Improvements

### DIFF
--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
@@ -197,8 +197,6 @@ Steps
 
                 Attempting to instantiate class from config...
                 Instantiating as a Datasource, since class_name is Datasource
-                Instantiating class from config without an explicit class_name is dangerous.
-                Consider adding an explicit class_name for None
                     Successfully instantiated Datasource
 
                 Execution engine: PandasExecutionEngine

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
@@ -195,7 +195,6 @@ Steps
 
                 Attempting to instantiate class from config...
                     Instantiating as a Datasource, since class_name is Datasource
-                Instantiating class from config without an explicit class_name is dangerous. Consider adding an explicit class_name for None
                     Successfully instantiated Datasource
 
                 Execution engine: PandasExecutionEngine

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
@@ -186,7 +186,6 @@ Steps
 
                 Attempting to instantiate class from config...
                 Instantiating as a Datasource, since class_name is Datasource
-                Instantiating class from config without an explicit class_name is dangerous. Consider adding an explicit class_name for None
                     Successfully instantiated Datasource
 
                 Execution engine: SparkDFExecutionEngine

--- a/docs/reference/core_concepts/datasource.rst
+++ b/docs/reference/core_concepts/datasource.rst
@@ -41,7 +41,7 @@ The ``Datasource`` is responsible for orchestrating the building of a Batch, usi
 .. code-block:: python
 
     new_batch = Batch(
-        data = batch_data,
+        data=batch_data,
         batch_request=batch_request
         batch_definition=batch_definition,
         batch_spec=batch_spec,

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -13,6 +13,7 @@ from great_expectations.core.id_dict import (
 )
 from great_expectations.exceptions import InvalidBatchIdError
 from great_expectations.types import DictDot, SerializableDictDot
+from great_expectations.validator.validation_graph import MetricConfiguration
 
 
 class BatchDefinition(SerializableDictDot):
@@ -472,5 +473,12 @@ class Batch(DictDot):
         }
         return json.dumps(json_dict, indent=2)
 
-    def head(self):
-        return self._data.head()
+    def head(self, n_rows=5, fetch_all=False):
+        # FIXME - we should use a Validator after resolving circularity
+        # Validator(self._data.execution_engine, batches=(self,)).get_metric(MetricConfiguration("table.head", {"batch_id": self.id}, {"n_rows": n_rows, "fetch_all": fetch_all}))
+        metric = MetricConfiguration(
+            "table.head",
+            {"batch_id": self.id},
+            {"n_rows": n_rows, "fetch_all": fetch_all},
+        )
+        return self._data.execution_engine.resolve_metrics((metric,))[metric.id]

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -520,8 +520,8 @@ class DatasourceConfig(DictDot):
         batch_kwargs_generators=None,
         connection_string=None,
         credentials=None,
-        introspection=None,
-        tables=None,
+        inferred_assets=None,
+        assets=None,
         boto3_options=None,
         reader_method=None,
         reader_options=None,
@@ -561,10 +561,10 @@ class DatasourceConfig(DictDot):
             self.connection_string = connection_string
         if credentials is not None:
             self.credentials = credentials
-        if introspection is not None:
-            self.introspection = introspection
-        if tables is not None:
-            self.tables = tables
+        if inferred_assets is not None:
+            self.inferred_assets = inferred_assets
+        if assets is not None:
+            self.assets = assets
         if boto3_options is not None:
             self.boto3_options = boto3_options
         if reader_method is not None:
@@ -611,8 +611,8 @@ class DatasourceConfigSchema(Schema):
     )
     connection_string = fields.String(required=False, allow_none=True)
     credentials = fields.Raw(required=False, allow_none=True)
-    introspection = fields.Dict(required=False, allow_none=True)
-    tables = fields.Dict(required=False, allow_none=True)
+    inferred_assets = fields.Dict(required=False, allow_none=True)
+    assets = fields.Dict(required=False, allow_none=True)
     boto3_options = fields.Dict(
         keys=fields.Str(), values=fields.Str(), required=False, allow_none=True
     )
@@ -635,8 +635,8 @@ class DatasourceConfigSchema(Schema):
         if (
             "connection_string" in data
             or "credentials" in data
-            or "introspection" in data
-            or "tables" in data
+            or "inferred_assets" in data
+            or "assets" in data
         ) and not (
             data["class_name"]
             in [

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -185,39 +185,9 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             )
         ]
 
-    def build_batch_spec(
-        self, batch_definition: BatchDefinition
-    ) -> SqlAlchemyDatasourceBatchSpec:
-        """
-        Build BatchSpec from batch_definition by calling DataConnector's build_batch_spec function.
-
-        Args:
-            batch_definition (BatchDefinition): to be used to build batch_spec
-
-        Returns:
-            BatchSpec built from batch_definition
-        """
-        batch_spec: BatchSpec = super().build_batch_spec(
-            batch_definition=batch_definition
-        )
-
-        data_asset_name: str = batch_definition.data_asset_name
-        if (
-            data_asset_name in self.data_assets
-            and self.data_assets[data_asset_name].get("batch_spec_passthrough")
-            and isinstance(
-                self.data_assets[data_asset_name].get("batch_spec_passthrough"), dict
-            )
-        ):
-            batch_spec.update(
-                self.data_assets[data_asset_name]["batch_spec_passthrough"]
-            )
-
-        return SqlAlchemyDatasourceBatchSpec(batch_spec)
-
     def _generate_batch_spec_parameters_from_batch_definition(
         self, batch_definition: BatchDefinition
-    ) -> dict:
+    ) -> Dict:
         """
         Build BatchSpec parameters from batch_definition with the following components:
             1. data_asset_name from batch_definition
@@ -243,8 +213,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         self,
         table_name: str,
     ):
-        """
-        'Split' by returning the whole table
+        """'Split' by returning the whole table
 
         Note: the table_name parameter is a required to keep the signature of this method consistent with other methods.
         """

--- a/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
@@ -156,7 +156,8 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
                 )
 
             data_asset_config = {
-                "table_name": metadata["schema_name"] + "." + metadata["table_name"],
+                "schema_name": metadata["schema_name"],
+                "table_name": metadata["table_name"],
             }
             if not splitter_method is None:
                 data_asset_config["splitter_method"] = splitter_method

--- a/great_expectations/datasource/data_connector/util.py
+++ b/great_expectations/datasource/data_connector/util.py
@@ -19,7 +19,7 @@ from great_expectations.core.id_dict import (
 )
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource.data_connector.sorter import Sorter
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
 
@@ -355,13 +355,3 @@ def _build_sorter_from_config(sorter_config: Dict[str, Any]) -> Sorter:
         },
     )
     return sorter
-
-
-def fetch_batch_data_as_pandas_df(batch_data):
-    if isinstance(batch_data, pd.DataFrame):
-        return batch_data
-    if pyspark_sql and isinstance(batch_data, pyspark_sql.DataFrame):
-        return batch_data.toPandas()
-    if isinstance(batch_data, SqlAlchemyBatchData):
-        return batch_data.head(fetch_all=True)
-    raise ge_exceptions.DataConnectorError("Unknown batch_data type encountered.")

--- a/great_expectations/exceptions/metric_exceptions.py
+++ b/great_expectations/exceptions/metric_exceptions.py
@@ -1,4 +1,6 @@
 """Exceptions related to metrics"""
+from collections import Iterable
+
 from great_expectations.exceptions import GreatExpectationsError
 
 
@@ -8,3 +10,11 @@ class MetricError(GreatExpectationsError):
 
 class MetricProviderError(MetricError):
     pass
+
+
+class MetricResolutionError(MetricError):
+    def __init__(self, message, failed_metrics):
+        super().__init__(message)
+        if not isinstance(failed_metrics, Iterable):
+            failed_metrics = (failed_metrics,)
+        self.failed_metrics = failed_metrics

--- a/great_expectations/execution_engine/pandas_batch_data.py
+++ b/great_expectations/execution_engine/pandas_batch_data.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+from great_expectations.execution_engine.execution_engine import BatchData
+
+
+class PandasBatchData(BatchData):
+    def __init__(self, execution_engine, dataframe: pd.DataFrame):
+        super().__init__(execution_engine=execution_engine)
+        self._dataframe = dataframe
+
+    @property
+    def dataframe(self):
+        return self._dataframe

--- a/great_expectations/execution_engine/sparkdf_batch_data.py
+++ b/great_expectations/execution_engine/sparkdf_batch_data.py
@@ -1,0 +1,11 @@
+from great_expectations.execution_engine.execution_engine import BatchData
+
+
+class SparkDFBatchData(BatchData):
+    def __init__(self, execution_engine, dataframe):
+        super().__init__(execution_engine)
+        self._dataframe = dataframe
+
+    @property
+    def dataframe(self):
+        return self._dataframe

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -1,0 +1,237 @@
+import logging
+import uuid
+
+from great_expectations.execution_engine.execution_engine import BatchData
+
+try:
+    import sqlalchemy as sa
+    from sqlalchemy.engine.default import DefaultDialect
+    from sqlalchemy.sql.elements import quoted_name
+except ImportError:
+    sa = None
+    quoted_name = None
+    DefaultDialect = None
+
+logger = logging.getLogger(__name__)
+
+
+class SqlAlchemyBatchData(BatchData):
+    """A class which represents a SQL alchemy batch, with properties including the construction of the batch itself
+    and several getters used to access various properties."""
+
+    def __init__(
+        self,
+        execution_engine,
+        record_set_name: str = None,
+        # Option 1
+        schema_name: str = None,
+        table_name: str = None,
+        # Option 2
+        query: str = None,
+        # Option 3
+        selectable=None,
+        create_temp_table: bool = True,
+        temp_table_name: str = None,
+        temp_table_schema_name: str = None,
+        use_quoted_name: bool = False,
+        source_table_name: str = None,
+        source_schema_name: str = None,
+    ):
+        """A Constructor used to initialize and SqlAlchemy Batch, create an id for it, and verify that all necessary
+        parameters have been provided. If a Query is given, also builds a temporary table for this query
+
+            Args:
+                engine (SqlAlchemy Engine): \
+                    A SqlAlchemy Engine or connection that will be used to access the data
+                record_set_name: (string or None): \
+                    The name of the record set available as a domain kwarg for Great Expectations validations. record_set_name
+                    can usually be None, but is required when there are multiple record_sets in the same Batch.
+                schema_name (string or None): \
+                    The name of the schema_name in which the databases lie
+                table_name (string or None): \
+                    The name of the table that will be accessed. Either this parameter or the query parameter must be
+                    specified. Default is 'None'.
+                query (string or None): \
+                    A query string representing a domain, which will be used to create a temporary table
+                selectable (Sqlalchemy Selectable or None): \
+                    A SqlAlchemy selectable representing a domain, which will be used to create a temporary table
+                create_temp_table (bool): \
+                    When building the batch data object from a query, this flag determines whether a temporary table should
+                    be created against which to validate data from the query. If False, a subselect statement will be used
+                    in each validation.
+                temp_table_name (str or None): \
+                    The name to use for a temporary table if one should be created. If None, a default name will be generated.
+                temp_table_schema_name (str or None): \
+                    The name of the schema in which a temporary table should be created. If None, the default schema will be
+                    used if a temporary table is requested.
+                use_quoted_name (bool): \
+                    If true, names should be quoted to preserve case sensitivity on databases that usually normalize them
+                source_table_name (str): \
+                    For SqlAlchemyBatchData based on selectables, source_table_name provides the name of the table on which
+                    the selectable is based. This is required for most kinds of table introspection (e.g. looking up column types)
+                source_schema_name (str): \
+                    For SqlAlchemyBatchData based on selectables, source_schema_name provides the name of the schema on which
+                    the selectable is based. This is required for most kinds of table introspection (e.g. looking up column types)
+
+        The query that will be executed against the DB can be determined in any of three ways:
+
+            1. Specify a `schema_name` and `table_name`. This will query the whole table as a record_set. If schema_name is None, then the default schema will be used.
+            2. Specify a `query`, which will be executed as-is to fetch the record_set. NOTE Abe 20201118 : This functionality is currently untested.
+            3. Specify a `selectable`, which will be to fetch the record_set. This is the primary path used by DataConnectors.
+
+        In the case of (2) and (3) you have the option to execute the query either as a temporary table, or as a subselect statement.
+
+        In general, temporary tables invite more optimization from the query engine itself. Subselect statements may sometimes be preffered, because they do not require write access on the database.
+
+
+        """
+        super().__init__(execution_engine)
+        engine = execution_engine.engine
+        self._engine = engine
+        self._record_set_name = record_set_name or "great_expectations_sub_selection"
+        if not isinstance(self._record_set_name, str):
+            raise TypeError(
+                f"record_set_name should be of type str, not {type(record_set_name)}"
+            )
+
+        self._schema_name = schema_name
+        self._use_quoted_name = use_quoted_name
+        self._source_table_name = source_table_name
+        self._source_schema_name = source_schema_name
+
+        if sum(bool(x) for x in [table_name, query, selectable is not None]) != 1:
+            raise ValueError(
+                "Exactly one of table_name, query, or selectable must be specified"
+            )
+        elif (query and schema_name) or (selectable is not None and schema_name):
+            raise ValueError(
+                "schema_name can only be used with table_name. Use temp_table_schema_name to provide a target schema for creating a temporary table."
+            )
+
+        if table_name:
+            # Suggestion: pull this block out as its own _function
+            if use_quoted_name:
+                table_name = quoted_name(table_name, quote=True)
+            if engine.dialect.name.lower() == "bigquery":
+                if schema_name is not None:
+                    logger.warning(
+                        "schema_name should not be used when passing a table_name for biquery. Instead, include the schema name in the table_name string."
+                    )
+                # In BigQuery the table name is already qualified with its schema name
+                self._selectable = sa.Table(
+                    table_name,
+                    sa.MetaData(),
+                    schema_name=None,
+                )
+            else:
+                self._selectable = sa.Table(
+                    table_name,
+                    sa.MetaData(),
+                    schema_name=schema_name,
+                )
+
+        elif create_temp_table:
+            if temp_table_name:
+                generated_table_name = temp_table_name
+            else:
+                # Suggestion: Pull this into a separate "_generate_temporary_table_name" method
+                generated_table_name = f"ge_tmp_{str(uuid.uuid4())[:8]}"
+                # mssql expects all temporary table names to have a prefix '#'
+                if engine.dialect.name.lower() == "mssql":
+                    generated_table_name = f"#{generated_table_name}"
+                if engine.dialect.name.lower() == "bigquery":
+                    raise ValueError(
+                        "No BigQuery dataset specified.  Include bigquery_temp_table in "
+                        "batch_spec_passthrough or a specify a default dataset in engine url"
+                    )
+            if selectable is not None:
+                # compile selectable to sql statement
+                query = selectable.compile(
+                    dialect=self.sql_engine_dialect,
+                    compile_kwargs={"literal_binds": True},
+                )
+            self._create_temporary_table(
+                generated_table_name,
+                query,
+                temp_table_schema_name=temp_table_schema_name,
+            )
+            self._selectable = sa.Table(
+                generated_table_name,
+                sa.MetaData(),
+                schema_name=temp_table_schema_name,
+            )
+        else:
+            if query:
+                self._selectable = sa.text(query)
+            else:
+                self._selectable = selectable.alias(self._record_set_name)
+
+    @property
+    def sql_engine_dialect(self) -> DefaultDialect:
+        """Returns the Batches' current engine dialect"""
+        return self._engine.dialect
+
+    @property
+    def record_set_name(self):
+        return self._record_set_name
+
+    @property
+    def source_table_name(self):
+        return self._source_table_name
+
+    @property
+    def source_schema_name(self):
+        return self._source_schema_name
+
+    @property
+    def selectable(self):
+        return self._selectable
+
+    @property
+    def use_quoted_name(self):
+        return self._use_quoted_name
+
+    def _create_temporary_table(
+        self, temp_table_name, query, temp_table_schema_name=None
+    ):
+        """
+        Create Temporary table based on sql query. This will be used as a basis for executing expectations.
+        :param query:
+        """
+        if self.sql_engine_dialect.name.lower() == "bigquery":
+            stmt = "CREATE OR REPLACE TABLE `{temp_table_name}` AS {query}".format(
+                temp_table_name=temp_table_name, query=query
+            )
+        elif self.sql_engine_dialect.name.lower() == "snowflake":
+            if temp_table_schema_name is not None:
+                temp_table_name = temp_table_schema_name + "." + temp_table_name
+            stmt = (
+                "CREATE OR REPLACE TEMPORARY TABLE {temp_table_name} AS {query}".format(
+                    temp_table_name=temp_table_name, query=query
+                )
+            )
+        elif self.sql_engine_dialect.name == "mysql":
+            # Note: We can keep the "MySQL" clause separate for clarity, even though it is the same as the
+            # generic case.
+            stmt = "CREATE TEMPORARY TABLE {temp_table_name} AS {query}".format(
+                temp_table_name=temp_table_name, query=query
+            )
+        elif self.sql_engine_dialect.name == "mssql":
+            # Insert "into #{temp_table_name}" in the custom sql query right before the "from" clause
+            # Split is case sensitive so detect case.
+            # Note: transforming query to uppercase/lowercase has unintended consequences (i.e.,
+            # changing column names), so this is not an option!
+            query = query.string  # extracting string from MSSQLCompiler object
+            if "from" in query:
+                strsep = "from"
+            else:
+                strsep = "FROM"
+            querymod = query.split(strsep, maxsplit=1)
+            stmt = (querymod[0] + "into {temp_table_name} from" + querymod[1]).format(
+                temp_table_name=temp_table_name
+            )
+        else:
+            stmt = 'CREATE TEMPORARY TABLE "{temp_table_name}" AS {query}'.format(
+                temp_table_name=temp_table_name, query=query
+            )
+        self._engine.execute(stmt)

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1,12 +1,9 @@
 import copy
 import datetime
 import logging
-import uuid
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
-
-import pandas as pd
 
 from great_expectations.core import IDDict
 from great_expectations.core.batch import BatchMarkers, BatchSpec
@@ -18,6 +15,9 @@ from great_expectations.exceptions import (
 )
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
+    SqlAlchemyBatchData,
+)
 from great_expectations.expectations.row_conditions import parse_condition_to_sqlalchemy
 from great_expectations.util import (
     filter_properties_dict,
@@ -125,237 +125,6 @@ def _get_dialect_type_module(dialect):
     return dialect
 
 
-class SqlAlchemyBatchData:
-    """A class which represents a SQL alchemy batch, with properties including the construction of the batch itself
-    and several getters used to access various properties."""
-
-    def __init__(
-        self,
-        engine,
-        record_set_name: str = None,
-        # Option 1
-        schema_name: str = None,
-        table_name: str = None,
-        # Option 2
-        query: str = None,
-        # Option 3
-        selectable=None,
-        create_temp_table: bool = True,
-        temp_table_name: str = None,
-        temp_table_schema_name: str = None,
-        use_quoted_name: bool = False,
-    ):
-        """A Constructor used to initialize and SqlAlchemy Batch, create an id for it, and verify that all necessary
-        parameters have been provided. If a Query is given, also builds a temporary table for this query
-
-            Args:
-                engine (SqlAlchemy Engine): \
-                    A SqlAlchemy Engine or connection that will be used to access the data
-                record_set_name: (string or None): \
-                    The name of the record set available as a domain kwarg for Great Expectations validations. record_set_name
-                    can usually be None, but is required when there are multiple record_sets in the same Batch.
-                schema_name (string or None): \
-                    The name of the schema_name in which the databases lie
-                table_name (string or None): \
-                    The name of the table that will be accessed. Either this parameter or the query parameter must be
-                    specified. Default is 'None'.
-                query (string or None): \
-                    A query string representing a domain, which will be used to create a temporary table
-                selectable (Sqlalchemy Selectable or None): \
-                    A SqlAlchemy selectable representing a domain, which will be used to create a temporary table
-                create_temp_table (bool): \
-                    When building the batch data object from a query, this flag determines whether a temporary table should
-                    be created against which to validate data from the query. If False, a subselect statement will be used
-                    in each validation.
-                temp_table_name (str or None): \
-                    The name to use for a temporary table if one should be created. If None, a default name will be generated.
-                temp_table_schema_name (str or None): \
-                    The name of the schema in which a temporary table should be created. If None, the default schema will be
-                    used if a temporary table is requested.
-                use_quoted_name (bool): \
-                    If true, names should be quoted to preserve case sensitivity on databases that usually normalize them
-
-        The query that will be executed against the DB can be determined in any of three ways:
-
-            1. Specify a `schema_name` and `table_name`. This will query the whole table as a record_set. If schema_name is None, then the default schema will be used.
-            2. Specify a `query`, which will be executed as-is to fetch the record_set. NOTE Abe 20201118 : This functionality is currently untested.
-            3. Specify a `selectable`, which will be to fetch the record_set. This is the primary path used by DataConnectors.
-
-        In the case of (2) and (3) you have the option to execute the query either as a temporary table, or as a subselect statement.
-
-        In general, temporary tables invite more optimization from the query engine itself. Subselect statements may sometimes be preffered, because they do not require write access on the database.
-
-
-        """
-        self._engine = engine
-        self._record_set_name = record_set_name or "great_expectations_sub_selection"
-        if not isinstance(self._record_set_name, str):
-            raise TypeError(
-                f"record_set_name should be of type str, not {type(record_set_name)}"
-            )
-
-        self._schema_name = schema_name
-        self._use_quoted_name = use_quoted_name
-
-        if sum(bool(x) for x in [table_name, query, selectable is not None]) != 1:
-            raise ValueError(
-                "Exactly one of table_name, query, or selectable must be specified"
-            )
-        elif (query and schema_name) or (selectable is not None and schema_name):
-            raise ValueError(
-                "schema_name can only be used with table_name. Use temp_table_schema_name to provide a target schema for creating a temporary table."
-            )
-
-        if table_name:
-            # Suggestion: pull this block out as its own _function
-            if use_quoted_name:
-                table_name = quoted_name(table_name, quote=True)
-            if engine.dialect.name.lower() == "bigquery":
-                if schema_name is not None:
-                    logger.warning(
-                        "schema_name should not be used when passing a table_name for biquery. Instead, include the schema name in the table_name string."
-                    )
-                # In BigQuery the table name is already qualified with its schema name
-                self._selectable = sa.Table(
-                    table_name,
-                    sa.MetaData(),
-                    schema_name=None,
-                )
-            else:
-                self._selectable = sa.Table(
-                    table_name,
-                    sa.MetaData(),
-                    schema_name=schema_name,
-                )
-
-        elif create_temp_table:
-            if temp_table_name:
-                generated_table_name = temp_table_name
-            else:
-                # Suggestion: Pull this into a separate "_generate_temporary_table_name" method
-                generated_table_name = f"ge_tmp_{str(uuid.uuid4())[:8]}"
-                # mssql expects all temporary table names to have a prefix '#'
-                if engine.dialect.name.lower() == "mssql":
-                    generated_table_name = f"#{generated_table_name}"
-                if engine.dialect.name.lower() == "bigquery":
-                    raise ValueError(
-                        "No BigQuery dataset specified.  Include bigquery_temp_table in "
-                        "batch_spec_passthrough or a specify a default dataset in engine url"
-                    )
-            if selectable is not None:
-                # compile selectable to sql statement
-                query = selectable.compile(
-                    dialect=self.sql_engine_dialect,
-                    compile_kwargs={"literal_binds": True},
-                )
-            self._create_temporary_table(
-                generated_table_name,
-                query,
-                temp_table_schema_name=temp_table_schema_name,
-            )
-            self._selectable = sa.Table(
-                generated_table_name,
-                sa.MetaData(),
-                schema_name=temp_table_schema_name,
-            )
-        else:
-            if query:
-                self._selectable = sa.text(query)
-            else:
-                self._selectable = selectable.alias(self._record_set_name)
-
-    @property
-    def sql_engine_dialect(self) -> DefaultDialect:
-        """Returns the Batches' current engine dialect"""
-        return self._engine.dialect
-
-    @property
-    def record_set_name(self):
-        return self._record_set_name
-
-    @property
-    def selectable(self):
-        return self._selectable
-
-    @property
-    def use_quoted_name(self):
-        return self._use_quoted_name
-
-    def _create_temporary_table(
-        self, temp_table_name, query, temp_table_schema_name=None
-    ):
-        """
-        Create Temporary table based on sql query. This will be used as a basis for executing expectations.
-        :param query:
-        """
-        if self.sql_engine_dialect.name.lower() == "bigquery":
-            stmt = "CREATE OR REPLACE TABLE `{temp_table_name}` AS {query}".format(
-                temp_table_name=temp_table_name, query=query
-            )
-        elif self.sql_engine_dialect.name.lower() == "snowflake":
-            if temp_table_schema_name is not None:
-                temp_table_name = temp_table_schema_name + "." + temp_table_name
-            stmt = (
-                "CREATE OR REPLACE TEMPORARY TABLE {temp_table_name} AS {query}".format(
-                    temp_table_name=temp_table_name, query=query
-                )
-            )
-        elif self.sql_engine_dialect.name == "mysql":
-            # Note: We can keep the "MySQL" clause separate for clarity, even though it is the same as the
-            # generic case.
-            stmt = "CREATE TEMPORARY TABLE {temp_table_name} AS {query}".format(
-                temp_table_name=temp_table_name, query=query
-            )
-        elif self.sql_engine_dialect.name == "mssql":
-            # Insert "into #{temp_table_name}" in the custom sql query right before the "from" clause
-            # Split is case sensitive so detect case.
-            # Note: transforming query to uppercase/lowercase has unintended consequences (i.e.,
-            # changing column names), so this is not an option!
-            query = query.string  # extracting string from MSSQLCompiler object
-            if "from" in query:
-                strsep = "from"
-            else:
-                strsep = "FROM"
-            querymod = query.split(strsep, maxsplit=1)
-            stmt = (querymod[0] + "into {temp_table_name} from" + querymod[1]).format(
-                temp_table_name=temp_table_name
-            )
-        else:
-            stmt = 'CREATE TEMPORARY TABLE "{temp_table_name}" AS {query}'.format(
-                temp_table_name=temp_table_name, query=query
-            )
-        self._engine.execute(stmt)
-
-    def head(self, n=5, fetch_all=False):
-        """Fetches the head of the table"""
-
-        if fetch_all:
-            result_object = self._engine.execute(
-                sa.select("*").select_from(self._selectable)
-            )
-        else:
-            result_object = self._engine.execute(
-                sa.select("*").limit(n).select_from(self._selectable)
-            )
-
-        rows = result_object.fetchall()
-
-        # Note: Abe 20201119: This should be a GE type
-        head_df = pd.DataFrame(rows, columns=result_object._metadata.keys)
-
-        return head_df
-
-    def row_count(self):
-        """Gets the number of rows"""
-
-        result_object = self._engine.execute(
-            sa.select([sa.func.count()]).select_from(self._selectable)
-        )
-        rows = result_object.fetchall()
-
-        return rows[0][0]
-
-
 class SqlAlchemyExecutionEngine(ExecutionEngine):
     def __init__(
         self,
@@ -366,6 +135,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         connection_string=None,
         url=None,
         batch_data_dict=None,
+        create_temp_table=True,
         **kwargs,  # These will be passed as optional parameters to the SQLAlchemy engine, **not** the ExecutionEngine
     ):
         """Builds a SqlAlchemyExecutionEngine, using a provided connection string/url/engine/credentials to access the
@@ -393,12 +163,13 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                     a url can be used to access the data. This will be overridden by all other configuration
                     options if any are provided.
         """
-        super().__init__(name=name, batch_data_dict=batch_data_dict)  # , **kwargs)
+        super().__init__(name=name, batch_data_dict=batch_data_dict)
         self._name = name
 
         self._credentials = credentials
         self._connection_string = connection_string
         self._url = url
+        self._create_temp_table = create_temp_table
 
         if engine is not None:
             if credentials is not None:
@@ -429,24 +200,24 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             "oracle",
         ]:
             # These are the officially included and supported dialects by sqlalchemy
-            self.dialect = import_library_module(
+            self.dialect_module = import_library_module(
                 module_name="sqlalchemy.dialects." + self.engine.dialect.name
             )
 
         elif self.engine.dialect.name.lower() == "snowflake":
-            self.dialect = import_library_module(
+            self.dialect_module = import_library_module(
                 module_name="snowflake.sqlalchemy.snowdialect"
             )
         elif self.engine.dialect.name.lower() == "redshift":
-            self.dialect = import_library_module(
+            self.dialect_module = import_library_module(
                 module_name="sqlalchemy_redshift.dialect"
             )
         elif self.engine.dialect.name.lower() == "bigquery":
-            self.dialect = import_library_module(
+            self.dialect_module = import_library_module(
                 module_name="pybigquery.sqlalchemy_bigquery"
             )
         else:
-            self.dialect = None
+            self.dialect_module = None
 
         if self.engine and self.engine.dialect.name.lower() in [
             "sqlite",
@@ -494,6 +265,10 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
     @property
     def url(self):
         return self._url
+
+    @property
+    def dialect(self):
+        return self.engine.dialect.name.lower()
 
     def _build_engine(self, credentials, **kwargs) -> "sa.engine.Engine":
         """
@@ -843,7 +618,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             for idx, id in enumerate(query["ids"]):
                 resolved_metrics[id] = convert_to_json_serializable(res[0][idx])
 
-        # Convert metrics to be serializable
         return resolved_metrics
 
     ### Splitter methods for partitioning tables ###
@@ -1034,12 +808,24 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         self, batch_spec: BatchSpec
     ) -> Tuple[Any, BatchMarkers]:
         selectable = self._build_selectable_from_batch_spec(batch_spec=batch_spec)
+
         if "bigquery_temp_table" in batch_spec:
             temp_table_name = batch_spec.get("bigquery_temp_table")
         else:
             temp_table_name = None
+
+        source_table_name = batch_spec.get("table_name", None)
+        source_schema_name = batch_spec.get("schema_name", None)
+
         batch_data = SqlAlchemyBatchData(
-            engine=self.engine, selectable=selectable, temp_table_name=temp_table_name
+            execution_engine=self,
+            selectable=selectable,
+            temp_table_name=temp_table_name,
+            create_temp_table=batch_spec.get(
+                "create_temp_table", self._create_temp_table
+            ),
+            source_table_name=source_table_name,
+            source_schema_name=source_schema_name,
         )
         batch_markers = BatchMarkers(
             {

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -424,7 +424,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
 def _get_dialect_type_module(
     execution_engine,
 ):
-    if execution_engine.dialect is None:
+    if execution_engine.dialect_module is None:
         logger.warning(
             "No sqlalchemy dialect found; relying in top-level sqlalchemy types."
         )
@@ -432,10 +432,10 @@ def _get_dialect_type_module(
     try:
         # Redshift does not (yet) export types to top level; only recognize base SA types
         if isinstance(
-            execution_engine.sql_engine_dialect,
+            execution_engine.dialect_module,
             sqlalchemy_redshift.dialect.RedshiftDialect,
         ):
-            return execution_engine.dialect.sa
+            return execution_engine.dialect_module.sa
     except (TypeError, AttributeError):
         pass
 
@@ -443,7 +443,7 @@ def _get_dialect_type_module(
     try:
         if (
             isinstance(
-                execution_engine.sql_engine_dialect,
+                execution_engine.dialect_module,
                 pybigquery.sqlalchemy_bigquery.BigQueryDialect,
             )
             and bigquery_types_tuple is not None
@@ -452,7 +452,7 @@ def _get_dialect_type_module(
     except (TypeError, AttributeError):
         pass
 
-    return execution_engine.dialect
+    return execution_engine.dialect_module
 
 
 def _native_type_type_map(type_):

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_proportion_of_unique_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_proportion_of_unique_values.py
@@ -24,10 +24,10 @@ def unique_proportion(_metrics):
     unique_values = _metrics.get("column.distinct_values.count")
     null_count = _metrics.get("column_values.nonnull.unexpected_count")
 
-    if total_values > 0:
+    if (total_values - null_count) > 0:
         return unique_values / (total_values - null_count)
     else:
-        return 0
+        return None
 
 
 class ColumnUniqueProportion(ColumnMetricProvider):

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_standard_deviation.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_standard_deviation.py
@@ -41,6 +41,8 @@ class ColumnStandardDeviation(ColumnMetricProvider):
         """SqlAlchemy Standard Deviation implementation"""
         if _dialect.name.lower() == "mssql":
             standard_deviation = sa.func.stdev(column)
+        elif _dialect.name.lower() == "sqlite":
+            raise NotImplementedError
         else:
             standard_deviation = sa.func.stddev_samp(column)
         return standard_deviation

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
@@ -1,5 +1,4 @@
-import uuid
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional
 
 from great_expectations.core import ExpectationConfiguration
 from great_expectations.execution_engine import (
@@ -17,10 +16,8 @@ from great_expectations.expectations.metrics.import_manager import F, Window
 from great_expectations.expectations.metrics.map_metric import (
     ColumnMapMetricProvider,
     column_condition_partial,
-    column_function_partial,
 )
 from great_expectations.expectations.metrics.map_metric import sa as sa
-from great_expectations.expectations.metrics.metric_provider import metric_value
 from great_expectations.validator.validation_graph import MetricConfiguration
 
 
@@ -31,22 +28,22 @@ class ColumnValuesUnique(ColumnMapMetricProvider):
     def _pandas(cls, column, **kwargs):
         return ~column.duplicated(keep=False)
 
-    # NOTE: 20201119 - JPC - We cannot split per-dialect into window and non-window functions
-    # @column_condition_partial(
-    #     engine=SqlAlchemyExecutionEngine,
-    # )
-    # def _sqlalchemy(cls, column, _table, **kwargs):
-    #     dup_query = (
-    #         sa.select([column])
-    #         .select_from(_table)
-    #         .group_by(column)
-    #         .having(sa.func.count(column) > 1)
-    #     )
-    #
-    #     return column.notin_(dup_query)
+    @column_condition_partial(
+        engine=SqlAlchemyExecutionEngine,
+    )
+    def _sqlalchemy(cls, column, _table, **kwargs):
+        dup_query = (
+            sa.select([column])
+            .select_from(_table)
+            .group_by(column)
+            .having(sa.func.count(column) > 1)
+        )
+
+        return column.notin_(dup_query)
 
     @column_condition_partial(
         engine=SqlAlchemyExecutionEngine,
+        dialect="mssql",
         partial_fn_type=MetricPartialFunctionTypes.WINDOW_CONDITION_FN,
     )
     def _sqlalchemy_window(cls, column, _table, **kwargs):
@@ -84,3 +81,29 @@ class ColumnValuesUnique(ColumnMapMetricProvider):
     )
     def _spark(cls, column, **kwargs):
         return F.count(F.lit(1)).over(Window.partitionBy(column)) <= 1
+
+    @classmethod
+    def _get_evaluation_dependencies(
+        cls,
+        metric: MetricConfiguration,
+        configuration: Optional[ExpectationConfiguration] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
+        runtime_configuration: Optional[dict] = None,
+    ):
+        dependencies = super()._get_evaluation_dependencies(
+            metric, configuration, execution_engine, runtime_configuration
+        )
+        metric_name = metric.metric_name
+        if (
+            metric_name.endswith(".unexpected_count")
+            and execution_engine.dialect == "mssql"
+        ):
+            # we mustn't use aggregate_fn in this case, since we'll be using a window_fn
+            # use the metric_value_kwargs computed for the partial_fn though
+            configuration = dependencies.pop("metric_partial_fn")
+            dependencies["unexpected_condition"] = MetricConfiguration(
+                metric_name[: -len(".unexpected_count")] + ".condition",
+                metric.metric_domain_kwargs,
+                configuration.metric_value_kwargs,
+            )
+        return dependencies

--- a/great_expectations/expectations/metrics/table_metric.py
+++ b/great_expectations/expectations/metrics/table_metric.py
@@ -1,26 +1,6 @@
 import logging
-from functools import wraps
-from typing import Any, Callable, Dict, Optional, Tuple, Type
 
-from great_expectations.core import ExpectationConfiguration
-from great_expectations.exceptions.metric_exceptions import MetricProviderError
-from great_expectations.execution_engine import (
-    ExecutionEngine,
-    PandasExecutionEngine,
-    SparkDFExecutionEngine,
-)
-from great_expectations.execution_engine.execution_engine import (
-    MetricPartialFunctionTypes,
-)
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
-    SqlAlchemyExecutionEngine,
-)
-from great_expectations.expectations.metrics.metric_provider import (
-    MetricProvider,
-    metric_value,
-)
-from great_expectations.expectations.registry import get_metric_provider
-from great_expectations.validator.validation_graph import MetricConfiguration
+from great_expectations.expectations.metrics.metric_provider import MetricProvider
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/expectations/metrics/table_metrics/__init__.py
+++ b/great_expectations/expectations/metrics/table_metrics/__init__.py
@@ -1,4 +1,5 @@
 from .table_column_count import TableColumnCount
 from .table_column_types import ColumnTypes
 from .table_columns import TableColumns
+from .table_head import TableHead
 from .table_row_count import TableRowCount

--- a/great_expectations/expectations/metrics/table_metrics/table_head.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_head.py
@@ -1,0 +1,110 @@
+from typing import Any, Dict, Tuple
+
+import pandas as pd
+
+from great_expectations.execution_engine import (
+    PandasExecutionEngine,
+    SparkDFExecutionEngine,
+    SqlAlchemyExecutionEngine,
+)
+from great_expectations.execution_engine.execution_engine import MetricDomainTypes
+from great_expectations.expectations.metrics.import_manager import sa
+from great_expectations.expectations.metrics.metric_provider import metric_value
+from great_expectations.expectations.metrics.table_metric import TableMetricProvider
+from great_expectations.validator.validation_graph import MetricConfiguration
+from great_expectations.validator.validator import Validator
+
+
+class TableHead(TableMetricProvider):
+    metric_name = "table.head"
+    value_keys = ("n_rows", "fetch_all")
+    default_kwarg_values = {"n_rows": 5, "fetch_all": False}
+
+    @metric_value(engine=PandasExecutionEngine)
+    def _pandas(
+        cls,
+        execution_engine: PandasExecutionEngine,
+        metric_domain_kwargs: Dict,
+        metric_value_kwargs: Dict,
+        metrics: Dict[Tuple, Any],
+        runtime_configuration: Dict,
+    ):
+        df, _, _ = execution_engine.get_compute_domain(
+            metric_domain_kwargs, domain_type=MetricDomainTypes.TABLE
+        )
+        if metric_value_kwargs.get("fetch_all", cls.default_kwarg_values["fetch_all"]):
+            return df
+        return df.head(metric_value_kwargs["n_rows"])
+
+    @metric_value(engine=SqlAlchemyExecutionEngine)
+    def _sqlalchemy(
+        cls,
+        execution_engine: SqlAlchemyExecutionEngine,
+        metric_domain_kwargs: Dict,
+        metric_value_kwargs: Dict,
+        metrics: Dict[Tuple, Any],
+        runtime_configuration: Dict,
+    ):
+        selectable, _, _ = execution_engine.get_compute_domain(
+            metric_domain_kwargs, domain_type=MetricDomainTypes.TABLE
+        )
+        df = None
+        table_name = getattr(selectable, "name", None)
+        if table_name is not None:
+            try:
+                if metric_value_kwargs["fetch_all"]:
+                    df = pd.read_sql_table(
+                        table_name=getattr(selectable, "name", None),
+                        schema=getattr(selectable, "schema", None),
+                        con=execution_engine.engine,
+                    )
+                else:
+                    df = next(
+                        pd.read_sql_table(
+                            table_name=getattr(selectable, "name", None),
+                            schema=getattr(selectable, "schema", None),
+                            con=execution_engine.engine,
+                            chunksize=metric_value_kwargs["n_rows"],
+                        )
+                    )
+            except (ValueError, NotImplementedError):
+                # it looks like MetaData that is used by pd.read_sql_table
+                # cannot work on a temp table.
+                # If it fails, we are trying to get the data using read_sql
+                df = None
+            except StopIteration:
+                validator = Validator(execution_engine=execution_engine)
+                columns = validator.get_metric(
+                    MetricConfiguration("table.columns", metric_domain_kwargs)
+                )
+                df = pd.DataFrame(columns=columns)
+        if df is None:
+            # we want to compile our selectable
+            stmt = sa.select(["*"]).select_from(selectable)
+            if metric_value_kwargs["fetch_all"]:
+                pass
+            else:
+                stmt = stmt.limit(metric_value_kwargs["n_rows"])
+            sql = stmt.compile(
+                dialect=execution_engine.engine.dialect,
+                compile_kwargs={"literal_binds": True},
+            )
+            df = pd.read_sql(sql, con=execution_engine.engine)
+
+        return df
+
+    @metric_value(engine=SparkDFExecutionEngine)
+    def _spark(
+        cls,
+        execution_engine: SparkDFExecutionEngine,
+        metric_domain_kwargs: Dict,
+        metric_value_kwargs: Dict,
+        metrics: Dict[Tuple, Any],
+        runtime_configuration: Dict,
+    ):
+        df, _, _ = execution_engine.get_compute_domain(
+            metric_domain_kwargs, domain_type=MetricDomainTypes.TABLE
+        )
+        if metric_value_kwargs["fetch_all"]:
+            return df.collect()
+        return df.head(metric_value_kwargs["n_rows"])

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -377,12 +377,14 @@ def display_profiled_column_evrs_as_section(
     """
 
     # TODO: replace this with a generic utility function, preferably a method on an ExpectationSuite class
-    column_evr_list = [
-        e
-        for e in evrs.results
-        if "column" in e.expectation_config.kwargs
-        and e.expectation_config.kwargs["column"] == column
-    ]
+    column_evr_list = []
+    for e in evrs.results:
+        if e.expectation_config is not None:
+            if (
+                "column" in e.expectation_config.kwargs
+                and e.expectation_config.kwargs["column"] == column
+            ):
+                column_evr_list.append(e)
 
     # TODO: Handle the case where zero evrs match the column name
 
@@ -444,4 +446,4 @@ def display_column_evrs_as_section(
 
 # When importing the jupyter_ux module, we set up a preferred logging configuration
 logger = logging.getLogger("great_expectations")
-setup_notebook_logging(logger)
+setup_notebook_logging(logger, log_level=logging.CRITICAL)

--- a/great_expectations/profile/basic_dataset_profiler.py
+++ b/great_expectations/profile/basic_dataset_profiler.py
@@ -6,6 +6,8 @@ from great_expectations.profile.base import (
     ProfilerDataType,
     ProfilerTypeMapping,
 )
+from great_expectations.validator.validation_graph import MetricConfiguration
+from great_expectations.validator.validator import Validator
 
 try:
     from sqlalchemy.exc import OperationalError
@@ -135,7 +137,10 @@ class BasicDatasetProfiler(BasicDatasetProfilerBase):
         df.expect_table_columns_to_match_ordered_list(None)
         df.set_config_value("interactive_evaluation", False)
 
-        columns = df.get_table_columns()
+        if isinstance(df, Validator):
+            columns = df.get_metric(MetricConfiguration("table.columns", dict()))
+        else:
+            columns = df.get_table_columns()
 
         meta_columns = {}
         for column in columns:
@@ -175,7 +180,6 @@ class BasicDatasetProfiler(BasicDatasetProfilerBase):
                     ProfilerCardinality.VERY_MANY,
                     ProfilerCardinality.UNIQUE,
                 ]:
-                    # TODO: change to class-first expectation structure?
                     df.expect_column_min_to_be_between(
                         column, min_value=None, max_value=None
                     )
@@ -231,7 +235,6 @@ class BasicDatasetProfiler(BasicDatasetProfilerBase):
                     ProfilerCardinality.VERY_MANY,
                     ProfilerCardinality.UNIQUE,
                 ]:
-                    # TODO: migrate to class first structure
                     df.expect_column_min_to_be_between(
                         column, min_value=None, max_value=None
                     )

--- a/great_expectations/render/renderer/column_section_renderer.py
+++ b/great_expectations/render/renderer/column_section_renderer.py
@@ -47,6 +47,8 @@ class ColumnSectionRenderer(Renderer):
     def _get_column_name(cls, ge_object):
         # This is broken out for ease of locating future validation here
         if isinstance(ge_object, list):
+            if len(ge_object) == 0:
+                return
             candidate_object = ge_object[0]
         else:
             candidate_object = ge_object

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1931,7 +1931,8 @@ data_connectors:
         partition_identifiers={
             "alphanumeric": "some_file",
         },
-        create_expectation_suite_with_name="A_expectation_suite",
+        expectation_suite_name="A_expectation_suite",
+        overwrite_existing_expectation_suite=True,
     )
     assert my_validator.expectation_suite_name == "A_expectation_suite"
 

--- a/tests/data_context/test_data_context_datasource_non_sql_methods.py
+++ b/tests/data_context/test_data_context_datasource_non_sql_methods.py
@@ -84,8 +84,8 @@ data_connectors:
         "letter": "A",
         "number": "101",
     }
-    assert isinstance(batch.data, pd.DataFrame)
-    assert batch.data.shape == (2, 3)
+    assert isinstance(batch.data.dataframe, pd.DataFrame)
+    assert batch.data.dataframe.shape == (2, 3)
 
 
 def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_configured_assets(
@@ -167,5 +167,5 @@ data_connectors:
         "timestamp": "19120414",
         "size": "1313",
     }
-    assert isinstance(batch.data, pd.DataFrame)
-    assert batch.data.shape == (1313, 7)
+    assert isinstance(batch.data.dataframe, pd.DataFrame)
+    assert batch.data.dataframe.shape == (1313, 7)

--- a/tests/data_context/test_data_context_datasource_sql_methods.py
+++ b/tests/data_context/test_data_context_datasource_sql_methods.py
@@ -6,7 +6,7 @@ from ruamel.yaml import YAML
 
 from great_expectations.core.batch import Batch, BatchRequest, PartitionRequest
 from great_expectations.exceptions.exceptions import DataContextError
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
 from great_expectations.marshmallow__shade.exceptions import ValidationError
@@ -301,7 +301,7 @@ def test_get_validator_expectation_suite_options(
         expectation_suite=some_more_expectations,
     )
 
-    # Successful specification using create_expectation_suite_with_name
+    # Successful specification using overwrite_existing_expectation_suite
     context.get_validator(
         batch_request=BatchRequest(
             datasource_name="my_sqlite_db",
@@ -311,18 +311,9 @@ def test_get_validator_expectation_suite_options(
                 partition_identifiers={"date": "2020-01-15"}
             ),
         ),
-        create_expectation_suite_with_name="yet_more_expectations",
+        expectation_suite_name="yet_more_expectations",
+        overwrite_existing_expectation_suite=True,
     )
-
-    # Failed specification, because the named expectation suite already exists
-    with pytest.raises(DataContextError):
-        context.get_validator(
-            datasource_name="my_sqlite_db",
-            data_connector_name="daily",
-            data_asset_name="table_partitioned_by_date_column__A",
-            date="2020-01-15",
-            create_expectation_suite_with_name="some_expectations",
-        )
 
     # Failed specification: incorrectly typed expectation suite
     with pytest.raises(ValidationError):
@@ -362,4 +353,3 @@ def test_get_batch_list_from_new_style_datasource_with_sql_datasource(
     )
     assert batch.batch_definition["partition_definition"] == {"date": "2020-01-15"}
     assert isinstance(batch.data, SqlAlchemyBatchData)
-    assert len(batch.data.head(fetch_all=True)) == 4

--- a/tests/data_context/test_data_context_test_yaml_config.py
+++ b/tests/data_context/test_data_context_test_yaml_config.py
@@ -291,7 +291,7 @@ def test_config_variables_in_test_yaml_config(empty_data_context, sa):
 class_name: SimpleSqlalchemyDatasource
 connection_string: sqlite:///${db_file}
 
-introspection:
+inferred_assets:
     ${data_connector_name}:
         data_asset_name_suffix: ${suffix}
         sampling_method: _sample_using_limit
@@ -337,7 +337,7 @@ credentials:
     port: 5432
     database: test_ci
 
-introspection:
+inferred_assets:
     whole_table_with_limits:
         sampling_method: _sample_using_limit
         sampling_kwargs:
@@ -470,7 +470,7 @@ data_connectors:
     )
     assert my_batch.batch_definition["data_asset_name"] == "A"
 
-    df_data = my_batch.data
+    df_data = my_batch.data.dataframe
     assert df_data.shape == (10, 10)
     df_data["date"] = df_data.apply(
         lambda row: datetime.datetime.strptime(row["date"], "%Y-%m-%d").date(), axis=1
@@ -626,9 +626,7 @@ data_connectors:
     )
     assert my_batch.batch_definition["data_asset_name"] == "A"
 
-    my_batch.head()
-
-    df_data = my_batch.data
+    df_data = my_batch.data.dataframe
     assert df_data.shape == (10, 10)
     df_data["date"] = df_data.apply(
         lambda row: datetime.datetime.strptime(row["date"], "%Y-%m-%d").date(), axis=1
@@ -663,7 +661,8 @@ data_connectors:
                 "hash_value": "f",
             },
         },
-        create_expectation_suite_with_name="my_expectations",
+        expectation_suite_name="my_expectations",
+        overwrite_existing_expectation_suite=True,
     )
     my_evr = my_validator.expect_column_values_to_be_between(
         column="d", min_value=1, max_value=31

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -7,6 +7,7 @@ from ruamel.yaml import YAML
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import BatchRequest, BatchSpec
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
+from great_expectations.validator.validator import Validator
 
 yaml = YAML()
 
@@ -550,10 +551,16 @@ def test_sampling_method__limit(
             }
         )
     )
-    assert len(batch_data.head(fetch_all=True)) == 20
+    execution_engine.load_batch_data("__", batch_data)
+    validator = Validator(execution_engine)
+    assert len(validator.head(fetch_all=True)) == 20
 
-    # TODO: Implement this test once get_batch_data_and_markers is returning a proper SqlAlchemyBatchData
-    # batch_data.expect_column_values_to_be_in_set("date", values=["2020-01-02"])
+    assert (
+        validator.expect_column_values_to_be_in_set(
+            "date", value_set=["2020-01-02"]
+        ).success
+        == False
+    )
 
 
 def test_sampling_method__random(
@@ -600,8 +607,9 @@ def test_sampling_method__mod(
             }
         )
     )
-
-    assert len(batch_data.head(fetch_all=True)) == 12
+    execution_engine.load_batch_data("__", batch_data)
+    validator = Validator(execution_engine)
+    assert len(validator.head(fetch_all=True)) == 12
 
 
 def test_sampling_method__a_list(
@@ -624,8 +632,9 @@ def test_sampling_method__a_list(
             }
         )
     )
-
-    assert len(batch_data.head(fetch_all=True)) == 4
+    execution_engine.load_batch_data("__", batch_data)
+    validator = Validator(execution_engine)
+    assert len(validator.head(fetch_all=True)) == 4
 
 
 def test_sampling_method__md5(
@@ -667,8 +676,9 @@ def test_to_make_sure_splitter_and_sampler_methods_are_optional(
             }
         )
     )
-
-    assert len(batch_data.head(fetch_all=True)) == 12
+    execution_engine.load_batch_data("__", batch_data)
+    validator = Validator(execution_engine)
+    assert len(validator.head(fetch_all=True)) == 12
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
         batch_spec=BatchSpec(
@@ -678,8 +688,9 @@ def test_to_make_sure_splitter_and_sampler_methods_are_optional(
             }
         )
     )
-
-    assert len(batch_data.head(fetch_all=True)) == 120
+    execution_engine.load_batch_data("__", batch_data)
+    validator = Validator(execution_engine)
+    assert len(validator.head(fetch_all=True)) == 120
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
         batch_spec=BatchSpec(
@@ -692,7 +703,9 @@ def test_to_make_sure_splitter_and_sampler_methods_are_optional(
         )
     )
 
-    assert len(batch_data.head(fetch_all=True)) == 120
+    execution_engine.load_batch_data("__", batch_data)
+    validator = Validator(execution_engine)
+    assert len(validator.head(fetch_all=True)) == 120
 
 
 def test_default_behavior_with_no_splitter(

--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -310,7 +310,7 @@ def test_get_batch_definitions_and_get_batch_basics(basic_pandas_datasource_v013
 
     # TODO Abe 20201104: Make sure this is what we truly want to do.
     assert batch.batch_request == {}
-    assert isinstance(batch.data, pd.DataFrame)
+    assert isinstance(batch.data.dataframe, pd.DataFrame)
     assert batch.batch_definition == BatchDefinition(
         datasource_name="my_datasource",
         data_connector_name="my_filesystem_data_connector",
@@ -356,7 +356,7 @@ def test_get_batch_definitions_and_get_batch_basics(basic_pandas_datasource_v013
         )
     )
     assert len(batch_list) == 1
-    assert isinstance(batch_list[0].data, pd.DataFrame)
+    assert isinstance(batch_list[0].data.dataframe, pd.DataFrame)
 
     my_df: pd.DataFrame = pd.DataFrame({"x": range(10), "y": range(10)})
     batch: Batch = basic_pandas_datasource_v013.get_batch_from_batch_definition(
@@ -414,16 +414,12 @@ def test_get_batch_list_from_batch_request(basic_pandas_datasource_v013):
     batch: Batch = batch_list[0]
 
     assert batch.batch_spec is not None
-    assert isinstance(batch.data, pd.DataFrame)
-    assert batch.data.shape[0] == 1313
+    assert isinstance(batch.data.dataframe, pd.DataFrame)
+    assert batch.data.dataframe.shape[0] == 1313
     assert (
         batch.batch_markers["pandas_data_fingerprint"]
         == "3aaabc12402f987ff006429a7756f5cf"
     )
-
-
-def test_get_batch_with_caching():
-    pass
 
 
 def test_get_batch_with_pipeline_style_batch_request(basic_pandas_datasource_v013):
@@ -457,9 +453,9 @@ def test_get_batch_with_pipeline_style_batch_request(basic_pandas_datasource_v01
 
     assert batch.batch_spec is not None
     assert batch.batch_definition["data_asset_name"] == data_asset_name
-    assert isinstance(batch.data, pd.DataFrame)
-    assert batch.data.shape == (2, 2)
-    assert batch.data["col2"].values[1] == 4
+    assert isinstance(batch.data.dataframe, pd.DataFrame)
+    assert batch.data.dataframe.shape == (2, 2)
+    assert batch.data.dataframe["col2"].values[1] == 4
     assert (
         batch.batch_markers["pandas_data_fingerprint"]
         == "1e461a0df5fe0a6db2c3bc4ef88ef1f0"

--- a/tests/execution_engine/test_execution_engine.py
+++ b/tests/execution_engine/test_execution_engine.py
@@ -8,7 +8,7 @@ from great_expectations.validator.validation_graph import MetricConfiguration
 
 # Testing ordinary process of adding column row condition
 def test_add_column_row_condition():
-    e = ExecutionEngine()
+    e = PandasExecutionEngine()
 
     # Checking that adding a simple column row condition is functional
     new_domain_kwargs = e.add_column_row_condition({}, "a")
@@ -43,7 +43,7 @@ def test_add_column_row_condition():
 
 # Edge cases
 def test_add_column_row_condition_with_unsupported_conditions():
-    e = ExecutionEngine()
+    e = PandasExecutionEngine()
 
     # Ensuring that an attempt to filter nans within base class yields an error
     with pytest.raises(GreatExpectationsError) as error:

--- a/tests/execution_engine/test_pandas_execution_engine.py
+++ b/tests/execution_engine/test_pandas_execution_engine.py
@@ -265,10 +265,14 @@ def test_dataframe_property_given_loaded_batch():
 
 
 def test_get_batch_data(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+            )
         )
+        .dataframe
     )
     assert split_df.shape == (120, 10)
 
@@ -278,10 +282,14 @@ def test_get_batch_data(test_df):
 
 
 def test_get_batch_with_split_on_whole_table(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df, splitter_method="_split_on_whole_table"
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df, splitter_method="_split_on_whole_table"
+            )
         )
+        .dataframe
     )
     assert split_df.shape == (120, 10)
 
@@ -289,12 +297,16 @@ def test_get_batch_with_split_on_whole_table(test_df):
 def test_get_batch_with_split_on_whole_table_filesystem(
     test_folder_connection_path_csv,
 ):
-    test_df = PandasExecutionEngine().get_batch_data(
-        PathBatchSpec(
-            path=os.path.join(test_folder_connection_path_csv, "test.csv"),
-            reader_method="read_csv",
-            splitter_method="_split_on_whole_table",
+    test_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            PathBatchSpec(
+                path=os.path.join(test_folder_connection_path_csv, "test.csv"),
+                reader_method="read_csv",
+                splitter_method="_split_on_whole_table",
+            )
         )
+        .dataframe
     )
     assert test_df.shape == (5, 2)
 
@@ -339,6 +351,7 @@ def test_get_batch_with_split_on_whole_table_s3_with_configured_asset_s3_data_co
             reader_method="read_csv",
             splitter_method="_split_on_whole_table",
         )
+        .dataframe
     )
     assert test_df.shape == (2, 2)
 
@@ -371,6 +384,7 @@ def test_get_batch_with_split_on_whole_table_s3():
             reader_method="read_csv",
             splitter_method="_split_on_whole_table",
         )
+        .dataframe
     )
     assert test_df.shape == (2, 2)
 
@@ -388,57 +402,73 @@ def test_get_batch_with_split_on_whole_table_s3():
 
 
 def test_get_batch_with_split_on_column_value(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_column_value",
-            splitter_kwargs={
-                "column_name": "batch_id",
-                "partition_definition": {"batch_id": 2},
-            },
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                splitter_method="_split_on_column_value",
+                splitter_kwargs={
+                    "column_name": "batch_id",
+                    "partition_definition": {"batch_id": 2},
+                },
+            )
         )
+        .dataframe
     )
     assert split_df.shape == (12, 10)
     assert (split_df.batch_id == 2).all()
 
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_column_value",
-            splitter_kwargs={
-                "column_name": "date",
-                "partition_definition": {"date": datetime.date(2020, 1, 30)},
-            },
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                splitter_method="_split_on_column_value",
+                splitter_kwargs={
+                    "column_name": "date",
+                    "partition_definition": {"date": datetime.date(2020, 1, 30)},
+                },
+            )
         )
+        .dataframe
     )
     assert (split_df).shape == (3, 10)
 
 
 def test_get_batch_with_split_on_converted_datetime(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_converted_datetime",
-            splitter_kwargs={
-                "column_name": "timestamp",
-                "partition_definition": {"timestamp": "2020-01-30"},
-            },
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                splitter_method="_split_on_converted_datetime",
+                splitter_kwargs={
+                    "column_name": "timestamp",
+                    "partition_definition": {"timestamp": "2020-01-30"},
+                },
+            )
         )
+        .dataframe
     )
     assert (split_df).shape == (3, 10)
 
 
 def test_get_batch_with_split_on_divided_integer(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_divided_integer",
-            splitter_kwargs={
-                "column_name": "id",
-                "divisor": 10,
-                "partition_definition": {"id": 5},
-            },
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                splitter_method="_split_on_divided_integer",
+                splitter_kwargs={
+                    "column_name": "id",
+                    "divisor": 10,
+                    "partition_definition": {"id": 5},
+                },
+            )
         )
+        .dataframe
     )
     assert split_df.shape == (10, 10)
     assert split_df.id.min() == 50
@@ -446,16 +476,20 @@ def test_get_batch_with_split_on_divided_integer(test_df):
 
 
 def test_get_batch_with_split_on_mod_integer(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_mod_integer",
-            splitter_kwargs={
-                "column_name": "id",
-                "mod": 10,
-                "partition_definition": {"id": 5},
-            },
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                splitter_method="_split_on_mod_integer",
+                splitter_kwargs={
+                    "column_name": "id",
+                    "mod": 10,
+                    "partition_definition": {"id": 5},
+                },
+            )
         )
+        .dataframe
     )
     assert split_df.shape == (12, 10)
     assert split_df.id.min() == 5
@@ -463,19 +497,23 @@ def test_get_batch_with_split_on_mod_integer(test_df):
 
 
 def test_get_batch_with_split_on_multi_column_values(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_multi_column_values",
-            splitter_kwargs={
-                "column_names": ["y", "m", "d"],
-                "partition_definition": {
-                    "y": 2020,
-                    "m": 1,
-                    "d": 5,
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                splitter_method="_split_on_multi_column_values",
+                splitter_kwargs={
+                    "column_names": ["y", "m", "d"],
+                    "partition_definition": {
+                        "y": 2020,
+                        "m": 1,
+                        "d": 5,
+                    },
                 },
-            },
+            )
         )
+        .dataframe
     )
     assert split_df.shape == (4, 10)
     assert (split_df.date == datetime.date(2020, 1, 5)).all()
@@ -499,7 +537,28 @@ def test_get_batch_with_split_on_multi_column_values(test_df):
 
 def test_get_batch_with_split_on_hashed_column(test_df):
     with pytest.raises(ge_exceptions.ExecutionEngineError):
-        split_df = PandasExecutionEngine().get_batch_data(
+        split_df = (
+            PandasExecutionEngine()
+            .get_batch_data(
+                RuntimeDataBatchSpec(
+                    batch_data=test_df,
+                    splitter_method="_split_on_hashed_column",
+                    splitter_kwargs={
+                        "column_name": "favorite_color",
+                        "hash_digits": 1,
+                        "partition_definition": {
+                            "hash_value": "a",
+                        },
+                        "hash_function_name": "I_am_not_valid",
+                    },
+                )
+            )
+            .dataframe
+        )
+
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
             RuntimeDataBatchSpec(
                 batch_data=test_df,
                 splitter_method="_split_on_hashed_column",
@@ -509,24 +568,11 @@ def test_get_batch_with_split_on_hashed_column(test_df):
                     "partition_definition": {
                         "hash_value": "a",
                     },
-                    "hash_function_name": "I_am_not_valid",
+                    "hash_function_name": "sha256",
                 },
             )
         )
-
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_hashed_column",
-            splitter_kwargs={
-                "column_name": "favorite_color",
-                "hash_digits": 1,
-                "partition_definition": {
-                    "hash_value": "a",
-                },
-                "hash_function_name": "sha256",
-            },
-        )
+        .dataframe
     )
     assert split_df.shape == (8, 10)
 
@@ -536,60 +582,82 @@ def test_get_batch_with_split_on_hashed_column(test_df):
 
 def test_sample_using_random(test_df):
     random.seed(1)
-    sampled_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(batch_data=test_df, sampling_method="_sample_using_random")
+    sampled_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df, sampling_method="_sample_using_random"
+            )
+        )
+        .dataframe
     )
     assert sampled_df.shape == (13, 10)
 
 
 def test_sample_using_mod(test_df):
-    sampled_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            sampling_method="_sample_using_mod",
-            sampling_kwargs={
-                "column_name": "id",
-                "mod": 5,
-                "value": 4,
-            },
+    sampled_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                sampling_method="_sample_using_mod",
+                sampling_kwargs={
+                    "column_name": "id",
+                    "mod": 5,
+                    "value": 4,
+                },
+            )
         )
+        .dataframe
     )
     assert sampled_df.shape == (24, 10)
 
 
 def test_sample_using_a_list(test_df):
-    sampled_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            sampling_method="_sample_using_a_list",
-            sampling_kwargs={
-                "column_name": "id",
-                "value_list": [3, 5, 7, 11],
-            },
+    sampled_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                sampling_method="_sample_using_a_list",
+                sampling_kwargs={
+                    "column_name": "id",
+                    "value_list": [3, 5, 7, 11],
+                },
+            )
         )
+        .dataframe
     )
     assert sampled_df.shape == (4, 10)
 
 
 def test_sample_using_md5(test_df):
     with pytest.raises(ge_exceptions.ExecutionEngineError):
-        sampled_df = PandasExecutionEngine().get_batch_data(
+        _ = (
+            PandasExecutionEngine()
+            .get_batch_data(
+                RuntimeDataBatchSpec(
+                    batch_data=test_df,
+                    sampling_method="_sample_using_hash",
+                    sampling_kwargs={
+                        "column_name": "date",
+                        "hash_function_name": "I_am_not_valid",
+                    },
+                )
+            )
+            .dataframe
+        )
+
+    sampled_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
             RuntimeDataBatchSpec(
                 batch_data=test_df,
                 sampling_method="_sample_using_hash",
-                sampling_kwargs={
-                    "column_name": "date",
-                    "hash_function_name": "I_am_not_valid",
-                },
+                sampling_kwargs={"column_name": "date", "hash_function_name": "md5"},
             )
         )
-
-    sampled_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            sampling_method="_sample_using_hash",
-            sampling_kwargs={"column_name": "date", "hash_function_name": "md5"},
-        )
+        .dataframe
     )
     assert sampled_df.shape == (10, 10)
     assert sampled_df.date.isin(
@@ -602,22 +670,26 @@ def test_sample_using_md5(test_df):
 
 ### Splitting + Sampling methods ###
 def test_get_batch_with_split_on_divided_integer_and_sample_on_list(test_df):
-    split_df = PandasExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_df,
-            splitter_method="_split_on_divided_integer",
-            splitter_kwargs={
-                "column_name": "id",
-                "divisor": 10,
-                "partition_definition": {"id": 5},
-            },
-            sampling_method="_sample_using_mod",
-            sampling_kwargs={
-                "column_name": "id",
-                "mod": 5,
-                "value": 4,
-            },
+    split_df = (
+        PandasExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_df,
+                splitter_method="_split_on_divided_integer",
+                splitter_kwargs={
+                    "column_name": "id",
+                    "divisor": 10,
+                    "partition_definition": {"id": 5},
+                },
+                sampling_method="_sample_using_mod",
+                sampling_kwargs={
+                    "column_name": "id",
+                    "mod": 5,
+                    "value": 4,
+                },
+            )
         )
+        .dataframe
     )
     assert split_df.shape == (2, 10)
     assert split_df.id.min() == 54

--- a/tests/execution_engine/test_sparkdf_execution_engine.py
+++ b/tests/execution_engine/test_sparkdf_execution_engine.py
@@ -238,18 +238,26 @@ def test_basic_setup(spark_session):
         ],
         pd_df.columns.tolist(),
     )
-    batch_data = SparkDFExecutionEngine().get_batch_data(
-        batch_spec=RuntimeDataBatchSpec(
-            batch_data=df,
-            data_asset_name="DATA_ASSET",
+    batch_data = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            batch_spec=RuntimeDataBatchSpec(
+                batch_data=df,
+                data_asset_name="DATA_ASSET",
+            )
         )
+        .dataframe
     )
     assert batch_data is not None
 
 
 def test_get_batch_data(test_sparkdf):
-    test_sparkdf = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(batch_data=test_sparkdf, data_asset_name="DATA_ASSET")
+    test_sparkdf = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(batch_data=test_sparkdf, data_asset_name="DATA_ASSET")
+        )
+        .dataframe
     )
     assert test_sparkdf.count() == 120
     assert len(test_sparkdf.columns) == 10
@@ -258,12 +266,16 @@ def test_get_batch_data(test_sparkdf):
 def test_get_batch_empty_splitter(test_folder_connection_path_csv, spark_session):
     # reader_method not configured because spark will configure own reader by default
     # reader_options are needed to specify the fact that the first line of test file is the header
-    test_sparkdf = SparkDFExecutionEngine().get_batch_data(
-        PathBatchSpec(
-            path=os.path.join(test_folder_connection_path_csv, "test.csv"),
-            reader_options={"header": True},
-            splitter_method=None,
+    test_sparkdf = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            PathBatchSpec(
+                path=os.path.join(test_folder_connection_path_csv, "test.csv"),
+                reader_options={"header": True},
+                splitter_method=None,
+            )
         )
+        .dataframe
     )
     assert test_sparkdf.count() == 5
     assert len(test_sparkdf.columns) == 2
@@ -273,12 +285,16 @@ def test_get_batch_empty_splitter_tsv(test_folder_connection_path_tsv, spark_ses
     # reader_method not configured because spark will configure own reader by default
     # reader_options are needed to specify the fact that the first line of test file is the header
     # reader_options are also needed to specify the separator (otherwise, comma will be used as the default separator)
-    test_sparkdf = SparkDFExecutionEngine().get_batch_data(
-        PathBatchSpec(
-            path=os.path.join(test_folder_connection_path_tsv, "test.tsv"),
-            reader_options={"header": True, "sep": "\t"},
-            splitter_method=None,
+    test_sparkdf = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            PathBatchSpec(
+                path=os.path.join(test_folder_connection_path_tsv, "test.tsv"),
+                reader_options={"header": True, "sep": "\t"},
+                splitter_method=None,
+            )
         )
+        .dataframe
     )
     assert test_sparkdf.count() == 5
     assert len(test_sparkdf.columns) == 2
@@ -289,11 +305,15 @@ def test_get_batch_empty_splitter_parquet(
 ):
     # Note: reader method and reader_options are not needed, because
     # SparkDFExecutionEngine automatically determines the file type as well as the schema of the Parquet file.
-    test_sparkdf = SparkDFExecutionEngine().get_batch_data(
-        PathBatchSpec(
-            path=os.path.join(test_folder_connection_path_parquet, "test.parquet"),
-            splitter_method=None,
+    test_sparkdf = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            PathBatchSpec(
+                path=os.path.join(test_folder_connection_path_parquet, "test.parquet"),
+                splitter_method=None,
+            )
         )
+        .dataframe
     )
     assert test_sparkdf.count() == 5
     assert len(test_sparkdf.columns) == 2
@@ -303,11 +323,15 @@ def test_get_batch_with_split_on_whole_table_filesystem(
     test_folder_connection_path_csv, spark_session
 ):
     # reader_method not configured because spark will configure own reader by default
-    test_sparkdf = SparkDFExecutionEngine().get_batch_data(
-        PathBatchSpec(
-            path=os.path.join(test_folder_connection_path_csv, "test.csv"),
-            splitter_method="_split_on_whole_table",
+    test_sparkdf = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            PathBatchSpec(
+                path=os.path.join(test_folder_connection_path_csv, "test.csv"),
+                splitter_method="_split_on_whole_table",
+            )
         )
+        .dataframe
     )
     assert test_sparkdf.count() == 6
     assert len(test_sparkdf.columns) == 2
@@ -341,31 +365,39 @@ def test_get_batch_with_split_on_whole_table_s3(spark_session):
             reader_options={"header": True},
             splitter_method="_split_on_whole_table",
         )
-    )
+    ).dataframe
     assert test_sparkdf.count() == 4
     assert len(test_sparkdf.columns) == 2
 
 
 def test_get_batch_with_split_on_whole_table(test_sparkdf):
-    test_sparkdf = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf, splitter_method="_split_on_whole_table"
+    test_sparkdf = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf, splitter_method="_split_on_whole_table"
+            )
         )
+        .dataframe
     )
     assert test_sparkdf.count() == 120
     assert len(test_sparkdf.columns) == 10
 
 
 def test_get_batch_with_split_on_column_value(test_sparkdf):
-    split_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_column_value",
-            splitter_kwargs={
-                "column_name": "batch_id",
-                "partition_definition": {"batch_id": 2},
-            },
+    split_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                splitter_method="_split_on_column_value",
+                splitter_kwargs={
+                    "column_name": "batch_id",
+                    "partition_definition": {"batch_id": 2},
+                },
+            )
         )
+        .dataframe
     )
     assert test_sparkdf.count() == 120
     assert len(test_sparkdf.columns) == 10
@@ -373,46 +405,58 @@ def test_get_batch_with_split_on_column_value(test_sparkdf):
     for val in collected:
         assert val.batch_id == 2
 
-    split_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_column_value",
-            splitter_kwargs={
-                "column_name": "date",
-                "partition_definition": {"date": datetime.date(2020, 1, 30)},
-            },
+    split_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                splitter_method="_split_on_column_value",
+                splitter_kwargs={
+                    "column_name": "date",
+                    "partition_definition": {"date": datetime.date(2020, 1, 30)},
+                },
+            )
         )
+        .dataframe
     )
     assert split_df.count() == 3
     assert len(split_df.columns) == 10
 
 
 def test_get_batch_with_split_on_converted_datetime(test_sparkdf):
-    split_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_converted_datetime",
-            splitter_kwargs={
-                "column_name": "timestamp",
-                "partition_definition": {"timestamp": "2020-01-03"},
-            },
+    split_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                splitter_method="_split_on_converted_datetime",
+                splitter_kwargs={
+                    "column_name": "timestamp",
+                    "partition_definition": {"timestamp": "2020-01-03"},
+                },
+            )
         )
+        .dataframe
     )
     assert split_df.count() == 2
     assert len(split_df.columns) == 10
 
 
 def test_get_batch_with_split_on_divided_integer(test_sparkdf):
-    split_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_divided_integer",
-            splitter_kwargs={
-                "column_name": "id",
-                "divisor": 10,
-                "partition_definition": {"id": 5},
-            },
+    split_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                splitter_method="_split_on_divided_integer",
+                splitter_kwargs={
+                    "column_name": "id",
+                    "divisor": 10,
+                    "partition_definition": {"id": 5},
+                },
+            )
         )
+        .dataframe
     )
     assert split_df.count() == 10
     assert len(split_df.columns) == 10
@@ -423,16 +467,20 @@ def test_get_batch_with_split_on_divided_integer(test_sparkdf):
 
 
 def test_get_batch_with_split_on_mod_integer(test_sparkdf):
-    split_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_mod_integer",
-            splitter_kwargs={
-                "column_name": "id",
-                "mod": 10,
-                "partition_definition": {"id": 5},
-            },
+    split_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                splitter_method="_split_on_mod_integer",
+                splitter_kwargs={
+                    "column_name": "id",
+                    "mod": 10,
+                    "partition_definition": {"id": 5},
+                },
+            )
         )
+        .dataframe
     )
 
     assert split_df.count() == 12
@@ -444,33 +492,14 @@ def test_get_batch_with_split_on_mod_integer(test_sparkdf):
 
 
 def test_get_batch_with_split_on_multi_column_values(test_sparkdf):
-    split_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_multi_column_values",
-            splitter_kwargs={
-                "column_names": ["y", "m", "d"],
-                "partition_definition": {
-                    "y": 2020,
-                    "m": 1,
-                    "d": 5,
-                },
-            },
-        )
-    )
-    assert split_df.count() == 4
-    assert len(split_df.columns) == 10
-    collected = split_df.collect()
-    for val in collected:
-        assert val.date == datetime.date(2020, 1, 5)
-
-    with pytest.raises(ValueError):
-        split_df = SparkDFExecutionEngine().get_batch_data(
+    split_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
             RuntimeDataBatchSpec(
                 batch_data=test_sparkdf,
                 splitter_method="_split_on_multi_column_values",
                 splitter_kwargs={
-                    "column_names": ["I", "dont", "exist"],
+                    "column_names": ["y", "m", "d"],
                     "partition_definition": {
                         "y": 2020,
                         "m": 1,
@@ -479,42 +508,77 @@ def test_get_batch_with_split_on_multi_column_values(test_sparkdf):
                 },
             )
         )
+        .dataframe
+    )
+    assert split_df.count() == 4
+    assert len(split_df.columns) == 10
+    collected = split_df.collect()
+    for val in collected:
+        assert val.date == datetime.date(2020, 1, 5)
+
+    with pytest.raises(ValueError):
+        split_df = (
+            SparkDFExecutionEngine()
+            .get_batch_data(
+                RuntimeDataBatchSpec(
+                    batch_data=test_sparkdf,
+                    splitter_method="_split_on_multi_column_values",
+                    splitter_kwargs={
+                        "column_names": ["I", "dont", "exist"],
+                        "partition_definition": {
+                            "y": 2020,
+                            "m": 1,
+                            "d": 5,
+                        },
+                    },
+                )
+            )
+            .dataframe
+        )
 
 
 def test_get_batch_with_split_on_hashed_column_incorrect_hash_function_name(
     test_sparkdf,
 ):
     with pytest.raises(ge_exceptions.ExecutionEngineError):
-        split_df = SparkDFExecutionEngine().get_batch_data(
+        split_df = (
+            SparkDFExecutionEngine()
+            .get_batch_data(
+                RuntimeDataBatchSpec(
+                    batch_data=test_sparkdf,
+                    splitter_method="_split_on_hashed_column",
+                    splitter_kwargs={
+                        "column_name": "favorite_color",
+                        "hash_digits": 1,
+                        "hash_function_name": "I_wont_work",
+                        "partition_definition": {
+                            "hash_value": "a",
+                        },
+                    },
+                )
+            )
+            .dataframe
+        )
+
+
+def test_get_batch_with_split_on_hashed_column(test_sparkdf):
+    split_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
             RuntimeDataBatchSpec(
                 batch_data=test_sparkdf,
                 splitter_method="_split_on_hashed_column",
                 splitter_kwargs={
                     "column_name": "favorite_color",
                     "hash_digits": 1,
-                    "hash_function_name": "I_wont_work",
+                    "hash_function_name": "sha256",
                     "partition_definition": {
                         "hash_value": "a",
                     },
                 },
             )
         )
-
-
-def test_get_batch_with_split_on_hashed_column(test_sparkdf):
-    split_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_hashed_column",
-            splitter_kwargs={
-                "column_name": "favorite_color",
-                "hash_digits": 1,
-                "hash_function_name": "sha256",
-                "partition_definition": {
-                    "hash_value": "a",
-                },
-            },
-        )
+        .dataframe
     )
     assert split_df.count() == 8
     assert len(split_df.columns) == 10
@@ -522,18 +586,26 @@ def test_get_batch_with_split_on_hashed_column(test_sparkdf):
 
 # ### Sampling methods ###
 def test_get_batch_empty_sampler(test_sparkdf):
-    sampled_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(batch_data=test_sparkdf, sampling_method=None)
+    sampled_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(batch_data=test_sparkdf, sampling_method=None)
+        )
+        .dataframe
     )
     assert sampled_df.count() == 120
     assert len(sampled_df.columns) == 10
 
 
 def test_sample_using_random(test_sparkdf):
-    sampled_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf, sampling_method="_sample_using_random"
+    sampled_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf, sampling_method="_sample_using_random"
+            )
         )
+        .dataframe
     )
     # The test dataframe contains 10 columns and 120 rows.
     assert len(sampled_df.columns) == 10
@@ -544,31 +616,39 @@ def test_sample_using_random(test_sparkdf):
 
 
 def test_sample_using_mod(test_sparkdf):
-    sampled_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            sampling_method="_sample_using_mod",
-            sampling_kwargs={
-                "column_name": "id",
-                "mod": 5,
-                "value": 4,
-            },
+    sampled_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                sampling_method="_sample_using_mod",
+                sampling_kwargs={
+                    "column_name": "id",
+                    "mod": 5,
+                    "value": 4,
+                },
+            )
         )
+        .dataframe
     )
     assert sampled_df.count() == 24
     assert len(sampled_df.columns) == 10
 
 
 def test_sample_using_a_list(test_sparkdf):
-    sampled_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            sampling_method="_sample_using_a_list",
-            sampling_kwargs={
-                "column_name": "id",
-                "value_list": [3, 5, 7, 11],
-            },
+    sampled_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                sampling_method="_sample_using_a_list",
+                sampling_kwargs={
+                    "column_name": "id",
+                    "value_list": [3, 5, 7, 11],
+                },
+            )
         )
+        .dataframe
     )
     assert sampled_df.count() == 4
     assert len(sampled_df.columns) == 10
@@ -576,28 +656,36 @@ def test_sample_using_a_list(test_sparkdf):
 
 def test_sample_using_md5_wrong_hash_function_name(test_sparkdf):
     with pytest.raises(ge_exceptions.ExecutionEngineError):
-        sampled_df = SparkDFExecutionEngine().get_batch_data(
+        sampled_df = (
+            SparkDFExecutionEngine()
+            .get_batch_data(
+                RuntimeDataBatchSpec(
+                    batch_data=test_sparkdf,
+                    sampling_method="_sample_using_hash",
+                    sampling_kwargs={
+                        "column_name": "date",
+                        "hash_function_name": "I_wont_work",
+                    },
+                )
+            )
+            .dataframe
+        )
+
+
+def test_sample_using_md5(test_sparkdf):
+    sampled_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
             RuntimeDataBatchSpec(
                 batch_data=test_sparkdf,
                 sampling_method="_sample_using_hash",
                 sampling_kwargs={
                     "column_name": "date",
-                    "hash_function_name": "I_wont_work",
+                    "hash_function_name": "md5",
                 },
             )
         )
-
-
-def test_sample_using_md5(test_sparkdf):
-    sampled_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            sampling_method="_sample_using_hash",
-            sampling_kwargs={
-                "column_name": "date",
-                "hash_function_name": "md5",
-            },
-        )
+        .dataframe
     )
     assert sampled_df.count() == 10
     assert len(sampled_df.columns) == 10
@@ -608,23 +696,27 @@ def test_sample_using_md5(test_sparkdf):
 
 
 def test_split_on_multi_column_values_and_sample_using_random(test_sparkdf):
-    returned_df = SparkDFExecutionEngine().get_batch_data(
-        RuntimeDataBatchSpec(
-            batch_data=test_sparkdf,
-            splitter_method="_split_on_multi_column_values",
-            splitter_kwargs={
-                "column_names": ["y", "m", "d"],
-                "partition_definition": {
-                    "y": 2020,
-                    "m": 1,
-                    "d": 5,
+    returned_df = (
+        SparkDFExecutionEngine()
+        .get_batch_data(
+            RuntimeDataBatchSpec(
+                batch_data=test_sparkdf,
+                splitter_method="_split_on_multi_column_values",
+                splitter_kwargs={
+                    "column_names": ["y", "m", "d"],
+                    "partition_definition": {
+                        "y": 2020,
+                        "m": 1,
+                        "d": 5,
+                    },
                 },
-            },
-            sampling_method="_sample_using_random",
-            sampling_kwargs={
-                "p": 0.5,
-            },
+                sampling_method="_sample_using_random",
+                sampling_kwargs={
+                    "p": 0.5,
+                },
+            )
         )
+        .dataframe
     )
 
     # The test dataframe contains 10 columns and 120 rows.
@@ -715,32 +807,12 @@ def dataframes_equal(first_table, second_table):
     return True
 
 
-# Builds a Spark Execution Engine
-def _build_spark_engine(df):
-    from pyspark.sql import SparkSession
-
-    spark = SparkSession.builder.getOrCreate()
-    df = spark.createDataFrame(
-        [
-            tuple(
-                None if isinstance(x, (float, int)) and np.isnan(x) else x
-                for x in record.tolist()
-            )
-            for record in df.to_records(index=False)
-        ],
-        df.columns.tolist(),
-    )
-    batch = Batch(data=df)
-    engine = SparkDFExecutionEngine(batch_data_dict={batch.id: batch.data})
-    return engine
-
-
 # Ensuring that, given aggregate metrics, they can be properly bundled together
 def test_sparkdf_batch_aggregate_metrics(caplog, spark_session):
     import datetime
 
     engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]})
+        spark_session, pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]})
     )
 
     desired_metric_1 = MetricConfiguration(
@@ -825,31 +897,11 @@ def test_sparkdf_batch_aggregate_metrics(caplog, spark_session):
     assert found_message
 
 
-# Ensuring functionality of compute_domain when no domain kwargs are given
-def test_get_compute_domain_with_no_domain_kwargs(spark_session):
-    engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
-    )
-    df = engine.dataframe
-
-    # Loading batch data
-    engine.load_batch_data(batch_data=df, batch_id="1234")
-    data, compute_kwargs, accessor_kwargs = engine.get_compute_domain(
-        domain_kwargs={}, domain_type="table"
-    )
-
-    # Ensuring that with no domain nothing happens to the data itself
-    assert dataframes_equal(
-        data, df
-    ), "Data does not match after getting compute domain"
-    assert compute_kwargs == {}, "Compute domain kwargs should be existent"
-    assert accessor_kwargs == {}, "Accessor kwargs have been modified"
-
 
 # Testing for only untested use case - multicolumn
 def test_get_compute_domain_with_column_pair(spark_session):
     engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
+        spark_session, pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
     )
     df = engine.dataframe
 
@@ -887,7 +939,8 @@ def test_get_compute_domain_with_column_pair(spark_session):
 # Testing for only untested use case - multicolumn
 def test_get_compute_domain_with_multicolumn(spark_session):
     engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None], "c": [1, 2, 3, None]})
+        spark_session,
+        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None], "c": [1, 2, 3, None]}),
     )
     df = engine.dataframe
 
@@ -922,107 +975,10 @@ def test_get_compute_domain_with_multicolumn(spark_session):
     assert accessor_kwargs == {}, "Accessor kwargs have been modified"
 
 
-# Testing whether compute domain is properly calculated, but this time obtaining a column
-def test_get_compute_domain_with_column_domain(spark_session):
-    engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
-    )
-    df = engine.dataframe
-
-    # Loading batch data
-    engine.load_batch_data(batch_data=df, batch_id="1234")
-    data, compute_kwargs, accessor_kwargs = engine.get_compute_domain(
-        domain_kwargs={"column": "a"}, domain_type="column"
-    )
-
-    # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
-    assert dataframes_equal(
-        data, df
-    ), "Data does not match after getting compute domain"
-    assert compute_kwargs == {}, "Compute domain kwargs should be empty"
-    assert accessor_kwargs == {"column": "a"}, "Accessor kwargs have been modified"
-
-
-# Using an unmeetable row condition to see if empty dataset will result in errors
-def test_get_compute_domain_with_row_condition(spark_session):
-    engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
-    )
-    df = engine.dataframe
-    expected_df = df.where("b > 2")
-
-    # Loading batch data
-    engine.load_batch_data(batch_data=df, batch_id="1234")
-
-    data, compute_kwargs, accessor_kwargs = engine.get_compute_domain(
-        domain_kwargs={"row_condition": "b > 2", "condition_parser": "spark"},
-        domain_type="identity",
-    )
-
-    # Ensuring data has been properly queried
-    assert dataframes_equal(
-        data, expected_df
-    ), "Data does not match after getting compute domain"
-
-    # Ensuring compute kwargs have not been modified
-    assert (
-        "row_condition" in compute_kwargs.keys()
-    ), "Row condition should be located within compute kwargs"
-    assert accessor_kwargs == {}, "Accessor kwargs have been modified"
-
-
-# What happens when we filter such that no value meets the condition?
-def test_get_compute_domain_with_unmeetable_row_condition(spark_session):
-    engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
-    )
-    df = engine.dataframe
-    expected_df = df.where("b > 24")
-
-    # Loading batch data
-    engine.load_batch_data(batch_data=df, batch_id="1234")
-
-    data, compute_kwargs, accessor_kwargs = engine.get_compute_domain(
-        domain_kwargs={
-            "row_condition": "b > 24",
-            "condition_parser": "spark",
-        },
-        domain_type="identity",
-    )
-    # Ensuring data has been properly queried
-    assert dataframes_equal(
-        data, expected_df
-    ), "Data does not match after getting compute domain"
-
-    # Ensuring compute kwargs have not been modified
-    assert (
-        "row_condition" in compute_kwargs.keys()
-    ), "Row condition should be located within compute kwargs"
-    assert accessor_kwargs == {}, "Accessor kwargs have been modified"
-
-    # Ensuring errors for column and column_ pair domains are caught
-    with pytest.raises(GreatExpectationsError) as e:
-        data, compute_kwargs, accessor_kwargs = engine.get_compute_domain(
-            domain_kwargs={
-                "row_condition": "b > 24",
-                "condition_parser": "spark",
-            },
-            domain_type="column",
-        )
-    with pytest.raises(GreatExpectationsError) as g:
-        data, compute_kwargs, accessor_kwargs = engine.get_compute_domain(
-            domain_kwargs={
-                "row_condition": "b > 24",
-                "condition_parser": "spark",
-            },
-            domain_type="column_pair",
-        )
-
-
 # Testing to ensure that great expectation experimental parser also works in terms of defining a compute domain
 def test_get_compute_domain_with_ge_experimental_condition_parser(spark_session):
     engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
+        spark_session, pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
     )
     df = engine.dataframe
 
@@ -1075,7 +1031,7 @@ def test_get_compute_domain_with_ge_experimental_condition_parser(spark_session)
 
 def test_get_compute_domain_with_nonexistent_condition_parser(spark_session):
     engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
+        spark_session, pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 3, 4, None]})
     )
     df = engine.dataframe
 
@@ -1096,7 +1052,7 @@ def test_get_compute_domain_with_nonexistent_condition_parser(spark_session):
 # Ensuring that we can properly inform user when metric doesn't exist - should get a metric provider error
 def test_resolve_metric_bundle_with_nonexistent_metric(spark_session):
     engine = _build_spark_engine(
-        pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]})
+        spark_session, pd.DataFrame({"a": [1, 2, 1, 2, 3, 3], "b": [4, 4, 4, 4, 4, 4]})
     )
 
     desired_metric_1 = MetricConfiguration(
@@ -1135,13 +1091,11 @@ def test_resolve_metric_bundle_with_nonexistent_metric(spark_session):
 
 # Making sure dataframe property is functional
 def test_dataframe_property_given_loaded_batch(spark_session):
-    from pyspark.sql import SparkSession
 
     engine = SparkDFExecutionEngine()
 
     df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10]})
-    spark = SparkSession.builder.getOrCreate()
-    df = spark.createDataFrame(df)
+    df = spark_session.createDataFrame(df)
 
     # Loading batch data
     engine.load_batch_data(batch_data=df, batch_id="1234")

--- a/tests/execution_engine/test_sqlalchemy_batch_data.py
+++ b/tests/execution_engine/test_sqlalchemy_batch_data.py
@@ -1,20 +1,25 @@
 import pandas as pd
 import pytest
 
+from great_expectations.execution_engine import SqlAlchemyExecutionEngine
+from great_expectations.validator.validator import Validator
+
 try:
     import sqlalchemy
 except ImportError:
     sqlalchemy = None
 
-
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
 
+from ..test_utils import get_sqlite_temp_table_names
+
 
 def test_instantiation_with_table_name(sqlite_view_engine):
+    engine = SqlAlchemyExecutionEngine(engine=sqlite_view_engine)
     batch_data = SqlAlchemyBatchData(
-        engine=sqlite_view_engine,
+        execution_engine=engine,
         table_name="test_table",
     )
 
@@ -32,61 +37,104 @@ def test_instantiation_with_table_name(sqlite_view_engine):
     assert batch_data.use_quoted_name == False
 
 
-def test_instantiation_with_query():
-    # Note Abe 20111119: Fill this in
-    pass
-
-
-def test_instantiation_with_selectable():
-    # Note Abe 20111119: Fill this in
-    pass
-
-
-def test_instantiation_errors(sqlite_view_engine):
-
-    with pytest.raises(TypeError):
-        SqlAlchemyBatchData()
-
-    with pytest.raises(ValueError):
-        SqlAlchemyBatchData(engine=sqlite_view_engine)
-
-    # Note Abe 20111119: Let's add tests for more error states
-
-
-def test_temp_table_mechanics():
-    pass
-
-
 def test_head(sqlite_view_engine):
     # Create a larger table so that we can downsample meaningfully
     df = pd.DataFrame({"a": range(100)})
     df.to_sql("test_table_2", con=sqlite_view_engine)
 
+    engine = SqlAlchemyExecutionEngine(engine=sqlite_view_engine)
     batch_data = SqlAlchemyBatchData(
-        engine=sqlite_view_engine,
+        execution_engine=engine,
         table_name="test_table_2",
     )
-    df = batch_data.head()
+    engine.load_batch_data("__", batch_data)
+    validator = Validator(execution_engine=engine)
+    df = validator.head()
     assert df.shape == (5, 2)
 
-    assert batch_data.head(fetch_all=True).shape == (100, 2)
-    assert batch_data.head(n=20).shape == (20, 2)
-    assert batch_data.head(n=20, fetch_all=True).shape == (100, 2)
+    assert validator.head(fetch_all=True).shape == (100, 2)
+    assert validator.head(n_rows=20).shape == (20, 2)
+    assert validator.head(n_rows=20, fetch_all=True).shape == (100, 2)
 
 
-def test_row_count(sqlite_view_engine):
-    # Create a larger table so that we can downsample meaningfully
-    df = pd.DataFrame({"a": range(100)})
-    df.to_sql("test_table_2", con=sqlite_view_engine)
+def test_instantiation_with_and_without_temp_table(sqlite_view_engine, sa):
 
-    batch_data = SqlAlchemyBatchData(
-        engine=sqlite_view_engine,
+    print(get_sqlite_temp_table_names(sqlite_view_engine))
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 1
+    assert get_sqlite_temp_table_names(sqlite_view_engine) == {"test_temp_view"}
+
+    engine = SqlAlchemyExecutionEngine(engine=sqlite_view_engine)
+    # When the SqlAlchemyBatchData object is based on a table, a new temp table is NOT created, even if create_temp_table=True
+    SqlAlchemyBatchData(
+        execution_engine=engine,
         table_name="test_table",
+        create_temp_table=True,
     )
-    assert batch_data.row_count() == 5
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 1
 
-    batch_data = SqlAlchemyBatchData(
-        engine=sqlite_view_engine,
-        table_name="test_table_2",
+    selectable = sa.select("*").select_from(sa.text("test_table"))
+
+    # If create_temp_table=False, a new temp table should NOT be created
+    SqlAlchemyBatchData(
+        execution_engine=engine,
+        selectable=selectable,
+        create_temp_table=False,
     )
-    assert batch_data.row_count() == 100
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 1
+
+    # If create_temp_table=True, a new temp table should be created
+    SqlAlchemyBatchData(
+        execution_engine=engine,
+        selectable=selectable,
+        create_temp_table=True,
+    )
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 2
+
+    # If create_temp_table=True, a new temp table should be created
+    SqlAlchemyBatchData(
+        execution_engine=engine,
+        selectable=selectable,
+        # create_temp_table defaults to True
+    )
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 3
+
+
+def test_instantiation_with_and_without_temp_table(sqlite_view_engine, sa):
+
+    print(get_sqlite_temp_table_names(sqlite_view_engine))
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 1
+    assert get_sqlite_temp_table_names(sqlite_view_engine) == {"test_temp_view"}
+
+    # When the SqlAlchemyBatchData object is based on a table, a new temp table is NOT created, even if create_temp_table=True
+    SqlAlchemyBatchData(
+        execution_engine=sqlite_view_engine,
+        table_name="test_table",
+        create_temp_table=True,
+    )
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 1
+
+    selectable = sa.select("*").select_from(sa.text("test_table"))
+
+    # If create_temp_table=False, a new temp table should NOT be created
+    SqlAlchemyBatchData(
+        execution_engine=sqlite_view_engine,
+        selectable=selectable,
+        create_temp_table=False,
+    )
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 1
+
+    # If create_temp_table=True, a new temp table should be created
+    SqlAlchemyBatchData(
+        execution_engine=sqlite_view_engine,
+        selectable=selectable,
+        create_temp_table=True,
+    )
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 2
+
+    # If create_temp_table=True, a new temp table should be created
+    SqlAlchemyBatchData(
+        execution_engine=sqlite_view_engine,
+        selectable=selectable,
+        # create_temp_table defaults to True
+    )
+    assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 3

--- a/tests/expectations/core/test_expect_column_value_z_scores_to_be_less_than.py
+++ b/tests/expectations/core/test_expect_column_value_z_scores_to_be_less_than.py
@@ -9,8 +9,10 @@ from great_expectations.execution_engine import (
     PandasExecutionEngine,
     SparkDFExecutionEngine,
 )
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
+)
+from great_expectations.execution_engine.sqlalchemy_execution_engine import (
     SqlAlchemyExecutionEngine,
 )
 from great_expectations.expectations.core.expect_column_value_z_scores_to_be_less_than import (
@@ -51,12 +53,11 @@ def test_sa_expect_column_value_z_scores_to_be_less_than_impl(postgresql_engine)
         },
     )
     expectation = ExpectColumnValueZScoresToBeLessThan(expectationConfiguration)
+    engine = SqlAlchemyExecutionEngine(engine=postgresql_engine)
     batch_data = SqlAlchemyBatchData(
-        engine=postgresql_engine, table_name="z_score_test_data"
+        execution_engine=engine, table_name="z_score_test_data"
     )
-    engine = SqlAlchemyExecutionEngine(
-        engine=postgresql_engine, batch_data_dict={"my_id": batch_data}
-    )
+    engine.load_batch_data("my_id", batch_data)
     result = expectation.validate(Validator(execution_engine=engine))
     assert result == ExpectationValidationResult(
         success=True,

--- a/tests/expectations/metrics/test_table_column_types.py
+++ b/tests/expectations/metrics/test_table_column_types.py
@@ -1,5 +1,6 @@
 from great_expectations.data_context.util import file_relative_path
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+from great_expectations.execution_engine import SqlAlchemyExecutionEngine
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
 from great_expectations.expectations.metrics.import_manager import reflection
@@ -10,16 +11,17 @@ def test_table_column_introspection(sa):
         __file__,
         "../../test_sets/test_cases_for_sql_data_connector.db",
     )
-    engine = sa.create_engine(f"sqlite:///{db_file}")
-
+    eng = sa.create_engine(f"sqlite:///{db_file}")
+    engine = SqlAlchemyExecutionEngine(engine=eng)
     batch_data = SqlAlchemyBatchData(
-        engine=engine, table_name="table_partitioned_by_date_column__A"
+        execution_engine=engine, table_name="table_partitioned_by_date_column__A"
     )
+    engine.load_batch_data("__", batch_data)
     assert isinstance(batch_data.selectable, sa.Table)
     assert batch_data.selectable.name == "table_partitioned_by_date_column__A"
     assert batch_data.selectable.schema is None
 
-    insp = reflection.Inspector.from_engine(engine)
+    insp = reflection.Inspector.from_engine(eng)
     columns = insp.get_columns(
         batch_data.selectable.name, schema=batch_data.selectable.schema
     )

--- a/tests/integration/profile/test_batch_profilers.py
+++ b/tests/integration/profile/test_batch_profilers.py
@@ -1,0 +1,82 @@
+import hashlib
+import json
+import os
+
+import pytest
+
+from great_expectations.core.batch import BatchRequest
+from great_expectations.data_context.util import file_relative_path
+from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
+
+from ...test_utils import get_sqlite_temp_table_names
+
+
+def test_BasicDatasetProfiler_with_sql_based_Validator(
+    data_context_with_sql_datasource_for_testing_get_batch,
+    sa,
+):
+    context = data_context_with_sql_datasource_for_testing_get_batch
+
+    filepath = file_relative_path(
+        __file__,
+        "../../test_sets/test_cases_for_sql_data_connector.db",
+    )
+    file_text = open(filepath, "rb").read()
+    checksum_pre = hashlib.md5(file_text).hexdigest()
+
+    my_profiler = BasicDatasetProfiler()
+    my_validator = context.get_validator(
+        datasource_name="my_sqlite_db",
+        data_connector_name="daily",
+        data_asset_name="table_partitioned_by_date_column__A",
+        partition_identifiers={"date": "2020-01-15"},
+        expectation_suite_name="my_expectation_suite",
+        overwrite_existing_expectation_suite=True,
+    )
+    sqlite_engine = my_validator.execution_engine.engine
+    temp_table_names_pre = get_sqlite_temp_table_names(sqlite_engine)
+    assert temp_table_names_pre == set()
+
+    my_profiler.profile(my_validator)
+
+    file_text = open(filepath, "rb").read()
+    temp_table_names_post = get_sqlite_temp_table_names(sqlite_engine)
+
+    # Verify that Profiling did not add a temp table.
+    assert temp_table_names_pre == temp_table_names_post
+
+    checksum_post = hashlib.md5(file_text).hexdigest()
+    # NOTE: Abe 20201203: This test somehow alters the contents of test_sets/test_cases_for_sql_data_connector.db
+    # This is not the desired behavior. Tests should be read-only.
+    # This file is committed as a test fixture---please be careful not to commit a changed version.
+    # For the moment, the best way to achieve this is to `chmod 440 tests/test_sets/test_cases_for_sql_data_connector.db`
+
+
+def test_BasicDatasetProfiler_with_pandas_based_Validator(
+    data_context_with_pandas_datasource_for_testing_get_batch,
+):
+    context = data_context_with_pandas_datasource_for_testing_get_batch
+
+    # batches = context.get_batch_list_from_new_style_datasource({
+    #     "datasource_name": "my_pandas_datasource",
+    #     "data_connector_name": "my_filesystem_data_connector",
+    #     "data_asset_name": "A",
+    # })
+    # for batch in batches:
+    #     print(batch.batch_definition)
+
+    my_profiler = BasicDatasetProfiler()
+    my_validator = context.get_validator(
+        datasource_name="my_pandas_datasource",
+        data_connector_name="my_filesystem_data_connector",
+        data_asset_name="A",
+        subdirectory="A",
+        number="1",
+        expectation_suite_name="my_expectation_suite",
+        overwrite_existing_expectation_suite=True,
+    )
+
+    expectations, validation_results = my_profiler.profile(my_validator)
+
+    print(json.dumps(expectations.to_json_dict(), indent=2))
+    print(json.dumps(validation_results.to_json_dict(), indent=2))

--- a/tests/test_definitions/test_expectations_cfe.py
+++ b/tests/test_definitions/test_expectations_cfe.py
@@ -6,14 +6,10 @@ import string
 
 import pandas as pd
 import pytest
-from pandas import DataFrame as pandas_DataFrame
 
-try:
-    from pyspark.sql import DataFrame as spark_DataFrame
-except ImportError:
-    spark_DataFrame = type(None)
-
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+from great_expectations.execution_engine.pandas_batch_data import PandasBatchData
+from great_expectations.execution_engine.sparkdf_batch_data import SparkDFBatchData
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
 from tests.conftest import build_test_backends_list_cfe
@@ -149,7 +145,7 @@ def pytest_generate_tests(metafunc):
                                     generate_test = True
                             elif validator_with_data and isinstance(
                                 validator_with_data.execution_engine.active_batch_data,
-                                pandas_DataFrame,
+                                PandasBatchData,
                             ):
                                 if "pandas" in test["only_for"]:
                                     generate_test = True
@@ -164,7 +160,7 @@ def pytest_generate_tests(metafunc):
                                     generate_test = True
                             elif validator_with_data and isinstance(
                                 validator_with_data.execution_engine.active_batch_data,
-                                spark_DataFrame,
+                                SparkDFBatchData,
                             ):
                                 if "spark" in test["only_for"]:
                                     generate_test = True
@@ -238,7 +234,7 @@ def pytest_generate_tests(metafunc):
                                 and validator_with_data
                                 and isinstance(
                                     validator_with_data.execution_engine.active_batch_data,
-                                    pandas_DataFrame,
+                                    PandasBatchData,
                                 )
                             )
                             or (
@@ -246,7 +242,7 @@ def pytest_generate_tests(metafunc):
                                 and validator_with_data
                                 and isinstance(
                                     validator_with_data.execution_engine.active_batch_data,
-                                    spark_DataFrame,
+                                    SparkDFBatchData,
                                 )
                             )
                         ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,8 +42,11 @@ from great_expectations.execution_engine import (
     PandasExecutionEngine,
     SparkDFExecutionEngine,
 )
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
+from great_expectations.execution_engine.sparkdf_batch_data import SparkDFBatchData
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
+)
+from great_expectations.execution_engine.sqlalchemy_execution_engine import (
     SqlAlchemyExecutionEngine,
 )
 from great_expectations.profile import ColumnsExistProfiler
@@ -849,10 +852,11 @@ def _build_sa_engine(df):
 
     eng = sa.create_engine("sqlite://", echo=False)
     df.to_sql("test", eng)
-    batch_data = SqlAlchemyBatchData(engine=eng, table_name="test")
+    engine = SqlAlchemyExecutionEngine(engine=eng)
+    batch_data = SqlAlchemyBatchData(execution_engine=engine, table_name="test")
     batch = Batch(data=batch_data)
-    engine = SqlAlchemyExecutionEngine(
-        engine=eng, batch_data_dict={batch.id: batch_data}
+    engine.load_batch_data(
+        batch_id=batch.batch_definition.to_id(), batch_data=batch_data
     )
     return engine
 
@@ -971,7 +975,10 @@ def _build_sa_validator_with_data(
 
     batch = Batch(data=batch_data)
     execution_engine = SqlAlchemyExecutionEngine(caching=caching, engine=engine)
-
+    batch_data = SqlAlchemyBatchData(
+        execution_engine=execution_engine, table_name=table_name
+    )
+    batch = Batch(data=batch_data)
     return Validator(execution_engine=execution_engine, batches=(batch,))
 
 
@@ -1258,7 +1265,7 @@ def check_json_test_result(test, result, data_asset=None):
             elif key == "unexpected_index_list":
                 if isinstance(data_asset, (SqlAlchemyDataset, SparkDFDataset)):
                     pass
-                elif isinstance(data_asset, (SqlAlchemyBatchData, SparkDataFrame)):
+                elif isinstance(data_asset, (SqlAlchemyBatchData, SparkDFBatchData)):
                     pass
                 else:
                     assert result["result"]["unexpected_index_list"] == value
@@ -1460,6 +1467,19 @@ def validate_uuid4(uuid_string: str) -> bool:
     # valid uuid4. This is bad for validation purposes.
 
     return val.hex == uuid_string.replace("-", "")
+
+
+def get_sqlite_temp_table_names(engine):
+    result = engine.execute(
+        """
+SELECT
+    name
+FROM
+    sqlite_temp_master
+"""
+    )
+    rows = result.fetchall()
+    return {row[0] for row in rows}
 
 
 def build_in_memory_store_backend(

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -316,6 +316,23 @@ def test_graph_validate_with_runtime_config(basic_datasource):
     ]
 
 
+def test_validator_default_expectation_args(
+    data_context_with_sql_datasource_for_testing_get_batch,
+):
+    context = data_context_with_sql_datasource_for_testing_get_batch
+
+    my_validator = context.get_validator(
+        datasource_name="my_sqlite_db",
+        data_connector_name="daily",
+        data_asset_name="table_partitioned_by_date_column__A",
+        partition_identifiers={"date": "2020-01-15"},
+        expectation_suite_name="test_suite",
+        overwrite_existing_expectation_suite=True,
+    )
+
+    print(my_validator.get_default_expectation_arguments())
+
+
 def test_validator_default_expectation_args__pandas(basic_datasource):
     df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10], "b": [1, 2, 3, 4, 5, None]})
 
@@ -354,7 +371,8 @@ def test_validator_default_expectation_args__sql(
         data_connector_name="daily",
         data_asset_name="table_partitioned_by_date_column__A",
         partition_identifiers={"date": "2020-01-15"},
-        create_expectation_suite_with_name="test_suite",
+        expectation_suite_name="test_suite",
+        overwrite_existing_expectation_suite=True,
     )
 
     print(my_validator.get_default_expectation_arguments())


### PR DESCRIPTION
This PR brings updates and enhancements in several areas, including:

* [ENHANCEMENT] BatchData in the new Datasource API is now more fully implemented, and exposes a `dataframe` or `
selectable` property, instead of exposing a raw data object. Similarly, it exposes an execution_engine property,
which is suitable for instantiating a Validator to produce metrics directly from a Batch. We intend to continue to
update BatchData as part of our plans to support Validations involving multiple tables, while preserving the
behavior for the common cases.
* [ENHANCEMENT] We updated the names of the keys used by SimpleSqlalchemyDatasource to be more consistent with names used in other DataConnector configurations. "introspection" is now "inferred_assets" and "tables" is now "assets"
* [FEATURE] Validator supports `get_metric` and `get_metrics` directly
* [FEATURE] Support for dialect-specific metric providers
* [ENHANCEMENT] Support for BatchData API
* [FEATURE] "table.head" metric supporting data snippets

Additionally, smaller improvements include:
* Hooks in place to avoid complete failure when metrics are unavailable, with improved error handling today.
* API improvements to Validator get Batch.
* Convenience methods and renamed parameters in experimental portions of DataContext API
* Metric-based head function for batches

