### PR TITLE
[DOCS] Added a link to the docs article that explains evaluation parameters to StoreEvaluationParametersAction docstring

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -578,6 +578,8 @@ class StoreEvaluationParametersAction(ValidationAction):
     Evaluation parameters allow expectations to refer to statistics/metrics computed
     in the process of validating other prior expectations.
 
+    Read more about evaluation parameters here: https://docs.greatexpectations.io/en/latest/reference/core_concepts/evaluation_parameters.html
+
     **Configuration**
 
     .. code-block:: yaml


### PR DESCRIPTION
Changes proposed in this pull request:
- Added a link to the docs article that explains evaluation parameters to StoreEvaluationParametersAction docstring (based on a user's question)
-
-


Previous Design Review notes:
- N/A
-
-


Thank you for submitting!
