### PR TITLE
[MAINTENANCE] Add integration test for two batch requests and one validator in multiple steps

### DIFF
--- a/tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py
+++ b/tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py
@@ -16,39 +16,37 @@ suite = context.get_expectation_suite("yellow_trip_data_validations")
 
 # Create a BatchRequest and instantiate a Validator with only the January data
 jan_batch_request: BatchRequest = BatchRequest(
-        datasource_name="taxi_pandas",
-        data_connector_name="monthly",
-        data_asset_name="my_reports",
-        data_connector_query={"batch_filter_parameters": {"month": "01"}},
-    )
+    datasource_name="taxi_pandas",
+    data_connector_name="monthly",
+    data_asset_name="my_reports",
+    data_connector_query={"batch_filter_parameters": {"month": "01"}},
+)
 
 validator: Validator = context.get_validator(
-        batch_request=jan_batch_request, expectation_suite=suite
-    )
+    batch_request=jan_batch_request, expectation_suite=suite
+)
 assert validator.active_batch_definition.batch_identifiers["month"] == "01"
 
 # Create a Batch from February data, then load it to the instantiated Validator
 feb_batch_request: BatchRequest = BatchRequest(
-        datasource_name="taxi_pandas",
-        data_connector_name="monthly",
-        data_asset_name="my_reports",
-        data_connector_query={"batch_filter_parameters": {"month": "02"}},
-    )
-
-feb_batch_list: List[Batch] = context.get_batch_list(
-    batch_request=feb_batch_request
+    datasource_name="taxi_pandas",
+    data_connector_name="monthly",
+    data_asset_name="my_reports",
+    data_connector_query={"batch_filter_parameters": {"month": "02"}},
 )
+
+feb_batch_list: List[Batch] = context.get_batch_list(batch_request=feb_batch_request)
 
 validator.load_batch(batch_list=feb_batch_list)
 assert validator.active_batch_definition.batch_identifiers["month"] == "02"
 
 # Create a Batch from March data, then load it to the instantiated Validator
 march_batch_request: BatchRequest = BatchRequest(
-        datasource_name="taxi_pandas",
-        data_connector_name="monthly",
-        data_asset_name="my_reports",
-        data_connector_query={"batch_filter_parameters": {"month": "03"}},
-    )
+    datasource_name="taxi_pandas",
+    data_connector_name="monthly",
+    data_asset_name="my_reports",
+    data_connector_query={"batch_filter_parameters": {"month": "03"}},
+)
 
 march_batch_list: List[Batch] = context.get_batch_list(
     batch_request=march_batch_request

--- a/tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py
+++ b/tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py
@@ -1,0 +1,106 @@
+from typing import List
+
+import numpy as np
+
+from great_expectations.core.batch import Batch, BatchRequest
+from great_expectations.data_context.data_context import DataContext
+from great_expectations.datasource.data_connector.batch_filter import (
+    BatchFilter,
+    build_batch_filter,
+)
+from great_expectations.validator.validation_graph import MetricConfiguration
+from great_expectations.validator.validator import Validator
+
+context = DataContext()
+suite = context.get_expectation_suite("yellow_trip_data_validations")
+
+# Create a BatchRequest and instantiate a Validator with only the January data
+jan_batch_request: BatchRequest = BatchRequest(
+        datasource_name="taxi_pandas",
+        data_connector_name="monthly",
+        data_asset_name="my_reports",
+        data_connector_query={"batch_filter_parameters": {"month": "01"}},
+    )
+
+validator: Validator = context.get_validator(
+        batch_request=jan_batch_request, expectation_suite=suite
+    )
+assert validator.active_batch_definition.batch_identifiers["month"] == "01"
+
+# Create a Batch from February data, then load it to the instantiated Validator
+feb_batch_request: BatchRequest = BatchRequest(
+        datasource_name="taxi_pandas",
+        data_connector_name="monthly",
+        data_asset_name="my_reports",
+        data_connector_query={"batch_filter_parameters": {"month": "02"}},
+    )
+
+feb_batch_list: List[Batch] = context.get_batch_list(
+    batch_request=feb_batch_request
+)
+
+validator.load_batch(batch_list=feb_batch_list)
+assert validator.active_batch_definition.batch_identifiers["month"] == "02"
+
+# Create a Batch from March data, then load it to the instantiated Validator
+march_batch_request: BatchRequest = BatchRequest(
+        datasource_name="taxi_pandas",
+        data_connector_name="monthly",
+        data_asset_name="my_reports",
+        data_connector_query={"batch_filter_parameters": {"month": "03"}},
+    )
+
+march_batch_list: List[Batch] = context.get_batch_list(
+    batch_request=march_batch_request
+)
+
+validator.load_batch(batch_list=march_batch_list)
+assert validator.active_batch_definition.batch_identifiers["month"] == "03"
+
+
+# Get the list of all batches contained by the Validator for use in the BatchFileter
+total_batch_definition_list: list = [
+    v.batch_definition for k, v in validator.batches.items()
+]
+
+# Filter to all batch_definitions prior to March
+jan_feb_batch_filter: BatchFilter = build_batch_filter(
+    data_connector_query_dict={
+        "custom_filter_function": lambda batch_identifiers: int(
+            batch_identifiers["month"]
+        )
+        < 3
+    }
+)
+jan_feb_batch_definition_list: list = (
+    jan_feb_batch_filter.select_from_data_connector_query(
+        batch_definition_list=total_batch_definition_list
+    )
+)
+
+# Get the highest max and lowest min between January and February
+cumulative_max = 0
+cumulative_min = np.Inf
+for batch_definition in jan_feb_batch_definition_list:
+    batch_id: str = batch_definition.id
+    current_max = validator.get_metric(
+        MetricConfiguration(
+            "column.max",
+            metric_domain_kwargs={"column": "fare_amount", "batch_id": batch_id},
+        )
+    )
+    cumulative_max = current_max if current_max > cumulative_max else cumulative_max
+
+    current_min = validator.get_metric(
+        MetricConfiguration(
+            "column.min",
+            metric_domain_kwargs={"column": "fare_amount", "batch_id": batch_id},
+        )
+    )
+    cumulative_min = current_min if current_min < cumulative_min else cumulative_min
+
+# Use the highest max and lowest min from Jan and Feb to create an expectation which we validate against March
+result = validator.expect_column_values_to_be_between(
+    "fare_amount", min_value=cumulative_min, max_value=cumulative_max
+)
+assert result["success"]

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -23,6 +23,13 @@ integration_test_matrix = [
         "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
         "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py",
     },
+    {
+        "name": "pandas_multiple_batch_requests_one_validator_multiple_steps",
+        "base_dir": file_relative_path(__file__, "../../"),
+        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py",
+    },
 ]
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
-Adds an integration test fixture demonstrating the Validator.load_batch() capabilities for the purposes of accessing metrics from multiple batches with a single Validator.

