### PR TITLE
[BUGFIX] Fix local variable referenced before assignment sqlalchemy_dataset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 
 Develop
 -----------------
-
+* [BUGFIX] Fix Local variable 'temp_table_schema_name' might be referenced before assignment bug in sqlalchemy_dataset.py
 
 0.13.6
 -----------------

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -493,7 +493,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         if self.engine.dialect.name.lower() == "bigquery":
             # In BigQuery the table name is already qualified with its schema name
             self._table = sa.Table(table_name, sa.MetaData(), schema=None)
-            query_schema = None
+            temp_table_schema_name = None
         else:
             try:
                 # use the schema name configured for the datasource


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix Local variable 'temp_table_schema_name' might be referenced before assignment bug in sqlalchemy_dataset.py
