### PR TITLE
[DOCS] Updating datasource docs to remove sample data output and general cleanup

### DIFF
--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_bigquery_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_bigquery_datasource.rst
@@ -9,47 +9,136 @@ This guide will help you add a BigQuery project (or a dataset) as a Datasource. 
 
   - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
   - Followed the `Google Cloud library guide <https://googleapis.dev/python/google-api-core/latest/auth.html>`_ for authentication
-  - Installed the pybigquery package for the BigQuery sqlalchemy dialect (``pip install pybigquery``)
+  - Installed the ``pybigquery`` package for the BigQuery sqlalchemy dialect (``pip install pybigquery``)
 
 Steps
 -----
 
+.. content-tabs::
 
-1. Run the following CLI command to begin the interactive Datasource creation process:
-
-.. code-block:: bash
-
-    great_expectations datasource new
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
 
-2. Choose "Big Query" from the list of database engines, when prompted.
-3. Identify the connection string you would like Great Expectations to use to connect to BigQuery, using the examples below and the `PyBigQuery <https://github.com/mxmzdlv/pybigquery>`_ documentation.
+        1. Run the following CLI command to begin the interactive Datasource creation process:
 
-    If you want Great Expectations to connect to your BigQuery project (without specifying a particular dataset), the URL should be:
+        .. code-block:: bash
 
-    .. code-block:: bash
-
-        bigquery://project-name
+            great_expectations datasource new
 
 
-    If you want Great Expectations to connect to a particular dataset inside your BigQuery project, the URL should be:
+        2. Choose "Big Query" from the list of database engines, when prompted.
+        3. Identify the connection string you would like Great Expectations to use to connect to BigQuery, using the examples below and the `PyBigQuery <https://github.com/mxmzdlv/pybigquery>`_ documentation.
+
+            If you want Great Expectations to connect to your BigQuery project (without specifying a particular dataset), the URL should be:
+
+            .. code-block:: bash
+
+                bigquery://project-name
 
 
-    .. code-block:: bash
-
-        bigquery://project-name/dataset-name
+            If you want Great Expectations to connect to a particular dataset inside your BigQuery project, the URL should be:
 
 
-    If you want Great Expectations to connect to one of the Google's public datasets, the URL should be:
+            .. code-block:: bash
 
-    .. code-block:: bash
+                bigquery://project-name/dataset-name
 
-        bigquery://project-name/bigquery-public-data
 
-5. Enter the connection string when prompted (and press Enter when asked "Would you like to proceed? [Y/n]:").
+            If you want Great Expectations to connect to one of the Google's public datasets, the URL should be:
 
