### PR TITLE
Expectation anonymizer supports v3 expectation registry

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -4,6 +4,10 @@
 Changelog
 #########
 
+develop
+-----------------
+* [MAINTENANCE] Expectation anonymizer supports v3 expectation registry (#3092)
+
 0.13.23
 -----------------
 * [BUGFIX] added expectation_config to ExpectationValidationResult when exception is raised (#2659) (thanks @peterdhansen))
@@ -61,7 +65,7 @@ Changelog
 * [DOCS] Adding in url links and style (#2999)
 * [DOCS] Adding a missing import to a documentation page (#2983) (thanks @rishabh-bhargava)
 * [DOCS]/GDOC-108/GDOC-143/Add in Contributing fields and updates (#2972)
-* [DOCS] Update rule-based profiler docs (#2987)    
+* [DOCS] Update rule-based profiler docs (#2987)
 * [DOCS] add image zoom plugin (#2979)
 * [MAINTENANCE] fix lint issues for docusaurus (#3004)
 * [Maintenance] update header to match GE.io (#2811)

--- a/great_expectations/core/usage_statistics/anonymizers/expectation_suite_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/expectation_suite_anonymizer.py
@@ -1,9 +1,20 @@
 from great_expectations.core.usage_statistics.anonymizers.anonymizer import Anonymizer
 from great_expectations.dataset import Dataset
+from great_expectations.expectations.registry import (
+    list_registered_expectation_implementations,
+)
 
-GE_EXPECTATION_TYPES = [
+v2_batchkwargs_api_supported_expectation_types = [
     el for el in Dataset.__dict__.keys() if el.startswith("expect_")
 ]
+
+v3_batchrequest_api_supported_expectation_types = (
+    list_registered_expectation_implementations()
+)
+
+GE_EXPECTATION_TYPES = set(v2_batchkwargs_api_supported_expectation_types).union(
+    set(v3_batchrequest_api_supported_expectation_types)
+)
 
 
 class ExpectationSuiteAnonymizer(Anonymizer):


### PR DESCRIPTION
Changes proposed in this pull request:
- Union the v2 api list of supported expectations with the v3 api registry of supported expectations as the list of supported expectations for the `expectation_suite_anonymizer.py`
- This ensures the anonymizer will recognize v3 api only expectations.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
