### PR TITLE
[MAINTENANCE] Raise an error instead of trying to parse paths that don't exist

### DIFF
--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -4,7 +4,7 @@ import platform
 import subprocess
 import sys
 import warnings
-from pathlib import Path, PosixPath, PurePosixPath, PureWindowsPath, WindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional, Union
 
 import click
@@ -698,62 +698,35 @@ def confirm_proceed_or_exit(
     return True
 
 
-def parse_cli_config_file_location(
-    config_file_location: str, windows: bool = None
-) -> dict:
+def parse_cli_config_file_location(config_file_location: str) -> dict:
     """
     Parse CLI yaml config file or directory location into directory and filename.
-    Automatically detects whether running on windows.
+    Uses pathlib to handle windows paths.
     Args:
         config_file_location: string of config_file_location
-        windows: set True to force handling of paths for windows, mainly for testing.
 
     Returns:
         {
             "directory": "directory/where/config/file/is/located",
-            "filename": "great_expectations.yml" # or filename passed to CLI
+            "filename": "great_expectations.yml"
         }
     """
 
     if config_file_location is not None and config_file_location != "":
 
-        # Check if running on Windows
-        if windows is not True:
-            windows: bool = "windows" in platform.platform().lower()
-
         config_file_location_path = Path(config_file_location)
-
-        # If running on windows, use WindowsPath else PosixPath
-        if windows:
-            pure_path: Union[PurePosixPath, PureWindowsPath] = PureWindowsPath(
-                config_file_location
-            )
-        else:
-            pure_path: Union[PurePosixPath, PureWindowsPath] = PurePosixPath(
-                config_file_location
-            )
 
         # If the file or directory exists, treat it appropriately
         # This handles files without extensions
         if config_file_location_path.is_file():
-            filename: Optional[str] = fr"{str(pure_path.name)}"
-            directory: Optional[str] = fr"{str(pure_path.parent)}"
+            filename: Optional[str] = fr"{str(config_file_location_path.name)}"
+            directory: Optional[str] = fr"{str(config_file_location_path.parent)}"
         elif config_file_location_path.is_dir():
             filename: Optional[str] = None
             directory: Optional[str] = config_file_location
 
-        # If the file or directory does not exist, treat it as a directory unless
-        #  there is a trailing extension
         else:
-            file_extension: str = pure_path.suffix
-            if file_extension == "":
-                # treat as directory
-                filename: Optional[str] = None
-                directory: Optional[str] = config_file_location
-            else:
-                # treat as file
-                filename: Optional[str] = fr"{str(pure_path.name)}"
-                directory: Optional[str] = fr"{str(pure_path.parent)}"
+            raise ge_exceptions.ConfigNotFoundError()
 
     else:
         # Return None if config_file_location is empty rather than default output of ""

--- a/tests/cli/test_toolkit.py
+++ b/tests/cli/test_toolkit.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 
+from great_expectations import exceptions as ge_exceptions
 from great_expectations.cli import toolkit
 from great_expectations.data_context import DataContext
 from great_expectations.exceptions import UnsupportedConfigVersionError
@@ -38,14 +39,21 @@ def test_load_data_context_with_error_handling_v1_config(v10_project_directory):
         DataContext(context_root_dir=v10_project_directory)
 
 
-def test_parse_cli_config_file_location_posix_paths():
+def test_parse_cli_config_file_location_posix_paths(tmp_path_factory):
+    """
+    What does this test and why?
+    We want to parse posix paths into their directory and filename parts
+    so that we can pass the directory to our data context constructor.
+    We need to be able to do that with all versions of path that can be input.
+    This tests for posix paths for files/dirs that don't exist and files/dirs that do.
+    Other tests handle testing for windows support.
+    """
 
     filename_fixtures = [
         {
             "input_path": "just_a_file.yml",
-            "windows": False,
             "expected": {
-                "directory": ".",
+                "directory": "",
                 "filename": "just_a_file.yml",
             },
         },
@@ -53,7 +61,6 @@ def test_parse_cli_config_file_location_posix_paths():
     absolute_path_fixtures = [
         {
             "input_path": "/path/to/file/filename.yml",
-            "windows": False,
             "expected": {
                 "directory": "/path/to/file",
                 "filename": "filename.yml",
@@ -61,7 +68,6 @@ def test_parse_cli_config_file_location_posix_paths():
         },
         {
             "input_path": "/absolute/directory/ending/slash/",
-            "windows": False,
             "expected": {
                 "directory": "/absolute/directory/ending/slash/",
                 "filename": None,
@@ -69,7 +75,6 @@ def test_parse_cli_config_file_location_posix_paths():
         },
         {
             "input_path": "/absolute/directory/ending/no/slash",
-            "windows": False,
             "expected": {
                 "directory": "/absolute/directory/ending/no/slash",
                 "filename": None,
@@ -79,7 +84,6 @@ def test_parse_cli_config_file_location_posix_paths():
     relative_path_fixtures = [
         {
             "input_path": "relative/path/to/file.yml",
-            "windows": False,
             "expected": {
                 "directory": "relative/path/to",
                 "filename": "file.yml",
@@ -87,7 +91,6 @@ def test_parse_cli_config_file_location_posix_paths():
         },
         {
             "input_path": "relative/path/to/directory/slash/",
-            "windows": False,
             "expected": {
                 "directory": "relative/path/to/directory/slash/",
                 "filename": None,
@@ -95,7 +98,6 @@ def test_parse_cli_config_file_location_posix_paths():
         },
         {
             "input_path": "relative/path/to/directory/no_slash",
-            "windows": False,
             "expected": {
                 "directory": "relative/path/to/directory/no_slash",
                 "filename": None,
@@ -106,23 +108,43 @@ def test_parse_cli_config_file_location_posix_paths():
     fixtures = filename_fixtures + absolute_path_fixtures + relative_path_fixtures
 
     for fixture in fixtures:
-        assert (
-            toolkit.parse_cli_config_file_location(
-                fixture["input_path"], windows=fixture.get("windows")
-            )
-            == fixture["expected"]
-        )
+        with pytest.raises(ge_exceptions.ConfigNotFoundError):
+            toolkit.parse_cli_config_file_location(fixture["input_path"])
+
+        # Create files and re-run assertions
+    root_dir = tmp_path_factory.mktemp("posix")
+    root_dir = str(root_dir)
+    for fixture in fixtures:
+        expected_dir = fixture.get("expected").get("directory")
+
+        # Make non-absolute path
+        if expected_dir is not None and expected_dir.startswith("/"):
+            expected_dir = expected_dir[1:]
+
+        expected_filename = fixture.get("expected").get("filename")
+        if expected_dir:
+            test_directory = os.path.join(root_dir, expected_dir)
+            os.makedirs(test_directory, exist_ok=True)
+            if expected_filename:
+                expected_filepath = os.path.join(test_directory, expected_filename)
+                with open(expected_filepath, "w") as fp:
+                    pass
+
+                output = toolkit.parse_cli_config_file_location(expected_filepath)
+
+                assert output == {
+                    "directory": os.path.join(root_dir, expected_dir),
+                    "filename": expected_filename,
+                }
 
 
 def test_parse_cli_config_file_location_posix_paths_existing_files_with_no_extension(
     tmp_path_factory,
 ):
-    # Create files and re-run assertions
 
     filename_no_extension_fixtures = [
         {
             "input_path": "relative/path/to/file/no_extension",
-            "windows": False,
             "expected": {
                 "directory": "relative/path/to/file",
                 "filename": "no_extension",
@@ -130,7 +152,6 @@ def test_parse_cli_config_file_location_posix_paths_existing_files_with_no_exten
         },
         {
             "input_path": "/absolute/path/to/file/no_extension",
-            "windows": False,
             "expected": {
                 "directory": "/absolute/path/to/file",
                 "filename": "no_extension",
@@ -138,7 +159,6 @@ def test_parse_cli_config_file_location_posix_paths_existing_files_with_no_exten
         },
         {
             "input_path": "no_extension",
-            "windows": False,
             "expected": {
                 "directory": None,
                 "filename": "no_extension",
@@ -146,7 +166,11 @@ def test_parse_cli_config_file_location_posix_paths_existing_files_with_no_exten
         },
     ]
 
-    # create no-extension files
+    for fixture in filename_no_extension_fixtures:
+        with pytest.raises(ge_exceptions.ConfigNotFoundError):
+            toolkit.parse_cli_config_file_location(fixture["input_path"])
+
+    # Create files and re-run assertions
 
     root_dir = tmp_path_factory.mktemp("posix")
     root_dir = str(root_dir)
@@ -166,9 +190,7 @@ def test_parse_cli_config_file_location_posix_paths_existing_files_with_no_exten
                 with open(expected_filepath, "w") as fp:
                     pass
 
-                output = toolkit.parse_cli_config_file_location(
-                    expected_filepath, windows=fixture.get("windows")
-                )
+                output = toolkit.parse_cli_config_file_location(expected_filepath)
 
                 assert output == {
                     "directory": os.path.join(root_dir, expected_dir),
@@ -181,7 +203,6 @@ def test_parse_cli_config_file_location_empty_paths():
     posix_fixtures = [
         {
             "input_path": None,
-            "windows": False,
             "expected": {
                 "directory": None,
                 "filename": None,
@@ -189,25 +210,6 @@ def test_parse_cli_config_file_location_empty_paths():
         },
         {
             "input_path": "",
-            "windows": False,
-            "expected": {
-                "directory": None,
-                "filename": None,
-            },
-        },
-    ]
-    windows_fixtures = [
-        {
-            "input_path": None,
-            "windows": True,
-            "expected": {
-                "directory": None,
-                "filename": None,
-            },
-        },
-        {
-            "input_path": "",
-            "windows": True,
             "expected": {
                 "directory": None,
                 "filename": None,
@@ -215,25 +217,30 @@ def test_parse_cli_config_file_location_empty_paths():
         },
     ]
 
-    fixtures = posix_fixtures + windows_fixtures
+    fixtures = posix_fixtures
 
     for fixture in fixtures:
         assert (
-            toolkit.parse_cli_config_file_location(
-                fixture["input_path"], windows=fixture.get("windows")
-            )
+            toolkit.parse_cli_config_file_location(fixture["input_path"])
             == fixture["expected"]
         )
 
 
-def test_parse_cli_config_file_location_windows_paths():
+def test_parse_cli_config_file_location_windows_paths(tmp_path_factory):
+    """
+    What does this test and why?
+    Since we are unable to test windows paths on our unix CI, this just
+    tests that if a file doesn't exist we raise an error.
+    Args:
+        tmp_path_factory:
+    Returns:
+    """
 
     filename_fixtures = [
         {
             "input_path": "just_a_file.yml",
-            "windows": True,
             "expected": {
-                "directory": ".",
+                "directory": "",
                 "filename": "just_a_file.yml",
             },
         },
@@ -241,7 +248,6 @@ def test_parse_cli_config_file_location_windows_paths():
     absolute_path_fixtures = [
         {
             "input_path": r"C:\absolute\windows\path\to\file.yml",
-            "windows": True,
             "expected": {
                 "directory": r"C:\absolute\windows\path\to",
                 "filename": "file.yml",
@@ -249,7 +255,6 @@ def test_parse_cli_config_file_location_windows_paths():
         },
         {
             "input_path": r"C:\absolute\windows\directory\ending\slash\\",
-            "windows": True,
             "expected": {
                 "directory": r"C:\absolute\windows\directory\ending\slash\\",
                 "filename": None,
@@ -257,7 +262,6 @@ def test_parse_cli_config_file_location_windows_paths():
         },
         {
             "input_path": r"C:\absolute\windows\directory\ending\no_slash",
-            "windows": True,
             "expected": {
                 "directory": r"C:\absolute\windows\directory\ending\no_slash",
                 "filename": None,
@@ -267,7 +271,6 @@ def test_parse_cli_config_file_location_windows_paths():
     relative_path_fixtures = [
         {
             "input_path": r"relative\windows\path\to\file.yml",
-            "windows": True,
             "expected": {
                 "directory": r"relative\windows\path\to",
                 "filename": "file.yml",
@@ -276,7 +279,6 @@ def test_parse_cli_config_file_location_windows_paths():
         # Double slash at end of raw string to escape slash
         {
             "input_path": r"relative\windows\path\to\directory\slash\\",
-            "windows": True,
             "expected": {
                 "directory": r"relative\windows\path\to\directory\slash\\",
                 "filename": None,
@@ -284,7 +286,6 @@ def test_parse_cli_config_file_location_windows_paths():
         },
         {
             "input_path": r"relative\windows\path\to\directory\no_slash",
-            "windows": True,
             "expected": {
                 "directory": r"relative\windows\path\to\directory\no_slash",
                 "filename": None,
@@ -294,9 +295,9 @@ def test_parse_cli_config_file_location_windows_paths():
     fixtures = filename_fixtures + absolute_path_fixtures + relative_path_fixtures
 
     for fixture in fixtures:
-        assert (
-            toolkit.parse_cli_config_file_location(
-                fixture["input_path"], windows=fixture.get("windows")
-            )
-            == fixture["expected"]
-        )
+        with pytest.raises(ge_exceptions.ConfigNotFoundError):
+            toolkit.parse_cli_config_file_location(fixture["input_path"])
+
+    # Create files and re-run assertions
+
+    # We are unable to create files with windows paths on our unix test CI


### PR DESCRIPTION
Changes proposed in this pull request:
- We now raise an error instead of trying to parse paths that don't exist when using the new cli `--config` flag
