### PR TITLE
[ENHANCEMENT] specify interpolation for pandas get_column_quantiles

### DIFF
--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -493,11 +493,22 @@ Notes:
         return self[column].median()
 
     def get_column_quantiles(self, column, quantiles, allow_relative_error=False):
-        if allow_relative_error is not False:
+        interpolation_options = ("linear", "lower", "higher", "midpoint", "nearest")
+
+        if not allow_relative_error:
+            allow_relative_error = "nearest"
+
+        if allow_relative_error not in interpolation_options:
             raise ValueError(
-                "PandasDataset does not support relative error in column quantiles."
+                f"If specified for pandas, allow_relative_error must be one an allowed value for the 'interpolation'"
+                f"parameter of .quantile() (one of {interpolation_options})"
             )
-        return self[column].quantile(quantiles, interpolation="nearest").tolist()
+
+        return (
+            self[column]
+            .quantile(quantiles, interpolation=allow_relative_error)
+            .tolist()
+        )
 
     def get_column_stdev(self, column):
         return self[column].std()

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
@@ -46,10 +46,19 @@ class ColumnQuantileValues(ColumnMetricProvider):
     value_keys = ("quantiles", "allow_relative_error")
 
     @column_aggregate_value(engine=PandasExecutionEngine)
-    def _pandas(cls, column, quantiles, **kwargs):
+    def _pandas(cls, column, quantiles, allow_relative_error, **kwargs):
         """Quantile Function"""
+        interpolation_options = ("linear", "lower", "higher", "midpoint", "nearest")
 
-        return column.quantile(quantiles, interpolation="nearest").tolist()
+        if not allow_relative_error:
+            allow_relative_error = "nearest"
+
+        if allow_relative_error not in interpolation_options:
+            raise ValueError(
+                f"If specified for pandas, allow_relative_error must be one an allowed value for the 'interpolation'"
+                f"parameter of .quantile() (one of {interpolation_options})"
+            )
+        return column.quantile(quantiles, interpolation=allow_relative_error).tolist()
 
     @metric_value(engine=SqlAlchemyExecutionEngine)
     def _sqlalchemy(

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse
 
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.dataset import PandasDataset
 from great_expectations.exceptions import ProfilerError
 from great_expectations.profile.base import (
     OrderedProfilerCardinality,
@@ -797,7 +798,11 @@ class UserConfigurableProfiler:
             "expect_column_quantile_values_to_be_between"
             not in self.excluded_expectations
         ):
-            allow_relative_error: bool = dataset.attempt_allowing_relative_error()
+            if isinstance(dataset, PandasDataset):
+                allow_relative_error = "lower"
+            else:
+                allow_relative_error = dataset.attempt_allowing_relative_error()
+
             quantile_result = dataset.expect_column_quantile_values_to_be_between(
                 column,
                 quantile_ranges={


### PR DESCRIPTION
Changes proposed in this pull request:
Working on the user-configurable profiler across pandas and SQL back-ends revealed that we were calculating quantile_values in pandas in a way that does not match the way that we are doing it in SQL. The same expectation on the same exact data was passing in one and failing in the other. We found that in pandas we are specifying "nearest" for interpolation, whereas SQL (or at least snowflake and postgres) use a calculation which would align with a "lower" interpolation for pandas. Since our default ("nearest") is different from the pandas default ("linear") which is different from the snowflake/postgres default (equivalent to "lower") James and I decided it would make sense to allow this to be specified for pandas.

Previous Design Review notes (James):
- Since the column_quantiles functions already have an "allow_relative_error" parameter that is not used in pandas, we decided that it would be ok to pass the interpolation in as an argument here since it does functionally it corresponds to allowing relative error.



Thank you for submitting!
