### PR TITLE
[BUGFIX] Can not create Azure Backend with TupleAzureBlobStoreBackend #2501

### DIFF
--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -972,6 +972,8 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
         forbidden_substrings=None,
         platform_specific_separator=False,
         fixed_length_key=False,
+        suppress_store_backend_id=False,
+        store_name=None,
     ):
         super().__init__(
             filepath_template=filepath_template,
@@ -980,6 +982,8 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
             forbidden_substrings=forbidden_substrings,
             platform_specific_separator=platform_specific_separator,
             fixed_length_key=fixed_length_key,
+            suppress_store_backend_id=suppress_store_backend_id,
+            store_name=store_name,
         )
         self.connection_string = connection_string
         self.prefix = prefix


### PR DESCRIPTION
I opened this issue yesterday #2501 and I think I have founded the solution.
The solution is to add the mandatory arguments to TupleAzureBlobStoreBackend (store_backend_id and store_name). They are mandatory because of the function instantiate_class_from_config : which is used by the CLI.

I created a container named _great-expectations-store_ in my azure storage account
Then in great_expectations.yml I set the following : 

great_expectations.yml
```
stores:
  az_site:
    class_name: SiteBuilder
    store_backend:
      class_name: TupleAzureBlobStoreBackend
      container: great-expectations-store
      connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
```

and in config_variables.yml
```
AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT>;AccountKey=<xX-YOUR-CONNEXION_STRING-xX==>"
```

**BONUS**
With this bug fixed, (I hope with this pull request), I propose to contribute to the documentation of the setup of Azure Backend for expectations/validations/datadocs. 