### PR TITLE
[ENHANCEMENT] Update checkpoint new notebook list asset names

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,8 @@ Develop
 * [ENHANCEMENT] Update `ConfiguredAssetSqlDataConnector.build_batch_spec` and `ConfiguredAssetFilePathDataConnector.build_batch_spec` to properly process `Asset.batch_spec_passthrough`
 * [ENHANCEMENT] Update `SqlAlchemyExecutionEngine.get_batch_data_and_markers` to handle `create_temp_table` in `RuntimeQueryBatchSpec`
 * [ENHANCEMENT] Usage stats messages for the v3 API CLI are now sent before and after the command runs # 2661
-* [ENHANCEMENT} Update the datasource new notebook for improved data asset inference
+* [ENHANCEMENT] Update the `datasource new` notebook for improved data asset inference
+* [ENHANCEMENT] Made stylistic improvements to the `checkpoint new` notebook
 * [BUGFIX] V3 API CLI docs build now opens all built sites rather than only the last one
 * [DOCS] Update how_to_create_a_new_checkpoint.rst with description of new CLI functionality
 * [DOCS] Update Configuring Datasources documentation for V3 API CLI

--- a/great_expectations/render/renderer/checkpoint_new_notebook_renderer.py
+++ b/great_expectations/render/renderer/checkpoint_new_notebook_renderer.py
@@ -47,6 +47,7 @@ Use this notebook to configure a new Checkpoint and add it to your project:
         self.add_code_cell(
             """from ruamel.yaml import YAML
 import great_expectations as ge
+from pprint import pprint
 
 yaml = YAML()
 context = ge.get_context()
@@ -61,13 +62,7 @@ The following cells show examples for listing your current configuration. You ca
         )
         self.add_code_cell(
             """# Run this cell to print out the names of your Datasources, Data Connectors and Data Assets
-
-for datasource_name, datasource in context.datasources.items():
-    print(f"datasource_name: {datasource_name}")
-    for data_connector_name, data_connector in datasource.data_connectors.items():
-        print(f"\tdata_connector_name: {data_connector_name}")
-        for data_asset_name in data_connector.get_available_data_asset_names():
-            print(f"\t\tdata_asset_name: {data_asset_name}")""",
+pprint(context.get_available_data_asset_names())""",
             lint=True,
         )
         self.add_code_cell("context.list_expectation_suite_names()")

--- a/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
+++ b/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
@@ -115,7 +115,7 @@ def checkpoint_new_notebook_assets():
             "cell_type": "code",
             "metadata": {},
             "execution_count": None,
-            "source": "from ruamel.yaml import YAML\nimport great_expectations as ge\n\nyaml = YAML()\ncontext = ge.get_context()",
+            "source": "from ruamel.yaml import YAML\nimport great_expectations as ge\nfrom pprint import pprint\n\nyaml = YAML()\ncontext = ge.get_context()",
             "outputs": [],
         },
     ]

--- a/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
+++ b/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
@@ -129,12 +129,7 @@ def checkpoint_new_notebook_assets():
             "cell_type": "code",
             "metadata": {},
             "execution_count": None,
-            "source": """# Run this cell to print out the names of your Datasources, Data Connectors and Data Assets\n\nfor datasource_name, datasource in context.datasources.items():
-    print(f"datasource_name: {datasource_name}")
-    for data_connector_name, data_connector in datasource.data_connectors.items():
-        print(f"\tdata_connector_name: {data_connector_name}")
-        for data_asset_name in data_connector.get_available_data_asset_names():
-            print(f"\t\tdata_asset_name: {data_asset_name}")""",
+            "source": """# Run this cell to print out the names of your Datasources, Data Connectors and Data Assets\npprint(context.get_available_data_asset_names())""",
             "outputs": [],
         },
         {


### PR DESCRIPTION
Changes proposed in this pull request:
- This updates the generated `checkpoint new` notebook to use an existing data context API call to list out all of the data assets instead of the pre-existing nested for loop.


