### PR TITLE
[FEATURE] ✨ Support for a new sqlalchemy dialect (ibm_db_sa) allowing IBM Db2 datasources

### DIFF
--- a/assets/docker/ibm_db2/docker-compose.yml
+++ b/assets/docker/ibm_db2/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.2'
+services:
+  db2:
+    image: ibmcom/db2
+    container_name: ibmdb2
+    environment:
+      DBNAME: test_ci
+      DB2INST1_PASSWORD: my_db_password
+      LICENSE: accept
+      PERSISTENT_HOME: 'false'
+    restart: unless-stopped
+    privileged: true
+    volumes:
+      - ./:/database
+    networks:
+      - dbnet
+    ports:
+      - "50000:50000"
+networks:
+  dbnet:
+    driver: bridge

--- a/assets/docker/ibm_db2/initialize_ibm_db2.py
+++ b/assets/docker/ibm_db2/initialize_ibm_db2.py
@@ -1,0 +1,167 @@
+import sqlalchemy as sa
+
+db2_conn = "db2+ibm_db://db2inst1:my_db_password@hostname:50000/test_ci"
+
+# start the SqlAlchemy engine
+engine = sa.create_engine(db2_conn, echo=True, echo_pool="debug")
+cnxn = engine.connect()
+metadata = sa.MetaData()
+
+# Create a schema
+schema_name = "bigsql"
+user_name = "db2inst1"
+try:
+    print("\n\nCREATING A SCHEMA")
+    sql = f"CREATE SCHEMA {schema_name} AUTHORIZATION {user_name};"
+    response = cnxn.execute(sql)
+    print("SUCCESS CREATING A SCHEMA")
+except Exception as e:
+    print("FAILED AT CREATING A SCHEMA")
+    print(e)
+
+# Configure a tablespace
+try:
+    # https://stackoverflow.com/questions/53610628/a-table-space-could-not-be-found-with-a-page-size-of-at-least-4096-that-autho
+    print("\n\nCREATING A TABLESPACE TO ENABLE THE CREATION OF TABLES")
+    sql = """CREATE USER TEMPORARY TABLESPACE "UTMP4K"
+             PAGESIZE 4096 MANAGED BY AUTOMATIC STORAGE
+             USING STOGROUP "IBMSTOGROUP"
+             EXTENTSIZE 4
+             PREFETCHSIZE AUTOMATIC
+             BUFFERPOOL "IBMDEFAULTBP"
+             OVERHEAD INHERIT
+             TRANSFERRATE INHERIT
+             FILE SYSTEM CACHING
+             DROPPED TABLE RECOVERY OFF;
+    """
+    response = cnxn.execute(sql)
+    print("SUCCESS CREATING A TABLESPACE TO ENABLE THE CREATION OF TABLES")
+except Exception as e:
+    print("FAILED AT CREATING A TABLESPACE TO ENABLE THE CREATION OF TABLES")
+    print(e)
+
+
+# Test creating a temporary table (auto-delete when connexion is closed)
+temp_table_name = "bigsql.GE_TMP_TABLE_1"
+try:
+    print("\n\nCREATE A TEMPORARY TABLE")
+    # working for PM user on BDL DEV
+    # the format of the schema works with both lowercase or uppercase
+    # FAILS with single quotes around <schema_name>.<table_name>
+    # Strange fact #1: the query fails running for the first time, and succeeds on the second!!!
+    # Strange fact #2: adding "TEMPORARY" solves this issue, and create the table at once!!!
+    # bug reported here: https://github.com/ibmdb/python-ibmdbsa/issues/93
+    sql = (
+        f"CREATE TEMPORARY TABLE {temp_table_name} ( ColOne int, ColTwo varchar(255), "
+        "ColThree varchar(255), ColFour varchar(255), ColFive varchar(255) );"
+    )
+    response = cnxn.execute(sql)
+    print(response)
+    print("SUCCESS CREATING A TEMPORARY TABLE")
+
+    print("\n\nINSERT DATA IN A TEMPORARY TABLE")
+    try:
+        # FAILS with single/DOUBLE quotes around <schema_name>.<table_name>
+        sql = (
+            f"INSERT INTO {temp_table_name} ( ColOne, ColTwo, ColThree, ColFour, ColFive) "
+            " VALUES ('1234', 'abcd', 'efgh', 'ijkl', 'mnop');"
+        )
+        response = cnxn.execute(sql)
+        print(response)
+        print("SUCCESS INSERTING DATA IN TEMPORARY TABLE")
+    except Exception as e2:
+        print("FAILED TO INSERT DATA IN TEMPORARY TABLE")
+        print(e2)
+except Exception as e:
+    print("FAILED TO CREATE A TEMPORARY TABLE")
+    print(e)
+
+
+try:
+    print("\n\nREADING DATA FROM TEMPORARY TABLE")
+    sql = f"SELECT * FROM {temp_table_name} FETCH FIRST 1 ROWS ONLY"
+    response = cnxn.execute(sql)
+    print(response.fetchone())
+    print("SUCCESS READING TABLE")
+except Exception as e:
+    print("FAILED TO READ THE TEMPORARY TABLE")
+    print(e)
+
+
+second_temp_table_name = "bigsql.GE_TMP_TABLE_2"
+try:
+    print("\n\nCREATE TEMPORARY TABLE FROM READING DATA FROM TABLE FIRST 1000 ROWS")
+    sql = (
+        f"CREATE TEMPORARY TABLE {second_temp_table_name} AS "
+        f"(SELECT * FROM {temp_table_name} FETCH FIRST 1000 ROWS ONLY);"
+    )
+    response = cnxn.execute(sql)
+    print(response)
+    print("SUCCESS CREATE TEMPORARY TABLE FROM READING TABLE FIRST 1000 ROWS")
+except Exception as e:
+    print(e)
+    print("FAILED TO CREATE TEMPORARY TABLE FROM READING THE TABLE FIRST 1000 ROWS")
+
+try:
+    print("\n\nREADING THE TEMPORARY TABLE")
+    sql = f"SELECT * FROM {second_temp_table_name};"
+    response = cnxn.execute(sql)
+    print(response.fetchone())
+    print("SUCCESS READING THE TEMPORARY TABLE")
+except Exception as e:
+    print(e)
+    print("FAILED AT READING THE TEMPORARY TABLE")
+
+
+
+permanent_table = "bigsql.GE_TABLE_ABC3"
+try:
+    # https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_71/sqlp/rbafycrttblas.htm
+    print("\n\nCREATE TABLE FROM READING DATA FROM TABLE FIRST 1000 ROWS")
+    sql = (
+        f"CREATE TABLE {permanent_table} AS "
+        f"(SELECT * FROM {second_temp_table_name}) WITH DATA"
+    )
+    response = cnxn.execute(sql)
+    print(response)
+    print("SUCCESS CREATE TABLE")
+except Exception as e:
+    print(e)
+    print("FAILED TO CREATE TABLE")
+
+try:
+    print("\n\nREADING TABLE")
+    sql = f"SELECT * FROM {permanent_table};"
+    response = cnxn.execute(sql)
+    print(response.fetchone())
+    print("SUCCESS READING TABLE")
+except Exception as e:
+    print(e)
+    print("FAILED READING TABLE")
+
+
+permanent_view = "bigsql.GE_VIEW_ABC3"
+try:
+    # https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_72/sqlp/rbafyviewnt.htm
+    print("\n\nCREATE VIEW FROM READING DATA FROM TABLE")
+    sql = (
+        f"CREATE VIEW {permanent_view} AS "
+        f"(SELECT * FROM {permanent_table})"
+    )
+    response = cnxn.execute(sql)
+    print(response)
+    print("SUCCESS CREATE VIEW")
+except Exception as e:
+    print(e)
+    print("FAILED TO CREATE VIEW")
+
+try:
+    print("\n\nREADING VIEW")
+    sql = f"SELECT * FROM {permanent_view};"
+    response = cnxn.execute(sql)
+    print(response.fetchone())
+    print("SUCCESS READING VIEW")
+except Exception as e:
+    print(e)
+    print("FAILED READING VIEW")
+

