### PR TITLE
[DOCS] Document that run_validation_operator doesn't work with V3 API

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 develop
 -----------------
 * [FEATURE] Enable BigQuery tests for Azure CI/CD #3155
-* [DOCS] Document that run_validation_operator doesn't work with v3 API
+* [DOCS] Document that run_validation_operator doesn't work with v3 API (#3168)
 * [BUGFIX] Snowflake connections are closed correctly by DOCS tests (#3104)
 * [BUGFIX] V2 API CLI now allows files to be read that require extra `reader_options` passed.  For instance `.csv.gz` files from S3. (#2695)
 

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 develop
 -----------------
 * [FEATURE] Enable BigQuery tests for Azure CI/CD #3155
+* [DOCS] Document that run_validation_operator doesn't work with v3 API
 * [BUGFIX] Snowflake connections are closed correctly by DOCS tests (#3104)
 * [BUGFIX] V2 API CLI now allows files to be read that require extra `reader_options` passed.  For instance `.csv.gz` files from S3. (#2695)
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1317,6 +1317,10 @@ class BaseDataContext:
         Run a validation operator to validate data assets and to perform the business logic around
         validation that the operator implements.
 
+        Note: This method will be deprecated along with the rest of the V2 (Batch Kwargs) API and "run_checkpoint"
+        should be used instead. This method currently only works with the V2 (Batch Kwargs) API and doesn't work with
+        the V3 (Batch Request) API.
+
         Args:
             validation_operator_name: name of the operator, as appears in the context's config file
             assets_to_validate: a list that specifies the data assets that the operator will validate. The members of


### PR DESCRIPTION
Resolves #3168.

See discussion on bug #3168 and in slack at https://greatexpectationstalk.slack.com/archives/CUTCNHN82/p1628003234044100

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation