### PR TITLE
Update Configuring Datasource documents with steps for using the v3 api

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Develop
 * [DOCS] Update how_to_create_a_new_checkpoint.rst with description of new CLI functionality
 * [ENHANCEMENT] V3 API CLI docs commands have better error messages and more consistent short flags
 * [BUGFIX] V3 API CLI docs build now opens all built sites rather than only the last one
+* [DOCS] Update Configuring Datasources documentation for V3 API CLI
 
 0.13.17
 -----------------

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_bigquery_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_bigquery_datasource.rst
@@ -5,11 +5,6 @@ How to configure a BigQuery Datasource
 
 This guide will help you add a BigQuery project (or a dataset) as a Datasource. This will allow you to validate tables and queries within this project. When you use a BigQuery Datasource, the validation is done in BigQuery itself. Your data is not downloaded.
 
-.. admonition:: Prerequisites: This how-to guide assumes you have already:
-
-  - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
-  - Followed the `Google Cloud library guide <https://googleapis.dev/python/google-api-core/latest/auth.html>`_ for authentication
-  - Installed the ``pybigquery`` package for the BigQuery sqlalchemy dialect (``pip install pybigquery``)
 
 Steps
 -----
@@ -18,6 +13,12 @@ Steps
 
     .. tab-container:: tab0
         :title: Show Docs for V2 (Batch Kwargs) API
+
+        .. admonition:: Prerequisites: This how-to guide assumes you have already:
+
+          - :ref:`Set up a working deployment of Great Expectations <tutorials__getting_started>`
+          - Followed the `Google Cloud library guide <https://googleapis.dev/python/google-api-core/latest/auth.html>`_ for authentication
+          - Installed the ``pybigquery`` package for the BigQuery sqlalchemy dialect (``pip install pybigquery``)
 
 
         1. Run the following CLI command to begin the interactive Datasource creation process:
@@ -69,18 +70,24 @@ Steps
             - Installed the ``pybigquery`` package for the BigQuery sqlalchemy dialect (``pip install pybigquery``)
 
 
-        #. **Instantiate a Data Context.**
+        1. Run the following CLI command to begin the interactive Datasource creation process:
 
-            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+            .. code-block:: bash
 
-            .. code-block:: python
+                great_expectations --v3-api datasource new
 
-                import great_expectations as ge
-                context = ge.get_context()
+        2. Choose "Big Query" from the list of database engines, when prompted.
 
-        #.  **Create or copy a yaml config.**
+        3. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
 
-                Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.  Great Expectations uses a ``connection_string`` to connect to BigQuery through SQLAlchemy (reference: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls).
+Additional Notes
+----------------
+
+        Within this notebook, you will have the opportunity to create your own yaml Datasource configuration. The following text walks through an example.
+
+        **BigQuery SimpleSqlalchemyDatasource Example**
+
+        3a.  Here is a simple example configuration. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.  Great Expectations uses a ``connection_string`` to connect to BigQuery through SQLAlchemy (reference: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls).
 
 
                 .. code-block:: python
@@ -98,13 +105,11 @@ Steps
             **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 
-        #. **Run context.test_yaml_config.**
+        3b. Test your config using ``context.test_yaml_config``.
 
             .. code-block:: python
 
-                context.test_yaml_config(
-                    yaml_config=config
-                )
+                context.test_yaml_config(yaml_config=config)
 
             When executed, ``test_yaml_config`` will instantiate the component and run through a ``self_check`` procedure to verify that the component works as expected.
 
@@ -126,10 +131,10 @@ Steps
                     Unmatched data_references (0 of 0): []
 
 
-            This means all has gone well and you can proceed with configuring your new Datasource.             If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
+            This means all has gone well and you can proceed with configuring your new Datasource. If something about your configuration wasn't set up correctly, ``test_yaml_config`` will raise an error.
 
 
-        #. **Save the config.**
+        3c. **Save the config.**
             Once you are satisfied with the config of your new Datasource, you can make it a permanent part of your Great Expectations configuration. The following method will save the new Datasource to your ``great_expectations.yml``:
 
             .. code-block:: python
@@ -140,9 +145,6 @@ Steps
 
             **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
-
-Additional notes
-----------------
 
 Environment variables can be used to store the SQLAlchemy URL instead of the file, if preferred - search documentation for "Managing Environment and Secrets".
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mssql_datasource.rst
@@ -71,7 +71,7 @@ Steps
 
         #. **Give your Datasource a name**
 
