### PR TITLE
[DOCS] Renamed the old and the new APIs in the docs and added an article that explains them

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 
 Develop
 -----------------
-
+* [DOCS] Renamed the "old" and the "new" APIs to "V2 (Batch Kwargs) API" and "V3 (Batch Request) API" and added an article with recommendations for choosing between them
 
 0.13.11
 -----------------

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -7,6 +7,11 @@ Guides
 
 This section contains a collection of practical step-by-step instructions to help you use Great Expectations.
 
+.. admonition:: Note!
+
+    Some guides in this section refer to two versions of our API: V2 (Batch Kwargs) and V3 (Batch Request). To understand which version fits your purpose, read this :ref:`article <v3_vs_v2_api>`.
+
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/guides/how_to_guides/configuring_data_contexts/how_to_instantiate_a_data_context_on_a_databricks_spark_cluster.rst
+++ b/docs/guides/how_to_guides/configuring_data_contexts/how_to_instantiate_a_data_context_on_a_databricks_spark_cluster.rst
@@ -35,7 +35,7 @@ This how-to-guide assumes that you are using a Databricks Notebook, and using th
     .. content-tabs::
 
         .. tab-container:: tab0
-            :title: Show Docs for Stable API (up to 0.12.x)
+            :title: Show Docs for V2 (Batch Kwargs) API
 
             .. code-block:: python
                 :linenos:
@@ -61,7 +61,7 @@ This how-to-guide assumes that you are using a Databricks Notebook, and using th
                 context = BaseDataContext(project_config=data_context_config)
 
         .. tab-container:: tab1
-            :title: Show Docs for Experimental API (0.13)
+            :title: Show Docs for V3 (Batch Request) API
 
             .. code-block:: python
                 :linenos:
@@ -179,7 +179,7 @@ Additional notes
     .. content-tabs::
 
         .. tab-container:: tab0
-            :title: Show Docs for Stable API (up to 0.12.x)
+            :title: Show Docs for V2 (Batch Kwargs) API
 
             Please note that this code-snippet assumes that you have already installed Great Expectations and configured a :ref:`Datasource <reference__core_concepts__datasources>`.
 
@@ -216,7 +216,7 @@ Additional notes
 
 
         .. tab-container:: tab1
-            :title: Show Docs for Experimental API (0.13)
+            :title: Show Docs for V3 (Batch Request) API
 
             .. code-block:: python
                 :linenos:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
@@ -13,7 +13,7 @@ Steps
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -108,7 +108,7 @@ Steps
                 The credentials will be saved in uncommitted/config_variables.yml under the key 'mssql_db'
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
@@ -13,7 +13,7 @@ Steps
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -105,7 +105,7 @@ Steps
 
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
@@ -14,7 +14,7 @@ Steps
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -105,7 +105,7 @@ Steps
 
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -234,7 +234,7 @@ Additional Notes
 ----------------
 
 #.
-    For the Stable API (up to 0.12.x), relative path locations (e.g. for the ``base_directory``) should be specified from the perspective of the directory, in which the
+    For the V2 (Batch Kwargs) API, relative path locations (e.g. for the ``base_directory``) should be specified from the perspective of the directory, in which the
 
     .. code-block:: bash
 
@@ -244,7 +244,7 @@ Additional Notes
 
 
 #.
-    For the Experimental API (0.13), relative path locations  (e.g. for the ``base_directory``) should be specified from the perspective of the ``great_expectations/`` directory.
+    For the V3 (Batch Request) API, relative path locations  (e.g. for the ``base_directory``) should be specified from the perspective of the ``great_expectations/`` directory.
 
 
 --------

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
@@ -13,7 +13,7 @@ Steps
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -123,7 +123,7 @@ Steps
 
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -13,7 +13,7 @@ Steps
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -144,7 +144,7 @@ Steps
 
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_self_managed_spark_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_self_managed_spark_datasource.rst
@@ -71,7 +71,7 @@ To enable running Great Expectations against dataframe created by Spark SQL quer
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         #. **Replace lines in great_expectations.yml file**
 
