### PR TITLE
[DOCS] Correct regex escape for data connectors

### DIFF
--- a/docs/guides/how_to_guides/configuring_datasources/how_to_choose_which_data_connector_to_use.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_choose_which_data_connector_to_use.rst
@@ -38,7 +38,7 @@ This config...
             class_name: InferredAssetFilesystemDataConnector
             base_directory: my_data/
             default_regex:
-                pattern: (.*)/.*-(\d+).csv
+                pattern: (.*)/.*-(\d+)\.csv
                 group_names:
                     - data_asset_name
                     - id
@@ -106,22 +106,22 @@ Then this config...
             base_directory: my_messier_data/
             assets:
                 A:
-                    pattern: (.+A)-(\\d+)\\.csv
+                    pattern: (.+A)-(\d+)\.csv
                     group_names:
                         - name
                         - id
                 B:
-                    pattern: (.+B)-(\\d+)\\.txt
+                    pattern: (.+B)-(\d+)\.txt
                     group_names:
                         - name
                         - val
                 C:
-                    pattern: (.+C)-(\\d+)\\.csv
+                    pattern: (.+C)-(\d+)\.csv
                     group_names:
                         - name
                         - id
                 D:
-                    pattern: (.+D)-(\\d+)\\.csv
+                    pattern: (.+D)-(\d+)\.csv
                     group_names:
                         - name
                         - id


### PR DESCRIPTION
Changes proposed in this pull request:
- Update data connector docs to correct regex escape sequences. Some regex was missing escapes around  the file extension`.` to specify the `.` character (not a pattern matching one).  Other's had escaped the `\` in the escape sequence eg `\\.`