### PR TITLE
[DOCS] Typo fix in Core Concepts/ Key Ideas section

### DIFF
--- a/docs/guides/how_to_guides/validation/how_to_trigger_slack_notifications_as_a_validation_action.rst
+++ b/docs/guides/how_to_guides/validation/how_to_trigger_slack_notifications_as_a_validation_action.rst
@@ -98,7 +98,7 @@ Additional notes
                 #--------------------------------
                 notify_with:
                   - local_site
-                  - gcs_site
+                  - s3_site
                 renderer:
                   module_name: great_expectations.render.renderer.slack_renderer
                   class_name: SlackRenderer

--- a/docs/reference/core_concepts.rst
+++ b/docs/reference/core_concepts.rst
@@ -20,9 +20,9 @@ If you only have time to remember a few key ideas about Great Expectations, make
 
 It all starts with ``Expectations``. An Expectation is how we communicate the way data *should* appear. It's also how Profilers communicate what they *learn* about data, and what Data Docs uses to *describe* data or *diagnose* problems. When lots of Expectations are grouped together to define a kind of data asset, like "monthly taxi rides", we call it an ``Expectation Suite``.
 
-``Datasources`` are the first thing you'll need to configure to use Great Expectations. A Datasource brings together a way of interacting with data (like a database or spark cluster) and some specific data (a description of that taxi ride data for last month). With a Datasource, you can get a Batch of data or a Validator that can evaluate expecations on data.
+``Datasources`` are the first thing you'll need to configure to use Great Expectations. A Datasource brings together a way of interacting with data (like a database or spark cluster) and some specific data (a description of that taxi ride data for last month). With a Datasource, you can get a Batch of data or a Validator that can evaluate expectations on data.
 
-When you're deploying Great Expectations, you'll use a ``Checkpoint`` to run a validation, testing wheher data meets expecations, and potentially performing other actions like building and saving a Data Docs site, sending a notification, or signaling a pipeline runner.
+When you're deploying Great Expectations, you'll use a ``Checkpoint`` to run a validation, testing whether data meets expecations, and potentially performing other actions like building and saving a Data Docs site, sending a notification, or signaling a pipeline runner.
 
 Great Expectations makes it possible to maintain state about data pipelines using ``Stores``. A Store is a generalized way of keeping Great Expectations objects, like Expectation Suites, Validation Results, Metrics, Checkpoints, or even Data Docs sites. Stores, and other configuration, is managed using a ``Data Context``. The Data Context configuration is usually stored as a yaml file or declared in your pipeline directly, and you should commit the configuration to version control to share it with your team.
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Typo fixed in two words.
