### PR TITLE
[MAINTENANCE] Enable os-integration pipeline on main to check during releases

### DIFF
--- a/azure-pipelines-os-integration.yml
+++ b/azure-pipelines-os-integration.yml
@@ -4,8 +4,8 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 # Deactivate os-integration to preserve scarce build resources
-# trigger:
-#   - main
+trigger:
+  - main
 #   - develop
 
 # pr: none


### PR DESCRIPTION
Changes proposed in this pull request:
- Re-enable os-integration pipeline on main so that it is run during releases and is not required to pass (which now includes the `db_integration_latest_sqlalchemy` stage which checks whether the latest version of sqlalchemy is compatible with GE - currently restricted to `sqlalchemy>=1.3.16,<1.4.10`)