--- a/assets/docker/ibm_db2/initialize_ibm_db2.py
+++ b/assets/docker/ibm_db2/initialize_ibm_db2.py
@@ -1,23 +1,11 @@
 import sqlalchemy as sa
 
-db2_conn = "db2+ibm_db://db2inst1:my_db_password@hostname:50000/test_ci"
+db2_conn = "db2+ibm_db://db2inst1:my_db_password@localhost:50000/test_ci"
 
 # start the SqlAlchemy engine
 engine = sa.create_engine(db2_conn, echo=True, echo_pool="debug")
 cnxn = engine.connect()
 metadata = sa.MetaData()
-
-# Create a schema
-schema_name = "bigsql"
-user_name = "db2inst1"
-try:
-    print("\n\nCREATING A SCHEMA")
-    sql = f"CREATE SCHEMA {schema_name} AUTHORIZATION {user_name};"
-    response = cnxn.execute(sql)
-    print("SUCCESS CREATING A SCHEMA")
-except Exception as e:
-    print("FAILED AT CREATING A SCHEMA")
-    print(e)
 
 # Configure a tablespace
 try:
@@ -39,129 +27,4 @@ try:
 except Exception as e:
     print("FAILED AT CREATING A TABLESPACE TO ENABLE THE CREATION OF TABLES")
     print(e)
