### PR TITLE
[BUGFIX] Fix packaging error breaking V3 CLI suite commands (#2719)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,9 +2,7 @@ include *.txt
 include LICENSE
 include great_expectations/data_context/checkpoint_template.yml
 include great_expectations/init_notebooks/*/*.ipynb
-include great_expectations/render/view/templates/*.j2
-include great_expectations/render/notebook_assets/*/*.md
-include great_expectations/render/notebook_assets/*/*.j2
+recursive-include great_expectations/render *.j2 *.md *.py
 graft great_expectations/render/view/static
 graft tests
 global-exclude *.py[co]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Develop
 -----------------
+* [BUGFIX] Fix packaging error breaking V3 CLI suite commands (#2719)
 
 0.13.18
 -----------------


### PR DESCRIPTION
* [BUGFIX] Fix packaging error breaking V3 CLI suite commands (#2719)

Verified manually by building source and binary distributions that were installed in clean environments.

