### PR TITLE
[ENHANCE] Update UserConfigurableProfiler to increase tolerance for mostly parameter of nullity expectations

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ develop
 * [BUGFIX] Sorter Configuration Added to DataConnectorConfig and DataConnectorConfigSchema #2572
 * [BUGFIX] Remove autosave of Checkpoints in test_yaml_config and store SimpleCheckpoint as Checkpoint #2549
 * [BUGFIX] Populate (data) asset name in data docs for SimpleSqlalchemy datasource
+* [ENHANCE] Update UserConfigurableProfiler to increase tolerance for mostly parameter of nullity expectations
 
 0.13.14
 -----------------

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import math
 
 import numpy as np
 from dateutil.parser import parse
@@ -1039,7 +1040,8 @@ class UserConfigurableProfiler:
             if not not_null_result.success:
                 unexpected_percent = float(not_null_result.result["unexpected_percent"])
                 if unexpected_percent >= 50 and not self.not_null_only:
-                    potential_mostly_value = unexpected_percent / 100.0
+                    potential_mostly_value = math.floor(unexpected_percent) / 100.0
+                    safe_mostly_value = max(0.001, potential_mostly_value)
                     profile_dataset._expectation_suite.remove_expectation(
                         ExpectationConfiguration(
                             expectation_type="expect_column_values_to_not_be_null",
@@ -1052,11 +1054,13 @@ class UserConfigurableProfiler:
                         not in self.excluded_expectations
                     ):
                         profile_dataset.expect_column_values_to_be_null(
-                            column, mostly=potential_mostly_value
+                            column, mostly=safe_mostly_value
                         )
                 else:
-                    potential_mostly_value = (100.0 - unexpected_percent) / 100.0
-                    safe_mostly_value = round(max(0.001, potential_mostly_value), 3)
+                    potential_mostly_value = (
+                        100.0 - math.ceil(unexpected_percent)
+                    ) / 100.0
+                    safe_mostly_value = max(0.001, potential_mostly_value)
                     profile_dataset.expect_column_values_to_not_be_null(
                         column, mostly=safe_mostly_value
                     )

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -1041,6 +1041,8 @@ class UserConfigurableProfiler:
                 unexpected_percent = float(not_null_result.result["unexpected_percent"])
                 if unexpected_percent >= 50 and not self.not_null_only:
                     potential_mostly_value = math.floor(unexpected_percent) / 100.0
+                    # A safe_mostly_value of 0.001 gives us a rough way of ensuring that we don't wind up with a mostly
+                    # value of 0 when we round
                     safe_mostly_value = max(0.001, potential_mostly_value)
                     profile_dataset._expectation_suite.remove_expectation(
                         ExpectationConfiguration(
@@ -1060,6 +1062,9 @@ class UserConfigurableProfiler:
                     potential_mostly_value = (
                         100.0 - math.ceil(unexpected_percent)
                     ) / 100.0
+
+                    # A safe_mostly_value of 0.001 gives us a rough way of ensuring that we don't wind up with a mostly
+                    # value of 0 when we round
                     safe_mostly_value = max(0.001, potential_mostly_value)
                     profile_dataset.expect_column_values_to_not_be_null(
                         column, mostly=safe_mostly_value

--- a/tests/profile/test_user_configurable_profiler_v2_batch_kwargs.py
+++ b/tests/profile/test_user_configurable_profiler_v2_batch_kwargs.py
@@ -34,6 +34,19 @@ def cardinality_dataset():
 
 
 @pytest.fixture()
+def nulls_dataset():
+    df = pd.DataFrame(
+        {
+            "mostly_null": [i if i % 3 == 0 else None for i in range(0, 1000)],
+            "mostly_not_null": [None if i % 3 == 0 else i for i in range(0, 1000)],
+        }
+    )
+    batch_df = PandasDataset(df)
+
+    return batch_df
+
+
+@pytest.fixture()
 def titanic_dataset():
     df = ge.read_csv(file_relative_path(__file__, "../test_sets/Titanic.csv"))
     batch_df = PandasDataset(df)
@@ -384,7 +397,7 @@ def test_primary_or_compound_key_not_found_in_columns(cardinality_dataset):
     assert ignored_column_profiler.primary_or_compound_key == ["col_unique", "col_one"]
 
 
-def test_config_with_not_null_only(possible_expectations_set):
+def test_config_with_not_null_only(nulls_dataset, possible_expectations_set):
     """
     What does this test do and why?
     Confirms that the not_null_only key in config works as expected.
@@ -392,13 +405,7 @@ def test_config_with_not_null_only(possible_expectations_set):
 
     excluded_expectations = [i for i in possible_expectations_set if "null" not in i]
 
-    df = pd.DataFrame(
-        {
-            "mostly_null": [i if i % 3 == 0 else None for i in range(0, 1000)],
-            "mostly_not_null": [None if i % 3 == 0 else i for i in range(0, 1000)],
-        }
-    )
-    batch_df = PandasDataset(df)
+    batch_df = nulls_dataset
 
     profiler_without_not_null_only = UserConfigurableProfiler(
         batch_df, excluded_expectations, not_null_only=False
@@ -425,6 +432,22 @@ def test_config_with_not_null_only(possible_expectations_set):
     no_config_suite = no_config_profiler.build_suite()
     _, expectations = get_set_of_columns_and_expectations_from_suite(no_config_suite)
     assert "expect_column_values_to_be_null" in expectations
+
+
+def test_nullity_expectations_mostly_tolerance(
+    nulls_dataset, possible_expectations_set
+):
+    excluded_expectations = [i for i in possible_expectations_set if "null" not in i]
+
+    batch_df = nulls_dataset
+
+    profiler = UserConfigurableProfiler(
+        batch_df, excluded_expectations, not_null_only=False
+    )
+    suite = profiler.build_suite()
+
+    for i in suite.expectations:
+        assert i["kwargs"]["mostly"] == 0.66
 
 
 def test_profiled_dataset_passes_own_validation(

--- a/tests/profile/test_user_configurable_profiler_v3_batch_request.py
+++ b/tests/profile/test_user_configurable_profiler_v3_batch_request.py
@@ -236,7 +236,21 @@ def taxi_validator_sqlalchemy(sa, titanic_data_context_modular_api):
     return get_sqlalchemy_runtime_validator_postgresql(df)
 
 
-@pytest.fixture
+@pytest.fixture()
+def nulls_validator(titanic_data_context_modular_api):
+    df = pd.DataFrame(
+        {
+            "mostly_null": [i if i % 3 == 0 else None for i in range(0, 1000)],
+            "mostly_not_null": [None if i % 3 == 0 else i for i in range(0, 1000)],
+        }
+    )
+
+    validator = get_pandas_runtime_validator(titanic_data_context_modular_api, df)
+
+    return validator
+
+
+@pytest.fixture()
 def cardinality_validator(titanic_data_context_modular_api):
     """
     What does this test do and why?
@@ -628,7 +642,7 @@ def test_primary_or_compound_key_not_found_in_columns(cardinality_validator):
 
 
 def test_config_with_not_null_only(
-    titanic_data_context_modular_api, possible_expectations_set
+    titanic_data_context_modular_api, nulls_validator, possible_expectations_set
 ):
     """
     What does this test do and why?
@@ -637,14 +651,7 @@ def test_config_with_not_null_only(
 
     excluded_expectations = [i for i in possible_expectations_set if "null" not in i]
 
-    df = pd.DataFrame(
-        {
-            "mostly_null": [i if i % 3 == 0 else None for i in range(0, 1000)],
-            "mostly_not_null": [None if i % 3 == 0 else i for i in range(0, 1000)],
-        }
-    )
-
-    validator = get_pandas_runtime_validator(titanic_data_context_modular_api, df)
+    validator = nulls_validator
 
     profiler_without_not_null_only = UserConfigurableProfiler(
         validator, excluded_expectations, not_null_only=False
@@ -671,6 +678,22 @@ def test_config_with_not_null_only(
     no_config_suite = no_config_profiler.build_suite()
     _, expectations = get_set_of_columns_and_expectations_from_suite(no_config_suite)
     assert "expect_column_values_to_be_null" in expectations
+
+
+def test_nullity_expectations_mostly_tolerance(
+    nulls_validator, possible_expectations_set
+):
+    excluded_expectations = [i for i in possible_expectations_set if "null" not in i]
+
+    validator = nulls_validator
+
+    profiler = UserConfigurableProfiler(
+        validator, excluded_expectations, not_null_only=False
+    )
+    suite = profiler.build_suite()
+
+    for i in suite.expectations:
+        assert i["kwargs"]["mostly"] == 0.66
 
 
 def test_profiled_dataset_passes_own_validation(


### PR DESCRIPTION
Changes proposed in this pull request:
- Previously, the tolerance for the `mostly` parameter for `expect_column_values_to_be_null` and `expect_column_values_to_not_be_null` was pretty precise, and so led to certain expectations failing right after creation. There has been some talk about increasing tolerance in the UserConfigurableProfiler, though figuring out an acceptable tolerance is pretty tricky. Given that `mostly` works off of a percentage, simply rounding to a whole percentage point seems like a natural fit, and so I have added this in.

