### PR TITLE
updated expect_column_values_to_be_in_type_list

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -228,8 +228,8 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             comp_types = []
             for type_ in expected_types_list:
                 try:
-                    comp_types.append(np.dtype(type_).type),
-                    comp_types.append(np.dtype(type_)),
+                    comp_types.append(np.dtype(type_).type)
+                    comp_types.append(np.dtype(type_))
                 except TypeError:
                     try:
                         pd_type = getattr(pd, type_)

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -228,7 +228,8 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             comp_types = []
             for type_ in expected_types_list:
                 try:
-                    comp_types.append(np.dtype(type_).type)
+                    comp_types.append(np.dtype(type_).type),
+                    comp_types.append(np.dtype(type_)),
                 except TypeError:
                     try:
                         pd_type = getattr(pd, type_)


### PR DESCRIPTION
There's an issue where pandas columns with Timestamp objects were failing `expect_column_values_to_be_in_type_list` due to a mismatch of types. I believe this is because we are appending `np.dtype(type_).type`, which evaluates to `numpy.dtype`, instead of `np.dtype(type_)` which is the type itself.

I don't know whether we had the original for a reason, or whether it was a mistake. For now, I am appending both to the list, as that doesn't seem to do any harm.