### PR TITLE
[MAINTENANCE] remove cli.project.upgrade event

### DIFF
--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -521,7 +521,6 @@ usage_statistics_record_schema = {
                         "cli.docs.list.end",
                         "cli.init.create",
                         "cli.project.check_config",
-                        "cli.project.upgrade",
                         "cli.project.upgrade.begin",
                         "cli.project.upgrade.end",
                         "cli.store.list",


### PR DESCRIPTION
Changes proposed in this pull request:
- remove cli.project.upgrade event (only begin and end events are valid since this event is new)