### PR TITLE
[BUGFIX] Fix rendering error 

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -23,6 +23,7 @@ Develop
 * [ENHANCEMENT] InMemoryStoreBackendDefaults which is useful for testing
 * [FEATURE] Add GeCloudStoreBackend with support for Checkpoints
 * [MAINTENANCE] DOCS integration tests have moved to a new pipeline
+* [BUGFIX] Fix serialization error in DataDocs rendering
 
 0.13.19
 -----------------

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -459,6 +459,7 @@ class Validator:
                             "exception_traceback": exception_traceback,
                             "exception_message": str(err),
                         },
+                        expectation_config=configuration,
                     )
                     evrs.append(result)
                 else:
@@ -488,6 +489,7 @@ class Validator:
                             "exception_traceback": exception_traceback,
                             "exception_message": str(err),
                         },
+                        expectation_config=configuration,
                     )
                     evrs.append(result)
                 else:

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -270,11 +270,12 @@ def test_graph_validate_with_exception(basic_datasource):
 
     validator = Validator(execution_engine=PandasExecutionEngine(), batches=[batch])
     validator.build_metric_dependency_graph = mock_error
-    
+
     result = validator.graph_validate(configurations=[expectation_configuration])
 
     assert len(result) == 1
     assert result[0].expectation_config is not None
+
 
 def test_graph_validate_with_bad_config(basic_datasource):
     df = pd.DataFrame({"a": [1, 5, 22, 3, 5, 10], "b": [1, 2, 3, 4, 5, None]})
@@ -310,7 +311,6 @@ def test_graph_validate_with_bad_config(basic_datasource):
         str(eee.value)
         == 'Error: The column "not_in_table" in BatchData does not exist.'
     )
-
 
 
 # Tests that runtime configuration actually works during graph validation


### PR DESCRIPTION
*  The failure was happening due to the fact that if exception was thrown during validation, expectation config was not set in the results. Fixed by passing expectation config to  `ExpectationValidationResult` c'tor on exception.
 
Closes #2908 

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

