### PR TITLE
[DOCS] Updated datasource new how-to guides to match new notebooks

### DIFF
--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
@@ -156,7 +156,9 @@ Steps
 
                 .. code-block:: python
 
+                    datasource_name = "my_mssql_datasource"
                     config = f"""
+                    name: {datasource_name}
                     class_name: SimpleSqlalchemyDatasource
                     connection_string: mssql+pyodbc://YOUR_MSSQL_USERNAME:YOUR_MSSQL_PASSWORD@YOUR_MSSQL_HOST:YOUR_MSSQL_PORT/YOUR_MSSQL_DATABASE?driver=ODBC Driver 17 for SQL Server&charset=utf&autocommit=true
                     introspection:
@@ -169,7 +171,6 @@ Steps
             .. code-block:: python
 
                 context.test_yaml_config(
-                    name="my_mssql_datasource",
                     yaml_config=config
                 )
 
@@ -209,12 +210,14 @@ Steps
             This means all has went well and you can proceed with exploring datasets in your new MSSQL datasource.
 
         #. **Save the config.**
+            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
 
-            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations setup.
-            First, create a new entry in the ``datasources`` section of your ``great_expectations/great_expectations.yml`` with the name of your Datasource (which is ``my_mssql_datasource`` in our example).
-            Next, copy the yml snippet from Step 4 into the new entry.
+            .. code-block:: python
 
-            **Note:** Please make sure the yml is indented correctly. This will save you from much frustration.
+                sanitize_yaml_and_save_datasource(context, config, overwrite_existing=False)
+
+            **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
+
 
 
 Additional notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
@@ -218,6 +218,7 @@ Steps
 
             **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
 
+            **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
 
 Additional notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
@@ -215,6 +215,7 @@ Steps
 
             **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
 
+            **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
 Additional notes
 ----------------

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
@@ -146,7 +146,9 @@ Steps
 
                 .. code-block:: python
 
+                    datasource_name = "my_mysql_datasource"
                     config = f"""
+                        name: {datasource_name}
                         class_name: SimpleSqlalchemyDatasource
                         credentials:
                           drivername: mysql+pymysql
@@ -166,7 +168,6 @@ Steps
             .. code-block:: python
 
                 context.test_yaml_config(
-                    name="mysql_datasource",
                     yaml_config=config
                 )
 
@@ -206,12 +207,13 @@ Steps
              This means all has went well and you can proceed with exploring data in your new MySql datasource.
 
         #. **Save the config.**
+            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
 
-            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations setup.
-            First, create a new entry in the ``datasources`` section of your ``great_expectations/great_expectations.yml`` with the name of your Datasource (which is ``mysql_datasource`` in our example).
-            Next, copy the yml snippet from Step 3 into the new entry.
+            .. code-block:: python
 
-            **Note:** Please make sure the yml is indented correctly. This will save you from much frustration.
+                sanitize_yaml_and_save_datasource(context, config, overwrite_existing=False)
+
+            **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
 
 
 Additional notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
@@ -154,36 +154,36 @@ Steps
 
         #. **Create or copy a yaml config.**
 
-            Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``DataSource``, with a ``ConfiguredAssetS3DataConnector`` and a ``PandasExecutionEngine``. The S3-``bucket`` name and ``prefix`` are passed in as strings.
+            Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``DataSource``, with a ``InferredAssetS3DataConnector`` and a ``PandasExecutionEngine``. The S3-``bucket`` name and ``prefix`` are passed in as strings.
 
-            **Note**: The ``ConfiguredAssetS3DataConnector`` used in this example is closely related to the ``InferreddAssetS3DataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
 
             .. code-block:: python
 
