### PR TITLE
[BUGFIX] Modify read_excel() to handle new optional-dependency openpyxl for pandas >= 1.3.0

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -11,8 +11,7 @@ Develop
   - Support for both single-batch and multi-batch use-cases showcased
   - Addition of the "bootstrap" mode of parameter estimation (default) to NumericMetricRangeMultiBatchParameterBuilder
   - Initial documentation
-* [BUGFIX] Require openpyxl to run test for read_excel() #2989
-
+* [BUGFIX] Skip test for read_excel() if openpyxl is not installed (pandas >= 1.3.0)  #2989
 
 0.13.21
 -----------------

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -6,12 +6,14 @@ Changelog
 
 Develop
 -----------------
+* [DOCS] Getting Started tutorial and integration tests
 * [FEATURE] INTRODUCING MAJOR IMPROVEMENTS to the new Rule-Based Profiler architecture and capabilities (Experimental):
   - Clean separation of concerns between DomainBuilder and ParameterBuilder logic
   - Support for both single-batch and multi-batch use-cases showcased
   - Addition of the "bootstrap" mode of parameter estimation (default) to NumericMetricRangeMultiBatchParameterBuilder
   - Initial documentation
 * [BUGFIX] Skip test for read_excel() if openpyxl is not installed (pandas >= 1.3.0)  #2989
+
 
 0.13.21
 -----------------

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -11,6 +11,8 @@ Develop
   - Support for both single-batch and multi-batch use-cases showcased
   - Addition of the "bootstrap" mode of parameter estimation (default) to NumericMetricRangeMultiBatchParameterBuilder
   - Initial documentation
+* [BUGFIX] Require openpyxl to run test for read_excel() #2989
+
 
 0.13.21
 -----------------

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -6,13 +6,12 @@ Changelog
 
 Develop
 -----------------
-* [DOCS] Getting Started tutorial and integration tests
 * [FEATURE] INTRODUCING MAJOR IMPROVEMENTS to the new Rule-Based Profiler architecture and capabilities (Experimental):
   - Clean separation of concerns between DomainBuilder and ParameterBuilder logic
   - Support for both single-batch and multi-batch use-cases showcased
   - Addition of the "bootstrap" mode of parameter estimation (default) to NumericMetricRangeMultiBatchParameterBuilder
   - Initial documentation
-* [BUGFIX] Skip test for read_excel() if openpyxl is not installed (pandas >= 1.3.0)  #2989
+* [BUGFIX] Modify read_excel() to handle new optional-dependency openpyxl for pandas >= 1.3.0 #2989
 
 
 0.13.21

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -496,7 +496,7 @@ def read_excel(
     try:
         df = pd.read_excel(filename, *args, **kwargs)
     except ImportError:
-        raise GreatExpectationsError(
+        raise ImportError(
             "Pandas now requires 'openpyxl' as an optional-dependency to read Excel files. Please use pip or conda to install openpyxl and try again"
         )
 

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -493,7 +493,13 @@ def read_excel(
     """
     import pandas as pd
 
-    df = pd.read_excel(filename, *args, **kwargs)
+    try:
+        df = pd.read_excel(filename, *args, **kwargs)
+    except ImportError:
+        raise GreatExpectationsError(
+            "Pandas now requires 'openpyxl' as an optional-dependency to read Excel files. Please use pip or conda to install openpyxl and try again"
+        )
+
     if dataset_class is None:
         verify_dynamic_loading_support(module_name=module_name)
         dataset_class = load_class(class_name=class_name, module_name=module_name)

--- a/requirements-dev-base.txt
+++ b/requirements-dev-base.txt
@@ -20,6 +20,7 @@ google-cloud-secret-manager>=1.0.0  # all_tests
 google-cloud-storage>=1.28.0  # all_tests
 isort==5.4.2  # lint
 moto[ec2]>=1.3.7,<2.0.0  # all_tests
+openpyxl>=3.0.7  # for read_excel test only
 pre-commit>=2.6.0  # lint
 pyarrow>=0.12.0  # all_tests
 pypd==1.1.0  # all_tests

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -25,6 +25,7 @@ from great_expectations.data_asset.data_asset import (
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.dataset import MetaPandasDataset, PandasDataset
 from great_expectations.exceptions import InvalidCacheValueError
+from great_expectations.util import is_library_loadable
 
 try:
     from unittest import mock
@@ -1014,6 +1015,10 @@ class TestIO(unittest.TestCase):
         assert isinstance(df, PandasDataset)
         assert sorted(list(df.keys())) == ["x", "y", "z"]
 
+    @pytest.mark.skipif(
+        not is_library_loadable(library_name="openpyxl"),
+        reason="pandas >= 1.3.0 reads Excel files with openpyxl by default ",
+    )
     def test_read_excel(self):
         script_path = os.path.dirname(os.path.realpath(__file__))
         df = ge.read_excel(

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -1017,7 +1017,7 @@ class TestIO(unittest.TestCase):
 
     @pytest.mark.skipif(
         not is_library_loadable(library_name="openpyxl"),
-        reason="pandas >= 1.3.0 reads Excel files with openpyxl by default ",
+        reason="GE uses pandas to read excel files, which requires openpyxl",
     )
     def test_read_excel(self):
         script_path = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Changes proposed in this pull request:
- GE uses pandas to read excel files, which reads excel files using openpyxl as of `pandas >= 1.3.0`
- Marked test for `read_excel` as `skip` if the `openpyxl` library cannot be loaded.
- Added `openpyxl` to `requirements-dev-base.txt`
- Added more informative error message for `read_excel()` function in `great_expectations/util.py`

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