-6. Should you need to modify your connection string, you can manually edit the
-   ``great_expectations/uncommitted/config_variables.yml`` file.
+            .. code-block:: bash
+
+                bigquery://project-name/bigquery-public-data
+
+        5. Enter the connection string when prompted (and press Enter when asked "Would you like to proceed? [Y/n]:").
+
+        6. Should you need to modify your connection string, you can manually edit the
+           ``great_expectations/uncommitted/config_variables.yml`` file.
+
+
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
+
+        .. admonition:: Prerequisites: This how-to guide assumes you have already:
+
+            - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
+            - :ref:`Understood the basics of Datasources <reference__core_concepts__datasources>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Followed the `Google Cloud library guide <https://googleapis.dev/python/google-api-core/latest/auth.html>`_ for authentication
+            - Installed the ``pybigquery`` package for the BigQuery sqlalchemy dialect (``pip install pybigquery``)
+
+
+        #. **Instantiate a Data Context.**
+
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+
+            .. code-block:: python
+
+                import great_expectations as ge
+                context = ge.get_context()
+
+        #.  **Create or copy a yaml config.**
+
+                Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.  Great Expectations uses a ``connection_string`` to connect to BigQuery through SQLAlchemy (reference: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls).
+
+
+                .. code-block:: python
+
+                    datasource_name = "my_bq_datasource"
+                    config = f"""
+                    name: {datasource_name}
+                    class_name: SimpleSqlalchemyDatasource
+                    connection_string: my_bq_connection_string
+                    introspection:
+                      whole_table:
+                        data_asset_name_suffix: __whole_table
+                    """
+
+            **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+
+
+        #. **Run context.test_yaml_config.**
+
+            .. code-block:: python
+
+                context.test_yaml_config(
+                    yaml_config=config
+                )
+
+            When executed, ``test_yaml_config`` will instantiate the component and run through a ``self_check`` procedure to verify that the component works as expected.
+
+            The resulting output will look something like this:
+
+            .. code-block:: bash
+
+                Attempting to instantiate class from config...
+                    Instantiating as a Datasource, since class_name is SimpleSqlalchemyDatasource
+                    Successfully instantiated SimpleSqlalchemyDatasource
+
+                Execution engine: SqlAlchemyExecutionEngine
+                Data connectors:
+                    whole_table : InferredAssetSqlDataConnector
+
+                    Available data_asset_names (1 of 1):
+		                imdb_100k_main__whole_table (1 of 1): [{}]
+
+                    Unmatched data_references (0 of 0): []
+
+
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+
+
+        #. **Save the config.**
+            Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
+
+            .. code-block:: python
+
+                sanitize_yaml_and_save_datasource(context, config, overwrite_existing=False)
+
+            **Note**: This will output a warning if a Datasource with the same name already exists. Use ``overwrite_existing=True`` to force overwriting.
+
+            **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
 
 Additional notes

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_configuredassetdataconnector.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_configuredassetdataconnector.rst
@@ -9,7 +9,7 @@ This guide demonstrates how to configure a ConfiguredAssetDataConnector, and pro
 
     - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
     - :ref:`Understand the basics of Datasources in 0.13 or later <reference__core_concepts__datasources>`
-    - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+    - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 Great Expectations provides two ``DataConnector`` classes for connecting to file-system-like data. This includes files on disk,
 but also S3 object stores, etc:
@@ -41,7 +41,7 @@ All of the examples below assume you’re testing configuration using something 
         yaml_config=config
     )
 
-If you’re not familiar with the ``test_yaml_config`` method, please check out: :ref:`How to configure DataContext components using test_yaml_config. <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+If you’re not familiar with the ``test_yaml_config`` method, please check out: :ref:`How to configure Data Context components using test_yaml_config. <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 Choose a DataConnector
 ----------------------
@@ -151,7 +151,7 @@ Then this configuration...
             'alpha-3.csv'
         ]
 
-Once configured, you can get a ``Validator`` from the ``DataContext`` as follows:
+Once configured, you can get a ``Validator`` from the ``Data Context`` as follows:
 
 .. code-block:: python
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
@@ -114,7 +114,7 @@ Steps
 
             - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources <reference__core_concepts__datasources>`
-            - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
             - Obtained database credentials for MSSQL, including username, password, hostname, and database.
 
         To add a MSSQL datasource, do the following:
@@ -134,9 +134,9 @@ Steps
 
                 pip install sqlalchemy
                 pip install pyodbc
-        #. **Instantiate a DataContext.**
+        #. **Instantiate a Data Context.**
 
-            Create a new Jupyter Notebook and instantiate a DataContext by running the following lines:
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
 
             .. code-block:: python
 
@@ -145,14 +145,8 @@ Steps
 
         #.  **Create or copy a yaml config.**
 
-                Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.  GE uses a ``connection_string`` to connect to MSSQL databases through sqlalchemy (reference: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls).
+                Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.  Great Expectations uses a ``connection_string`` to connect to MSSQL databases through SQLAlchemy (reference: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls).
 
-                ``SimpleSqlalchemyDatasource`` is a sub-class of ``Datasource`` that automatically configures a ``SqlDataConnector``, and is one you will probably want to use when connecting to data in an sql database. (More information on ``Datasources``
-                in GE 0.13 can found in :ref:`Core Great Expectations Concepts document. <reference__core_concepts>`)
-
-                This example also uses ``introspection`` to configure the datasource, where each table in the database is associated with its own ``data_asset``.  A deeper explanation on the different modes of building ``data_asset`` from data (``introspective`` / ``inferred`` vs ``configured``) can be found in the :ref:`Core Great Expectations Concepts document. <reference__core_concepts>`
-
-                Also, additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
                 .. code-block:: python
 
@@ -165,6 +159,9 @@ Steps
                       whole_table:
                         data_asset_name_suffix: __whole_table
                     """
+
+            **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+
 
         #. **Run context.test_yaml_config.**
 
@@ -193,21 +190,9 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-                    Choosing an example data reference...
-                        Reference chosen: {}
 
-                    Fetching batch data...
-                    [(58098,)]
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
-                            Showing 5 rows
-                       movieId                               title                                         genres
-                    0        1                    Toy Story (1995)  Adventure|Animation|Children|Comedy|Fantasy\r
-                    1        2                      Jumanji (1995)                   Adventure|Children|Fantasy\r
-                    2        3             Grumpier Old Men (1995)                               Comedy|Romance\r
-                    3        4            Waiting to Exhale (1995)                         Comedy|Drama|Romance\r
-                    4        5  Father of the Bride Part II (1995)                                       Comedy\r
-
-            This means all has went well and you can proceed with exploring datasets in your new MSSQL datasource.
 
         #. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
@@ -191,7 +191,7 @@ Steps
                     Unmatched data_references (0 of 0): []
 
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
 
         #. **Save the config.**

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
@@ -186,7 +186,7 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
         #. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
@@ -111,7 +111,7 @@ Steps
 
             - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources <reference__core_concepts__datasources>`