-            When prompted, provide a custom name for your Snowflake data source, or hit Enter to accept the default.
+            When prompted, provide a custom name for your MSSQL data source, or hit Enter to accept the default.
 
             .. code-block:: bash
 
@@ -134,16 +134,45 @@ Steps
 
                 pip install sqlalchemy
                 pip install pyodbc
-        #. **Instantiate a Data Context.**
+        #. **Run datasource new**
 
-            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+            From the command line, run:
 
-            .. code-block:: python
+            .. code-block:: bash
 
-                import great_expectations as ge
-                context = ge.get_context()
+                great_expectations --v3-api datasource new
 
-        #.  **Create or copy a yaml config.**
+
+        #. **Choose "Relational database (SQL)"**
+
+            .. code-block:: bash
+
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
+                : 2
+
+        #. **Choose 'other'**
+
+            .. code-block:: bash
+
+                Which database backend are you using?
+                    1. MySQL
+                    2. Postgres
+                    3. Redshift
+                    4. Snowflake
+                    5. BigQuery
+                    6. other - Do you have a working SQLAlchemy connection string?
+                : 6
+
+        #. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
+
+Additional Notes
+----------------
+
+        Within this notebook, you will have the opportunity to create your own yaml Datasource configuration. The following text walks through an example.
+
+        #.  **MSSQL SimpleSqlalchemyDatasource Example.**
 
                 Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.  Great Expectations uses a ``connection_string`` to connect to MSSQL databases through SQLAlchemy (reference: https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls).
 
@@ -163,7 +192,7 @@ Steps
             **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 
-        #. **Run context.test_yaml_config.**
+        #. **Test your config using ``context.test_yaml_config``.**
 
             .. code-block:: python
 
@@ -205,9 +234,6 @@ Steps
 
             **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
-
-Additional notes
-----------------
 
 The following blog post provides a useful overview of using SqlAlchemy to connect to MSSQL.
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_mysql_datasource.rst
@@ -125,16 +125,45 @@ Steps
                 pip install sqlalchemy
                 pip install PyMySQL
 
-        #. **Instantiate a Data Context.**
+        #. **Run datasource new**
 
-            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+            From the command line, run:
 
-            .. code-block:: python
+            .. code-block:: bash
 
-                import great_expectations as ge
-                context = ge.get_context()
+                great_expectations --v3-api datasource new
 
-        #.  **Create or copy a yaml config.**
+        #. **Choose "Relational database (SQL)"**
+
+            .. code-block:: bash
+
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
+                : 2
+
+        #. **Choose MySQL**
+
+            .. code-block:: bash
+
+                Which database backend are you using?
+                    1. MySQL
+                    2. Postgres
+                    3. Redshift
+                    4. Snowflake
+                    5. BigQuery
+                    6. other - Do you have a working SQLAlchemy connection string?
+                : 1
+
+        #. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
+
+
+Additional notes
+----------------
+
+        Within this notebook, you will have the opportunity to create your own yaml Datasource configuration. The following text walks through an example.
+
+        #.  **MySql SimpleSqlalchemyDatasource Example.**
 
                 Parameters can be set as strings, or passed in as environment variables. In the following example, a yaml config is configured for a ``SimpleSqlalchemyDatasource`` with associated credentials passed in as strings.
 
