### PR TITLE
[DOCS] remove invalid image

### DIFF
--- a/docs/guides/tutorials/getting_started/set_up_data_docs.rst
+++ b/docs/guides/tutorials/getting_started/set_up_data_docs.rst
@@ -15,8 +15,6 @@ If you scroll down, you will see all Expectations that were generated for the ``
 
 We also see the **observed values** for this batch, which is exactly the numbers 1 through 6 that we expected. This makes sense, since we're developing the Expectation using the January data batch.
 
-.. figure:: /images/validation_results_column.png
-
 **Feel free to click around and explore Data Docs a little more.** You will find two more interesting features:
 
 #. If you click on the *Home* page, you will see a list of all validation runs.


### PR DESCRIPTION
The image shown in the docs is no longer generated as of great-expectations 0.13.17.

I currently am shown this when following along with the tutorial on my pc:

![image](https://user-images.githubusercontent.com/10238802/115328780-2e8eaf00-a15f-11eb-8619-d76943512344.png)

However the current image on this tutorial page shows an entry for KL with a bar graph:

![image](https://docs.greatexpectations.io/en/latest/_images/validation_results_column.png)
Feel free to use my image as a replacement if it helps.