### PR TITLE
[BUGFIX] Fix wrong parentheses that causes a always true assertation

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1096,8 +1096,8 @@ class TableExpectation(Expectation, ABC):
                 assert min_val is None or is_parseable_date(
                     min_val
                 ), "Provided min threshold must be a dateutil-parseable date"
-                assert (
-                    max_val is None or is_parseable_date(max_val),
+                assert max_val is None or is_parseable_date(
+                    max_val
                 ), "Provided max threshold must be a dateutil-parseable date"
             else:
                 assert min_val is None or isinstance(


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix the wrong usage of parentheses that makes assertation always returns a true result.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