-
-
-# Test creating a temporary table (auto-delete when connexion is closed)
-temp_table_name = "bigsql.GE_TMP_TABLE_1"
-try:
-    print("\n\nCREATE A TEMPORARY TABLE")
-    # working for PM user on BDL DEV
-    # the format of the schema works with both lowercase or uppercase
-    # FAILS with single quotes around <schema_name>.<table_name>
-    # Strange fact #1: the query fails running for the first time, and succeeds on the second!!!
-    # Strange fact #2: adding "TEMPORARY" solves this issue, and create the table at once!!!
-    # bug reported here: https://github.com/ibmdb/python-ibmdbsa/issues/93
-    sql = (
-        f"CREATE TEMPORARY TABLE {temp_table_name} ( ColOne int, ColTwo varchar(255), "
-        "ColThree varchar(255), ColFour varchar(255), ColFive varchar(255) );"
-    )
-    response = cnxn.execute(sql)
-    print(response)
-    print("SUCCESS CREATING A TEMPORARY TABLE")
-
-    print("\n\nINSERT DATA IN A TEMPORARY TABLE")
-    try:
-        # FAILS with single/DOUBLE quotes around <schema_name>.<table_name>
-        sql = (
-            f"INSERT INTO {temp_table_name} ( ColOne, ColTwo, ColThree, ColFour, ColFive) "
-            " VALUES ('1234', 'abcd', 'efgh', 'ijkl', 'mnop');"
-        )
-        response = cnxn.execute(sql)
-        print(response)
-        print("SUCCESS INSERTING DATA IN TEMPORARY TABLE")
-    except Exception as e2:
-        print("FAILED TO INSERT DATA IN TEMPORARY TABLE")
-        print(e2)
-except Exception as e:
-    print("FAILED TO CREATE A TEMPORARY TABLE")
-    print(e)
-
-
-try:
-    print("\n\nREADING DATA FROM TEMPORARY TABLE")
-    sql = f"SELECT * FROM {temp_table_name} FETCH FIRST 1 ROWS ONLY"
-    response = cnxn.execute(sql)
-    print(response.fetchone())
-    print("SUCCESS READING TABLE")
-except Exception as e:
-    print("FAILED TO READ THE TEMPORARY TABLE")
-    print(e)
-
-
-second_temp_table_name = "bigsql.GE_TMP_TABLE_2"
-try:
-    print("\n\nCREATE TEMPORARY TABLE FROM READING DATA FROM TABLE FIRST 1000 ROWS")
-    sql = (
-        f"CREATE TEMPORARY TABLE {second_temp_table_name} AS "
-        f"(SELECT * FROM {temp_table_name} FETCH FIRST 1000 ROWS ONLY);"
-    )
-    response = cnxn.execute(sql)
-    print(response)
-    print("SUCCESS CREATE TEMPORARY TABLE FROM READING TABLE FIRST 1000 ROWS")
-except Exception as e:
-    print(e)
-    print("FAILED TO CREATE TEMPORARY TABLE FROM READING THE TABLE FIRST 1000 ROWS")
-
-try:
-    print("\n\nREADING THE TEMPORARY TABLE")
-    sql = f"SELECT * FROM {second_temp_table_name};"
-    response = cnxn.execute(sql)
-    print(response.fetchone())
-    print("SUCCESS READING THE TEMPORARY TABLE")
-except Exception as e:
-    print(e)
-    print("FAILED AT READING THE TEMPORARY TABLE")
-
-
-
-permanent_table = "bigsql.GE_TABLE_ABC3"
-try:
-    # https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_71/sqlp/rbafycrttblas.htm
-    print("\n\nCREATE TABLE FROM READING DATA FROM TABLE FIRST 1000 ROWS")
-    sql = (
-        f"CREATE TABLE {permanent_table} AS "
-        f"(SELECT * FROM {second_temp_table_name}) WITH DATA"
-    )
-    response = cnxn.execute(sql)
-    print(response)
-    print("SUCCESS CREATE TABLE")
-except Exception as e:
-    print(e)
-    print("FAILED TO CREATE TABLE")
-
-try:
-    print("\n\nREADING TABLE")
-    sql = f"SELECT * FROM {permanent_table};"
-    response = cnxn.execute(sql)
-    print(response.fetchone())
-    print("SUCCESS READING TABLE")
-except Exception as e:
-    print(e)
-    print("FAILED READING TABLE")
-
-
-permanent_view = "bigsql.GE_VIEW_ABC3"
-try:
-    # https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_72/sqlp/rbafyviewnt.htm
-    print("\n\nCREATE VIEW FROM READING DATA FROM TABLE")
-    sql = (
-        f"CREATE VIEW {permanent_view} AS "
-        f"(SELECT * FROM {permanent_table})"
-    )
-    response = cnxn.execute(sql)
-    print(response)
-    print("SUCCESS CREATE VIEW")
-except Exception as e:
-    print(e)
-    print("FAILED TO CREATE VIEW")
-
-try:
-    print("\n\nREADING VIEW")
-    sql = f"SELECT * FROM {permanent_view};"
-    response = cnxn.execute(sql)
-    print(response.fetchone())
-    print("SUCCESS READING VIEW")
-except Exception as e:
-    print(e)
-    print("FAILED READING VIEW")
 

