### PR TITLE
[BUGFIX] Don't stop SparkContext when running in Databricks

### DIFF
--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -107,7 +107,7 @@ def in_databricks() -> bool:
     Returns:
         bool
     """
-    return 'DATABRICKS_RUNTIME_VERSION' in os.environ
+    return "DATABRICKS_RUNTIME_VERSION" in os.environ
 
 
 def convert_to_json_serializable(data):

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -2,10 +2,10 @@ import copy
 import datetime
 import decimal
 import logging
+import os
 import sys
 from collections import OrderedDict
 from collections.abc import Mapping
-import os
 from typing import Any, Dict, Iterable, List, Optional, Union
 from urllib.parse import urlparse
 

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -5,6 +5,7 @@ import logging
 import sys
 from collections import OrderedDict
 from collections.abc import Mapping
+import os
 from typing import Any, Dict, Iterable, List, Optional, Union
 from urllib.parse import urlparse
 
@@ -97,6 +98,16 @@ def in_jupyter_notebook():
             return False  # Other type (?)
     except NameError:
         return False  # Probably standard Python interpreter
+
+
+def in_databricks() -> bool:
+    """
+    Tests whether we are in a Databricks environment.
+
+    Returns:
+        bool
+    """
+    return 'DATABRICKS_RUNTIME_VERSION' in os.environ
 
 
 def convert_to_json_serializable(data):
@@ -548,6 +559,11 @@ def get_or_create_spark_session(
 def spark_restart_required(
     current_spark_config: List[tuple], desired_spark_config: dict
 ) -> bool:
+
+    # we can't change spark context config values within databricks runtimes
+    if in_databricks():
+        return False
+
     current_spark_config_dict: dict = {k: v for (k, v) in current_spark_config}
     if desired_spark_config.get("spark.app.name") != current_spark_config_dict.get(
         "spark.app.name"

--- a/tests/integration/spark/test_spark_config.py
+++ b/tests/integration/spark/test_spark_config.py
@@ -80,4 +80,7 @@ def test_spark_config_execution_engine(spark_session, databricks_runtime):
     else:
         # spark context should not be stopped, i.e. the spark app id is kept
         assert old_app_id == execution_engine.spark.sparkContext.applicationId
-        assert ("spark.app.name", "default_great_expectations_spark_application") in conf
+        assert (
+            "spark.app.name",
+            "default_great_expectations_spark_application",
+        ) in conf

--- a/tests/integration/spark/test_spark_config.py
+++ b/tests/integration/spark/test_spark_config.py
@@ -1,9 +1,9 @@
 import logging
 import os
 from typing import Dict, List
-from packaging.version import parse as parse_version
 
 import pytest
+from packaging.version import parse as parse_version
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/spark/test_spark_config.py
+++ b/tests/integration/spark/test_spark_config.py
@@ -2,9 +2,7 @@ import logging
 import os
 from typing import Dict, List
 
-
 import pytest
-import unittest.mock as mock
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/spark/test_spark_config.py
+++ b/tests/integration/spark/test_spark_config.py
@@ -74,7 +74,7 @@ def test_spark_config_execution_engine(spark_session, databricks_runtime):
     # Test that our values were set if not running in a Databricks runtime
     conf: List[tuple] = execution_engine.spark.sparkContext.getConf().getAll()
     if not databricks_runtime:
-        # spark context should restarted, i.e. the spark app id will change
+        # spark context should be restarted, i.e. the spark app id will change
         assert old_app_id != execution_engine.spark.sparkContext.applicationId
         assert ("spark.app.name", "great_expectations-ee-config") in conf
         assert ("spark.sql.catalogImplementation", "hive") in conf

--- a/tests/integration/spark/test_spark_config.py
+++ b/tests/integration/spark/test_spark_config.py
@@ -100,5 +100,3 @@ def test_spark_config_execution_engine(spark_session, databricks_runtime):
             assert ("spark.app.name", "great_expectations-ee-config") in conf
             assert ("spark.sql.catalogImplementation", "hive") in conf
             assert ("spark.executor.memory", "512m") in conf
-
-            

--- a/tests/integration/spark/test_spark_config.py
+++ b/tests/integration/spark/test_spark_config.py
@@ -52,7 +52,7 @@ def test_spark_config_execution_engine(spark_session, databricks_runtime):
     old_app_id = spark_session.sparkContext.applicationId
     if databricks_runtime:
         # simulate a databricks runtime environment by setting the databricks runtime version
-        os.environ['DATABRICKS_RUNTIME_VERSION'] = '7.3'
+        os.environ["DATABRICKS_RUNTIME_VERSION"] = "7.3"
 
     name: str = "great_expectations-ee-config"
     spark_config: Dict[str, str] = {


### PR DESCRIPTION
This PR is a proposal and should fix #2561. 

`SparkContext` configuration values can't be set once a Databricks cluster is started. This PR avoids the `SparkContext` "restart" (with user-defined configuration values) that actually breaks the Databricks runtimes.

I have tested it against Databricks runtime 7.3 and seems to fix the issue. Different `SparkSession` builder logic must be handled depending on the `pyspark` version used as described [here](https://spark.apache.org/docs/3.0.0/pyspark-migration-guide.html#upgrading-from-pyspark-24-to-30).