### PR TITLE
[MAINTENANCE] Remove extraneous linebreak

### DIFF
--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -370,9 +370,8 @@ def delete_checkpoint(
         checkpoint_name=checkpoint_name,
         usage_event=usage_event,
     )
-    confirm_prompt: str = f"""\nAre you sure you want to delete the Checkpoint "{checkpoint_name}" (this action is
-irreversible)?"
-    """
+    confirm_prompt: str = f"""\nAre you sure you want to delete the Checkpoint "{checkpoint_name}" (this action is irreversible)?"
+"""
     continuation_message: str = (
         f'The Checkpoint "{checkpoint_name}" was not deleted.  Exiting now.'
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove extraneous linebreak from `checkpoint delete` v3 API CLI command confirmation message