+                datasource_name = "my_pandas_s3_datasource"
                 config = f"""
                         class_name: Datasource
                         execution_engine:
                           class_name: PandasExecutionEngine
                         data_connectors:
                           my_data_connector:
-                            class_name: ConfiguredAssetS3DataConnector
-                            bucket: YOUR_S3_BUCKET_NAME
-                            prefix: YOUR_S3_PREFIX_NAME
-                            assets:
-                              test_asset:
-                                pattern: (.+)\\.csv
-                                group_names:
-                                  - full_name
+                            datasource_name: {datasource_name}
+                            class_name: InferredAssetS3DataConnector
+                            bucket: my_s3_bucket
+                            prefix: my_s3_directory/
+                            default_regex:
+                              group_names: data_asset_name
+                              pattern: (.*)
                         """
 
-            Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            **Note**: The ``InferredAssetS3DataConnector`` used in this example is closely related to the ``ConfiguredAssetS3DataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
+
+            **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         #. **Run context.test_yaml_config.**
 
             .. code-block:: python
 
                 context.test_yaml_config(
-                    name="my_pandas_s3_datasource",
                     yaml_config=config
                 )
 
@@ -230,12 +230,14 @@ Steps
                 botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied
 
         #. **Save the config.**
+            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
 
-            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations setup.
-            First, create a new entry in the ``datasources`` section of your ``great_expectations/great_expectations.yml`` with the name of your Datasource (which is ``my_pandas_s3_datasource`` in our example).
-            Next, copy the yml snippet from Step 3 into the new entry.
+            .. code-block:: python
 
-            **Note:** Please make sure the yml is indented correctly. This will save you from much frustration.
+                sanitize_yaml_and_save_datasource(context, config, overwrite_existing=False)
+
+            **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
+
 
 ----------------
 Additional Notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -262,6 +262,7 @@ Steps
 
             **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
 
+            **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
 ----------------
 Additional Notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -192,9 +192,9 @@ Steps
                   drivername: postgresql+psycopg2
                   username: YOUR_REDSHIFT_USERNAME
                   password: YOUR_REDSHIFT_PASSWORD
-                  host: my-datawarehouse-name.abcde1qrstuw.us-east-1.redshift.amazonaws.com
+                  host: YOUR_REDSHIFT_HOSTNAME
                   port: 5439
-                  database: dev
+                  database: YOUR_REDSHIFT_DATABASE
                   query:
                       sslmode: prefer
                 introspection:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -184,7 +184,9 @@ Steps
 
             .. code-block:: python
 
+                datasource_name = "my_redshift_datasource"
                 config = f"""
+                name: {datasource_name}
                 class_name: SimpleSqlalchemyDatasource
                 credentials:
                   drivername: postgresql+psycopg2
@@ -205,7 +207,6 @@ Steps
             .. code-block:: python
 
                 context.test_yaml_config(
-                    name="my_redshift_datasource",
                     yaml_config=config
                 )
 
@@ -253,12 +254,13 @@ Steps
                 FATAL:  password authentication failed for user "my_username"
 
         #. **Save the config.**
+            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
 
-            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations setup.
-            First, create a new entry in the ``datasources`` section of your ``great_expectations/great_expectations.yml`` with the name of your Datasource (which is ``my_redshift_datasource`` in our example).
-            Next, copy the yml snippet from Step 3 into the new entry.
+            .. code-block:: python
 
-            **Note:** Please make sure the yml is indented correctly. This will save you from much frustration.
+                sanitize_yaml_and_save_datasource(context, config, overwrite_existing=False)
+
+            **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
 
 
 ----------------

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
@@ -300,6 +300,7 @@ Steps
 
             **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
 
+            **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
 ----------------
 Additional Notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
@@ -230,7 +230,9 @@ Steps
 
                 .. code-block:: python
 
+                    datasource_name = "my_snowflake_datasource"
                     config = f"""
+                        name: {datasource_name}
                         class_name: SimpleSqlalchemyDatasource
                         credentials:
                           drivername: snowflake