--- a/assets/docker/ibm_db2/initialize_ibm_db2.py
+++ b/assets/docker/ibm_db2/initialize_ibm_db2.py
@@ -27,4 +27,3 @@ try:
 except Exception as e:
     print("FAILED AT CREATING A TABLESPACE TO ENABLE THE CREATION OF TABLES")
     print(e)
-

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -619,15 +619,17 @@ def _collect_bigquery_credentials(default_credentials=None):
 
     return credentials
 
+
 def _collect_ibm_db2_credentials(default_credentials=None):
     if default_credentials is None:
         default_credentials = {}
 
     credentials = {"drivername": "db2+ibm_db"}
 
+    db_hostname = os.getenv("GE_TEST_LOCAL_DB_HOSTNAME", "localhost")
     credentials["host"] = click.prompt(
         "What is the host for the IBM Db2 connection?",
-        default=default_credentials.get("host", "host.docker.internal"),
+        default=default_credentials.get("host", db_hostname),
     ).strip()
     credentials["port"] = click.prompt(
         "What is the port for the IBM Db2 connection?",
@@ -649,6 +651,7 @@ def _collect_ibm_db2_credentials(default_credentials=None):
     ).strip()
 
     return credentials
+
 
 def _collect_mysql_credentials(default_credentials=None):
     # We are insisting on pymysql driver when adding a MySQL datasource through the CLI

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -247,7 +247,8 @@ class MetaSqlAlchemyDataset(Dataset):
                     ignore_values_condition=ignore_values_condition,
                 )
 
-            count_results: dict = dict(self.engine.execute(count_query).fetchone())
+            query_compiled = count_query.compile(compile_kwargs={"literal_binds": True})
+            count_results: dict = dict(self.engine.execute(query_compiled).fetchone())
 
             # Handle case of empty table gracefully:
             if (

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -719,7 +719,10 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
                 ).label("null_count"),
             ]
         ).select_from(self._table)
