### PR TITLE
[MAINTENANCE] Add nightly CI run to test the Latest SQLAlchemy version with GE/postgres

### DIFF
--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -1,0 +1,25 @@
+name: Latest SQLAlchemy
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies including latest sqlalchemy version
+        run: |
+          pip install --requirement requirements-dev-util.txt --requirement requirements-dev-test.txt --requirement requirements-dev-sqlalchemy.txt
+          pip install .
+          pip install --requirement requirements.txt
+          pip install --upgrade SQLAlchemy
+      - name: Test with pytest
+        run: |
+          pytest --no-spark --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -1,11 +1,32 @@
 name: Latest SQLAlchemy
-on: [pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
-  build:
+  postgres:
+    name: Test latest sqlalchemy with postgres
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_DB: test_ci
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8]
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,3 +44,42 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --no-spark --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          channel: '#notifications-builds'
+        if: always()
+
+#        actions-setup-mysql
+#https://github:
+#  com/marketplace/actions/actions-setup-mysql:
+#  mysql:
+#    name: Test latest sqlalchemy with mysql
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        python-version: [ 3.8 ]
+#    env:
+#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#    steps:
+#      - uses: actions/checkout@v2
+#        with:
+#          ref: ${{ github.head_ref }}
+#      - name: Set up Python ${{ matrix.python-version }}
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#      - name: Install dependencies including latest sqlalchemy version
+#        run: |
+#          pip install --requirement requirements-dev-util.txt --requirement requirements-dev-test.txt --requirement requirements-dev-sqlalchemy.txt
+#          pip install .
+#          pip install --requirement requirements.txt
+#          pip install --upgrade SQLAlchemy
+#      - name: Test with pytest
+#        run: |
+#          pytest --no-spark --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+#      - uses: act10ns/slack@v1
+#        with:
+#          status: ${{ job.status }}
+#          channel: '#notifications-builds'
+#        if: always()

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -5,13 +5,10 @@ on:
 jobs:
   postgres:
     name: Test latest sqlalchemy with postgres
-    # Service containers to run with `container-job`
     services:
-      # Label used to access the service container
       postgres:
-        # Docker Hub image
         image: postgres
-        # Provide the password for postgres
+        # Our tests assume an empty password so do not provide it
         ports:
           - 5432:5432
         env:
@@ -29,7 +26,6 @@ jobs:
         python-version: [3.8]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #GE_TEST_LOCAL_DB_HOSTNAME: localhost
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,8 +43,8 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --no-spark --ignore=tests/cli --ignore=tests/integration/usage_statistics
-      - uses: act10ns/slack@v1
-        name: Notify via Slack
+      - name: Notify via Slack
+        uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}
           channel: '#notifications-builds'

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -3,7 +3,7 @@ on: [push]
 #   schedule:
 #     - cron: '0 0 * * *'
 jobs:
-  postgres:
+  postgres-job:
     name: Test latest sqlalchemy with postgres
     # Service containers to run with `container-job`
     services:
@@ -46,6 +46,7 @@ jobs:
         run: |
           pytest --no-spark --ignore=tests/cli --ignore=tests/integration/usage_statistics tests/core/test_batch_related_objects.py
       - uses: act10ns/slack@v1
+        name: Notify via Slack
         with:
           status: ${{ job.status }}
           channel: '#notifications-builds'

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -1,6 +1,6 @@
 name: Latest SQLAlchemy
 on: [push, pull_request]
-#   schedule: 
+#   schedule:
 #     - cron: '0 0 * * *'
 jobs:
   postgres:
@@ -37,9 +37,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies including latest sqlalchemy version
         run: |
-          pip install --requirement requirements-dev-util.txt --requirement requirements-dev-test.txt --requirement requirements-dev-sqlalchemy.txt
+          pip install --requirement requirements-dev-util.txt --requirement requirements-dev-test.txt --requirement requirements-dev-sqlalchemy.txt -c constraints-dev.txt
           pip install .
-          pip install --requirement requirements.txt
+          pip install --requirement requirements.txt -c constraints-dev.txt
           pip install --upgrade SQLAlchemy
       - name: Test with pytest
         run: |

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -1,7 +1,7 @@
 name: Latest SQLAlchemy
