### PR TITLE
[MAINTENANCE] Inferring Semantic Domain Type

### DIFF
--- a/great_expectations/profiler/domain_builder/inferred_semantic_domain_type.py
+++ b/great_expectations/profiler/domain_builder/inferred_semantic_domain_type.py
@@ -1,0 +1,15 @@
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional, Union
+
+from great_expectations.core.domain_types import SemanticDomainTypes
+from great_expectations.core.util import convert_to_json_serializable
+from great_expectations.types import SerializableDictDot
+
+
+@dataclass
+class InferredSemanticDomainType(SerializableDictDot):
+    semantic_domain_type: Optional[Union[str, SemanticDomainTypes]] = None
+    details: Optional[Dict[str, Any]] = None
+
+    def to_json_dict(self) -> dict:
+        return convert_to_json_serializable(data=asdict(self))

--- a/great_expectations/profiler/domain_builder/simple_semantic_type_domain_builder.py
+++ b/great_expectations/profiler/domain_builder/simple_semantic_type_domain_builder.py
@@ -7,7 +7,7 @@ from great_expectations.profiler.domain_builder.column_domain_builder import (
 )
 from great_expectations.profiler.domain_builder.domain import Domain
 from great_expectations.profiler.util import (
-    translate_table_column_type_to_semantic_domain_type,
+    infer_table_column_type_to_semantic_domain_type,
 )
 from great_expectations.validator.validator import MetricConfiguration, Validator
 
