### PR TITLE
[DOCS] add "select data_connector" to "Create first expectation" tutorial

### DIFF
--- a/docs/tutorials/getting_started/create_your_first_expectations.md
+++ b/docs/tutorials/getting_started/create_your_first_expectations.md
@@ -33,6 +33,11 @@ Select data_connector
     2. default_runtime_data_connector_name
 : 1
 
+Select data_connector
+    1. default_inferred_data_connector_name
+    2. default_runtime_data_connector_name
+: 1
+
 Which data asset (accessible by data connector "taxi_data_example_data_connector") would you like to use?
     1. yellow_tripdata_sample_2019-01.csv
     2. yellow_tripdata_sample_2019-02.csv

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -9,6 +9,7 @@ develop
 -----------------
 * [MAINTENANCE] Expectation anonymizer supports v3 expectation registry (#3092)
 * [FEATURE] Add sqlalchemy engine support for `column.most_common_value` metric
+* [DOCS] Add "Select data_connector" to "Create your first Expectations" tutorial
 
 
 0.13.24


### PR DESCRIPTION
Changes proposed in this pull request:
- running the v3 "create first expectation" tutorial is adding an additional step asking to select the data_connector when creating a new suite
- this change is updating the CLI output in create_your_first_expectations.md

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [X] I have made corresponding changes to the documentation

Thank you for submitting!