-        count_results = dict(self.engine.execute(count_query).fetchone())
+        response = self.engine.execute(
+            count_query.compile(compile_kwargs={"literal_binds": True})
+        )
+        count_results = dict(response.fetchone())
         element_count = int(count_results.get("element_count") or 0)
         null_count = int(count_results.get("null_count") or 0)
         return element_count - null_count

--- a/great_expectations/datasource/data_connector/util.py
+++ b/great_expectations/datasource/data_connector/util.py
@@ -190,7 +190,7 @@ def _invert_regex_to_data_reference_template(
     regex_pattern: str,
     group_names: List[str],
 ) -> str:
-    """Create a string template based on a regex and corresponding list of group names.
+    r"""Create a string template based on a regex and corresponding list of group names.
 
     For example:
 

--- a/great_expectations/datasource/types/__init__.py
+++ b/great_expectations/datasource/types/__init__.py
@@ -18,5 +18,6 @@ class SupportedDatabases(enum.Enum):
     REDSHIFT = "Redshift"
     SNOWFLAKE = "Snowflake"
     BIGQUERY = "BigQuery"
+    IBM_DB2 = "IBMdb2"
     OTHER = "other - Do you have a working SQLAlchemy connection string?"
     # TODO MSSQL

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -224,7 +224,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             "mssql",
             "snowflake",
             "mysql",
-            "ibm_db_sa"
+            "ibm_db_sa",
         ]:
             # sqlite/mssql temp tables only persist within a connection so override the engine
             self.engine = self.engine.connect()

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -224,6 +224,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             "mssql",
             "snowflake",
             "mysql",
+            "ibm_db_sa"
         ]:
             # sqlite/mssql temp tables only persist within a connection so override the engine
             self.engine = self.engine.connect()

--- a/requirements-dev-sqlalchemy.txt
+++ b/requirements-dev-sqlalchemy.txt
@@ -20,3 +20,4 @@ snowflake-connector-python==2.3.8  # sqlalchemy_tests
 snowflake-sqlalchemy>=1.2.3  # sqlalchemy_tests
 sqlalchemy>=1.3.16,<1.4  # sqlalchemy_tests
 sqlalchemy-redshift>=0.7.7  # sqlalchemy_tests
+ibm-db-sa>=0.3.6  # sqlalchemy_tests

--- a/requirements-dev-sqlalchemy.txt
+++ b/requirements-dev-sqlalchemy.txt
@@ -3,6 +3,7 @@
 # To run tests for smaller subsets of infrastructure, please look at other requirements-dev-*.txt files.
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
+ibm-db-sa>=0.3.6  # sqlalchemy_tests
 psycopg2-binary>=2.7.6  # sqlalchemy_tests
 pyathena>=1.11
 pybigquery>=0.4.15  # sqlalchemy_tests
@@ -20,4 +21,3 @@ snowflake-connector-python==2.3.8  # sqlalchemy_tests
 snowflake-sqlalchemy>=1.2.3  # sqlalchemy_tests
 sqlalchemy>=1.3.16,<1.4  # sqlalchemy_tests
 sqlalchemy-redshift>=0.7.7  # sqlalchemy_tests
-ibm-db-sa>=0.3.6  # sqlalchemy_tests

--- a/tests/cli/test_datasource_ibm_db2.py
+++ b/tests/cli/test_datasource_ibm_db2.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+from great_expectations.cli.datasource import _collect_ibm_db2_credentials
+
+
+@patch("click.prompt")
+def test_ibm_db2_credentials(mock_prompt):
+    mock_prompt.side_effect = [
+        "my_db2_server",
+        "12345",
+        "my_db2_username",
+        "my_db2_password",
+        "my_db2_database_name",
+    ]
+
+    credentials = _collect_ibm_db2_credentials(None)
+
+    assert credentials == {
+        "drivername": "db2+ibm_db",
+        "database": "my_db2_database_name",
+        "host": "my_db2_server",
+        "password": "my_db2_password",
+        "username": "my_db2_username",
+        "port": "12345",
+    }

