### PR TITLE
[BUGFIX] Render 0 properly in datadocs

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -24,6 +24,7 @@ Develop
 * [FEATURE] Add GeCloudStoreBackend with support for Checkpoints
 * [MAINTENANCE] DOCS integration tests have moved to a new pipeline
 * [BUGFIX] Fix serialization error in DataDocs rendering
+* [BUGFIX] Fix datadocs rendering issue where 0 value was displayed as `--`
 
 0.13.19
 -----------------

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -24,7 +24,7 @@ Develop
 * [FEATURE] Add GeCloudStoreBackend with support for Checkpoints
 * [MAINTENANCE] DOCS integration tests have moved to a new pipeline
 * [BUGFIX] Fix serialization error in DataDocs rendering
-* [BUGFIX] Fix datadocs rendering issue where 0 value was displayed as `--`
+* [BUGFIX] Fix rendering of observed value in datadocs when the value is 0
 
 0.13.19
 -----------------

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -475,7 +475,7 @@ class Expectation(metaclass=MetaExpectation):
         if result_dict is None:
             return "--"
 
-        if result_dict.get("observed_value"):
+        if result_dict.get("observed_value") is not None:
             observed_value = result_dict.get("observed_value")
             if isinstance(observed_value, (int, float)) and not isinstance(
                 observed_value, bool

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -240,6 +240,20 @@ def test_ValidationResultsTableContentBlockRenderer_get_observed_value(evr_succe
         ),
     )
 
+    evr_success_zero = ExpectationValidationResult(
+        success=True,
+        result={"observed_value": 0},
+        exception_info={
+            "raised_exception": False,
+            "exception_message": None,
+            "exception_traceback": None,
+        },
+        expectation_config=ExpectationConfiguration(
+            expectation_type="expect_table_row_count_to_be_between",
+            kwargs={"min_value": 0, "max_value": None, "result_format": "SUMMARY"},
+        ),
+    )
+
     # test _get_observed_value when evr.result["observed_value"] exists
     output_1 = get_renderer_impl(
         object_name=evr_success.expectation_config.expectation_type,
@@ -264,6 +278,12 @@ def test_ValidationResultsTableContentBlockRenderer_get_observed_value(evr_succe
         renderer_type="renderer.diagnostic.observed_value",
     )[1](result=evr_expect_column_values_to_be_null)
     assert output_4 == "100% null"
+    # test _get_observed_value to be 0
+    output_5 = get_renderer_impl(
+        object_name=evr_success_zero.expectation_config.expectation_type,
+        renderer_type="renderer.diagnostic.observed_value",
+    )[1](result=evr_success_zero)
+    assert output_5 == "0"
 
 
 def test_ValidationResultsTableContentBlockRenderer_get_unexpected_statement(


### PR DESCRIPTION
Fixed renderer check to account for `0` values

Closes #2922 


Before:
![image](https://user-images.githubusercontent.com/14918053/122598417-ccf1a080-d03a-11eb-9590-dfa20f14fca2.png)

After:
![image](https://user-images.githubusercontent.com/14918053/122598455-ded34380-d03a-11eb-9612-435b5fe8bdc2.png)


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
