### PR TITLE
[MAINTENANCE] Improve robustness of integration test_runner

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Develop
 
 * [BUGFIX] Allow decimals without leading zero in evaluation parameter URN
 * [ENHANCEMENT] Enable instantiation of a validator with a multiple batch BatchRequest
+* [MAINTENANCE] Improve robustness of integration test_runner
 0.13.19
 -----------------
 * [BUGFIX] Fix packaging error breaking V3 CLI suite commands (#2719)

--- a/tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py
+++ b/tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py
@@ -29,4 +29,5 @@ batch_request_march = BatchRequest(
 validator_march = context.get_validator(
     batch_request=batch_request_march, expectation_suite=suite
 )
-print(validator_march.expect_table_row_count_to_equal(value=february_table_row_count))
+result = validator_march.expect_table_row_count_to_equal(value=february_table_row_count)
+assert result["success"]

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -9,12 +9,19 @@ from assets.scripts.build_gallery import execute_shell_command
 from great_expectations.data_context.util import file_relative_path
 
 integration_test_matrix = [
+    # {
+    #     "name": "pandas_two_batch_requests_two_validators",
+    #     "base_dir": file_relative_path(__file__, "../../"),
+    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
+    # },
     {
-        "name": "pandas_two_batch_requests_two_validators",
+        "name": "pandas_one_multi_batch_request_one_validator",
         "base_dir": file_relative_path(__file__, "../../"),
         "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
         "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
+        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py",
     },
 ]
 
@@ -74,7 +81,7 @@ def test_docs(test_configuration, tmp_path):
         errs = res.stderr.decode("utf-8")
         print(outs)
         print(errs)
-        assert len(errs) == 0
+        assert res.returncode == 0
     except:
         raise
     finally:

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -9,19 +9,14 @@ from assets.scripts.build_gallery import execute_shell_command
 from great_expectations.data_context.util import file_relative_path
 
 integration_test_matrix = [
-    # {
-    #     "name": "pandas_two_batch_requests_two_validators",
-    #     "base_dir": file_relative_path(__file__, "../../"),
-    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
-    # },
     {
-        "name": "pandas_one_multi_batch_request_one_validator",
+        "name": "pandas_two_batch_requests_two_validators",
         "base_dir": file_relative_path(__file__, "../../"),
         "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
         "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py",
+        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
+        "expected_stderrs": "",
+        "expected_stdouts": "",
     },
 ]
 
@@ -77,11 +72,24 @@ def test_docs(test_configuration, tmp_path):
         # Execute test
         res = subprocess.run(["python", script_path], capture_output=True)
         # Check final state
+        expected_stderrs = test_configuration.get("expected_stderrs")
+        expected_stdouts = test_configuration.get("expected_stdouts")
+        expected_failure = test_configuration.get("expected_failure")
         outs = res.stdout.decode("utf-8")
         errs = res.stderr.decode("utf-8")
         print(outs)
         print(errs)
-        assert res.returncode == 0
+
+        if expected_stderrs:
+            assert expected_stderrs == errs
+
+        if expected_stdouts:
+            assert expected_stdouts == outs
+
+        if expected_failure:
+            assert res.returncode != 0
+        else:
+            assert res.returncode == 0
     except:
         raise
     finally:


### PR DESCRIPTION
Changes proposed in this pull request:
- Previously, `tests/integration/test_runner.py` would fail if anything were to be logged to `stderr`. This would cause failures for situations like `logger.warning`s, and `tqdm` progress bars.
- This is now updated to pass or fail based on the exit code of the `subprocess.run` rather than the length of `stderr` which will avoid false failures.
