### PR TITLE
[DOCS] Update Configuring metadata stores documentation for V3 API CLI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Develop
 * [DOCS] Update how_to_create_a_new_checkpoint.rst with description of new CLI functionality
 * [DOCS] Update Configuring Datasources documentation for V3 API CLI
 * [DOCS] Update Configuring Data Docs documentation for V3 API CLI
+* [DOCS] Update Configuring metadata stores documentation for V3 API CLI
 * [DOCS] Fix typos in "How to load a database table, view, or query result as a batch" guide and update with `create_temp_table` info
 * [DOCS] Update "How to add a Validation Operator" guide to make it clear it is only for V2 API
 

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_azure_blob_storage.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_azure_blob_storage.rst
@@ -17,92 +17,184 @@ By default, Validations are stored in JSON format in the ``uncommitted/validatio
 
 Steps
 -----
+.. content-tabs::
 
-1. **Configure the** ``config_variables.yml`` **file with your azure storage credentials**
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-    We recommend that azure storage credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add azure storage credentials under the key ``AZURE_STORAGE_CONNECTION_STRING``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
+        1. **Configure the** ``config_variables.yml`` **file with your azure storage credentials**
 
-    .. code-block:: yaml
+            We recommend that azure storage credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add azure storage credentials under the key ``AZURE_STORAGE_CONNECTION_STRING``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
 
-        AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
-        
+            .. code-block:: yaml
 
-2. **Identify your Data Context Validations Store**
-
-    In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
-
-    .. code-block:: yaml
-
-        validations_store_name: validations_store
-
-        stores:
-            validations_store:
-                class_name: ValidationsStore
-                store_backend:
-                    class_name: TupleFilesystemStoreBackend
-                    base_directory: uncommitted/validations/
+                AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
 
 
-3. **Update your configuration file to include a new store for Validations on Azure storage account**
+        2. **Identify your Data Context Validations Store**
 
-    In our case, the name is set to ``validations_AZ_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleAzureBlobStoreBackend``,  ``container`` will be set to the name of your blob container (the equivalent of S3 bucket for Azure) you wish to store your validations, ``prefix`` will be set to the folder in the container where Validation files will be located, and ``connection_string`` will be set to ``${AZURE_STORAGE_CONNECTION_STRING}``, which references the corresponding key in the ``config_variables.yml`` file.
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        validations_store_name: validations_AZ_store
+                validations_store_name: validations_store
 
