### PR TITLE
[ENHANCEMENT] CLI docs commands have better error messages and more consistent short flags

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,8 @@ Changelog
 Develop
 -----------------
 * [DOCS] Update how_to_create_a_new_checkpoint.rst with description of new CLI functionality
-
+* [ENHANCEMENT] V3 API CLI docs commands have better error messages and more consistent short flags
+* [BUGFIX] V3 API CLI docs build now opens all built sites rather than only the last one
 
 0.13.17
 -----------------

--- a/great_expectations/cli/build_docs.py
+++ b/great_expectations/cli/build_docs.py
@@ -1,21 +1,24 @@
+from typing import List, Optional
+
+from great_expectations import DataContext
 from great_expectations.cli import toolkit
 from great_expectations.cli.cli_logging import logger
 from great_expectations.cli.pretty_printing import cli_message
 
 
-def build_docs(context, site_name=None, view=True, assume_yes=False):
+def build_docs(
+    context: DataContext,
+    site_names: Optional[List[str]] = None,
+    view: bool = True,
+    assume_yes: bool = False,
+) -> None:
     """Build documentation in a context"""
     logger.debug("Starting cli.datasource.build_docs")
 
-    if site_name is not None:
-        site_names = [site_name]
-    else:
-        site_names = None
     index_page_locator_infos = context.build_data_docs(
         site_names=site_names, dry_run=True
     )
-
-    msg = "\nThe following Data Docs sites will be built:\n\n"
+    msg: str = "\nThe following Data Docs sites will be built:\n\n"
     for site_name, index_page_locator_info in index_page_locator_infos.items():
         msg += " - <cyan>{}:</cyan> ".format(site_name)
         msg += "{}\n".format(index_page_locator_info)
@@ -29,5 +32,6 @@ def build_docs(context, site_name=None, view=True, assume_yes=False):
 
     cli_message("Done building Data Docs")
 
-    if view:
-        context.open_data_docs(site_name=site_name, only_if_exists=True)
+    if view and site_names:
+        for site_to_open in site_names:
+            context.open_data_docs(site_name=site_to_open, only_if_exists=True)

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -71,7 +71,7 @@ def datasource_new(ctx, name, jupyter):
     toolkit.send_usage_message(
         data_context=context, event="cli.datasource.new", success=True
     )
-    _interactive_datasource_new_flow(context, datasource_name=name, jupyter=jupyter)
+    _datasource_new_flow(context, datasource_name=name, jupyter=jupyter)
 
 
 @datasource.command(name="delete")
@@ -129,7 +129,7 @@ def _build_datasource_intro_string(datasources):
     return f"{datasource_count} Datasources found:"
 
 
