### PR TITLE
[BUGFIX] Handle expect_compound_columns_to_be_unique in UserConfigurableProfiler for V3

### DIFF
--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -900,6 +900,7 @@ class UserConfigurableProfiler:
             if isinstance(profile_dataset, Validator) and not hasattr(
                 profile_dataset, "expect_compound_columns_to_be_unique"
             ):
+                # TODO: Remove this upon implementation of this expectation for V3
                 logger.warning(
                     "expect_compound_columns_to_be_unique is not currently available in the V3 (Batch Request) API. Specifying a compound key will not add any expectations. This will be updated when that expectation becomes available."
                 )

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -897,7 +897,15 @@ class UserConfigurableProfiler:
             len(column_list) > 1
             and "expect_compound_columns_to_be_unique" not in self.excluded_expectations
         ):
-            profile_dataset.expect_compound_columns_to_be_unique(column_list)
+            if isinstance(profile_dataset, Validator) and not hasattr(
+                profile_dataset, "expect_compound_columns_to_be_unique"
+            ):
+                logger.warning(
+                    "expect_compound_columns_to_be_unique is not currently available in the V3 (Batch Request) API. Specifying a compound key will not add any expectations. This will be updated when that expectation becomes available."
+                )
+                return profile_dataset
+            else:
+                profile_dataset.expect_compound_columns_to_be_unique(column_list)
         elif len(column_list) < 1:
             raise ValueError(
                 "When specifying a primary or compound key, column_list must not be empty"

--- a/tests/profile/test_user_configurable_profiler_v3_batch_request.py
+++ b/tests/profile/test_user_configurable_profiler_v3_batch_request.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 import string
@@ -46,6 +47,8 @@ try:
 except ImportError:
     postgresqltypes = None
     POSTGRESQL_TYPES = {}
+
+logger = logging.getLogger(__name__)
 
 
 def get_pandas_runtime_validator(context, df):
@@ -247,6 +250,36 @@ def cardinality_validator(titanic_data_context_modular_api):
         }
     )
     return get_pandas_runtime_validator(titanic_data_context_modular_api, df)
