### PR TITLE
[ENHANCEMENT] RTD works alongside docusaurus

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs_rtd/conf.py
   fail_on_warning: false  # set to true once builds are no longer producing warnings
 
 # Build documentation with MkDocs
@@ -23,4 +23,4 @@ python:
   version: 3.8
 #   system_packages: true
   install:
-    - requirements: docs/requirements.txt
+    - requirements: docs_rtd/requirements.txt

--- a/docs_rtd/conf.py
+++ b/docs_rtd/conf.py
@@ -258,7 +258,7 @@ autodoc_member_order = "bysource"
 
 def process_docstring(app, what, name, obj, options, lines):
 
-    from docs.feature_annotation_parser import parse_feature_annotation
+    from docs_rtd.feature_annotation_parser import parse_feature_annotation
 
     docstring = "\n".join(lines)
     annotation_list = parse_feature_annotation(docstring)


### PR DESCRIPTION
This PR attempts to re-enable RTD builds alongside docusaurus during the transition between docs hosting platforms.