-def _interactive_datasource_new_flow(
+def _datasource_new_flow(
     context: DataContext, datasource_name: Optional[str] = None, jupyter: bool = True
 ) -> None:
     files_or_sql_selection = click.prompt(

--- a/great_expectations/cli/docs.py
+++ b/great_expectations/cli/docs.py
@@ -25,19 +25,38 @@ def docs(ctx):
 @docs.command(name="build")
 @click.option(
     "--site-name",
-    "-s",
-    help="The site for which to generate documentation. See data_docs section in great_expectations.yml",
+    "-sn",
+    help="The site for which to generate documentation. If not present all sites will be built. See data_docs section in great_expectations.yml",
 )
 @click.option(
-    "--view/--no-view",
+    "--no-view",
+    "-nv",
+    "no_view",
+    is_flag=True,
     help="By default open in browser unless you specify the --no-view flag",
-    default=True,
+    default=False,
 )
 @click.pass_context
-def docs_build(ctx, site_name, view=True):
+def docs_build(ctx, site_name=None, no_view=False):
     """Build Data Docs for a project."""
     context: DataContext = ctx.obj.data_context
-    build_docs(context, site_name=site_name, view=view, assume_yes=ctx.obj.assume_yes)
+    if site_name is not None and site_name not in context.get_site_names():
+        toolkit.exit_with_failure_message_and_stats(
+            context,
+            usage_event="cli.docs.build",
+            message=f"<red>The specified site name `{site_name}` does not exist in this project.</red>",
+        )
+    if site_name is None:
+        sites_to_build = context.get_site_names()
+    else:
+        sites_to_build = [site_name]
+
+    build_docs(
+        context,
+        site_names=sites_to_build,
+        view=not no_view,
+        assume_yes=ctx.obj.assume_yes,
+    )
     toolkit.send_usage_message(
         data_context=context, event="cli.docs.build", success=True
     )
@@ -84,15 +103,19 @@ def docs_list(ctx):
     help="With this, all sites will get their data docs cleaned out. See data_docs section in great_expectations.yml",
 )
 @click.pass_context
-def clean_data_docs(ctx, site_name=None, all_sites=False):
-    """Delete data docs"""
+def docs_clean(ctx, site_name=None, all_sites=False):
+    """
+    Remove all files from a Data Docs site.
+
+    This is a useful first step if you wish to completely re-build a site from scratch.
+    """
     context = ctx.obj.data_context
 
     if (site_name is None and all_sites is False) or (site_name and all_sites):
         toolkit.exit_with_failure_message_and_stats(
             context,
             usage_event="cli.docs.clean",
-            message="<red>Please specify either --all to remove all sites or a specific site using --site_name</red>",
+            message="<red>Please specify either --all to clean all sites or a specific site using --site-name</red>",
         )
     try:
         # if site_name is None, context.clean_data_docs(site_name=site_name)

--- a/tests/cli/test_docs.py
+++ b/tests/cli/test_docs.py
@@ -1,19 +1,16 @@
 import os
 
+import mock
 import pytest
 from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
+from great_expectations.data_context import BaseDataContext
 from tests.cli.utils import (
     VALIDATION_OPERATORS_DEPRECATION_MESSAGE,
     assert_no_logging_messages_or_tracebacks,
 )
-
-try:
-    from unittest import mock
-except ImportError:
-    from unittest import mock
 
 
 def test_docs_help_output(caplog):
@@ -21,43 +18,112 @@ def test_docs_help_output(caplog):
     result = runner.invoke(cli, ["--v3-api", "docs"], catch_exceptions=False)
     assert result.exit_code == 0
     assert "build  Build Data Docs for a project." in result.stdout
+    assert "list   List known Data Docs sites." in result.stdout
+    assert "clean  Remove all files from a Data Docs site." in result.stdout
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
+@pytest.mark.parametrize(
+    "invocation, cli_input, expected_stdout, expected_browser_call_count",
+    [
+        ("--v3-api docs build", "\n", "Would you like to proceed? [Y/n]", 1),
+        ("--v3-api --assume-yes docs build", None, "", 1),
+        (
+            "--v3-api docs build --site-name local_site",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            1,
+        ),
+        ("--v3-api --assume-yes docs build --site-name local_site", None, "", 1),
+        (
+            "--v3-api docs build -sn local_site",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            1,
+        ),
+        ("--v3-api --assume-yes docs build -sn local_site", None, "", 1),
+        # All the same but with --no-view
+        ("--v3-api docs build --no-view", "\n", "Would you like to proceed? [Y/n]", 0),
+        ("--v3-api --assume-yes docs build --no-view", None, "", 0),
+        (
+            "--v3-api docs build --site-name local_site --no-view",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            0,
+        ),
+        (
+            "--v3-api --assume-yes docs build --site-name local_site --no-view",
+            None,
+            "",
+            0,
+        ),
+        (
+            "--v3-api docs build -sn local_site --no-view",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            0,
+        ),
+        ("--v3-api --assume-yes docs build -sn local_site --no-view", None, "", 0),
+        # All the same but with --nv
+        ("--v3-api docs build -nv", "\n", "Would you like to proceed? [Y/n]", 0),
+        ("--v3-api --assume-yes docs build -nv", None, "", 0),
+        (
+            "--v3-api docs build --site-name local_site -nv",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            0,
+        ),
+        (
+            "--v3-api --assume-yes docs build --site-name local_site -nv",
+            None,
+            "",
+            0,
+        ),
+        (
+            "--v3-api docs build -sn local_site -nv",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            0,
+        ),
+        ("--v3-api --assume-yes docs build -sn local_site -nv", None, "", 0),
+    ],
+)
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-def test_docs_build_view(
+def test_docs_build_happy_paths_build_site_on_single_site_context(
     mock_webbrowser,
     mock_emit,
+    invocation,
+    cli_input,
+    expected_stdout,
+    expected_browser_call_count,
     caplog,
     monkeypatch,
     titanic_data_context_stats_enabled_config_version_3,
 ):
     context = titanic_data_context_stats_enabled_config_version_3
     root_dir = context.root_directory
-
     runner = CliRunner(mix_stderr=False)
     monkeypatch.chdir(os.path.dirname(context.root_directory))
     result = runner.invoke(
         cli,
-        "--v3-api docs build",
-        input="\n",
+        invocation,
+        input=cli_input,
         catch_exceptions=False,
     )
     stdout = result.stdout
 
     assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 1
-    assert "Would you like to proceed?" in stdout
-    assert "Building" in stdout
-    assert "The following Data Docs sites will be built:" in stdout
+    assert "The following Data Docs sites will be built" in stdout
     assert "local_site" in stdout
-    assert "great_expectations/uncommitted/data_docs/local_site/index.html" in stdout
+    assert "Building Data Docs..." in stdout
+    assert "Done building Data Docs" in stdout
+    assert expected_stdout in stdout
+    assert mock_webbrowser.call_count == expected_browser_call_count
 
-    assert mock_emit.call_count == 4
-    assert mock_emit.call_args_list == [
+    expected_usage_stats_messages = [
         mock.call(
             {"event_payload": {}, "event": "data_context.__init__", "success": True}
         ),
@@ -68,13 +134,18 @@ def test_docs_build_view(
                 "success": True,
             }
         ),
-        mock.call(
-            {
-                "event_payload": {},
-                "event": "data_context.open_data_docs",
-                "success": True,
-            }
-        ),
+    ]
+    if expected_browser_call_count == 1:
+        expected_usage_stats_messages.append(
+            mock.call(
+                {
+                    "event_payload": {},
+                    "event": "data_context.open_data_docs",
+                    "success": True,
+                }
+            ),
+        )
+    expected_usage_stats_messages.append(
         mock.call(
             {
                 "event": "cli.docs.build",
@@ -82,7 +153,8 @@ def test_docs_build_view(
                 "success": True,
             }
         ),
-    ]
+    )
+    assert mock_emit.call_args_list == expected_usage_stats_messages
 
     context = DataContext(root_dir)
     obs_urls = context.get_docs_sites_urls()
@@ -104,113 +176,148 @@ def test_docs_build_view(
         click_result=result,
     )
 
-
-@mock.patch(
-    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
-)
-@mock.patch("webbrowser.open", return_value=True, side_effect=None)
-def test_docs_build_no_view(
-    mock_webbrowser,
-    mock_emit,
-    caplog,
-    monkeypatch,
-    titanic_data_context_stats_enabled_config_version_3,
-):
-    context = titanic_data_context_stats_enabled_config_version_3
-    root_dir = context.root_directory
-
-    runner = CliRunner(mix_stderr=False)
-    monkeypatch.chdir(os.path.dirname(context.root_directory))
-    result = runner.invoke(
-        cli,
-        "--v3-api docs build --no-view",
-        input="\n",
-        catch_exceptions=False,
-    )
-    stdout = result.stdout
-
-    assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 0
-
-    assert "Would you like to proceed?" in stdout
-    assert "Building" in stdout
-    assert "The following Data Docs sites will be built:" in stdout
-    assert "local_site" in stdout
-    assert "great_expectations/uncommitted/data_docs/local_site/index.html" in stdout
-
-    assert mock_emit.call_count == 3
-    assert mock_emit.call_args_list == [
-        mock.call(
-            {"event_payload": {}, "event": "data_context.__init__", "success": True}
-        ),
-        mock.call(
-            {
-                "event_payload": {},
-                "event": "data_context.build_data_docs",
-                "success": True,
-            }
-        ),
-        mock.call(
-            {
-                "event": "cli.docs.build",
-                "event_payload": {"api_version": "v3"},
-                "success": True,
-            }
-        ),
-    ]
-
-    context = DataContext(root_dir)
-    obs_urls = context.get_docs_sites_urls()
-
-    assert len(obs_urls) == 1
-    assert (
-        "great_expectations/uncommitted/data_docs/local_site/index.html"
-        in obs_urls[0]["site_url"]
-    )
-    site_dir = os.path.join(
-        root_dir, context.GE_UNCOMMITTED_DIR, "data_docs", "local_site"
-    )
-    assert os.path.isdir(site_dir)
-    # Note the fixture has no expectations or validations - only check the index
-    assert os.path.isfile(os.path.join(site_dir, "index.html"))
-
     assert_no_logging_messages_or_tracebacks(
         my_caplog=caplog,
         click_result=result,
     )
 
 
+@pytest.fixture
+def context_with_two_sites(titanic_data_context_stats_enabled_config_version_3):
+    context = titanic_data_context_stats_enabled_config_version_3
+    config = context.get_config_with_variables_substituted()
+    config.data_docs_sites["team_site"] = {
+        "class_name": "SiteBuilder",
+        "store_backend": {
+            "class_name": "TupleFilesystemStoreBackend",
+            "base_directory": "uncommitted/data_docs/team_site/",
+        },
+        "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
+    }
+    temp_context = BaseDataContext(config, context_root_dir=context.root_directory)
+    new_context = DataContext(context.root_directory)
+    new_context.set_config(temp_context.get_config_with_variables_substituted())
+    new_context._save_project_config()
+    assert new_context.get_site_names() == ["local_site", "team_site"]
+    return new_context
+
+
+@pytest.mark.parametrize(
+    "invocation, cli_input, expected_stdout, expected_browser_call_count, expected_built_site_names",
+    [
+        (
+            "--v3-api docs build",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            2,
+            ["local_site", "team_site"],
+        ),
+        ("--v3-api --assume-yes docs build", None, "", 2, ["local_site", "team_site"]),
+        (
+            "--v3-api docs build --site-name team_site",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            1,
+            ["team_site"],
+        ),
+        (
+            "--v3-api --assume-yes docs build --site-name team_site",
+            None,
+            "",
+            1,
+            ["team_site"],
+        ),
+        (
+            "--v3-api docs build -sn team_site",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            1,
+            ["team_site"],
+        ),
+        ("--v3-api --assume-yes docs build -sn team_site", None, "", 1, ["team_site"]),
+        # All the same but with --no-view
+        (
+            "--v3-api docs build --no-view",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            0,
+            ["local_site", "team_site"],
+        ),
+        (
+            "--v3-api --assume-yes docs build --no-view",
+            None,
+            "",
+            0,
+            ["local_site", "team_site"],
+        ),
+        (
+            "--v3-api docs build --site-name team_site --no-view",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            0,
+            ["team_site"],
+        ),
+        (
+            "--v3-api --assume-yes docs build --site-name team_site --no-view",
+            None,
+            "",
+            0,
+            ["team_site"],
+        ),
+        (
+            "--v3-api docs build -sn team_site --no-view",
+            "\n",
+            "Would you like to proceed? [Y/n]",
+            0,
+            ["team_site"],
+        ),
+        (
+            "--v3-api --assume-yes docs build -sn team_site --no-view",
+            None,
+            "",
+            0,
+            ["team_site"],
+        ),
+    ],
+)
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @mock.patch("webbrowser.open", return_value=True, side_effect=None)
-def test_docs_build_assume_yes(
+def test_docs_build_happy_paths_build_site_on_multiple_site_context(
     mock_webbrowser,
     mock_emit,
+    invocation,
+    cli_input,
+    expected_stdout,
+    expected_browser_call_count,
+    expected_built_site_names,
     caplog,
     monkeypatch,
-    titanic_data_context_stats_enabled_config_version_3,
+    context_with_two_sites,
 ):
-    context = titanic_data_context_stats_enabled_config_version_3
+    context = context_with_two_sites
+    assert context.get_site_names() == ["local_site", "team_site"]
 
+    root_dir = context.root_directory
     runner = CliRunner(mix_stderr=False)
     monkeypatch.chdir(os.path.dirname(context.root_directory))
     result = runner.invoke(
         cli,
-        "--v3-api --assume-yes docs build --no-view",
+        invocation,
+        input=cli_input,
         catch_exceptions=False,
     )
     stdout = result.stdout
 
     assert result.exit_code == 0
-    assert mock_webbrowser.call_count == 0
+    assert "The following Data Docs sites will be built" in stdout
+    assert "Building Data Docs..." in stdout
+    assert "Done building Data Docs" in stdout
+    assert expected_stdout in stdout
+    assert mock_webbrowser.call_count == expected_browser_call_count
 
-    assert "Would you like to proceed? [Y/n]:" not in stdout
-    # This assertion is extra assurance since this test is too permissive if we change the confirmation message
-    assert "[Y/n]" not in stdout
-
-    assert mock_emit.call_count == 3
-    assert mock_emit.call_args_list == [
+    expected_usage_stats_messages = [
         mock.call(
             {"event_payload": {}, "event": "data_context.__init__", "success": True}
         ),
@@ -221,6 +328,18 @@ def test_docs_build_assume_yes(
                 "success": True,
             }
         ),
+    ]
+    for _ in range(expected_browser_call_count):
+        expected_usage_stats_messages.append(
+            mock.call(
+                {
+                    "event_payload": {},
+                    "event": "data_context.open_data_docs",
+                    "success": True,
+                }
+            ),
+        )
+    expected_usage_stats_messages.append(
         mock.call(
             {
                 "event": "cli.docs.build",
@@ -228,7 +347,23 @@ def test_docs_build_assume_yes(
                 "success": True,
             }
         ),
-    ]
+    )
+    assert mock_emit.call_args_list == expected_usage_stats_messages
+
+    context = DataContext(root_dir)
+    for expected_site_name in expected_built_site_names:
+        assert expected_site_name in stdout
+        site_dir = os.path.join(
+            root_dir, context.GE_UNCOMMITTED_DIR, "data_docs", expected_site_name
+        )
+        assert os.path.isdir(site_dir)
+        # Note the fixture has no expectations or validations - only check the index
+        assert os.path.isfile(os.path.join(site_dir, "index.html"))
+
+    assert_no_logging_messages_or_tracebacks(
+        my_caplog=caplog,
+        click_result=result,
+    )
 
     assert_no_logging_messages_or_tracebacks(
         my_caplog=caplog,
@@ -316,32 +451,50 @@ def context_with_site_built(titanic_data_context_stats_enabled_config_version_3)
 
 
 @pytest.mark.parametrize(
-    "invocation,expected_error",
+    "invocation,expected_error,expected_usage_event",
     [
         (
             "--v3-api docs clean",
-            "Please specify either --all to remove all sites or a specific site using --site_name",
+            "Please specify either --all to clean all sites or a specific site using --site-name",
+            "cli.docs.clean",
         ),
         (
             "--v3-api docs clean --site-name local_site --all",
-            "Please specify either --all to remove all sites or a specific site using --site_name",
+            "Please specify either --all to clean all sites or a specific site using --site-name",
+            "cli.docs.clean",
         ),
         (
             "--v3-api docs clean --site-name fake_site",
             "The specified site name `fake_site` does not exist in this project.",
+            "cli.docs.clean",
+        ),
+        (
+            "--v3-api docs build --site-name fake_site",
+            "The specified site name `fake_site` does not exist in this project.",
+            "cli.docs.build",
         ),
     ],
 )
+@mock.patch("webbrowser.open", return_value=True, side_effect=None)
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
-def test_docs_clean_raises_helpful_errors(
-    mock_emit, invocation, expected_error, caplog, monkeypatch, context_with_site_built
+def test_docs_clean_and_build_raises_helpful_errors(
+    mock_emit,
+    mock_webbrowser,
+    invocation,
+    expected_error,
+    expected_usage_event,
+    caplog,
+    monkeypatch,
+    context_with_site_built,
 ):
     """
-    Test that helpful error messages are raised when:
+    Test helpful error messages for docs build and docs clean
+        - invalid site names are specified via --site-name
+
+    For docs clean:
         - invalid combinations of the --all and --site-name flags are used
-        - invalid site names are specified
     """
     context = context_with_site_built
     runner = CliRunner(mix_stderr=True)
@@ -362,20 +515,12 @@ def test_docs_clean_raises_helpful_errors(
         ),
         mock.call(
             {
-                "event": "cli.docs.clean",
+                "event": expected_usage_event,
                 "event_payload": {"api_version": "v3"},
                 "success": False,
             }
         ),
     ]
-    expected_index_path = os.path.join(
-        context.root_directory,
-        context.GE_UNCOMMITTED_DIR,
-        "data_docs",
-        "local_site",
-        "index.html",
-    )
-    assert os.path.isfile(expected_index_path)
 
     assert_no_logging_messages_or_tracebacks(
         my_caplog=caplog,
@@ -395,7 +540,7 @@ def test_docs_clean_raises_helpful_errors(
 @mock.patch(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
-def test_docs_clean_valid_site_name_and_all_flag_combinations_clean_sites(
+def test_docs_clean_happy_paths_clean_expected_sites(
     mock_emit, invocation, caplog, monkeypatch, context_with_site_built
 ):
     context = context_with_site_built

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -4,7 +4,11 @@ import shutil
 import pytest
 
 import great_expectations as ge
+from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.util import file_relative_path
+from tests.integration.usage_statistics.test_integration_usage_statistics import (
+    USAGE_STATISTICS_QA_URL,
+)
 
 
 @pytest.fixture()
@@ -115,3 +119,44 @@ def create_common_data_context_files(context_path, asset_config_path):
 
 def copy_relative_path(relative_src, dest):
     shutil.copy(file_relative_path(__file__, relative_src), dest)
+
+
+@pytest.fixture
+def basic_data_context_config():
+    return DataContextConfig(
+        **{
+            "commented_map": {},
+            "config_version": 2,
+            "plugins_directory": "plugins/",
+            "evaluation_parameter_store_name": "evaluation_parameter_store",
+            "validations_store_name": "does_not_have_to_be_real",
+            "expectations_store_name": "expectations_store",
+            "config_variables_file_path": "uncommitted/config_variables.yml",
+            "datasources": {},
+            "stores": {
+                "expectations_store": {
+                    "class_name": "ExpectationsStore",
+                    "store_backend": {
+                        "class_name": "TupleFilesystemStoreBackend",
+                        "base_directory": "expectations/",
+                    },
+                },
+                "evaluation_parameter_store": {
+                    "module_name": "great_expectations.data_context.store",
+                    "class_name": "EvaluationParameterStore",
+                },
+            },
+            "data_docs_sites": {},
+            "validation_operators": {
+                "default": {
+                    "class_name": "ActionListValidationOperator",
+                    "action_list": [],
+                }
+            },
+            "anonymous_usage_statistics": {
+                "enabled": True,
+                "data_context_id": "6a52bdfa-e182-455b-a825-e69f076e67d6",
+                "usage_statistics_url": USAGE_STATISTICS_QA_URL,
+            },
+        }
+    )

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -22,7 +22,6 @@ from great_expectations.data_context import (
 from great_expectations.data_context.store import ExpectationsStore
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
-    DataContextConfig,
     DataContextConfigDefaults,
     DatasourceConfig,
 )
@@ -39,9 +38,6 @@ from great_expectations.datasource import (
 )
 from great_expectations.datasource.types.batch_kwargs import PathBatchKwargs
 from great_expectations.util import gen_directory_tree_str
-from tests.integration.usage_statistics.test_integration_usage_statistics import (
-    USAGE_STATISTICS_QA_URL,
-)
 from tests.test_utils import create_files_in_directory, safe_remove
 
 try:
@@ -687,47 +683,6 @@ def test_add_store(empty_data_context):
     assert isinstance(new_store, ExpectationsStore)
 
 
-@pytest.fixture
-def basic_data_context_config():
-    return DataContextConfig(
-        **{
-            "commented_map": {},
-            "config_version": 2,
-            "plugins_directory": "plugins/",
-            "evaluation_parameter_store_name": "evaluation_parameter_store",
-            "validations_store_name": "does_not_have_to_be_real",
-            "expectations_store_name": "expectations_store",
-            "config_variables_file_path": "uncommitted/config_variables.yml",
-            "datasources": {},
-            "stores": {
-                "expectations_store": {
-                    "class_name": "ExpectationsStore",
-                    "store_backend": {
-                        "class_name": "TupleFilesystemStoreBackend",
-                        "base_directory": "expectations/",
-                    },
-                },
-                "evaluation_parameter_store": {
-                    "module_name": "great_expectations.data_context.store",
-                    "class_name": "EvaluationParameterStore",
-                },
-            },
-            "data_docs_sites": {},
-            "validation_operators": {
-                "default": {
-                    "class_name": "ActionListValidationOperator",
-                    "action_list": [],
-                }
-            },
-            "anonymous_usage_statistics": {
-                "enabled": True,
-                "data_context_id": "6a52bdfa-e182-455b-a825-e69f076e67d6",
-                "usage_statistics_url": USAGE_STATISTICS_QA_URL,
-            },
-        }
-    )
-
-
 def test_ExplorerDataContext(titanic_data_context):
     context_root_directory = titanic_data_context.root_directory
     explorer_data_context = ExplorerDataContext(context_root_directory)
@@ -1274,151 +1229,6 @@ def test_build_batch_kwargs(titanic_multibatch_data_context):
     paths.append(os.path.basename(batch_kwargs["path"]))
 
     assert {"Titanic_1912.csv", "Titanic_1911.csv"} == set(paths)
-
-
-def test_existing_local_data_docs_urls_returns_url_on_project_with_no_datasources_and_a_site_configured(
-    tmp_path_factory,
-):
-    """
-    This test ensures that a url will be returned for a default site even if a
-    datasource is not configured, and docs are not built.
-    """
-    empty_directory = str(tmp_path_factory.mktemp("another_empty_project"))
-    DataContext.create(empty_directory)
-    context = DataContext(os.path.join(empty_directory, DataContext.GE_DIR))
-
-    obs = context.get_docs_sites_urls(only_if_exists=False)
-    assert len(obs) == 1
-    assert obs[0]["site_url"].endswith(
-        "great_expectations/uncommitted/data_docs/local_site/index.html"
-    )
-
-
-def test_existing_local_data_docs_urls_returns_single_url_from_customized_local_site(
-    tmp_path_factory,
-):
-    empty_directory = str(tmp_path_factory.mktemp("yo_yo"))
-    DataContext.create(empty_directory)
-    ge_dir = os.path.join(empty_directory, DataContext.GE_DIR)
-    context = DataContext(ge_dir)
-
-    context._project_config["data_docs_sites"] = {
-        "my_rad_site": {
-            "class_name": "SiteBuilder",
-            "store_backend": {
-                "class_name": "TupleFilesystemStoreBackend",
-                "base_directory": "uncommitted/data_docs/some/local/path/",
-            },
-        }
-    }
-
-    # TODO Workaround project config programmatic config manipulation
-    #  statefulness issues by writing to disk and re-upping a new context
-    context._save_project_config()
-    context = DataContext(ge_dir)
-    context.build_data_docs()
-
-    expected_path = os.path.join(
-        ge_dir, "uncommitted/data_docs/some/local/path/index.html"
-    )
-    assert os.path.isfile(expected_path)
-
-    obs = context.get_docs_sites_urls()
-    assert obs == [
-        {"site_name": "my_rad_site", "site_url": "file://{}".format(expected_path)}
-    ]
-
-
-def test_existing_local_data_docs_urls_returns_multiple_urls_from_customized_local_site(
-    tmp_path_factory,
-):
-    empty_directory = str(tmp_path_factory.mktemp("yo_yo_ma"))
-    DataContext.create(empty_directory)
-    ge_dir = os.path.join(empty_directory, DataContext.GE_DIR)
-    context = DataContext(ge_dir)
-
-    context._project_config["data_docs_sites"] = {
-        "my_rad_site": {
-            "class_name": "SiteBuilder",
-            "store_backend": {
-                "class_name": "TupleFilesystemStoreBackend",
-                "base_directory": "uncommitted/data_docs/some/path/",
-            },
-        },
-        "another_just_amazing_site": {
-            "class_name": "SiteBuilder",
-            "store_backend": {
-                "class_name": "TupleFilesystemStoreBackend",
-                "base_directory": "uncommitted/data_docs/another/path/",
-            },
-        },
-    }
-
-    # TODO Workaround project config programmatic config manipulation
-    #  statefulness issues by writing to disk and re-upping a new context
-    context._save_project_config()
-    context = DataContext(ge_dir)
-    context.build_data_docs()
-    data_docs_dir = os.path.join(ge_dir, "uncommitted/data_docs/")
-
-    path_1 = os.path.join(data_docs_dir, "some/path/index.html")
-    path_2 = os.path.join(data_docs_dir, "another/path/index.html")
-    for expected_path in [path_1, path_2]:
-        assert os.path.isfile(expected_path)
-
-    obs = context.get_docs_sites_urls()
-
-    assert obs == [
-        {"site_name": "my_rad_site", "site_url": "file://{}".format(path_1)},
-        {
-            "site_name": "another_just_amazing_site",
-            "site_url": "file://{}".format(path_2),
-        },
-    ]
-
-
-def test_build_data_docs_skipping_index_does_not_build_index(
-    tmp_path_factory,
-):
-    # TODO What's the latest and greatest way to use configs rather than my hackery?
-    empty_directory = str(tmp_path_factory.mktemp("empty"))
-    DataContext.create(empty_directory)
-    ge_dir = os.path.join(empty_directory, DataContext.GE_DIR)
-    context = DataContext(ge_dir)
-    config = context.get_config()
-    config.data_docs_sites = {
-        "local_site": {
-            "class_name": "SiteBuilder",
-            "store_backend": {
-                "class_name": "TupleFilesystemStoreBackend",
-                "base_directory": os.path.join("uncommitted", "data_docs"),
-            },
-        },
-    }
-    context._project_config = config
-
-    # TODO Workaround project config programmatic config manipulation
-    #  statefulness issues by writing to disk and re-upping a new context
-    context._save_project_config()
-    del context
-    context = DataContext(ge_dir)
-    data_docs_dir = os.path.join(ge_dir, "uncommitted", "data_docs")
-    index_path = os.path.join(data_docs_dir, "index.html")
-    assert not os.path.isfile(index_path)
-
-    context.build_data_docs(build_index=False)
-    assert os.path.isdir(os.path.join(data_docs_dir, "static"))
-    assert not os.path.isfile(index_path)
-
-
-def test_get_site_names(
-    tmp_path_factory, empty_data_context, basic_data_context_config
-):
-    assert empty_data_context.get_site_names() == ["local_site"]
-    assert basic_data_context_config.data_docs_sites == {}
-    base_path = tmp_path_factory.mktemp("foo")
-    context = BaseDataContext(basic_data_context_config, context_root_dir=base_path)
-    assert context.get_site_names() == []
 
 
 def test_load_config_variables_file(

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -3,6 +3,8 @@ from unittest import mock
 
 import pytest
 
+from great_expectations import DataContext
+from great_expectations.data_context import BaseDataContext
 from great_expectations.exceptions import DataContextError
 
 
@@ -259,3 +261,163 @@ def test_clean_data_docs_on_context_with_multiple_sites_with_non_existent_site_n
     context = context_with_multiple_built_sites
     with pytest.raises(DataContextError):
         assert context.clean_data_docs(site_name="not_a_real_site")
+
+
+def test_existing_local_data_docs_urls_returns_url_on_project_with_no_datasources_and_a_site_configured(
+    tmp_path_factory,
+):
+    """
+    This test ensures that a url will be returned for a default site even if a
+    datasource is not configured, and docs are not built.
+    """
+    empty_directory = str(tmp_path_factory.mktemp("another_empty_project"))
+    DataContext.create(empty_directory)
+    context = DataContext(os.path.join(empty_directory, DataContext.GE_DIR))
+
+    obs = context.get_docs_sites_urls(only_if_exists=False)
+    assert len(obs) == 1
+    assert obs[0]["site_url"].endswith(
+        "great_expectations/uncommitted/data_docs/local_site/index.html"
+    )
+
+
+def test_existing_local_data_docs_urls_returns_single_url_from_customized_local_site(
+    tmp_path_factory,
+):
+    empty_directory = str(tmp_path_factory.mktemp("yo_yo"))
+    DataContext.create(empty_directory)
+    ge_dir = os.path.join(empty_directory, DataContext.GE_DIR)
+    context = DataContext(ge_dir)
+
+    context._project_config["data_docs_sites"] = {
+        "my_rad_site": {
+            "class_name": "SiteBuilder",
+            "store_backend": {
+                "class_name": "TupleFilesystemStoreBackend",
+                "base_directory": "uncommitted/data_docs/some/local/path/",
+            },
+        }
+    }
+
+    # TODO Workaround project config programmatic config manipulation
+    #  statefulness issues by writing to disk and re-upping a new context
+    context._save_project_config()
+    context = DataContext(ge_dir)
+    context.build_data_docs()
+
+    expected_path = os.path.join(
+        ge_dir, "uncommitted/data_docs/some/local/path/index.html"
+    )
+    assert os.path.isfile(expected_path)
+
+    obs = context.get_docs_sites_urls()
+    assert obs == [
+        {"site_name": "my_rad_site", "site_url": "file://{}".format(expected_path)}
+    ]
+
+
+def test_existing_local_data_docs_urls_returns_multiple_urls_from_customized_local_site(
+    tmp_path_factory,
+):
+    empty_directory = str(tmp_path_factory.mktemp("yo_yo_ma"))
+    DataContext.create(empty_directory)
+    ge_dir = os.path.join(empty_directory, DataContext.GE_DIR)
+    context = DataContext(ge_dir)
+
+    context._project_config["data_docs_sites"] = {
+        "my_rad_site": {
+            "class_name": "SiteBuilder",
+            "store_backend": {
+                "class_name": "TupleFilesystemStoreBackend",
+                "base_directory": "uncommitted/data_docs/some/path/",
+            },
+        },
+        "another_just_amazing_site": {
+            "class_name": "SiteBuilder",
+            "store_backend": {
+                "class_name": "TupleFilesystemStoreBackend",
+                "base_directory": "uncommitted/data_docs/another/path/",
+            },
+        },
+    }
+
+    # TODO Workaround project config programmatic config manipulation
+    #  statefulness issues by writing to disk and re-upping a new context
+    context._save_project_config()
+    context = DataContext(ge_dir)
+    context.build_data_docs()
+    data_docs_dir = os.path.join(ge_dir, "uncommitted/data_docs/")
+
+    path_1 = os.path.join(data_docs_dir, "some/path/index.html")
+    path_2 = os.path.join(data_docs_dir, "another/path/index.html")
+    for expected_path in [path_1, path_2]:
+        assert os.path.isfile(expected_path)
+
+    obs = context.get_docs_sites_urls()
+
+    assert obs == [
+        {"site_name": "my_rad_site", "site_url": "file://{}".format(path_1)},
+        {
+            "site_name": "another_just_amazing_site",
+            "site_url": "file://{}".format(path_2),
+        },
+    ]
+
+
+def test_build_data_docs_skipping_index_does_not_build_index(
+    tmp_path_factory,
+):
+    # TODO What's the latest and greatest way to use configs rather than my hackery?
+    empty_directory = str(tmp_path_factory.mktemp("empty"))
+    DataContext.create(empty_directory)
+    ge_dir = os.path.join(empty_directory, DataContext.GE_DIR)
+    context = DataContext(ge_dir)
+    config = context.get_config()
+    config.data_docs_sites = {
+        "local_site": {
+            "class_name": "SiteBuilder",
+            "store_backend": {
+                "class_name": "TupleFilesystemStoreBackend",
+                "base_directory": os.path.join("uncommitted", "data_docs"),
+            },
+        },
+    }
+    context._project_config = config
+
+    # TODO Workaround project config programmatic config manipulation
+    #  statefulness issues by writing to disk and re-upping a new context
+    context._save_project_config()
+    del context
+    context = DataContext(ge_dir)
+    data_docs_dir = os.path.join(ge_dir, "uncommitted", "data_docs")
+    index_path = os.path.join(data_docs_dir, "index.html")
+    assert not os.path.isfile(index_path)
+
+    context.build_data_docs(build_index=False)
+    assert os.path.isdir(os.path.join(data_docs_dir, "static"))
+    assert not os.path.isfile(index_path)
+
+
+def test_get_site_names_with_no_sites(tmpdir, basic_data_context_config):
+    context = BaseDataContext(basic_data_context_config, context_root_dir=tmpdir)
+    assert context.get_site_names() == []
+
+
+def test_get_site_names_with_site(titanic_data_context_stats_enabled_config_version_3):
+    context = titanic_data_context_stats_enabled_config_version_3
+    assert context.get_site_names() == ["local_site"]
+
+
+def test_get_site_names_with_three_sites(tmpdir, basic_data_context_config):
+    basic_data_context_config.data_docs_sites = {}
+    for i in range(3):
+        basic_data_context_config.data_docs_sites[f"site-{i}"] = {
+            "class_name": "SiteBuilder",
+            "store_backend": {
+                "class_name": "TupleFilesystemStoreBackend",
+                "base_directory": f"uncommitted/data_docs/site-{i}/",
+            },
+            "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
+        }
+    context = BaseDataContext(basic_data_context_config, context_root_dir=tmpdir)
+    assert context.get_site_names() == ["site-0", "site-1", "site-2"]


### PR DESCRIPTION
* [ENHANCEMENT] V3 API CLI docs commands have better error messages and more consistent short flags
* [BUGFIX] V3 API CLI docs build now opens all built sites rather than only the last one
* new set of parameterized v3 CLI `docs` tests to cover multiple sites
* consolidated DataContext data docs tests into single test file
* improved test coverage of v3 CLI `docs` commands through parameterization
* moved test fixture to be shared within a module


Previous Design Review notes:
- This PR addresses several issues found in UAT testing V3 API CLI `docs` commands

**Note I've added a few "guided tour" comments in the PR to aid in asynchronous review**
