### PR TITLE
[DOCS] Fix documentation links generated within template

### DIFF
--- a/great_expectations/data_context/templates.py
+++ b/great_expectations/data_context/templates.py
@@ -36,7 +36,7 @@ PROJECT_HELP_COMMENT = f"""
 # Here you can define datasources, batch kwargs generators, integrations and
 # more. This file is intended to be committed to your repo. For help with
 # configuration please:
-#   - Read our docs: https://docs.greatexpectations.io/en/latest/how_to_guides/spare_parts/data_context_reference.html#configuration
+#   - Read our docs: https://docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html#configuration
 #   - Join our slack channel: http://greatexpectations.io/slack
 
 # config_version refers to the syntactic version of this config file, and is used in maintaining backwards compatibility
@@ -45,7 +45,7 @@ config_version: {DataContextConfigDefaults.DEFAULT_CONFIG_VERSION.value}
 
 # Datasources tell Great Expectations where your data lives and how to get it.
 # You can use the CLI command `great_expectations datasource new` to help you
-# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource_reference.html
+# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource.html
 datasources: {{}}
 """
 

--- a/tests/data_context/fixtures/version_2-0_but_no_version_defined/great_expectations.yml
+++ b/tests/data_context/fixtures/version_2-0_but_no_version_defined/great_expectations.yml
@@ -3,7 +3,7 @@
 # Here you can define datasources, batch kwargs generators, integrations and
 # more. This file is intended to be committed to your repo. For help with
 # configuration please:
-#   - Read our docs: https://docs.greatexpectations.io/en/latest/how_to_guides/spare_parts/data_context_reference.html#configuration
+#   - Read our docs: https://docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html#configuration
 #   - Join our slack channel: http://greatexpectations.io/slack
 
 # config_version refers to the syntactic version of this config file, and is used in maintaining backwards compatibility
@@ -13,7 +13,7 @@
 
 # Datasources tell Great Expectations where your data lives and how to get it.
 # You can use the CLI command `great_expectations datasource new` to help you
-# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource_reference.html
+# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource.html
 datasources: {}
 
 # This config file supports variable substitution which enables: 1) keeping

--- a/tests/data_context/test_templates.py
+++ b/tests/data_context/test_templates.py
@@ -81,7 +81,7 @@ def project_help_comment():
 # Here you can define datasources, batch kwargs generators, integrations and
 # more. This file is intended to be committed to your repo. For help with
 # configuration please:
-#   - Read our docs: https://docs.greatexpectations.io/en/latest/how_to_guides/spare_parts/data_context_reference.html#configuration
+#   - Read our docs: https://docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html#configuration
 #   - Join our slack channel: http://greatexpectations.io/slack
 
 # config_version refers to the syntactic version of this config file, and is used in maintaining backwards compatibility
@@ -90,7 +90,7 @@ config_version: 3
 
 # Datasources tell Great Expectations where your data lives and how to get it.
 # You can use the CLI command `great_expectations datasource new` to help you
-# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource_reference.html
+# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource.html
 datasources: {}
 """
     return PROJECT_HELP_COMMENT

--- a/tests/profile/fixtures/great_expectations_titanic_0.13.yml
+++ b/tests/profile/fixtures/great_expectations_titanic_0.13.yml
@@ -3,7 +3,7 @@
 # Here you can define datasources, batch kwargs generators, integrations and
 # more. This file is intended to be committed to your repo. For help with
 # configuration please:
-#   - Read our docs: https://docs.greatexpectations.io/en/latest/how_to_guides/spare_parts/data_context_reference.html#configuration
+#   - Read our docs: https://docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html#configuration
 #   - Join our slack channel: http://greatexpectations.io/slack
 
 # config_version refers to the syntactic version of this config file, and is used in maintaining backwards compatibility
@@ -12,7 +12,7 @@ config_version: 2.0
 
 # Datasources tell Great Expectations where your data lives and how to get it.
 # You can use the CLI command `great_expectations datasource new` to help you
-# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource_reference.html
+# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource.html
 datasources:
   my_pandas_runtime_datasource:
     class_name: Datasource


### PR DESCRIPTION
Changes proposed in this pull request:
- The documentation links for data context points to invalid URL. 
Invalid URL: https://docs.greatexpectations.io/en/latest/how_to_guides/spare_parts/data_context_reference.html#configuration 
Valid URL: https://docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html#configuration 

- The documentation links for adding new data source also points to invalid URL.
Invalid URL: https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource_reference.html 
Valid URL: https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource.html

The proposed changes fix these invalid links. 
