### PR TITLE
[BUGFIX] Fixed broken link in Docusaurus Getting Started Tutorial

### DIFF
--- a/docs/tutorials/getting_started/validate_your_data.md
+++ b/docs/tutorials/getting_started/validate_your_data.md
@@ -70,4 +70,4 @@ In this tutorial, we have covered the following basic capabilities of Great Expe
 As a final, **optional step**, you can check out the next section on how to customize your deployment in order to configure options such as where to store Expectations, validation results, and Data Docs. And if you want to stop here, feel free to join our [Slack community](https://greatexpectations.io/slack) to say hi to fellow Great Expectations users in the **#beginners** channel!
 
 Also, if you would like to view the full script used in this Tutorial, see it on GitHub:
-  - [getting_started.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/tutorials/getting_started/getting_started.py)
+  - [getting_started.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/tutorials/getting-started/getting_started.py)


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed broken link in Getting Started Tutorial 
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
