### PR TITLE
updated UserConfigurableProfiler date parsing error handling

### DIFF
--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -901,11 +901,6 @@ class UserConfigurableProfiler:
                 except TypeError:
                     pass
 
-                try:
-                    min_value = min_value + datetime.timedelta(days=-365)
-                except OverflowError:
-                    min_value = datetime.datetime.min
-
             dataset._expectation_suite.remove_expectation(
                 ExpectationConfiguration(
                     expectation_type="expect_column_min_to_be_between",
@@ -925,11 +920,6 @@ class UserConfigurableProfiler:
                     max_value = parse(max_value)
                 except TypeError:
                     pass
-
-                try:
-                    max_value = max_value + datetime.timedelta(days=-365)
-                except OverflowError:
-                    max_value = datetime.datetime.max
 
             dataset._expectation_suite.remove_expectation(
                 ExpectationConfiguration(

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -897,11 +897,14 @@ class UserConfigurableProfiler:
 
             if min_value is not None:
                 try:
-                    min_value = min_value
+                    min_value = parse(min_value)
+                except TypeError:
+                    pass
+
+                try:
+                    min_value = min_value + datetime.timedelta(days=-365)
                 except OverflowError:
                     min_value = datetime.datetime.min
-                except TypeError:
-                    min_value = parse(min_value)
 
             dataset._expectation_suite.remove_expectation(
                 ExpectationConfiguration(
@@ -919,11 +922,14 @@ class UserConfigurableProfiler:
             ).result["observed_value"]
             if max_value is not None:
                 try:
-                    max_value = max_value
+                    max_value = parse(max_value)
+                except TypeError:
+                    pass
+
+                try:
+                    max_value = max_value + datetime.timedelta(days=-365)
                 except OverflowError:
                     max_value = datetime.datetime.max
-                except TypeError:
-                    max_value = parse(max_value)
 
             dataset._expectation_suite.remove_expectation(
                 ExpectationConfiguration(


### PR DESCRIPTION
Changes proposed in this pull request:
-#2431 introduced updated error handling for date parsing. This made sense to me, so I'm incorporating it into the UserConfigurableProfiler as well