+
+
+@pytest.fixture
+def taxi_data_ignored_columns():
+    return [
+        "pickup_location_id",
+        "dropoff_location_id",
+        "fare_amount",
+        "extra",
+        "mta_tax",
+        "tip_amount",
+        "tolls_amount",
+        "improvement_surcharge",
+        "congestion_surcharge",
+    ]
+
+
+@pytest.fixture
+def taxi_data_semantic_types():
+    return {
+        "datetime": ["pickup_datetime", "dropoff_datetime"],
+        "numeric": ["total_amount", "passenger_count"],
+        "value_set": [
+            "payment_type",
+            "rate_code_id",
+            "store_and_fwd_flag",
+            "passenger_count",
+        ],
+        "boolean": ["store_and_fwd_flag"],
+    }
 
 
 def test_profiler_init_no_config(
@@ -686,7 +719,11 @@ def test_column_cardinality_functions(cardinality_validator):
 
 
 def test_profiler_all_expectation_types_pandas(
-    titanic_data_context_modular_api, taxi_validator_pandas, possible_expectations_set
+    titanic_data_context_modular_api,
+    taxi_validator_pandas,
+    possible_expectations_set,
+    taxi_data_semantic_types,
+    taxi_data_ignored_columns,
 ):
     """
     What does this test do and why?
@@ -694,33 +731,10 @@ def test_profiler_all_expectation_types_pandas(
     """
     context = titanic_data_context_modular_api
 
-    ignored_columns = [
-        "pickup_location_id",
-        "dropoff_location_id",
-        "fare_amount",
-        "extra",
-        "mta_tax",
-        "tip_amount",
-        "tolls_amount",
-        "improvement_surcharge",
-        "congestion_surcharge",
-    ]
-    semantic_types = {
-        "datetime": ["pickup_datetime", "dropoff_datetime"],
-        "numeric": ["total_amount", "passenger_count"],
-        "value_set": [
-            "payment_type",
-            "rate_code_id",
-            "store_and_fwd_flag",
-            "passenger_count",
-        ],
-        "boolean": ["store_and_fwd_flag"],
-    }
-
     profiler = UserConfigurableProfiler(
         taxi_validator_pandas,
-        semantic_types_dict=semantic_types,
-        ignored_columns=ignored_columns,
+        semantic_types_dict=taxi_data_semantic_types,
+        ignored_columns=taxi_data_ignored_columns,
         # TODO: Add primary_or_compound_key test
         #  primary_or_compound_key=[
         #     "vendor_id",
@@ -750,7 +764,7 @@ def test_profiler_all_expectation_types_pandas(
     }
 
     ignored_included_columns_overlap = [
-        i for i in columns_with_expectations if i in ignored_columns
+        i for i in columns_with_expectations if i in taxi_data_ignored_columns
     ]
     assert len(ignored_included_columns_overlap) == 0
 
@@ -766,7 +780,11 @@ def test_profiler_all_expectation_types_pandas(
     reason="requires pyspark to be installed",
 )
 def test_profiler_all_expectation_types_spark(
-    titanic_data_context_modular_api, taxi_validator_spark, possible_expectations_set
+    titanic_data_context_modular_api,
+    taxi_validator_spark,
+    possible_expectations_set,
+    taxi_data_semantic_types,
+    taxi_data_ignored_columns,
 ):
     """
     What does this test do and why?
@@ -774,34 +792,10 @@ def test_profiler_all_expectation_types_spark(
     """
     context = titanic_data_context_modular_api
 
-    ignored_columns = [
-        "pickup_location_id",
-        "dropoff_location_id",
-        "fare_amount",
-        "extra",
-        "mta_tax",
-        "tip_amount",
-        "tolls_amount",
-        "improvement_surcharge",
-        "congestion_surcharge",
-    ]
-
-    semantic_types = {
-        "datetime": ["pickup_datetime", "dropoff_datetime"],
-        "numeric": ["total_amount", "passenger_count"],
-        "value_set": [
-            "payment_type",
-            "rate_code_id",
-            "store_and_fwd_flag",
-            "passenger_count",
-        ],
-        "boolean": ["store_and_fwd_flag"],
-    }
-
     profiler = UserConfigurableProfiler(
         taxi_validator_spark,
-        semantic_types_dict=semantic_types,
-        ignored_columns=ignored_columns,
+        semantic_types_dict=taxi_data_semantic_types,
+        ignored_columns=taxi_data_ignored_columns,
         # TODO: Add primary_or_compound_key test
         #  primary_or_compound_key=[
         #     "vendor_id",
@@ -831,7 +825,7 @@ def test_profiler_all_expectation_types_spark(
     }
 
     ignored_included_columns_overlap = [
-        i for i in columns_with_expectations if i in ignored_columns
+        i for i in columns_with_expectations if i in taxi_data_ignored_columns
     ]
     assert len(ignored_included_columns_overlap) == 0
 
@@ -850,6 +844,8 @@ def test_profiler_all_expectation_types_sqlalchemy(
     titanic_data_context_modular_api,
     taxi_validator_sqlalchemy,
     possible_expectations_set,
+    taxi_data_semantic_types,
+    taxi_data_ignored_columns,
 ):
     """
     What does this test do and why?
@@ -860,33 +856,10 @@ def test_profiler_all_expectation_types_sqlalchemy(
 
     context = titanic_data_context_modular_api
 
-    ignored_columns = [
-        "pickup_location_id",
-        "dropoff_location_id",
-        "fare_amount",
-        "extra",
-        "mta_tax",
-        "tip_amount",
-        "tolls_amount",
-        "improvement_surcharge",
-        "congestion_surcharge",
-    ]
-    semantic_types = {
-        "datetime": ["pickup_datetime", "dropoff_datetime"],
-        "numeric": ["total_amount", "passenger_count"],
-        "value_set": [
-            "payment_type",
-            "rate_code_id",
-            "store_and_fwd_flag",
-            "passenger_count",
-        ],
-        "boolean": ["store_and_fwd_flag"],
-    }
-
     profiler = UserConfigurableProfiler(
         taxi_validator_sqlalchemy,
-        semantic_types_dict=semantic_types,
-        ignored_columns=ignored_columns,
+        semantic_types_dict=taxi_data_semantic_types,
+        ignored_columns=taxi_data_ignored_columns,
         # TODO: Add primary_or_compound_key test
         #  primary_or_compound_key=[
         #     "vendor_id",
@@ -916,7 +889,7 @@ def test_profiler_all_expectation_types_sqlalchemy(
     }
 
     ignored_included_columns_overlap = [
-        i for i in columns_with_expectations if i in ignored_columns
+        i for i in columns_with_expectations if i in taxi_data_ignored_columns
     ]
     assert len(ignored_included_columns_overlap) == 0
 
@@ -925,3 +898,82 @@ def test_profiler_all_expectation_types_sqlalchemy(
     )
 
     assert results["success"]
+
+
+def test_error_handling_for_expect_compound_columns_to_be_unique(
+    taxi_validator_pandas, taxi_data_ignored_columns, caplog
+):
+    # TODO: When this expectation is implemented for V3, remove this test and test for this expectation
+    ignored_columns = taxi_data_ignored_columns + [
+        "pickup_datetime",
+        "dropoff_datetime",
+        "total_amount",
+        "passenger_count",
+        "payment_type",
+        "rate_code_id",
+        "store_and_fwd_flag",
+        "passenger_count",
+        "store_and_fwd_flag",
+        "vendor_id",
+        "trip_distance",
+    ]
+
+    profiler = UserConfigurableProfiler(
+        taxi_validator_pandas,
+        ignored_columns=ignored_columns,
+        primary_or_compound_key=[
+            "vendor_id",
+            "pickup_datetime",
+            "dropoff_datetime",
+            "trip_distance",
+            "pickup_location_id",
+            "dropoff_location_id",
+        ],
+    )
+    with caplog.at_level(logging.WARNING):
+        suite = profiler.build_suite()
+
+    log_warnings = caplog.messages
+    assert len(log_warnings) == 1
+
+    assert (
+        log_warnings[0]
+        == "expect_compound_columns_to_be_unique is not currently available in the V3 (Batch Request) API. Specifying a compound key will not add any expectations. This will be updated when that expectation becomes available."
+    )
+
+    assert len(suite.expectations) == 2
+
+    (
+        columns_with_expectations,
+        expectations_from_suite,
+    ) = get_set_of_columns_and_expectations_from_suite(suite)
+
+    expected_expectations = {
+        "expect_table_columns_to_match_ordered_list",
+        "expect_table_row_count_to_be_between",
+    }
+
+    assert expected_expectations == expectations_from_suite
+
+    profiler_with_single_column_key = UserConfigurableProfiler(
+        taxi_validator_pandas,
+        ignored_columns=ignored_columns,
+        primary_or_compound_key=["pickup_datetime"],
+    )
+
+    suite = profiler_with_single_column_key.build_suite()
+
+    assert len(suite.expectations) == 3
+
+    (
+        columns_with_expectations,
+        expectations_from_suite,
+    ) = get_set_of_columns_and_expectations_from_suite(suite)
+
+    expected_expectations = {
+        "expect_table_columns_to_match_ordered_list",
+        "expect_table_row_count_to_be_between",
+        "expect_column_values_to_be_unique",
+    }
+
+    assert expected_expectations == expectations_from_suite


### PR DESCRIPTION
`expect_compound_column_values_to_be_unique` is not currently implemented in the V3 (Batch Request) API, so previously attempting to specify a compound key with the UserConfigurableProfiler would return an error. This addresses that case with a warning, and adds tests.

This also checks to see whether this expectation is available on the Validator, and if it is, it should return the expectation. I included a TODO to remove the check upon implementation, but it should work even if the check is not removed.