@@ -114,7 +114,7 @@ To enable running Great Expectations against dataframe created by Spark SQL quer
         Now, when creating new expectation suite, query `main` will be available in the list of datasources.
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         #. **Replace lines in great_expectations.yml file**
 
@@ -163,7 +163,7 @@ Additional Notes
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         #. **Configuring Spark options**
 
@@ -205,7 +205,7 @@ Additional Notes
                 spark.hadoop.hive.metastore.uris    thrift://localhost:9083
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         #. **Configuring Spark options**
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
@@ -19,7 +19,7 @@ Steps
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -189,7 +189,7 @@ Steps
             After this confirmation, you can proceed with exploring the data sets in your new Snowflake Datasource.
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -365,7 +365,7 @@ Additional Notes
 
 
 #.
-    **Single sign-on (SSO) Authentication for Experimental API (0.13)**
+    **Single sign-on (SSO) Authentication for V3 (Batch Request) API**
 
     Add ``connect_args`` and ``authenticator`` to ``credentials`` in the yaml configuration.
     The value for ``authenticator`` can be ``externalbrowser``, or a valid okta URL.
@@ -391,7 +391,7 @@ Additional Notes
     **Note** This feature is still experimental, so please leave us a comment below if you run into any problems.
 
 #.
-    **Key pair Authentication for Experimental API (0.13)**
+    **Key pair Authentication for V3 (Batch Request) API**
 
     Add ``private_key_path`` and optional ``private_key_passphrase`` to ``credentials`` in the yaml configuration.
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
@@ -14,7 +14,7 @@ Steps
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -106,7 +106,7 @@ Steps
             Finally, if all goes well and you receive a confirmation on your Terminal screen, you can proceed with exploring the data sets in your new filesystem-backed Spark data source.
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -234,7 +234,7 @@ Additional Notes
     command is executed.
 
 #.
-    For the Experimental API (0.13), relative path locations should be specified from the perspective of the ``great_expectations/`` directory.
+    For the V3 (Batch Request) API, relative path locations should be specified from the perspective of the ``great_expectations/`` directory.
 
 --------
 Comments

--- a/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_a_new_expectation_suite_without_the_cli.rst
+++ b/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_a_new_expectation_suite_without_the_cli.rst
@@ -8,7 +8,7 @@ In some environments, you might not be able to use the :ref:`CLI <command_line>`
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -57,7 +57,7 @@ In some environments, you might not be able to use the :ref:`CLI <command_line>`
         This will create a JSON file with your Expectation Suite in the Store you have configured, which you can then load and use for :ref:`how_to_guides__validation`.
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 

--- a/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_an_expectation_suite_with_the_user_configurable_profiler.rst
+++ b/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_an_expectation_suite_with_the_user_configurable_profiler.rst
@@ -8,7 +8,7 @@ This guide will help you create a new Expectation Suite by profiling your data w
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -240,7 +240,7 @@ This guide will help you create a new Expectation Suite by profiling your data w
             - ``expect_compound_columns_to_be_unique`` (if a compound key is specified for ``primary_or_compound_key``)
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: The UserConfigurableProfiler is not currently configured to work with the 0.13 Experimental API.
 

--- a/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations.rst
+++ b/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations.rst
@@ -11,7 +11,7 @@ Beginning in version 0.13, we have introduced a new API focused on enabling Modu
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         Most of the core Great Expectations expectations are built using expectation decorators, and using decorators on existing logic can make bringing custom integrations into your pipeline tests easy.
 
@@ -428,7 +428,7 @@ Beginning in version 0.13, we have introduced a new API focused on enabling Modu
             }
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         How to define a custom Expectation type
         _________________________________________________________________

