### PR TITLE
[BUGFIX] Update DefaultExpectationConfigurationBuilder to Handle All Parameters Of ExpectationConfiguration Properly

### DIFF
--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.rule_based_profiler.domain_builder.domain import Domain
@@ -14,36 +14,48 @@ from great_expectations.rule_based_profiler.parameter_builder.parameter_containe
 class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
     """
     Class which creates ExpectationConfiguration out of a given Expectation type and
-    parameter_name-to-parameter_fully_qualified_parameter_name map (name-value pairs supplied as kwargs dictionary).
+    parameter_name-to-parameter_fully_qualified_parameter_name map (name-value pairs supplied as expectation_kwargs and
+    kwargs dictionaries).
     """
 
-    def __init__(self, expectation_type: str = None, **kwargs):
+    def __init__(
+        self,
+        expectation_type: str,
+        expectation_kwargs: Optional[Dict[str, str]] = None,
+        meta: Optional[Dict[str, Any]] = None,
+        success_on_last_run: Optional[bool] = None,
+        **kwargs,
+    ):
         self._expectation_type = expectation_type
-        self._parameter_name_to_fully_qualified_parameter_name_dict = kwargs
+        if expectation_kwargs is None:
+            expectation_kwargs = {}
+        self._expectation_kwargs = expectation_kwargs
+        self._expectation_kwargs.update(kwargs)
+        if meta is None:
+            meta = {}
+        self._meta = meta
+        self._success_on_last_run = success_on_last_run
 
     def _build_expectation_configuration(
         self,
         domain: Domain,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
-        **kwargs
     ) -> ExpectationConfiguration:
-        expectation_kwargs: dict = {}
         parameter_name: str
         fully_qualified_parameter_name: str
-        for (
-            parameter_name,
-            fully_qualified_parameter_name,
-        ) in self._parameter_name_to_fully_qualified_parameter_name_dict.items():
-            expectation_kwargs[parameter_name] = get_parameter_value(
+        expectation_kwargs: Dict[str, Any] = {
+            parameter_name: get_parameter_value(
                 fully_qualified_parameter_name=fully_qualified_parameter_name,
                 domain=domain,
                 variables=variables,
                 parameters=parameters,
             )
-
-        expectation_kwargs.update(kwargs)
-
+            for parameter_name, fully_qualified_parameter_name in self._expectation_kwargs.items()
+        }
         return ExpectationConfiguration(
-            expectation_type=self._expectation_type, kwargs=expectation_kwargs
+            expectation_type=self._expectation_type,
+            kwargs=expectation_kwargs,
+            meta=self._meta,
+            success_on_last_run=self._success_on_last_run,
         )

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -14,10 +14,9 @@ class ExpectationConfigurationBuilder(ABC):
         domain: Domain,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
-        **kwargs
     ) -> ExpectationConfiguration:
         return self._build_expectation_configuration(
-            domain=domain, variables=variables, parameters=parameters, **kwargs
+            domain=domain, variables=variables, parameters=parameters
         )
 
     @abstractmethod
@@ -26,6 +25,5 @@ class ExpectationConfigurationBuilder(ABC):
         domain: Domain,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
-        **kwargs
     ) -> ExpectationConfiguration:
         pass

--- a/great_expectations/rule_based_profiler/profiler.py
+++ b/great_expectations/rule_based_profiler/profiler.py
@@ -144,6 +144,7 @@ class Profiler:
 
         if validator is None:
             if batch:
+                # TODO: <Alex>ALEX -- Note, not specifying an "expectation_suite" explicitly causes: expectation_suite_name = "default" -- this seems problematic.</Alex>
                 validator = Validator(
                     execution_engine=batch.data.execution_engine, batches=[batch]
                 )
@@ -154,6 +155,7 @@ class Profiler:
                         raise ge_exceptions.ProfilerExecutionError(
                             f"batch {batch.id} does not share an execution engine with all other batches in the same batches list."
                         )
+                # TODO: <Alex>ALEX -- Note, not specifying an "expectation_suite" explicitly causes: expectation_suite_name = "default" -- this seems problematic.</Alex>
                 validator = Validator(
                     execution_engine=execution_engine, batches=batches
                 )
@@ -162,7 +164,8 @@ class Profiler:
                     raise ge_exceptions.ProfilerExecutionError(
                         message="Unable to profile using a batch_request if no data_context is provided."
                     )
-                validator = self.data_context.get_validator(batch_request)
+                # TODO: <Alex>ALEX -- Note, not specifying an "expectation_suite" explicitly causes: expectation_suite_name = "default" -- this seems problematic.</Alex>
+                validator = self.data_context.get_validator(batch_request=batch_request)
 
         # Verify that all requested batch_ids are loaded
         if batch_ids is None:

