### PR TITLE
[FEATURE] Port over guide for Slack notifications for validation actions

### DIFF
--- a/docs/guides/validation/validation_actions/how-to-trigger-slack-notifications-as-a-validation-action.md
+++ b/docs/guides/validation/validation_actions/how-to-trigger-slack-notifications-as-a-validation-action.md
@@ -1,5 +1,112 @@
 ---
 title: How to trigger Slack notifications as a Validation Action
 ---
+import Prerequisites from '../../../guides/connecting_to_your_data/components/prerequisites.jsx';
 
-This article is a stub.
+This guide will help you trigger Slack notifications as a `Validation Action`.
+It will allow you to send a Slack message including information about a Validation Result, including whether or not the Validation succeeded.
+
+<Prerequisites>
+
+- Configured a Slack app with the Webhook function enabled (See Additional Resources below for more information on setting up a new Slack app).
+- Obtained the Webhook address for your Slack app.
+- Identified the Slack channel that messages will be sent to.
+
+</Prerequisites>
+
+Steps
+-----
+
+1. Open `uncommitted/config_variables.yml` file and add `validation_notification_slack_webhook` variable by adding the following line:
+
+```yaml
+validation_notification_slack_webhook: [address to web hook]
+```
+
+
+2. Open `great_expectations.yml` and add `send_slack_notification_on_validation_result` action to `validation_operators`. Make sure the following section exists in the `great_expectations.yml` file.
+
+```yaml
+validation_operators:
+    action_list_operator:
+        # To learn how to configure sending Slack notifications during evaluation
+        # (and other customizations), read: https://docs.greatexpectations.io/en/latest/reference/validation_operators/action_list_validation_operator.html
+        class_name: ActionListValidationOperator
+        action_list:
+        #--------------------------------
+        # here is what you will be adding
+        #--------------------------------
+        - name: send_slack_notification_on_validation_result # name can be set to any value
+          action:
+            class_name: SlackNotificationAction
+            # put the actual webhook URL in the uncommitted/config_variables.yml file
+            slack_webhook: ${validation_notification_slack_webhook}
+            notify_on: all # possible values: "all", "failure", "success"
+            notify_with: # optional list containing the DataDocs sites to include in the notification. Defaults to including links to all configured sites.
+            renderer:
+              module_name: great_expectations.render.renderer.slack_renderer
+              class_name: SlackRenderer
+```
+
+3. Run your `action_list_operator`, to validate a batch of data and receive Slack notification on the success or failure of validation suite.  
+
+```python
+context.run_validation_operator('action_list_operator', assets_to_validate=batch, run_name="slack_test")
+```
+
+  If successful, you should receive a Slack message that looks like this:
+
+![slack_notification_example](../../../images/slack_notification_example.png)
+
+
+Additional notes
+--------------------
+
+- If your `great_expectations.yml` contains multiple configurations for Data Docs sites, all of them will be included in the Slack notification by default. If you would like to be more specific, you can configure the `notify_with` variable in your `great_expectations.yml`.
+- The following example will configure the Slack message to include links Data Docs at `local_site` and `s3_site`.
+
+```yaml
+    # Example data_docs_sites configuration
+    data_docs_sites:
+      local_site:
+        class_name: SiteBuilder
+        show_how_to_buttons: true
+        store_backend:
+          class_name: TupleFilesystemStoreBackend
+          base_directory: uncommitted/data_docs/local_site/
+        site_index_builder:
+          class_name: DefaultSiteIndexBuilder
+      s3_site:  # this is a user-selected name - you may select your own
+        class_name: SiteBuilder
+        store_backend:
+          class_name: TupleS3StoreBackend
+          bucket: data-docs.my_org  # UPDATE the bucket name here to match the bucket you configured above.
+        site_index_builder:
+          class_name: DefaultSiteIndexBuilder
+          show_cta_footer: true
+
+    validation_operators:
+        action_list_operator:
+        ...
+        - name: send_slack_notification_on_validation_result # name can be set to any value
+              action:
+                class_name: SlackNotificationAction
+                # put the actual webhook URL in the uncommitted/config_variables.yml file
+                slack_webhook: ${validation_notification_slack_webhook}
+                notify_on: all # possible values: "all", "failure", "success"
+                #--------------------------------
+                # This is what was configured
+                #--------------------------------
+                notify_with:
+                  - local_site
+                  - s3_site
+                renderer:
+                  module_name: great_expectations.render.renderer.slack_renderer
+                  class_name: SlackRenderer
+```
+
+
+Additional resources
+--------------------
+
+- Instructions on how to set up a Slack app with webhook can be found in the documentation for the [Slack API](https://api.slack.com/messaging/webhooks#)

--- a/docs/guides/validation/validation_actions/how-to-trigger-slack-notifications-as-a-validation-action.md
+++ b/docs/guides/validation/validation_actions/how-to-trigger-slack-notifications-as-a-validation-action.md
@@ -3,7 +3,7 @@ title: How to trigger Slack notifications as a Validation Action
 ---
 import Prerequisites from '../../../guides/connecting_to_your_data/components/prerequisites.jsx';
 
-This guide will help you trigger Slack notifications as a `Validation Action`.
+This guide will help you trigger Slack notifications as a [Validation Action](../../../reference/validation.md).
 It will allow you to send a Slack message including information about a Validation Result, including whether or not the Validation succeeded.
 
 <Prerequisites>


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Convert `.rst` guide around Slack notifications for validation actions to `.md` for Docusaurus
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
