### PR TITLE
[ENHANCEMENT] Ensure consistent usage of the Canonical Execution Engine API through the use of the ExecutionEngine.get_compute_domain() method.

### DIFF
--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -320,7 +320,7 @@ Please check your config."""
         domain_kwargs: dict,
         domain_type: Union[str, MetricDomainTypes],
         accessor_keys: Optional[Iterable[str]] = None,
-    ) -> Tuple[pyspark.sql.DataFrame, dict, dict]:
+    ) -> Tuple[DataFrame, dict, dict]:
         """Uses a given batch dictionary and domain kwargs (which include a row condition and a condition parser)
         to obtain and/or query a batch. Returns in the format of a Pandas Series if only a single column is desired,
         or otherwise a Data Frame.

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -320,7 +320,7 @@ Please check your config."""
         domain_kwargs: dict,
         domain_type: Union[str, MetricDomainTypes],
         accessor_keys: Optional[Iterable[str]] = None,
-    ) -> Tuple["pyspark.sql.DataFrame", dict, dict]:
+    ) -> Tuple[pyspark.sql.DataFrame, dict, dict]:
         """Uses a given batch dictionary and domain kwargs (which include a row condition and a condition parser)
         to obtain and/or query a batch. Returns in the format of a Pandas Series if only a single column is desired,
         or otherwise a Data Frame.

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -170,7 +170,7 @@ class SqlAlchemyBatchData(BatchData):
             else:
                 self._selectable = selectable.alias(self._record_set_name)
 
-        self._ephemeral_selectable = None
+        self._engine_ready_selectable = None
 
     @property
     def sql_engine_dialect(self) -> DefaultDialect:
@@ -194,12 +194,12 @@ class SqlAlchemyBatchData(BatchData):
         return self._selectable
 
     @property
-    def ephemeral_selectable(self):
-        return self._ephemeral_selectable
+    def engine_ready_selectable(self):
+        return self._engine_ready_selectable
 
-    @ephemeral_selectable.setter
-    def ephemeral_selectable(self, ephemeral_selectable):
-        self._ephemeral_selectable = ephemeral_selectable
+    @engine_ready_selectable.setter
+    def engine_ready_selectable(self, engine_ready_selectable):
+        self._engine_ready_selectable = engine_ready_selectable
 
     @property
     def use_quoted_name(self):

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -195,10 +195,24 @@ class SqlAlchemyBatchData(BatchData):
 
     @property
     def engine_ready_selectable(self):
+        """
+        The "selectable" property is set during the instantiation of "SqlAlchemyBatchData".  However, depending on the
+        specifics of "domain_kwargs" passed to "SqlAlchemyExecutionEngine.get_compute_domain()", the actual "selectable"
+        may need to change before getting passed to the "SqlAlchemy.engine.execute()" commands of the form
+        "engine.execute(sa.select([...]).select_from(engine_ready_selectable).<where,group_by,limit>.fetch<one|all>()".
+        This property must be a separate state variable of "SqlAlchemyBatchData", because the value of "self.selectable"
+        set during the instantiation of "SqlAlchemyBatchData" must not be altered, because its original value is reused.
+        :return: Sqlalchemy Selectable or None
+        """
         return self._engine_ready_selectable
 
     @engine_ready_selectable.setter
     def engine_ready_selectable(self, engine_ready_selectable):
+        """
+        This is the setter method, allowing "SqlAlchemyExecutionEngine.get_compute_domain()", to pass this property (as
+        defined in the property definition for "SqlAlchemyBatchData.engine_ready_selectable") to metric computations.
+        :param engine_ready_selectable: Sqlalchemy Selectable or None
+        """
         self._engine_ready_selectable = engine_ready_selectable
 
     @property

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -170,6 +170,8 @@ class SqlAlchemyBatchData(BatchData):
             else:
                 self._selectable = selectable.alias(self._record_set_name)
 
+        self._ephemeral_selectable = None
+
     @property
     def sql_engine_dialect(self) -> DefaultDialect:
         """Returns the Batches' current engine dialect"""
@@ -190,6 +192,14 @@ class SqlAlchemyBatchData(BatchData):
     @property
     def selectable(self):
         return self._selectable
+
+    @property
+    def ephemeral_selectable(self):
+        return self._ephemeral_selectable
+
+    @ephemeral_selectable.setter
+    def ephemeral_selectable(self, ephemeral_selectable):
+        self._ephemeral_selectable = ephemeral_selectable
 
     @property
     def use_quoted_name(self):

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -408,6 +408,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             # TODO: Add logic to handle record_set_name once implemented
             # (i.e. multiple record sets (tables) in one batch
             if domain_kwargs["table"] != data_object.selectable.name:
+                # noinspection PyProtectedMember
                 selectable = sa.Table(
                     domain_kwargs["table"],
                     sa.MetaData(),
@@ -471,7 +472,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                     logger.warning(
                         f'Unexpected key(s) {unexpected_keys_str} found in domain_kwargs for domain type "{domain_type.value}".'
                     )
-            data_object.ephemeral_selectable = selectable
+            data_object.engine_ready_selectable = selectable
             return data_object, compute_domain_kwargs, accessor_domain_kwargs
 
         # If user has stated they want a column, checking if one is provided, and
@@ -572,7 +573,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                         ]
                         selectable = sa.select(to_select).select_from(selectable)
 