--- a/tests/cli/test_init_missing_libraries.py
+++ b/tests/cli/test_init_missing_libraries.py
@@ -260,6 +260,19 @@ def test_cli_init_db_snowflake_without_library_installed_instructs_user(
     strict=True,
 )
 @pytest.mark.skipif(
+    is_library_loadable(library_name="ibm_db_sa"),
+    reason="requires ibm_db_sa (IBM Db2 plugin) to NOT be installed",
+)
+def test_cli_init_db_ibm_db2_without_library_installed_instructs_user(
+    caplog,
+    tmp_path_factory,
+):
+    _library_not_loaded_test(
+        tmp_path_factory, "\n\n2\n6\nmy_db\nn\n", "ibm_db_sa", "ibm_db_sa", caplog
+    )
+
+
+@pytest.mark.skipif(
     is_library_loadable(library_name="pyspark"),
     reason="requires pyspark to NOT be installed",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,7 @@ def pytest_addoption(parser):
         help="If set, run aws integration tests",
     )
 
+
 def build_test_backends_list(metafunc):
     test_backends = ["PandasDataset"]
     no_spark = metafunc.config.getoption("--no-spark")
@@ -177,15 +178,18 @@ def build_test_backends_list(metafunc):
             test_backends += ["mysql"]
         ibm_db2 = metafunc.config.getoption("--ibm_db2")
         if sa and ibm_db2:
+            db_hostname = os.getenv("GE_TEST_LOCAL_DB_HOSTNAME", "localhost")
             try:
                 # db2+ibm_db://username:password@servername[:port]/database
-                engine = sa.create_engine("db2+ibm_db://db2inst1:my_db_password@host.docker.internal/test_ci")
+                engine = sa.create_engine(
+                    f"db2+ibm_db://db2inst1:my_db_password@{db_hostname}/test_ci"
+                )
                 conn = engine.connect()
                 conn.close()
             except (ImportError, sa.exc.SQLAlchemyError):
                 raise ImportError(
                     "IBM Db2 tests are requested, but unable to connect to the IBM Db2 instance at "
-                    "'db2+ibm_db://db2inst1:my_db_password@host.docker.internal/test_ci'"
+                    f"'db2+ibm_db://db2inst1:my_db_password@{db_hostname}/test_ci'"
                 )
             test_backends += ["ibm_db2"]
         mssql = metafunc.config.getoption("--mssql")
@@ -278,15 +282,18 @@ def build_test_backends_list_cfe(metafunc):
             test_backends += ["mssql"]
         ibm_db2 = metafunc.config.getoption("--ibm_db2")
         if sa and ibm_db2:
+            db_hostname = os.getenv("GE_TEST_LOCAL_DB_HOSTNAME", "localhost")
             try:
                 # db2+ibm_db://username:password@servername[:port]/database
-                engine = sa.create_engine("db2+ibm_db://db2inst1:my_db_password@host.docker.internal/test_ci")
+                engine = sa.create_engine(
+                    f"db2+ibm_db://db2inst1:my_db_password@{db_hostname}/test_ci"
+                )
                 conn = engine.connect()
                 conn.close()
             except (ImportError, sa.exc.SQLAlchemyError):
                 raise ImportError(
                     "IBM Db2 tests are requested, but unable to connect to the IBM Db2 instance at "
-                    "'db2+ibm_db://db2inst1:my_db_password@host.docker.internal/test_ci'"
+                    f"'db2+ibm_db://db2inst1:my_db_password@{db_hostname}/test_ci'"
                 )
             test_backends += ["ibm_db2"]
     return test_backends