--- a/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.rst
+++ b/docs/guides/how_to_guides/creating_and_editing_expectations/how_to_create_expectations_that_span_multiple_batches_using_evaluation_parameters.rst
@@ -8,7 +8,7 @@ This guide will help you create Expectations that span multiple :ref:`Batches <r
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -141,7 +141,7 @@ This guide will help you create Expectations that span multiple :ref:`Batches <r
                 In general, the development loop for testing and debugging URN and Evaluation Parameters is not very user-friendly. We plan to simplify this workflow in the future. In the meantime, we welcome questions in the `Great Expectations discussion forum <https://discuss.great_expectations.io>`_ and `Slack channel <https://great_expectations.io/slack>`_.
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 

--- a/docs/guides/how_to_guides/creating_batches/how_to_load_a_pandas_dataframe_as_a_batch.rst
+++ b/docs/guides/how_to_guides/creating_batches/how_to_load_a_pandas_dataframe_as_a_batch.rst
@@ -8,7 +8,7 @@ This guide will help you load a Pandas DataFrame as a Batch for use in creating 
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -82,7 +82,7 @@ This guide will help you load a Pandas DataFrame as a Batch for use in creating 
 
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
 
         What used to be called a “batch” in the old API was replaced with :ref:`Validator <reference__core_concepts__validation>`. A Validator knows how to validate a particular batch of data on a particular :ref:`Execution Engine <reference__core_concepts>` against a particular :ref:`Expectation Suite <reference__core_concepts__expectations__expectation_suites>`. In interactive mode, the Validator can store and update an Expectation Suite while conducting Data Discovery or Exploratory Data Analysis.

--- a/docs/guides/how_to_guides/creating_batches/how_to_load_a_spark_dataframe_as_a_batch.rst
+++ b/docs/guides/how_to_guides/creating_batches/how_to_load_a_spark_dataframe_as_a_batch.rst
@@ -8,7 +8,7 @@ This guide will help you load a Spark DataFrame as a Batch for use in creating E
 .. content-tabs::
 
     .. tab-container:: tab0
-        :title: Show Docs for Stable API (up to 0.12.x)
+        :title: Show Docs for V2 (Batch Kwargs) API
 
         .. admonition:: Prerequisites: This how-to guide assumes you have already:
 
@@ -82,7 +82,7 @@ This guide will help you load a Spark DataFrame as a Batch for use in creating E
 
 
     .. tab-container:: tab1
-        :title: Show Docs for Experimental API (0.13)
+        :title: Show Docs for V3 (Batch Request) API
 
 
         What used to be called a “batch” in the old API was replaced with a :ref:`Validator <reference__core_concepts__validation>`. A Validator knows how to validate a particular batch of data on a particular :ref:`Execution Engine <reference__core_concepts>` against a particular :ref:`Expectation Suite <reference__core_concepts__expectations__expectation_suites>`. In interactive mode, the Validator can store and update an Expectation Suite while conducting Data Discovery or Exploratory Data Analysis.

--- a/docs/guides/how_to_guides/migrating_versions.rst
+++ b/docs/guides/how_to_guides/migrating_versions.rst
@@ -47,17 +47,17 @@ The 0.13 major release of Great Expectations introduced a group of new features 
 
 We are actively working on incorporating user feedback, documenting the new V3 API, and making the CLI work with it.
 
-Here are our current recommendations for choosing between the V2 and V3 APIs:
+Here are our current recommendations for choosing between V2 and V3 APIs:
 
-Always install the latest 0.13.x release in order to keep up to date with various enhancements and bug fixes.
+* Always install the latest 0.13.x release in order to keep up to date with various enhancements and bug fixes.
 
-If you start a new project, use V3 API with the following two exceptions:
+* If you start a new project, use V3 API with the following two exceptions:
 
     * If you heavily rely on the CLI
 
     * If you validate in-memory Spark or Pandas DataFrames
 
