### PR TITLE
[BUGFIX] MySQL temp_table Bug

### DIFF
--- a/examples/expectations/column_map_expectation_template.py
+++ b/examples/expectations/column_map_expectation_template.py
@@ -63,24 +63,26 @@ class ExpectColumnValuesToEqualThree(ColumnMapExpectation):
     """TODO: add a docstring here"""
 
     # These examples will be shown in the public gallery, and also executed as unit tests for your Expectation
-    examples = [{
-        "data": {
-            "mostly_threes": [3, 3, 3, 3, 3, 3, 2, -1, None, None],
-        },
-        "tests": [
-            {
-                "title": "positive_test_with_mostly",
-                "exact_match_out": False,
-                "include_in_gallery": True,
-                "in": {"column": "mostly_threes", "mostly": 0.6},
-                "out": {
-                    "success": True,
-                    "unexpected_index_list": [6, 7],
-                    "unexpected_list": [2, -1],
-                },
-            }
-        ],
-    }]
+    examples = [
+        {
+            "data": {
+                "mostly_threes": [3, 3, 3, 3, 3, 3, 2, -1, None, None],
+            },
+            "tests": [
+                {
+                    "title": "positive_test_with_mostly",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {"column": "mostly_threes", "mostly": 0.6},
+                    "out": {
+                        "success": True,
+                        "unexpected_index_list": [6, 7],
+                        "unexpected_list": [2, -1],
+                    },
+                }
+            ],
+        }
+    ]
 
     # This dictionary contains metadata for display in the public gallery
     library_metadata = {

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -1785,6 +1785,24 @@ WHERE
             .having(sa.func.count(sa.column(column)) > 1)
         )
 
+        # Will - 20210126
+        # This is a special case that needs to be handled for mysql, where you cannot refer to a temp_table
+        # more than once in the same query. So instead of passing dup_query as-is, a second temp_table is created with
+        # just the column we will be performing the expectation on, and the query is performed against it.
+        if self.sql_engine_dialect.name.lower() == "mysql":
+            temp_table_name = f"ge_tmp_{str(uuid.uuid4())[:8]}"
+            temp_table_stmt = "CREATE TEMPORARY TABLE {new_temp_table} AS SELECT tmp.{column_name} FROM {source_table} tmp".format(
+                new_temp_table=temp_table_name,
+                source_table=self._table,
+                column_name=column,
+            )
+            self.engine.execute(temp_table_stmt)
+            dup_query = (
+                sa.select([sa.column(column)])
+                .select_from(sa.text(temp_table_name))
+                .group_by(sa.column(column))
+                .having(sa.func.count(sa.column(column)) > 1)
+            )
         return sa.column(column).notin_(dup_query)
 
     def _get_dialect_regex_expression(self, column, regex, positive=True):

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -262,7 +262,7 @@ class ExecutionEngine:
         Returns:
             A tuple consisting of three elements:
 
-            1. data correspondig to the compute domain;
+            1. data corresponding to the compute domain;
             2. a modified copy of domain_kwargs describing the domain of the data returned in (1);
             3. a dictionary describing the access instructions for data elements included in the compute domain
                 (e.g. specific column name).

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -452,6 +452,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             "sqlite",
             "mssql",
             "snowflake",
+            "mysql",
         ]:
             # sqlite/mssql temp tables only persist within a connection so override the engine
             self.engine = self.engine.connect()

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
@@ -31,6 +31,16 @@
         "unique": "INTEGER",
         "null": "NVARCHAR",
         "mult_dup": "VARCHAR"
+      },
+      "mysql": {
+        "a": "CHAR",
+        "b": "CHAR",
+        "c": "INTEGER",
+        "d": "CHAR",
+        "n": "INTEGER",
+        "unique": "INTEGER",
+        "null": "CHAR",
+        "mult_dup": "CHAR"
       }
     },
     "tests" : [


### PR DESCRIPTION
Changes proposed in this pull request:

**Background**
- `mysql` has does not allow you to refer to a temp_table more than once in the same query. [Link to MySQL Doc](https://dev.mysql.com/doc/refman/8.0/en/temporary-table-problems.html).
- This has caused issues (#2199 and #1862) with the Expectation `expect_column_values_to_be_unique()`, which generates a list of duplicate values using an inner query that refers to a temp_table, and applies it as a column_map_expectation, which refers to the temp_table a second time. 
-  To solve this issue, a second temp_table is created with just the duplicate values from the column the expectation is being run on. This second temp_table is referenced when running the column_map_expectation. (please see inline comments for more details). 
- For pre-0.13 the change was in `sqlalchemy_dataset.py`
- For 0.13 the corresponding change was made in `metrics/column_map_metrics/column_values_unique.py`

**Tests**
-  This issue was missed by the test framework for both pre-0.13 and 0.13 Expectations. This was because `SqlAlchemyDataset` and `SqlAlchemyBatchData` were both instantiated by referring to a table-name, which did not result in the creation of a temp_table. This was different from how the same objects would be instantiated through `batch_kwargs` or `validator`. 
- To solve this issue, `SqlAlchemyDataset` and `SqlAlchemyBatchData` are now instantiated using a query (`"SELECT * FROM"  + test_table_name`) in the case of a `mysql` backend. 

**Related Issues**
- closes #2199 
- closes #1862
