### PR TITLE
[BUGFIX] Usage stats cli payload schema

### DIFF
--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -322,35 +322,18 @@ cli_suite_edit_expectation_suite_payload_schema = {
     "additionalProperties": False,
 }
 
-api_version_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "api_version": {"type": "string", "maxLength": 256},
-    },
-    "additionalProperties": False,
-}
-
-cancelled_cli_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "cancelled": {"type": ["boolean", "null"]},
-    },
-    "additionalProperties": False,
-}
-
 cli_payload_schema = {
     "$schema": "http://json-schema.org/schema#",
     "title": "cli-payload",
-    "definitions": {
-        "api_version_definition": api_version_payload_schema,
-        "cancelled_cli_definition": cancelled_cli_payload_schema,
-    },
     "type": "object",
     "properties": {
-        "api_version": {"$ref": "#/definitions/api_version_definition"},
-        "cancelled": {"$ref": "#/definitions/cancelled_cli_definition"},
+        "api_version": {
+            "type": "string",
+            "maxLength": 256,
+        },
+        "cancelled": {
+            "type": ["boolean", "null"],
+        },
     },
     "additionalProperties": False,
 }
@@ -538,6 +521,7 @@ usage_statistics_record_schema = {
                         "cli.docs.list.end",
                         "cli.init.create",
                         "cli.project.check_config",
+                        "cli.project.upgrade",
                         "cli.project.upgrade.begin",
                         "cli.project.upgrade.end",
                         "cli.store.list",

--- a/tests/core/usage_statistics/test_usage_stats_schema.py
+++ b/tests/core/usage_statistics/test_usage_stats_schema.py
@@ -161,15 +161,16 @@ def test_usage_stats_empty_payload_messages():
         "data_context.build_data_docs",
         "data_context.open_data_docs",
     ]
-    for message in usage_stats_records_messages:
-        jsonschema.validate(
-            valid_usage_statistics_messages[message][0],
-            usage_statistics_record_schema,
-        )
-        jsonschema.validate(
-            valid_usage_statistics_messages[message][0]["event_payload"],
-            empty_payload_schema,
-        )
+    for message_type in usage_stats_records_messages:
+        for message in valid_usage_statistics_messages[message_type]:
+            jsonschema.validate(
+                message,
+                usage_statistics_record_schema,
+            )
+            jsonschema.validate(
+                message["event_payload"],
+                empty_payload_schema,
+            )
 
 
 def test_usage_stats_cli_payload_messages():

--- a/tests/core/usage_statistics/test_usage_stats_schema.py
+++ b/tests/core/usage_statistics/test_usage_stats_schema.py
@@ -188,7 +188,7 @@ def test_usage_stats_cli_payload_messages():
         "cli.docs.list",
         "cli.init.create",
         "cli.project.check_config",
-        # "cli.project.upgrade",
+        "cli.project.upgrade",
         "cli.store.list",
         "cli.suite.delete",
         "cli.suite.demo",
@@ -198,12 +198,9 @@ def test_usage_stats_cli_payload_messages():
         "cli.validation_operator.list",
         "cli.validation_operator.run",
     ]
-    for message in usage_stats_records_messages:
-        jsonschema.validate(
-            valid_usage_statistics_messages[message][0],
-            usage_statistics_record_schema,
-        )
-        jsonschema.validate(
-            valid_usage_statistics_messages[message][0]["event_payload"],
-            cli_payload_schema,
-        )
+    for message_type in usage_stats_records_messages:
+        for message in valid_usage_statistics_messages[message_type]:
+            jsonschema.validate(
+                message,
+                usage_statistics_record_schema,
+            )


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix cli payload schema
- Test all valid usage stats messages in test_usage_stats_cli_payload_messages and test_usage_stats_empty_payload_messages
- Note that other tests in test_usage_stats_schema.py should also test more than the first message in the group

There will be a forthcoming PR into the usage_stats repository related to this