### PR TITLE
[BUGFIX] `expect_column_kurtosis_to_be_between.py` contained `-np.inf` which could not be rendered in gallery

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
@@ -247,7 +247,7 @@ class ExpectColumnKurtosisToBeBetween(ColumnExpectation):
                     "title": "positive_test_neg_kurtosis",
                     "exact_match_out": False,
                     "include_in_gallery": True,
-                    "in": {"column": "a", "min_value": -np.inf, "max_value": 0},
+                    "in": {"column": "a", "min_value": -1000, "max_value": 0},
                     "out": {"success": True, "observed_value": -1.3313434082203324},
                 },
                 {

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
@@ -247,7 +247,7 @@ class ExpectColumnKurtosisToBeBetween(ColumnExpectation):
                     "title": "positive_test_neg_kurtosis",
                     "exact_match_out": False,
                     "include_in_gallery": True,
-                    "in": {"column": "a", "min_value": -float("inf"), "max_value": 0},
+                    "in": {"column": "a", "min_value": -1000, "max_value": 0},
                     "out": {"success": True, "observed_value": -1.3313434082203324},
                 },
                 {

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_kurtosis_to_be_between.py
@@ -247,7 +247,7 @@ class ExpectColumnKurtosisToBeBetween(ColumnExpectation):
                     "title": "positive_test_neg_kurtosis",
                     "exact_match_out": False,
                     "include_in_gallery": True,
-                    "in": {"column": "a", "min_value": -1000, "max_value": 0},
+                    "in": {"column": "a", "min_value": -float("inf"), "max_value": 0},
                     "out": {"success": True, "observed_value": -1.3313434082203324},
                 },
                 {


### PR DESCRIPTION
Changes proposed in this pull request:
- Adjust test parameter value to negative integer instead
- Added task to Asana to write a check for JSON config to check if contributed expectations can be rendered in gallery

