### PR TITLE
[MAINTENANCE] changelog update for PR that has already been merged

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Develop
 -----------------
 * [FEATURE] New implementation of Checkpoints that uses dedicated CheckpointStore (based on the new ConfigurationStore mechanism) #2311, #2338
 * [BUGFIX] Fix issue causing incorrect identification of partially-implemented expectations as not abstract #2334
+* [BUGFIX] DataContext with multiple DataSources no longer scans all configurations #2250
 
 
 0.13.7


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds the following line to changelog for GE 0.13.8 : 

`
 [BUGFIX] DataContext with multiple DataSources no longer scans all configurations #2250
`