-        data_object.ephemeral_selectable = selectable
+        data_object.engine_ready_selectable = selectable
         return data_object, compute_domain_kwargs, accessor_domain_kwargs
 
     def resolve_metric_bundle(
@@ -622,7 +623,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                 query["domain_kwargs"], domain_type=SemanticDomainTypes.IDENTITY.value
             )
             assert len(query["select"]) == len(query["ids"])
-            selectable = data_object.ephemeral_selectable
+            selectable = data_object.engine_ready_selectable
             try:
                 res = self.engine.execute(
                     sa.select(query["select"]).select_from(selectable)

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -368,7 +368,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         domain_kwargs: Dict,
         domain_type: Union[str, MetricDomainTypes],
         accessor_keys: Optional[Iterable[str]] = None,
-    ) -> Tuple[Select, dict, dict]:
+    ) -> Tuple[SqlAlchemyBatchData, dict, dict]:
         """Uses a given batch dictionary and domain kwargs to obtain a SqlAlchemy column object.
 
         Args:
@@ -381,7 +381,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             describing the domain and simply transferred with their associated values into accessor_domain_kwargs.
 
         Returns:
-            SqlAlchemy column
+            SqlAlchemy compute domain
         """
         # Extracting value from enum if it is given for future computation
         domain_type = MetricDomainTypes(domain_type)
@@ -471,7 +471,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                     logger.warning(
                         f'Unexpected key(s) {unexpected_keys_str} found in domain_kwargs for domain type "{domain_type.value}".'
                     )
-            return selectable, compute_domain_kwargs, accessor_domain_kwargs
+            data_object.ephemeral_selectable = selectable
+            return data_object, compute_domain_kwargs, accessor_domain_kwargs
 
         # If user has stated they want a column, checking if one is provided, and
         elif domain_type == MetricDomainTypes.COLUMN:
@@ -571,8 +572,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                         ]
                         selectable = sa.select(to_select).select_from(selectable)
 
-        # Letting selectable fall through
-        return selectable, compute_domain_kwargs, accessor_domain_kwargs
+        data_object.ephemeral_selectable = selectable
+        return data_object, compute_domain_kwargs, accessor_domain_kwargs
 
     def resolve_metric_bundle(
         self,
@@ -617,10 +618,11 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             )
             queries[domain_id]["ids"].append(metric_to_resolve.id)
         for query in queries.values():
