### PR TITLE
[ENHANCEMENT] CLI `init` command implemented for v3 api

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Develop
 * [ENHANCEMENT] CLI `docs build` command implemented for v3 api
 * [ENHANCEMENT] CLI `docs clean` command implemented for v3 api
 * [MAINTENANCE] Add testing for overwrite_existing in sanitize_yaml_and_save_datasource #2613
+* [ENHANCEMENT] CLI `init` command implemented for v3 api
 
 0.13.15
 -----------------

--- a/great_expectations/cli/cli_messages.py
+++ b/great_expectations/cli/cli_messages.py
@@ -9,9 +9,9 @@ GREETING = r"""<cyan>
              ~ Always know what to expect from your data ~
 </cyan>"""
 
-LETS_BEGIN_PROMPT = """Let's configure a new Data Context.
+LETS_BEGIN_PROMPT = """Let's create a new Data Context to hold your project configuration.
 
-First, Great Expectations will create a new directory:
+Great Expectations will create a new directory with the following structure:
 
     great_expectations
     |-- great_expectations.yml
@@ -60,8 +60,6 @@ Great Expectations added some missing files required to run.
   - You may need to add secrets to `<yellow>great_expectations/uncommitted/config_variables.yml</yellow>` to finish onboarding.
 """
 
-BUILD_DOCS_PROMPT = "Would you like to build & view this project's Data Docs!?"
-
 NO_DATASOURCES_FOUND = """<red>Error: No datasources were found.</red> Please add one by:
   - running `<green>great_expectations datasource new</green>` or
   - by editing the {} file
@@ -69,7 +67,23 @@ NO_DATASOURCES_FOUND = """<red>Error: No datasources were found.</red> Please ad
     DataContext.GE_YML
 )
 
-SETUP_SUCCESS = "\n<cyan>Congratulations! Great Expectations is now set up.</cyan>"
+READY_FOR_CUSTOMIZATION = """<cyan>Congratulations! You are now ready to customize your Great Expectations configuration.</cyan>"""
+
+HOW_TO_CUSTOMIZE = f"""\n<cyan>You can customize your configuration in many ways. Here are some examples:</cyan>
+
+  <cyan>Use the CLI to:</cyan>
+    - Run `<green>great_expectations datasource new</green>` to connect to your data
+    - Run `<green>great_expectations checkpoint new <checkpoint_name></green>` to bundle data with Expectation Suite(s) in a Checkpoint definition for later re-validation
+    - Create, edit, list, profile Expectation Suites
+    - Manage and customize Data Docs, Stores
+
+  <cyan>Edit your configuration in {DataContext.GE_YML} to:</cyan>
+    - Move Stores to the cloud
+    - Add Slack notifications, PagerDuty alerts, etc.
+    - Customize your Data Docs
+
+<cyan>Please see our documentation for more configuration options!</cyan>
+"""
 
 SECTION_SEPARATOR = "\n================================================================================\n"
 

--- a/great_expectations/cli/cli_messages.py
+++ b/great_expectations/cli/cli_messages.py
@@ -33,9 +33,8 @@ RUN_INIT_AGAIN = (
     "OK. You must run <green>great_expectations init</green> to fix the missing files!"
 )
 
-COMPLETE_ONBOARDING_PROMPT = """To run locally, we need some files that are not in source control.
-  - Anything existing will not be modified.
-  - Would you like to fix this automatically?"""
+COMPLETE_ONBOARDING_PROMPT = """
+It looks like you have a partially initialized Great Expectations project. Would you like to fix this automatically by adding the missing files (existing files will not be modified)?"""
 
 SLACK_SETUP_INTRO = """
 <cyan>========== Slack Notifications ==========</cyan>

--- a/great_expectations/cli/cli_messages.py
+++ b/great_expectations/cli/cli_messages.py
@@ -59,13 +59,6 @@ Great Expectations added some missing files required to run.
   - You may need to add secrets to `<yellow>great_expectations/uncommitted/config_variables.yml</yellow>` to finish onboarding.
 """
 
-NO_DATASOURCES_FOUND = """<red>Error: No datasources were found.</red> Please add one by:
-  - running `<green>great_expectations datasource new</green>` or
-  - by editing the {} file
-""".format(
-    DataContext.GE_YML
-)
-
 READY_FOR_CUSTOMIZATION = """<cyan>Congratulations! You are now ready to customize your Great Expectations configuration.</cyan>"""
 
 HOW_TO_CUSTOMIZE = f"""\n<cyan>You can customize your configuration in many ways. Here are some examples:</cyan>
