### PR TITLE
[ENHANCEMENT] Added SerializableDotDict (as a JSON-serializable extension of DotDict)

### DIFF
--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -19,6 +19,7 @@ from great_expectations import exceptions as ge_exceptions
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.types import SerializableDictDot
+from great_expectations.types.base import SerializableDotDict
 
 # Updated from the stack overflow version below to concatenate lists
 # https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
@@ -125,7 +126,7 @@ def convert_to_json_serializable(data):
 
     # If it's one of our types, we use our own conversion; this can move to full schema
     # once nesting goes all the way down
-    if isinstance(data, SerializableDictDot):
+    if isinstance(data, (SerializableDictDot, SerializableDotDict)):
         return data.to_json_dict()
 
     try:
@@ -238,7 +239,7 @@ def ensure_json_serializable(data):
         test_obj may also be converted in place.
     """
 
-    if isinstance(data, SerializableDictDot):
+    if isinstance(data, (SerializableDictDot, SerializableDotDict)):
         return
 
     try:

--- a/great_expectations/types/base.py
+++ b/great_expectations/types/base.py
@@ -45,3 +45,14 @@ class DotDict(dict):
     def to_yaml(cls, representer, node):
         """Use dict representation for DotDict (and subtypes by default)"""
         return representer.represent_dict(node)
+
+
+class SerializableDotDict(DotDict):
+    """
+    Analogously to the way "SerializableDictDot" extends "DictDot" to provide JSON serialization, the present class,
+    "SerializableDotDict" extends "DotDict" to provide JSON-serializable version of the "DotDict" class as well.
+    Since "DotDict" is already YAML-serializable, "SerializableDotDict" is both YAML-serializable and JSON-serializable.
+    """
+
+    def to_json_dict(self) -> dict:
+        raise NotImplementedError


### PR DESCRIPTION
### Scope
* The addition of SerializableDotDict (as a simple JSON-serializable extension of DotDict) is useful in support of the RuleBasedProfiler functionality.  In particular, it will make the `Domain` class naturally pass the `ensure_json_serializable()` filter and be compatible with the `convert_to_json_serializable()` method.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [ENHANCEMENT], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


Thank you for submitting!
