### PR TITLE
[DOCS] Capitalize python to Python in new docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@ title: Changelog
 * [FEATURE] Pass on meta-data from expectation json to validation result json (#2881) (Thanks @sushrut9898)
 * [FEATURE] Add sqlalchemy engine support for `column.most_common_value` metric (#3020) (Thanks @shpolina)
 * [BUGFIX] Added newline to CLI message for consistent formatting (#3127) (Thanks @ismaildawoodjee)
-* [BUGFIX] fix pip install snowflake build error with python 3.9 (#3119) (Thanks @jdimatteo)
+* [BUGFIX] fix pip install snowflake build error with Python 3.9 (#3119) (Thanks @jdimatteo)
 * [BUGFIX] Populate (data) asset name in data docs for RuntimeDataConnector (#3105) (Thanks @ceshine)
 * [DOCS] Correct path to docs_rtd/changelog.rst (#3120) (Thanks @jdimatteo)
 * [DOCS] Fix broken links in "How to write a 'How to Guide'" (#3112)

--- a/docs/contributing/contributing_setup.md
+++ b/docs/contributing/contributing_setup.md
@@ -45,7 +45,7 @@ In order to contribute to Great Expectations, you will need the following:
 
 * We do not currently follow a strict naming convention for branches. Please pick something clear and self-explanatory, so that it will be easy for others to get the gist of your work.
 
-### Install python dependencies
+### Install Python dependencies
 
 #### 5. Create a new virtual environment
 
@@ -63,7 +63,7 @@ This is not required, but highly recommended.
 
 * MacOS users will be able to pip / pip3 install `requirements-dev.txt` using the above command from within conda, yet Windows users utilizing a conda environment will need to individually install all files within requirements-dev.txt
 
-* This will ensure that sure you have the right libraries installed in your python environment.
+* This will ensure that sure you have the right libraries installed in your Python environment.
 
 	* Note that you can also substitute requirements-dev-test.txt to only install requirements required for testing all backends, and requirements-dev-spark.txt or requirements-dev-sqlalchemy.txt if you would like to add support for spark or sqlalchemy tests, respectively. For some database backends, such as MSSQL additional driver installation may required in your environment; see below for more information.
 

--- a/docs/deployment_patterns/how_to_run_a_checkpoint_in_airflow.md
+++ b/docs/deployment_patterns/how_to_run_a_checkpoint_in_airflow.md
@@ -46,7 +46,7 @@ Another option is to use the output of the `great_expectations --v3-api checkpoi
 
     ...
 
-    A python script was created that runs the checkpoint named: `my_checkpoint`
+    A Python script was created that runs the checkpoint named: `my_checkpoint`
     - The script is located in `great_expectations/uncommitted/my_checkpoint.py`
     - The script can be run with `python great_expectations/uncommitted/my_checkpoint.py`
     ```

--- a/docs/guides/connecting_to_your_data/components/where_to_run_code.md
+++ b/docs/guides/connecting_to_your_data/components/where_to_run_code.md
@@ -22,7 +22,7 @@ great_expectations --v3-api datasource new
 </TabItem>
 <TabItem value="yaml">
 
-If you use Great Expectations in an environment that has filesystem access, and prefer not to use the CLI, run the code in this guide in a notebook or other python script.
+If you use Great Expectations in an environment that has filesystem access, and prefer not to use the CLI, run the code in this guide in a notebook or other Python script.
 
 See [🍏 CORE SKILL ICON How to instantiate a Data Context](#) for details.
 

--- a/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
+++ b/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
@@ -154,7 +154,7 @@ The value of `examples` is a list of examples.
 
 Each example is a dictionary with two keys:
 
-* `data`: defines the input data of the example as a table/data frame. In this example the table has one column named “mostly_threes” with 10 rows. If you define multiple columns, make sure that they have the same number of rows. If possible, include test data and tests that includes null values (None in the python test definition).
+* `data`: defines the input data of the example as a table/data frame. In this example the table has one column named “mostly_threes” with 10 rows. If you define multiple columns, make sure that they have the same number of rows. If possible, include test data and tests that includes null values (None in the Python test definition).
 
 * `tests`: a list of test cases that use the data defined above as input to validate
 	* `title` should be a descriptive name for the test case. Make sure to have no spaces.

--- a/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_expectations.md
+++ b/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_expectations.md
@@ -212,7 +212,7 @@ It is often helpful to generate examples showing the functionality of your Expec
 
 If you plan on contributing your Expectation back to the library of main Expectations, you should build a JSON test for it in the `tests/test_definitions/name_of_your_expectation directory`.
 
-#### 7. Import: To use a custom Expectation, you need to ensure it has been imported into the running python interpreter. While including the module in your plugins/ directory will make it *available* to import, you must still import the Expectation:
+#### 7. Import: To use a custom Expectation, you need to ensure it has been imported into the running Python interpreter. While including the module in your plugins/ directory will make it *available* to import, you must still import the Expectation:
 
 ````python
 # get a validator

--- a/docs/guides/miscellaneous/how_to_write_a_how_to_guide.md
+++ b/docs/guides/miscellaneous/how_to_write_a_how_to_guide.md
@@ -110,7 +110,7 @@ If the user has data in Mongo and wants to configure a Datasource, no additional
 ```
 
 :::warning
-Make sure that you lint your script before you finalize the line numbers in your Markdown file. This will prevent unintended line changes and save you pain when the linter changes your python file without you realizing it.
+Make sure that you lint your script before you finalize the line numbers in your Markdown file. This will prevent unintended line changes and save you pain when the linter changes your Python file without you realizing it.
 
 :::
 - Most steps will also require user input, such as a connection string that needs to be replaced, or a step that allows for testing (such as running `test_yaml_config()`).

--- a/docs/guides/setup/installation/local.md
+++ b/docs/guides/setup/installation/local.md
@@ -6,7 +6,7 @@ import Congratulations from '/docs/guides/setup/components/install_congrats.md'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This guide will help you Install Great Expectations locally for use with python
+This guide will help you Install Great Expectations locally for use with Python
 
 ## Steps
 
@@ -16,7 +16,7 @@ First, check that you have python3 with pip installed
 
 ```console
 python --version
-# or if multiple versions of python installed
+# or if multiple versions of Python installed
 python3 --version
 python3 -m pip --version
 ```

--- a/docs/reference/expectations/expectations.md
+++ b/docs/reference/expectations/expectations.md
@@ -3,7 +3,7 @@ title: Expectations
 ---
 
 
-An Expectation is a statement describing a verifiable property of data. Like assertions in traditional python unit
+An Expectation is a statement describing a verifiable property of data. Like assertions in traditional Python unit
 tests, Expectations provide a flexible, declarative language for describing expected behavior. Unlike traditional unit
 tests, Great Expectations applies Expectations to data instead of code.
 


### PR DESCRIPTION
Changes proposed in this pull request:
- `python` refers to the interpreter and CLI utility while `Python` refers to the official name of the language. Perhaps a bit pedantic but changes here reflect these two different usages accurately.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.