### PR TITLE
[BUGFIX] Update util.convert_to_json_serializable() to handle UUID type

### DIFF
--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -3,8 +3,8 @@ import datetime
 import decimal
 import logging
 import os
-import uuid
 import sys
+import uuid
 from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any, Dict, Iterable, List, Optional, Union

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -3,6 +3,7 @@ import datetime
 import decimal
 import logging
 import os
+import uuid
 import sys
 from collections import OrderedDict
 from collections.abc import Mapping
@@ -170,6 +171,9 @@ def convert_to_json_serializable(data):
 
     elif isinstance(data, (datetime.datetime, datetime.date)):
         return data.isoformat()
+
+    elif isinstance(data, uuid.UUID):
+        return str(data)
 
     # Use built in base type from numpy, https://docs.scipy.org/doc/numpy-1.13.0/user/basics.types.html
     # https://github.com/numpy/numpy/pull/9505


### PR DESCRIPTION
## Issue
When using custom expectation for validating UUIDs, it throws following error when processing the results:
```python
Traceback (most recent call last):
...
...
  File "/home/yifangu/.pyenv/versions/ge/lib/python3.8/site-packages/great_expectations/core/util.py", line 220, in convert_to_json_serializable
    raise TypeError(
TypeError: ffffffff-ffff-ffff-ffff-ffffffffffff is of type UUID which cannot be serialized.
```

## Changes proposed in this pull request:
- Add conversion for UUID type so that it could process the results properly