### PR TITLE
[ENHANCEMENT][BUGFIX][DOCS] batch_spec_passthrough updates, handling of create_temp_table, docs updates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,16 @@ Changelog
 
 Develop
 -----------------
-* [DOCS] Update how_to_create_a_new_checkpoint.rst with description of new CLI functionality
 * [ENHANCEMENT] V3 API CLI docs commands have better error messages and more consistent short flags
+* [ENHANCEMENT] Update all Data Connectors to allow for `batch_spec_passthrough` in config
+* [ENHANCEMENT] Update `DataConnector.build_batch_spec` to use `batch_spec_passthrough` in config
+* [ENHANCEMENT] Update `ConfiguredAssetSqlDataConnector.build_batch_spec` and `ConfiguredAssetFilePathDataConnector.build_batch_spec` to properly process `Asset.batch_spec_passthrough`
+* [ENHANCEMENT] Update `SqlAlchemyExecutionEngine.get_batch_data_and_markers` to handle `create_temp_table` in `RuntimeQueryBatchSpec`
 * [BUGFIX] V3 API CLI docs build now opens all built sites rather than only the last one
+* [DOCS] Update how_to_create_a_new_checkpoint.rst with description of new CLI functionality
 * [DOCS] Update Configuring Datasources documentation for V3 API CLI
+* [DOCS] Fix typos in "How to load a database table, view, or query result as a batch" guide and update with `create_temp_table` info
+* [DOCS] Update "How to add a Validation Operator" guide to make it clear it is only for V2 API
 
 0.13.17
 -----------------

