### PR TITLE
[DOCS] Fix version name in V3 Quick start tutorial

### DIFF
--- a/docs_rtd/guides/tutorials/getting_started_v3_api/initialize_a_data_context.rst
+++ b/docs_rtd/guides/tutorials/getting_started_v3_api/initialize_a_data_context.rst
@@ -3,7 +3,7 @@
 Set up the tutorial data and initialize a Data Context
 ======================================================
 
-**Welcome to the Great Expectations Getting Started tutorial for the V3 (Batch Kwargs) API!** This tutorial will walk you through a simple exercise where you create an Expectation suite that catches a data issue in a sample data set we provide.
+**Welcome to the Great Expectations Getting Started tutorial for the V3 (Batch Request) API!** This tutorial will walk you through a simple exercise where you create an Expectation suite that catches a data issue in a sample data set we provide.
 
 .. admonition:: Prerequisites for the tutorial:
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix version name in V3 getting started tutorial. From: `Kwargs` to: `Request`
