### PR TITLE
Adding github workflow to remind author of changelog when opening PR

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -20,7 +20,8 @@ jobs:
 
             Please don't forget to add a clear and succinct description of your change
             under the **Develop** header in `docs/changelog.rst`, if applicable. This will
-            help us with the release process.
+            help us with the release process. See the [Contribution checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html#how-to-submit-a-pull-request)
+            in the Great Expectations documentation for the type of labels to use!
 
 
             :sparkles: **Thank you!** :sparkles:"

--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -1,0 +1,28 @@
+name: changelog-bot
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - develop
+jobs:
+  create-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create comment
+        uses: jungwinter/comment@v1
+        with:
+          type: create
+          body: "**HOWDY! This is your friendly** :robot: **CHANGELOG bot** :robot:
+
+            ------------------------------------------------------------------------
+
+
+            Please don't forget to add a clear and succinct description of your change
+            under the **Develop** header in `docs/changelog.rst`, if applicable. This will
+            help us with the release process.
+
+
+            :sparkles: **Thank you!** :sparkles:"
+          issue_number: ${{github.event.number}}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As discussed, we want to get better at adding relevant changes to the changelog. This workflow adds a comment
- The action I picked was the most-starred on github marketplace, so I expect it to work/remain supported for a while?
- The workflow only runs when opening a PR against develop, other changes are probably less relevant - happy to change that though
- Only posts once (on opening a PR), probably not necessary to post on every change, but I can add other triggers
- Doesn't block merging, since not every change needs a changelog entry
- I spent too much time on the fancy formatting and I will defend the use of emojis. Screenshot attached.

<img width="948" alt="Screen Shot 2021-03-10 at 6 17 19 PM" src="https://user-images.githubusercontent.com/1734474/110711374-753ad200-81cd-11eb-8a30-ccca66ffb6aa.png">
