### PR TITLE
[BUGFIX] Handle limit for oracle with rownum

### DIFF
--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -266,7 +266,8 @@ class MetaSqlAlchemyDataset(Dataset):
                     .select_from(self._table)
                     .where(
                         sa.and_(
-                            sa.not_(expected_condition), sa.not_(ignore_values_condition)
+                            sa.not_(expected_condition),
+                            sa.not_(ignore_values_condition),
                         )
                     )
                 )
@@ -276,15 +277,14 @@ class MetaSqlAlchemyDataset(Dataset):
                     .select_from(self._table)
                     .where(
                         sa.and_(
-                            sa.not_(expected_condition), sa.not_(ignore_values_condition)
+                            sa.not_(expected_condition),
+                            sa.not_(ignore_values_condition),
                         )
                     )
                     .limit(unexpected_count_limit)
                 )
             query = str(
-                raw_query.compile(
-                    self.engine, compile_kwargs={"literal_binds": True}
-                )
+                raw_query.compile(self.engine, compile_kwargs={"literal_binds": True})
             )
             # use rownum instead of limit in oracle
             if self.engine.dialect.name.lower() == "oracle":

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -259,17 +259,37 @@ class MetaSqlAlchemyDataset(Dataset):
             count_results["null_count"] = int(count_results["null_count"])
             count_results["unexpected_count"] = int(count_results["unexpected_count"])
 
-            # Retrieve unexpected values
-            unexpected_query_results = self.engine.execute(
-                sa.select([sa.column(column)])
-                .select_from(self._table)
-                .where(
-                    sa.and_(
-                        sa.not_(expected_condition), sa.not_(ignore_values_condition)
+            # limit doesn't compile properly for oracle so we will append rownum to query string later
+            if self.engine.dialect.name.lower() == "oracle":
+                raw_query = (
+                    sa.select([sa.column(column)])
+                    .select_from(self._table)
+                    .where(
+                        sa.and_(
+                            sa.not_(expected_condition), sa.not_(ignore_values_condition)
+                        )
                     )
                 )
-                .limit(unexpected_count_limit)
+            else:
+                raw_query = (
+                    sa.select([sa.column(column)])
+                    .select_from(self._table)
+                    .where(
+                        sa.and_(
+                            sa.not_(expected_condition), sa.not_(ignore_values_condition)
+                        )
+                    )
+                    .limit(unexpected_count_limit)
+                )
+            query = str(
+                raw_query.compile(
+                    self.engine, compile_kwargs={"literal_binds": True}
+                )
             )
+            # use rownum instead of limit in oracle
+            if self.engine.dialect.name.lower() == "oracle":
+                query += "\nAND ROWNUM <= %d" % unexpected_count_limit
+            unexpected_query_results = self.engine.execute(query)
 
             nonnull_count: int = (
                 count_results["element_count"] - count_results["null_count"]

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -145,11 +145,15 @@ class SqlAlchemyBatchData(BatchData):
                         "batch_spec_passthrough or a specify a default dataset in engine url"
                     )
             if selectable is not None:
-                # compile selectable to sql statement
-                query = selectable.compile(
-                    dialect=self.sql_engine_dialect,
-                    compile_kwargs={"literal_binds": True},
-                )
+                if engine.dialect.name.lower() == "oracle":
+                    # oracle query was already passed as a string
+                    query = selectable
+                else:
+                    # compile selectable to sql statement
+                    query = selectable.compile(
+                        dialect=self.sql_engine_dialect,
+                        compile_kwargs={"literal_binds": True},
+                    )
             self._create_temporary_table(
                 generated_table_name,
                 query,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -772,7 +772,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             == hash_value
         )
 
-    def _build_selectable_from_batch_spec(self, batch_spec) -> Select:
+    def _build_selectable_from_batch_spec(self, batch_spec) -> Union[Select, str]:
         table_name: str = batch_spec["table_name"]
         if "splitter_method" in batch_spec:
             splitter_fn = getattr(self, batch_spec["splitter_method"])
@@ -886,9 +886,14 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                 source_schema_name=source_schema_name,
             )
         elif isinstance(batch_spec, SqlAlchemyDatasourceBatchSpec):
-            selectable: Select = self._build_selectable_from_batch_spec(
-                batch_spec=batch_spec
-            )
+            if engine.dialect.name.lower() == "oracle":
+                selectable: str = self._build_selectable_from_batch_spec(
+                    batch_spec=batch_spec
+                )
+            else:
+                selectable: Select = self._build_selectable_from_batch_spec(
+                    batch_spec=batch_spec
+                )
 
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -886,7 +886,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                 source_schema_name=source_schema_name,
             )
         elif isinstance(batch_spec, SqlAlchemyDatasourceBatchSpec):
-            if engine.dialect.name.lower() == "oracle":
+            if self.engine.dialect.name.lower() == "oracle":
                 selectable: str = self._build_selectable_from_batch_spec(
                     batch_spec=batch_spec
                 )

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -212,7 +212,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             "sqlite",
             "oracle",
             "mssql",
-            "oracle",
         ]:
             # These are the officially included and supported dialects by sqlalchemy
             self.dialect_module = import_library_module(
@@ -799,7 +798,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                     .limit(batch_spec["sampling_kwargs"]["n"])
                 )
             else:
-
+                
                 sampler_fn = getattr(self, batch_spec["sampling_method"])
                 return (
                     sa.select("*")


### PR DESCRIPTION
This is a bugfix commit that should have been included with PR #[2609](https://github.com/great-expectations/great_expectations/pull/2609).

Oracle does not support the LIMIT keyword. This workaround is similar to the one used in [sqlalchemy_datasource.py](https://github.com/great-expectations/great_expectations/blob/develop/great_expectations/datasource/sqlalchemy_datasource.py#L426) starting on line 426.