### PR TITLE
[BUGFIX] Docs integration tests now only run when `--docs-tests` option is specified

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -362,7 +362,8 @@ stages:
           - script: |
               pip install pytest pytest-azurepipelines
               # TODO enable spark tests
-              pytest -v -m docs --no-spark tests/integration/test_script_runner.py
+              # TODO enable sqlalchemy once cloud resources are working again
+              pytest -v --docs-tests -m docs --no-spark --no-sqlalchemy tests/integration/test_script_runner.py
             displayName: 'pytest'
             env:
               # snowflake credentials

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -10,6 +10,7 @@ Develop
 * [DOCS] Remove broken links
 * [DOCS] Fix typo in SlackNotificationAction docstring
 * [BUGFIX] Allow decimals without leading zero in evaluation parameter URN
+* [BUGFIX] Docs integration tests now only run when `--docs-tests` option is specified
 * [ENHANCEMENT] Enable instantiation of a validator with a multiple batch BatchRequest
 * [ENHANCEMENT] Adds a batch_request_list parameter to DataContext.get_validator to enable instantiation of a Validator with batches from multiple BatchRequests
 * [ENHANCEMENT] Add a Validator.load_batch method to enable loading of additional Batches to an instantiated Validator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="If set, run aws integration tests",
     )
+    parser.addoption(
+        "--docs-tests",
+        action="store_true",
+        help="If set, integration tests for docs",
+    )
 
 
 def build_test_backends_list(metafunc):
@@ -149,12 +154,18 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption("--aws-integration"):
         # --aws-integration given in cli: do not skip aws-integration tests
         return
+    if config.getoption("--docs-tests"):
+        # --docs-tests given in cli: do not skip documentation integration tests
+        return
     skip_aws_integration = pytest.mark.skip(
         reason="need --aws-integration option to run"
     )
+    skip_docs_integration = pytest.mark.skip(reason="need --docs-tests option to run")
     for item in items:
         if "aws_integration" in item.keywords:
             item.add_marker(skip_aws_integration)
+        if "docs" in item.keywords:
+            item.add_marker(skip_docs_integration)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--docs-tests",
         action="store_true",
-        help="If set, integration tests for docs",
+        help="If set, run integration tests for docs",
     )
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Docs integration tests were running for all stages in Azure pipelines, even though only the `docusaurus_tests` stage has access to the necessary resources and environment variables.
- As a solution, we have added a `--docs-tests` flag that will cause `docs` tests to run only when the flag is specified. 
- Also re-added `--no-sqlalchemy` flag to `docusaurus_tests` until cloud resources are working with our sandbox accounts