### PR TITLE
[FIX] Update naming of confidence_level in integration test fixture

### DIFF
--- a/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
+++ b/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
@@ -8,7 +8,7 @@ profiler_config = """
 # located in tests/test_sets/taxi_yellow_trip_data_samples/
 
 variables:
-  confidence_level: 9.75e-1
+  false_positive_rate: 0.01
   mostly: 1.0
 
 rules:
@@ -26,7 +26,7 @@ rules:
               index: "-6:-1"
         metric_name: table.row_count
         metric_domain_kwargs: $domain.domain_kwargs
-        confidence_level: $variables.confidence_level
+        false_positive_rate: $variables.false_positive_rate
         round_decimals: 0
         truncate_values:
           lower_bound: 0
@@ -62,7 +62,7 @@ rules:
               index: "-6:-1"
         metric_name: column.min
         metric_domain_kwargs: $domain.domain_kwargs
-        confidence_level: $variables.confidence_level
+        false_positive_rate: $variables.false_positive_rate
         round_decimals: 2
       - parameter_name: max_range
         class_name: NumericMetricRangeMultiBatchParameterBuilder
@@ -74,7 +74,7 @@ rules:
               index: "-6:-1"
         metric_name: column.max
         metric_domain_kwargs: $domain.domain_kwargs
-        confidence_level: $variables.confidence_level
+        false_positive_rate: $variables.false_positive_rate
         round_decimals: 2
     expectation_configuration_builders:
       - expectation_type: expect_column_min_to_be_between


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Update naming of `confidence_level` to `false_positive_rate` in multibatch integration test
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
