### PR TITLE
[ENHANCEMENT] Make naming of `assets` in SqlDataConnectors consistent with other DataConnectors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ develop
 * [ENHANCEMENT] DataContext.clean_data_docs now raises helpful errors
 * [ENHANCEMENT] CLI `init` command implemented for v3 api
 * [ENHANCEMENT] CLI `store list` command implemented for v3 api
+* [ENHANCEMENT] Make naming of assets in SqlDataConnectors consistent with other DataConnectors
 * [BUGFIX] Fixed issue where Sorters were not being applied correctly when ``data_connector_query`` contained limit or index  #2617
 * [MAINTENANCE] Add testing for overwrite_existing in sanitize_yaml_and_save_datasource #2613
 

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -1,10 +1,7 @@
 from typing import Dict, List, Optional
 
 from great_expectations.core import IDDict
-from great_expectations.core.batch import (
-    BatchDefinition,
-    BatchRequest,
-)
+from great_expectations.core.batch import BatchDefinition, BatchRequest
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.datasource.data_connector.data_connector import DataConnector
 from great_expectations.datasource.data_connector.util import (
@@ -154,7 +151,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
                 data_connector_name=self.name,
                 data_asset_name=batch_request.data_asset_name,
                 batch_identifiers=IDDict(batch_identifiers),
-                batch_spec_passthrough=batch_request.batch_spec_passthrough
+                batch_spec_passthrough=batch_request.batch_spec_passthrough,
             )
             if batch_definition_matches_batch_request(batch_definition, batch_request):
                 batch_definition_list.append(batch_definition)
@@ -203,9 +200,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
                 self.assets[data_asset_name].get("batch_spec_passthrough"), dict
             )
         ):
-            batch_spec.update(
-                self.assets[data_asset_name]["batch_spec_passthrough"]
-            )
+            batch_spec.update(self.assets[data_asset_name]["batch_spec_passthrough"])
 
         return SqlAlchemyDatasourceBatchSpec(batch_spec)
 

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -1,10 +1,11 @@
 from typing import Dict, List, Optional
 
+from great_expectations.core import IDDict
 from great_expectations.core.batch import (
     BatchDefinition,
     BatchRequest,
-    PartitionDefinition,
 )
+from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.datasource.data_connector.data_connector import DataConnector
 from great_expectations.datasource.data_connector.util import (
     batch_definition_matches_batch_request,
@@ -82,12 +83,12 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             column_names = self._get_column_names_from_splitter_kwargs(
                 data_asset_config["splitter_kwargs"]
             )
-            partition_definition_list = [dict(zip(column_names, row)) for row in rows]
+            batch_identifiers_list = [dict(zip(column_names, row)) for row in rows]
 
         else:
-            partition_definition_list = [{}]
+            batch_identifiers_list = [{}]
 
-        return partition_definition_list
+        return batch_identifiers_list
 
     def _refresh_data_references_cache(self):
         self._data_references_cache = {}
@@ -100,9 +101,9 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
                 )
             )
 
-            # TODO Abe 20201029 : Apply sorters to partition_definition_list here
+            # TODO Abe 20201029 : Apply sorters to batch_identifiers_list here
             # TODO Will 20201102 : add sorting code here
-            self._data_references_cache[data_asset_name] = partition_definition_list
+            self._data_references_cache[data_asset_name] = batch_identifiers_list
 
     def _get_column_names_from_splitter_kwargs(self, splitter_kwargs) -> List[str]:
         column_names: List[str] = []
@@ -147,12 +148,13 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
                 f"data_asset_name {batch_request.data_asset_name} is not recognized."
             )
 
-        for partition_definition in sub_cache:
+        for batch_identifiers in sub_cache:
             batch_definition: BatchDefinition = BatchDefinition(
                 datasource_name=self.datasource_name,
                 data_connector_name=self.name,
                 data_asset_name=batch_request.data_asset_name,
-                partition_definition=PartitionDefinition(partition_definition),
+                batch_identifiers=IDDict(batch_identifiers),
+                batch_spec_passthrough=batch_request.batch_spec_passthrough
             )
             if batch_definition_matches_batch_request(batch_definition, batch_request):
                 batch_definition_list.append(batch_definition)
@@ -173,7 +175,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
                 datasource_name=self.datasource_name,
                 data_connector_name=self.name,
                 data_asset_name=data_asset_name,
