### PR TITLE
[MAINTENANCE]Adjusted the expected output of the run_diagnostics method in a test

### DIFF
--- a/tests/expectations/test_run_diagnostics.py
+++ b/tests/expectations/test_run_diagnostics.py
@@ -312,20 +312,9 @@ def test_self_check_on_an_existing_expectation():
         "library_metadata": {
             "maturity": "production",
             "package": "great_expectations",
-            "tags": [
-                "arrows",
-                "design",
-                "flows",
-                "prototypes",
-                "svg",
-                "whiteboarding",
-                "wireframe",
-                "wirefames",
-            ],
-            "contributors": [
-                "@shinnyshinshin",
-                "@abegong",
-            ],
+            "requirements": [],
+            "tags": ["core expectation", "column map expectation"],
+            "contributors": ["@great_expectations"],
         },
         # "test_report": [
         #     {


### PR DESCRIPTION
After the expectations' metadata was edited, we needed to adjust the expected output in one test.