### PR TITLE
[ENHANCEMENT] Temporarily show informative error message when GE is initialized with SqlAlchemy > 1.4.0  

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,23 +115,21 @@ stages:
 
           - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
-        # TODO : ensure compatibility with sqlalchemy > 1.4.0 to remove this line
-          - script: y | pip uninstall sqlalchemy
-            displayName: 'Uninstalling sqlalchemy for non-sqlalchemy tests'
           - bash: pip install  pandas
             condition: eq(variables['pandas.version'], 'latest')
             displayName: 'Install pandas latest'
-
           - bash: pip install  pandas==$(pandas.version)
             condition: ne(variables['pandas.version'], 'latest')
             displayName: 'Install pandas - $(pandas.version)'
-
           - script: |
               pip install  $(GE_pytest_pip_opts)
               pip install  --requirement requirements.txt
               # Consider fragmenting *all* integration tests into separate folder and run
               pip install  .
             displayName: 'Install dependencies'
+          # TODO : ensure compatibility with sqlalchemy > 1.4.0 to remove this line
+          - script: y | pip uninstall sqlalchemy
+            displayName: 'Uninstalling sqlalchemy for non-sqlalchemy tests'
 
           - script: |
               pip install  pytest pytest-cov pytest-azurepipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ stages:
           - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
         # TODO : ensure compatibility with sqlalchemy > 1.4.0 to remove this line
-          - script: yes | pip uninstall sqlalchemy
+          - script: y | pip uninstall sqlalchemy
             displayName: 'Uninstalling sqlalchemy for non-sqlalchemy tests'
           - bash: pip install  pandas
             condition: eq(variables['pandas.version'], 'latest')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,6 +116,11 @@ stages:
           - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
+          - script: |
+              pip uninstall sqlalchemy
+              y
+            display: 'Uninstalling sqlalchemy for non-sqlalchemy tests`
+            
           - bash: pip install  pandas
             condition: eq(variables['pandas.version'], 'latest')
             displayName: 'Install pandas latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ stages:
               # Consider fragmenting *all* integration tests into separate folder and run
               pip install  .
             displayName: 'Install dependencies'
-            
+
           - script: |
               pip install  pytest pytest-cov pytest-azurepipelines
               pytest $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,10 +127,6 @@ stages:
               # Consider fragmenting *all* integration tests into separate folder and run
               pip install  .
             displayName: 'Install dependencies'
-          # TODO : ensure compatibility with sqlalchemy > 1.4.0 to remove this line
-          - script: y | pip uninstall sqlalchemy
-            displayName: 'Uninstalling sqlalchemy for non-sqlalchemy tests'
-
           - script: |
               pip install  pytest pytest-cov pytest-azurepipelines
               pytest $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,18 +115,22 @@ stages:
 
           - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
+
           - bash: pip install  pandas
             condition: eq(variables['pandas.version'], 'latest')
             displayName: 'Install pandas latest'
+
           - bash: pip install  pandas==$(pandas.version)
             condition: ne(variables['pandas.version'], 'latest')
             displayName: 'Install pandas - $(pandas.version)'
+
           - script: |
               pip install  $(GE_pytest_pip_opts)
               pip install  --requirement requirements.txt
               # Consider fragmenting *all* integration tests into separate folder and run
               pip install  .
             displayName: 'Install dependencies'
+            
           - script: |
               pip install  pytest pytest-cov pytest-azurepipelines
               pytest $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,12 +115,9 @@ stages:
 
           - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
-
-          - script: |
-              pip uninstall sqlalchemy
-              y
-            display: 'Uninstalling sqlalchemy for non-sqlalchemy tests`
-            
+        # TODO : ensure compatibility with sqlalchemy > 1.4.0 to remove this line
+          - script: yes | pip uninstall sqlalchemy
+            displayName: 'Uninstalling sqlalchemy for non-sqlalchemy tests'
           - bash: pip install  pandas
             condition: eq(variables['pandas.version'], 'latest')
             displayName: 'Install pandas latest'

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -14,6 +14,7 @@ from great_expectations.exceptions.exceptions import GreatExpectationsError
 
 try:
     import sqlalchemy as sa
