### PR TITLE
[MAINTENANCE] Make Domain Extend IDDict; Insure BatchID is Included in MetricConfiguration; Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To see Great Expectations in action on your own data:
 
 ```
 
-(We recommend deploying within a virtual environment. If you’re not familiar with pip, virtual environments, notebooks, or git, you may want to check out the [Supporting Resources](http://docs.greatexpectations.io/en/latest/reference/supporting_resources.html) will teach you how to get up and running in minutes before continuing.)
+(We recommend deploying within a virtual environment. If you’re not familiar with pip, virtual environments, notebooks, or git, you may want to check out the [Supporting Resources](http://docs.greatexpectations.io/en/latest/reference/supporting_resources.html), which will teach you how to get up and running in minutes.)
 
 For full documentation, visit [Great Expectations on readthedocs.io](http://great-expectations.readthedocs.io/en/latest/).
 

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -27,7 +27,9 @@ class ColumnDomainBuilder(DomainBuilder):
         table_column_names: List[str] = validator.get_metric(
             metric=MetricConfiguration(
                 metric_name="table.columns",
-                metric_domain_kwargs={},
+                metric_domain_kwargs={
+                    "batch_id": validator.active_batch_id,
+                },
                 metric_value_kwargs=None,
                 metric_dependencies=None,
             )

--- a/great_expectations/rule_based_profiler/domain_builder/domain.py
+++ b/great_expectations/rule_based_profiler/domain_builder/domain.py
@@ -1,18 +1,38 @@
-from dataclasses import asdict, dataclass
 from typing import Any, Dict, Optional, Union
 
 from great_expectations.core import IDDict
 from great_expectations.core.util import convert_to_json_serializable
-from great_expectations.types import SerializableDictDot
+from great_expectations.types.base import DotDict
 
 
-@dataclass
-class Domain(SerializableDictDot):
-    domain_kwargs: Optional[Dict[str, Union[str, Dict[str, Any]]]] = None
+class Domain(IDDict, DotDict):
+    # Adding an explicit constructor to highlight the specific properties that will be used.
+    def __init__(self, domain_kwargs: Optional[Dict[str, Any]] = None):
+        domain_kwargs_dot_dict: DotDict = self._convert_dictionaries_to_dot_dicts(
+            source=domain_kwargs
+        )
+        super().__init__(domain_kwargs=domain_kwargs_dot_dict)
 
     def to_json_dict(self) -> dict:
-        return convert_to_json_serializable(data=asdict(self))
+        return convert_to_json_serializable(data=self)
 
     @property
+    # Adding this property for convenience (also, in the future, arguments may not be all set to their default values).
     def id(self) -> str:
-        return IDDict(self.to_json_dict()).to_id()
+        return self.to_id(id_keys=None, id_ignore_keys=None)
+
+    def _convert_dictionaries_to_dot_dicts(
+        self, source: Optional[Any] = None
+    ) -> Optional[Union[Any, DotDict]]:
+        if source is None:
+            return None
+
+        if isinstance(source, dict):
+            if not isinstance(source, DotDict):
+                source = DotDict(source)
+            key: str
+            value: Any
+            for key, value in source.items():
+                source[key] = self._convert_dictionaries_to_dot_dicts(source=value)
+
+        return source

--- a/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
@@ -18,10 +18,9 @@ class DomainBuilder(ABC):
         batch_ids: Optional[List[str]] = None,
     ) -> List[Domain]:
         """
-        :param validator
+        :param validator If a Validator is provided, "Validator.active batch id" is used.
         :param batch_ids: A list of batch_ids to use when profiling (e.g. can be a subset of batches provided via
-        Validator, batch, batches, batch_request).  If not provided, all batches are used.  If a Validator is provided,
-        Validator active batch id is used.
+        Validator, batch, batches, batch_request).  If not provided, all batches are used.
 
         Note: In this class, we do not verify that all of these batch_ids are accessible; this should be done elsewhere
         (with an error raised in the appropriate situations).
@@ -38,5 +37,19 @@ class DomainBuilder(ABC):
         validator: Optional[Validator] = None,
         batch_ids: Optional[List[str]] = None,
     ) -> List[Domain]:
-        """_get_domains is the primary workhorse for the DomainBuilder"""
+        """
+        _get_domains is the primary workhorse for the DomainBuilder
+
+        IMPORTANT: If an implementation sets "batch_id": my_batch_id in "Domain.domain_kwargs" and also calls
+        "validator.get_metric()" as part of its logic, then "MetricConfiguration" must also set "batch_id" as follows:
+        validator.get_metric(
+            metric=MetricConfiguration(
+                metric_name="my_metric",
+                metric_domain_kwargs={key_mdkw0: value_mdkw0, key_mdkw1: value_mdkw1, "batch_id": my_batch_id,},
+                metric_value_kwargs={key_mvkw0: value_mvkw0, key_mvkw1: value_mvkw1,},
+                metric_dependencies={key_mdeps0: value_mdeps0, key_mdeps1: value_mdeps1,},
+            )
+        )
+        """
+
         pass

--- a/great_expectations/rule_based_profiler/domain_builder/simple_column_suffix_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/simple_column_suffix_domain_builder.py
@@ -46,7 +46,9 @@ class SimpleColumnSuffixDomainBuilder(DomainBuilder):
         table_column_names: List[str] = validator.get_metric(
             metric=MetricConfiguration(
                 metric_name="table.columns",
-                metric_domain_kwargs={},
+                metric_domain_kwargs={
+                    "batch_id": validator.active_batch_id,
+                },
                 metric_value_kwargs=None,
                 metric_dependencies=None,
             )

--- a/great_expectations/rule_based_profiler/domain_builder/simple_semantic_type_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/simple_semantic_type_domain_builder.py
@@ -49,7 +49,9 @@ class SimpleSemanticTypeColumnDomainBuilder(ColumnDomainBuilder):
         column_types_dict_list: List[Dict[str, Any]] = validator.get_metric(
             metric=MetricConfiguration(
                 metric_name="table.column_types",
-                metric_domain_kwargs={},
+                metric_domain_kwargs={
+                    "batch_id": validator.active_batch_id,
+                },
                 metric_value_kwargs={
                     "include_nested": True,
                 },
@@ -60,7 +62,9 @@ class SimpleSemanticTypeColumnDomainBuilder(ColumnDomainBuilder):
         table_column_names: List[str] = validator.get_metric(
             metric=MetricConfiguration(
                 metric_name="table.columns",
-                metric_domain_kwargs={},
+                metric_domain_kwargs={
+                    "batch_id": validator.active_batch_id,
+                },
                 metric_value_kwargs=None,
                 metric_dependencies=None,
             )

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -698,11 +698,6 @@ class Validator:
         return batch_list
 
     @property
-    def batches(self):
-        """Getter for batches"""
-        return self._batches
-
-    @property
     def batches(self) -> Dict[str, Batch]:
         """Getter for batches"""
         return self._batches


### PR DESCRIPTION
### Scope
This PR incorporates feedback for PR #2788 .  Specific improvements are:
* Make `Domain` object extend `IDDict` for compatibility.
* Insure that `batch_id` is set in usage of `MetricConfiguration` in `DomainBuilder` implementations.
* Delete duplicate code (a cleanup from a previous bad merge).


Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
