### PR TITLE
[MAINTENANCE] Alice workflow cleanup / reference specific column

### DIFF
--- a/tests/rule_based_profiler/alice_user_workflow_fixture.py
+++ b/tests/rule_based_profiler/alice_user_workflow_fixture.py
@@ -41,10 +41,7 @@ def alice_columnar_table_single_batch():
         ExpectationConfiguration(
             **{
                 "expectation_type": "expect_column_values_to_be_of_type",
-                "kwargs": {
-                    "column": "user_id",
-                    "type_": "INTEGER",
-                },
+                "kwargs": {"column": "user_id", "type_": "INTEGER",},
                 "meta": {},
             }
         ),
@@ -62,29 +59,21 @@ def alice_columnar_table_single_batch():
         ExpectationConfiguration(
             **{
                 "expectation_type": "expect_column_values_to_not_be_null",
-                "kwargs": {
-                    "column": "user_id",
-                },
+                "kwargs": {"column": "user_id",},
                 "meta": {},
             }
         ),
     ]
 
-    event_ts_column_data: Dict[str: str] = {
+    event_ts_column_data: Dict[str:str] = {
         "column_name": "event_ts",
         "observed_max_time_str": "2004-10-19 11:05:20",
     }
 
-    my_rule_for_timestamps_column_data: List[Dict[str: str]] = [
+    my_rule_for_timestamps_column_data: List[Dict[str:str]] = [
         event_ts_column_data,
-        {
-            "column_name": "server_ts",
-            "observed_max_time_str": "2004-10-19 11:05:20",
-        },
-        {
-            "column_name": "device_ts",
-            "observed_max_time_str": "2004-10-19 11:05:22",
-        },
+        {"column_name": "server_ts", "observed_max_time_str": "2004-10-19 11:05:20",},
+        {"column_name": "device_ts", "observed_max_time_str": "2004-10-19 11:05:22",},
     ]
     my_rule_for_timestamps_expectation_configurations: List[
         ExpectationConfiguration
@@ -106,18 +95,14 @@ def alice_columnar_table_single_batch():
                 ExpectationConfiguration(
                     **{
                         "expectation_type": "expect_column_values_to_be_increasing",
-                        "kwargs": {
-                            "column": column_data["column_name"],
-                        },
+                        "kwargs": {"column": column_data["column_name"],},
                         "meta": {},
                     }
                 ),
                 ExpectationConfiguration(
                     **{
                         "expectation_type": "expect_column_values_to_be_dateutil_parseable",
-                        "kwargs": {
-                            "column": column_data["column_name"],
-                        },
+                        "kwargs": {"column": column_data["column_name"],},
                         "meta": {},
                     }
                 ),

--- a/tests/rule_based_profiler/alice_user_workflow_fixture.py
+++ b/tests/rule_based_profiler/alice_user_workflow_fixture.py
@@ -70,11 +70,13 @@ def alice_columnar_table_single_batch():
         ),
     ]
 
-    my_rule_for_timestamps_column_data: List[Dict[str, str]] = [
-        {
-            "column_name": "event_ts",
-            "observed_max_time_str": "2004-10-19 11:05:20",
-        },
+    event_ts_column_data: Dict[str: str] = {
+        "column_name": "event_ts",
+        "observed_max_time_str": "2004-10-19 11:05:20",
+    }
+
+    my_rule_for_timestamps_column_data: List[Dict[str: str]] = [
+        event_ts_column_data,
         {
             "column_name": "server_ts",
             "observed_max_time_str": "2004-10-19 11:05:20",
@@ -143,15 +145,15 @@ def alice_columnar_table_single_batch():
                         "kwargs": {
                             "column": column_data["column_name"],
                             "min_value": "2004-10-19T10:23:54",  # From variables
-                            "max_value": column_data[
+                            "max_value": event_ts_column_data[
                                 "observed_max_time_str"
-                            ],  # From data
+                            ],  # Pin to event_ts column
                         },
                         "meta": {
                             "notes": {
                                 "format": "markdown",
                                 "content": [
-                                    "### This expectation should be replaced with the below expectation"
+                                    "### This expectation confirms that the event_ts contains the latest timestamp of all domains"
                                 ],
                             }
                         },

--- a/tests/rule_based_profiler/alice_user_workflow_fixture.py
+++ b/tests/rule_based_profiler/alice_user_workflow_fixture.py
@@ -65,12 +65,12 @@ def alice_columnar_table_single_batch():
         ),
     ]
 
-    event_ts_column_data: Dict[str:str] = {
+    event_ts_column_data: Dict[str, str] = {
         "column_name": "event_ts",
         "observed_max_time_str": "2004-10-19 11:05:20",
     }
 
-    my_rule_for_timestamps_column_data: List[Dict[str:str]] = [
+    my_rule_for_timestamps_column_data: List[Dict[str, str]] = [
         event_ts_column_data,
         {"column_name": "server_ts", "observed_max_time_str": "2004-10-19 11:05:20",},
         {"column_name": "device_ts", "observed_max_time_str": "2004-10-19 11:05:22",},

--- a/tests/rule_based_profiler/alice_user_workflow_fixture.py
+++ b/tests/rule_based_profiler/alice_user_workflow_fixture.py
@@ -41,7 +41,10 @@ def alice_columnar_table_single_batch():
         ExpectationConfiguration(
             **{
                 "expectation_type": "expect_column_values_to_be_of_type",
-                "kwargs": {"column": "user_id", "type_": "INTEGER",},
+                "kwargs": {
+                    "column": "user_id",
+                    "type_": "INTEGER",
+                },
                 "meta": {},
             }
         ),
@@ -59,7 +62,9 @@ def alice_columnar_table_single_batch():
         ExpectationConfiguration(
             **{
                 "expectation_type": "expect_column_values_to_not_be_null",
-                "kwargs": {"column": "user_id",},
+                "kwargs": {
+                    "column": "user_id",
+                },
                 "meta": {},
             }
         ),
@@ -72,8 +77,14 @@ def alice_columnar_table_single_batch():
 
     my_rule_for_timestamps_column_data: List[Dict[str, str]] = [
         event_ts_column_data,
-        {"column_name": "server_ts", "observed_max_time_str": "2004-10-19 11:05:20",},
-        {"column_name": "device_ts", "observed_max_time_str": "2004-10-19 11:05:22",},
+        {
+            "column_name": "server_ts",
+            "observed_max_time_str": "2004-10-19 11:05:20",
+        },
+        {
+            "column_name": "device_ts",
+            "observed_max_time_str": "2004-10-19 11:05:22",
+        },
     ]
     my_rule_for_timestamps_expectation_configurations: List[
         ExpectationConfiguration
@@ -95,14 +106,18 @@ def alice_columnar_table_single_batch():
                 ExpectationConfiguration(
                     **{
                         "expectation_type": "expect_column_values_to_be_increasing",
-                        "kwargs": {"column": column_data["column_name"],},
+                        "kwargs": {
+                            "column": column_data["column_name"],
+                        },
                         "meta": {},
                     }
                 ),
                 ExpectationConfiguration(
                     **{
                         "expectation_type": "expect_column_values_to_be_dateutil_parseable",
-                        "kwargs": {"column": column_data["column_name"],},
+                        "kwargs": {
+                            "column": column_data["column_name"],
+                        },
                         "meta": {},
                     }
                 ),

--- a/tests/rule_based_profiler/alice_user_workflow_simplified_profiler_config.yml
+++ b/tests/rule_based_profiler/alice_user_workflow_simplified_profiler_config.yml
@@ -1,6 +1,5 @@
 # Note: This config is simplified by assuming class_name, module_name, metric_domain_kwargs, column, etc where appropriate
 # Note: This simplification scheme has not been implemented, so please refer to the alice_user_workflow_verbose_profiler_config.yml for a working config
-# Simplification methods for ExpectationConfigurationBuilders are still being discussed
 variables:
   max_user_id: 999999999999
   min_timestamp: 2004-10-19 10:23:54
@@ -16,7 +15,6 @@ rules:
         class_name: MetricParameterBuilder
         metric_name: column.min
     expectation_configuration_builders:
-      # Note: Simplification methods for ExpectationConfigurationBuilders are still being discussed
       - expectation_type: expect_column_values_to_be_between
         min_value: $parameter.my_min_user_id.column.min
         max_value: $variables.max_user_id
@@ -32,6 +30,8 @@ rules:
       - parameter_name: my_max_event_ts
         class_name: MetricParameterBuilder
         metric_name: column.max
+        metric_domain_kwargs:
+          column: event_ts # This parameter is computed only on the event_ts column
     expectation_configuration_builders:
       - expectation_type: expect_column_values_to_be_of_type
         type_: TIMESTAMP
@@ -45,11 +45,11 @@ rules:
             format: markdown
             content:
               - ### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**
-#      - expectation_type: expect_column_max_to_be_between
-#        min_value: $variables.min_timestamp
-#        max_value: $parameter.my_max_event_ts.<TBD how to reference event_ts domain>.column.max
-#        meta:
-#          notes:
-#            format: markdown
-#            content:
-#              - ### This expectation confirms that the event_ts contains the latest timestamp of all domains
+      - expectation_type: expect_column_max_to_be_between
+        min_value: $variables.min_timestamp
+        max_value: $parameter.my_max_event_ts.column.max
+        meta:
+          notes:
+            format: markdown
+            content:
+              - ### This expectation confirms that the event_ts contains the latest timestamp of all domains

--- a/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
+++ b/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
@@ -42,13 +42,20 @@ rules:
       module_name: great_expectations.rule_based_profiler.domain_builder
       column_name_suffixes:
         - _ts
-    parameter_builders: # TODO: <Alex>ALEX Anthony, AJB -- we might need to discuss potentially enriching this.</Alex>
-      - parameter_name: my_max_event_ts
+    parameter_builders:
+      - parameter_name: my_max_ts
         class_name: MetricParameterBuilder
         module_name: great_expectations.rule_based_profiler.parameter_builder
         metric_name: column.max
         metric_domain_kwargs: $domain.domain_kwargs
-      - parameter_name: my_min_event_ts
+      - parameter_name: my_max_event_ts
+        class_name: MetricParameterBuilder
+        module_name: great_expectations.rule_based_profiler.parameter_builder
+        metric_name: column.max
+        # Note this parameter builder computes parameters only on the provided domain:
+        metric_domain_kwargs:
+          column: event_ts
+      - parameter_name: my_min_ts
         class_name: MetricParameterBuilder
         module_name: great_expectations.rule_based_profiler.parameter_builder
         metric_name: column.min
@@ -78,7 +85,8 @@ rules:
             format: markdown
             content:
               - "### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**"
-      # TODO: This expectation should be replaced with the expectation below that references a parameter from a specific domain
+        # Note: This expectation accesses a parameter for a set domain (event_ts)
+        # to confirm that the event_ts contains the latest timestamp of all _ts domains
       - expectation_type: expect_column_max_to_be_between
         class_name: DefaultExpectationConfigurationBuilder
         module_name: great_expectations.rule_based_profiler.expectation_configuration_builder
@@ -89,20 +97,4 @@ rules:
           notes:
             format: markdown
             content:
-              - "### This expectation should be replaced with the below expectation"
-        # TODO: This expectation needs to access a parameter for a set domain (event_ts)
-        # TODO: to confirm that the event_ts contains the latest timestamp of all domains
-#      - expectation_type: expect_column_max_to_be_between
-#        class_name: DefaultExpectationConfigurationBuilder
-#        module_name: great_expectations.rule_based_profiler.expectation_configuration_builder
-#        column: $domain.domain_kwargs.column
-#        min_value: $variables.min_timestamp
-        # TODO: How to reference the event_ts domain?<Alex>ALEX -- Anthony: ParameterBuilder has access to domain name; hence, fully_qualified_parameter_name can contain column_name (from domain_kwargs).  Would this work?</Alex>
-#        max_value: $parameter.my_max_event_ts.parameter[0].column.max
-#        or
-#        max_value: $parameter.my_max_event_ts.event_ts.column.max
-#        meta:
-#         notes:
-#           format: markdown
-#           content:
-#             - ### This expectation confirms that the event_ts contains the latest timestamp of all domains
+              - "### This expectation confirms that the event_ts contains the latest timestamp of all domains"

--- a/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
+++ b/tests/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
@@ -42,15 +42,6 @@ rules:
       module_name: great_expectations.rule_based_profiler.domain_builder
       column_name_suffixes:
         - _ts
-      # TODO: This functionality does not yet exist
-      # The proposal here is that a user could specify names for domains to be referenced later
-      # specifically instead of via indexing
-      # (e.g. helpful if the parent domain changes and additional subdomains are added -
-      # e.g. more columns in the table).
-      # user_input_list_of_domain_names:
-      #   - event_ts
-      #   - server_ts
-      #   - device_ts
     parameter_builders: # TODO: <Alex>ALEX Anthony, AJB -- we might need to discuss potentially enriching this.</Alex>
       - parameter_name: my_max_event_ts
         class_name: MetricParameterBuilder


### PR DESCRIPTION
Changes proposed in this pull request:
- The alice workflow todos are now moved to tasks and only explanatory notes left in the simplified since it is not yet implemented
- Alice now references `event_ts` column as a parameter, pinning the domain