--- a/docs/guides/how_to_guides/creating_batches/how_to_load_a_database_table_view_or_query_result_as_a_batch.rst
+++ b/docs/guides/how_to_guides/creating_batches/how_to_load_a_database_table_view_or_query_result_as_a_batch.rst
@@ -146,7 +146,7 @@ This guide shows how to get a :ref:`batch <reference__core_concepts__batches>` o
             - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
             - :ref:`Understand the basics of Datasources in the V3 (Batch Request) API <reference__core_concepts__datasources>`
             - :ref:`Configured a Data Context using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
-            - :ref:`Configured a RuntimeDataConnector <how_to_guides__creating_batches__how_to_configure_a_runtime_data_connector>`
+            - :ref:`Configured a Runtime Data Connector <how_to_guides__creating_batches__how_to_configure_a_runtime_data_connector>`
             - Identified a ``query`` that you would like to use as the data to validate.
 
 
@@ -173,7 +173,7 @@ This guide shows how to get a :ref:`batch <reference__core_concepts__batches>` o
 
         1. Configure a Datasource
 
-          Configure a :ref:`Datasource <reference__core_concepts__datasources>` using the :ref:`RuntimeDataConnector <reference__core_concepts__datasources>` to connect to your SQL database. Since we are using a SQL database, we use the ``SqlAlchemyExecutionEngine``. You can use ``batch_identifiers`` to define what data you are able to attach as additional metadata to your Batch using the ``batch_identifiers`` parameter (shown in step 3).
+          Configure a :ref:`Datasource <reference__core_concepts__datasources>` using the :ref:`Runtime Data Connector <reference__core_concepts__datasources>` to connect to your SQL database. Since we are using a SQL database, we use the ``SqlAlchemyExecutionEngine``. You can use ``batch_identifiers`` to define what data you are able to attach as additional metadata to your Batch using the ``batch_identifiers`` parameter (shown in step 3).
 
           By default, the SqlAlchemy Execution Engine will create a temporary table using a given query (provided in step 3). This has a performance advantage when creating and working with a Batch because the query will only be executed once (when the temporary table is created). If you would like to override this default behavior (for example, if you do not have permissions to create a temporary table), you may do so by setting ``create_temp_table`` to ``False`` in the Execution Engine configuration. You may also override the default behavior at runtime, on a case-by-case basis via the ``batch_spec_passthrough`` argument of a Runtime Batch Request (see step 3 for details).
 
@@ -216,7 +216,7 @@ This guide shows how to get a :ref:`batch <reference__core_concepts__batches>` o
 
         3. Construct a Runtime Batch Request
 
-          We will create a ``RuntimeBatchRequest`` and pass it our query via the ``runtime_parameters`` argument, under the ``query`` key. The ``batch_identifiers`` argument is required and must be a non-empty dictionary containing all of the Batch Identifiers specified in your Runtime Data Connector configuration.
+          We will create a Runtime Batch Request and pass it our query via the ``runtime_parameters`` argument, under the ``query`` key. The ``batch_identifiers`` argument is required and must be a non-empty dictionary containing all of the Batch Identifiers specified in your Runtime Data Connector configuration.
 
           By default, the associated SqlAlchemy Execution Engine will create a temporary table with your given query unless configured otherwise (see step 1). If you would like to control this behavior at runtime, instead of in configuration, you may do so by setting ``create_temp_table`` to ``False`` via the Runtime Batch Request's ``batch_spec_passthrough`` argument.
 

--- a/docs/guides/how_to_guides/creating_batches/how_to_load_a_database_table_view_or_query_result_as_a_batch.rst
+++ b/docs/guides/how_to_guides/creating_batches/how_to_load_a_database_table_view_or_query_result_as_a_batch.rst
@@ -18,96 +18,93 @@ This guide shows how to get a :ref:`batch <reference__core_concepts__batches>` o
           - Optionally, configured a Batch Kwargs Generator to support inspecting your database and dynamically building Batch Kwargs.
 
 
-        Steps
-        -----
+        **Steps**
 
-        #. Construct Batch Kwargs that describe the data you plan to validate.
+        1. Construct Batch Kwargs that describe the data you plan to validate.
 
-            For example, if your configured datasource is named "my_db" and you plan to validate data in a view called "my_view" located in the "my_schema" schema:
+          For example, if your configured datasource is named "my_db" and you plan to validate data in a view called "my_view" located in the "my_schema" schema:
 
-            - To manually build ``table`` or ``view``-based Batch Kwargs, create a dictionary:
+          - To manually build ``table`` or ``view``-based Batch Kwargs, create a dictionary:
 
-                .. code-block:: python
+            .. code-block:: python
 
-                    batch_kwargs = {
-                        "datasource": "my_db",
-                        "schema": "my_schema",  # schema is optional; default schema will be used if it is omitted
-                        "table": "my_view"  # note that the "table" key is used even to validate a view
+                batch_kwargs = {
+                    "datasource": "my_db",
+                    "schema": "my_schema",  # schema is optional; default schema will be used if it is omitted
+                    "table": "my_view"  # note that the "table" key is used even to validate a view
+                }
+
+          - To use a Batch Kwargs Generator, call the ``build_batch_kwargs`` method:
+
+            For example, if your configured generator is called ``my_generator`` and you wish to access the ``my_view`` asset, you can call:
+
+            .. code-block:: python
+
+                batch_kwargs = context.build_batch_kwargs("my_db", "my_generator", "my_view")
+
+          - To manually build ``query``-based Batch Kwargs, create a dictionary:
+
+            .. code-block:: python
+
+                batch_kwargs = {
+                    "datasource": "my_db",
+                    "query": "SELECT * FROM my_schema.my_table WHERE '1988-01-01' <= date AND date < '1989-01-01';
+                }
+
+          - To use a Query Batch Kwargs Generator, call the ``build_batch_kwargs`` method:
+
+            .. code-block:: python
+
+                batch_kwargs = context.build_batch_kwargs(
+                    "my_db",
+                    "queries",
+                    "movies_by_date",
+                    query_parameters={
+                        "start": "1988-01-01",
+                        "end": "1989-01-01"
                     }
-
-            - To use a Batch Kwargs Generator, call the ``build_batch_kwargs`` method:
-
-                For example, if your configured generator is called ``my_generator`` and you wish to access the ``my_view`` asset, you can call:
-
-                .. code-block:: python
-
-                    batch_kwargs = context.build_batch_kwargs("my_db", "my_generator", "my_view")
-
-            - To manually build ``query``-based Batch Kwargs, create a dictionary:
-
-                .. code-block:: python
-
-                    batch_kwargs = {
-                        "datasource": "my_db",
-                        "query": "SELECT * FROM my_schema.my_table WHERE '1988-01-01' <= date AND date < '1989-01-01';
-                    }
-
-            - To use a Query Batch Kwargs Generator, call the ``build_batch_kwargs`` method:
-
-                .. code-block:: python
-
-                    batch_kwargs = context.build_batch_kwargs(
-                        "my_db",
-                        "queries",
-                        "movies_by_date",
-                        query_parameters={
-                            "start": "1988-01-01",
-                            "end": "1989-01-01"
-                        }
-                    )
-
-        #. **Obtain an Expectation Suite to use to validate your batch**.
-
-            .. code-block:: python
-
-                expectation_suite_name = "npi.warning"  # choose an appropriate name for your suite
-
-            If you have not already created a suite, you can do so now.
-
-            .. code-block:: python
-
-                # Note, you can add the "overwrite_existing" flag to the below command if the suite
-                # exists but you would like to replace it.
-                context.create_expectation_suite(expectation_suite_name)
-
-
-        #. **Get the batch to validate**.
-
-            .. code-block:: python
-
-                batch = context.get_batch(
-                    batch_kwargs=batch_kwargs,
-                    expectation_suite_name=expectation_suite_name
                 )
 
+        2. Obtain an Expectation Suite to use to validate your batch.
 
-        Now that you have a Batch, you can use it to create Expectations or validate the data.
+          .. code-block:: python
 
+              expectation_suite_name = "npi.warning"  # choose an appropriate name for your suite
 
-        Additional Notes
-        ----------------
-            * If you are using Snowflake, and you have lowercase table or column names:
-                * If you are loading your batch with a table, you can use pass `"use_quoted_name":True` into your `batch_kwargs` dictionary. This will use the SQL Alchemy quoted_name method to ensure case sensitivity for your table and column names.
-                * If you are loading your batch with a query, if you have lowercase column names, you still need to pass `"use_quoted_name":True` into your `batch_kwargs` dictionary. You will also need to wrap your query in single quotes, and your table or column name in double quotes like so:
-                .. code-block:: python
+          If you have not already created a suite, you can do so now.
 
-                    batch_kwargs = {
-                        ...
-                        "use_quoted_name": True,
-                        "query: 'select "lowercase_column_one", "lowercase_column_two" from "lowercase_table_name" limit 100'
-                        ...
-                    }
-            * For more information on configuring a Batch Kwargs generator, please see the relevant guides. The above code snippets use the following configuration:
+          .. code-block:: python
+
+              # Note, you can add the "overwrite_existing" flag to the below command if the suite
+              # exists but you would like to replace it.
+              context.create_expectation_suite(expectation_suite_name)
+
+        3. Get the batch to validate.
+
+          .. code-block:: python
+
+              batch = context.get_batch(
+                  batch_kwargs=batch_kwargs,
+                  expectation_suite_name=expectation_suite_name
+              )
+
+          Now that you have a Batch, you can use it to create Expectations or validate the data.
+
+        **Additional Notes**
+          * If you are using Snowflake, and you have lowercase table or column names:
+          * If you are loading your batch with a table, you can use pass `"use_quoted_name":True` into your `batch_kwargs` dictionary. This will use the SQL Alchemy quoted_name method to ensure case sensitivity for your table and column names.
+          * If you are loading your batch with a query, if you have lowercase column names, you still need to pass `"use_quoted_name":True` into your `batch_kwargs` dictionary. You will also need to wrap your query in single quotes, and your table or column name in double quotes like so:
+
+            .. code-block:: python
+
+                batch_kwargs = {
+                    ...
+                    "use_quoted_name": True,
+                    "query: 'select "lowercase_column_one", "lowercase_column_two" from "lowercase_table_name" limit 100'
+                    ...
+                }
+
+          * For more information on configuring a Batch Kwargs generator, please see the relevant guides. The above code snippets use the following configuration:
 
             .. code-block:: yaml
 
@@ -127,7 +124,6 @@ This guide shows how to get a :ref:`batch <reference__core_concepts__batches>` o
                         filepath_suffix: .sql
                         base_directory: queries
 
-
             .. code-block:: bash
 
                 great_expectations/
@@ -137,7 +133,6 @@ This guide shows how to get a :ref:`batch <reference__core_concepts__batches>` o
             .. code-block:: sql
 
                 SELECT * FROM movies WHERE '$start'::date <= release_date AND release_date <= '$end'::date;
-
 
     .. tab-container:: tab1
         :title: Show Docs for V3 (Batch Request) API

--- a/docs/guides/how_to_guides/creating_batches/how_to_load_a_database_table_view_or_query_result_as_a_batch.rst
+++ b/docs/guides/how_to_guides/creating_batches/how_to_load_a_database_table_view_or_query_result_as_a_batch.rst
@@ -186,7 +186,7 @@ This guide shows how to get a :ref:`batch <reference__core_concepts__batches>` o
                   class_name: SqlAlchemyExecutionEngine
                   module_name: great_expectations.execution_engine
                   connection_string: sqlite:///my_db_file # Insert your SqlAlchemy connection string here
-                  # create_temp_table is optional and defaults to True - override this behavior here
+                  # create_temp_table is optional and defaults to True - you may override this behavior here
                   create_temp_table: False
                 data_connectors:
                   insert_your_runtime_data_connector_name_here:

--- a/docs/guides/how_to_guides/validation/how_to_add_a_validation_operator.rst
+++ b/docs/guides/how_to_guides/validation/how_to_add_a_validation_operator.rst
@@ -1,7 +1,9 @@
 .. _how_to_guides__validation__how_to_add_a_validation_operator:
 
-How to add a Validation Operator
-======================================
+How to add a Validation Operator - V2 (Batch Kwargs) API
+=========================================================
+
+.. note:: This guide is only relevant if you are using the V2 (Batch Kwargs) API. For the V3 (Batch Request) API, please refer to the Checkpoints (>=0.13.12) tab in the guide on :ref:`How to create a new Checkpoint<how_to_guides__validation__how_to_create_a_new_checkpoint>`.
 
 This guide will help you add a new instance of a :ref:`Validation Operator <checkpoints_and_actions>`. Validation Operators give you the ability to encode business logic around validation, such as validating multiple batches of data together, differentiating between warnings and errors, and kicking off actions based on the results of validation.
 

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -292,6 +292,7 @@ class DataConnectorConfig(DictDot):
         max_keys=None,
         boto3_options=None,
         sorters=None,
+        batch_spec_passthrough=None,
         **kwargs,
     ):
         self._class_name = class_name
@@ -318,6 +319,8 @@ class DataConnectorConfig(DictDot):
             self.boto3_options = boto3_options
         if sorters is not None:
             self.sorters = sorters
+        if batch_spec_passthrough is not None:
+            self.batch_spec_passthrough = batch_spec_passthrough
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -376,6 +379,7 @@ class DataConnectorConfigSchema(Schema):
         cls_or_instance=fields.Str(), required=False, allow_none=True
     )
     skip_inapplicable_tables = fields.Boolean(required=False, allow_none=True)
+    batch_spec_passthrough = fields.Dict(required=False, allow_none=True)
 
     @validates_schema
     def validate_schema(self, data, **kwargs):

--- a/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
@@ -39,6 +39,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
         execution_engine: Optional[ExecutionEngine] = None,
         default_regex: Optional[dict] = None,
         sorters: Optional[list] = None,
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         """
         Base class for DataConnectors that connect to filesystem-like data by taking in
@@ -52,6 +53,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
             execution_engine (ExecutionEngine): Execution Engine object to actually read the data
             default_regex (dict): Optional dict the filter and organize the data_references.
             sorters (list): Optional list if you want to sort the data_references
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         logger.debug(f'Constructing ConfiguredAssetFilePathDataConnector "{name}".')
         super().__init__(
@@ -60,6 +62,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
             execution_engine=execution_engine,
             default_regex=default_regex,
             sorters=sorters,
+            batch_spec_passthrough=batch_spec_passthrough
         )
 
         if assets is None:

--- a/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
@@ -1,5 +1,5 @@
-from copy import deepcopy
 import logging
+from copy import deepcopy
 from typing import Dict, List, Optional, Union
 
 import great_expectations.exceptions as ge_exceptions
@@ -62,7 +62,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
             execution_engine=execution_engine,
             default_regex=default_regex,
             sorters=sorters,
-            batch_spec_passthrough=batch_spec_passthrough
+            batch_spec_passthrough=batch_spec_passthrough,
         )
 
         if assets is None:
@@ -238,15 +238,19 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
 
         data_asset_name: str = batch_definition.data_asset_name
         if (
-                data_asset_name in self.assets
-                and self.assets[data_asset_name].get("batch_spec_passthrough")
-                and isinstance(
-            self.assets[data_asset_name].get("batch_spec_passthrough"), dict
-        )
+            data_asset_name in self.assets
+            and self.assets[data_asset_name].get("batch_spec_passthrough")
+            and isinstance(
+                self.assets[data_asset_name].get("batch_spec_passthrough"), dict
+            )
         ):
             # batch_spec_passthrough from data_asset
-            batch_spec_passthrough = deepcopy(self.assets[data_asset_name]["batch_spec_passthrough"])
-            batch_definition_batch_spec_passthrough = deepcopy(batch_definition.batch_spec_passthrough) or {}
+            batch_spec_passthrough = deepcopy(
+                self.assets[data_asset_name]["batch_spec_passthrough"]
+            )
+            batch_definition_batch_spec_passthrough = (
+                deepcopy(batch_definition.batch_spec_passthrough) or {}
+            )
             # batch_spec_passthrough from Batch Definition supercedes batch_spec_passthrough from data_asset
             batch_spec_passthrough.update(batch_definition_batch_spec_passthrough)
             batch_definition.batch_spec_passthrough = batch_spec_passthrough

--- a/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
@@ -239,9 +239,9 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
         data_asset_name: str = batch_definition.data_asset_name
         if (
             data_asset_name in self.assets
-            and self.assets[data_asset_name].get("batch_spec_passthrough")
+            and self.assets[data_asset_name].batch_spec_passthrough
             and isinstance(
-                self.assets[data_asset_name].get("batch_spec_passthrough"), dict
+                self.assets[data_asset_name].batch_spec_passthrough, dict
             )
         ):
             # batch_spec_passthrough from data_asset

--- a/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
@@ -240,9 +240,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
         if (
             data_asset_name in self.assets
             and self.assets[data_asset_name].batch_spec_passthrough
-            and isinstance(
-                self.assets[data_asset_name].batch_spec_passthrough, dict
-            )
+            and isinstance(self.assets[data_asset_name].batch_spec_passthrough, dict)
         ):
             # batch_spec_passthrough from data_asset
             batch_spec_passthrough = deepcopy(

--- a/great_expectations/datasource/data_connector/configured_asset_filesystem_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_filesystem_data_connector.py
@@ -63,7 +63,7 @@ class ConfiguredAssetFilesystemDataConnector(ConfiguredAssetFilePathDataConnecto
             execution_engine=execution_engine,
             default_regex=default_regex,
             sorters=sorters,
-            batch_spec_passthrough=batch_spec_passthrough
+            batch_spec_passthrough=batch_spec_passthrough,
         )
 
         self._base_directory = base_directory

--- a/great_expectations/datasource/data_connector/configured_asset_filesystem_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_filesystem_data_connector.py
@@ -37,6 +37,7 @@ class ConfiguredAssetFilesystemDataConnector(ConfiguredAssetFilePathDataConnecto
         default_regex: Optional[dict] = None,
         glob_directive: str = "**/*",
         sorters: Optional[list] = None,
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         """
         Base class for DataConnectors that connect to data on a filesystem. This class supports the configuration of default_regex
@@ -50,6 +51,7 @@ class ConfiguredAssetFilesystemDataConnector(ConfiguredAssetFilePathDataConnecto
             default_regex (dict): Optional dict the filter and organize the data_references.
             glob_directive (str): glob for selecting files in directory (defaults to *)
             sorters (list): Optional list if you want to sort the data_references
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
 
         """
         logger.debug(f'Constructing ConfiguredAssetFilesystemDataConnector "{name}".')
@@ -61,6 +63,7 @@ class ConfiguredAssetFilesystemDataConnector(ConfiguredAssetFilePathDataConnecto
             execution_engine=execution_engine,
             default_regex=default_regex,
             sorters=sorters,
+            batch_spec_passthrough=batch_spec_passthrough
         )
 
         self._base_directory = base_directory

--- a/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
@@ -48,6 +48,7 @@ class ConfiguredAssetS3DataConnector(ConfiguredAssetFilePathDataConnector):
         delimiter: Optional[str] = "/",
         max_keys: Optional[int] = 1000,
         boto3_options: Optional[dict] = None,
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         """
         ConfiguredAssetDataConnector for connecting to S3.
@@ -64,6 +65,7 @@ class ConfiguredAssetS3DataConnector(ConfiguredAssetFilePathDataConnector):
             delimiter (str): S3 delimiter
             max_keys (int): S3 max_keys (default is 1000)
             boto3_options (dict): optional boto3 options
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         logger.debug(f'Constructing ConfiguredAssetS3DataConnector "{name}".')
 
@@ -74,6 +76,7 @@ class ConfiguredAssetS3DataConnector(ConfiguredAssetFilePathDataConnector):
             assets=assets,
             default_regex=default_regex,
             sorters=sorters,
+            batch_spec_passthrough=batch_spec_passthrough
         )
         self._bucket = bucket
         self._prefix = os.path.join(prefix, "")

--- a/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
@@ -76,7 +76,7 @@ class ConfiguredAssetS3DataConnector(ConfiguredAssetFilePathDataConnector):
             assets=assets,
             default_regex=default_regex,
             sorters=sorters,
-            batch_spec_passthrough=batch_spec_passthrough
+            batch_spec_passthrough=batch_spec_passthrough,
         )
         self._bucket = bucket
         self._prefix = os.path.join(prefix, "")

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -28,6 +28,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         datasource_name (str): The name of the Datasource that contains it
         execution_engine (ExecutionEngine): An ExecutionEngine
         data_assets (str): data_assets
+        batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
     """
 
     def __init__(
@@ -36,6 +37,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         datasource_name: str,
         execution_engine: Optional[ExecutionEngine] = None,
         data_assets: Optional[Dict[str, dict]] = None,
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         if data_assets is None:
             data_assets = {}
@@ -45,6 +47,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             name=name,
             datasource_name=datasource_name,
             execution_engine=execution_engine,
+            batch_spec_passthrough=batch_spec_passthrough
         )
 
     @property

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -48,7 +48,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             name=name,
             datasource_name=datasource_name,
             execution_engine=execution_engine,
-            batch_spec_passthrough=batch_spec_passthrough
+            batch_spec_passthrough=batch_spec_passthrough,
         )
 
     @property
@@ -207,8 +207,12 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             )
         ):
             # batch_spec_passthrough from data_asset
-            batch_spec_passthrough = deepcopy(self.data_assets[data_asset_name]["batch_spec_passthrough"])
-            batch_definition_batch_spec_passthrough = deepcopy(batch_definition.batch_spec_passthrough) or {}
+            batch_spec_passthrough = deepcopy(
+                self.data_assets[data_asset_name]["batch_spec_passthrough"]
+            )
+            batch_definition_batch_spec_passthrough = (
+                deepcopy(batch_definition.batch_spec_passthrough) or {}
+            )
             # batch_spec_passthrough from Batch Definition supercedes batch_spec_passthrough from data_asset
             batch_spec_passthrough.update(batch_definition_batch_spec_passthrough)
             batch_definition.batch_spec_passthrough = batch_spec_passthrough

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from copy import deepcopy
 from typing import Any, List, Optional, Tuple
 
 from great_expectations.core.batch import (
@@ -123,7 +124,7 @@ class DataConnector:
             )
         )
         # batch_spec_passthrough via Data Connector config
-        batch_spec_passthrough: dict = self.batch_spec_passthrough
+        batch_spec_passthrough: dict = deepcopy(self.batch_spec_passthrough)
 
         # batch_spec_passthrough from batch_definition supercedes batch_spec_passthrough from Data Connector config
         if isinstance(batch_definition.batch_spec_passthrough, dict):

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -65,6 +65,10 @@ class DataConnector:
         self._batch_spec_passthrough = batch_spec_passthrough or {}
 
     @property
+    def batch_spec_passthrough(self) -> dict:
+        return self._batch_spec_passthrough
+
+    @property
     def name(self) -> str:
         return self._name
 

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -43,7 +43,7 @@ class DataConnector:
         name: str,
         datasource_name: str,
         execution_engine: Optional[ExecutionEngine] = None,
-        batch_spec_passthrough: Optional[dict] = None
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         """
         Base class for DataConnectors

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -122,9 +122,14 @@ class DataConnector:
                 batch_definition=batch_definition
             )
         )
-        batch_spec_passthrough: dict = batch_definition.batch_spec_passthrough
-        if isinstance(batch_spec_passthrough, dict):
-            batch_spec_params.update(batch_spec_passthrough)
+        # batch_spec_passthrough via Data Connector config
+        batch_spec_passthrough: dict = self.batch_spec_passthrough
+
+        # batch_spec_passthrough from batch_definition supercedes batch_spec_passthrough from Data Connector config
+        if isinstance(batch_definition.batch_spec_passthrough, dict):
+            batch_spec_passthrough.update(batch_definition.batch_spec_passthrough)
+
+        batch_spec_params.update(batch_spec_passthrough)
         batch_spec: BatchSpec = BatchSpec(**batch_spec_params)
         return batch_spec
 

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -43,6 +43,7 @@ class DataConnector:
         name: str,
         datasource_name: str,
         execution_engine: Optional[ExecutionEngine] = None,
+        batch_spec_passthrough: Optional[dict] = None
     ):
         """
         Base class for DataConnectors
@@ -51,7 +52,7 @@ class DataConnector:
             name (str): required name for DataConnector
             datasource_name (str): required name for datasource
             execution_engine (ExecutionEngine): optional reference to ExecutionEngine
-
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         self._name = name
         self._datasource_name = datasource_name
@@ -61,6 +62,7 @@ class DataConnector:
         self._data_references_cache = {}
 
         self._data_context_root_directory = None
+        self._batch_spec_passthrough = batch_spec_passthrough or {}
 
     @property
     def name(self) -> str:

--- a/great_expectations/datasource/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/file_path_data_connector.py
@@ -43,6 +43,7 @@ class FilePathDataConnector(DataConnector):
         execution_engine: Optional[ExecutionEngine] = None,
         default_regex: Optional[dict] = None,
         sorters: Optional[list] = None,
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         """
         Base class for DataConnectors that connect to filesystem-like data. This class supports the configuration of default_regex
@@ -54,6 +55,7 @@ class FilePathDataConnector(DataConnector):
             execution_engine (ExecutionEngine): Execution Engine object to actually read the data
             default_regex (dict): Optional dict the filter and organize the data_references.
             sorters (list): Optional list if you want to sort the data_references
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         logger.debug(f'Constructing FilePathDataConnector "{name}".')
 
@@ -61,6 +63,7 @@ class FilePathDataConnector(DataConnector):
             name=name,
             datasource_name=datasource_name,
             execution_engine=execution_engine,
+            batch_spec_passthrough=batch_spec_passthrough,
         )
 
         if default_regex is None:

--- a/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
@@ -43,6 +43,7 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
             execution_engine (ExecutionEngine): ExecutionEngine object to actually read the data
             default_regex (dict): Optional dict the filter and organize the data_references.
             sorters (list): Optional list if you want to sort the data_references
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         logger.debug(f'Constructing InferredAssetFilePathDataConnector "{name}".')
 
@@ -52,9 +53,8 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
             execution_engine=execution_engine,
             default_regex=default_regex,
             sorters=sorters,
+            batch_spec_passthrough=batch_spec_passthrough
         )
-
-        self._batch_spec_passthrough = batch_spec_passthrough or {}
 
     def _refresh_data_references_cache(self):
         """ refreshes data_reference cache """

--- a/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
@@ -53,7 +53,7 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
             execution_engine=execution_engine,
             default_regex=default_regex,
             sorters=sorters,
-            batch_spec_passthrough=batch_spec_passthrough
+            batch_spec_passthrough=batch_spec_passthrough,
         )
 
     def _refresh_data_references_cache(self):

--- a/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
@@ -129,8 +129,6 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
             batch_definition=batch_definition
         )
 
-        batch_spec.update(self._batch_spec_passthrough)
-
         return PathBatchSpec(batch_spec)
 
     def _get_batch_definition_list_from_cache(self) -> List[BatchDefinition]:

--- a/great_expectations/datasource/data_connector/inferred_asset_filesystem_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_filesystem_data_connector.py
@@ -49,6 +49,7 @@ class InferredAssetFilesystemDataConnector(InferredAssetFilePathDataConnector):
             execution_engine (ExecutionEngine): ExecutionEngine object to actually read the data
             default_regex (dict): Optional dict the filter and organize the data_references.
             sorters (list): Optional list if you want to sort the data_references
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         logger.debug(f'Constructing InferredAssetFilesystemDataConnector "{name}".')
 

--- a/great_expectations/datasource/data_connector/inferred_asset_s3_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_s3_data_connector.py
@@ -63,6 +63,7 @@ class InferredAssetS3DataConnector(InferredAssetFilePathDataConnector):
             delimiter (str): S3 delimiter
             max_keys (int): S3 max_keys (default is 1000)
             boto3_options (dict): optional boto3 options
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         logger.debug(f'Constructing InferredAssetS3DataConnector "{name}".')
 

--- a/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
@@ -74,7 +74,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
             datasource_name=datasource_name,
             execution_engine=execution_engine,
             data_assets=None,
-            batch_spec_passthrough=batch_spec_passthrough
+            batch_spec_passthrough=batch_spec_passthrough,
         )
 
         # This cache will contain a "config" for each data_asset discovered via introspection.

--- a/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
@@ -32,6 +32,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
         included_tables: Optional[list] = None,
         skip_inapplicable_tables: Optional[bool] = True,
         introspection_directives: Optional[dict] = None,
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         """
         InferredAssetDataConnector for connecting to data on a SQL database
@@ -53,6 +54,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
                 If True, tables that can't be successfully queried using sampling and splitter methods are excluded from inferred data_asset_names.
                 If False, the class will throw an error during initialization if any such tables are encountered.
             introspection_directives (Dict): Arguments passed to the introspection method to guide introspection
+            batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
         """
         self._data_asset_name_prefix = data_asset_name_prefix
         self._data_asset_name_suffix = data_asset_name_suffix
@@ -72,6 +74,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
             datasource_name=datasource_name,
             execution_engine=execution_engine,
             data_assets=None,
+            batch_spec_passthrough=batch_spec_passthrough
         )
 
         # This cache will contain a "config" for each data_asset discovered via introspection.

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -27,12 +27,26 @@ DEFAULT_DELIMITER: str = "-"
 
 
 class RuntimeDataConnector(DataConnector):
+    """
+    A DataConnector that allows users to specify a Batch's data directly using a RuntimeBatchRequest that contains
+    either an in-memory Pandas or Spark DataFrame, a filesystem or S3 path, or an arbitrary SQL query
+
+    Args:
+        name (str): The name of this DataConnector
+        datasource_name (str): The name of the Datasource that contains it
+        execution_engine (ExecutionEngine): An ExecutionEngine
+        batch_identifiers (list): a list of keys that must be defined in the batch_identifiers dict of
+        RuntimeBatchRequest
+        batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
+    """
+
     def __init__(
         self,
         name: str,
         datasource_name: str,
         execution_engine: Optional[ExecutionEngine] = None,
         batch_identifiers: Optional[list] = None,
+        batch_spec_passthrough: Optional[dict] = None,
     ):
         logger.debug(f'Constructing RuntimeDataConnector "{name}".')
 
@@ -40,6 +54,7 @@ class RuntimeDataConnector(DataConnector):
             name=name,
             datasource_name=datasource_name,
             execution_engine=execution_engine,
+            batch_spec_passthrough=batch_spec_passthrough
         )
 
         self._batch_identifiers = batch_identifiers

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -54,7 +54,7 @@ class RuntimeDataConnector(DataConnector):
             name=name,
             datasource_name=datasource_name,
             execution_engine=execution_engine,
-            batch_spec_passthrough=batch_spec_passthrough
+            batch_spec_passthrough=batch_spec_passthrough,
         )
 
         self._batch_identifiers = batch_identifiers


### PR DESCRIPTION
Changes proposed in this pull request:
- Update all Data Connectors to allow for `batch_spec_passthrough` in config
- Update `DataConnector.build_batch_spec` to use `batch_spec_passthrough` in config
- Update `ConfiguredAssetSqlDataConnector.build_batch_spec` and `ConfiguredAssetFilePathDataConnector.build_batch_spec` to properly process `Asset.batch_spec_passthrough`
- Update `SqlAlchemyExecutionEngine.get_batch_data_and_markers` to handle `create_temp_table` in `RuntimeQueryBatchSpec`
- Fix typos in "How to load a database table, view, or query result as a batch" guide and update with `create_temp_table` info
- Update "How to add a Validation Operator" guide to make it clear it is only for V2 API

Previous Design Review notes:
- Discussed expected behavior of `create_temp_table` with @jcampbell on 4/2/2021