-            - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
             - Obtained database credentials for MySql, including username, password, hostname, and database.
 
         To add a MySql datasource, do the following:
@@ -125,9 +125,9 @@ Steps
                 pip install sqlalchemy
                 pip install PyMySQL
 
-        #. **Instantiate a DataContext.**
+        #. **Instantiate a Data Context.**
 
-            Create a new Jupyter Notebook and instantiate a DataContext by running the following lines:
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
 
             .. code-block:: python
 
@@ -137,12 +137,6 @@ Steps
         #.  **Create or copy a yaml config.**
 
                 Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.
-                ``SimpleSqlalchemyDatasource`` is a sub-class of ``Datasource`` that automatically configures a ``SqlDataConnector``, and is one you will probably want to use in connecting data living in a sql database. More information on ``Datasources``
-                in GE 0.13 can found in :ref:`Core Great Expectations Concepts document. <reference__core_concepts>`
-
-                This example also uses ``introspection`` to configure the datasource, where each table in the database is associated with its own ``data_asset``.  A deeper explanation on the different modes of building ``data_asset`` from data (``introspective`` / ``inferred`` vs ``configured``) can be found in the :ref:`Core Great Expectations Concepts document. <reference__core_concepts>`
-
-                Also, additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
                 .. code-block:: python
 