--- a/great_expectations/rule_based_profiler/profiler.py
+++ b/great_expectations/rule_based_profiler/profiler.py
@@ -84,7 +84,7 @@ class Profiler:
                 expectation_configuration_builders.append(
                     instantiate_class_from_config(
                         configuration_builder_config,
-                        runtime_environment={"data_context": data_context},
+                        runtime_environment={},
                         config_defaults={
                             "class_name": "DefaultExpectationConfigurationBuilder",
                             "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder",

--- a/tests/rule_based_profiler/alice_user_workflow_fixture.py
+++ b/tests/rule_based_profiler/alice_user_workflow_fixture.py
@@ -127,14 +127,14 @@ def alice_columnar_table_single_batch():
                             "min_value": "2004-10-19T10:23:54",  # From variables
                             "max_value": "2004-10-19T10:23:54",  # From variables
                         },
-                        "meta": {},
-                        # TODO: meta field handling is not yet working
-                        # "meta": {
-                        #     "format": "markdown",
-                        #     "content": [
-                        #         "### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**"
-                        #     ],
-                        # },
+                        "meta": {
+                            "notes": {
+                                "format": "markdown",
+                                "content": [
+                                    "### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**"
+                                ],
+                            }
+                        },
                     }
                 ),
                 ExpectationConfiguration(
@@ -147,14 +147,14 @@ def alice_columnar_table_single_batch():
                                 "observed_max_time_str"
                             ],  # From data
                         },
-                        "meta": {},
-                        # TODO: meta field handling is not yet working
-                        # "meta": {
-                        #     "format": "markdown",
-                        #     "content": [
-                        #         "### This expectation should be replaced with the below expectation"
-                        #     ],
-                        # },
+                        "meta": {
+                            "notes": {
+                                "format": "markdown",
+                                "content": [
+                                    "### This expectation should be replaced with the below expectation"
+                                ],
+                            }
+                        },
                     }
                 ),
             ]

--- a/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
+++ b/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
@@ -87,8 +87,7 @@ rules:
             format: markdown
             content:
               - "### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**"
-      # TODO: This expectation should be replaced with the expectation below that references a parameter
-      # TODO: from a specific domain
+      # TODO: This expectation should be replaced with the expectation below that references a parameter from a specific domain
       - expectation_type: expect_column_max_to_be_between
         class_name: DefaultExpectationConfigurationBuilder
         module_name: great_expectations.rule_based_profiler.expectation_configuration_builder
@@ -107,11 +106,10 @@ rules:
 #        module_name: great_expectations.rule_based_profiler.expectation_configuration_builder
 #        column: $domain.domain_kwargs.column
 #        min_value: $variables.min_timestamp
-        # TODO: How to reference the event_ts domain?
+        # TODO: How to reference the event_ts domain?<Alex>ALEX -- Anthony: ParameterBuilder has access to domain name; hence, fully_qualified_parameter_name can contain column_name (from domain_kwargs).  Would this work?</Alex>
 #        max_value: $parameter.my_max_event_ts.parameter[0].column.max
 #        or
 #        max_value: $parameter.my_max_event_ts.event_ts.column.max
-        # TODO: These additional kwargs are not being handled correctly
 #        meta:
 #         notes:
 #           format: markdown

--- a/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
+++ b/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
@@ -82,12 +82,11 @@ rules:
         column: $domain.domain_kwargs.column
         min_value: $variables.min_timestamp
         max_value: $variables.min_timestamp
-      # TODO: These additional kwargs are not being handled correctly
-      #   meta:
-      #     notes:
-      #       format: markdown
-      #       content:
-      #         - ### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**
+        meta:
+          notes:
+            format: markdown
+            content:
+              - "### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**"
       # TODO: This expectation should be replaced with the expectation below that references a parameter
       # TODO: from a specific domain
       - expectation_type: expect_column_max_to_be_between
@@ -96,12 +95,11 @@ rules:
         column: $domain.domain_kwargs.column
         min_value: $variables.min_timestamp
         max_value: $parameter.my_max_event_ts.column.max
-        # TODO: These additional kwargs are not being handled correctly
-#        meta:
-#         notes:
-#           format: markdown
-#           content:
-#             - ### This expectation should be replaced with the below expectation
+        meta:
+          notes:
+            format: markdown
+            content:
+              - "### This expectation should be replaced with the below expectation"
         # TODO: This expectation needs to access a parameter for a set domain (event_ts)
         # TODO: to confirm that the event_ts contains the latest timestamp of all domains
 #      - expectation_type: expect_column_max_to_be_between


### PR DESCRIPTION
### Notes
* This enables the `meta` to be part of `ExpectationConfiguration` (in fact, all arguments are now enabled)
* @anthonyburdi Please see my response to your question (line 109 in `tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml`) -- I would like to remove up as many "TODO" items as possible (ideally with additional examples), so let us discuss.  Thank you!
* Test fixtures were updated (note that the expected `meta` did not match the configured -- small fix was made).

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
