### PR TITLE
[WIP][ENHANCEMENT] Add batch_request_list parameter to `DataContext.get_validator()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Develop
 
 * [BUGFIX] Allow decimals without leading zero in evaluation parameter URN
 * [ENHANCEMENT] Enable instantiation of a validator with a multiple batch BatchRequest
+* [ENHANCEMENT] Adds a batch_request_list parameter to DataContext.get_validator to enable instantiation of a Validator with batches from multiple BatchRequests
 * [MAINTENANCE] Improve robustness of integration test_runner
 * [MAINTENANCE] CLI tests now support click 8.0 and 7.x
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1696,8 +1696,8 @@ class BaseDataContext:
         if batch_request_list:
             batch_list: List = []
             for batch_request in batch_request_list:
-                batch_list.append(
-                    *self.get_batch_list(
+                batch_list.extend(
+                    self.get_batch_list(
                         datasource_name=datasource_name,
                         data_connector_name=data_connector_name,
                         data_asset_name=data_asset_name,

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1688,10 +1688,10 @@ class BaseDataContext:
                 bool(x)
                 for x in [batch_request is not None, batch_request_list is not None]
             )
-            != 1
+            > 1
         ):
             raise ValueError(
-                "Exactly one of batch_request or batch_request_list_must_be_specified"
+                "Only one of batch_request or batch_request_list may be specified"
             )
         if batch_request_list:
             batch_list: List = []

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -632,6 +632,10 @@ def test_instantiate_validator_with_a_list_of_batch_requests(
         validator_one_batch_request_two_batches.batches.keys()
         == validator_two_batch_requests_two_batches.batches.keys()
     )
+    assert (
+        validator_one_batch_request_two_batches.active_batch_id
+        == validator_two_batch_requests_two_batches.active_batch_id
+    )
 
     with pytest.raises(ValueError) as ve:
         validator: Validator = context.get_validator(

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -644,5 +644,5 @@ def test_instantiate_validator_with_a_list_of_batch_requests(
             expectation_suite=suite,
         )
     assert ve.value.args == (
-        "Exactly one of batch_request or batch_request_list_must_be_specified",
+        "Only one of batch_request or batch_request_list may be specified",
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- This adds a `batch_request_list` parameter to the `get_validator` method of a DataContext class to enable a workflow whereby one can instantiate a Validator with batches from multiple BatchRequests