### PR TITLE
[BUGFIX] Add python=3.7 argument to conda env creation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,8 +11,8 @@ Develop
 * [DOCS] How to load a Pandas DataFrame as a Batch #2327
 * [ENHANCEMENT] Add possibility to pass boto3 configuration to TupleS3StoreBackend (Thanks for #1691 to @mgorsk1!) #2371
 * [BUGFIX] Display correct unexpected_percent in DataDocs - corrects the result object from map expectations to return the same "unexpected_percent" as is used to evaluate success (excluding null values from the denominator). The old value is now returned in a key called "unexpected_percent_total" (thanks @mlondschien) #1875
-* [BUGFIX] Add python=3.7 argument to conda env creation #2391
-* [MAINTENANCE] Add checkpoint store to store backend defaults (thanks @scouvreur!) #2378
+* [BUGFIX] Add python=3.7 argument to conda env creation (thanks @scouvreur!) #2391
+* [MAINTENANCE] Add checkpoint store to store backend defaults #2378
 
 0.13.8
 -----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,8 @@ Develop
 * [DOCS] How to load a Pandas DataFrame as a Batch #2327
 * [ENHANCEMENT] Add possibility to pass boto3 configuration to TupleS3StoreBackend (Thanks for #1691 to @mgorsk1!) #2371
 * [BUGFIX] Display correct unexpected_percent in DataDocs - corrects the result object from map expectations to return the same "unexpected_percent" as is used to evaluate success (excluding null values from the denominator). The old value is now returned in a key called "unexpected_percent_total" (thanks @mlondschien) #1875
-* [MAINTENANCE] Add checkpoint store to store backend defaults #2378
+* [BUGFIX] Add python=3.7 argument to conda env creation #2391
+* [MAINTENANCE] Add checkpoint store to store backend defaults (thanks @scouvreur!) #2378
 
 0.13.8
 -----------------

--- a/docs/contributing/setting_up_your_dev_environment.rst
+++ b/docs/contributing/setting_up_your_dev_environment.rst
@@ -52,7 +52,7 @@ Install python dependencies
 
     * Make a new virtual environment (e.g. using virtualenv or conda), name it "great_expectations_dev" or similar.
     * Ex virtualenv: ``python3 -m venv <path_to_environments_folder>/great_expectations_dev`` and then ``<source path_to_environments_folder>/great_expectations_dev/bin/activate``
-    * Ex conda: ``conda create --name great_expectations_dev`` and then ``conda activate great_expectations_dev``
+    * Ex conda: ``conda create --name great_expectations_dev python=3.7`` and then ``conda activate great_expectations_dev``
     * This is not required, but highly recommended.
 
 **6. Install dependencies from requirements-dev.txt**

--- a/docs/contributing/setting_up_your_dev_environment.rst
+++ b/docs/contributing/setting_up_your_dev_environment.rst
@@ -56,7 +56,7 @@ Install python dependencies
 
     * Make a new virtual environment (e.g. using virtualenv or conda), name it "great_expectations_dev" or similar.
     * Ex virtualenv: ``python3 -m venv <path_to_environments_folder>/great_expectations_dev`` and then ``<source path_to_environments_folder>/great_expectations_dev/bin/activate``
-    * Ex conda: ``conda create --name great_expectations_dev python=3.7`` and then ``conda activate great_expectations_dev``
+    * Ex conda: ``conda create --name great_expectations_dev python=3.7`` and then ``conda activate great_expectations_dev`` (we support multiple python versions, you may select something other than 3.7).
     * This is not required, but highly recommended.
 
 **6. Install dependencies from requirements-dev.txt**


### PR DESCRIPTION
Closes issue #2390

Changes proposed in this pull request:
- enforce conda env python version to 3.7 to avoid dependency issues