@@ -250,7 +252,6 @@ Steps
             .. code-block:: python
 
                 context.test_yaml_config(
-                    name="my_snowflake_datasource",
                     yaml_config=config
                 )
 
@@ -289,13 +290,16 @@ Steps
 
             This means all has went well and you can proceed with exploring data with your new Snowflake datasource.
 
+
         #. **Save the config.**
+            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
 
-            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations setup.
-            First, create a new entry in the ``datasources`` section of your ``great_expectations/great_expectations.yml`` with the name of your Datasource (which is ``my_snowflake_datasource`` in our example).
-            Next, copy the yml snippet from Step 3 into the new entry.
+            .. code-block:: python
 
-            **Note:** Please make sure the yml is indented correctly. This will save you from much frustration.
+                sanitize_yaml_and_save_datasource(context, config, overwrite_existing=False)
+
+            **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
+
 
 ----------------
 Additional Notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
@@ -140,40 +140,38 @@ Steps
 
         #.  **Create or copy a yaml config.**
 
-                Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``Datasource``, with a ``ConfiguredAssetFilesystemDataConnector`` and ``SparkDFExecutionEngine``.
+                Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``Datasource``, with a ``InferredFilesystemDataConnector`` and ``SparkDFExecutionEngine``.
 
                 The config also defines ``TestAsset``, which has ``name``, ``timestamp`` and ``size`` as ``group_names``, which are informative fields of the filename that are extracted by the regex ``pattern``.
 
-                **Note**: The ``ConfiguredAssetFilesystemDataConnector`` used in this example is closely related to the ``InferredAssetFilesystemDataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
 
                 .. code-block:: python
 
+                    datasource_name = "my_spark_datasource"
                     config = f"""
+                    name: {datasource_name}
                     class_name: Datasource
                     execution_engine:
                       class_name: SparkDFExecutionEngine
                     data_connectors:
                       my_data_connector:
-                        class_name: ConfiguredAssetFilesystemDataConnector
+                        datasource_name: {datasource_name}
+                        class_name: InferredAssetFilesystemDataConnector
                         base_directory: test_directory/
-                        glob_directive: "*.csv"
-                        assets:
-                          TestAsset:
-                            pattern: (.+)_(\\d+)_(\\d+)\\.csv
-                            group_names:
-                              - name
-                              - timestamp
-                              - size
+                        default_regex:
+                          group_names: data_asset_name
+                          pattern: (.*)
                     """
 
-                Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+                **Note**: The ``InferredAssetFilesystemDataConnector`` used in this example is closely related to the ``ConfiguredAssetFilesystemDataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
+
+                **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         #. **Run context.test_yaml_config.**
 
             .. code-block:: python
 
                 context.test_yaml_config(
-                    name="my_sparkdf_datasource",
                     yaml_config=config
                 )
 
@@ -212,13 +210,16 @@ Steps
 
             This means all has gone well and you can proceed with exploring data with your new filesystem-backed Pandas data source.
 
+
         #. **Save the config.**
+            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
 
-            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations setup.
-            First, create a new entry in the ``datasources`` section of your ``great_expectations/great_expectations.yml`` with the name of your Datasource (which is ``my_sparkdf_datasource`` in our example).
-            Next, copy the yml snippet from Step 3 into the new entry.
+            .. code-block:: python
 
-            **Note:** Please make sure the yml is indented correctly. This will save you from much frustration.
+                sanitize_yaml_and_save_datasource(context, config, overwrite_existing=False)
+
+            **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=False`` to force overwriting.
+
 
 ----------------
 Additional Notes


### PR DESCRIPTION
Changes proposed in this pull request:
- adding the "save datasource" method to the datasource docs
- replacing configured* data connectors with inferred* to match the new datasource new notebooks
- removed the redundant name param in test_yaml_config

Test plan:
- tested the pandas/file, pandas/s3 snippets
- tested the postgres path to verify that the SQL related snippets work
- did *not* test spark df snippet - anyone can verify this?