@@ -161,6 +155,8 @@ Steps
                           whole_table:
                             data_asset_name_suffix: __whole_table
                         """
+
+            **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 
         #. **Run context.test_yaml_config.**
@@ -190,21 +186,7 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-                    Choosing an example data reference...
-                        Reference chosen: {}
-
-                        Fetching batch data...
-                [(58098,)]
-
-                        Showing 5 rows
-                   movieId                               title                                         genres
-                0        1                    Toy Story (1995)  Adventure|Animation|Children|Comedy|Fantasy\r
-                1        2                      Jumanji (1995)                   Adventure|Children|Fantasy\r
-                2        3             Grumpier Old Men (1995)                               Comedy|Romance\r
-                3        4            Waiting to Exhale (1995)                         Comedy|Drama|Romance\r
-                4        5  Father of the Bride Part II (1995)                                       Comedy\r
-
-             This means all has went well and you can proceed with exploring data in your new MySql datasource.
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
         #. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
@@ -111,13 +111,13 @@ Steps
 
             - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources <reference__core_concepts__datasources>`
-            - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         To add a Pandas filesystem datasource, do the following:
 
-        #. **Instantiate a DataContext.**
+        #. **Instantiate a Data Context.**
 
-            Create a new Jupyter Notebook and instantiate a DataContext by running the following lines:
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
 
             .. code-block:: python
 
@@ -174,7 +174,8 @@ Steps
                         pattern: (.+)_(\\d+)_(\\d+)\\.csv
 
 
-                Additional examples of yaml configurations can be found in  :ref:`how_to_guides_how_to_configure_a_inferredassetdataconnector` and :ref:`how_to_guides_how_to_configure_a_configuredassetdataconnector`.
+            **Note**: The ``InferredAssetS3DataConnector`` used in this example is closely related to the ``ConfiguredAssetS3DataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
+
 
         #. **Run context.test_yaml_config.**
 
@@ -205,16 +206,10 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-                    Choosing an example data reference...
-                        Reference chosen: abe_20201119_200.csv
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
-                        Fetching batch data...
+            **Note:** Pay attention to the "Available data_asset_names" and "Unmatched data_references" output to ensure that the regex pattern you specified matches your desired data files.
 
-                        Showing 5 rows
-                        ...
-
-
-            Pay attention to the "Available data_asset_names" and "Unmatched data_references" output to ensure that the regex pattern you specified matches your desired data files.
 
         #. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
@@ -206,7 +206,7 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
             **Note:** Pay attention to the "Available data_asset_names" and "Unmatched data_references" output to ensure that the regex pattern you specified matches your desired data files.
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
@@ -207,7 +207,7 @@ Steps
                     Unmatched data_references (0 of 0): []
 
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
             **Note:** Pay attention to the "Available data_asset_names" and "Unmatched data_references" output to ensure that the regex pattern you specified matches your desired data files.
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_s3_datasource.rst
@@ -129,7 +129,7 @@ Steps
 
             - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources <reference__core_concepts__datasources>`
-            - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         To add an S3-backed Pandas datasource do the following:
 
@@ -143,9 +143,9 @@ Steps
                 pip install fsspec
                 pip install s3fs
 
-        #. **Instantiate a DataContext.**
+        #. **Instantiate a Data Context.**
 
-            Create a new Jupyter Notebook and instantiate a DataContext by running the following lines:
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
 
             .. code-block:: python
 
@@ -177,7 +177,6 @@ Steps
 
             **Note**: The ``InferredAssetS3DataConnector`` used in this example is closely related to the ``ConfiguredAssetS3DataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
 
-            **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         #. **Run context.test_yaml_config.**
 
@@ -207,27 +206,11 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-                    Choosing an example data reference...
-                        Reference chosen: abe_20201119_200.csv
 
-                        Fetching batch data...
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
-                        Showing 5 rows
-                   Unnamed: 0                                           Name PClass    Age     Sex  Survived  SexCode
-                0           1                   Allen, Miss Elisabeth Walton    1st  29.00  female         1        1
-                1           2                    Allison, Miss Helen Loraine    1st   2.00  female         0        1
-                2           3            Allison, Mr Hudson Joshua Creighton    1st  30.00    male         0        0
-                3           4  Allison, Mrs Hudson JC (Bessie Waldo Daniels)    1st  25.00  female         0        1
-                4           5                  Allison, Master Hudson Trevor    1st   0.92    male         1        0
+            **Note:** Pay attention to the "Available data_asset_names" and "Unmatched data_references" output to ensure that the regex pattern you specified matches your desired data files.
 
-            If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.  Whenever possible, test_yaml_config provides helpful warnings and error messages. It can't solve every problem, but it can solve many.
-
-            .. code-block:: bash
-
-                ...
-
-                raise error_class(parsed_response, operation_name)
-                botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied
 
         #. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -230,7 +230,7 @@ Steps
                 Unmatched data_references (0 of 0): []
 
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
         #. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -150,7 +150,7 @@ Steps
 
             - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources <reference__core_concepts__datasources>`
-            - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         To add a Redshift datasource, do the following:
 
@@ -167,9 +167,9 @@ Steps
                 # or if on macOS:
                 pip install psycopg2-binary
 
-        #. **Instantiate a DataContext.**
+        #. **Instantiate a Data Context.**
 
-            Create a new Jupyter Notebook and instantiate a DataContext by running the following lines:
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
 
             .. code-block:: python
 
@@ -179,8 +179,6 @@ Steps
         #. **Create or copy a yaml config.**
 
             Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials.  Username, password, host, port, and database are set as strings.
-
-            Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
             .. code-block:: python
 
@@ -201,6 +199,8 @@ Steps
                   whole_table:
                     data_asset_name_suffix: __whole_table
                 """