-        stores:
-            validations_AZ_store:
-                class_name: ValidationsStore
-                store_backend:
-                    class_name: TupleAzureBlobStoreBackend
-                    container: <blob-container>
-                    prefix: validations
-                    connection_string: ${AZURE_STORAGE_CONNECTION_STRING}    
-
-    .. note::
-        If the container is called ``$web`` (for :ref:`hosting and sharing data docs on azure blob storage <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_azure_blob_storage>`) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
-
-4. **Copy existing Validations JSON files to the Azure blob**. (This step is optional).
-
-    One way to copy Validations into Azure Blob Storage is by using the ``az storage blob upload`` command, which is part of the Azure SDK. The following example will copy one Validation from a local folder to the Azure blob.   Information on other ways to copy Validation JSON files, like the Azure Storage browser in the Azure Portal, can be found in the `Documentation for Azure <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal>`_.
-
-    .. code-block:: bash
-
-        export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
-        az storage blob upload -f <local/path/to/validation.json> -c <GREAT-EXPECTATION-DEDICATED-AZURE-BLOB-CONTAINER-NAME> -n <PREFIX>/<validation.json>
-        example with a validation related to the exp1 expectation: 
-        az storage blob upload -f great_expectations/uncommitted/validations/exp1/20210306T104406.877327Z/20210306T104406.877327Z/8313fb37ca59375eb843adf388d4f882.json -c <blob-container> -n validations/exp1/20210306T104406.877327Z/20210306T104406.877327Z/8313fb37ca59375eb843adf388d4f882.json
-        Finished[#############################################################]  100.0000%
-        {
-          "etag": "\"0x8D8E09F894650C7\"",
-          "lastModified": "2021-03-06T12:58:28+00:00"
-        }
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
 
 
-5. **Confirm that the new Validations store has been added by running** ``great_expectations store list``.
+        3. **Update your configuration file to include a new store for Validations on Azure storage account**
 
-    Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_AZ_store`` we just configured.  This is ok, since Great Expectations will look for Validations in Azure Blob as long as we set the ``validations_store_name`` variable to ``validations_AZ_store``, and the config for ``validations_store`` can be removed if you would like.
+            In our case, the name is set to ``validations_AZ_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleAzureBlobStoreBackend``,  ``container`` will be set to the name of your blob container (the equivalent of S3 bucket for Azure) you wish to store your validations, ``prefix`` will be set to the folder in the container where Validation files will be located, and ``connection_string`` will be set to ``${AZURE_STORAGE_CONNECTION_STRING}``, which references the corresponding key in the ``config_variables.yml`` file.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_AZ_store
+
+                stores:
+                    validations_AZ_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleAzureBlobStoreBackend
+                            container: <blob-container>
+                            prefix: validations
+                            connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
+
+            .. note::
+                If the container is called ``$web`` (for :ref:`hosting and sharing data docs on azure blob storage <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_azure_blob_storage>`) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
+
+        4. **Copy existing Validations JSON files to the Azure blob**. (This step is optional).
+
+            One way to copy Validations into Azure Blob Storage is by using the ``az storage blob upload`` command, which is part of the Azure SDK. The following example will copy one Validation from a local folder to the Azure blob.   Information on other ways to copy Validation JSON files, like the Azure Storage browser in the Azure Portal, can be found in the `Documentation for Azure <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal>`_.
+
+            .. code-block:: bash
+
+                export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+                az storage blob upload -f <local/path/to/validation.json> -c <GREAT-EXPECTATION-DEDICATED-AZURE-BLOB-CONTAINER-NAME> -n <PREFIX>/<validation.json>
+                example with a validation related to the exp1 expectation:
+                az storage blob upload -f great_expectations/uncommitted/validations/exp1/20210306T104406.877327Z/20210306T104406.877327Z/8313fb37ca59375eb843adf388d4f882.json -c <blob-container> -n validations/exp1/20210306T104406.877327Z/20210306T104406.877327Z/8313fb37ca59375eb843adf388d4f882.json
+                Finished[#############################################################]  100.0000%
+                {
+                  "etag": "\"0x8D8E09F894650C7\"",
+                  "lastModified": "2021-03-06T12:58:28+00:00"
+                }
 
 
-    .. code-block:: bash
-    
-        great_expectations store list               
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations store list``.
 
-         - name: validations_store
-           class_name: ValidationsStore
-           store_backend:
-             class_name: TupleFilesystemStoreBackend
-             base_directory: uncommitted/validations/
+            Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_AZ_store`` we just configured.  This is ok, since Great Expectations will look for Validations in Azure Blob as long as we set the ``validations_store_name`` variable to ``validations_AZ_store``, and the config for ``validations_store`` can be removed if you would like.
 
-         - name: validations_AZ_store
-           class_name: ValidationsStore
-           store_backend:
-             class_name: TupleAzureBlobStoreBackend
-             connection_string: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
-             container: <blob-container>
-             prefix: validations
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                 - name: validations_store
+                   class_name: ValidationsStore
+                   store_backend:
+                     class_name: TupleFilesystemStoreBackend
+                     base_directory: uncommitted/validations/
+
+                 - name: validations_AZ_store
+                   class_name: ValidationsStore
+                   store_backend:
+                     class_name: TupleAzureBlobStoreBackend
+                     connection_string: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+                     container: <blob-container>
+                     prefix: validations
              
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
+
+        1. **Configure the** ``config_variables.yml`` **file with your azure storage credentials**
+
+            We recommend that azure storage credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add azure storage credentials under the key ``AZURE_STORAGE_CONNECTION_STRING``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
+
+            .. code-block:: yaml
+
+                AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+
+
+        2. **Identify your Data Context Validations Store**
+
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_store
+
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+
+        3. **Update your configuration file to include a new store for Validations on Azure storage account**
+
+            In our case, the name is set to ``validations_AZ_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleAzureBlobStoreBackend``,  ``container`` will be set to the name of your blob container (the equivalent of S3 bucket for Azure) you wish to store your validations, ``prefix`` will be set to the folder in the container where Validation files will be located, and ``connection_string`` will be set to ``${AZURE_STORAGE_CONNECTION_STRING}``, which references the corresponding key in the ``config_variables.yml`` file.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_AZ_store
+
+                stores:
+                    validations_AZ_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleAzureBlobStoreBackend
+                            container: <blob-container>
+                            prefix: validations
+                            connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
+
+            .. note::
+                If the container is called ``$web`` (for :ref:`hosting and sharing data docs on azure blob storage <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_azure_blob_storage>`) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
+
+        4. **Copy existing Validations JSON files to the Azure blob**. (This step is optional).
+
+            One way to copy Validations into Azure Blob Storage is by using the ``az storage blob upload`` command, which is part of the Azure SDK. The following example will copy one Validation from a local folder to the Azure blob.   Information on other ways to copy Validation JSON files, like the Azure Storage browser in the Azure Portal, can be found in the `Documentation for Azure <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal>`_.
+
+            .. code-block:: bash
+
+                export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+                az storage blob upload -f <local/path/to/validation.json> -c <GREAT-EXPECTATION-DEDICATED-AZURE-BLOB-CONTAINER-NAME> -n <PREFIX>/<validation.json>
+                example with a validation related to the exp1 expectation:
+                az storage blob upload -f great_expectations/uncommitted/validations/exp1/20210306T104406.877327Z/20210306T104406.877327Z/8313fb37ca59375eb843adf388d4f882.json -c <blob-container> -n validations/exp1/20210306T104406.877327Z/20210306T104406.877327Z/8313fb37ca59375eb843adf388d4f882.json
+                Finished[#############################################################]  100.0000%
+                {
+                  "etag": "\"0x8D8E09F894650C7\"",
+                  "lastModified": "2021-03-06T12:58:28+00:00"
+                }
+
+
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations --v3-api store list``.
+
+            Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_AZ_store`` we just configured.  This is ok, since Great Expectations will look for Validations in Azure Blob as long as we set the ``validations_store_name`` variable to ``validations_AZ_store``, and the config for ``validations_store`` can be removed if you would like.
+
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                 - name: validations_store
+                   class_name: ValidationsStore
+                   store_backend:
+                     class_name: TupleFilesystemStoreBackend
+                     base_directory: uncommitted/validations/
+
+                 - name: validations_AZ_store
+                   class_name: ValidationsStore
+                   store_backend:
+                     class_name: TupleAzureBlobStoreBackend
+                     connection_string: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+                     container: <blob-container>
+                     prefix: validations
+
 
 6. **Confirm that the Validations store has been correctly configured.**
 

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.rst
@@ -15,46 +15,86 @@ By default, Validations are stored in JSON format in the ``uncommitted/validatio
 
 Steps
 -----
+.. content-tabs::
 
-1. **Configure your GCP credentials**
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-    Check that your environment is configured with the appropriate authentication credentials needed to connect to the GCS bucket where Validations will be stored.
+        1. **Configure your GCP credentials**
 
-    The Google Cloud Platform documentation describes how to verify your `authentication for the Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_, which includes:
+            Check that your environment is configured with the appropriate authentication credentials needed to connect to the GCS bucket where Validations will be stored.
 
-        1. Creating a Google Cloud Platform (GCP) service account,
-        2. Setting the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable,
-        3. Verifying authentication by running a simple `Google Cloud Storage client <https://cloud.google.com/storage/docs/reference/libraries>`_ library script.
+            The Google Cloud Platform documentation describes how to verify your `authentication for the Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_, which includes:
 
-2. **Identify your Data Context Validations Store**
+                1. Creating a Google Cloud Platform (GCP) service account,
+                2. Setting the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable,
+                3. Verifying authentication by running a simple `Google Cloud Storage client <https://cloud.google.com/storage/docs/reference/libraries>`_ library script.
 
-    In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
+        2. **Identify your Data Context Validations Store**
 
-    .. code-block:: yaml
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
 
-        validations_store_name: validations_store
+            .. code-block:: yaml
 
-        stores:
-            validations_store:
+                validations_store_name: validations_store
+
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+
+        3. **Update your configuration file to include a new store for Validations on GCS**
+
+            In our case, the name is set to ``validations_GCS_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to your GCP project, ``bucket`` will be set to the address of your GCS bucket, and ``prefix`` will be set to the folder on GCS where Validation files will be located.
+
+
+            .. warning::
+                If you are also storing :ref:`Expectations in GCS <how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_gcs>` or :ref:`DataDocs in GCS <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_gcs>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_GCS_store
+                stores:
+                    validations_GCS_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleGCSStoreBackend
+                            project: '<your_GCP_project_name>'
+                            bucket: '<your_GCS_bucket_name>'
+                            prefix: '<your_GCS_folder_name>'
+
+
+        4. **Copy existing Validation results to the GCS bucket**. (This step is optional).
+
+            One way to copy Validations into GCS is by using the ``gsutil cp`` command, which is part of the Google Cloud SDK. In the example below, two Validation results, ``Validation1`` and ``Validation2`` are copied to the GCS bucket.   Information on other ways to copy Validation results, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+
+            .. code-block:: bash
+
+                gsutil cp uncommitted/validations/Validation1.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+                gsutil cp uncommitted/validations/Validation2.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+
+                Operation completed over 2 objects/58.8 KiB.
+
+
+
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations store list``.
+
+            Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_GCS_store`` we just configured.  This is ok, since Great Expectations will look for Validations in GCS as long as we set the ``validations_store_name`` variable to ``validations_GCS_store``, and the config for ``validations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                - name: validations_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: uncommitted/validations/
 
-
-3. **Update your configuration file to include a new store for Validations on GCS**
-
-    In our case, the name is set to ``validations_GCS_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to your GCP project, ``bucket`` will be set to the address of your GCS bucket, and ``prefix`` will be set to the folder on GCS where Validation files will be located.
-
-
-    .. warning::
-        If you are also storing :ref:`Expectations in GCS <how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_gcs>` or :ref:`DataDocs in GCS <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_gcs>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
-
-    .. code-block:: yaml
-
-        validations_store_name: validations_GCS_store
-        stores:
-            validations_GCS_store:
+                - name: validations_GCS_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: TupleGCSStoreBackend
@@ -62,42 +102,90 @@ Steps
                     bucket: '<your_GCS_bucket_name>'
                     prefix: '<your_GCS_folder_name>'
 
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
 
-4. **Copy existing Validation results to the GCS bucket**. (This step is optional).
+        1. **Configure your GCP credentials**
 
-    One way to copy Validations into GCS is by using the ``gsutil cp`` command, which is part of the Google Cloud SDK. In the example below, two Validation results, ``Validation1`` and ``Validation2`` are copied to the GCS bucket.   Information on other ways to copy Validation results, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+            Check that your environment is configured with the appropriate authentication credentials needed to connect to the GCS bucket where Validations will be stored.
 
-    .. code-block:: bash
+            The Google Cloud Platform documentation describes how to verify your `authentication for the Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_, which includes:
 
-        gsutil cp uncommitted/validations/Validation1.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
-        gsutil cp uncommitted/validations/Validation2.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+                1. Creating a Google Cloud Platform (GCP) service account,
+                2. Setting the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable,
+                3. Verifying authentication by running a simple `Google Cloud Storage client <https://cloud.google.com/storage/docs/reference/libraries>`_ library script.
 
-        Operation completed over 2 objects/58.8 KiB.
+        2. **Identify your Data Context Validations Store**
+
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_store
+
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+
+        3. **Update your configuration file to include a new store for Validations on GCS**
+
+            In our case, the name is set to ``validations_GCS_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to your GCP project, ``bucket`` will be set to the address of your GCS bucket, and ``prefix`` will be set to the folder on GCS where Validation files will be located.
+
+
+            .. warning::
+                If you are also storing :ref:`Expectations in GCS <how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_gcs>` or :ref:`DataDocs in GCS <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_gcs>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_GCS_store
+                stores:
+                    validations_GCS_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleGCSStoreBackend
+                            project: '<your_GCP_project_name>'
+                            bucket: '<your_GCS_bucket_name>'
+                            prefix: '<your_GCS_folder_name>'
+
+
+        4. **Copy existing Validation results to the GCS bucket**. (This step is optional).
+
+            One way to copy Validations into GCS is by using the ``gsutil cp`` command, which is part of the Google Cloud SDK. In the example below, two Validation results, ``Validation1`` and ``Validation2`` are copied to the GCS bucket.   Information on other ways to copy Validation results, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+
+            .. code-block:: bash
+
+                gsutil cp uncommitted/validations/Validation1.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+                gsutil cp uncommitted/validations/Validation2.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+
+                Operation completed over 2 objects/58.8 KiB.
 
 
 
-5. **Confirm that the new Validations store has been added by running** ``great_expectations store list``.
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations --v3-api store list``.
 
-    Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_GCS_store`` we just configured.  This is ok, since Great Expectations will look for Validations in GCS as long as we set the ``validations_store_name`` variable to ``validations_GCS_store``, and the config for ``validations_store`` can be removed if you would like.
+            Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_GCS_store`` we just configured.  This is ok, since Great Expectations will look for Validations in GCS as long as we set the ``validations_store_name`` variable to ``validations_GCS_store``, and the config for ``validations_store`` can be removed if you would like.
 
-    .. code-block:: bash
+            .. code-block:: bash
 
-        great_expectations store list
+                great_expectations --v3-api store list
 
-        - name: validations_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: uncommitted/validations/
+                - name: validations_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: uncommitted/validations/
 
-        - name: validations_GCS_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: TupleGCSStoreBackend
-            project: '<your_GCP_project_name>'
-            bucket: '<your_GCS_bucket_name>'
-            prefix: '<your_GCS_folder_name>'
-
+                - name: validations_GCS_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: TupleGCSStoreBackend
+                    project: '<your_GCP_project_name>'
+                    bucket: '<your_GCS_bucket_name>'
+                    prefix: '<your_GCS_folder_name>'
 
 
 6. **Confirm that the Validations store has been correctly configured.**

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_s3.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_s3.rst
@@ -15,84 +15,167 @@ By default, Validation results are stored in the ``uncommitted/validations/`` di
 Steps
 -----
 
-1. **Configure** `boto3 <https://github.com/boto/boto3>`_ **to connect to the Amazon S3 bucket where Validation results will be stored.**
+.. content-tabs::
 
-    Instructions on how to set up `boto3 <https://github.com/boto/boto3>`_ with AWS can be found at boto3's `documentation site <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_.
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-2. **Identify your Data Context Validations Store**
+        1. **Configure** `boto3 <https://github.com/boto/boto3>`_ **to connect to the Amazon S3 bucket where Validation results will be stored.**
 
-    Look for the following section in your Data Context's ``great_expectations.yml`` file:
+            Instructions on how to set up `boto3 <https://github.com/boto/boto3>`_ with AWS can be found at boto3's `documentation site <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_.
 
-    .. code-block:: yaml
+        2. **Identify your Data Context Validations Store**
 
-        validations_store_name: validations_store
+            Look for the following section in your Data Context's ``great_expectations.yml`` file:
 
-        stores:
-            validations_store:
+            .. code-block:: yaml
+
+                validations_store_name: validations_store
+
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+            The configuration file tells Great Expectations to look for Validations in a store called ``validations_store``. It also creates a ``ValidationsStore`` called ``validations_store`` that is backed by a Filesystem and will store validations under the ``base_directory`` ``uncommitted/validations`` (the default).
+
+
+        3. **Update your configuration file to include a new store for Validation results on S3.**
+
+            In the example below, the new store's name is set to ``validations_S3_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleS3StoreBackend``, ``bucket`` will be set to the address of your S3 bucket, and ``prefix`` will be set to the folder in your S3 bucket where Validation results will be located.
+
+
+            .. warning::
+                If you are also storing :ref:`Expectations in S3 <how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_amazon_s3>`, or :ref:`DataDocs in S3 <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_s3>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_S3_store
+
+                stores:
+                    validations_S3_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleS3StoreBackend
+                            bucket: '<your_s3_bucket_name>'
+                            prefix: '<your_s3_bucket_folder_name>'
+
+
+        4. **Copy existing Validation results to the S3 bucket**. (This step is optional).
+
+            One way to copy Validations into Amazon S3 is by using the ``aws s3 sync`` command.  As mentioned earlier, the ``base_directory`` is set to ``uncommitted/validations/`` by default. In the example below, two Validation results, ``Validation1`` and ``Validation2`` are copied to Amazon S3.  Your output should looks something like this:
+
+            .. code-block:: bash
+
+                aws s3 sync '<base_directory>' s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'
+
+                upload: uncommitted/validations/val1/val1.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/val1.json
+                upload: uncommitted/validations/val2/val2.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/val2.json
+
+
+
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations store list`` **.**
+
+            Notice the output contains two Validations Stores: the original ``validations_store`` on the local filesystem and the ``validations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Validation results on the S3 bucket as long as we set the ``validations_store_name`` variable to ``validations_S3_store``.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                - name: validations_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: uncommitted/validations/
 
-    The configuration file tells Great Expectations to look for Validations in a store called ``validations_store``. It also creates a ``ValidationsStore`` called ``validations_store`` that is backed by a Filesystem and will store validations under the ``base_directory`` ``uncommitted/validations`` (the default).
-
-
-3. **Update your configuration file to include a new store for Validation results on S3.**
-
-    In the example below, the new store's name is set to ``validations_S3_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleS3StoreBackend``, ``bucket`` will be set to the address of your S3 bucket, and ``prefix`` will be set to the folder in your S3 bucket where Validation results will be located.
-
-
-    .. warning::
-        If you are also storing :ref:`Expectations in S3 <how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_amazon_s3>`, or :ref:`DataDocs in S3 <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_s3>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
-
-    .. code-block:: yaml
-
-        validations_store_name: validations_S3_store
-
-        stores:
-            validations_S3_store:
+                - name: validations_S3_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: TupleS3StoreBackend
                     bucket: '<your_s3_bucket_name>'
                     prefix: '<your_s3_bucket_folder_name>'
 
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
 
-4. **Copy existing Validation results to the S3 bucket**. (This step is optional).
+        1. **Configure** `boto3 <https://github.com/boto/boto3>`_ **to connect to the Amazon S3 bucket where Validation results will be stored.**
 
-    One way to copy Validations into Amazon S3 is by using the ``aws s3 sync`` command.  As mentioned earlier, the ``base_directory`` is set to ``uncommitted/validations/`` by default. In the example below, two Validation results, ``Validation1`` and ``Validation2`` are copied to Amazon S3.  Your output should looks something like this:
+            Instructions on how to set up `boto3 <https://github.com/boto/boto3>`_ with AWS can be found at boto3's `documentation site <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_.
 
-    .. code-block:: bash
+        2. **Identify your Data Context Validations Store**
 
-        aws s3 sync '<base_directory>' s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'
+            Look for the following section in your Data Context's ``great_expectations.yml`` file:
 
-        upload: uncommitted/validations/val1/val1.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/val1.json
-        upload: uncommitted/validations/val2/val2.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/val2.json
+            .. code-block:: yaml
 
+                validations_store_name: validations_store
 
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
 
-5. **Confirm that the new Validations store has been added by running** ``great_expectations store list`` **.**
-
-    Notice the output contains two Validations Stores: the original ``validations_store`` on the local filesystem and the ``validations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Validation results on the S3 bucket as long as we set the ``validations_store_name`` variable to ``validations_S3_store``.
-
-    .. code-block:: bash
-
-        great_expectations store list
-
-        - name: validations_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: uncommitted/validations/
-
-        - name: validations_S3_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: TupleS3StoreBackend
-            bucket: '<your_s3_bucket_name>'
-            prefix: '<your_s3_bucket_folder_name>'
+            The configuration file tells Great Expectations to look for Validations in a store called ``validations_store``. It also creates a ``ValidationsStore`` called ``validations_store`` that is backed by a Filesystem and will store validations under the ``base_directory`` ``uncommitted/validations`` (the default).
 
 
+        3. **Update your configuration file to include a new store for Validation results on S3.**
+
+            In the example below, the new store's name is set to ``validations_S3_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleS3StoreBackend``, ``bucket`` will be set to the address of your S3 bucket, and ``prefix`` will be set to the folder in your S3 bucket where Validation results will be located.
+
+
+            .. warning::
+                If you are also storing :ref:`Expectations in S3 <how_to_guides__configuring_metadata_stores__how_to_configure_an_expectation_store_in_amazon_s3>`, or :ref:`DataDocs in S3 <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_s3>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_S3_store
+
+                stores:
+                    validations_S3_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleS3StoreBackend
+                            bucket: '<your_s3_bucket_name>'
+                            prefix: '<your_s3_bucket_folder_name>'
+
+
+        4. **Copy existing Validation results to the S3 bucket**. (This step is optional).
+
+            One way to copy Validations into Amazon S3 is by using the ``aws s3 sync`` command.  As mentioned earlier, the ``base_directory`` is set to ``uncommitted/validations/`` by default. In the example below, two Validation results, ``Validation1`` and ``Validation2`` are copied to Amazon S3.  Your output should looks something like this:
+
+            .. code-block:: bash
+
+                aws s3 sync '<base_directory>' s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'
+
+                upload: uncommitted/validations/val1/val1.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/val1.json
+                upload: uncommitted/validations/val2/val2.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/val2.json
+
+
+
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations --v3-api store list`` **.**
+
+            Notice the output contains two Validations Stores: the original ``validations_store`` on the local filesystem and the ``validations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Validation results on the S3 bucket as long as we set the ``validations_store_name`` variable to ``validations_S3_store``.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                - name: validations_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: uncommitted/validations/
+
+                - name: validations_S3_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: TupleS3StoreBackend
+                    bucket: '<your_s3_bucket_name>'
+                    prefix: '<your_s3_bucket_folder_name>'
 
 6. **Confirm that the Validations store has been correctly configured.**
 

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_on_a_filesystem.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_on_a_filesystem.rst
@@ -15,69 +15,141 @@ By default, Validation results are stored in the ``uncommitted/validations/`` di
 Steps
 -----
 
-1. **Configure a new folder on your filesystem where Validation results will be stored.**
+.. content-tabs::
 
-    Create a new folder where you would like to store your Validation results, and move your existing Validation results over to the new location. In our case, the name of the Validation result is ``npi_validations`` and the path to our new storage location is ``shared_validations/``.
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-    .. code-block:: bash
+        1. **Configure a new folder on your filesystem where Validation results will be stored.**
 
-        # in the great_expectations/ folder
-        mkdir shared_validations
-        mv uncommitted/validations/npi_validations/ uncommitted/shared_validations/
+            Create a new folder where you would like to store your Validation results, and move your existing Validation results over to the new location. In our case, the name of the Validation result is ``npi_validations`` and the path to our new storage location is ``shared_validations/``.
+
+            .. code-block:: bash
+
+                # in the great_expectations/ folder
+                mkdir shared_validations
+                mv uncommitted/validations/npi_validations/ uncommitted/shared_validations/
 
 
-2. **Identify your Data Context Validations Store**
+        2. **Identify your Data Context Validations Store**
 
-    In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        validations_store_name: validations_store
+                validations_store_name: validations_store
 
-        stores:
-            validations_store:
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+
+
+        3. **Update your configuration file to include a new store for Validation results on your filesystem**
+
+            In the example below, Validations Store is being set to ``shared_validations_filesystem_store``, but it can be any name you like.  Also, the ``base_directory`` is being set to ``uncommitted/shared_validations/``, but it can be set to any path accessible by Great Expectations.
+
+            .. code-block:: yaml
+
+                validations_store_name: shared_validations_filesystem_store
+
+                stores:
+                    shared_validations_filesystem_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/shared_validations/
+
+
+        4. **Confirm that the location has been updated by running** ``great_expectations store list``.
+
+            Notice the output contains two Validation stores: the original ``validations_store`` and the ``shared_validations_filesystem_store`` we just configured.  This is ok, since Great Expectations will look for Validations in the ``uncommitted/shared_validations/`` folder as long as we set the ``validations_store_name`` variable to ``shared_validations_filesystem_store``. The config for ``validations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                - name: validations_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: uncommitted/validations/
 
-
-
-3. **Update your configuration file to include a new store for Validation results on your filesystem**
-
-    In the example below, Validations Store is being set to ``shared_validations_filesystem_store``, but it can be any name you like.  Also, the ``base_directory`` is being set to ``uncommitted/shared_validations/``, but it can be set to any path accessible by Great Expectations.
-
-    .. code-block:: yaml
-
-        validations_store_name: shared_validations_filesystem_store
-
-        stores:
-            shared_validations_filesystem_store:
+                - name: shared_validations_filesystem_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: uncommitted/shared_validations/
 
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
 
-4. **Confirm that the location has been updated by running** ``great_expectations store list``.
+        1. **Configure a new folder on your filesystem where Validation results will be stored.**
 
-    Notice the output contains two Validation stores: the original ``validations_store`` and the ``shared_validations_filesystem_store`` we just configured.  This is ok, since Great Expectations will look for Validations in the ``uncommitted/shared_validations/`` folder as long as we set the ``validations_store_name`` variable to ``shared_validations_filesystem_store``. The config for ``validations_store`` can be removed if you would like.
+            Create a new folder where you would like to store your Validation results, and move your existing Validation results over to the new location. In our case, the name of the Validation result is ``npi_validations`` and the path to our new storage location is ``shared_validations/``.
 
-    .. code-block:: bash
+            .. code-block:: bash
 
-        great_expectations store list
+                # in the great_expectations/ folder
+                mkdir shared_validations
+                mv uncommitted/validations/npi_validations/ uncommitted/shared_validations/
 
-        - name: validations_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: uncommitted/validations/
 
-        - name: shared_validations_filesystem_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: uncommitted/shared_validations/
+        2. **Identify your Data Context Validations Store**
+
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_store
+
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+
+
+        3. **Update your configuration file to include a new store for Validation results on your filesystem**
+
+            In the example below, Validations Store is being set to ``shared_validations_filesystem_store``, but it can be any name you like.  Also, the ``base_directory`` is being set to ``uncommitted/shared_validations/``, but it can be set to any path accessible by Great Expectations.
+
+            .. code-block:: yaml
+
+                validations_store_name: shared_validations_filesystem_store
+
+                stores:
+                    shared_validations_filesystem_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/shared_validations/
+
+
+        4. **Confirm that the location has been updated by running** ``great_expectations --v3-api store list``.
+
+            Notice the output contains two Validation stores: the original ``validations_store`` and the ``shared_validations_filesystem_store`` we just configured.  This is ok, since Great Expectations will look for Validations in the ``uncommitted/shared_validations/`` folder as long as we set the ``validations_store_name`` variable to ``shared_validations_filesystem_store``. The config for ``validations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                - name: validations_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: uncommitted/validations/
+
+                - name: shared_validations_filesystem_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: uncommitted/shared_validations/
 
 
 5. **Confirm that the Validations store has been correctly configured**

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_to_postgresql.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_a_validation_result_store_to_postgresql.rst
@@ -15,93 +15,185 @@ By default, Validations are stored in JSON format in the ``uncommitted/validatio
 Steps
 -----
 
-1. **Configure the** ``config_variables.yml`` **file with your database credentials**
+.. content-tabs::
 
-    We recommend that database credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add database credentials under the key ``db_creds``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-    .. code-block:: yaml
+        1. **Configure the** ``config_variables.yml`` **file with your database credentials**
 
-        db_creds:
-            drivername: postgres
-            host: '<your_host_name>'
-            port: '<your_port>'
-            username: '<your_username>'
-            password: '<your_password>'
-            database: '<your_database_name>'
-    
-    It is also possible to specify `schema` as an additional keyword argument if you would like to use a specific schema as the backend, but this is entirely optional.
+            We recommend that database credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add database credentials under the key ``db_creds``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        db_creds:
-            drivername: postgres
-            host: '<your_host_name>'
-            port: '<your_port>'
-            username: '<your_username>'
-            password: '<your_password>'
-            database: '<your_database_name>'
-            schema: '<your_schema_name>'
+                db_creds:
+                    drivername: postgres
+                    host: '<your_host_name>'
+                    port: '<your_port>'
+                    username: '<your_username>'
+                    password: '<your_password>'
+                    database: '<your_database_name>'
 
-2. **Identify your Data Context Validations Store**
+            It is also possible to specify `schema` as an additional keyword argument if you would like to use a specific schema as the backend, but this is entirely optional.
 
-    In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
+            .. code-block:: yaml
+
+                db_creds:
+                    drivername: postgres
+                    host: '<your_host_name>'
+                    port: '<your_port>'
+                    username: '<your_username>'
+                    password: '<your_password>'
+                    database: '<your_database_name>'
+                    schema: '<your_schema_name>'
+
+        2. **Identify your Data Context Validations Store**
+
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
 
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        validations_store_name: validations_store
+                validations_store_name: validations_store
 
-        stores:
-            validations_store:
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+        3. **Update your configuration file to include a new store for Validations on PostgreSQL**
+
+            In our case, the name is set to ``validations_postgres_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``DatabaseStoreBackend``, and ``credentials`` will be set to ``${db_creds}``, which references the corresponding key in the ``config_variables.yml`` file.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_postgres_store
+
+                stores:
+                    validations_postgres_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: DatabaseStoreBackend
+                            credentials: ${db_creds}
+
+
+
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations store list``.
+
+            Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_postgres_store`` we just configured.  This is ok, since Great Expectations will look for Validations in PostgreSQL as long as we set the ``validations_store_name`` variable to ``validations_postgres_store``. The config for ``validations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                - name: validations_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: uncommitted/validations/
 
-3. **Update your configuration file to include a new store for Validations on PostgreSQL**
-
-    In our case, the name is set to ``validations_postgres_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``DatabaseStoreBackend``, and ``credentials`` will be set to ``${db_creds}``, which references the corresponding key in the ``config_variables.yml`` file.
-
-    .. code-block:: yaml
-
-        validations_store_name: validations_postgres_store
-
-        stores:
-            validations_postgres_store:
+                - name: validations_postgres_store
                 class_name: ValidationsStore
                 store_backend:
                     class_name: DatabaseStoreBackend
-                    credentials: ${db_creds}
+                    credentials:
+                        database: '<your_db_name>'
+                        drivername: postgresql
+                        host: '<your_host_name>'
+                        password: ******
+                        port: '<your_port>'
+                        username: '<your_username>'
+
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
+
+        1. **Configure the** ``config_variables.yml`` **file with your database credentials**
+
+            We recommend that database credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add database credentials under the key ``db_creds``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
+
+            .. code-block:: yaml
+
+                db_creds:
+                    drivername: postgres
+                    host: '<your_host_name>'
+                    port: '<your_port>'
+                    username: '<your_username>'
+                    password: '<your_password>'
+                    database: '<your_database_name>'
+
+            It is also possible to specify `schema` as an additional keyword argument if you would like to use a specific schema as the backend, but this is entirely optional.
+
+            .. code-block:: yaml
+
+                db_creds:
+                    drivername: postgres
+                    host: '<your_host_name>'
+                    port: '<your_port>'
+                    username: '<your_username>'
+                    password: '<your_password>'
+                    database: '<your_database_name>'
+                    schema: '<your_schema_name>'
+
+        2. **Identify your Data Context Validations Store**
+
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Validations in a store called ``validations_store``. The ``base_directory`` for ``validations_store`` is set to ``uncommitted/validations/`` by default.
+
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_store
+
+                stores:
+                    validations_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: uncommitted/validations/
+
+        3. **Update your configuration file to include a new store for Validations on PostgreSQL**
+
+            In our case, the name is set to ``validations_postgres_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``DatabaseStoreBackend``, and ``credentials`` will be set to ``${db_creds}``, which references the corresponding key in the ``config_variables.yml`` file.
+
+            .. code-block:: yaml
+
+                validations_store_name: validations_postgres_store
+
+                stores:
+                    validations_postgres_store:
+                        class_name: ValidationsStore
+                        store_backend:
+                            class_name: DatabaseStoreBackend
+                            credentials: ${db_creds}
 
 
 
-5. **Confirm that the new Validations store has been added by running** ``great_expectations store list``.
+        5. **Confirm that the new Validations store has been added by running** ``great_expectations --v3-api store list``.
 
-    Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_postgres_store`` we just configured.  This is ok, since Great Expectations will look for Validations in PostgreSQL as long as we set the ``validations_store_name`` variable to ``validations_postgres_store``. The config for ``validations_store`` can be removed if you would like.
+            Notice the output contains two Validation stores: the original ``validations_store`` on the local filesystem and the ``validations_postgres_store`` we just configured.  This is ok, since Great Expectations will look for Validations in PostgreSQL as long as we set the ``validations_store_name`` variable to ``validations_postgres_store``. The config for ``validations_store`` can be removed if you would like.
 
-    .. code-block:: bash
+            .. code-block:: bash
 
-        great_expectations store list
+                great_expectations --v3-api store list
 
-        - name: validations_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: uncommitted/validations/
+                - name: validations_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: uncommitted/validations/
 
-        - name: validations_postgres_store
-        class_name: ValidationsStore
-        store_backend:
-            class_name: DatabaseStoreBackend
-            credentials:
-                database: '<your_db_name>'
-                drivername: postgresql
-                host: '<your_host_name>'
-                password: ******
-                port: '<your_port>'
-                username: '<your_username>'
-
-
+                - name: validations_postgres_store
+                class_name: ValidationsStore
+                store_backend:
+                    class_name: DatabaseStoreBackend
+                    credentials:
+                        database: '<your_db_name>'
+                        drivername: postgresql
+                        host: '<your_host_name>'
+                        password: ******
+                        port: '<your_port>'
+                        username: '<your_username>'
 
 6. **Confirm that the Validations store has been correctly configured.**
 

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_amazon_s3.rst
@@ -15,41 +15,80 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 Steps
 -----
 
-1. **Configure** `boto3 <https://github.com/boto/boto3>`_ **to connect to the Amazon S3 bucket where Expectations will be stored.**
+.. content-tabs::
 
-    Instructions on how to set up `boto3 <https://github.com/boto/boto3>`_ with AWS can be found at boto3's `documentation site <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_.
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-2. **Identify your Data Context Expectations Store**
+        1. **Configure** `boto3 <https://github.com/boto/boto3>`_ **to connect to the Amazon S3 bucket where Expectations will be stored.**
 
-    In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+            Instructions on how to set up `boto3 <https://github.com/boto/boto3>`_ with AWS can be found at boto3's `documentation site <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_.
+
+        2. **Identify your Data Context Expectations Store**
+
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        expectations_store_name: expectations_store
+                expectations_store_name: expectations_store
 
-        stores:
-            expectations_store:
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
+
+
+
+        3. **Update your configuration file to include a new store for Expectations on S3.**
+
+            In our case, the name is set to ``expectations_S3_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleS3StoreBackend``, ``bucket`` will be set to the address of your S3 bucket, and ``prefix`` will be set to the folder where Expectation files will be located.
+
+            .. warning::
+                If you are also storing :ref:`Validations in S3 <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_s3>` or :ref:`DataDocs in S3 <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_s3>`,  please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_S3_store
+
+                stores:
+                    expectations_S3_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleS3StoreBackend
+                            bucket: '<your_s3_bucket_name>'
+                            prefix: '<your_s3_bucket_folder_name>'
+
+
+        4. **Copy existing Expectation JSON files to the S3 bucket**. (This step is optional).
+
+            One way to copy Expectations into Amazon S3 is by using the ``aws s3 sync`` command.  As mentioned earlier, the ``base_directory`` is set to ``expectations/`` by default. In the example below, two Expectations, ``exp1`` and ``exp2`` are copied to Amazon S3.  Your output should looks something like this:
+
+            .. code-block:: bash
+
+                aws s3 sync '<base_directory>' s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'
+
+                upload: ./exp1.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/exp1.json
+                upload: ./exp2.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/exp2.json
+
+
+        5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``.
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the S3 bucket as long as we set the ``expectations_name`` variable to ``expectations_S3_store``.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                - name: expectations_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: expectations/
 
-
-
-3. **Update your configuration file to include a new store for Expectations on S3.**
-
-    In our case, the name is set to ``expectations_S3_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleS3StoreBackend``, ``bucket`` will be set to the address of your S3 bucket, and ``prefix`` will be set to the folder where Expectation files will be located.
-
-    .. warning::
-        If you are also storing :ref:`Validations in S3 <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_s3>` or :ref:`DataDocs in S3 <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_s3>`,  please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
-
-    .. code-block:: yaml
-
-        expectations_store_name: expectations_S3_store
-
-        stores:
-            expectations_S3_store:
+                - name: expectations_S3_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleS3StoreBackend
@@ -57,51 +96,108 @@ Steps
                     prefix: '<your_s3_bucket_folder_name>'
 
 
-4. **Copy existing Expectation JSON files to the S3 bucket**. (This step is optional).
+        6. **Confirm that Expectations can be accessed from Amazon S3 by running** ``great_expectations suite list``.
 
-    One way to copy Expectations into Amazon S3 is by using the ``aws s3 sync`` command.  As mentioned earlier, the ``base_directory`` is set to ``expectations/`` by default. In the example below, two Expectations, ``exp1`` and ``exp2`` are copied to Amazon S3.  Your output should looks something like this:
+            If you followed Step 4, The output should include the 2 Expectations we copied to Amazon S3: ``exp1`` and ``exp2``.  If you did not copy Expectations to the new Store, you will see a message saying no expectations were found.
 
-    .. code-block:: bash
+            .. code-block:: bash
 
-        aws s3 sync '<base_directory>' s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'
+                great_expectations suite list
 
-        upload: ./exp1.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/exp1.json
-        upload: ./exp2.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/exp2.json
+                2 Expectation Suites found:
+                 - exp1
+                 - exp2
 
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
 
-5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``.
+        1. **Configure** `boto3 <https://github.com/boto/boto3>`_ **to connect to the Amazon S3 bucket where Expectations will be stored.**
 
-    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the S3 bucket as long as we set the ``expectations_name`` variable to ``expectations_S3_store``.
+            Instructions on how to set up `boto3 <https://github.com/boto/boto3>`_ with AWS can be found at boto3's `documentation site <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_.
 
-    .. code-block:: bash
+        2. **Identify your Data Context Expectations Store**
 
-        great_expectations store list
-
-        - name: expectations_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: expectations/
-
-        - name: expectations_S3_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: TupleS3StoreBackend
-            bucket: '<your_s3_bucket_name>'
-            prefix: '<your_s3_bucket_folder_name>'
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
 
-6. **Confirm that Expectations can be accessed from Amazon S3 by running** ``great_expectations suite list``.
+            .. code-block:: yaml
 
-    If you followed Step 4, The output should include the 2 Expectations we copied to Amazon S3: ``exp1`` and ``exp2``.  If you did not copy Expectations to the new Store, you will see a message saying no expectations were found.
+                expectations_store_name: expectations_store
 
-    .. code-block:: bash
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
 
-        great_expectations suite list
 
-        2 Expectation Suites found:
-         - exp1
-         - exp2
+
+        3. **Update your configuration file to include a new store for Expectations on S3.**
+
+            In our case, the name is set to ``expectations_S3_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleS3StoreBackend``, ``bucket`` will be set to the address of your S3 bucket, and ``prefix`` will be set to the folder where Expectation files will be located.
+
+            .. warning::
+                If you are also storing :ref:`Validations in S3 <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_s3>` or :ref:`DataDocs in S3 <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_s3>`,  please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_S3_store
+
+                stores:
+                    expectations_S3_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleS3StoreBackend
+                            bucket: '<your_s3_bucket_name>'
+                            prefix: '<your_s3_bucket_folder_name>'
+
+
+        4. **Copy existing Expectation JSON files to the S3 bucket**. (This step is optional).
+
+            One way to copy Expectations into Amazon S3 is by using the ``aws s3 sync`` command.  As mentioned earlier, the ``base_directory`` is set to ``expectations/`` by default. In the example below, two Expectations, ``exp1`` and ``exp2`` are copied to Amazon S3.  Your output should looks something like this:
+
+            .. code-block:: bash
+
+                aws s3 sync '<base_directory>' s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'
+
+                upload: ./exp1.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/exp1.json
+                upload: ./exp2.json to s3://'<your_s3_bucket_name>'/'<your_s3_bucket_folder_name>'/exp2.json
+
+
+        5. **Confirm that the new Expectations store has been added by running** ``great_expectations --v3-api store list``.
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_S3_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the S3 bucket as long as we set the ``expectations_name`` variable to ``expectations_S3_store``.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                - name: expectations_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: expectations/
+
+                - name: expectations_S3_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleS3StoreBackend
+                    bucket: '<your_s3_bucket_name>'
+                    prefix: '<your_s3_bucket_folder_name>'
+
+
+        6. **Confirm that Expectations can be accessed from Amazon S3 by running** ``great_expectations --v3-api suite list``.
+
+            If you followed Step 4, The output should include the 2 Expectations we copied to Amazon S3: ``exp1`` and ``exp2``.  If you did not copy Expectations to the new Store, you will see a message saying no expectations were found.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api suite list
+
+                2 Expectation Suites found:
+                 - exp1
+                 - exp2
 
 If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.  Also, please reach out to us on `Slack <https://greatexpectations.io/slack>`_ if you would like to learn more, or have any questions.
 

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_azure_blob_storage.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_azure_blob_storage.rst
@@ -17,105 +17,212 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 Steps
 -----
 
-1. **Configure the** ``config_variables.yml`` **file with your azure storage credentials**
+.. content-tabs::
 
-    We recommend that azure storage credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add azure storage credentials under the key ``AZURE_STORAGE_CONNECTION_STRING``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-    .. code-block:: yaml
+        1. **Configure the** ``config_variables.yml`` **file with your azure storage credentials**
 
-        AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
-        
+            We recommend that azure storage credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add azure storage credentials under the key ``AZURE_STORAGE_CONNECTION_STRING``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
 
-2. **Identify your Data Context Expectations Store**
+            .. code-block:: yaml
 
-    In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
-
-    .. code-block:: yaml
-
-        expectations_store_name: expectations_store
-
-        stores:
-            expectations_store:
-                class_name: ExpectationsStore
-                store_backend:
-                    class_name: TupleFilesystemStoreBackend
-                    base_directory: expectations/
+                AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
 
 
-3. **Update your configuration file to include a new store for Expectations on Azure storage account**
+        2. **Identify your Data Context Expectations Store**
 
-    In our case, the name is set to ``expectations_AZ_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleAzureBlobStoreBackend``,  ``container`` will be set to the name of your blob container (the equivalent of S3 bucket for Azure) you wish to store your expectations, ``prefix`` will be set to the folder in the container where Expectation files will be located, and ``connection_string`` will be set to ``${AZURE_STORAGE_CONNECTION_STRING}``, which references the corresponding key in the ``config_variables.yml`` file.
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        expectations_store_name: expectations_AZ_store
+                expectations_store_name: expectations_store
 
-        stores:
-            expectations_AZ_store:
-                class_name: ExpectationsStore
-                store_backend:
-                  class_name: TupleAzureBlobStoreBackend
-                  container: <blob-container>
-                  prefix: expectations
-                  connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
 
-    .. note::
-        If the container is called ``$web`` (for :ref:`hosting and sharing data docs on azure blob storage <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_azure_blob_storage>`) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
-  
 
-4. **Copy existing Expectation JSON files to the Azure blob**. (This step is optional).
+        3. **Update your configuration file to include a new store for Expectations on Azure storage account**
 
-    One way to copy Expectations into Azure Blob Storage is by using the ``az storage blob upload`` command, which is part of the Azure SDK. The following example will copy one Expectation, ``exp1`` from a local folder to the Azure blob.   Information on other ways to copy Expectation JSON files, like the Azure Storage browser in the Azure Portal, can be found in the `Documentation for Azure <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal>`_.
+            In our case, the name is set to ``expectations_AZ_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleAzureBlobStoreBackend``,  ``container`` will be set to the name of your blob container (the equivalent of S3 bucket for Azure) you wish to store your expectations, ``prefix`` will be set to the folder in the container where Expectation files will be located, and ``connection_string`` will be set to ``${AZURE_STORAGE_CONNECTION_STRING}``, which references the corresponding key in the ``config_variables.yml`` file.
 
-    .. code-block:: bash
+            .. code-block:: yaml
 
-        export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
-        az storage blob upload -f <local/path/to/expectation.json> -c <GREAT-EXPECTATION-DEDICATED-AZURE-BLOB-CONTAINER-NAME> -n <PREFIX>/<expectation.json>
-        example : 
-        az storage blob upload -f great_expectations/expectations/exp1.json -c <blob-container> -n expectations/exp1.json
-        
-        Finished[#############################################################]  100.0000%
-        {
-        "etag": "\"0x8D8E08E5DA47F84\"",
-        "lastModified": "2021-03-06T10:55:33+00:00"
-        }
-        
-        
-5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``
+                expectations_store_name: expectations_AZ_store
 
-    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_AZ_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in Azure Blob as long as we set the ``expectations_store_name`` variable to ``expectations_AZ_store``, which we did in the previous step.  The config for ``expectations_store`` can be removed if you would like.
+                stores:
+                    expectations_AZ_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                          class_name: TupleAzureBlobStoreBackend
+                          container: <blob-container>
+                          prefix: expectations
+                          connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
 
-    .. code-block:: bash
+            .. note::
+                If the container is called ``$web`` (for :ref:`hosting and sharing data docs on azure blob storage <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_azure_blob_storage>`) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
 
-        great_expectations store list
 
-         - name: expectations_store
-           class_name: ExpectationsStore
-           store_backend:
-             class_name: TupleFilesystemStoreBackend
-             base_directory: expectations/
+        4. **Copy existing Expectation JSON files to the Azure blob**. (This step is optional).
 
-         - name: expectations_AZ_store
-           class_name: ExpectationsStore
-           store_backend:
-             class_name: TupleAzureBlobStoreBackend
-             connection_string: DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>
-             container: <blob-container>
-             prefix: expectations
-     
-        
-6. **Confirm that Expectations can be accessed from Azure Blob Storage by running** ``great_expectations suite list``.
+            One way to copy Expectations into Azure Blob Storage is by using the ``az storage blob upload`` command, which is part of the Azure SDK. The following example will copy one Expectation, ``exp1`` from a local folder to the Azure blob.   Information on other ways to copy Expectation JSON files, like the Azure Storage browser in the Azure Portal, can be found in the `Documentation for Azure <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal>`_.
 
-    If you followed Step 4, the output should include the Expectation we copied to Azure Blob: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no Expectations were found.
+            .. code-block:: bash
 
-    .. code-block:: bash
+                export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+                az storage blob upload -f <local/path/to/expectation.json> -c <GREAT-EXPECTATION-DEDICATED-AZURE-BLOB-CONTAINER-NAME> -n <PREFIX>/<expectation.json>
+                example :
+                az storage blob upload -f great_expectations/expectations/exp1.json -c <blob-container> -n expectations/exp1.json
 
-        great_expectations suite list
-        
-        Using v2 (Batch Kwargs) API
-        1 Expectation Suite found:
-        - exp1
-     
+                Finished[#############################################################]  100.0000%
+                {
+                "etag": "\"0x8D8E08E5DA47F84\"",
+                "lastModified": "2021-03-06T10:55:33+00:00"
+                }
+
+
+        5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_AZ_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in Azure Blob as long as we set the ``expectations_store_name`` variable to ``expectations_AZ_store``, which we did in the previous step.  The config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                 - name: expectations_store
+                   class_name: ExpectationsStore
+                   store_backend:
+                     class_name: TupleFilesystemStoreBackend
+                     base_directory: expectations/
+
+                 - name: expectations_AZ_store
+                   class_name: ExpectationsStore
+                   store_backend:
+                     class_name: TupleAzureBlobStoreBackend
+                     connection_string: DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>
+                     container: <blob-container>
+                     prefix: expectations
+
+
+        6. **Confirm that Expectations can be accessed from Azure Blob Storage by running** ``great_expectations suite list``.
+
+            If you followed Step 4, the output should include the Expectation we copied to Azure Blob: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no Expectations were found.
+
+            .. code-block:: bash
+
+                great_expectations suite list
+
+                Using v2 (Batch Kwargs) API
+                1 Expectation Suite found:
+                - exp1
+
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
+
+        1. **Configure the** ``config_variables.yml`` **file with your azure storage credentials**
+
+            We recommend that azure storage credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add azure storage credentials under the key ``AZURE_STORAGE_CONNECTION_STRING``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
+
+            .. code-block:: yaml
+
+                AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+
+
+        2. **Identify your Data Context Expectations Store**
+
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_store
+
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
+
+
+        3. **Update your configuration file to include a new store for Expectations on Azure storage account**
+
+            In our case, the name is set to ``expectations_AZ_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleAzureBlobStoreBackend``,  ``container`` will be set to the name of your blob container (the equivalent of S3 bucket for Azure) you wish to store your expectations, ``prefix`` will be set to the folder in the container where Expectation files will be located, and ``connection_string`` will be set to ``${AZURE_STORAGE_CONNECTION_STRING}``, which references the corresponding key in the ``config_variables.yml`` file.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_AZ_store
+
+                stores:
+                    expectations_AZ_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                          class_name: TupleAzureBlobStoreBackend
+                          container: <blob-container>
+                          prefix: expectations
+                          connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
+
+            .. note::
+                If the container is called ``$web`` (for :ref:`hosting and sharing data docs on azure blob storage <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_azure_blob_storage>`) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
+
+
+        4. **Copy existing Expectation JSON files to the Azure blob**. (This step is optional).
+
+            One way to copy Expectations into Azure Blob Storage is by using the ``az storage blob upload`` command, which is part of the Azure SDK. The following example will copy one Expectation, ``exp1`` from a local folder to the Azure blob.   Information on other ways to copy Expectation JSON files, like the Azure Storage browser in the Azure Portal, can be found in the `Documentation for Azure <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal>`_.
+
+            .. code-block:: bash
+
+                export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>"
+                az storage blob upload -f <local/path/to/expectation.json> -c <GREAT-EXPECTATION-DEDICATED-AZURE-BLOB-CONTAINER-NAME> -n <PREFIX>/<expectation.json>
+                example :
+                az storage blob upload -f great_expectations/expectations/exp1.json -c <blob-container> -n expectations/exp1.json
+
+                Finished[#############################################################]  100.0000%
+                {
+                "etag": "\"0x8D8E08E5DA47F84\"",
+                "lastModified": "2021-03-06T10:55:33+00:00"
+                }
+
+
+        5. **Confirm that the new Expectations store has been added by running** ``great_expectations --v3-api store list``
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_AZ_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in Azure Blob as long as we set the ``expectations_store_name`` variable to ``expectations_AZ_store``, which we did in the previous step.  The config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                 - name: expectations_store
+                   class_name: ExpectationsStore
+                   store_backend:
+                     class_name: TupleFilesystemStoreBackend
+                     base_directory: expectations/
+
+                 - name: expectations_AZ_store
+                   class_name: ExpectationsStore
+                   store_backend:
+                     class_name: TupleAzureBlobStoreBackend
+                     connection_string: DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=<YOUR-STORAGE-ACCOUNT-NAME>;AccountKey=<YOUR-STORAGE-ACCOUNT-KEY==>
+                     container: <blob-container>
+                     prefix: expectations
+
+
+        6. **Confirm that Expectations can be accessed from Azure Blob Storage by running** ``great_expectations --v3-api suite list``.
+
+            If you followed Step 4, the output should include the Expectation we copied to Azure Blob: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no Expectations were found.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api suite list
+
+                Using v2 (Batch Kwargs) API
+                1 Expectation Suite found:
+                - exp1
+
 
 .. discourse::
     :topic_identifier: 179

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_in_gcs.rst
@@ -14,47 +14,86 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 
 Steps
 -----
+.. content-tabs::
 
-1. **Configure your GCP credentials**
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-    Check that your environment is configured with the appropriate authentication credentials needed to connect to the GCS bucket where Expectations will be stored.
+        1. **Configure your GCP credentials**
 
-    The Google Cloud Platform documentation describes how to verify your `authentication for the Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_, which includes:
+            Check that your environment is configured with the appropriate authentication credentials needed to connect to the GCS bucket where Expectations will be stored.
 
-        1. Creating a Google Cloud Platform (GCP) service account,
-        2. Setting the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable,
-        3. Verifying authentication by running a simple `Google Cloud Storage client <https://cloud.google.com/storage/docs/reference/libraries>`_ library script.
+            The Google Cloud Platform documentation describes how to verify your `authentication for the Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_, which includes:
 
-2. **Identify your Data Context Expectations Store**
+                1. Creating a Google Cloud Platform (GCP) service account,
+                2. Setting the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable,
+                3. Verifying authentication by running a simple `Google Cloud Storage client <https://cloud.google.com/storage/docs/reference/libraries>`_ library script.
 
-    In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+        2. **Identify your Data Context Expectations Store**
+
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        expectations_store_name: expectations_store
+                expectations_store_name: expectations_store
 
-        stores:
-            expectations_store:
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
+
+
+        3. **Update your configuration file to include a new store for Expectations on GCS**
+
+            In our case, the name is set to ``expectations_GCS_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to your GCP project, ``bucket`` will be set to the address of your GCS bucket, and ``prefix`` will be set to the folder on GCS where Expectation files will be located.
+
+
+            .. warning::
+                If you are also storing :ref:`Validations in GCS <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_gcs>` or :ref:`DataDocs in GCS <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_gcs>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_GCS_store
+                stores:
+                    expectations_GCS_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleGCSStoreBackend
+                            project: '<your_GCP_project_name>'
+                            bucket: '<your_GCS_bucket_name>'
+                            prefix: '<your_GCS_folder_name>'
+
+
+        4. **Copy existing Expectation JSON files to the GCS bucket**. (This step is optional).
+
+            One way to copy Expectations into GCS is by using the ``gsutil cp`` command, which is part of the Google Cloud SDK. The following example will copy one Expectation, ``exp1`` from a local folder to the GCS bucket.   Information on other ways to copy Expectation JSON files, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+
+            .. code-block:: bash
+
+                gsutil cp exp1.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+
+                Operation completed over 1 objects/58.8 KiB.
+
+
+
+        5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``.
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_GCS_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in GCS as long as we set the ``expectations_store_name`` variable to ``expectations_GCS_store``, and the config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                - name: expectations_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: expectations/
 
-
-3. **Update your configuration file to include a new store for Expectations on GCS**
-
-    In our case, the name is set to ``expectations_GCS_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to your GCP project, ``bucket`` will be set to the address of your GCS bucket, and ``prefix`` will be set to the folder on GCS where Expectation files will be located.
-
-
-    .. warning::
-        If you are also storing :ref:`Validations in GCS <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_gcs>` or :ref:`DataDocs in GCS <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_gcs>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
-
-    .. code-block:: yaml
-
-        expectations_store_name: expectations_GCS_store
-        stores:
-            expectations_GCS_store:
+                - name: expectations_GCS_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleGCSStoreBackend
@@ -63,52 +102,113 @@ Steps
                     prefix: '<your_GCS_folder_name>'
 
 
-4. **Copy existing Expectation JSON files to the GCS bucket**. (This step is optional).
+        6. **Confirm that Expectations can be accessed from GCS by running** ``great_expectations suite list``.
 
-    One way to copy Expectations into GCS is by using the ``gsutil cp`` command, which is part of the Google Cloud SDK. The following example will copy one Expectation, ``exp1`` from a local folder to the GCS bucket.   Information on other ways to copy Expectation JSON files, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+            If you followed Step 4, the output should include the Expectation we copied to GCS: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no Expectations were found.
 
-    .. code-block:: bash
+            .. code-block:: bash
 
-        gsutil cp exp1.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+                great_expectations suite list
 
-        Operation completed over 1 objects/58.8 KiB.
+                1 Expectation Suite found:
+                 - exp1
 
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
 
+        1. **Configure your GCP credentials**
 
-5. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``.
+            Check that your environment is configured with the appropriate authentication credentials needed to connect to the GCS bucket where Expectations will be stored.
 
-    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_GCS_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in GCS as long as we set the ``expectations_store_name`` variable to ``expectations_GCS_store``, and the config for ``expectations_store`` can be removed if you would like.
+            The Google Cloud Platform documentation describes how to verify your `authentication for the Google Cloud API <https://cloud.google.com/docs/authentication/getting-started>`_, which includes:
 
-    .. code-block:: bash
+                1. Creating a Google Cloud Platform (GCP) service account,
+                2. Setting the ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable,
+                3. Verifying authentication by running a simple `Google Cloud Storage client <https://cloud.google.com/storage/docs/reference/libraries>`_ library script.
 
-        great_expectations store list
+        2. **Identify your Data Context Expectations Store**
 
-        - name: expectations_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: expectations/
-
-        - name: expectations_GCS_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: TupleGCSStoreBackend
-            project: '<your_GCP_project_name>'
-            bucket: '<your_GCS_bucket_name>'
-            prefix: '<your_GCS_folder_name>'
+            In your ``great_expectations.yml``, look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
 
-6. **Confirm that Expectations can be accessed from GCS by running** ``great_expectations suite list``.
+            .. code-block:: yaml
 
-    If you followed Step 4, the output should include the Expectation we copied to GCS: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no Expectations were found.
+                expectations_store_name: expectations_store
 
-    .. code-block:: bash
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
 
-        great_expectations suite list
 
-        1 Expectation Suite found:
-         - exp1
+        3. **Update your configuration file to include a new store for Expectations on GCS**
 
+            In our case, the name is set to ``expectations_GCS_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``TupleGCSStoreBackend``, ``project`` will be set to your GCP project, ``bucket`` will be set to the address of your GCS bucket, and ``prefix`` will be set to the folder on GCS where Expectation files will be located.
+
+
+            .. warning::
+                If you are also storing :ref:`Validations in GCS <how_to_guides__configuring_metadata_stores__how_to_configure_a_validation_result_store_in_gcs>` or :ref:`DataDocs in GCS <how_to_guides__configuring_data_docs__how_to_host_and_share_data_docs_on_gcs>`, please ensure that the ``prefix`` values are disjoint and one is not a substring of the other.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_GCS_store
+                stores:
+                    expectations_GCS_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleGCSStoreBackend
+                            project: '<your_GCP_project_name>'
+                            bucket: '<your_GCS_bucket_name>'
+                            prefix: '<your_GCS_folder_name>'
+
+
+        4. **Copy existing Expectation JSON files to the GCS bucket**. (This step is optional).
+
+            One way to copy Expectations into GCS is by using the ``gsutil cp`` command, which is part of the Google Cloud SDK. The following example will copy one Expectation, ``exp1`` from a local folder to the GCS bucket.   Information on other ways to copy Expectation JSON files, like the Cloud Storage browser in the Google Cloud Console, can be found in the `Documentation for Google Cloud <https://cloud.google.com/storage/docs/uploading-objects>`_.
+
+            .. code-block:: bash
+
+                gsutil cp exp1.json gs://'<your_GCS_bucket_name>'/'<your_GCS_folder_name>'
+
+                Operation completed over 1 objects/58.8 KiB.
+
+
+
+        5. **Confirm that the new Expectations store has been added by running** ``great_expectations --v3-api store list``.
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_GCS_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in GCS as long as we set the ``expectations_store_name`` variable to ``expectations_GCS_store``, and the config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                - name: expectations_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: expectations/
+
+                - name: expectations_GCS_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleGCSStoreBackend
+                    project: '<your_GCP_project_name>'
+                    bucket: '<your_GCS_bucket_name>'
+                    prefix: '<your_GCS_folder_name>'
+
+
+        6. **Confirm that Expectations can be accessed from GCS by running** ``great_expectations --v3-api suite list``.
+
+            If you followed Step 4, the output should include the Expectation we copied to GCS: ``exp1``.  If you did not copy Expectations to the new Store, you will see a message saying no Expectations were found.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api suite list
+
+                1 Expectation Suite found:
+                 - exp1
 
 
 If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.  Also, please reach out to us on `Slack <https://greatexpectations.io/slack>`_ if you would like to learn more, or have any questions.

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_on_a_filesystem.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_on_a_filesystem.rst
@@ -15,82 +15,165 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 Steps
 -----
 
-1. **Configure a new folder on your filesystem where Expectations will be stored.**
+.. content-tabs::
 
-    Create a new folder where you would like to store your Expectations, and move your existing Expectation files over to the new location. In our case, the name of the Expectations file is ``npi_expectations`` and the path to our new storage location is ``/shared_expectations``.
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
-    .. code-block:: bash
+        1. **Configure a new folder on your filesystem where Expectations will be stored.**
 
-        # in the great_expectations/ folder
-        mkdir shared_expectations
-        mv expectations/npi_expectations.json shared_expectations/
+            Create a new folder where you would like to store your Expectations, and move your existing Expectation files over to the new location. In our case, the name of the Expectations file is ``npi_expectations`` and the path to our new storage location is ``/shared_expectations``.
+
+            .. code-block:: bash
+
+                # in the great_expectations/ folder
+                mkdir shared_expectations
+                mv expectations/npi_expectations.json shared_expectations/
 
 
-2. **Identify your Data Context Expectations Store**
+        2. **Identify your Data Context Expectations Store**
 
-    In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        expectations_store_name: expectations_store
+                expectations_store_name: expectations_store
 
-        stores:
-            expectations_store:
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
+
+
+        3. **Update your configuration file to include a new store for Expectations results on your filesystem**
+
+            In the example below, Expectations Store is being set to ``shared_expectations_filesystem_store`` with the ``base_directory`` set to ``shared_expectations/``.
+
+            .. code-block:: yaml
+
+                expectations_store_name: shared_expectations_filesystem_store
+
+                stores:
+                    shared_expectations_filesystem_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: shared_expectations/
+
+
+
+        4. **Confirm that the location has been updated by running** ``great_expectations store list``.
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``shared_expectations_filesystem_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the ``shared_expectations/`` folder as long as we set the ``expectations_store_name`` variable to ``shared_expectations_filesystem_store``.  The config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                2 Stores found:
+
+                - name: expectations_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: expectations/
 
-
-3. **Update your configuration file to include a new store for Expectations results on your filesystem**
-
-    In the example below, Expectations Store is being set to ``shared_expectations_filesystem_store`` with the ``base_directory`` set to ``shared_expectations/``.
-
-    .. code-block:: yaml
-
-        expectations_store_name: shared_expectations_filesystem_store
-
-        stores:
-            shared_expectations_filesystem_store:
+                - name: shared_expectations_filesystem_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: shared_expectations/
 
 
+        5. **Confirm that Expectations can be read from the new storage location by running** ``great_expectations suite list``.
 
-4. **Confirm that the location has been updated by running** ``great_expectations store list``.
+            .. code-block:: bash
 
-    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``shared_expectations_filesystem_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the ``shared_expectations/`` folder as long as we set the ``expectations_store_name`` variable to ``shared_expectations_filesystem_store``.  The config for ``expectations_store`` can be removed if you would like.
+                great_expectations suite list
 
-    .. code-block:: bash
+                1 Expectation Suite found:
+                    - npi_expectations
 
-        great_expectations store list
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
 
-        2 Stores found:
+        1. **Configure a new folder on your filesystem where Expectations will be stored.**
 
-        - name: expectations_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: expectations/
+            Create a new folder where you would like to store your Expectations, and move your existing Expectation files over to the new location. In our case, the name of the Expectations file is ``npi_expectations`` and the path to our new storage location is ``/shared_expectations``.
 
-        - name: shared_expectations_filesystem_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: shared_expectations/
+            .. code-block:: bash
+
+                # in the great_expectations/ folder
+                mkdir shared_expectations
+                mv expectations/npi_expectations.json shared_expectations/
 
 
-5. **Confirm that Expectations can be read from the new storage location by running** ``great_expectations suite list``.
+        2. **Identify your Data Context Expectations Store**
 
-    .. code-block:: bash
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
 
-        great_expectations suite list
+            .. code-block:: yaml
 
-        1 Expectation Suite found:
-            - npi_expectations
+                expectations_store_name: expectations_store
 
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
+
+
+        3. **Update your configuration file to include a new store for Expectations results on your filesystem**
+
+            In the example below, Expectations Store is being set to ``shared_expectations_filesystem_store`` with the ``base_directory`` set to ``shared_expectations/``.
+
+            .. code-block:: yaml
+
+                expectations_store_name: shared_expectations_filesystem_store
+
+                stores:
+                    shared_expectations_filesystem_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: shared_expectations/
+
+
+
+        4. **Confirm that the location has been updated by running** ``great_expectations --v3-api store list``.
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``shared_expectations_filesystem_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in the ``shared_expectations/`` folder as long as we set the ``expectations_store_name`` variable to ``shared_expectations_filesystem_store``.  The config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                2 Stores found:
+
+                - name: expectations_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: expectations/
+
+                - name: shared_expectations_filesystem_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: shared_expectations/
+
+
+        5. **Confirm that Expectations can be read from the new storage location by running** ``great_expectations --v3-api suite list``.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api suite list
+
+                1 Expectation Suite found:
+                    - npi_expectations
 
 Additional Notes
 ----------------

--- a/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_to_postgresql.rst
+++ b/docs/guides/how_to_guides/configuring_metadata_stores/how_to_configure_an_expectation_store_to_postgresql.rst
@@ -14,114 +14,233 @@ By default, newly profiled Expectations are stored in JSON format in the ``expec
 Steps
 -----
 
-1. **Configure the** ``config_variables.yml`` **file with your database credentials**
+.. content-tabs::
 
-    We recommend that database credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add database credentials under the key ``db_creds``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
-
-    .. code-block:: yaml
-
-        db_creds:
-            drivername: postgres
-            host: '<your_host_name>'
-            port: '<your_port>'
-            username: '<your_username>'
-            password: '<your_password>'
-            database: '<your_database_name>'
+    .. tab-container:: tab0
+        :title: Show Docs for V2 (Batch Kwargs) API
 
 
-2. **Identify your Data Context Expectations Store**
+        1. **Configure the** ``config_variables.yml`` **file with your database credentials**
 
-    In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+            We recommend that database credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add database credentials under the key ``db_creds``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
 
-    .. code-block:: yaml
+            .. code-block:: yaml
 
-        expectations_store_name: expectations_store
+                db_creds:
+                    drivername: postgres
+                    host: '<your_host_name>'
+                    port: '<your_port>'
+                    username: '<your_username>'
+                    password: '<your_password>'
+                    database: '<your_database_name>'
 
-        stores:
-            expectations_store:
+
+        2. **Identify your Data Context Expectations Store**
+
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_store
+
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
+
+
+        3. **Update your configuration file to include a new store for Expectations on PostgreSQL**
+
+            In our case, the name is set to ``expectations_postgres_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``DatabaseStoreBackend``, and ``credentials`` will be set to ``${db_creds}``, which references the corresponding key in the ``config_variables.yml`` file.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_postgres_store
+
+                stores:
+                    expectations_postgres_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: DatabaseStoreBackend
+                            credentials: ${db_creds}
+
+
+        4. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_postgres_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in PostgreSQL as long as we set the ``expectations_store_name`` variable to ``expectations_postgres_store``, which we did in the previous step.  The config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations store list
+
+                - name: expectations_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: TupleFilesystemStoreBackend
                     base_directory: expectations/
 
-
-3. **Update your configuration file to include a new store for Expectations on PostgreSQL**
-
-    In our case, the name is set to ``expectations_postgres_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``DatabaseStoreBackend``, and ``credentials`` will be set to ``${db_creds}``, which references the corresponding key in the ``config_variables.yml`` file.
-
-    .. code-block:: yaml
-
-        expectations_store_name: expectations_postgres_store
-
-        stores:
-            expectations_postgres_store:
+                - name: expectations_postgres_store
                 class_name: ExpectationsStore
                 store_backend:
                     class_name: DatabaseStoreBackend
-                    credentials: ${db_creds}
+                    credentials:
+                        database: '<your_db_name>'
+                        drivername: postgresql
+                        host: '<your_host_name>'
+                        password: ******
+                        port: '<your_port>'
+                        username: '<your_username>'
 
 
-4. **Confirm that the new Expectations store has been added by running** ``great_expectations store list``
+        5. **Create a new Expectation Suite by running** ``great_expectations suite new``
 
-    Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_postgres_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in PostgreSQL as long as we set the ``expectations_store_name`` variable to ``expectations_postgres_store``, which we did in the previous step.  The config for ``expectations_store`` can be removed if you would like.
+            This command prompts you to create and name a new Expectation Suite and to select a sample batch of data for the Suite to describe. Behind the scenes, Great Expectations will create a new table in your database called ``ge_expectations_store``, and populate the fields ``expectation_suite_name`` and ``value`` with information from the newly created Expectation Suite.
 
-    .. code-block:: bash
+            If you follow the prompts and create an Expectation Suite called ``exp1``, you can expect to see output similar to the following :
 
-        great_expectations store list
+            .. code-block:: bash
 
-        - name: expectations_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: TupleFilesystemStoreBackend
-            base_directory: expectations/
+                great_expectations suite new
 
-        - name: expectations_postgres_store
-        class_name: ExpectationsStore
-        store_backend:
-            class_name: DatabaseStoreBackend
-            credentials:
-                database: '<your_db_name>'
-                drivername: postgresql
-                host: '<your_host_name>'
-                password: ******
-                port: '<your_port>'
-                username: '<your_username>'
+                #  ...
+
+                Name the new Expectation Suite: exp1
+
+                Great Expectations will choose a couple of columns and generate expectations about them
+                to demonstrate some examples of assertions you can make about your data.
+
+                Great Expectations will store these expectations in a new Expectation Suite 'exp1' here:
+
+                postgresql://'<your_db_name>'/exp1
+
+                #  ...
 
 
-5. **Create a new Expectation Suite by running** ``great_expectations suite new``
+        6. **Confirm that Expectations can be accessed from PostgreSQL by running** ``great_expectations suite list``
 
-    This command prompts you to create and name a new Expectation Suite and to select a sample batch of data for the Suite to describe. Behind the scenes, Great Expectations will create a new table in your database called ``ge_expectations_store``, and populate the fields ``expectation_suite_name`` and ``value`` with information from the newly created Expectation Suite.
+            The output should include the Expectation Suite we created in the previous step: ``exp1``.
 
-    If you follow the prompts and create an Expectation Suite called ``exp1``, you can expect to see output similar to the following :
+            .. code-block:: bash
 
-    .. code-block:: bash
+                great_expectations suite list
 
-        great_expectations suite new
-
-        #  ...
-
-        Name the new Expectation Suite: exp1
-
-        Great Expectations will choose a couple of columns and generate expectations about them
-        to demonstrate some examples of assertions you can make about your data.
-
-        Great Expectations will store these expectations in a new Expectation Suite 'exp1' here:
-
-        postgresql://'<your_db_name>'/exp1
-
-        #  ...
+                1 Expectation Suites found:
+                 - exp1
 
 
-6. **Confirm that Expectations can be accessed from PostgreSQL by running** ``great_expectations suite list``
+    .. tab-container:: tab1
+        :title: Show Docs for V3 (Batch Request) API
 
-    The output should include the Expectation Suite we created in the previous step: ``exp1``.
+        1. **Configure the** ``config_variables.yml`` **file with your database credentials**
 
-    .. code-block:: bash
+            We recommend that database credentials be stored in the  ``config_variables.yml`` file, which is located in the ``uncommitted/`` folder by default, and is not part of source control.  The following lines add database credentials under the key ``db_creds``. Additional options for configuring the ``config_variables.yml`` file or additional environment variables can be found `here. <https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html>`_
 
-        great_expectations suite list
+            .. code-block:: yaml
 
-        1 Expectation Suites found:
-         - exp1
+                db_creds:
+                    drivername: postgres
+                    host: '<your_host_name>'
+                    port: '<your_port>'
+                    username: '<your_username>'
+                    password: '<your_password>'
+                    database: '<your_database_name>'
+
+
+        2. **Identify your Data Context Expectations Store**
+
+            In your ``great_expectations.yml`` , look for the following lines.  The configuration tells Great Expectations to look for Expectations in a store called ``expectations_store``. The ``base_directory`` for ``expectations_store`` is set to ``expectations/`` by default.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_store
+
+                stores:
+                    expectations_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: TupleFilesystemStoreBackend
+                            base_directory: expectations/
+
+
+        3. **Update your configuration file to include a new store for Expectations on PostgreSQL**
+
+            In our case, the name is set to ``expectations_postgres_store``, but it can be any name you like.  We also need to make some changes to the ``store_backend`` settings.  The ``class_name`` will be set to ``DatabaseStoreBackend``, and ``credentials`` will be set to ``${db_creds}``, which references the corresponding key in the ``config_variables.yml`` file.
+
+            .. code-block:: yaml
+
+                expectations_store_name: expectations_postgres_store
+
+                stores:
+                    expectations_postgres_store:
+                        class_name: ExpectationsStore
+                        store_backend:
+                            class_name: DatabaseStoreBackend
+                            credentials: ${db_creds}
+
+
+        4. **Confirm that the new Expectations store has been added by running** ``great_expectations --v3-api store list``
+
+            Notice the output contains two Expectation stores: the original ``expectations_store`` on the local filesystem and the ``expectations_postgres_store`` we just configured.  This is ok, since Great Expectations will look for Expectations in PostgreSQL as long as we set the ``expectations_store_name`` variable to ``expectations_postgres_store``, which we did in the previous step.  The config for ``expectations_store`` can be removed if you would like.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api store list
+
+                - name: expectations_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: TupleFilesystemStoreBackend
+                    base_directory: expectations/
+
+                - name: expectations_postgres_store
+                class_name: ExpectationsStore
+                store_backend:
+                    class_name: DatabaseStoreBackend
+                    credentials:
+                        database: '<your_db_name>'
+                        drivername: postgresql
+                        host: '<your_host_name>'
+                        password: ******
+                        port: '<your_port>'
+                        username: '<your_username>'
+
+
+        5. **Create a new Expectation Suite by running** ``great_expectations --v3-api suite new``
+
+            This command prompts you to create and name a new Expectation Suite and to select a sample batch of data for the Suite to describe. Behind the scenes, Great Expectations will create a new table in your database called ``ge_expectations_store``, and populate the fields ``expectation_suite_name`` and ``value`` with information from the newly created Expectation Suite.
+
+            If you follow the prompts and create an Expectation Suite called ``exp1``, you can expect to see output similar to the following :
+
+            .. code-block:: bash
+
+                great_expectations --v3-api suite new
+
+                #  ...
+
+                Name the new Expectation Suite: exp1
+
+                Great Expectations will choose a couple of columns and generate expectations about them
+                to demonstrate some examples of assertions you can make about your data.
+
+                Great Expectations will store these expectations in a new Expectation Suite 'exp1' here:
+
+                postgresql://'<your_db_name>'/exp1
+
+                #  ...
+
+
+        6. **Confirm that Expectations can be accessed from PostgreSQL by running** ``great_expectations --v3-api suite list``
+
+            The output should include the Expectation Suite we created in the previous step: ``exp1``.
+
+            .. code-block:: bash
+
+                great_expectations --v3-api suite list
+
+                1 Expectation Suites found:
+                 - exp1
 
 
 If it would be useful to you, please comment with a +1 and feel free to add any suggestions or questions below.  Also, please reach out to us on `Slack <https://greatexpectations.io/slack>`_ if you would like to learn more, or have any questions.


### PR DESCRIPTION
Changes proposed in this pull request:
- Update Configuring metadata stores documentation for V3 API CLI, e.g. change any CLI mention to use the `--v3-api` flag