@@ -85,5 +78,3 @@ HOW_TO_CUSTOMIZE = f"""\n<cyan>You can customize your configuration in many ways
 """
 
 SECTION_SEPARATOR = "\n================================================================================\n"
-
-DONE = "Done"

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -65,6 +65,10 @@ def init(ctx, usage_stats):
     cli_message(GREETING)
 
     if DataContext.does_config_exist_on_disk(ge_dir):
+        message = (
+            f"""Warning. An existing `{DataContext.GE_YML}` was found here: {ge_dir}."""
+        )
+        warnings.warn(message)
         try:
             project_filestructure_exists = (
                 DataContext.does_config_exist_on_disk(ge_dir)
@@ -72,9 +76,6 @@ def init(ctx, usage_stats):
                 and DataContext.config_variables_yml_exist(ge_dir)
             )
             if project_filestructure_exists:
-                # Ensure the context can be instantiated
-                message = f"""Warning. An existing `{DataContext.GE_YML}` was found here: {ge_dir}."""
-                warnings.warn(message)
                 cli_message(PROJECT_IS_COMPLETE)
                 sys.exit(0)
             else:

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -101,7 +101,6 @@ def init(ctx, usage_stats):
         if not ctx.obj.assume_yes:
             if not click.confirm(LETS_BEGIN_PROMPT, default=True):
                 cli_message(RUN_INIT_AGAIN)