-            selectable, compute_domain_kwargs, _ = self.get_compute_domain(
+            data_object, compute_domain_kwargs, _ = self.get_compute_domain(
                 query["domain_kwargs"], domain_type=SemanticDomainTypes.IDENTITY.value
             )
             assert len(query["select"]) == len(query["ids"])
+            selectable = data_object.ephemeral_selectable
             try:
                 res = self.engine.execute(
                     sa.select(query["select"]).select_from(selectable)
@@ -849,7 +851,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                         """
             )
 
-        batch_data: SqlAlchemyBatchData
         batch_markers: BatchMarkers = BatchMarkers(
             {
                 "ge_load_time": datetime.datetime.now(datetime.timezone.utc).strftime(
@@ -867,6 +868,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         source_table_name = batch_spec.get("table_name", None)
         source_schema_name = batch_spec.get("schema_name", None)
 
+        batch_data: Optional[SqlAlchemyBatchData] = None
         if isinstance(batch_spec, RuntimeQueryBatchSpec):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
             query: str = batch_spec.query

--- a/great_expectations/expectations/metrics/column_aggregate_metric.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metric.py
@@ -132,7 +132,7 @@ def column_aggregate_partial(engine: Type[ExecutionEngine], **kwargs):
                     # We do not copy here because if compute domain is different, it will be copied by get_compute_domain
                     compute_domain_kwargs = metric_domain_kwargs
                 (
-                    selectable,
+                    batch_data,
                     compute_domain_kwargs,
                     accessor_domain_kwargs,
                 ) = execution_engine.get_compute_domain(
@@ -149,6 +149,7 @@ def column_aggregate_partial(engine: Type[ExecutionEngine], **kwargs):
                     )
 
                 dialect = sqlalchemy_engine.dialect
+                selectable = batch_data.ephemeral_selectable
                 metric_aggregate = metric_fn(
                     cls,
                     column=sa.column(column_name),

--- a/great_expectations/expectations/metrics/column_aggregate_metric.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metric.py
@@ -149,7 +149,7 @@ def column_aggregate_partial(engine: Type[ExecutionEngine], **kwargs):
                     )
 
                 dialect = sqlalchemy_engine.dialect
-                selectable = batch_data.ephemeral_selectable
+                selectable = batch_data.engine_ready_selectable
                 metric_aggregate = metric_fn(
                     cls,
                     column=sa.column(column_name),

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
@@ -143,7 +143,7 @@ class ColumnHistogram(ColumnMetricProvider):
                 ).label("bin_" + str(len(bins) - 1))
             )
 
-        selectable = batch_data.ephemeral_selectable
+        selectable = batch_data.engine_ready_selectable
         query = (
             sa.select(case_conditions)
             .where(

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
@@ -59,7 +59,7 @@ class ColumnHistogram(ColumnMetricProvider):
             column: the name of the column for which to get the histogram
             bins: tuple of bin edges for which to get histogram values; *must* be tuple to support caching
         """
-        selectable, _, accessor_domain_kwargs = execution_engine.get_compute_domain(
+        batch_data, _, accessor_domain_kwargs = execution_engine.get_compute_domain(
             domain_kwargs=metric_domain_kwargs, domain_type=MetricDomainTypes.COLUMN
         )
         column = accessor_domain_kwargs["column"]
@@ -143,6 +143,7 @@ class ColumnHistogram(ColumnMetricProvider):
                 ).label("bin_" + str(len(bins) - 1))
             )
 
+        selectable = batch_data.ephemeral_selectable
         query = (
             sa.select(case_conditions)
             .where(

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_median.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_median.py
@@ -60,7 +60,7 @@ class ColumnMedian(ColumnMetricProvider):
         nonnull_count = metrics.get("column_values.nonnull.count")
         if not nonnull_count:
             return None
-        selectable = batch_data.ephemeral_selectable
+        selectable = batch_data.engine_ready_selectable
         element_values = sqlalchemy_engine.execute(
             sa.select([column])
             .order_by(column)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_median.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_median.py
@@ -44,7 +44,7 @@ class ColumnMedian(ColumnMetricProvider):
         runtime_configuration: Dict,
     ):
         (
-            selectable,
+            batch_data,
             compute_domain_kwargs,
             accessor_domain_kwargs,
         ) = execution_engine.get_compute_domain(
@@ -60,6 +60,7 @@ class ColumnMedian(ColumnMetricProvider):
         nonnull_count = metrics.get("column_values.nonnull.count")
         if not nonnull_count:
             return None
+        selectable = batch_data.ephemeral_selectable
         element_values = sqlalchemy_engine.execute(
             sa.select([column])
             .order_by(column)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
@@ -96,7 +96,7 @@ class ColumnQuantileValues(ColumnMetricProvider):
         dialect = sqlalchemy_engine.dialect
         quantiles = metric_value_kwargs["quantiles"]
         allow_relative_error = metric_value_kwargs.get("allow_relative_error", False)
-        selectable = batch_data.ephemeral_selectable
+        selectable = batch_data.engine_ready_selectable
         if dialect.name.lower() == "mssql":
             return _get_column_quantiles_mssql(
                 column=column,

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
@@ -84,7 +84,7 @@ class ColumnQuantileValues(ColumnMetricProvider):
         runtime_configuration: Dict,
     ):
         (
-            selectable,
+            batch_data,
             compute_domain_kwargs,
             accessor_domain_kwargs,
         ) = execution_engine.get_compute_domain(
@@ -96,6 +96,7 @@ class ColumnQuantileValues(ColumnMetricProvider):
         dialect = sqlalchemy_engine.dialect
         quantiles = metric_value_kwargs["quantiles"]
         allow_relative_error = metric_value_kwargs.get("allow_relative_error", False)
+        selectable = batch_data.ephemeral_selectable
         if dialect.name.lower() == "mssql":
             return _get_column_quantiles_mssql(
                 column=column,

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
@@ -109,7 +109,7 @@ class ColumnValueCounts(ColumnMetricProvider):
                 query = query.order_by(sa.column(column))
         elif sort == "count":
             query = query.order_by(sa.column("count").desc())
-        selectable = batch_data.ephemeral_selectable
+        selectable = batch_data.engine_ready_selectable
         results = execution_engine.engine.execute(
             query.select_from(selectable)
         ).fetchall()

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
@@ -80,7 +80,7 @@ class ColumnValueCounts(ColumnMetricProvider):
         if collate is not None:
             raise ValueError("collate parameter is not supported in PandasDataset")
 
-        selectable, _, accessor_domain_kwargs = execution_engine.get_compute_domain(
+        batch_data, _, accessor_domain_kwargs = execution_engine.get_compute_domain(
             metric_domain_kwargs, MetricDomainTypes.COLUMN
         )
         column = accessor_domain_kwargs["column"]
@@ -109,6 +109,7 @@ class ColumnValueCounts(ColumnMetricProvider):
                 query = query.order_by(sa.column(column))
         elif sort == "count":
             query = query.order_by(sa.column("count").desc())
+        selectable = batch_data.ephemeral_selectable
         results = execution_engine.engine.execute(
             query.select_from(selectable)
         ).fetchall()

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
@@ -164,7 +164,7 @@ class ColumnValuesBetweenCount(MetricProvider):
             )
 
         (
-            selectable,
+            batch_data,
             compute_domain_kwargs,
             accessor_domain_kwargs,
         ) = execution_engine.get_compute_domain(
@@ -194,6 +194,7 @@ class ColumnValuesBetweenCount(MetricProvider):
             else:
                 condition = sa.and_(column >= min_value, column <= max_value)
 
+        selectable = batch_data.ephemeral_selectable
         return execution_engine.engine.execute(
             sa.select([sa.func.count()]).select_from(selectable).where(condition)
         ).scalar()

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_between_count.py
@@ -194,7 +194,7 @@ class ColumnValuesBetweenCount(MetricProvider):
             else:
                 condition = sa.and_(column >= min_value, column <= max_value)
 
-        selectable = batch_data.ephemeral_selectable
+        selectable = batch_data.engine_ready_selectable
         return execution_engine.engine.execute(
             sa.select([sa.func.count()]).select_from(selectable).where(condition)
         ).scalar()

--- a/great_expectations/expectations/metrics/map_metric.py
+++ b/great_expectations/expectations/metrics/map_metric.py
@@ -164,7 +164,7 @@ def column_function_partial(
                     )
 
                 dialect = execution_engine.dialect_module
-                selectable = batch_data.ephemeral_selectable
+                selectable = batch_data.engine_ready_selectable
                 column_function = metric_fn(
                     cls,
                     sa.column(column_name),
@@ -388,7 +388,7 @@ def column_condition_partial(
                 sqlalchemy_engine: sa.engine.Engine = execution_engine.engine
 
                 dialect = execution_engine.dialect_module
-                selectable = batch_data.ephemeral_selectable
+                selectable = batch_data.engine_ready_selectable
                 expected_condition = metric_fn(
                     cls,
                     sa.column(column_name),
@@ -877,7 +877,7 @@ def _sqlalchemy_map_condition_unexpected_count_value(
                     else_=0,
                 ).label("condition")
             ]
-            selectable = batch_data.ephemeral_selectable
+            selectable = batch_data.engine_ready_selectable
             inner_case_query: sa.sql.dml.Insert = temp_table_obj.insert().from_select(
                 count_case_statement,
                 sa.select(count_case_statement).select_from(selectable),
@@ -939,7 +939,7 @@ def _sqlalchemy_column_map_condition_values(
             message=f'Error: The column "{column_name}" in BatchData does not exist.'
         )
 
-    selectable = batch_data.ephemeral_selectable
+    selectable = batch_data.engine_ready_selectable
     query = (
         sa.select([sa.column(column_name).label("unexpected_values")])
         .select_from(selectable)
@@ -989,7 +989,7 @@ def _sqlalchemy_column_map_condition_value_counts(
 
     column: sa.Column = sa.column(column_name)
 
-    selectable = batch_data.ephemeral_selectable
+    selectable = batch_data.engine_ready_selectable
     return execution_engine.engine.execute(
         sa.select([column, sa.func.count(column)])
         .select_from(selectable)
@@ -1017,7 +1017,7 @@ def _sqlalchemy_map_condition_rows(
         compute_domain_kwargs, domain_type=SemanticDomainTypes.IDENTITY.value
     )
 
-    selectable = batch_data.ephemeral_selectable
+    selectable = batch_data.engine_ready_selectable
     query = (
         sa.select([sa.text("*")]).select_from(selectable).where(unexpected_condition)
     )

--- a/great_expectations/expectations/metrics/table_metrics/table_column_types.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_column_types.py
@@ -47,21 +47,12 @@ class ColumnTypes(TableMetricProvider):
         metrics: Dict[Tuple, Any],
         runtime_configuration: Dict,
     ):
-        batch_id = metric_domain_kwargs.get("batch_id")
-        if batch_id is None:
-            if execution_engine.active_batch_data_id is not None:
-                batch_id = execution_engine.active_batch_data_id
-            else:
-                raise GreatExpectationsError(
-                    "batch_id could not be determined from domain kwargs and no active_batch_data is loaded into the "
-                    "execution engine"
-                )
-        batch_data = execution_engine.loaded_batch_data_dict.get(batch_id)
-        if batch_data is None:
-            raise GreatExpectationsError(
-                "the requested batch is not available; please load the batch into the execution engine."
-            )
-        return _get_sqlalchemy_column_metadata(execution_engine.engine, batch_data)
+        batch_data, _, _ = execution_engine.get_compute_domain(
+            metric_domain_kwargs, domain_type=MetricDomainTypes.TABLE
+        )
+        return _get_sqlalchemy_column_metadata(
+            engine=execution_engine.engine, batch_data=batch_data
+        )
 
     @metric_value(engine=SparkDFExecutionEngine)
     def _spark(

--- a/great_expectations/expectations/metrics/table_metrics/table_head.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_head.py
@@ -49,7 +49,7 @@ class TableHead(TableMetricProvider):
             metric_domain_kwargs, domain_type=MetricDomainTypes.TABLE
         )
         df = None
-        selectable = batch_data.ephemeral_selectable
+        selectable = batch_data.engine_ready_selectable
         table_name = getattr(selectable, "name", None)
         if table_name is not None:
             try:

--- a/great_expectations/expectations/metrics/table_metrics/table_head.py
+++ b/great_expectations/expectations/metrics/table_metrics/table_head.py
@@ -45,10 +45,11 @@ class TableHead(TableMetricProvider):
         metrics: Dict[Tuple, Any],
         runtime_configuration: Dict,
     ):
-        selectable, _, _ = execution_engine.get_compute_domain(
+        batch_data, _, _ = execution_engine.get_compute_domain(
             metric_domain_kwargs, domain_type=MetricDomainTypes.TABLE
         )
         df = None
+        selectable = batch_data.ephemeral_selectable
         table_name = getattr(selectable, "name", None)
         if table_name is not None:
             try:

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pstats
+import re
 import time
 from collections import OrderedDict
 from datetime import datetime
@@ -945,3 +946,7 @@ def generate_library_json_from_registered_expectations():
         library_json[expectation_name] = report_object
 
     return library_json
+
+
+def delete_blank_lines(text: str) -> str:
+    return re.sub(r"\n\s*\n", "\n", text, flags=re.MULTILINE)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -47,40 +47,52 @@ Commands:
 
 
 def test_cli_command_entrance(caplog):
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(cli, catch_exceptions=False)
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(cli, catch_exceptions=False)
     assert result.exit_code == 0
+    print(
+        f"\n[ALEX_TEST] RESULT_OUTPUT:\n{result.output} ; TYPE: {str(type(result.output))}"
+    )
+    print(
+        f"\n[ALEX_TEST] TOPLEVEL_HELP:\n{TOP_LEVEL_HELP} ; TYPE: {str(type(TOP_LEVEL_HELP))}"
+    )
     assert result.output == TOP_LEVEL_HELP
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_top_level_help(caplog):
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(cli, "--help", catch_exceptions=False)
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(cli, "--help", catch_exceptions=False)
     assert result.exit_code == 0
+    print(
+        f"\n[ALEX_TEST] RESULT_OUTPUT:\n{result.output} ; TYPE: {str(type(result.output))}"
+    )
+    print(
+        f"\n[ALEX_TEST] TOPLEVEL_HELP:\n{TOP_LEVEL_HELP} ; TYPE: {str(type(TOP_LEVEL_HELP))}"
+    )
     assert result.output == TOP_LEVEL_HELP
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_top_level_help_with_v3_flag(caplog):
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(cli, "--v3-api --help", catch_exceptions=False)
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(cli, "--v3-api --help", catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output == TOP_LEVEL_HELP
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
 def test_cli_command_invalid_command(caplog):
-    runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(cli, "--v3-api blarg")
+    runner: CliRunner = CliRunner(mix_stderr=False)
+    result: Result = runner.invoke(cli, "--v3-api blarg")
     assert result.exit_code == 2
     assert "Error: No such command" in result.stderr
     assert ("'blarg'" in result.stderr) or ('"blarg"' in result.stderr)
 
 
 def test_cli_ge_version_exists(caplog):
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(cli, "--v3-api --version", catch_exceptions=False)
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(cli, "--v3-api --version", catch_exceptions=False)
     assert ge_version in str(result.output)
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
@@ -89,9 +101,11 @@ def test_cli_works_from_adjacent_directory_without_config_flag(
     monkeypatch, empty_data_context
 ):
     """We don't care about the NOUN here just combinations of the config flag"""
-    runner = CliRunner(mix_stderr=True)
+    runner: CliRunner = CliRunner(mix_stderr=True)
     monkeypatch.chdir(os.path.dirname(empty_data_context.root_directory))
-    result = runner.invoke(cli, "--v3-api checkpoint list", catch_exceptions=False)
+    result: Result = runner.invoke(
+        cli, "--v3-api checkpoint list", catch_exceptions=False
+    )
     assert result.exit_code == 0
     assert "No Checkpoints found" in result.output
 
@@ -100,9 +114,11 @@ def test_cli_works_from_great_expectations_directory_without_config_flag(
     monkeypatch, empty_data_context
 ):
     """We don't care about the NOUN here just combinations of the config flag"""
-    runner = CliRunner(mix_stderr=True)
+    runner: CliRunner = CliRunner(mix_stderr=True)
     monkeypatch.chdir(empty_data_context.root_directory)
-    result = runner.invoke(cli, "--v3-api checkpoint list", catch_exceptions=False)
+    result: Result = runner.invoke(
+        cli, "--v3-api checkpoint list", catch_exceptions=False
+    )
     assert result.exit_code == 0
     assert "No Checkpoints found" in result.output
 
@@ -111,11 +127,11 @@ def test_cli_works_from_random_directory_with_config_flag_fully_specified_yml(
     monkeypatch, empty_data_context, tmp_path_factory
 ):
     """We don't care about the NOUN here just combinations of the config flag"""
-    context = empty_data_context
-    runner = CliRunner(mix_stderr=True)
-    temp_dir = tmp_path_factory.mktemp("config_flag_check")
+    context: DataContext = empty_data_context
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    temp_dir: str = str(tmp_path_factory.mktemp("config_flag_check"))
     monkeypatch.chdir(temp_dir)
-    result = runner.invoke(
+    result: Result = runner.invoke(
         cli,
         f"--config {context.root_directory}/great_expectations.yml --v3-api checkpoint list",
         catch_exceptions=False,
@@ -128,11 +144,11 @@ def test_cli_works_from_random_directory_with_config_flag_great_expectations_dir
     monkeypatch, empty_data_context, tmp_path_factory
 ):
     """We don't care about the NOUN here just combinations of the config flag"""
-    context = empty_data_context
-    runner = CliRunner(mix_stderr=True)
-    temp_dir = tmp_path_factory.mktemp("config_flag_check")
+    context: DataContext = empty_data_context
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    temp_dir: str = str(tmp_path_factory.mktemp("config_flag_check"))
     monkeypatch.chdir(temp_dir)
-    result = runner.invoke(
+    result: Result = runner.invoke(
         cli,
         f"--config {context.root_directory} --v3-api checkpoint list",
         catch_exceptions=False,
@@ -145,11 +161,11 @@ def test_cli_works_from_random_directory_with_c_flag_fully_specified_yml(
     monkeypatch, empty_data_context, tmp_path_factory
 ):
     """We don't care about the NOUN here just combinations of the config flag"""
-    context = empty_data_context
-    runner = CliRunner(mix_stderr=True)
-    temp_dir = tmp_path_factory.mktemp("config_flag_check")
+    context: DataContext = empty_data_context
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    temp_dir: str = str(tmp_path_factory.mktemp("config_flag_check"))
     monkeypatch.chdir(temp_dir)
-    result = runner.invoke(
+    result: Result = runner.invoke(
         cli,
         f"-c {context.root_directory}/great_expectations.yml --v3-api checkpoint list",
         catch_exceptions=False,
@@ -162,11 +178,11 @@ def test_cli_works_from_random_directory_with_c_flag_great_expectations_director
     monkeypatch, empty_data_context, tmp_path_factory
 ):
     """We don't care about the NOUN here just combinations of the config flag"""
-    context = empty_data_context
-    runner = CliRunner(mix_stderr=True)
-    temp_dir = tmp_path_factory.mktemp("config_flag_check")
+    context: DataContext = empty_data_context
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    temp_dir: str = str(tmp_path_factory.mktemp("config_flag_check"))
     monkeypatch.chdir(temp_dir)
-    result = runner.invoke(
+    result: Result = runner.invoke(
         cli,
         f"-c {context.root_directory} --v3-api checkpoint list",
         catch_exceptions=False,
@@ -175,20 +191,20 @@ def test_cli_works_from_random_directory_with_c_flag_great_expectations_director
     assert "No Checkpoints found" in result.output
 
 
-CONFIG_NOT_FOUND_ERROR_MESSAGE = "No great_expectations directory was found here!"
+CONFIG_NOT_FOUND_ERROR_MESSAGE: str = "No great_expectations directory was found here!"
 
 
 def test_cli_config_not_found_raises_error_for_datasource_list(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "datasource", "list"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
-    result = runner.invoke(
+    result: Result = runner.invoke(
         cli, ["--v3-api", "datasource", "list"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -197,10 +213,10 @@ def test_cli_config_not_found_raises_error_for_datasource_list(
 def test_cli_config_not_found_raises_error_for_datasource_new(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "datasource", "new"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -213,16 +229,16 @@ def test_cli_config_not_found_raises_error_for_datasource_new(
 def test_cli_config_not_found_raises_error_for_datasource_delete(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         ["-c", "./", "--v3-api", "datasource", "delete", "new"],
         catch_exceptions=False,
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
-    result = runner.invoke(
+    result: Result = runner.invoke(
         cli, ["--v3-api", "datasource", "delete", "new"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -231,10 +247,10 @@ def test_cli_config_not_found_raises_error_for_datasource_delete(
 def test_cli_config_not_found_raises_error_for_project_check_config(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         ["-c", "./", "--v3-api", "project", "check-config"],
         catch_exceptions=False,
@@ -249,10 +265,10 @@ def test_cli_config_not_found_raises_error_for_project_check_config(
 def test_cli_config_not_found_raises_error_for_project_upgrade(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         ["-c", "./", "--v3-api", "project", "upgrade"],
         catch_exceptions=False,
@@ -267,10 +283,10 @@ def test_cli_config_not_found_raises_error_for_project_upgrade(
 def test_cli_config_not_found_raises_error_for_store_list(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "store", "list"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -279,10 +295,10 @@ def test_cli_config_not_found_raises_error_for_store_list(
 
 
 def test_cli_config_not_found_raises_error_for_suite_new(tmp_path_factory, monkeypatch):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "suite", "new"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -293,10 +309,10 @@ def test_cli_config_not_found_raises_error_for_suite_new(tmp_path_factory, monke
 def test_cli_config_not_found_raises_error_for_suite_list(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "suite", "list"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -307,10 +323,10 @@ def test_cli_config_not_found_raises_error_for_suite_list(
 def test_cli_config_not_found_raises_error_for_suite_scaffold(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         ["-c", "./", "--v3-api", "suite", "new", "--profile", "--interactive"],
         catch_exceptions=False,
@@ -327,10 +343,10 @@ def test_cli_config_not_found_raises_error_for_suite_scaffold(
 def test_cli_config_not_found_raises_error_for_suite_edit(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "suite", "edit", "FAKE"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -343,10 +359,10 @@ def test_cli_config_not_found_raises_error_for_suite_edit(
 def test_cli_config_not_found_raises_error_for_suite_delete(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "suite", "delete", "deleteme"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -359,10 +375,10 @@ def test_cli_config_not_found_raises_error_for_suite_delete(
 def test_cli_config_not_found_raises_error_for_checkpoint_new(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "checkpoint", "new"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -375,10 +391,10 @@ def test_cli_config_not_found_raises_error_for_checkpoint_new(
 def test_cli_config_not_found_raises_error_for_checkpoint_list(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli, ["-c", "./", "--v3-api", "checkpoint", "list"], catch_exceptions=False
     )
     assert CONFIG_NOT_FOUND_ERROR_MESSAGE in result.output
@@ -391,10 +407,10 @@ def test_cli_config_not_found_raises_error_for_checkpoint_list(
 def test_cli_config_not_found_raises_error_for_checkpoint_delete(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         ["-c", "./", "--v3-api", "checkpoint", "delete", "deleteme"],
         catch_exceptions=False,
@@ -409,10 +425,10 @@ def test_cli_config_not_found_raises_error_for_checkpoint_delete(
 def test_cli_config_not_found_raises_error_for_docs_clean(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         [
             "-c",
@@ -429,10 +445,10 @@ def test_cli_config_not_found_raises_error_for_docs_clean(
 
 
 def test_cli_config_not_found_raises_error_for_docs_list(tmp_path_factory, monkeypatch):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         [
             "-c",
@@ -451,10 +467,10 @@ def test_cli_config_not_found_raises_error_for_docs_list(tmp_path_factory, monke
 def test_cli_config_not_found_raises_error_for_docs_build(
     tmp_path_factory, monkeypatch
 ):
-    tmp_dir = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
+    tmp_dir: str = str(tmp_path_factory.mktemp("test_cli_config_not_found"))
     monkeypatch.chdir(tmp_dir)
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(
+    runner: CliRunner = CliRunner(mix_stderr=True)
+    result: Result = runner.invoke(
         cli,
         ["-c", "./", "--v3-api", "docs", "build", "--no-view"],
         catch_exceptions=False,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -8,10 +8,12 @@ from ruamel.yaml import YAML
 from great_expectations import DataContext
 from great_expectations import __version__ as ge_version
 from great_expectations.cli import cli
+from great_expectations.util import delete_blank_lines
 from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 
 yaml = YAML()
 yaml.default_flow_style = False
+
 
 TOP_LEVEL_HELP = """Usage: great_expectations [OPTIONS] COMMAND [ARGS]...
 
@@ -50,13 +52,9 @@ def test_cli_command_entrance(caplog):
     runner: CliRunner = CliRunner(mix_stderr=True)
     result: Result = runner.invoke(cli, catch_exceptions=False)
     assert result.exit_code == 0
-    print(
-        f"\n[ALEX_TEST] RESULT_OUTPUT:\n{result.output} ; TYPE: {str(type(result.output))}"
+    assert delete_blank_lines(text=result.output) == delete_blank_lines(
+        text=TOP_LEVEL_HELP
     )
-    print(
-        f"\n[ALEX_TEST] TOPLEVEL_HELP:\n{TOP_LEVEL_HELP} ; TYPE: {str(type(TOP_LEVEL_HELP))}"
-    )
-    assert result.output == TOP_LEVEL_HELP
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
@@ -64,13 +62,9 @@ def test_cli_top_level_help(caplog):
     runner: CliRunner = CliRunner(mix_stderr=True)
     result: Result = runner.invoke(cli, "--help", catch_exceptions=False)
     assert result.exit_code == 0
-    print(
-        f"\n[ALEX_TEST] RESULT_OUTPUT:\n{result.output} ; TYPE: {str(type(result.output))}"
+    assert delete_blank_lines(text=result.output) == delete_blank_lines(
+        text=TOP_LEVEL_HELP
     )
-    print(
-        f"\n[ALEX_TEST] TOPLEVEL_HELP:\n{TOP_LEVEL_HELP} ; TYPE: {str(type(TOP_LEVEL_HELP))}"
-    )
-    assert result.output == TOP_LEVEL_HELP
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 
@@ -78,7 +72,9 @@ def test_cli_top_level_help_with_v3_flag(caplog):
     runner: CliRunner = CliRunner(mix_stderr=True)
     result: Result = runner.invoke(cli, "--v3-api --help", catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output == TOP_LEVEL_HELP
+    assert delete_blank_lines(text=result.output) == delete_blank_lines(
+        text=TOP_LEVEL_HELP
+    )
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -248,7 +248,7 @@ def test_get_compute_domain_with_no_domain_kwargs(sa):
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
@@ -273,7 +273,7 @@ def test_get_compute_domain_with_column_pair(sa):
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
@@ -302,7 +302,7 @@ def test_get_compute_domain_with_column_pair(sa):
         )
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data2.ephemeral_selectable)
+        sa.select(["*"]).select_from(data2.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
@@ -331,7 +331,7 @@ def test_get_compute_domain_with_multicolumn(sa):
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
@@ -353,7 +353,7 @@ def test_get_compute_domain_with_multicolumn(sa):
         )
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
@@ -380,7 +380,7 @@ def test_get_compute_domain_with_column_domain(sa):
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
@@ -403,7 +403,7 @@ def test_get_compute_domain_with_column_domain(sa):
         sa.select([sa.column("a")]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
@@ -433,7 +433,7 @@ def test_get_compute_domain_with_unmeetable_row_condition(sa):
         .where(sa.column("b") > 24)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
@@ -468,7 +468,7 @@ def test_get_compute_domain_with_ge_experimental_condition_parser(sa):
         .where(sa.column("b") == 2)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
@@ -501,7 +501,7 @@ def test_get_compute_domain_with_ge_experimental_condition_parser(sa):
         .where(sa.column("b") == 2)
     ).fetchall()
     domain_data = engine.engine.execute(
-        sa.select(["*"]).select_from(data.ephemeral_selectable)
+        sa.select(["*"]).select_from(data.engine_ready_selectable)
     ).fetchall()
 
     # Ensuring compute kwargs have not been modified

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -247,7 +247,9 @@ def test_get_compute_domain_with_no_domain_kwargs(sa):
     raw_data = engine.engine.execute(
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -270,7 +272,9 @@ def test_get_compute_domain_with_column_pair(sa):
     raw_data = engine.engine.execute(
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -297,7 +301,9 @@ def test_get_compute_domain_with_column_pair(sa):
             engine.active_batch_data.selectable
         )
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data2)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data2.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -324,7 +330,9 @@ def test_get_compute_domain_with_multicolumn(sa):
     raw_data = engine.engine.execute(
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -344,7 +352,9 @@ def test_get_compute_domain_with_multicolumn(sa):
             engine.active_batch_data.selectable
         )
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that with no domain nothing happens to the data itself
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -369,7 +379,9 @@ def test_get_compute_domain_with_column_domain(sa):
     raw_data = engine.engine.execute(
         sa.select(["*"]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -390,7 +402,9 @@ def test_get_compute_domain_with_column_domain(sa):
     raw_data = engine.engine.execute(
         sa.select([sa.column("a")]).select_from(engine.active_batch_data.selectable)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -418,7 +432,9 @@ def test_get_compute_domain_with_unmeetable_row_condition(sa):
         .select_from(engine.active_batch_data.selectable)
         .where(sa.column("b") > 24)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -451,7 +467,9 @@ def test_get_compute_domain_with_ge_experimental_condition_parser(sa):
         .select_from(engine.active_batch_data.selectable)
         .where(sa.column("b") == 2)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring that column domain is now an accessor kwarg, and data remains unmodified
     assert raw_data == domain_data, "Data does not match after getting compute domain"
@@ -482,7 +500,9 @@ def test_get_compute_domain_with_ge_experimental_condition_parser(sa):
         .select_from(engine.active_batch_data.selectable)
         .where(sa.column("b") == 2)
     ).fetchall()
-    domain_data = engine.engine.execute(sa.select(["*"]).select_from(data)).fetchall()
+    domain_data = engine.engine.execute(
+        sa.select(["*"]).select_from(data.ephemeral_selectable)
+    ).fetchall()
 
     # Ensuring compute kwargs have not been modified
     assert (

--- a/tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py
+++ b/tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+from great_expectations.core.batch import BatchRequest
+from great_expectations.data_context.data_context import DataContext
+from great_expectations.datasource.data_connector.batch_filter import (
+    BatchFilter,
+    build_batch_filter,
+)
+from great_expectations.validator.validation_graph import MetricConfiguration
+
+context = DataContext()
+suite = context.get_expectation_suite("yellow_trip_data_validations")
+
+# This BatchRequest will retrieve all three batches from 2019 ("01", "02", "03")
+multi_batch_request = BatchRequest(
+    datasource_name="taxi_pandas",
+    data_connector_name="monthly",
+    data_asset_name="my_reports",
+    data_connector_query={"batch_filter_parameters": {"year": "2019"}},
+)
+
+# Instantiate the Validator
+validator_multi_batch = context.get_validator(
+    batch_request=multi_batch_request, expectation_suite=suite
+)
+
+# The active batch should be March, as this should be the last one loaded. Confirming here.
+assert validator_multi_batch.active_batch_definition.batch_identifiers["month"] == "03"
+
+# Get the list of all batches contained by the Validator for use in the BatchFileter
+total_batch_definition_list: list = [
+    v.batch_definition for k, v in validator_multi_batch.batches.items()
+]
+
+# Filter to all batch_definitions prior to March
+jan_feb_batch_filter: BatchFilter = build_batch_filter(
+    data_connector_query_dict={
+        "custom_filter_function": lambda batch_identifiers: int(
+            batch_identifiers["month"]
+        )
+        < 3
+    }
+)
+jan_feb_batch_definition_list: list = (
+    jan_feb_batch_filter.select_from_data_connector_query(
+        batch_definition_list=total_batch_definition_list
+    )
+)
+
+# Get the highest max and lowest min between January and February
+cumulative_max = 0
+cumulative_min = np.Inf
+for batch_definition in jan_feb_batch_definition_list:
+    batch_id: str = batch_definition.id
+    current_max = validator_multi_batch.get_metric(
+        MetricConfiguration(
+            "column.max",
+            metric_domain_kwargs={"column": "fare_amount", "batch_id": batch_id},
+        )
+    )
+    cumulative_max = current_max if current_max > cumulative_max else cumulative_max
+
+    current_min = validator_multi_batch.get_metric(
+        MetricConfiguration(
+            "column.min",
+            metric_domain_kwargs={"column": "fare_amount", "batch_id": batch_id},
+        )
+    )
+    cumulative_min = current_min if current_min < cumulative_min else cumulative_min
+
+# Use the highest max and lowest min from Jan and Feb to create an expectation which we validate against March
+result = validator_multi_batch.expect_column_values_to_be_between(
+    "fare_amount", min_value=cumulative_min, max_value=cumulative_max
+)
+assert result["success"]

--- a/tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py
+++ b/tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py
@@ -5,7 +5,7 @@ from great_expectations.validator.validation_graph import MetricConfiguration
 context = DataContext()
 suite = context.get_expectation_suite("yellow_trip_data_validations")
 
-# February BatchRequest and Validator
+# Get February BatchRequest and Validator
 batch_request_february = BatchRequest(
     datasource_name="taxi_pandas",
     data_connector_name="monthly",
@@ -15,11 +15,13 @@ batch_request_february = BatchRequest(
 validator_february = context.get_validator(
     batch_request=batch_request_february, expectation_suite=suite
 )
+
+# Get the table row count for February
 february_table_row_count = validator_february.get_metric(
     MetricConfiguration("table.row_count", metric_domain_kwargs={})
 )
 
-# March BatchRequest and Validator
+# Get March BatchRequest and Validator
 batch_request_march = BatchRequest(
     datasource_name="taxi_pandas",
     data_connector_name="monthly",
@@ -29,5 +31,7 @@ batch_request_march = BatchRequest(
 validator_march = context.get_validator(
     batch_request=batch_request_march, expectation_suite=suite
 )
+
+# Create a row count expectation based on the February row count, and validate it against the March row count
 result = validator_march.expect_table_row_count_to_equal(value=february_table_row_count)
 assert result["success"]

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -15,8 +15,13 @@ integration_test_matrix = [
         "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
         "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
         "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
-        "expected_stderrs": "",
-        "expected_stdouts": "",
+    },
+    {
+        "name": "pandas_one_multi_batch_request_one_validator",
+        "base_dir": file_relative_path(__file__, "../../"),
+        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py",
     },
 ]
 


### PR DESCRIPTION
### Scope
This work removes deviations from such key interfaces as `ExecutionEngine.get_compute_domain()` in client classes in the `metrics` focused sections, and also cleans up the `active_batch_id` related methods in the `Validator` class.  These inefficiencies were identified as a result of working on a SPIKE aimed at researching the usage of `batch_id` in `domain_kwargs`.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