@@ -75,7 +75,7 @@ class SimpleSemanticTypeColumnDomainBuilder(ColumnDomainBuilder):
         semantic_column_type: str
         for column_name in column_names:
             semantic_column_type: SemanticDomainTypes = (
-                translate_table_column_type_to_semantic_domain_type(
+                infer_table_column_type_to_semantic_domain_type(
                     validator=validator, column_name=column_name
                 )
             )

--- a/great_expectations/profiler/domain_builder/simple_semantic_type_domain_builder.py
+++ b/great_expectations/profiler/domain_builder/simple_semantic_type_domain_builder.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.domain_types import MetricDomainTypes, SemanticDomainTypes
@@ -9,10 +9,7 @@ from great_expectations.profiler.domain_builder.domain import Domain
 from great_expectations.profiler.domain_builder.inferred_semantic_domain_type import (
     InferredSemanticDomainType,
 )
-from great_expectations.profiler.util import (
-    infer_semantic_domain_type_from_table_column_type,
-    parse_semantic_domain_type_argument,
-)
+from great_expectations.profiler.util import parse_semantic_domain_type_argument
 from great_expectations.validator.validator import MetricConfiguration, Validator
 
 
@@ -74,7 +71,7 @@ class SimpleSemanticTypeColumnDomainBuilder(ColumnDomainBuilder):
         semantic_domain_type: SemanticDomainTypes
         for column_name in table_column_names:
             inferred_semantic_domain_type = (
-                infer_semantic_domain_type_from_table_column_type(
+                self.infer_semantic_domain_type_from_table_column_type(
                     validator=validator, column_name=column_name
                 )
             )
@@ -92,3 +89,99 @@ class SimpleSemanticTypeColumnDomainBuilder(ColumnDomainBuilder):
                 )
 
         return domains
+
+    # This method (default implementation) can be overwritten (with different implementation mechanisms) by subclasses.
+    # noinspection PyMethodMayBeStatic
+    def infer_semantic_domain_type_from_table_column_type(
+        self, validator: Validator, column_name: str
+    ) -> InferredSemanticDomainType:
+        # Note: As of Python 3.8, specifying argument type in Lambda functions is not supported by Lambda syntax.
+        column_types_dict_list: List[Dict[str, Any]] = list(
+            filter(
+                lambda column_type_dict: column_name in column_type_dict,
+                validator.get_metric(
+                    metric=MetricConfiguration(
+                        metric_name="table.column_types",
+                        metric_domain_kwargs={},
+                        metric_value_kwargs={
+                            "include_nested": True,
+                        },
+                        metric_dependencies=None,
+                    )
+                ),
+            )
+        )
+        if len(column_types_dict_list) != 1:
+            raise ge_exceptions.ProfilerExecutionError(
+                message=f"""Error: {len(column_types_dict_list)} columns were found while obtaining semantic type \
+    information.  Please ensure that the specified column name refers to exactly one column.
+    """
+            )
+
+        column_type: str = cast(str, column_types_dict_list[0][column_name]).upper()
+
+        semantic_column_type: SemanticDomainTypes
+        if column_type in (
+            set([type_name.upper() for type_name in ProfilerTypeMapping.INT_TYPE_NAMES])
+            | set(
+                [
+                    type_name.upper()
+                    for type_name in ProfilerTypeMapping.FLOAT_TYPE_NAMES
+                ]
+            )
+        ):
+            semantic_column_type = SemanticDomainTypes.NUMERIC
+        elif column_type in set(
+            [type_name.upper() for type_name in ProfilerTypeMapping.STRING_TYPE_NAMES]
+        ):
+            semantic_column_type = SemanticDomainTypes.TEXT
+        elif column_type in set(
+            [type_name.upper() for type_name in ProfilerTypeMapping.BOOLEAN_TYPE_NAMES]
+        ):
+            semantic_column_type = SemanticDomainTypes.LOGIC
+        elif column_type in set(
+            [type_name.upper() for type_name in ProfilerTypeMapping.DATETIME_TYPE_NAMES]
+        ):
+            semantic_column_type = SemanticDomainTypes.DATETIME
+        elif column_type in set(
+            [type_name.upper() for type_name in ProfilerTypeMapping.BINARY_TYPE_NAMES]
+        ):
+            semantic_column_type = SemanticDomainTypes.BINARY
+        elif column_type in set(
+            [type_name.upper() for type_name in ProfilerTypeMapping.CURRENCY_TYPE_NAMES]
+        ):
+            semantic_column_type = SemanticDomainTypes.CURRENCY
+        elif column_type in set(
+            [type_name.upper() for type_name in ProfilerTypeMapping.IDENTITY_TYPE_NAMES]
+        ):
+            semantic_column_type = SemanticDomainTypes.IDENTITY
+        elif column_type in (
+            set(
+                [
+                    type_name.upper()
+                    for type_name in ProfilerTypeMapping.MISCELLANEOUS_TYPE_NAMES
+                ]
+            )
+            | set(
+                [
+                    type_name.upper()
+                    for type_name in ProfilerTypeMapping.RECORD_TYPE_NAMES
+                ]
+            )
+        ):
+            semantic_column_type = SemanticDomainTypes.MISCELLANEOUS
+        else:
+            semantic_column_type = SemanticDomainTypes.UNKNOWN
+
+        inferred_semantic_column_type: InferredSemanticDomainType = (
+            InferredSemanticDomainType(
+                semantic_domain_type=semantic_column_type,
+                details={
+                    "algorithm_type": "deterministic",
+                    "mechanism": "lookup_table",
+                    "source": "great_expectations.profile.base.ProfilerTypeMapping",
+                },
+            )
+        )
+
+        return inferred_semantic_column_type

--- a/great_expectations/profiler/util.py
+++ b/great_expectations/profiler/util.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations import DataContext
 from great_expectations.core.batch import BatchDefinition, BatchRequest
-from great_expectations.core.domain_types import SemanticDomainTypes
 from great_expectations.profiler.domain_builder.domain import Domain
 from great_expectations.profiler.parameter_builder.parameter_container import (
     DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
@@ -13,45 +12,6 @@ from great_expectations.profiler.parameter_builder.parameter_container import (
     ParameterNode,
     validate_fully_qualified_parameter_name,
 )
-
-
-def parse_semantic_domain_type_argument(
-    semantic_types: Optional[
-        Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
-    ] = None
-) -> List[SemanticDomainTypes]:
-    if semantic_types is None:
-        return []
-
-    semantic_type: Union[str, SemanticDomainTypes]
-    if isinstance(semantic_types, str):
-        return [
-            SemanticDomainTypes[semantic_type]
-            for semantic_type in [semantic_types]
-            if SemanticDomainTypes.has_member_key(key=semantic_type)
-        ]
-    if isinstance(semantic_types, SemanticDomainTypes):
-        return [semantic_type for semantic_type in [semantic_types]]
-    elif isinstance(semantic_types, List):
-        if all([isinstance(semantic_type, str) for semantic_type in semantic_types]):
-            return [
-                SemanticDomainTypes[semantic_type]
-                for semantic_type in semantic_types
-                if SemanticDomainTypes.has_member_key(key=semantic_type)
-            ]
-        elif all(
-            [
-                isinstance(semantic_type, SemanticDomainTypes)
-                for semantic_type in semantic_types
-            ]
-        ):
-            return [semantic_type for semantic_type in semantic_types]
-        else:
-            raise ValueError(
-                "All elements in semantic_types list must be either of str or SemanticDomainTypes type."
-            )
-    else:
-        raise ValueError("Unrecognized semantic_types directive.")
 
 
 def get_parameter_value(

--- a/great_expectations/profiler/util.py
+++ b/great_expectations/profiler/util.py
@@ -18,7 +18,7 @@ from great_expectations.validator.validation_graph import MetricConfiguration
 from great_expectations.validator.validator import Validator
 
 
-def translate_table_column_type_to_semantic_domain_type(
+def infer_table_column_type_to_semantic_domain_type(
     validator: Validator, column_name: str
 ) -> SemanticDomainTypes:
     # Note: As of Python 3.8, specifying argument type in Lambda functions is not supported by Lambda syntax.

--- a/great_expectations/profiler/util.py
+++ b/great_expectations/profiler/util.py
@@ -1,14 +1,10 @@
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations import DataContext
 from great_expectations.core.batch import BatchDefinition, BatchRequest
 from great_expectations.core.domain_types import SemanticDomainTypes
-from great_expectations.profile.base import ProfilerTypeMapping
 from great_expectations.profiler.domain_builder.domain import Domain
-from great_expectations.profiler.domain_builder.inferred_semantic_domain_type import (
-    InferredSemanticDomainType,
-)
 from great_expectations.profiler.parameter_builder.parameter_container import (
     DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
     DOMAIN_KWARGS_PARAMETER_NAME,
@@ -17,95 +13,6 @@ from great_expectations.profiler.parameter_builder.parameter_container import (
     ParameterNode,
     validate_fully_qualified_parameter_name,
 )
-from great_expectations.validator.validation_graph import MetricConfiguration
-from great_expectations.validator.validator import Validator
-
-
-def infer_semantic_domain_type_from_table_column_type(
-    validator: Validator, column_name: str
-) -> InferredSemanticDomainType:
-    # Note: As of Python 3.8, specifying argument type in Lambda functions is not supported by Lambda syntax.
-    column_types_dict_list: List[Dict[str, Any]] = list(
-        filter(
-            lambda column_type_dict: column_name in column_type_dict,
-            validator.get_metric(
-                metric=MetricConfiguration(
-                    metric_name="table.column_types",
-                    metric_domain_kwargs={},
-                    metric_value_kwargs={
-                        "include_nested": True,
-                    },
-                    metric_dependencies=None,
-                )
-            ),
-        )
-    )
-    if len(column_types_dict_list) != 1:
-        raise ge_exceptions.ProfilerExecutionError(
-            message=f"""Error: {len(column_types_dict_list)} columns were found while obtaining semantic type \
-information.  Please ensure that the specified column name refers to exactly one column.
-"""
-        )
-
-    column_type: str = cast(str, column_types_dict_list[0][column_name]).upper()
-
-    semantic_column_type: SemanticDomainTypes
-    if column_type in (
-        set([type_name.upper() for type_name in ProfilerTypeMapping.INT_TYPE_NAMES])
-        | set([type_name.upper() for type_name in ProfilerTypeMapping.FLOAT_TYPE_NAMES])
-    ):
-        semantic_column_type = SemanticDomainTypes.NUMERIC
-    elif column_type in set(
-        [type_name.upper() for type_name in ProfilerTypeMapping.STRING_TYPE_NAMES]
-    ):
-        semantic_column_type = SemanticDomainTypes.TEXT
-    elif column_type in set(
-        [type_name.upper() for type_name in ProfilerTypeMapping.BOOLEAN_TYPE_NAMES]
-    ):
-        semantic_column_type = SemanticDomainTypes.LOGIC
-    elif column_type in set(
-        [type_name.upper() for type_name in ProfilerTypeMapping.DATETIME_TYPE_NAMES]
-    ):
-        semantic_column_type = SemanticDomainTypes.DATETIME
-    elif column_type in set(
-        [type_name.upper() for type_name in ProfilerTypeMapping.BINARY_TYPE_NAMES]
-    ):
-        semantic_column_type = SemanticDomainTypes.BINARY
-    elif column_type in set(
-        [type_name.upper() for type_name in ProfilerTypeMapping.CURRENCY_TYPE_NAMES]
-    ):
-        semantic_column_type = SemanticDomainTypes.CURRENCY
-    elif column_type in set(
-        [type_name.upper() for type_name in ProfilerTypeMapping.IDENTITY_TYPE_NAMES]
-    ):
-        semantic_column_type = SemanticDomainTypes.IDENTITY
-    elif column_type in (
-        set(
-            [
-                type_name.upper()
-                for type_name in ProfilerTypeMapping.MISCELLANEOUS_TYPE_NAMES
-            ]
-        )
-        | set(
-            [type_name.upper() for type_name in ProfilerTypeMapping.RECORD_TYPE_NAMES]
-        )
-    ):
-        semantic_column_type = SemanticDomainTypes.MISCELLANEOUS
-    else:
-        semantic_column_type = SemanticDomainTypes.UNKNOWN
-
-    inferred_semantic_column_type: InferredSemanticDomainType = (
-        InferredSemanticDomainType(
-            semantic_domain_type=semantic_column_type,
-            details={
-                "algorithm_type": "deterministic",
-                "mechanism": "lookup_table",
-                "source": "great_expectations.profile.base.ProfilerTypeMapping",
-            },
-        )
-    )
-
-    return inferred_semantic_column_type
 
 
 def parse_semantic_domain_type_argument(


### PR DESCRIPTION
### Scope
* Semantic Domain Types are inferred -- not "directly translated" -- from structured column types.
* Method to infer semantic domain type from structured column type must be in `SimpleSemanticDomainBuilder` in order to subclasses to be able to overwrite this default method.
* Typed object for `InferredSemanticDomain` type that contains the actual type and the inference metadata.