+
     if parse_version(sa.__version__) >= parse_version("1.4.0"):
         raise GreatExpectationsError(
             f"""

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -14,13 +14,12 @@ from great_expectations.exceptions.exceptions import GreatExpectationsError
 
 try:
     import sqlalchemy as sa
-
     if parse_version(sa.__version__) >= parse_version("1.4.0"):
         raise GreatExpectationsError(
             f"""
 
         Great Expectations version {__version__} is currently incompatible with SqlAlchemy 1.4.0 and higher.
-        You have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy to < 1.4.0 while we work on a proper fix.
+        You currently have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy to < 1.4.0 while we work on a proper fix.
         """
         )
 except ImportError:

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -4,6 +4,25 @@ from ._version import get_versions  # isort:skip
 __version__ = get_versions()["version"]  # isort:skip
 del get_versions  # isort:skip
 
+
+# 20210401 Will - Temporary fix to warn users against current incompatibility with Sqlalchemy 1.4.0
+# To be removed once a better fix is implemented
+
+import sys
+from great_expectations.exceptions.exceptions import GreatExpectationsError
+try:
+    import sqlalchemy as sa
+    sa_version = tuple(map(int, (sa.__version__.split("."))))
+    if sa_version >= (1, 4, 0):
+        raise GreatExpectationsError(f"""
+        
+        Great Expectations version {__version__} is currently incompatible with SqlAlchemy 1.4.0 and higher. 
+        You currently have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy < 1.4.0 while we work on a proper fix. 
+        Thank you - GE Core Team
+        """)
+except ImportError:
+    pass
+
 from great_expectations.data_context import DataContext
 
 from .util import (

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -9,15 +9,20 @@ del get_versions  # isort:skip
 # To be removed once a better fix is implemented
 
 from packaging.version import parse as parse_version
+
 from great_expectations.exceptions.exceptions import GreatExpectationsError
+
 try:
     import sqlalchemy as sa
+
     if parse_version(sa.__version__) >= parse_version("1.4.0"):
-        raise GreatExpectationsError(f"""
+        raise GreatExpectationsError(
+            f"""
 
         Great Expectations version {__version__} is currently incompatible with SqlAlchemy 1.4.0 and higher.
         You have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy to < 1.4.0 while we work on a proper fix.
-        """)
+        """
+        )
 except ImportError:
     pass
 

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -18,7 +18,6 @@ try:
         
         Great Expectations version {__version__} is currently incompatible with SqlAlchemy 1.4.0 and higher. 
         You currently have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy < 1.4.0 while we work on a proper fix. 
-        Thank you - GE Core Team
         """)
 except ImportError:
     pass

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -23,7 +23,7 @@ try:
         You currently have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy to < 1.4.0 while we work on a proper fix.
         """
         )
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     pass
 
 from great_expectations.data_context import DataContext

--- a/great_expectations/__init__.py
+++ b/great_expectations/__init__.py
@@ -8,16 +8,15 @@ del get_versions  # isort:skip
 # 20210401 Will - Temporary fix to warn users against current incompatibility with Sqlalchemy 1.4.0
 # To be removed once a better fix is implemented
 
-import sys
+from packaging.version import parse as parse_version
 from great_expectations.exceptions.exceptions import GreatExpectationsError
 try:
     import sqlalchemy as sa
-    sa_version = tuple(map(int, (sa.__version__.split("."))))
-    if sa_version >= (1, 4, 0):
+    if parse_version(sa.__version__) >= parse_version("1.4.0"):
         raise GreatExpectationsError(f"""
-        
-        Great Expectations version {__version__} is currently incompatible with SqlAlchemy 1.4.0 and higher. 
-        You currently have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy < 1.4.0 while we work on a proper fix. 
+
+        Great Expectations version {__version__} is currently incompatible with SqlAlchemy 1.4.0 and higher.
+        You have SqlAlchemy version {sa.__version__}. Please downgrade SqlAlchemy to < 1.4.0 while we work on a proper fix.
         """)
 except ImportError:
     pass

--- a/tests/cli/test_init_missing_libraries.py
+++ b/tests/cli/test_init_missing_libraries.py
@@ -140,7 +140,7 @@ but the package `{library_name}` containing this library is not installed.
     )
 
     # NOW, IN AN EVIL KNOWN ONLY TO SLEEPLESS PROGRAMMERS, WE USE OUR UTILITY TO INSTALL SQLALCHEMY
-    _ = execute_shell_command_with_progress_polling("pip install `sqlalchemy<1.4.0`")
+    _ = execute_shell_command_with_progress_polling("pip install 'sqlalchemy<1.4.0'")
 
 
 @pytest.mark.xfail(

--- a/tests/cli/test_init_missing_libraries.py
+++ b/tests/cli/test_init_missing_libraries.py
@@ -140,7 +140,7 @@ but the package `{library_name}` containing this library is not installed.
     )
 
     # NOW, IN AN EVIL KNOWN ONLY TO SLEEPLESS PROGRAMMERS, WE USE OUR UTILITY TO INSTALL SQLALCHEMY
-    _ = execute_shell_command_with_progress_polling("pip install sqlalchemy")
+    _ = execute_shell_command_with_progress_polling("pip install `sqlalchemy<1.4.0`")
 
 
 @pytest.mark.xfail(

--- a/tests/cli/v012/test_init_missing_libraries.py
+++ b/tests/cli/v012/test_init_missing_libraries.py
@@ -133,7 +133,7 @@ but the package `{library_name}` containing this library is not installed.
     )
 
     # NOW, IN AN EVIL KNOWN ONLY TO SLEEPLESS PROGRAMMERS, WE USE OUR UTILITY TO INSTALL SQLALCHEMY
-    _ = execute_shell_command_with_progress_polling("pip install sqlalchemy")
+    _ = execute_shell_command_with_progress_polling("pip install `sqlalchemy<1.4.0`")
 
 
 @pytest.mark.skipif(

--- a/tests/cli/v012/test_init_missing_libraries.py
+++ b/tests/cli/v012/test_init_missing_libraries.py
@@ -133,7 +133,7 @@ but the package `{library_name}` containing this library is not installed.
     )
 
     # NOW, IN AN EVIL KNOWN ONLY TO SLEEPLESS PROGRAMMERS, WE USE OUR UTILITY TO INSTALL SQLALCHEMY
-    _ = execute_shell_command_with_progress_polling("pip install `sqlalchemy<1.4.0`")
+    _ = execute_shell_command_with_progress_polling("pip install 'sqlalchemy<1.4.0'")
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Changes proposed in this pull request:

- Check the version of SqlAlchemy during initialization. If the version is greater than 1.4.0 then raise an informative error to the user. 
- The current error message is as follows : 

```
    raise GreatExpectationsError(f"""
great_expectations.exceptions.exceptions.GreatExpectationsError:

        Great Expectations version 0.13.16 is currently incompatible with SqlAlchemy 1.4.0 and higher.
        You currently have SqlAlchemy version 1.4.4. Please downgrade SqlAlchemy < 1.4.0 while we work on a proper fix.
```