### PR TITLE
[DOCS] Allow logging for docs integration tests

### DIFF
--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -39,11 +39,6 @@ __all__ = [
     ge_urn,
 ]
 
-# <WILL> this is the marker
-# logging.basicConfig(
-#     format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
-#     level=logging.DEBUG
-# )
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -39,7 +39,6 @@ __all__ = [
     ge_urn,
 ]
 
-
 logger = logging.getLogger(__name__)
 
 RESULT_FORMATS = ["BOOLEAN_ONLY", "BASIC", "COMPLETE", "SUMMARY"]

--- a/great_expectations/core/__init__.py
+++ b/great_expectations/core/__init__.py
@@ -39,6 +39,12 @@ __all__ = [
     ge_urn,
 ]
 
+# <WILL> this is the marker
+# logging.basicConfig(
+#     format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+#     level=logging.DEBUG
+# )
+
 logger = logging.getLogger(__name__)
 
 RESULT_FORMATS = ["BOOLEAN_ONLY", "BASIC", "COMPLETE", "SUMMARY"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,5 +8,5 @@ markers =
     docs: mark a test as a docs test
     integration: mark test as an integration test
 
-log_cli_format = %(asctime)s %(levelname)s %(message)s
-log_cli_date_format = %H:%M:%S
+log_cli_format = [%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s
+log_cli_date_format = %m/%d/%Y %I:%M:%S

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,6 @@ junit_family=xunit2
 markers =
     docs: mark a test as a docs test
     integration: mark test as an integration test
+
+log_cli_format = %(asctime)s %(levelname)s %(message)s
+log_cli_date_format = %H:%M:%S

--- a/tests/integration/docusaurus/connecting_to_your_data/database/util.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/util.py
@@ -1,16 +1,59 @@
+import os
+import logging
+
+#logger = logging.getLogger("tests.integration.test_script_runner")
+
+logger = logging.getLogger(__name__)
+print("~~~~~~~~~~~~~")
+print("~~~~~~~~~~~~~")
+print("~~~~~~~~~~~~~")
+print(__name__)
+print("~~~~~~~~~~~~~")
+print("~~~~~~~~~~~~~")
+print("~~~~~~~~~~~~~")
+
+
+#logger = logging.getLogger("docusaurus_logger")
+
+# logging_level = os.environ.get("DOCS_LOG_LEVEL")
+#
+# logging_level = "DEBUG"
+# if logging_level:
+#     logging.basicConfig(
+#         format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+#         level=logging_level
+#     )
+# else:
+#     logging.basicConfig(
+#         format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+#     )
+
 def load_data_into_database(
     table_name: str, csv_path: str, connection_string: str
 ) -> None:
+
     import pandas as pd
     import sqlalchemy as sa
 
+    logger.warning("Starting tests.integration.docusaurus load_data_into_database")
+
     engine = sa.create_engine(connection_string)
-    engine.execute(f"DROP TABLE IF EXISTS {table_name}")
-    print(f"Dropping table {table_name}")
-    df = pd.read_csv(csv_path)
-    df = df.head(
-        10
-    )  # <WILL> This line is here to address performance issues we have been running into with cloud resources (ie redshift). Can be taken out
-    print(f"Creating table {table_name} from {csv_path}")
-    df.to_sql(name=table_name, con=engine, index=False)
-    engine.dispose()
+    connection = engine.connect()
+    try:
+        connection.execute(f"DROP TABLE IF EXISTS {table_name}")
+        logger.debug(f"Dropping table {table_name} from database")
+        df = pd.read_csv(csv_path)
+        df = df.head(
+            10
+        )  # <WILL> This line is here to address performance issues we have been running into with cloud resources (ie redshift). Can be taken out
+        logger.debug(f"Creating table {table_name} from {csv_path}")
+        df.to_sql(name=table_name, con=engine, index=False)
+        logger.debug(f"tests.integration.docusaurus data loaded into database")
+    except Exception as e:
+        logger.error(
+            "Unexpected error in tests.integration.docusaurus load_data_into_database: "
+            + str(e)
+        )
+    finally:
+        connection.close()
+        engine.dispose()

--- a/tests/integration/docusaurus/connecting_to_your_data/database/util.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/util.py
@@ -1,32 +1,7 @@
-import os
-import logging
+from tests.integration.util import get_logger_from_config_file
 
-#logger = logging.getLogger("tests.integration.test_script_runner")
+logger = get_logger_from_config_file()
 
-logger = logging.getLogger(__name__)
-print("~~~~~~~~~~~~~")
-print("~~~~~~~~~~~~~")
-print("~~~~~~~~~~~~~")
-print(__name__)
-print("~~~~~~~~~~~~~")
-print("~~~~~~~~~~~~~")
-print("~~~~~~~~~~~~~")
-
-
-#logger = logging.getLogger("docusaurus_logger")
-
-# logging_level = os.environ.get("DOCS_LOG_LEVEL")
-#
-# logging_level = "DEBUG"
-# if logging_level:
-#     logging.basicConfig(
-#         format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
-#         level=logging_level
-#     )
-# else:
-#     logging.basicConfig(
-#         format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
-#     )
 
 def load_data_into_database(
     table_name: str, csv_path: str, connection_string: str
@@ -35,7 +10,7 @@ def load_data_into_database(
     import pandas as pd
     import sqlalchemy as sa
 
-    logger.warning("Starting tests.integration.docusaurus load_data_into_database")
+    logger.debug("Starting tests.integration.docusaurus load_data_into_database")
 
     engine = sa.create_engine(connection_string)
     connection = engine.connect()

--- a/tests/integration/logging.conf
+++ b/tests/integration/logging.conf
@@ -13,7 +13,7 @@ handlers=consoleHandler
 
 [logger_docs]
 # The following value can be modified to output log messages to console
-level=DEBUG
+level=WARNING
 qualname=docs
 handlers=consoleHandler
 
@@ -23,6 +23,6 @@ date_format = %m/%d/%Y %I:%M:%S
 
 [handler_consoleHandler]
 class=StreamHandler
-level=DEBUG
+level=WARNING
 formatter=consoleFormatter
 args=(sys.stdout,)

--- a/tests/integration/logging.conf
+++ b/tests/integration/logging.conf
@@ -8,10 +8,11 @@ keys=consoleHandler
 keys=consoleFormatter
 
 [logger_root]
-level=DEBUG
+level=WARNING
 handlers=consoleHandler
 
 [logger_docs]
+# The following value can be modified to output log messages to console
 level=DEBUG
 qualname=docs
 handlers=consoleHandler

--- a/tests/integration/logging.conf
+++ b/tests/integration/logging.conf
@@ -1,0 +1,27 @@
+[loggers]
+keys=docs, root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=consoleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler
+
+[logger_docs]
+level=DEBUG
+qualname=docs
+handlers=consoleHandler
+
+[formatter_consoleFormatter]
+format=[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s
+date_format = %m/%d/%Y %I:%M:%S
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=consoleFormatter
+args=(sys.stdout,)

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -70,29 +70,29 @@ docs_test_matrix = [
     #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
     #     "extra_backend_dependencies": BackendDependencies.REDSHIFT,
     # },
-    # {
-    #     "name": "getting_started",
-    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "user_flow_script": "tests/integration/docusaurus/tutorials/getting-started/getting_started.py",
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_python_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-    #     "extra_backend_dependencies": BackendDependencies.POSTGRESQL,
-    # },
+    {
+        "name": "getting_started",
+        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "user_flow_script": "tests/integration/docusaurus/tutorials/getting-started/getting_started.py",
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_python_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+        "extra_backend_dependencies": BackendDependencies.POSTGRESQL,
+    },
     {
         "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py",
         "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
@@ -100,82 +100,82 @@ docs_test_matrix = [
         "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
         "extra_backend_dependencies": BackendDependencies.POSTGRESQL,
     },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/snowflake_python_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-    #     "extra_backend_dependencies": BackendDependencies.SNOWFLAKE,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/snowflake_yaml_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-    #     "extra_backend_dependencies": BackendDependencies.SNOWFLAKE,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_yaml_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
-    #     "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_python_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
-    #     "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_yaml_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_python_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/template/script_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py",
-    #     "extra_backend_dependencies": BackendDependencies.SPARK,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_python_example.py",
-    #     "extra_backend_dependencies": BackendDependencies.SPARK,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "extra_backend_dependencies": BackendDependencies.SPARK,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_python_example.py",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "extra_backend_dependencies": BackendDependencies.SPARK,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_yaml_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-    #     "extra_backend_dependencies": BackendDependencies.MYSQL,
-    # },
-    # {
-    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_python_example.py",
-    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-    #     "extra_backend_dependencies": BackendDependencies.MYSQL,
-    # },
-    # {
-    #     "name": "rule_base_profiler_multi_batch_example",
-    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "user_flow_script": "tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py",
-    # },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/snowflake_python_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+        "extra_backend_dependencies": BackendDependencies.SNOWFLAKE,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/snowflake_yaml_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+        "extra_backend_dependencies": BackendDependencies.SNOWFLAKE,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_yaml_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
+        "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_python_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
+        "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_yaml_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_python_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/template/script_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py",
+        "extra_backend_dependencies": BackendDependencies.SPARK,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_python_example.py",
+        "extra_backend_dependencies": BackendDependencies.SPARK,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "extra_backend_dependencies": BackendDependencies.SPARK,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_python_example.py",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "extra_backend_dependencies": BackendDependencies.SPARK,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_yaml_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+        "extra_backend_dependencies": BackendDependencies.MYSQL,
+    },
+    {
+        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_python_example.py",
+        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+        "extra_backend_dependencies": BackendDependencies.MYSQL,
+    },
+    {
+        "name": "rule_base_profiler_multi_batch_example",
+        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "user_flow_script": "tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py",
+    },
 ]
 """
 TODO(cdkini): Kept running into a sqlalchemy.exc.OperationalError when running Snowflake tests.

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -9,6 +9,13 @@ import pytest
 from assets.scripts.build_gallery import execute_shell_command
 from great_expectations.data_context.util import file_relative_path
 
+# proposing that we are doing this:
+import logging
+logger = logging.getLogger(__name__)
+
+
+
+
 
 class BackendDependencies(enum.Enum):
     BIGQUERY = "BIGQUERY"
@@ -67,29 +74,29 @@ docs_test_matrix = [
     #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
     #     "extra_backend_dependencies": BackendDependencies.REDSHIFT,
     # },
-    {
-        "name": "getting_started",
-        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "user_flow_script": "tests/integration/docusaurus/tutorials/getting-started/getting_started.py",
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_python_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-        "extra_backend_dependencies": BackendDependencies.POSTGRESQL,
-    },
+    # {
+    #     "name": "getting_started",
+    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "user_flow_script": "tests/integration/docusaurus/tutorials/getting-started/getting_started.py",
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_python_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+    #     "extra_backend_dependencies": BackendDependencies.POSTGRESQL,
+    # },
     {
         "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py",
         "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
@@ -111,68 +118,68 @@ docs_test_matrix = [
     #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
     #     "extra_backend_dependencies": BackendDependencies.SNOWFLAKE,
     # },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_yaml_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
-        "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_python_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
-        "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_yaml_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_python_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/template/script_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py",
-        "extra_backend_dependencies": BackendDependencies.SPARK,
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_python_example.py",
-        "extra_backend_dependencies": BackendDependencies.SPARK,
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "extra_backend_dependencies": BackendDependencies.SPARK,
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_python_example.py",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "extra_backend_dependencies": BackendDependencies.SPARK,
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_yaml_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-        "extra_backend_dependencies": BackendDependencies.MYSQL,
-    },
-    {
-        "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_python_example.py",
-        "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
-        "extra_backend_dependencies": BackendDependencies.MYSQL,
-    },
-    {
-        "name": "rule_base_profiler_multi_batch_example",
-        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "user_flow_script": "tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py",
-    },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_yaml_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
+    #     "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/sqlite_python_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples/sqlite/",
+    #     "extra_backend_dependencies": BackendDependencies.SQLALCHEMY,
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_yaml_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_python_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/template/script_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py",
+    #     "extra_backend_dependencies": BackendDependencies.SPARK,
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_python_example.py",
+    #     "extra_backend_dependencies": BackendDependencies.SPARK,
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "extra_backend_dependencies": BackendDependencies.SPARK,
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_python_example.py",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "extra_backend_dependencies": BackendDependencies.SPARK,
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_yaml_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+    #     "extra_backend_dependencies": BackendDependencies.MYSQL,
+    # },
+    # {
+    #     "user_flow_script": "tests/integration/docusaurus/connecting_to_your_data/database/mysql_python_example.py",
+    #     "data_context_dir": "tests/integration/fixtures/no_datasources/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "util_script": "tests/integration/docusaurus/connecting_to_your_data/database/util.py",
+    #     "extra_backend_dependencies": BackendDependencies.MYSQL,
+    # },
+    # {
+    #     "name": "rule_base_profiler_multi_batch_example",
+    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "user_flow_script": "tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py",
+    # },
 ]
 """
 TODO(cdkini): Kept running into a sqlalchemy.exc.OperationalError when running Snowflake tests.
@@ -187,26 +194,26 @@ integration_test_matrix = [
         "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
         "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py",
     },
-    {
-        "name": "pandas_two_batch_requests_two_validators",
-        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
-        "expected_stderrs": "",
-        "expected_stdouts": "",
-    },
-    {
-        "name": "pandas_multiple_batch_requests_one_validator_multiple_steps",
-        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py",
-    },
-    {
-        "name": "pandas_multiple_batch_requests_one_validator_one_step",
-        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_one_step.py",
-    },
+    # {
+    #     "name": "pandas_two_batch_requests_two_validators",
+    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
+    #     "expected_stderrs": "",
+    #     "expected_stdouts": "",
+    # },
+    # {
+    #     "name": "pandas_multiple_batch_requests_one_validator_multiple_steps",
+    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py",
+    # },
+    # {
+    #     "name": "pandas_multiple_batch_requests_one_validator_one_step",
+    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_one_step.py",
+    # },
 ]
 
 
@@ -224,6 +231,14 @@ def pytest_parsed_arguments(request):
 @pytest.mark.parametrize("test_configuration", docs_test_matrix, ids=idfn)
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 def test_docs(test_configuration, tmp_path, pytest_parsed_arguments):
+    print("~~~~~~~~~~~~~")
+    print("~~~~~~~~~~~~~")
+    print("~~~~~~~~~~~~~")
+    print(__name__)
+    print("~~~~~~~~~~~~~")
+    print("~~~~~~~~~~~~~")
+    print("~~~~~~~~~~~~~")
+
     _check_for_skipped_tests(pytest_parsed_arguments, test_configuration)
     _execute_integration_test(test_configuration, tmp_path)
 
@@ -253,6 +268,7 @@ def _execute_integration_test(test_configuration, tmp_path):
         )
         os.chdir(tmp_path)
         # Ensure GE is installed in our environment
+        logger.debug("Docusaurus test is installing GE")
         ge_requirement = test_configuration.get("ge_requirement", "great_expectations")
         execute_shell_command(f"pip install {ge_requirement}")
 
@@ -261,6 +277,7 @@ def _execute_integration_test(test_configuration, tmp_path):
         #
 
         # DataContext
+        logger.debug("Docusaurus test is copying DataContext folder")
         if test_configuration.get("data_context_dir"):
             context_source_dir = os.path.join(
                 base_dir, test_configuration.get("data_context_dir")
@@ -271,7 +288,9 @@ def _execute_integration_test(test_configuration, tmp_path):
                 test_context_dir,
             )
 
+
         # Test Data
+        logger.debug("Docusaurus test is copying test data folder")
         if test_configuration.get("data_dir") is not None:
             source_data_dir = os.path.join(base_dir, test_configuration.get("data_dir"))
             test_data_dir = os.path.join(tmp_path, "data")
@@ -289,6 +308,8 @@ def _execute_integration_test(test_configuration, tmp_path):
         shutil.copyfile(script_source, script_path)
 
         # Util Script
+        logger.debug("Docusaurus test is copying util_script.py for database tests")
+
         if test_configuration.get("util_script") is not None:
             script_source = os.path.join(
                 base_dir,
@@ -300,13 +321,20 @@ def _execute_integration_test(test_configuration, tmp_path):
         # Check initial state
 
         # Execute test
+
+        # this is what is preventing a lot of this from happening??
+        # how do you have the configure the logging.
         res = subprocess.run(["python", script_path], capture_output=True)
+        #res = subprocess.call(["python", script_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
         # Check final state
         expected_stderrs = test_configuration.get("expected_stderrs")
         expected_stdouts = test_configuration.get("expected_stdouts")
         expected_failure = test_configuration.get("expected_failure")
         outs = res.stdout.decode("utf-8")
         errs = res.stderr.decode("utf-8")
+        #res.stderr.close()
+        #res.stdout.close()
         print(outs)
         print(errs)
 

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -190,26 +190,26 @@ integration_test_matrix = [
         "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
         "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/one_multi_batch_request_one_validator.py",
     },
-    # {
-    #     "name": "pandas_two_batch_requests_two_validators",
-    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
-    #     "expected_stderrs": "",
-    #     "expected_stdouts": "",
-    # },
-    # {
-    #     "name": "pandas_multiple_batch_requests_one_validator_multiple_steps",
-    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py",
-    # },
-    # {
-    #     "name": "pandas_multiple_batch_requests_one_validator_one_step",
-    #     "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
-    #     "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
-    #     "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_one_step.py",
-    # },
+    {
+        "name": "pandas_two_batch_requests_two_validators",
+        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/two_batch_requests_two_validators.py",
+        "expected_stderrs": "",
+        "expected_stdouts": "",
+    },
+    {
+        "name": "pandas_multiple_batch_requests_one_validator_multiple_steps",
+        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_multiple_steps.py",
+    },
+    {
+        "name": "pandas_multiple_batch_requests_one_validator_one_step",
+        "data_context_dir": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/great_expectations",
+        "data_dir": "tests/test_sets/taxi_yellow_trip_data_samples",
+        "user_flow_script": "tests/integration/fixtures/yellow_trip_data_pandas_fixture/multiple_batch_requests_one_validator_one_step.py",
+    },
 ]
 
 
@@ -308,11 +308,7 @@ def _execute_integration_test(test_configuration, tmp_path):
         # Check initial state
 
         # Execute test
-
-        # this is what is preventing a lot of this from happening??
-        # how do you have the configure the logging.
         res = subprocess.run(["python", script_path], capture_output=True)
-        # res = subprocess.call(["python", script_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         # Check final state
         expected_stderrs = test_configuration.get("expected_stderrs")
@@ -320,8 +316,6 @@ def _execute_integration_test(test_configuration, tmp_path):
         expected_failure = test_configuration.get("expected_failure")
         outs = res.stdout.decode("utf-8")
         errs = res.stderr.decode("utf-8")
-        # res.stderr.close()
-        # res.stdout.close()
         print(outs)
         print(errs)
 

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -8,13 +8,9 @@ import pytest
 
 from assets.scripts.build_gallery import execute_shell_command
 from great_expectations.data_context.util import file_relative_path
+from tests.integration.util import get_logger_from_config_file
 
-# proposing that we are doing this:
-import logging
-logger = logging.getLogger(__name__)
-
-
-
+logger = get_logger_from_config_file()
 
 
 class BackendDependencies(enum.Enum):
@@ -231,14 +227,6 @@ def pytest_parsed_arguments(request):
 @pytest.mark.parametrize("test_configuration", docs_test_matrix, ids=idfn)
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python3.7")
 def test_docs(test_configuration, tmp_path, pytest_parsed_arguments):
-    print("~~~~~~~~~~~~~")
-    print("~~~~~~~~~~~~~")
-    print("~~~~~~~~~~~~~")
-    print(__name__)
-    print("~~~~~~~~~~~~~")
-    print("~~~~~~~~~~~~~")
-    print("~~~~~~~~~~~~~")
-
     _check_for_skipped_tests(pytest_parsed_arguments, test_configuration)
     _execute_integration_test(test_configuration, tmp_path)
 
@@ -288,7 +276,6 @@ def _execute_integration_test(test_configuration, tmp_path):
                 test_context_dir,
             )
 
-
         # Test Data
         logger.debug("Docusaurus test is copying test data folder")
         if test_configuration.get("data_dir") is not None:
@@ -325,7 +312,7 @@ def _execute_integration_test(test_configuration, tmp_path):
         # this is what is preventing a lot of this from happening??
         # how do you have the configure the logging.
         res = subprocess.run(["python", script_path], capture_output=True)
-        #res = subprocess.call(["python", script_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        # res = subprocess.call(["python", script_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         # Check final state
         expected_stderrs = test_configuration.get("expected_stderrs")
@@ -333,8 +320,8 @@ def _execute_integration_test(test_configuration, tmp_path):
         expected_failure = test_configuration.get("expected_failure")
         outs = res.stdout.decode("utf-8")
         errs = res.stderr.decode("utf-8")
-        #res.stderr.close()
-        #res.stdout.close()
+        # res.stderr.close()
+        # res.stdout.close()
         print(outs)
         print(errs)
 

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,0 +1,11 @@
+import logging
+import os
+from logging import config
+
+dirname = os.path.dirname(__file__)
+
+
+def get_logger_from_config_file():
+    config.fileConfig(os.path.join(dirname, "logging.conf"))
+    logger = logging.getLogger("docs")
+    return logger


### PR DESCRIPTION
# What is the purpose of this PR?

This PR enables logging for DOCS integration tests and other integration tests that are run with `test_script_runner.py`. It is not intended to be a complete implementation of logging for all DOCS integration tests, but serve as a framework that can be iterated upon.

Currently logging for Great Expectations is most-often handled at the module-level, using the following convention:

```python
logger = logging.getLogger(__name__)
```
This means that logger names track the package/module hierarchy, and it’s intuitively obvious where events are logged just from the logger name. [Relevant Stack Overflow](https://stackoverflow.com/questions/50714316/how-to-use-logging-getlogger-name-in-multiple-modules)

Although this is a helpful approach in most cases, the scripts for DOCS integration tests are run as `subprocess` in `test_script_runner.py`. Therefore the log settings do not get passed in to each individual subprocess. This has introduced a number of challenges, especially when it comes to debugging the scripts for DOC integration tests.

# Proposed solution

We propose to store the configuration information for a named logger, `docs`, in a configuration file: `logging.conf` that lives in the `/tests/integration` folder.

The configuration will allow the logging level to be set for all files that load the `docs` logger, and output log messages to the console.  The configuration information is loaded by a helper function `get_logger_from_config_file()`, which is located in ``/tests/integration/util.py`.  The logging configuration can be loaded by each subprocess by calling:

```python
  logger = get_logger_from_config_file()

  # logging a DEBUG message using the docs logger
  logger.debug("Hello I am a debug message")
```

# How to use the logging information :

If you would like to view DEBUG messages, then the following line can be changed to `DEBUG` in `logging.conf` (default value is `WARNING`)

```
[logger_docs]
level=DEBUG 
qualname=docs
handlers=consoleHandler
```

When you run `pytest`, you'll begin seeing messages like this:

```console
[2021-07-27 16:00:21,759] {test_script_runner.py:259} DEBUG - Docusaurus test is installing GE
[2021-07-27 16:00:21,759] {test_script_runner.py:259} DEBUG - Docusaurus test is installing GE
[2021-07-27 16:00:26,641] {test_script_runner.py:268} DEBUG - Docusaurus test is copying DataContext folder
```

**NOTE** : Changing this setting will only affect the `docs` logger, which means messages will only appear from files where the logger was loaded by using:

```python
logger = get_logger_from_config_file()
```

To use it in conjunction with the module-level logger describe above, we can pass in the following parameters to pytest:

```pytest --log-cli-level=DEBUG [other pytest settings]```

### Definition of Done
- Closes GE-392
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

Thank you for submitting!