+
+            **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         #. **Run context.test_yaml_config.**
 
@@ -229,29 +229,8 @@ Steps
 
                 Unmatched data_references (0 of 0): []
 
-                Choosing an example data reference...
-                    Reference chosen: {}
 
-                    Fetching batch data...
-
-                    Showing 5 rows
-                   movieid                               title                                       genres
-                    0        1                    Toy Story (1995)  Adventure|Animation|Children|Comedy|Fantasy
-                    1        3             Grumpier Old Men (1995)                               Comedy|Romance
-                    2        5  Father of the Bride Part II (1995)                                       Comedy
-                    3        7                      Sabrina (1995)                               Comedy|Romance
-                    4        9                 Sudden Death (1995)                                       Action
-
-
-
-            If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.  Whenever possible, ``test_yaml_config`` provides helpful warnings and error messages, like the example below. It can't solve every problem, but it can solve many.
-
-            .. code-block:: bash
-
-                ...
-
-                psycopg2.OperationalError: FATAL:  password authentication failed for user "my_username"
-                FATAL:  password authentication failed for user "my_username"
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
         #. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
@@ -195,7 +195,7 @@ Steps
 
             - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources <reference__core_concepts__datasources>`
-            - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         To add a Snowflake datasource, do the following:
 
@@ -209,9 +209,9 @@ Steps
                 pip install snowflake-connector-python
                 pip install snowflake-sqlalchemy
 
-        #. **Instantiate a DataContext.**
+        #. **Instantiate a Data Context.**
 
-            Create a new Jupyter Notebook and instantiate a DataContext by running the following lines:
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
 
             .. code-block:: python
 
@@ -221,12 +221,7 @@ Steps
         #.  **Create or copy a yaml config.**
 
                 Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials using username and password authentication.  Username, password, host, database and query are set as strings.
-                ``SimpleSqlalchemyDatasource`` is a sub-class of ``Datasource`` that automatically configures a ``SqlDataConnector``, and is one you will probably want to use in connecting data living in a sql database. More information on ``Datasources``
-                in GE 0.13 can found in :ref:`Core Great Expectations Concepts document. <reference__core_concepts>`
 
-                This example also uses ``introspection`` to configure the datasource, where each table in the database is associated with its own ``data_asset``.  A deeper explanation on the different modes of building ``data_asset`` from data (``introspective`` / ``inferred`` vs ``configured``) can be found in the :ref:`Core Great Expectations Concepts document. <reference__core_concepts>`
-
-                Also, additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`. Examples of yaml configurations for Key pair and SSO authentication can be found in the **Additional Notes** section below.
 
                 .. code-block:: python
 
