### PR TITLE
[MAINTENANCE] Improve Coding Practices in "great_expectations/expectations/expectation.py"

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1343,20 +1343,18 @@ class ColumnMapExpectation(TableExpectation, ABC):
         unexpected_values = metrics.get(self.map_metric + ".unexpected_values")
         unexpected_index_list = metrics.get(self.map_metric + ".unexpected_index_list")
 
-        if total_count is None:
-            nonnull_count = None
+        if total_count is None or null_count is None:
+            total_count = nonnull_count = 0
         else:
             nonnull_count = total_count - null_count
 
         success = None
-        if total_count is None or null_count is None:
+        if total_count == 0 or nonnull_count == 0:
             # Vacuously true
             success = True
         elif nonnull_count > 0:
             success_ratio = float(nonnull_count - unexpected_count) / nonnull_count
             success = success_ratio >= mostly
-        elif total_count == 0 or nonnull_count == 0:
-            success = True
 
         return _format_map_output(
             result_format=parse_result_format(result_format),
@@ -1538,20 +1536,18 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
         null_count = metrics.get("column_values.nonnull.unexpected_count")
         unexpected_count = metrics.get(self.map_metric + ".unexpected_count")
 
-        if total_count is None:
-            nonnull_count = None
+        if total_count is None or null_count is None:
+            total_count = nonnull_count = 0
         else:
             nonnull_count = total_count - null_count
 
         success = None
-        if total_count is None or null_count is None:
+        if total_count == 0 or nonnull_count == 0:
             # Vacuously true
             success = True
         elif nonnull_count > 0:
             success_ratio = float(nonnull_count - unexpected_count) / nonnull_count
             success = success_ratio >= mostly
-        elif total_count == 0 or nonnull_count == 0:
-            success = True
 
         return _format_map_output(
             result_format=parse_result_format(result_format),

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1340,36 +1340,32 @@ class ColumnMapExpectation(TableExpectation, ABC):
         total_count = metrics.get("table.row_count")
         null_count = metrics.get("column_values.nonnull.unexpected_count")
         unexpected_count = metrics.get(self.map_metric + ".unexpected_count")
+        unexpected_values = metrics.get(self.map_metric + ".unexpected_values")
+        unexpected_index_list = metrics.get(self.map_metric + ".unexpected_index_list")
+
+        if total_count is None:
+            nonnull_count = None
+        else:
+            nonnull_count = total_count - null_count
 
         success = None
         if total_count is None or null_count is None:
             # Vacuously true
             success = True
-        elif (total_count - null_count) != 0:
-            success_ratio = (total_count - unexpected_count - null_count) / (
-                total_count - null_count
-            )
+        elif nonnull_count > 0:
+            success_ratio = float(nonnull_count - unexpected_count) / nonnull_count
             success = success_ratio >= mostly
-        elif total_count == 0 or (total_count - null_count) == 0:
+        elif total_count == 0 or nonnull_count == 0:
             success = True
-
-        try:
-            nonnull_count = metrics.get("table.row_count") - metrics.get(
-                "column_values.nonnull.unexpected_count"
-            )
-        except TypeError:
-            nonnull_count = None
 
         return _format_map_output(
             result_format=parse_result_format(result_format),
             success=success,
-            element_count=metrics.get("table.row_count"),
+            element_count=total_count,
             nonnull_count=nonnull_count,
-            unexpected_count=metrics.get(self.map_metric + ".unexpected_count"),
-            unexpected_list=metrics.get(self.map_metric + ".unexpected_values"),
-            unexpected_index_list=metrics.get(
-                self.map_metric + ".unexpected_index_list"
-            ),
+            unexpected_count=unexpected_count,
+            unexpected_list=unexpected_values,
+            unexpected_index_list=unexpected_index_list,
         )
 
 
@@ -1542,24 +1538,20 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
         null_count = metrics.get("column_values.nonnull.unexpected_count")
         unexpected_count = metrics.get(self.map_metric + ".unexpected_count")
 
+        if total_count is None:
+            nonnull_count = None
+        else:
+            nonnull_count = total_count - null_count
+
         success = None
         if total_count is None or null_count is None:
             # Vacuously true
             success = True
-        elif (total_count - null_count) != 0:
-            success_ratio = (total_count - unexpected_count - null_count) / (
-                total_count - null_count
-            )
+        elif nonnull_count > 0:
+            success_ratio = float(nonnull_count - unexpected_count) / nonnull_count
             success = success_ratio >= mostly
-        elif total_count == 0 or (total_count - null_count) == 0:
+        elif total_count == 0 or nonnull_count == 0:
             success = True
-
-        try:
-            nonnull_count = metrics.get("table.row_count") - metrics.get(
-                "column_values.nonnull.unexpected_count"
-            )
-        except TypeError:
-            nonnull_count = None
 
         return _format_map_output(
             result_format=parse_result_format(result_format),


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GE-320/GE-432
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