@@ -2261,7 +2268,8 @@ def dataset_sample_data(test_backend):
         "ibm_db2": {
             "infinities": "DOUBLE_PRECISION",
             "nulls": "DOUBLE_PRECISION",
-            "naturals": "INTEGER"},
+            "naturals": "INTEGER",
+        },
         "spark": {
             "infinities": "FloatType",
             "nulls": "FloatType",

--- a/tests/render/test_default_markdown_view.py
+++ b/tests/render/test_default_markdown_view.py
@@ -487,7 +487,7 @@ def test_render_expectation_suite_for_Markdown(expectation_suite_to_render_with_
     md_str = md_str.replace(" ", "").replace("\t", "").replace("\n", "")
     assert (
         md_str
-        == """
+        == r"""
    # Validation Results
 ## Overview
 ### Info

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -574,8 +574,9 @@ def get_dataset(
         if not create_engine:
             return None
 
+        db_hostname = os.getenv("GE_TEST_LOCAL_DB_HOSTNAME", "localhost")
         engine = create_engine(
-            "db2+ibm_db://db2inst1:my_db_password@host.docker.internal/test_ci",
+            f"db2+ibm_db://db2inst1:my_db_password@{db_hostname}/test_ci",
         )
         sql_dtypes = {}
         if (
@@ -1017,7 +1018,7 @@ def _build_sa_validator_with_data(
         )
     elif sa_engine_name == "ibm_db2":
         engine = create_engine(
-            "db2+ibm_db://db2inst1:my_db_password@host.docker.internal/test_ci"
+            "db2+ibm_db://db2inst1:my_db_password@{db_hostname}/test_ci"
         )
     else:
         engine = None

--- a/tests/test_utils_modular.py
+++ b/tests/test_utils_modular.py
@@ -1,5 +1,5 @@
 def candidate_test_is_on_temporary_notimplemented_list_cfe(context, expectation_type):
-    if context in ["sqlite", "postgresql", "mysql", "mssql"]:
+    if context in ["sqlite", "postgresql", "mysql", "mssql", "ibm_db2"]:
         return expectation_type in [
             "expect_select_column_values_to_be_unique_within_record",
             # "expect_table_columns_to_match_set",


### PR DESCRIPTION
This PR enables a new datasource within the existing family of SqlAlchemy-based datasources: IBM Db2 instances.

This has been possible thanks to the team behind the SqlAlchemy adapter for IBM data servers [`ibm_db_sa`](https://github.com/ibmdb/python-ibmdbsa/graphs/contributors) 🍾 and the Transparens team at [Statnett](https://www.statnett.no/en/).

This feature does not introduce breaking changes of any sort, and we have tried to integrate the dialect minimizing the additions of if/else, thus minimizing the breaking changes as the SqlAlchemy dataset classes may evolve.

## Context & Previous Design Review notes

- Adding a new IBM Db datasource worked out-of-the-box specifying the right dialect[+driver] (i.e. `db2+ibm_db://...`), but the creation of the first profiled expectation suite failed
- The problem was discussed on [Slack thread-1](https://greatexpectationstalk.slack.com/archives/CUTCNHN82/p1610549356328500), [Slack thread-2](https://greatexpectationstalk.slack.com/archives/CUTCNHN82/p1612481581205100) and in a long interesting Zoom meeting with Eugene and Ben, where the initial assumption of the failure was related to the creation of temporary tables (limited permission to create tables)
- Many internal tests outside GE proved us wrong, and we learned that for most SqlAlchemy engine, temporary tables are handled in a way that having a schema doesn't matter, and they disappear when the connection is gone. IBM Db therefore required the same treatment as a few other dataset types where the `self.engine` object needs to be overwritten with its connection `self.engine.connect()`
- From there on, our integration wasn't to generalize the use of an optional schema for temporary tables, but to integrate the specifics of the IBM Db dialect (ibm_db_sa) similarly to the other SqlAlchemy adapters.


## Changes proposed in this pull request

- Following the guide to add/test a new SqlAlchemy dataset class (https://docs.greatexpectations.io/en/latest/guides/how_to_guides/miscellaneous/how_to_add_and_test_a_new_sqlalchemydataset_class.html)
    1. install/document dependencies
    1. changes to `sqlalchemy_dataset.py`
    1. changes to `conftest.py`
    1. changes to `tests/test_utils.py`
    1. use tests to verify consistency with other database
- Implementing the minimum amount of dialect-specific types, methods, elif clause
- Implementing a CLI integration for the dialect (`2.SQL` > `6.Ibm Db2` > ...)
- Including a docker-compose setup for deploying a local IBM Db2 instance (`great_expectations/assets/docker/ibm_db2`) and initialize it to operate temporary tables.
- Fixing SQL/SqlAlchemy queries to:
    - create temporary tables
    - read the types of the column of a temporary table
    - include compilation of the queries, where necessary.
- try to use [gitmoji](https://gitmoji.dev/) for explicit/visual meaning of the commit messages 📝 ;)



Thank you for ~~submitting~~ **reviewing!** 🤩
