### PR TITLE
[DOCS] Port over "How to instantiate a DataContext on an EMR Spark Cluster" from RTD to Docusaurus

### DIFF
--- a/docs/deployment_patterns/how-to-instantiate-a-data-context-on-an-emr-spark-cluster.md
+++ b/docs/deployment_patterns/how-to-instantiate-a-data-context-on-an-emr-spark-cluster.md
@@ -1,5 +1,46 @@
 ---
 title: How to instantiate a Data Context on an EMR Spark cluster
 ---
+import Prerequisites from '../guides/connecting_to_your_data/components/prerequisites.jsx'
 
-This article is a stub.
+This guide will help you instantiate a Data Context on an EMR Spark cluster.
+
+
+The guide demonstrates the recommended path for instantiating a Data Context without a full configuration directory and without using the Great Expectations [command line interface (CLI)](../guides/miscellaneous/how-to-use-the-great-expectations-cli.md).
+
+
+<Prerequisites>
+
+- [Followed the Getting Started tutorial and have a basic familiarity with the Great Expectations configuration](../tutorials/getting-started/intro.md).
+
+</Prerequisites>
+
+Steps
+-----
+
+1. **Install Great Expectations on your EMR Spark cluster.**
+
+   Copy this code snippet into a cell in your EMR Spark notebook and run it:
+
+    ```python
+  sc.install_pypi_package("great_expectations")
+    ```
+
+
+2. **Configure a Data Context in code.**
+
+    Follow the steps for creating an in-code Data Context in [How to instantiate a Data Context without a yml file](../guides/setup/configuring-data-contexts/how-to-instantiate-a-data-context-without-a-yml-file.md).
+
+    The snippet at the end of the guide shows Python code that instantiates and configures a Data Context in code for an EMR Spark cluster. Copy this snippet into a cell in your EMR Spark notebook or use the other examples to customize your configuration.
+
+
+3. **Test your configuration.**
+
+       Execute the cell with the snippet above.
+
+       Then copy this code snippet into a cell in your EMR Spark notebook, run it and verify that no error is displayed:
+
+      ```python
+      context.list_datasources()
+      ```
+


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Port over .rst guide to .md
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
