### PR TITLE
[BUGFIX] Added newline to CLI message for consistent formatting

### DIFF
--- a/great_expectations/cli/batch_request.py
+++ b/great_expectations/cli/batch_request.py
@@ -138,7 +138,7 @@ def select_data_connector_name(
             for i, data_connector_name in enumerate(data_connector_names, 1)
         ]
     )
-choices += "\n" # Necessary for consistent spacing between prompts
+    choices += "\n"  # Necessary for consistent spacing between prompts
     option_selection: str = click.prompt(
         msg_prompt_select_data_connector_name + "\n" + choices,
         type=click.Choice(

--- a/great_expectations/cli/batch_request.py
+++ b/great_expectations/cli/batch_request.py
@@ -137,7 +137,7 @@ def select_data_connector_name(
             f"    {i}. {data_connector_name}"
             for i, data_connector_name in enumerate(data_connector_names, 1)
         ]
-    )
+    ) + "/n"
     option_selection: str = click.prompt(
         msg_prompt_select_data_connector_name + "\n" + choices,
         type=click.Choice(

--- a/great_expectations/cli/batch_request.py
+++ b/great_expectations/cli/batch_request.py
@@ -137,7 +137,7 @@ def select_data_connector_name(
             f"    {i}. {data_connector_name}"
             for i, data_connector_name in enumerate(data_connector_names, 1)
         ]
-    ) + "/n"
+    ) + "\n"
     option_selection: str = click.prompt(
         msg_prompt_select_data_connector_name + "\n" + choices,
         type=click.Choice(

--- a/great_expectations/cli/batch_request.py
+++ b/great_expectations/cli/batch_request.py
@@ -137,7 +137,8 @@ def select_data_connector_name(
             f"    {i}. {data_connector_name}"
             for i, data_connector_name in enumerate(data_connector_names, 1)
         ]
-    ) + "\n"
+    )
+choices += "\n" # Necessary for consistent spacing between prompts
     option_selection: str = click.prompt(
         msg_prompt_select_data_connector_name + "\n" + choices,
         type=click.Choice(

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -213,7 +213,7 @@ def _process_suite_new_flags_and_prompt(
             interactive = True
     else:
         suite_create_method: str = click.prompt(
-            """\
+            """
 How would you like to create your Expectation Suite?
     1. Manually, without interacting with a sample batch of data (default)
     2. Interactively, with a sample batch of data
@@ -521,7 +521,7 @@ options can be used.
             interactive = True
     else:
         suite_edit_method: str = click.prompt(
-            """\
+            """
 How would you like to edit your Expectation Suite?
     1. Manually, without interacting with a sample batch of data (default)
     2. Interactively, with a sample batch of data

--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -905,7 +905,7 @@ def get_batch_request_using_datasource_name(
     ] = None,
 ) -> Optional[Union[str, Dict[str, Union[str, int, Dict[str, Any]]]]]:
     cli_message(
-        string="A batch of data is required to edit the suite - let's help you to specify it."
+        string="\nA batch of data is required to edit the suite - let's help you to specify it."
     )
 
     datasource: BaseDatasource = select_datasource(

--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -905,7 +905,7 @@ def get_batch_request_using_datasource_name(
     ] = None,
 ) -> Optional[Union[str, Dict[str, Union[str, int, Dict[str, Any]]]]]:
     cli_message(
-        string="\nA batch of data is required to edit the suite - let's help you to specify it."
+        string="\nA batch of data is required to edit the suite - let's help you to specify it.\n"
     )
 
     datasource: BaseDatasource = select_datasource(

--- a/scripts/trace_docs_deps.py
+++ b/scripts/trace_docs_deps.py
@@ -35,7 +35,7 @@ from typing import List, Set
 
 
 def find_docusaurus_refs(dir: str) -> List[str]:
-    """ Finds any Docusaurus links within a target directory (i.e. ```python file=...#L10-20) """
+    """Finds any Docusaurus links within a target directory (i.e. ```python file=...#L10-20)"""
     linked_files: Set[str] = set()
     pattern: str = (
         r"\`\`\`[a-zA-Z]+ file"  # Format of internal links used by Docusaurus
@@ -58,7 +58,7 @@ def _parse_file_from_docusaurus_link(line: str) -> str:
 
 
 def get_local_imports(files: List[str]) -> List[str]:
-    """ Parses a list of files to determine local imports; external dependencies are discarded """
+    """Parses a list of files to determine local imports; external dependencies are discarded"""
     imports: Set[str] = set()
 
     for file in files:
@@ -82,7 +82,7 @@ def get_local_imports(files: List[str]) -> List[str]:
 
 
 def get_import_paths(imports: List[str]) -> List[str]:
-    """ Takes a list of imports and determines the relative path to each source file or module """
+    """Takes a list of imports and determines the relative path to each source file or module"""
     paths: List[str] = []
 
     for imp in imports:

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -3098,7 +3098,7 @@ def suite_new_messages():
         "warning_profile": "Warning: Ignoring the --manual flag and entering interactive mode since you passed the --profile flag",
         "happy_path_batch_request": "Entering interactive mode since you passed the --batch-request flag",
         "warning_batch_request": "Warning: Ignoring the --manual flag and entering interactive mode since you passed the --batch-request flag",
-        "happy_path_prompt_call": """\
+        "happy_path_prompt_call": """
 How would you like to create your Expectation Suite?
     1. Manually, without interacting with a sample batch of data (default)
     2. Interactively, with a sample batch of data
@@ -3468,7 +3468,7 @@ def suite_edit_messages():
         "warning_datasource_name": "Warning: Ignoring the --manual flag and entering interactive mode since you passed the --datasource-name flag",
         "happy_path_batch_request": "Entering interactive mode since you passed the --batch-request flag",
         "warning_batch_request": "Warning: Ignoring the --manual flag and entering interactive mode since you passed the --batch-request flag",
-        "happy_path_prompt_call": """\
+        "happy_path_prompt_call": """
 How would you like to edit your Expectation Suite?
     1. Manually, without interacting with a sample batch of data (default)
     2. Interactively, with a sample batch of data


### PR DESCRIPTION
Adding newlines to some of the CLI prompts when creating/editing a new Expectation Suite
`great_expectations --v3-api suite new`
This is a trivial change, and mainly to have a consistent format between the steps while creating a new Expectation Suite

Changes proposed in this pull request:
- Adding newline characters to the CLI prompt in creating an Expectation Suite, for consistent formatting (`A batch of data...`)
- Adding newline before create and edit Expectation Suite prompts (and modified suite_new and suite_edit tests to match the new prompts) (`How would you like...`)
- Putting colon prompt during `Select data_connector` step to a newline

![newline_formatting](https://user-images.githubusercontent.com/58870992/127428787-3baa9f2a-d025-4cf0-9bd7-9dccede8530f.png)

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have added unit tests where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
