### PR TITLE
[DOCS] Align 2 more TOC items to spec

### DIFF
--- a/docs/guides/setup/components/defaultPrerequisiteItems.jsx
+++ b/docs/guides/setup/components/defaultPrerequisiteItems.jsx
@@ -27,7 +27,7 @@ export default class Prerequisites extends React.Component {
 
   defaultPrerequisiteItems () {
     return [
-      <li key={0.1}>Completed the <a href='/docs/tutorials/getting-started/intro'>Getting Started Tutorial</a></li>,
+      <li key={0.1}>Completed the <a href='/docs/tutorials/getting-started/intro'>Getting Started Tutorial</a></li>
     ]
   }
 

--- a/docs/guides/setup/components/install_prereq.jsx
+++ b/docs/guides/setup/components/install_prereq.jsx
@@ -1,12 +1,11 @@
 import React from 'react'
 
-import Prerequisites from "./defaultPrerequisiteItems.jsx";
+import Prerequisites from './defaultPrerequisiteItems.jsx'
 
 export default class InsPrerequisites extends Prerequisites {
-
   defaultPrerequisiteItems () {
     return [
-      <li key={0.1}>Completed the <a href='/docs/tutorials/getting-started/intro'>Getting Started Tutorial</a></li>,
+      <li key={0.1}>Completed the <a href='/docs/tutorials/getting-started/intro'>Getting Started Tutorial</a></li>
     ]
   }
 }

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,23 +23,6 @@ module.exports = {
       ]
     },
     {
-    type: 'category',
-    label: 'Deployment Patterns',
-    items: [
-        'deployment_patterns/how-to-instantiate-a-data-context-on-an-emr-spark-cluster',
-        'deployment_patterns/how-to-instantiate-a-data-context-on-databricks-spark-cluster',
-        'deployment_patterns/how-to-run-a-checkpoint-in-airflow',
-        {
-          type: 'category',
-          label: 'Contributing',
-          items:[
-            'deployment_patterns/contributing/how-to-add-a-new-deployment-pattern-document',
-            'deployment_patterns/contributing/how-to-contribute-to-an-existing-deployment-pattern-document'
-          ]
-        },
-      ]
-    },
-    {
       type: 'category',
       label: 'How to Guides',
       items: [
@@ -66,7 +49,7 @@ module.exports = {
                 'guides/setup/configuring-data-contexts/how-to-configure-datacontext-components-using-test_yaml_config',
                 'guides/setup/configuring-data-contexts/how-to-configure-credentials-using-a-yaml-file-or-environment-variables',
                 'guides/setup/configuring-data-contexts/how-to-configure-credentials-using-a-secrets-store',
-                'guides/setup/configuring-data-contexts/how-to-instantiate-a-data-context-without-a-yml-file',
+                'guides/setup/configuring-data-contexts/how-to-instantiate-a-data-context-without-a-yml-file'
               ]
             },
             {
@@ -95,7 +78,7 @@ module.exports = {
                 'guides/setup/configuring-data-docs/how-to-host-and-share-data-docs-on-gcs',
                 'guides/setup/configuring-data-docs/how-to-host-and-share-data-docs-on-amazon-s3'
               ]
-            },
+            }
           ]
         },
         {
@@ -107,13 +90,6 @@ module.exports = {
             'guides/connecting_to_your_data/how-to-create-a-batch-of-data-from-an-in-memory-spark-or-pandas-dataframe',
             'guides/connecting_to_your_data/how-to-create-a-new-expectation-suite-using-the-cli',
             'guides/connecting_to_your_data/how-to-get-a-batch-of-data-from-a-configured-datasource',
-            {
-              type: 'category',
-              label: '💭 In-memory',
-              items: [
-                { type: 'doc', id: 'guides/connecting_to_your_data/in_memory/pandas' },
-              ]
-            },
             {
               type: 'category',
               label: '🚀 Database',
@@ -132,20 +108,27 @@ module.exports = {
               type: 'category',
               label: '📁 Filesystem',
               items: [
-                { type: 'doc', id: 'guides/connecting_to_your_data/filesystem/pandas' },
-                { type: 'doc', id: 'guides/connecting_to_your_data/filesystem/spark' }
+                'guides/connecting_to_your_data/filesystem/pandas',
+                'guides/connecting_to_your_data/filesystem/spark'
               ]
             },
             {
               type: 'category',
               label: '☁️ Cloud',
               items: [
-                { type: 'doc', id: 'guides/connecting_to_your_data/cloud/s3/pandas' },
-                { type: 'doc', id: 'guides/connecting_to_your_data/cloud/s3/spark' },
-                { type: 'doc', id: 'guides/connecting_to_your_data/cloud/gcs/pandas' },
-                { type: 'doc', id: 'guides/connecting_to_your_data/cloud/gcs/spark' },
-                { type: 'doc', id: 'guides/connecting_to_your_data/cloud/azure/pandas' },
-                { type: 'doc', id: 'guides/connecting_to_your_data/cloud/azure/spark' }
+                'guides/connecting_to_your_data/cloud/s3/pandas',
+                'guides/connecting_to_your_data/cloud/s3/spark',
+                'guides/connecting_to_your_data/cloud/gcs/pandas',
+                'guides/connecting_to_your_data/cloud/gcs/spark',
+                'guides/connecting_to_your_data/cloud/azure/pandas',
+                'guides/connecting_to_your_data/cloud/azure/spark'
+              ]
+            },
+            {
+              type: 'category',
+              label: '💭 In-memory',
+              items: [
+                'guides/connecting_to_your_data/in_memory/pandas'
               ]
             },
             {
@@ -204,9 +187,9 @@ module.exports = {
               items: [
                 'guides/expectations/creating_custom_expectations/how-to-create-custom-expectations',
                 'guides/expectations/creating_custom_expectations/how-to-create-custom-expectations-from-a-sql-query',
-                'guides/expectations/creating_custom_expectations/how-to-create-custom-parameterized-expectations',
+                'guides/expectations/creating_custom_expectations/how-to-create-custom-parameterized-expectations'
               ]
-            },
+            }
           ]
         },
         {
@@ -236,7 +219,7 @@ module.exports = {
               type: 'category',
               label: 'Contributing',
               items: [
-                'guides/validation/contributing/how-to-contribute-a-new-validation-action',
+                'guides/validation/contributing/how-to-contribute-a-new-validation-action'
               ]
             },
             {
@@ -247,31 +230,47 @@ module.exports = {
                 'guides/validation/validation_actions/how-to-trigger-email-as-a-validation-action',
                 'guides/validation/validation_actions/how-to-trigger-opsgenie-notifications-as-a-validation-action',
                 'guides/validation/validation_actions/how-to-trigger-slack-notifications-as-a-validation-action',
-                'guides/validation/validation_actions/how-to-update-data-docs-as-a-validation-action',
+                'guides/validation/validation_actions/how-to-update-data-docs-as-a-validation-action'
               ]
-            },
+            }
           ]
         },
         {
           type: 'category',
           label: '🧰 Miscellaneous',
           items: [
-            { type: 'doc', id: 'guides/miscellaneous/how-to-use-the-project-check-config-command'},
-            { type: 'doc', id: 'guides/miscellaneous/how-to-use-the-great-expectations-cli'},
-            { type: 'doc', id: 'guides/miscellaneous/how-to-quickly-explore-expectations-in-a-notebook'},
+            { type: 'doc', id: 'guides/miscellaneous/how-to-use-the-project-check-config-command' },
+            { type: 'doc', id: 'guides/miscellaneous/how-to-use-the-great-expectations-cli' },
+            { type: 'doc', id: 'guides/miscellaneous/how-to-quickly-explore-expectations-in-a-notebook' },
             { type: 'doc', id: 'guides/miscellaneous/how-to-configure-notebooks-generated-by-suite-edit' },
             { type: 'doc', id: 'guides/miscellaneous/how-to-add-comments-to-a-page-on-docs.greatexpectations.io' },
             { type: 'doc', id: 'guides/miscellaneous/how-to-use-the-great-expectation-docker-images' },
             { type: 'doc', id: 'guides/miscellaneous/how-to-write-a-how-to-guide-docusaurus' },
             { type: 'doc', id: 'guides/miscellaneous/how-to-template' }
           ]
-        },
+        }
       ]
     },
-
-    { type: 'doc', id: 'reference/core-concepts'},
-    { type: 'doc', id: 'community'},
-    { type: 'doc', id: 'contributing/contributing'},
-    { type: 'doc', id: 'changelog'},
+    {
+      type: 'category',
+      label: 'Deployment Patterns',
+      items: [
+        'deployment_patterns/how-to-instantiate-a-data-context-on-an-emr-spark-cluster',
+        'deployment_patterns/how-to-instantiate-a-data-context-on-databricks-spark-cluster',
+        'deployment_patterns/how-to-run-a-checkpoint-in-airflow',
+        {
+          type: 'category',
+          label: 'Contributing',
+          items: [
+            'deployment_patterns/contributing/how-to-add-a-new-deployment-pattern-document',
+            'deployment_patterns/contributing/how-to-contribute-to-an-existing-deployment-pattern-document'
+          ]
+        }
+      ]
+    },
+    { type: 'doc', id: 'reference/core-concepts' },
+    { type: 'doc', id: 'community' },
+    { type: 'doc', id: 'contributing/contributing' },
+    { type: 'doc', id: 'changelog' }
   ]
 }


### PR DESCRIPTION

Changes proposed in this pull request:
- Aligned two items in TOC to match spec
- linting
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