-    * If you have an existing project on the V2 API, keep using the V2 API for your existing projects.
+* Keep using V2 API for your existing projects.
 
 
 We will announce when V3 API can be used for new projects without any caveats. Also, we will announce when we have documentation/procedure for migrating existing projects from using V2 API to using V3 API.

--- a/docs/guides/how_to_guides/migrating_versions.rst
+++ b/docs/guides/how_to_guides/migrating_versions.rst
@@ -35,6 +35,33 @@ You will most likely be prompted to install a new template. Rest assured that
 your original yaml file will be archived automatically for you. Even so, it's
 in your source control system already, right? ;-)
 
+.. _v3_vs_v2_api:
+
+***************************************************
+V3 (Batch Request) API vs The V2 (Batch Kwargs) API
+***************************************************
+
+The 0.13 major release of Great Expectations introduced a group of new features based on “new style” Datasources and Modular Expectations that we call the V3 (Batch Request) API. The V2 (Batch Kwargs) API will be deprecated in the future.
+
+0.13.x releases are compatible with both versions of the API. V3 API is currently marked as experimental.
+
+We are actively working on incorporating user feedback, documenting the new V3 API, and making the CLI work with it.
+
+Here are our current recommendations for choosing between the V2 and V3 APIs:
+
+Always install the latest 0.13.x release in order to keep up to date with various enhancements and bug fixes.
+
+If you start a new project, use V3 API with the following two exceptions:
+
+    * If you heavily rely on the CLI
+
+    * If you validate in-memory Spark or Pandas DataFrames
+
+    * If you have an existing project on the V2 API, keep using the V2 API for your existing projects.
+
+
+We will announce when V3 API can be used for new projects without any caveats. Also, we will announce when we have documentation/procedure for migrating existing projects from using V2 API to using V3 API.
+
 .. _upgrading_to_0.13:
 
 *************************

--- a/docs/guides/how_to_guides/miscellaneous/how_to_write_a_how_to_guide.rst
+++ b/docs/guides/how_to_guides/miscellaneous/how_to_write_a_how_to_guide.rst
@@ -123,12 +123,12 @@ The following code snippet shows how two tabs (``tab0`` and ``tab1``) can be cre
         .. content-tabs::
 
             .. tab-container:: tab0
-                :title: Show Docs for Stable API (up to 0.12.x)
+                :title: Show Docs for V2 (Batch Kwargs) API
 
                 # Content for Stable API #
 
             .. tab-container:: tab1
-                :title: Show Docs for Experimental API (0.13)
+                :title: Show Docs for V3 (Batch Request) API
 
                 # Content for Experimental API #
 

--- a/docs/guides/tutorials/how_to_create_expectations.rst
+++ b/docs/guides/tutorials/how_to_create_expectations.rst
@@ -85,7 +85,7 @@ edit this Expectation Suite, use the :ref:`CLI <command_line>` again to generate
 
 If you do not use the :ref:`CLI <command_line>`, create a new notebook in the``great_expectations/notebooks/`` folder in your project.
 
-.. admonition:: If Using Experimental API (0.13)
+.. admonition:: If Using V3 (Batch Request) API
 
     The following steps are only applicable for the stable API (up to 0.12.x). If you are using the experimental API (0.13), follow the steps outlined in the how-to guide on :ref:`how to create a Expectation Suite without the CLI <how_to_guides__creating_and_editing_expectations__how_to_create_a_new_expectation_suite_without_the_cli>`.
 


### PR DESCRIPTION
#### Changes proposed in this pull request:
- To clarify the two versions of our API, we renamed the old and the new APIs to "V2 (Batch Kwargs) API" and "V3 (Batch Request) API". All references to the old names in the docs were replaced. A new article explaining the versions and how to choose between them was added.


#### Previous Design Review notes:
- The changes follow the core team's decisions documented here: https://docs.google.com/document/d/11NN6aqmyXcIQ5ciP0jpg06geAcs1nXT73dKmguzHu30/edit


Thank you for submitting!