@@ -246,6 +241,9 @@ Steps
                           whole_table:
                             data_asset_name_suffix: __whole_table
                         """
+
+            **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+
 
         #. **Run context.test_yaml_config.**
 
@@ -274,21 +272,8 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-                    Choosing an example data reference...
-                        Reference chosen: {}
 
-                        Fetching batch data...
-                        [(50832,)]
-
-                Showing 5 rows
-               movieid                               title                                       genres
-                0        1                    Toy Story (1995)  Adventure|Animation|Children|Comedy|Fantasy
-                1        2                      Jumanji (1995)                   Adventure|Children|Fantasy
-                2        3             Grumpier Old Men (1995)                               Comedy|Romance
-                3        4            Waiting to Exhale (1995)                         Comedy|Drama|Romance
-                4        5  Father of the Bride Part II (1995)                                       Comedy
-
-            This means all has went well and you can proceed with exploring data with your new Snowflake datasource.
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
 
         #. **Save the config.**

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
@@ -273,7 +273,7 @@ Steps
                     Unmatched data_references (0 of 0): []
 
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
 
         #. **Save the config.**

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
@@ -114,13 +114,13 @@ Steps
             - Setup ``SPARK_HOME`` and ``JAVA_HOME`` variables for runtime environment.
             - :ref:`Set up a working deployment of Great Expectations. <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources. <reference__core_concepts__datasources>`
-            - Learned how to configure a :ref:`DataContext using test_yaml_config. <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+            - Learned how to configure a :ref:`Data Context using test_yaml_config. <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         To add a Pandas filesystem datasource, do the following:
 
-        #. **Instantiate a DataContext.**
+        #. **Instantiate a Data Context.**
 
-            Create a new Jupyter Notebook and instantiate a DataContext by running the following lines:
+            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
 
             .. code-block:: python
 
@@ -141,8 +141,6 @@ Steps
         #.  **Create or copy a yaml config.**
 
                 Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``Datasource``, with a ``InferredFilesystemDataConnector`` and ``SparkDFExecutionEngine``.
-
-                The config also defines ``TestAsset``, which has ``name``, ``timestamp`` and ``size`` as ``group_names``, which are informative fields of the filename that are extracted by the regex ``pattern``.
 
 
                 .. code-block:: python
@@ -165,7 +163,6 @@ Steps
 
                 **Note**: The ``InferredAssetFilesystemDataConnector`` used in this example is closely related to the ``ConfiguredAssetFilesystemDataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
 
-                **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure DataContext components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
         #. **Run context.test_yaml_config.**
 
@@ -196,19 +193,8 @@ Steps
 
                     Unmatched data_references (0 of 0): []
 
-                    Choosing an example data reference...
-                        Reference chosen: abe_20201119_200.csv
 
-                        Fetching batch data...
-
-                        Showing 5 rows
-                0  None                                           Name  PClass  Age     Sex  Survived  SexCode
-                1     1                   Allen, Miss Elisabeth Walton     1st   29  female         1        1
-                2     2                    Allison, Miss Helen Loraine     1st    2  female         0        1
-                3     3            Allison, Mr Hudson Joshua Creighton     1st   30    male         0        0
-                4     4  Allison, Mrs Hudson JC (Bessie Waldo Daniels)     1st   25  female         0        1
-
-            This means all has gone well and you can proceed with exploring data with your new filesystem-backed Pandas data source.
+            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
 
         #. **Save the config.**

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
@@ -194,7 +194,7 @@ Steps
                     Unmatched data_references (0 of 0): []
 
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
 
         #. **Save the config.**

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_an_emr_spark_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_an_emr_spark_datasource.rst
@@ -3,7 +3,7 @@
 How to configure an EMR Spark Datasource
 ========================================
 
-In most cases, using spark on EMR is easiest to configure using a dynamic DataContext configuration in your notebook. Please see the guide on :ref:`how to instantiate a Data Context on an EMR Spark Cluster for details! <how_to_instantiate_a_data_context_on_an_emr_spark_cluster>`.
+In most cases, using spark on EMR is easiest to configure using a dynamic Data Context configuration in your notebook. Please see the guide on :ref:`how to instantiate a Data Context on an EMR Spark Cluster for details! <how_to_instantiate_a_data_context_on_an_emr_spark_cluster>`.
 
 .. discourse::
     :topic_identifier: 172

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_an_inferredassetdataconnector.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_an_inferredassetdataconnector.rst
@@ -10,7 +10,7 @@ can use for configuration.
 
     - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
     - :ref:`Understand the basics of Datasources in 0.13 or later <reference__core_concepts__datasources>`
-    - Learned how to configure a :ref:`DataContext using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+    - Learned how to configure a :ref:`Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 Great Expectations provides two types of ``DataConnector`` classes for connecting to file-system-like data. This includes files on disk,
 but also S3 object stores, etc:
@@ -43,7 +43,7 @@ All of the examples below assume you’re testing configurations using something
     """)
 
 
-If you’re not familiar with the ``test_yaml_config`` method, please check out: :ref:`How to configure DataContext components using test_yaml_config. <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
+If you’re not familiar with the ``test_yaml_config`` method, please check out: :ref:`How to configure Data Context components using test_yaml_config. <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 Choose a DataConnector
 ----------------------
@@ -170,7 +170,7 @@ Then this configuration...
 
     Unmatched data_references (0 of 0): []
 
-Once configured, you can get ``Validators`` from the ``DataContext`` as follows:
+Once configured, you can get ``Validators`` from the ``Data Context`` as follows:
 
 .. code-block:: python
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed example output to match code changes
- Some general cleanup to match our style guide for spelling and conciseness of "how to" guides
- Added a v3 API guide for BigQuery!
