### PR TITLE
[ENHANCEMENT] GE-7 Clarifications and minor tweaks

### DIFF
--- a/great_expectations/profiler/parameter_builder/multi_batch_bootstrapped_metric_distribution_parameter_builder.py
+++ b/great_expectations/profiler/parameter_builder/multi_batch_bootstrapped_metric_distribution_parameter_builder.py
@@ -66,6 +66,7 @@ class MultiBatchBootstrappedMetricDistributionParameterBuilder(
         **kwargs
     ) -> ParameterContainer:
         samples = []
+        # TODO: 20210426 AJB I think we need to handle not passing batch_ids here and everywhere else by processing all batches if `batch_ids is None`
         for batch_id in batch_ids:
             metric_domain_kwargs = copy(rule_state.active_domain["domain_kwargs"])
             metric_domain_kwargs.update({"batch_id": batch_id})

--- a/great_expectations/profiler/profiler.py
+++ b/great_expectations/profiler/profiler.py
@@ -110,7 +110,7 @@ class Profiler:
             :param batch: A Batch object to profile on
             :param batches: A list of Batch objects
             :param batch_request: A Batch request utilized to obtain a Validator Object
-            :param batch_ids: A batch id used to identify data. If not provided, validator active batch id is used.
+            :param batch_ids: A list of batch_ids to use when profiling (e.g. can be a subset of batches provided via validator, batch, batches, batch_request). If not provided, all batches are used. If a Validator is provided, validator active batch id is used. Note, we also verify that all of these batch_ids are accessible and throw an error if not.
             :param data_context: A DataContext object used to define a great_expectations project environment
             :param expectation_suite_name: A name for returned Expectation suite.
         :return: Set of rule evaluation results in the form of an Expectation suite

--- a/great_expectations/profiler/profiler.py
+++ b/great_expectations/profiler/profiler.py
@@ -165,8 +165,8 @@ class Profiler:
             )
         suite = ExpectationSuite(expectation_suite_name=expectation_suite_name)
         for rule in self._rules:
-            result = rule.evaluate(validator, batch_ids)
-            for config in result:
-                suite.add_expectation(config)
+            expectation_configurations = rule.evaluate(validator, batch_ids)
+            for expectation_configuration in expectation_configurations:
+                suite.add_expectation(expectation_configuration)
 
         return suite

--- a/great_expectations/profiler/rule/rule.py
+++ b/great_expectations/profiler/rule/rule.py
@@ -56,7 +56,7 @@ class Rule:
         :return: List of Corresponding Expectation Configurations representing every configured rule
         """
         rule_state: RuleState = RuleState(variables=self._variables)
-        configurations: List[ExpectationConfiguration] = []
+        expectation_configurations: List[ExpectationConfiguration] = []
 
         rule_state.domains = self._domain_builder.get_domains(
             validator=validator, batch_ids=batch_ids
@@ -83,10 +83,10 @@ class Rule:
             for (
                 expectation_configuration_builder
             ) in self._expectation_configuration_builders:
-                configurations.append(
+                expectation_configurations.append(
                     expectation_configuration_builder.build_expectation_configuration(
                         rule_state=rule_state
                     )
                 )
 
-        return configurations
+        return expectation_configurations


### PR DESCRIPTION
A few clarifications / todos
Changes proposed in this pull request:
- clarify `batch_ids` param in `Profiler.profile()` docstring
- clarify `configurations` in `Rule.evaluate()` as `expectation_configurations`
- add TODO for handling passed `batch_ids` appropriately
- Clarify configurations in Profiler.profile()
- For GE-7 task