### PR TITLE
[DOCS] Fix broken link to example DAG

### DIFF
--- a/docs_rtd/guides/workflows_patterns/deployment_airflow.rst
+++ b/docs_rtd/guides/workflows_patterns/deployment_airflow.rst
@@ -71,7 +71,7 @@ The ``GreatExpectationsOperator`` supports multiple ways of invoking validation 
 
 By default, a ``GreatExpectationsOperator`` task will run validation and raise an ``AirflowException`` if any of the tests fails. To override this behavior and continue running even if tests fail, set the ``fail_task_on_validation_failure`` flag to ``False``.
 
-For more information about possible parameters and examples, see the `README in the repository <https://github.com/great-expectations/airflow-provider-great-expectations>`_, and the `example DAG in the provider package <https://github.com/great-expectations/airflow-provider-great-expectations/tree/main/great_expectations_provider/examples>`_
+For more information about possible parameters and examples, see the `README in the repository <https://github.com/great-expectations/airflow-provider-great-expectations>`_, and the `example DAG in the provider package <https://github.com/great-expectations/airflow-provider-great-expectations/tree/main/great_expectations_provider/example_dags>`_
 
 
 Running validation using a ``PythonOperator``

--- a/docs_rtd/guides/workflows_patterns/deployment_airflow.rst
+++ b/docs_rtd/guides/workflows_patterns/deployment_airflow.rst
@@ -35,7 +35,7 @@ We will now explain the supported methods for using Great Expectations within an
 Running validation using the ``GreatExpectationsOperator``
 -----------------------------------------------------------
 
-The ``GreatExpectationsOperator`` in the `Great Expectations Airflow Provider package <https://github.com/great-expectations/airflow-provider-great-expectations>`_ is a convenient way to invoke validation with Great Expectations in an Airflow DAG. See the `example DAG in the examples folder <https://github.com/great-expectations/airflow-provider-great-expectations/blob/main/great_expectations_provider/examples/example_great_expectations_dag.py>`_ for several methods to use the operator.
+The ``GreatExpectationsOperator`` in the `Great Expectations Airflow Provider package <https://github.com/great-expectations/airflow-provider-great-expectations>`_ is a convenient way to invoke validation with Great Expectations in an Airflow DAG. See the `example DAG in the examples folder <https://github.com/great-expectations/airflow-provider-great-expectations/blob/main/great_expectations_provider/example_dags/example_great_expectations_dag.py>`_ for several methods to use the operator.
 
 1. Ensure that the ``great_expectations`` directory that defines your Data Context is accessible by your DAG. Typically, it will be located in the same project as your DAG, but you can point the operator at any location.
 


### PR DESCRIPTION
Fix broken link to example DAG source code 

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
