### PR TITLE
[ENHANCEMENT] CLI `store list` command implemented for v3 api

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Develop
 * [MAINTENANCE] Add testing for overwrite_existing in sanitize_yaml_and_save_datasource #2613
 * [ENHANCEMENT] DataContext.clean_data_docs now raises helpful errors
 * [ENHANCEMENT] CLI `init` command implemented for v3 api
+* [ENHANCEMENT] CLI `store list` command implemented for v3 api
 
 0.13.15
 -----------------

--- a/great_expectations/cli/store.py
+++ b/great_expectations/cli/store.py
@@ -2,11 +2,7 @@ import click
 
 from great_expectations import DataContext
 from great_expectations.cli import toolkit
-from great_expectations.cli.pretty_printing import (
-    cli_message,
-    cli_message_dict,
-    display_not_implemented_message_and_exit,
-)
+from great_expectations.cli.pretty_printing import cli_message, cli_message_dict
 
 
 @click.group()
@@ -28,34 +24,13 @@ def store(ctx):
 @click.pass_context
 def store_list(ctx):
     """List known Stores."""
-    display_not_implemented_message_and_exit()
     context = ctx.obj.data_context
+    stores = context.list_stores()
+    cli_message(f"{len(stores)} Stores found:")
+    for store in stores:
+        cli_message("")
+        cli_message_dict(store)
 
-    try:
-        stores = context.list_stores()
-
-        if len(stores) == 0:
-            cli_message("No Stores found")
-            toolkit.send_usage_message(
-                data_context=context, event="cli.store.list", success=True
-            )
-            return
-        elif len(stores) == 1:
-            list_intro_string = "1 Store found:"
-        else:
-            list_intro_string = "{} Stores found:".format(len(stores))
-
-        cli_message(list_intro_string)
-
-        for store in stores:
-            cli_message("")
-            cli_message_dict(store)
-
-        toolkit.send_usage_message(
-            data_context=context, event="cli.store.list", success=True
-        )
-    except Exception as e:
-        toolkit.send_usage_message(
-            data_context=context, event="cli.store.list", success=False
-        )
-        raise e
+    toolkit.send_usage_message(
+        data_context=context, event="cli.store.list", success=True
+    )

--- a/tests/cli/test_store.py
+++ b/tests/cli/test_store.py
@@ -1,120 +1,48 @@
 import os
 
-import pytest
+import mock
 from click.testing import CliRunner
 
-from great_expectations import DataContext
 from great_expectations.cli import cli
 from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 
-def test_store_list_with_zero_stores(caplog, empty_data_context, monkeypatch):
-    project_dir = empty_data_context.root_directory
-    context = DataContext(project_dir)
-    context._project_config.stores = {}
-    context._save_project_config()
-    runner = CliRunner(mix_stderr=False)
-    monkeypatch.chdir(os.path.dirname(project_dir))
-    result = runner.invoke(
-        cli,
-        "--v3-api store list",
-        catch_exceptions=False,
-    )
-    assert result.exit_code == 1
-    assert (
-        "Your configuration file is not a valid yml file likely due to a yml syntax error"
-        in result.output.strip()
-    )
-
-    assert_no_logging_messages_or_tracebacks(caplog, result)
-
-
-@pytest.mark.xfail(
-    reason="This command is not yet implemented for the modern API",
-    run=True,
-    strict=True,
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
-def test_store_list_with_two_stores(caplog, empty_data_context, monkeypatch):
-    project_dir = empty_data_context.root_directory
-    context = DataContext(project_dir)
-    del context._project_config.stores["validations_store"]
-    del context._project_config.stores["evaluation_parameter_store"]
-    context._project_config.validations_store_name = "expectations_store"
-    context._project_config.evaluation_parameter_store_name = "expectations_store"
-    context._save_project_config()
-
+def test_store_list_stores(
+    mock_emit, caplog, empty_data_context_stats_enabled, monkeypatch
+):
+    project_dir = empty_data_context_stats_enabled.root_directory
     runner = CliRunner(mix_stderr=False)
     monkeypatch.chdir(os.path.dirname(project_dir))
-
-    expected_result = """\
-2 Stores found:[0m
-[0m
- - [36mname:[0m expectations_store[0m
-   [36mclass_name:[0m ExpectationsStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m expectations/[0m
-[0m
- - [36mname:[0m checkpoint_store[0m
-   [36mclass_name:[0m CheckpointStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m checkpoints/[0m
-     [36msuppress_store_backend_id:[0m True[0m"""
-
-    result = runner.invoke(
-        cli,
-        f"--v3-api store list",
-        catch_exceptions=False,
-    )
-
-    assert result.exit_code == 0
-    assert result.output.strip() == expected_result
-
-    assert_no_logging_messages_or_tracebacks(caplog, result)
-
-
-@pytest.mark.xfail(
-    reason="This command is not yet implemented for the modern API",
-    run=True,
-    strict=True,
-)
-def test_store_list_with_four_stores(caplog, empty_data_context, monkeypatch):
-    project_dir = empty_data_context.root_directory
-    runner = CliRunner(mix_stderr=False)
-    monkeypatch.chdir(os.path.dirname(project_dir))
-
-    expected_result = """\
-4 Stores found:[0m
-[0m
- - [36mname:[0m expectations_store[0m
-   [36mclass_name:[0m ExpectationsStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m expectations/[0m
-[0m
- - [36mname:[0m validations_store[0m
-   [36mclass_name:[0m ValidationsStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m uncommitted/validations/[0m
-[0m
- - [36mname:[0m evaluation_parameter_store[0m
-   [36mclass_name:[0m EvaluationParameterStore[0m
-[0m
- - [36mname:[0m checkpoint_store[0m
-   [36mclass_name:[0m CheckpointStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m checkpoints/[0m
-     [36msuppress_store_backend_id:[0m True[0m"""
-
     result = runner.invoke(
         cli,
         f"--v3-api store list",
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert result.output.strip() == expected_result
+    for expected_output in [
+        "4 Stores found",
+        "expectations_store",
+        "validations_store",
+        "evaluation_parameter_store",
+        "checkpoint_store",
+    ]:
+        assert expected_output in result.output
+
+    assert mock_emit.call_count == 2
+    assert mock_emit.call_args_list == [
+        mock.call(
+            {"event_payload": {}, "event": "data_context.__init__", "success": True}
+        ),
+        mock.call(
+            {
+                "event": "cli.store.list",
+                "event_payload": {"api_version": "v3"},
+                "success": True,
+            }
+        ),
+    ]
 
     assert_no_logging_messages_or_tracebacks(caplog, result)


### PR DESCRIPTION
* [ENHANCEMENT] CLI `store list` command implemented for v3 api

* Note this PR removed tests that were testing artificial and invalid situations and the resulting code:
    - One that tested a DataContext with 2 stores (redundant)
    - one that tested a DataContext with no stores (invalid)