-on: [push]
-#   schedule:
-#     - cron: '0 0 * * *'
+on:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   postgres:
     name: Test latest sqlalchemy with postgres
@@ -46,44 +46,10 @@ jobs:
           pip install --upgrade SQLAlchemy
       - name: Test with pytest
         run: |
-          pytest --no-spark --ignore=tests/cli --ignore=tests/integration/usage_statistics tests/core/test_batch_related_objects.py
+          pytest --no-spark --ignore=tests/cli --ignore=tests/integration/usage_statistics
       - uses: act10ns/slack@v1
         name: Notify via Slack
         with:
           status: ${{ job.status }}
           channel: '#notifications-builds'
         if: always()
-
-#        actions-setup-mysql
-#https://github:
-#  com/marketplace/actions/actions-setup-mysql:
-#  mysql:
-#    name: Test latest sqlalchemy with mysql
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        python-version: [ 3.8 ]
-#    env:
-#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          ref: ${{ github.head_ref }}
-#      - name: Set up Python ${{ matrix.python-version }}
-#        uses: actions/setup-python@v2
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#      - name: Install dependencies including latest sqlalchemy version
-#        run: |
-#          pip install --requirement requirements-dev-util.txt --requirement requirements-dev-test.txt --requirement requirements-dev-sqlalchemy.txt
-#          pip install .
-#          pip install --requirement requirements.txt
-#          pip install --upgrade SQLAlchemy
-#      - name: Test with pytest
-#        run: |
-#          pytest --no-spark --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
-#      - uses: act10ns/slack@v1
-#        with:
-#          status: ${{ job.status }}
-#          channel: '#notifications-builds'
-#        if: always()

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -1,5 +1,5 @@
 name: Latest SQLAlchemy
-on: [push, pull_request]
+on: [push]
 #   schedule:
 #     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -27,6 +27,7 @@ jobs:
         python-version: [3.8]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      GE_TEST_LOCAL_DB_HOSTNAME: postgres
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -43,7 +43,7 @@ jobs:
           pip install --upgrade SQLAlchemy
       - name: Test with pytest
         run: |
-          pytest --no-spark --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+          pytest --no-spark --napoleon-docstrings --ignore=tests/cli --ignore=tests/integration/usage_statistics tests/core/test_batch_related_objects.py
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -43,7 +43,7 @@ jobs:
           pip install --upgrade SQLAlchemy
       - name: Test with pytest
         run: |
-          pytest --no-spark --napoleon-docstrings --ignore=tests/cli --ignore=tests/integration/usage_statistics tests/core/test_batch_related_objects.py
+          pytest --no-spark --ignore=tests/cli --ignore=tests/integration/usage_statistics tests/core/test_batch_related_objects.py
       - uses: act10ns/slack@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -1,7 +1,7 @@
 name: Latest SQLAlchemy
-on:
-  schedule:
-    - cron: '0 0 * * *'
+on: [push, pull_request]
+#   schedule: 
+#     - cron: '0 0 * * *'
 jobs:
   postgres:
     name: Test latest sqlalchemy with postgres

--- a/.github/workflows/test-sqlalchemy-latest.yml
+++ b/.github/workflows/test-sqlalchemy-latest.yml
@@ -3,7 +3,7 @@ on: [push]
 #   schedule:
 #     - cron: '0 0 * * *'
 jobs:
-  postgres-job:
+  postgres:
     name: Test latest sqlalchemy with postgres
     # Service containers to run with `container-job`
     services:
@@ -12,6 +12,8 @@ jobs:
         # Docker Hub image
         image: postgres
         # Provide the password for postgres
+        ports:
+          - 5432:5432
         env:
           POSTGRES_DB: test_ci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -27,7 +29,7 @@ jobs:
         python-version: [3.8]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      GE_TEST_LOCAL_DB_HOSTNAME: postgres
+      #GE_TEST_LOCAL_DB_HOSTNAME: localhost
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Changes proposed in this pull request for Jira GE-47:
- Add a nightly action to test our CI pipeline with the latest version of SQLAlchemy (even if we pin to an earlier version in our requirements because of issues)
- Send a slack notification to #notifications-builds 
- Note: Currently only runs on postgres, this should be extended for mysql and mssql