### PR TITLE
[ENHANCEMENT} Update the `datasource new` notebook for improved data asset inference

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Develop
 * [ENHANCEMENT] Update `ConfiguredAssetSqlDataConnector.build_batch_spec` and `ConfiguredAssetFilePathDataConnector.build_batch_spec` to properly process `Asset.batch_spec_passthrough`
 * [ENHANCEMENT] Update `SqlAlchemyExecutionEngine.get_batch_data_and_markers` to handle `create_temp_table` in `RuntimeQueryBatchSpec`
 * [ENHANCEMENT] Usage stats messages for the v3 API CLI are now sent before and after the command runs # 2661
+* [ENHANCEMENT} Update the datasource new notebook for improved data asset inference
 * [BUGFIX] V3 API CLI docs build now opens all built sites rather than only the last one
 * [DOCS] Update how_to_create_a_new_checkpoint.rst with description of new CLI functionality
 * [DOCS] Update Configuring Datasources documentation for V3 API CLI

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -307,7 +307,8 @@ data_connectors:
     datasource_name: {{datasource_name}}
     base_directory: {self.base_path}
     default_regex:
-      group_names: data_asset_name
+      group_names: 
+        - data_asset_name
       pattern: (.*)
 """'''
 

--- a/tests/cli/test_datasource_new_helpers.py
+++ b/tests/cli/test_datasource_new_helpers.py
@@ -517,7 +517,8 @@ data_connectors:
     datasource_name: {datasource_name}
     base_directory: ../path/to/data
     default_regex:
-      group_names: data_asset_name
+      group_names: 
+        - data_asset_name
       pattern: (.*)
 """'''
     )
@@ -564,7 +565,8 @@ data_connectors:
     datasource_name: {datasource_name}
     base_directory: ../path/to/data
     default_regex:
-      group_names: data_asset_name
+      group_names: 
+        - data_asset_name
       pattern: (.*)
 """'''
     )

--- a/tests/cli/test_datasource_new_pandas_paths.py
+++ b/tests/cli/test_datasource_new_pandas_paths.py
@@ -64,7 +64,7 @@ def _run_cli_datasource_new_path_test(
             "data_connectors": {
                 "my_datasource_example_data_connector": {
                     "default_regex": {
-                        "group_names": "data_asset_name",
+                        "group_names": ["data_asset_name"],
                         "pattern": "(.*)",
                     },
                     "module_name": "great_expectations.datasource.data_connector",

--- a/tests/cli/test_datasource_pandas.py
+++ b/tests/cli/test_datasource_pandas.py
@@ -205,7 +205,7 @@ def test_cli_datasource_new(
             "data_connectors": {
                 "my_datasource_example_data_connector": {
                     "default_regex": {
-                        "group_names": "data_asset_name",
+                        "group_names": ["data_asset_name"],
                         "pattern": "(.*)",
                     },
                     "module_name": "great_expectations.datasource.data_connector",
@@ -346,7 +346,7 @@ def test_cli_datasource_new_with_name_param(
             "data_connectors": {
                 "foo_example_data_connector": {
                     "default_regex": {
-                        "group_names": "data_asset_name",
+                        "group_names": ["data_asset_name"],
                         "pattern": "(.*)",
                     },
                     "module_name": "great_expectations.datasource.data_connector",
@@ -413,7 +413,7 @@ def test_cli_datasource_new_from_misc_directory(
             "data_connectors": {
                 "my_datasource_example_data_connector": {
                     "default_regex": {
-                        "group_names": "data_asset_name",
+                        "group_names": ["data_asset_name"],
                         "pattern": "(.*)",
                     },
                     "module_name": "great_expectations.datasource.data_connector",


### PR DESCRIPTION
Changes proposed in this pull request:
- The yaml snippet generated in `great_expectations datasource new` was missing a hyphen after group names. Consequently, the data_asset inferred was incorrectly bundled, which made it difficult to create a batch. Adding a hyphen ensured the yaml list was correct which makes it easier to infer the correct data asset


