### PR TITLE
[MAINTENANCE] CLI tests now support click 8.0 and 7.x

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ Develop
 * [BUGFIX] Allow decimals without leading zero in evaluation parameter URN
 * [ENHANCEMENT] Enable instantiation of a validator with a multiple batch BatchRequest
 * [MAINTENANCE] Improve robustness of integration test_runner
+* [MAINTENANCE] CLI tests now support click 8.0 and 7.x
+
 0.13.19
 -----------------
 * [BUGFIX] Fix packaging error breaking V3 CLI suite commands (#2719)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2,6 +2,7 @@ import os
 from typing import List
 from unittest import mock
 
+import pytest
 from click.testing import CliRunner, Result
 from ruamel.yaml import YAML
 
@@ -13,28 +14,50 @@ from tests.cli.utils import assert_no_logging_messages_or_tracebacks
 yaml = YAML()
 yaml.default_flow_style = False
 
-TOP_LEVEL_HELP = """Usage: great_expectations [OPTIONS] COMMAND [ARGS]...
+
+@pytest.mark.parametrize("invocation", [None, "--help", "--v3-api --help"])
+def test_cli_command_help(caplog, invocation):
+    runner = CliRunner(mix_stderr=True)
+    result = runner.invoke(cli, invocation, catch_exceptions=False)
+    assert result.exit_code == 0
+    # Note that click 8.0 fixed a longstanding bug in 7.x which added empty
+    # lines in "Options". This test looks for chunks of output to support both.
+    assert (
+        """Usage: great_expectations [OPTIONS] COMMAND [ARGS]...
 
   Welcome to the great_expectations CLI!
 
   Most commands follow this format: great_expectations <NOUN> <VERB>
 
   The nouns are: checkpoint, datasource, docs, init, project, store, suite,
-  validation-operator. Most nouns accept the following verbs: new, list, edit
-
-Options:
+  validation-operator. Most nouns accept the following verbs: new, list, edit"""
+        in result.output
+    )
+    assert (
+        """Options:
   --version                Show the version and exit.
   --v2-api / --v3-api      Default to v2 (Batch Kwargs) API. Use --v3-api for v3
-                           (Batch Request) API
-
-  -v, --verbose            Set great_expectations to use verbose output.
-  -c, --config TEXT        Path to great_expectations configuration file
+                           (Batch Request) API"""
+        in result.output
+    )
+    assert (
+        "  -v, --verbose            Set great_expectations to use verbose output."
+        in result.output
+    )
+    assert (
+        """  -c, --config TEXT        Path to great_expectations configuration file
                            location (great_expectations.yml). Inferred if not
-                           provided.
-
-  -y, --assume-yes, --yes  Assume "yes" for all prompts.
+                           provided."""
+        in result.output
+    )
+    assert (
+        """  -y, --assume-yes, --yes  Assume "yes" for all prompts.
   --help                   Show this message and exit.
-
+"""
+        in result.output
+    )
+    assert (
+        """
 Commands:
   checkpoint  Checkpoint operations
   datasource  Datasource operations
@@ -44,29 +67,8 @@ Commands:
   store       Store operations
   suite       Expectation Suite operations
 """
-
-
-def test_cli_command_entrance(caplog):
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(cli, catch_exceptions=False)
-    assert result.exit_code == 0
-    assert result.output == TOP_LEVEL_HELP
-    assert_no_logging_messages_or_tracebacks(caplog, result)
-
-
-def test_cli_top_level_help(caplog):
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(cli, "--help", catch_exceptions=False)
-    assert result.exit_code == 0
-    assert result.output == TOP_LEVEL_HELP
-    assert_no_logging_messages_or_tracebacks(caplog, result)
-
-
-def test_cli_top_level_help_with_v3_flag(caplog):
-    runner = CliRunner(mix_stderr=True)
-    result = runner.invoke(cli, "--v3-api --help", catch_exceptions=False)
-    assert result.exit_code == 0
-    assert result.output == TOP_LEVEL_HELP
+        in result.output
+    )
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
 


### PR DESCRIPTION
This PR consolidates 3 tests into 1 via parameterization and makes the tests more robust to a bugfix in click.

Previous Design Review notes:

- small team discussion on 5/13
