### PR TITLE
[BUGFIX] expect_column_kl_divergence_to_be_less_than to not double count on lowest bin boundary

### DIFF
--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -298,7 +298,7 @@ class ExpectColumnKlDivergenceToBeLessThan(TableExpectation):
             below_partition = MetricConfiguration(
                 "column_values.between.count",
                 metric_domain_kwargs=domain_kwargs,
-                metric_value_kwargs={"max_value": bins[0]},
+                metric_value_kwargs={"max_value": bins[0], "strict_max": True},
             )
             above_partition = MetricConfiguration(
                 "column_values.between.count",


### PR DESCRIPTION
with v3 api, the column_values.between.count metric no longer has "strict_max" default to True.

So the kl_divergence will count anything on the lowest boundary as both in the tail and in the lowest bin. 