-                # TODO ensure this is covered by a test
                 exit(0)
 
         try:

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -7,6 +7,7 @@ from great_expectations import DataContext
 from great_expectations import exceptions as ge_exceptions
 from great_expectations.cli import toolkit
 from great_expectations.cli.cli_messages import (
+    COMPLETE_ONBOARDING_PROMPT,
     GREETING,
     HOW_TO_CUSTOMIZE,
     LETS_BEGIN_PROMPT,
@@ -74,14 +75,19 @@ def init(ctx, view, usage_stats):
                 # Ensure the context can be instantiated
                 cli_message(PROJECT_IS_COMPLETE)
                 sys.exit(0)
+            else:
+                # Prompt to modify the project to add missing files
+                if not ctx.obj.assume_yes:
+                    if not click.confirm(COMPLETE_ONBOARDING_PROMPT, default=True):
+                        cli_message(RUN_INIT_AGAIN)
+                        exit(0)
+
         except (DataContextError, DatasourceInitializationError) as e:
             cli_message("<red>{}</red>".format(e.message))
             sys.exit(1)
 
         try:
-            context = DataContext.create(
-                target_directory, usage_statistics_enabled=usage_stats
-            )
+            DataContext.create(target_directory, usage_statistics_enabled=usage_stats)
             cli_message(ONBOARDING_COMPLETE)
             # TODO if this is correct, ensure this is covered by a test
             # cli_message(SETUP_SUCCESS)

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -40,18 +40,12 @@ except ImportError:
 
 @click.command()
 @click.option(
-    # Note this --no-view option is mostly here for tests
-    "--view/--no-view",
-    help="By default open in browser unless you specify the --no-view flag.",
-    default=True,
-)
-@click.option(
     "--usage-stats/--no-usage-stats",
     help="By default, usage statistics are enabled unless you specify the --no-usage-stats flag.",
     default=True,
 )
 @click.pass_context
-def init(ctx, view, usage_stats):
+def init(ctx, usage_stats):
     """
     Initialize a new Great Expectations project.
 

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -70,12 +70,12 @@ def init(ctx, usage_stats):
         )
         warnings.warn(message)
         try:
-            project_filestructure_exists = (
+            project_file_structure_exists = (
                 DataContext.does_config_exist_on_disk(ge_dir)
                 and DataContext.all_uncommitted_directories_exist(ge_dir)
                 and DataContext.config_variables_yml_exist(ge_dir)
             )
-            if project_filestructure_exists:
+            if project_file_structure_exists:
                 cli_message(PROJECT_IS_COMPLETE)
                 sys.exit(0)
             else:
@@ -92,9 +92,7 @@ def init(ctx, usage_stats):
         try:
             DataContext.create(target_directory, usage_statistics_enabled=usage_stats)
             cli_message(ONBOARDING_COMPLETE)
-            # TODO if this is correct, ensure this is covered by a test
-            # cli_message(SETUP_SUCCESS)
-            # exit(0)
+
         except DataContextError as e:
             cli_message("<red>{}</red>".format(e.message))
             # TODO ensure this is covered by a test

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 
 import click
 
@@ -71,8 +72,15 @@ def init(ctx, view, usage_stats):
 
     if DataContext.does_config_exist_on_disk(ge_dir):
         try:
-            if DataContext.is_project_initialized(ge_dir):
+            project_filestructure_exists = (
+                DataContext.does_config_exist_on_disk(ge_dir)
+                and DataContext.all_uncommitted_directories_exist(ge_dir)
+                and DataContext.config_variables_yml_exist(ge_dir)
+            )
+            if project_filestructure_exists:
                 # Ensure the context can be instantiated
+                message = f"""Warning. An existing `{DataContext.GE_YML}` was found here: {ge_dir}."""
+                warnings.warn(message)
                 cli_message(PROJECT_IS_COMPLETE)
                 sys.exit(0)
             else:

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -6,26 +6,22 @@ import click
 from great_expectations import DataContext
 from great_expectations import exceptions as ge_exceptions
 from great_expectations.cli import toolkit
-from great_expectations.cli.build_docs import build_docs
 from great_expectations.cli.cli_messages import (
-    BUILD_DOCS_PROMPT,
     GREETING,
+    HOW_TO_CUSTOMIZE,
     LETS_BEGIN_PROMPT,
     ONBOARDING_COMPLETE,
     PROJECT_IS_COMPLETE,
+    READY_FOR_CUSTOMIZATION,
     RUN_INIT_AGAIN,
     SECTION_SEPARATOR,
-    SETUP_SUCCESS,
     SLACK_LATER,
     SLACK_SETUP_COMPLETE,
     SLACK_SETUP_INTRO,
     SLACK_SETUP_PROMPT,
     SLACK_WEBHOOK_PROMPT,
 )
-from great_expectations.cli.pretty_printing import (
-    cli_message,
-    display_not_implemented_message_and_exit,
-)
+from great_expectations.cli.pretty_printing import cli_message
 from great_expectations.exceptions import (
     DataContextError,
     DatasourceInitializationError,
@@ -63,7 +59,6 @@ def init(ctx, view, usage_stats):
     It scaffolds directories, sets up notebooks, creates a project file, and
     appends to a `.gitignore` file.
     """
-    display_not_implemented_message_and_exit()
     directory = toolkit.parse_cli_config_file_location(
         config_file_location=ctx.obj.config_file_location
     ).get("directory")
@@ -78,6 +73,7 @@ def init(ctx, view, usage_stats):
             if DataContext.is_project_initialized(ge_dir):
                 # Ensure the context can be instantiated
                 cli_message(PROJECT_IS_COMPLETE)
+                sys.exit(0)
         except (DataContextError, DatasourceInitializationError) as e:
             cli_message("<red>{}</red>".format(e.message))
             sys.exit(1)
@@ -112,94 +108,10 @@ def init(ctx, view, usage_stats):
             # TODO ensure this is covered by a test
             cli_message("<red>{}</red>".format(e))
 
-    # Skip the rest of setup if --assume-yes flag is passed
-    if ctx.obj.assume_yes:
-        cli_message(SECTION_SEPARATOR)
-        cli_message(SETUP_SUCCESS)
-        sys.exit(0)
-
-    try:
-        # if expectations exist, offer to build docs
-        context = DataContext(ge_dir)
-        if context.list_expectation_suites():
-            if click.confirm(BUILD_DOCS_PROMPT, default=True):
-                build_docs(context, view=view)
-
-        else:
-            datasources = context.list_datasources()
-            if len(datasources) == 0:
-                cli_message(SECTION_SEPARATOR)
-                if not click.confirm(
-                    "Would you like to configure a Datasource?", default=True
-                ):
-                    cli_message("Okay, bye!")
-                    sys.exit(1)
-                datasource_name, data_source_type = add_datasource_impl(
-                    context, choose_one_data_asset=False
-                )
-                if not datasource_name:  # no datasource was created
-                    sys.exit(1)
-
-            datasources = context.list_datasources()
-            if len(datasources) == 1:
-                datasource_name = datasources[0]["name"]
-
-                cli_message(SECTION_SEPARATOR)
-                if not click.confirm(
-                    "Would you like to profile new Expectations for a single data asset within your new Datasource?",
-                    default=True,
-                ):
-                    cli_message(
-                        "Okay, exiting now. To learn more about Profilers, run great_expectations profile --help or visit docs.greatexpectations.io!"
-                    )
-                    sys.exit(1)
-
-                (
-                    success,
-                    suite_name,
-                    profiling_results,
-                ) = toolkit.create_expectation_suite(
-                    context,
-                    datasource_name=datasource_name,
-                    additional_batch_kwargs={"limit": 1000},
-                    flag_build_docs=False,
-                    open_docs=False,
-                )
-
-                cli_message(SECTION_SEPARATOR)
-                if not click.confirm(
-                    "Would you like to build Data Docs?", default=True
-                ):
-                    cli_message(
-                        "Okay, exiting now. To learn more about Data Docs, run great_expectations docs --help or visit docs.greatexpectations.io!"
-                    )
-                    sys.exit(1)
-
-                build_docs(context, view=False)
-
-                if not click.confirm(
-                    "\nWould you like to view your new Expectations in Data Docs? This will open a new browser window.",
-                    default=True,
-                ):
-                    cli_message(
-                        "Okay, exiting now. You can view the site that has been created in a browser, or visit docs.greatexpectations.io for more information!"
-                    )
-                    sys.exit(1)
-                toolkit.attempt_to_open_validation_results_in_data_docs(
-                    context, profiling_results
-                )
-
-                cli_message(SECTION_SEPARATOR)
-                cli_message(SETUP_SUCCESS)
-                sys.exit(0)
-    except (
-        DataContextError,
-        ge_exceptions.ProfilerError,
-        OSError,
-        SQLAlchemyError,
-    ) as e:
-        cli_message("<red>{}</red>".format(e))
-        sys.exit(1)
+    cli_message(SECTION_SEPARATOR)
+    cli_message(READY_FOR_CUSTOMIZATION)
+    cli_message(HOW_TO_CUSTOMIZE)
+    sys.exit(0)
 
 
 def _slack_setup(context):

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -34,10 +34,6 @@ def test_cli_init_on_new_project(
     project_dir_path = tmp_path / "test_cli_init_diff"
     project_dir_path.mkdir()
     project_dir = str(project_dir_path)
-    os.makedirs(os.path.join(project_dir, "data"))
-    data_path = os.path.join(project_dir, "data", "Titanic.csv")
-    fixture_path = file_relative_path(__file__, "../test_sets/Titanic.csv")
-    shutil.copy(fixture_path, data_path)
 
     runner = CliRunner(mix_stderr=False)
     monkeypatch.chdir(project_dir)
@@ -150,10 +146,6 @@ def test_cancelled_cli_init_on_new_project(
     project_dir_path = tmp_path / "test_cli_init_diff"
     project_dir_path.mkdir()
     project_dir = str(project_dir_path)
-    os.makedirs(os.path.join(project_dir, "data"))
-    data_path = os.path.join(project_dir, "data", "Titanic.csv")
-    fixture_path = file_relative_path(__file__, "../test_sets/Titanic.csv")
-    shutil.copy(fixture_path, data_path)
 
     runner = CliRunner(mix_stderr=False)
     monkeypatch.chdir(project_dir)
@@ -214,13 +206,6 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_then
     root_dir_path = tmp_path / "hiya"
     root_dir_path.mkdir()
     root_dir = str(root_dir_path)
-    data_folder_path = os.path.join(root_dir, "data")
-    os.makedirs(data_folder_path)
-    data_path = os.path.join(data_folder_path, "Titanic.csv")
-    fixture_path = file_relative_path(
-        __file__, os.path.join("..", "test_sets", "Titanic.csv")
-    )
-    shutil.copy(fixture_path, data_path)
 
     # Create a new project from scratch that we will use for the test in the next step
 
@@ -321,13 +306,6 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
     root_dir_path = tmp_path / "hiya"
     root_dir_path.mkdir()
     root_dir = str(root_dir_path)
-    data_folder_path = os.path.join(root_dir, "data")
-    os.makedirs(os.path.join(root_dir, "data"))
-    data_path: str = os.path.join(data_folder_path, "Titanic.csv")
-    fixture_path: str = file_relative_path(
-        __file__, os.path.join("..", "test_sets", "Titanic.csv")
-    )
-    shutil.copy(fixture_path, data_path)
 
     # Create a new project from scratch that we will use for the test in the next step
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 from unittest import mock
 
@@ -14,6 +13,112 @@ from great_expectations.data_context.util import file_relative_path
 from great_expectations.util import gen_directory_tree_str
 from tests.cli.test_cli import yaml
 from tests.cli.utils import assert_no_logging_messages_or_tracebacks
+
+
+@pytest.mark.xfail(
+    reason="This command is not yet implemented for the modern API",
+    run=True,
+    strict=True,
+)
+@freeze_time("09/26/2019 13:42:41")
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
+)
+def test_cli_init_on_new_project(
+    mock_emit, mock_webbrowser, caplog, tmp_path_factory, monkeypatch
+):
+    monkeypatch.delenv(
+        "GE_USAGE_STATS", raising=False
+    )  # Undo the project-wide test default
+    project_dir = str(tmp_path_factory.mktemp("test_cli_init_diff"))
+    os.makedirs(os.path.join(project_dir, "data"))
+    data_path = os.path.join(project_dir, "data", "Titanic.csv")
+    fixture_path = file_relative_path(__file__, "../test_sets/Titanic.csv")
+    shutil.copy(fixture_path, data_path)
+
+    runner = CliRunner(mix_stderr=False)
+    monkeypatch.chdir(project_dir)
+    result = runner.invoke(
+        cli,
+        ["--v3-api", "--assume-yes", "init"],
+        catch_exceptions=False,
+    )
+    stdout = result.output
+    assert mock_webbrowser.call_count == 0
+
+    assert len(stdout) < 6000, "CLI output is unreasonably long."
+    assert "Always know what to expect from your data" in stdout
+    assert "What data would you like Great Expectations to connect to" not in stdout
+    assert "What are you processing your files with" not in stdout
+    assert (
+        "Enter the path of a data file (relative or absolute, s3a:// and gs:// paths are ok too)"
+        not in stdout
+    )
+    assert "Name the new Expectation Suite [Titanic.warning]" not in stdout
+    assert (
+        "Great Expectations will choose a couple of columns and generate expectations about them"
+        not in stdout
+    )
+    assert "Generating example Expectation Suite..." not in stdout
+    assert "Building" not in stdout
+    assert "Data Docs" not in stdout
+    assert "Done generating example Expectation Suite" not in stdout
+    assert "Great Expectations is now set up" in stdout
+
+    assert os.path.isdir(os.path.join(project_dir, "great_expectations"))
+    config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
+    assert os.path.isfile(config_path)
+
+    config = yaml.load(open(config_path))
+    assert config["datasources"] == {}
+
+    obs_tree = gen_directory_tree_str(os.path.join(project_dir, "great_expectations"))
+
+    assert (
+        obs_tree
+        == """great_expectations/
+    .gitignore
+    great_expectations.yml
+    checkpoints/
+    expectations/
+        .ge_store_backend_id
+    notebooks/
+        pandas/
+            validation_playground.ipynb
+        spark/
+            validation_playground.ipynb
+        sql/
+            validation_playground.ipynb
+    plugins/
+        custom_data_docs/
+            renderers/
+            styles/
+                data_docs_custom_styles.css
+            views/
+    uncommitted/
+        config_variables.yml
+        data_docs/
+        validations/
+            .ge_store_backend_id
+"""
+    )
+
+    assert mock_emit.call_count == 2
+    assert mock_emit.call_args_list == [
+        mock.call(
+            {"event_payload": {}, "event": "data_context.__init__", "success": True}
+        ),
+        mock.call(
+            {
+                "event_payload": {"api_version": "v3"},
+                "event": "cli.init.create",
+                "success": True,
+            }
+        ),
+    ]
+
+    assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 @pytest.mark.xfail(

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -8,7 +8,6 @@ from click.testing import CliRunner, Result
 from great_expectations import DataContext
 from great_expectations.cli import cli
 from great_expectations.data_context.templates import CONFIG_VARIABLES_TEMPLATE
-from great_expectations.data_context.util import file_relative_path
 from great_expectations.util import gen_directory_tree_str
 from tests.cli.test_cli import yaml
 from tests.cli.utils import assert_no_logging_messages_or_tracebacks
@@ -48,11 +47,13 @@ def test_cli_init_on_new_project(
 
     assert len(stdout) < 6000, "CLI output is unreasonably long."
     assert "Always know what to expect from your data" in stdout
+    lets_create_data_context = (
+        "Let's create a new Data Context to hold your project configuration."
+    )
     if invocation == "--v3-api init":
-        assert (
-            "Let's create a new Data Context to hold your project configuration."
-            in stdout
-        )
+        assert lets_create_data_context in stdout
+    if invocation == "--v3-api --assume-yes init":
+        assert lets_create_data_context not in stdout
     assert (
         "Congratulations! You are now ready to customize your Great Expectations configuration."
         in stdout

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -199,7 +199,7 @@ def test_cancelled_cli_init_on_new_project(
 
 
 @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_yes_to_fixing_them(
+def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_then_yes_to_fixing_them(
     mock_webbrowser,
     caplog,
     monkeypatch,

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -20,12 +20,11 @@ from tests.cli.utils import assert_no_logging_messages_or_tracebacks
         ("--v3-api --assume-yes init", ""),
     ],
 )
-@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 def test_cli_init_on_new_project(
-    mock_emit, mock_webbrowser, invocation, input, caplog, tmp_path, monkeypatch
+    mock_emit, invocation, input, caplog, tmp_path, monkeypatch
 ):
     monkeypatch.delenv(
         "GE_USAGE_STATS", raising=False
@@ -43,7 +42,6 @@ def test_cli_init_on_new_project(
         catch_exceptions=False,
     )
     stdout = result.output
-    assert mock_webbrowser.call_count == 0
 
     assert len(stdout) < 6000, "CLI output is unreasonably long."
     assert "Always know what to expect from your data" in stdout
@@ -134,13 +132,10 @@ def test_cli_init_on_new_project(
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
-def test_cancelled_cli_init_on_new_project(
-    mock_emit, mock_webbrowser, caplog, tmp_path, monkeypatch
-):
+def test_cancelled_cli_init_on_new_project(mock_emit, caplog, tmp_path, monkeypatch):
     monkeypatch.delenv(
         "GE_USAGE_STATS", raising=False
     )  # Undo the project-wide test default
@@ -157,7 +152,6 @@ def test_cancelled_cli_init_on_new_project(
         catch_exceptions=False,
     )
     stdout = result.output
-    assert mock_webbrowser.call_count == 0
 
     assert len(stdout) < 6000, "CLI output is unreasonably long."
     assert "Always know what to expect from your data" in stdout
@@ -191,9 +185,7 @@ def test_cancelled_cli_init_on_new_project(
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_then_yes_to_fixing_them(
-    mock_webbrowser,
     caplog,
     monkeypatch,
     tmp_path,
@@ -220,7 +212,6 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_then
     )
     stdout = result.output
     assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 0
 
     assert (
         "Congratulations! You are now ready to customize your Great Expectations configuration."
@@ -244,7 +235,6 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_then
     stdout = result.stdout
 
     assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 0
     assert (
         "It looks like you have a partially initialized Great Expectations project. Would you like to fix this automatically by adding the missing files (existing files will not be modified)?"
         in stdout
@@ -275,7 +265,6 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_then
     stdout = result.stdout
 
     assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 0
     assert (
         "It looks like you have a partially initialized Great Expectations project. Would you like to fix this automatically by adding the missing files (existing files will not be modified)?"
         in stdout
@@ -297,9 +286,7 @@ def test_cli_init_on_existing_project_with_no_uncommitted_dirs_answering_no_then
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
-@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
-    mock_webbrowser,
     caplog,
     monkeypatch,
     tmp_path,
@@ -319,7 +306,6 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 0
 
     # Now the test begins - rerun the init on an existing project
 
@@ -335,7 +321,6 @@ def test_cli_init_on_complete_existing_project_all_uncommitted_dirs_exist(
             catch_exceptions=False,
         )
     stdout = result.stdout
-    assert mock_webbrowser.call_count == 0
 
     assert result.exit_code == 0
     assert "This looks like an existing project that" in stdout


### PR DESCRIPTION
Changes proposed in this pull request:
- Implement `great_expectations init` command for v3 (Batch Request) API
- Current functionality does not mirror the v2 `init` CLI but instead creates the project configuration folder structure and example files, eliminating the interactivity.
- Remove the `--view` option