@@ -159,7 +188,7 @@ Steps
             **Note**: Additional examples of yaml configurations for various filesystems and databases can be found in the following document: :ref:`How to configure Data Context components using test_yaml_config <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
 
-        #. **Run context.test_yaml_config.**
+        #. **Test your config using ``context.test_yaml_config``.**
 
             .. code-block:: python
 
@@ -199,8 +228,6 @@ Steps
 
             **Note**: The credentials will be stored in ``uncommitted/config_variables.yml`` to prevent checking them into version control.
 
-Additional notes
-----------------
 
 * The default configuration of the most recent MySQL releases does not support some GROUP_BY operations used in Great Expectations. To use the full range of statistical Expectations, you need to disable the ``ONLY_FULL_GROUP_BY`` ``sql_mode`` setting. Please see the following article for more information https://stackoverflow.com/questions/36829911/how-to-resolve-order-by-clause-is-not-in-select-list-caused-mysql-5-7-with-sel).
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_pandas_filesystem_datasource.rst
@@ -115,14 +115,48 @@ Steps
 
         To add a Pandas filesystem datasource, do the following:
 
-        #. **Instantiate a Data Context.**
+        #. **Run datasource new**
 
-            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+            From the command line, run:
 
-            .. code-block:: python
+            .. code-block:: bash
 
-                import great_expectations as ge
-                context = ge.get_context()
+                great_expectations --v3-api datasource new
+
+        #. **Choose "Files on a filesystem (for processing with Pandas or Spark)"**
+
+            .. code-block:: bash
+
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
+                : 1
+
+        #. **Choose Pandas**
+
+            .. code-block:: bash
+
+                What are you processing your files with?
+                    1. Pandas
+                    2. PySpark
+                : 1
+
+        #. **Specify the directory path for data files**
+
+            .. code-block:: bash
+
+                Enter the path (relative or absolute) of the root directory where the data files are stored.
+                : /path/to/directory/containing/your/data/files
+
+        #. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
+
+
+Additional notes
+----------------
+
+        #.  **Pandas Datasource Example.**
+
+            Within this notebook, you will have the opportunity to create your own yaml Datasource configuration. The following text walks through an example.
 
 
         #. **List files in your directory.**
@@ -177,7 +211,7 @@ Steps
             **Note**: The ``InferredAssetS3DataConnector`` used in this example is closely related to the ``ConfiguredAssetS3DataConnector`` with some key differences. More information can be found in :ref:`How to choose which DataConnector to use. <which_data_connector_to_use>`
 
 
-        #. **Run context.test_yaml_config.**
+        #. **Test your config using ``context.test_yaml_config``.**
 
             .. code-block:: python
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -167,14 +167,45 @@ Steps
                 # or if on macOS:
                 pip install psycopg2-binary
 
-        #. **Instantiate a Data Context.**
+        #. **Run datasource new**
 
-            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+            From the command line, run:
 
-            .. code-block:: python
+            .. code-block:: bash
 
-                import great_expectations as ge
-                context = ge.get_context()
+                great_expectations datasource new
+
+        #. **Choose "Relational database (SQL)"**
+
+            .. code-block:: bash
+
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
+                : 2
+
+        #. **Choose Redshift**
+
+            .. code-block:: bash
+
+                Which database backend are you using?
+                    1. MySQL
+                    2. Postgres
+                    3. Redshift
+                    4. Snowflake
+                    5. BigQuery
+                    6. other - Do you have a working SQLAlchemy connection string?
+                : 3
+
+        #. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
+
+
+Additional notes
+----------------
+
+        #.  **Redshift SimpleSqlalchemyDatasource Example.**
+
+            Within this notebook, you will have the opportunity to create your own yaml Datasource configuration. The following text walks through an example.
 
         #. **Create or copy a yaml config.**
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_redshift_datasource.rst
@@ -173,7 +173,7 @@ Steps
 
             .. code-block:: bash
 
-                great_expectations datasource new
+                great_expectations --v3-api datasource new
 
         #. **Choose "Relational database (SQL)"**
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_self_managed_spark_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_self_managed_spark_datasource.rst
@@ -19,59 +19,59 @@ Steps
 
 To enable running Great Expectations against dataframe created by Spark SQL query, follow below steps:
 
-#. **Run datasource new**
-
-    From the command line, run:
-
-    .. code-block:: bash
-
-        great_expectations datasource new
-
-#. **Choose "Files on a filesystem (for processing with Pandas or Spark)"**
-
-    .. code-block:: bash
-
-        What data would you like Great Expectations to connect to?
-            1. Files on a filesystem (for processing with Pandas or Spark)
-            2. Relational database (SQL)
-
-        : 1
-
-#. **Choose PySpark**
-
-    .. code-block:: bash
-
-        What are you processing your files with?
-            1. Pandas
-            2. PySpark
-
-        : 2
-
-#. **Enter /tmp** (it doesn't matter what you enter as we will replace this in a few steps).
-
-    .. code-block:: bash
-
-        Enter the path (relative or absolute) of the root directory where the data files are stored.
-
-        : /tmp
-
-#. **Enter spark_dataframe**
-
-    .. code-block:: bash
-
-        Give your new Datasource a short name.
-        [tmp__dir]: spark_dataframe
-
-#. **Enter Y**
-
-    .. code-block:: bash
-
-        Would you like to proceed? [Y/n]: Y
-
 .. content-tabs::
 
     .. tab-container:: tab0
         :title: Show Docs for V2 (Batch Kwargs) API
+
+        #. **Run datasource new**
+
+            From the command line, run:
+
+            .. code-block:: bash
+
+                great_expectations datasource new
+
+        #. **Choose "Files on a filesystem (for processing with Pandas or Spark)"**
+
+            .. code-block:: bash
+
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
+
+                : 1
+
+        #. **Choose PySpark**
+
+            .. code-block:: bash
+
+                What are you processing your files with?
+                    1. Pandas
+                    2. PySpark
+
+                : 2
+
+        #. **Enter /tmp** (it doesn't matter what you enter as we will replace this in a few steps).
+
+            .. code-block:: bash
+
+                Enter the path (relative or absolute) of the root directory where the data files are stored.
+
+                : /tmp
+
+        #. **Enter spark_dataframe**
+
+            .. code-block:: bash
+
+                Give your new Datasource a short name.
+                [tmp__dir]: spark_dataframe
+
+        #. **Enter Y**
+
+            .. code-block:: bash
+
+                Would you like to proceed? [Y/n]: Y
 
         #. **Replace lines in great_expectations.yml file**
 
@@ -116,45 +116,43 @@ To enable running Great Expectations against dataframe created by Spark SQL quer
     .. tab-container:: tab1
         :title: Show Docs for V3 (Batch Request) API
 
-        #. **Replace lines in great_expectations.yml file**
+        #. **Run datasource new**
 
-        .. code-block:: yaml
+            From the command line, run:
 
-            datasources:
-              spark_dataframe:
-                data_asset_type:
-                  class_name: SparkDFDataset
-                  module_name: great_expectations.dataset
-                batch_kwargs_generators:
-                  subdir_reader:
-                    class_name: SubdirReaderBatchKwargsGenerator
-                    base_directory: /tmp
-                class_name: SparkDFDatasource
-                module_name: great_expectations.datasource
+            .. code-block:: bash
 
-        with
+                great_expectations --v3-api datasource new
 
-        .. code-block:: yaml
+        #. **Choose "Files on a filesystem (for processing with Pandas or Spark)"**
 
-            datasources:
-              spark_dataframe:
-                class_name: Datasource
-                execution_engine:
-                  class_name: SparkDFExecutionEngine
-                data_connectors:
-                  simple_filesystem_data_connector:
-                    class_name: InferredAssetFilesystemDataConnector
-                    base_directory: /root/directory/containing/data/files
-                    glob_directive: '*'
-                    default_regex:
-                      pattern: (.+)\.csv
-                      group_names:
-                      - data_asset_name
+            .. code-block:: bash
 
-        #. **Fill values:**
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
 
-        * **base_directory** - Either absolute path or relative path with respect to Great Expectations installation directory is acceptable
-        * **class_name** - A different DataConnector class with its corresponding configuration parameters may be substituted into the above snippet as best suitable for the given use case.
+                : 1
+
+        #. **Choose PySpark**
+
+            .. code-block:: bash
+
+                What are you processing your files with?
+                    1. Pandas
+                    2. PySpark
+
+                : 2
+
+        #. **Enter /tmp** (it doesn't matter what you enter as we will replace this in a few steps).
+
+            .. code-block:: bash
+
+                Enter the path (relative or absolute) of the root directory where the data files are stored.
+
+                : /tmp
+
+        #. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
 
 ----------------
 Additional Notes
@@ -233,7 +231,13 @@ Additional Notes
                       group_names:
                       - data_asset_name
 
-        Full list of Spark configuration options is available here: [https://spark.apache.org/docs/latest/configuration.html](https://spark.apache.org/docs/latest/configuration.html)
+
+        **Fill values:**
+
+        * **base_directory** - Either absolute path or relative path with respect to Great Expectations installation directory is acceptable
+        * **class_name** - A different DataConnector class with its corresponding configuration parameters may be substituted into the above snippet as best suitable for the given use case.
+
+        The full list of Spark configuration options is available here: [https://spark.apache.org/docs/latest/configuration.html](https://spark.apache.org/docs/latest/configuration.html)
 
 .. discourse::
     :topic_identifier: 170

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
@@ -209,14 +209,54 @@ Steps
                 pip install snowflake-connector-python
                 pip install snowflake-sqlalchemy
 
-        #. **Instantiate a Data Context.**
+        #. **Run datasource new**
 
-            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+            From the command line, run:
 
-            .. code-block:: python
+            .. code-block:: bash
 
-                import great_expectations as ge
-                context = ge.get_context()
+                great_expectations --v3-api datasource new
+
+        #. **Choose "Relational database (SQL)"**
+
+            .. code-block:: bash
+
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
+                : 2
+
+        #. **Choose Snowflake**
+
+            .. code-block:: bash
+
+                Which database backend are you using?
+                    1. MySQL
+                    2. Postgres
+                    3. Redshift
+                    4. Snowflake
+                    5. BigQuery
+                    6. other - Do you have a working SQLAlchemy connection string?
+                : 4
+
+        #. **Choose an authentication mechanism**
+
+            .. code-block:: bash
+
+                What authentication method would you like to use?
+
+                1. User and Password
+                2. Single sign-on (SSO)
+                3. Key pair authentication
+
+
+Additional notes
+----------------
+
+        #.  **Snowflake SimpleSqlalchemyDatasource Example.**
+
+            Within this notebook, you will have the opportunity to create your own yaml Datasource configuration. The following text walks through an example.
+
 
         #.  **Create or copy a yaml config.**
 

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_snowflake_datasource.rst
@@ -249,6 +249,8 @@ Steps
                 2. Single sign-on (SSO)
                 3. Key pair authentication
 
+        #. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
+
 
 Additional notes
 ----------------

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_a_spark_filesystem_datasource.rst
@@ -116,16 +116,51 @@ Steps
             - :ref:`Understand the basics of Datasources. <reference__core_concepts__datasources>`
             - Learned how to configure a :ref:`Data Context using test_yaml_config. <how_to_guides_how_to_configure_datacontext_components_using_test_yaml_config>`
 
-        To add a Pandas filesystem datasource, do the following:
+        To add a Spark filesystem datasource, do the following:
 
-        #. **Instantiate a Data Context.**
+        #. **Run datasource new**
 
-            Create a new Jupyter Notebook and instantiate a Data Context by running the following lines:
+            From the command line, run:
 
-            .. code-block:: python
+            .. code-block:: bash
 
-                import great_expectations as ge
-                context = ge.get_context()
+                great_expectations --v3-api datasource new
+
+        #. **Choose "Files on a filesystem (for processing with Pandas or Spark)"**
+
+            .. code-block:: bash
+
+                What data would you like Great Expectations to connect to?
+                    1. Files on a filesystem (for processing with Pandas or Spark)
+                    2. Relational database (SQL)
+                : 1
+
+
+        #. **Choose PySpark**
+
+            .. code-block:: bash
+
+                What are you processing your files with?
+                    1. Pandas
+                    2. PySpark
+                : 2
+
+        #. **Specify the directory path for data files**
+
+            .. code-block:: bash
+
+                Enter the path (relative or absolute) of the root directory where the data files are stored.
+                : /path/to/directory/containing/your/data/files
+
+        #. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
+
+
+Additional notes
+----------------
+
+        #.  **Spark Datasource Example.**
+
+            Within this notebook, you will have the opportunity to create your own yaml Datasource configuration. The following text walks through an example.
 
 
         #. **List files in your directory.**

--- a/docs/guides/how_to_guides/configuring_datasources/how_to_configure_an_athena_datasource.rst
+++ b/docs/guides/how_to_guides/configuring_datasources/how_to_configure_an_athena_datasource.rst
@@ -16,9 +16,21 @@ Steps
 
 1. Run the following CLI command to begin the interactive Datasource creation process:
 
-.. code-block:: bash
+.. content-tabs::
 
-    great_expectations datasource new
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
+
+        .. code-block:: bash
+
+            great_expectations datasource new
+
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
+
+        .. code-block:: bash
+
+            great_expectations --v3-api datasource new
 
 
 2. Choose "other" from the list of database engines, when prompted.
@@ -41,10 +53,25 @@ Steps
         awsathena+rest://@athena.{region}.amazonaws.com/{database}?s3_staging_dir={s3_path}
 
 
-5. Enter the connection string when prompted (and press Enter when asked "Would you like to proceed? [Y/n]:").
+.. content-tabs::
 
-6. Should you need to modify your connection string, you can manually edit the
-   ``great_expectations/uncommitted/config_variables.yml`` file.
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
+
+        5. Enter the connection string when prompted (and press Enter when asked "Would you like to proceed? [Y/n]:").
+
+        6. Should you need to modify your connection string, you can manually edit the
+           ``great_expectations/uncommitted/config_variables.yml`` file.
+
+
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
+
+        5. You will be presented with a Jupyter Notebook which will guide you through the steps of creating a Datasource.
+
+        6. Follow the steps in this Jupyter Notebook including entering the connection string in the yaml configuration.
+
+
 
 
 Additional notes


### PR DESCRIPTION
Changes proposed in this pull request:
- Update all `Configuring Datasource` documents with steps for using the v3 api via the `--v3-api` flag except for `How to configure a Pandas/S3 Datasource` which will be completed in a separate PR.