-                partition_definition=PartitionDefinition(data_reference),
+                batch_identifiers=IDDict(data_reference),
             )
         ]
 
@@ -213,7 +215,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         """
         Build BatchSpec parameters from batch_definition with the following components:
             1. data_asset_name from batch_definition
-            2. partition_definition from batch_definition
+            2. batch_identifiers from batch_definition
             3. data_asset from data_connector
 
         Args:

--- a/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
@@ -168,9 +168,9 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
             if not sampling_kwargs is None:
                 data_asset_config["sampling_kwargs"] = sampling_kwargs
 
-            # Attempt to fetch a list of partition_definitions from the table
+            # Attempt to fetch a list of batch_identifiers from the table
             try:
-                self._get_partition_definition_list_from_data_asset_config(
+                self._get_batch_identifiers_list_from_data_asset_config(
                     data_asset_name,
                     data_asset_config,
                 )

--- a/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
@@ -71,14 +71,14 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
             name=name,
             datasource_name=datasource_name,
             execution_engine=execution_engine,
-            data_assets=None,
+            assets=None,
         )
 
         # This cache will contain a "config" for each data_asset discovered via introspection.
-        # This approach ensures that ConfiguredAssetSqlDataConnector._data_assets and _introspected_data_assets_cache store objects of the same "type"
+        # This approach ensures that ConfiguredAssetSqlDataConnector._assets and _introspected_assets_cache store objects of the same "type"
         # Note: We should probably turn them into AssetConfig objects
-        self._introspected_data_assets_cache = {}
-        self._refresh_introspected_data_assets_cache(
+        self._introspected_assets_cache = {}
+        self._refresh_introspected_assets_cache(
             self._data_asset_name_prefix,
             self._data_asset_name_suffix,
             self._include_schema_name,
@@ -92,11 +92,11 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
         )
 
     @property
-    def data_assets(self) -> Dict[str, Asset]:
-        return self._introspected_data_assets_cache
+    def assets(self) -> Dict[str, Asset]:
+        return self._introspected_assets_cache
 
     def _refresh_data_references_cache(self):
-        self._refresh_introspected_data_assets_cache(
+        self._refresh_introspected_assets_cache(
             self._data_asset_name_prefix,
             self._data_asset_name_suffix,
             self._include_schema_name,
@@ -111,7 +111,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
 
         super()._refresh_data_references_cache()
 
-    def _refresh_introspected_data_assets_cache(
+    def _refresh_introspected_assets_cache(
         self,
         data_asset_name_prefix: str = None,
         data_asset_name_suffix: str = None,
@@ -168,16 +168,16 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
             if not sampling_kwargs is None:
                 data_asset_config["sampling_kwargs"] = sampling_kwargs
 
-            # Attempt to fetch a list of batch_identifiers from the table
+            # Attempt to fetch a list of partition_definitions from the table
             try:
-                self._get_batch_identifiers_list_from_data_asset_config(
+                self._get_partition_definition_list_from_data_asset_config(
                     data_asset_name,
                     data_asset_config,
                 )
             except OperationalError as e:
                 # If it doesn't work, then...
                 if skip_inapplicable_tables:
-                    # No harm done. Just don't include this table in the list of data_assets.
+                    # No harm done. Just don't include this table in the list of assets.
                     continue
 
                 else:
@@ -187,7 +187,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
                     ) from e
 
             # Store an asset config for each introspected data asset.
-            self._introspected_data_assets_cache[data_asset_name] = data_asset_config
+            self._introspected_assets_cache[data_asset_name] = data_asset_config
 
     def _introspect_db(
         self,

--- a/great_expectations/datasource/simple_sqlalchemy_datasource.py
+++ b/great_expectations/datasource/simple_sqlalchemy_datasource.py
@@ -76,7 +76,7 @@ class SimpleSqlalchemyDatasource(BaseDatasource):
                 if data_connector_name not in self.data_connectors:
                     data_connector_config = {
                         "class_name": "ConfiguredAssetSqlDataConnector",
-                        "data_assets": {},
+                        "assets": {},
                     }
                     self._build_data_connector_from_config(
                         data_connector_name, data_connector_config

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -6,6 +6,7 @@ from ruamel.yaml import YAML
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import BatchRequest, BatchSpec
+from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
 from great_expectations.validator.validator import Validator
 
@@ -96,7 +97,9 @@ def test_get_batch_definition_list_from_batch_request(
                 datasource_name="FAKE_Datasource_NAME",
                 data_connector_name="my_sql_data_connector",
                 data_asset_name="table_partitioned_by_date_column__A",
-                partition_request={"batch_identifiers": {"date": "2020-01-01"}},
+                data_connector_query={
+                    "batch_filter_parameters": {"date": "2020-01-01"}
+                },
             )
         )
     )
@@ -108,7 +111,7 @@ def test_get_batch_definition_list_from_batch_request(
                 datasource_name="FAKE_Datasource_NAME",
                 data_connector_name="my_sql_data_connector",
                 data_asset_name="table_partitioned_by_date_column__A",
-                partition_request={"batch_identifiers": {}},
+                data_connector_query={"batch_filter_parameters": {}},
             )
         )
     )
@@ -124,8 +127,8 @@ def test_get_batch_definition_list_from_batch_request(
     #             datasource_name="FAKE_Datasource_NAME",
     #             data_connector_name="my_sql_data_connector",
     #             data_asset_name="table_partitioned_by_date_column__A",
-    #             partition_request={
-    #                 "batch_identifiers": {},
+    #             data_connector_query={
+    #                 "batch_filter_parameters": {},
     #                 "date" : "2020-01-01",
     #             }
     #         )
@@ -210,7 +213,7 @@ def test_example_A(test_cases_for_sql_data_connector_sqlite_execution_engine):
         #     "batch_spec": {
         #         "table_name": "table_partitioned_by_date_column__A",
         #         "data_asset_name": "table_partitioned_by_date_column__A",
-        #         "partition_definition": {"date": "2020-01-02"},
+        #         "batch_identifiers": {"date": "2020-01-02"},
         #         "splitter_method": "_split_on_column_value",
         #         "splitter_kwargs": {"column_name": "date"},
         #     },
@@ -263,7 +266,7 @@ def test_example_B(test_cases_for_sql_data_connector_sqlite_execution_engine):
         #     "batch_spec": {
         #         "table_name": "table_partitioned_by_timestamp_column__B",
         #         "data_asset_name": "table_partitioned_by_timestamp_column__B",
-        #         "partition_definition": {"timestamp": "2020-01-02"},
+        #         "batch_identifiers": {"timestamp": "2020-01-02"},
         #         "splitter_method": "_split_on_converted_datetime",
         #         "splitter_kwargs": {"column_name": "timestamp"},
         #     },
@@ -319,7 +322,7 @@ def test_example_C(test_cases_for_sql_data_connector_sqlite_execution_engine):
         #     "batch_spec": {
         #         "table_name": "table_partitioned_by_regularly_spaced_incrementing_id_column__C",
         #         "data_asset_name": "table_partitioned_by_regularly_spaced_incrementing_id_column__C",
-        #         "partition_definition": {"id": 1},
+        #         "batch_identifiers": {"id": 1},
         #         "splitter_method": "_split_on_divided_integer",
         #         "splitter_kwargs": {"column_name": "id", "divisor": 10},
         #     },
@@ -372,7 +375,7 @@ def test_example_E(test_cases_for_sql_data_connector_sqlite_execution_engine):
         #     "batch_spec": {
         #         "table_name": "table_partitioned_by_incrementing_batch_id__E",
         #         "data_asset_name": "table_partitioned_by_incrementing_batch_id__E",
-        #         "partition_definition": {"batch_id": 1},
+        #         "batch_identifiers": {"batch_id": 1},
         #         "splitter_method": "_split_on_column_value",
         #         "splitter_kwargs": {"column_name": "batch_id"},
         #     },
@@ -426,7 +429,7 @@ def test_example_F(test_cases_for_sql_data_connector_sqlite_execution_engine):
         #     "batch_spec": {
         #         "table_name": "table_partitioned_by_foreign_key__F",
         #         "data_asset_name": "table_partitioned_by_foreign_key__F",
-        #         "partition_definition": {"session_id": 2},
+        #         "batch_identifiers": {"session_id": 2},
         #         "splitter_method": "_split_on_column_value",
         #         "splitter_kwargs": {"column_name": "session_id"},
         #     },
@@ -483,7 +486,7 @@ def test_example_G(test_cases_for_sql_data_connector_sqlite_execution_engine):
         #     "batch_spec": {
         #         "table_name": "table_partitioned_by_multiple_columns__G",
         #         "data_asset_name": "table_partitioned_by_multiple_columns__G",
-        #         "partition_definition": {
+        #         "batch_identifiers": {
         #             "y": 2020,
         #             "m": 1,
         #             "d": 2,
@@ -554,10 +557,10 @@ def test_sampling_method__limit(
     execution_engine = test_cases_for_sql_data_connector_sqlite_execution_engine
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-        batch_spec=BatchSpec(
+        batch_spec=SqlAlchemyDatasourceBatchSpec(
             {
                 "table_name": "table_partitioned_by_date_column__A",
-                "partition_definition": {},
+                "batch_identifiers": {},
                 "splitter_method": "_split_on_whole_table",
                 "splitter_kwargs": {},
                 "sampling_method": "_sample_using_limit",
@@ -583,10 +586,10 @@ def test_sampling_method__random(
     execution_engine = test_cases_for_sql_data_connector_sqlite_execution_engine
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-        batch_spec=BatchSpec(
+        batch_spec=SqlAlchemyDatasourceBatchSpec(
             {
                 "table_name": "table_partitioned_by_date_column__A",
-                "partition_definition": {},
+                "batch_identifiers": {},
                 "splitter_method": "_split_on_whole_table",
                 "splitter_kwargs": {},
                 "sampling_method": "_sample_using_random",
@@ -606,10 +609,10 @@ def test_sampling_method__mod(
     execution_engine = test_cases_for_sql_data_connector_sqlite_execution_engine
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-        batch_spec=BatchSpec(
+        batch_spec=SqlAlchemyDatasourceBatchSpec(
             {
                 "table_name": "table_partitioned_by_date_column__A",
-                "partition_definition": {},
+                "batch_identifiers": {},
                 "splitter_method": "_split_on_whole_table",
                 "splitter_kwargs": {},
                 "sampling_method": "_sample_using_mod",
@@ -632,10 +635,10 @@ def test_sampling_method__a_list(
     execution_engine = test_cases_for_sql_data_connector_sqlite_execution_engine
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-        batch_spec=BatchSpec(
+        batch_spec=SqlAlchemyDatasourceBatchSpec(
             {
                 "table_name": "table_partitioned_by_date_column__A",
-                "partition_definition": {},
+                "batch_identifiers": {},
                 "splitter_method": "_split_on_whole_table",
                 "splitter_kwargs": {},
                 "sampling_method": "_sample_using_a_list",
@@ -658,7 +661,7 @@ def test_sampling_method__md5(
 
     # SQlite doesn't support MD5
     # batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-    #     batch_spec=BatchSpec({
+    #     batch_spec=SqlAlchemyDatasourceBatchSpec({
     #         "table_name": "table_partitioned_by_date_column__A",
     #         "partition_definition": {},
     #         "splitter_method": "_split_on_whole_table",
@@ -677,10 +680,10 @@ def test_to_make_sure_splitter_and_sampler_methods_are_optional(
     execution_engine = test_cases_for_sql_data_connector_sqlite_execution_engine
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-        batch_spec=BatchSpec(
+        batch_spec=SqlAlchemyDatasourceBatchSpec(
             {
                 "table_name": "table_partitioned_by_date_column__A",
-                "partition_definition": {},
+                "batch_identifiers": {},
                 "sampling_method": "_sample_using_mod",
                 "sampling_kwargs": {
                     "column_name": "id",
@@ -695,10 +698,10 @@ def test_to_make_sure_splitter_and_sampler_methods_are_optional(
     assert len(validator.head(fetch_all=True)) == 12
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-        batch_spec=BatchSpec(
+        batch_spec=SqlAlchemyDatasourceBatchSpec(
             {
                 "table_name": "table_partitioned_by_date_column__A",
-                "partition_definition": {},
+                "batch_identifiers": {},
             }
         )
     )
@@ -707,10 +710,10 @@ def test_to_make_sure_splitter_and_sampler_methods_are_optional(
     assert len(validator.head(fetch_all=True)) == 120
 
     batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
-        batch_spec=BatchSpec(
+        batch_spec=SqlAlchemyDatasourceBatchSpec(
             {
                 "table_name": "table_partitioned_by_date_column__A",
-                "partition_definition": {},
+                "batch_identifiers": {},
                 "splitter_method": "_split_on_whole_table",
                 "splitter_kwargs": {},
             }
@@ -752,7 +755,7 @@ def test_default_behavior_with_no_splitter(
         )
     )
     assert len(batch_definition_list) == 1
-    assert batch_definition_list[0]["partition_definition"] == {}
+    assert batch_definition_list[0]["batch_identifiers"] == {}
 
     batch_definition_list = (
         my_data_connector.get_batch_definition_list_from_batch_request(
@@ -760,12 +763,12 @@ def test_default_behavior_with_no_splitter(
                 datasource_name="FAKE_Datasource_NAME",
                 data_connector_name="my_sql_data_connector",
                 data_asset_name="table_partitioned_by_date_column__A",
-                partition_request={},
+                data_connector_query={},
             )
         )
     )
     assert len(batch_definition_list) == 1
-    assert batch_definition_list[0]["partition_definition"] == {}
+    assert batch_definition_list[0]["batch_identifiers"] == {}
 
     batch_definition_list = (
         my_data_connector.get_batch_definition_list_from_batch_request(
@@ -773,12 +776,12 @@ def test_default_behavior_with_no_splitter(
                 datasource_name="FAKE_Datasource_NAME",
                 data_connector_name="my_sql_data_connector",
                 data_asset_name="table_partitioned_by_date_column__A",
-                partition_request={"batch_identifiers": {}},
+                data_connector_query={"batch_filter_parameters": {}},
             )
         )
     )
     assert len(batch_definition_list) == 1
-    assert batch_definition_list[0]["partition_definition"] == {}
+    assert batch_definition_list[0]["batch_identifiers"] == {}
 
 
 def test_behavior_with_whole_table_splitter(
@@ -813,7 +816,7 @@ def test_behavior_with_whole_table_splitter(
         )
     )
     assert len(batch_definition_list) == 1
-    assert batch_definition_list[0]["partition_definition"] == {}
+    assert batch_definition_list[0]["batch_identifiers"] == {}
 
     batch_definition_list = (
         my_data_connector.get_batch_definition_list_from_batch_request(
@@ -821,12 +824,12 @@ def test_behavior_with_whole_table_splitter(
                 datasource_name="FAKE_Datasource_NAME",
                 data_connector_name="my_sql_data_connector",
                 data_asset_name="table_partitioned_by_date_column__A",
-                partition_request={},
+                data_connector_query={},
             )
         )
     )
     assert len(batch_definition_list) == 1
-    assert batch_definition_list[0]["partition_definition"] == {}
+    assert batch_definition_list[0]["batch_identifiers"] == {}
 
     batch_definition_list = (
         my_data_connector.get_batch_definition_list_from_batch_request(
@@ -834,9 +837,9 @@ def test_behavior_with_whole_table_splitter(
                 datasource_name="FAKE_Datasource_NAME",
                 data_connector_name="my_sql_data_connector",
                 data_asset_name="table_partitioned_by_date_column__A",
-                partition_request={"batch_identifiers": {}},
+                data_connector_query={"batch_filter_parameters": {}},
             )
         )
     )
     assert len(batch_definition_list) == 1
-    assert batch_definition_list[0]["partition_definition"] == {}
+    assert batch_definition_list[0]["batch_identifiers"] == {}

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -10,6 +10,11 @@ from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
 from great_expectations.validator.validator import Validator
 
+try:
+    sqlalchemy = pytest.importorskip("sqlalchemy")
+except ImportError:
+    sqlalchemy = None
+
 yaml = YAML()
 
 
@@ -663,7 +668,7 @@ def test_sampling_method__md5(
     # batch_data, batch_markers = execution_engine.get_batch_data_and_markers(
     #     batch_spec=SqlAlchemyDatasourceBatchSpec({
     #         "table_name": "table_partitioned_by_date_column__A",
-    #         "partition_definition": {},
+    #         "batch_identifiers": {},
     #         "splitter_method": "_split_on_whole_table",
     #         "splitter_kwargs": {},
     #         "sampling_method": "_sample_using_md5",

--- a/tests/datasource/test_new_datasource_with_sql_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_sql_data_connector.py
@@ -42,7 +42,7 @@ data_connectors:
     my_sqlite_db:
         class_name: ConfiguredAssetSqlDataConnector
 
-        data_assets:
+        assets:
 
             table_partitioned_by_date_column__A:
                 splitter_method: _split_on_converted_datetime


### PR DESCRIPTION
Changes proposed in this pull request:
- Make naming of `assets` in SqlDataConnectors consistent with other DataConnectors (`self._data_asset` --> `self._asset`)
- This will allow for a more consistent configuration for UAT, and enable sorting in Sql in a subsequent PR