### PR TITLE
[BUGFIX] Populate (data) asset name in data docs for SimpleSqlalchemy datasource

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ develop
 * [FEATURE] Added support for references to secrets stores for AWS Secrets Manager, GCP Secret Manager and Azure Key Vault in `great_expectations.yml` project config file (Thanks @Cedric-Magnan!)
 * [BUGFIX] Sorter Configuration Added to DataConnectorConfig and DataConnectorConfigSchema #2572
 * [BUGFIX] Remove autosave of Checkpoints in test_yaml_config and store SimpleCheckpoint as Checkpoint #2549
+* [BUGFIX] Populate (data) asset name in data docs for SimpleSqlalchemy datasource
 
 0.13.14
 -----------------

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -195,6 +195,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         """
         data_asset_name: str = batch_definition.data_asset_name
         return {
+            "data_asset_name": data_asset_name,
             "table_name": data_asset_name,
             "partition_definition": batch_definition.partition_definition,
             **self.data_assets[data_asset_name],

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -56,6 +56,7 @@ def test_basic_self_check(test_cases_for_sql_data_connector_sqlite_execution_eng
             "n_rows": 8,
             "batch_spec": {
                 "table_name": "table_partitioned_by_date_column__A",
+                "data_asset_name": "table_partitioned_by_date_column__A",
                 "partition_definition": {"date": "2020-01-02"},
                 "splitter_method": "_split_on_column_value",
                 "splitter_kwargs": {"column_name": "date"},
@@ -206,6 +207,7 @@ def test_example_A(test_cases_for_sql_data_connector_sqlite_execution_engine):
             "n_rows": 8,
             "batch_spec": {
                 "table_name": "table_partitioned_by_date_column__A",
+                "data_asset_name": "table_partitioned_by_date_column__A",
                 "partition_definition": {"date": "2020-01-02"},
                 "splitter_method": "_split_on_column_value",
                 "splitter_kwargs": {"column_name": "date"},
@@ -257,6 +259,7 @@ def test_example_B(test_cases_for_sql_data_connector_sqlite_execution_engine):
             "n_rows": 8,
             "batch_spec": {
                 "table_name": "table_partitioned_by_timestamp_column__B",
+                "data_asset_name": "table_partitioned_by_timestamp_column__B",
                 "partition_definition": {"timestamp": "2020-01-02"},
                 "splitter_method": "_split_on_converted_datetime",
                 "splitter_kwargs": {"column_name": "timestamp"},
@@ -311,6 +314,7 @@ def test_example_C(test_cases_for_sql_data_connector_sqlite_execution_engine):
             "n_rows": 10,
             "batch_spec": {
                 "table_name": "table_partitioned_by_regularly_spaced_incrementing_id_column__C",
+                "data_asset_name": "table_partitioned_by_regularly_spaced_incrementing_id_column__C",
                 "partition_definition": {"id": 1},
                 "splitter_method": "_split_on_divided_integer",
                 "splitter_kwargs": {"column_name": "id", "divisor": 10},
@@ -362,6 +366,7 @@ def test_example_E(test_cases_for_sql_data_connector_sqlite_execution_engine):
             "n_rows": 9,
             "batch_spec": {
                 "table_name": "table_partitioned_by_incrementing_batch_id__E",
+                "data_asset_name": "table_partitioned_by_incrementing_batch_id__E",
                 "partition_definition": {"batch_id": 1},
                 "splitter_method": "_split_on_column_value",
                 "splitter_kwargs": {"column_name": "batch_id"},
@@ -414,6 +419,7 @@ def test_example_F(test_cases_for_sql_data_connector_sqlite_execution_engine):
             "n_rows": 2,
             "batch_spec": {
                 "table_name": "table_partitioned_by_foreign_key__F",
+                "data_asset_name": "table_partitioned_by_foreign_key__F",
                 "partition_definition": {"session_id": 2},
                 "splitter_method": "_split_on_column_value",
                 "splitter_kwargs": {"column_name": "session_id"},
@@ -469,6 +475,7 @@ def test_example_G(test_cases_for_sql_data_connector_sqlite_execution_engine):
             "n_rows": 8,
             "batch_spec": {
                 "table_name": "table_partitioned_by_multiple_columns__G",
+                "data_asset_name": "table_partitioned_by_multiple_columns__G",
                 "partition_definition": {
                     "y": 2020,
                     "m": 1,

--- a/tests/datasource/test_new_datasource_with_sql_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_sql_data_connector.py
@@ -89,6 +89,7 @@ data_connectors:
                 "example_data_reference": {
                     "batch_spec": {
                         "table_name": "table_partitioned_by_date_column__A",
+                        "data_asset_name": "table_partitioned_by_date_column__A",
                         "partition_definition": {"date": "2020-01"},
                         "splitter_method": "_split_on_converted_datetime",
                         "splitter_kwargs": {
@@ -704,6 +705,7 @@ def test_basic_instantiation_of_InferredAssetSqlDataConnector(
             "batch_spec": {
                 "schema_name": "main",
                 "table_name": "table_containing_id_spacers_for_D",
+                "data_asset_name": "prexif__table_containing_id_spacers_for_D__xiffus",
                 "partition_definition": {},
             },
             "n_rows": 30,
@@ -791,6 +793,7 @@ def test_more_complex_instantiation_of_InferredAssetSqlDataConnector(
                 "partition_definition": {},
                 "schema_name": "main",
                 "table_name": "table_containing_id_spacers_for_D",
+                "data_asset_name": "main.table_containing_id_spacers_for_D__whole",
             },
             "n_rows": 30,
         },


### PR DESCRIPTION
Fixes #2585

Changes proposed in this pull request:
- populate missing entry for data_asset_name when using sql connector
