### PR TITLE
[BUGFIX] Update typo in Checkpoint Slack webhook unit test

### DIFF
--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -209,7 +209,7 @@ def test_simple_checkpoint_raises_error_on_missing_slack_webhook_when_notify_on_
 def test_simple_checkpoint_raises_error_on_missing_slack_webhook_when_notify_on_is_not_default(
     empty_data_context, slack_notification_action, webhook
 ):
-    for condition in ["faliure", "success"]:
+    for condition in ["failure", "success"]:
         with pytest.raises(ValueError):
             SimpleCheckpointConfigurator(
                 "foo", empty_data_context, notify_on=condition


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Fix typo of "faliure" to "failure" in unit test (as originally proposed by @cclauss in #3064 )


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
