### PR TITLE
[MAINTENANCE] Pin json-schema version

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -26,6 +26,7 @@ Develop
 * [ENHANCEMENT] InMemoryStoreBackendDefaults which is useful for testing
 * [FEATURE] Add GeCloudStoreBackend with support for Checkpoints
 * [MAINTENANCE] DOCS integration tests have moved to a new pipeline
+* [MAINTENANCE] Pin json-schema version
 * [BUGFIX] Fix rendering of observed value in datadocs when the value is 0 #2923 (thanks @shpolina)
 * [MAINTENANCE] Allow tests to properly connect to local sqlite db on Windows (thanks @shpolina)
 * [BUGFIX] Fix serialization error in DataDocs rendering #2908 (thanks @shpolina)

--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -6,14 +6,14 @@
 
 # An anonymized string *must* be an md5 hash, so must have exactly 32 characters
 anonymized_string_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "string",
     "minLength": 32,
     "maxLength": 32,
 }
 
 anonymized_datasource_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-datasource",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "oneOf": [
@@ -32,7 +32,7 @@ anonymized_datasource_schema = {
 }
 
 anonymized_class_info_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-class-info",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "oneOf": [
@@ -52,7 +52,7 @@ anonymized_class_info_schema = {
 }
 
 anonymized_store_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-store",
     "definitions": {
         "anonymized_string": anonymized_string_schema,
@@ -76,7 +76,7 @@ anonymized_store_schema = {
 }
 
 anonymized_action_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-action",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "oneOf": [
@@ -94,7 +94,7 @@ anonymized_action_schema = {
 }
 
 anonymized_validation_operator_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-validation-operator",
     "definitions": {
         "anonymized_string": anonymized_string_schema,
@@ -120,14 +120,14 @@ anonymized_validation_operator_schema = {
 }
 
 empty_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {},
     "additionalProperties": False,
 }
 
 anonymized_data_docs_site_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-data-docs-site",
     "definitions": {
         "anonymized_string": anonymized_string_schema,
@@ -154,7 +154,7 @@ anonymized_data_docs_site_schema = {
 }
 
 anonymized_expectation_suite_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-expectation-suite-schema",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "oneOf": [
@@ -247,7 +247,7 @@ init_payload_schema = {
 }
 
 anonymized_batch_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "anonymized-batch",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "oneOf": [
@@ -277,7 +277,7 @@ anonymized_batch_schema = {
 }
 
 run_validation_operator_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions": {
         "anonymized_string": anonymized_string_schema,
         "anonymized_batch": anonymized_batch_schema,
@@ -296,7 +296,7 @@ run_validation_operator_payload_schema = {
 }
 
 save_or_edit_expectation_suite_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "type": "object",
     "properties": {
@@ -309,7 +309,7 @@ save_or_edit_expectation_suite_payload_schema = {
 }
 
 cli_suite_expectation_suite_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "type": "object",
     "properties": {
@@ -326,7 +326,7 @@ cli_suite_expectation_suite_payload_schema = {
 }
 
 cli_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "cli-payload",
     "type": "object",
     "properties": {
@@ -342,7 +342,7 @@ cli_payload_schema = {
 }
 
 cli_new_ds_choice_payload_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {
         "type": {"type": "string", "maxLength": 256},
@@ -355,7 +355,7 @@ cli_new_ds_choice_payload_schema = {
 
 
 datasource_sqlalchemy_connect_payload = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "properties": {
         "anonymized_name": {"type": "string", "maxLength": 256},
@@ -366,7 +366,7 @@ datasource_sqlalchemy_connect_payload = {
 }
 
 usage_statistics_record_schema = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "definitions": {
         "anonymized_string": anonymized_string_schema,
         "anonymized_datasource": anonymized_datasource_schema,


### PR DESCRIPTION
Changes proposed in this pull request:
- Pin jsonschema version to the latest version used in AWS API Gateway (Draft-04). See: https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-models

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
