### PR TITLE
[ENHANCEMENT] RuntimeDataConnector messaging is made more clear for `test_yaml_config()`

### DIFF
--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -205,6 +205,9 @@ class DataConnector:
             pretty_print (bool): should the output be printed?
             max_examples (int): how many data_references should be printed?
 
+        Returns:
+            report_obj (dict): dictionary containing self_check output
+
         """
         if len(self._data_references_cache) == 0:
             self._refresh_data_references_cache()
@@ -254,10 +257,8 @@ class DataConnector:
         len_unmatched_data_references = len(unmatched_data_references)
         if pretty_print:
             print(
-                f"\n\tUnmatched data_references ({min(len_unmatched_data_references, max_examples)} of {len_unmatched_data_references}):",
-                unmatched_data_references[:max_examples],
+                f"\n\tUnmatched data_references ({min(len_unmatched_data_references, max_examples)} of {len_unmatched_data_references}):{unmatched_data_references[:max_examples]}\n"
             )
-            print()
 
         report_obj["unmatched_data_reference_count"] = len_unmatched_data_references
         report_obj["example_unmatched_data_references"] = unmatched_data_references[

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -257,6 +257,7 @@ class DataConnector:
                 f"\n\tUnmatched data_references ({min(len_unmatched_data_references, max_examples)} of {len_unmatched_data_references}):",
                 unmatched_data_references[:max_examples],
             )
+            print()
 
         report_obj["unmatched_data_reference_count"] = len_unmatched_data_references
         report_obj["example_unmatched_data_references"] = unmatched_data_references[

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -323,10 +323,11 @@ appear among the configured batch identifiers.
             pretty_print (bool): should the output be printed?
             max_examples (int): how many data_references should be printed?
 
+        Returns:
+            report_obj (dict): dictionary containing self_check output
         """
         if pretty_print:
-            print("\t" + self.name, ":", self.__class__.__name__)
-            print()
+            print(f"\t{self.name}:{self.__class__.__name__}\n")
         asset_names = self.get_available_data_asset_names()
         asset_names.sort()
         len_asset_names = len(asset_names)
@@ -343,7 +344,6 @@ appear among the configured batch identifiers.
             print(
                 f"\tAvailable data_asset_names ({min(len_asset_names, max_examples)} of {len_asset_names}):"
             )
-        if pretty_print:
             print(
                 "\t\t"
                 + "Note : RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest"
@@ -353,11 +353,10 @@ appear among the configured batch identifiers.
         len_unmatched_data_references = len(unmatched_data_references)
 
         if pretty_print:
-            print(
-                f"\n\tUnmatched data_references ({min(len_unmatched_data_references, max_examples)} of {len_unmatched_data_references}):",
-                unmatched_data_references[:max_examples],
-            )
-            print()
+            if pretty_print:
+                print(
+                    f"\n\tUnmatched data_references ({min(len_unmatched_data_references, max_examples)} of {len_unmatched_data_references}): {unmatched_data_references[:max_examples]}\n"
+                )
         report_obj["unmatched_data_reference_count"] = len_unmatched_data_references
         report_obj["example_unmatched_data_references"] = unmatched_data_references[
             :max_examples

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -316,7 +316,9 @@ appear among the configured batch identifiers.
         3. also print unmatched data_references, and allow the user to modify the regex or glob configuration if necessary
 
         However, in the case of the RuntimeDataConnector there is no example data_asset_names until the data is passed
-        in through the RuntimeBatchRequest. Therefore, there will be a
+        in through the RuntimeBatchRequest. Therefore, there will be a note displayed to the user saying that
+        RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest.
+
         Args:
             pretty_print (bool): should the output be printed?
             max_examples (int): how many data_references should be printed?
@@ -349,10 +351,16 @@ appear among the configured batch identifiers.
 
         unmatched_data_references = self.get_unmatched_data_references()
         len_unmatched_data_references = len(unmatched_data_references)
+
         if pretty_print:
             print(
                 f"\n\tUnmatched data_references ({min(len_unmatched_data_references, max_examples)} of {len_unmatched_data_references}):",
                 unmatched_data_references[:max_examples],
             )
             print()
+        report_obj["unmatched_data_reference_count"] = len_unmatched_data_references
+        report_obj["example_unmatched_data_references"] = unmatched_data_references[
+            :max_examples
+        ]
+
         return report_obj

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -334,7 +334,7 @@ appear among the configured batch identifiers.
             "data_asset_count": len_asset_names,
             "example_data_asset_names": asset_names[:max_examples],
             "data_assets": {},
-            "note": "RuntimeDataConnector will not have data asset until passed in through RuntimeBatchRequest"
+            "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest"
             # "data_reference_count": self.
         }
         if pretty_print:

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -305,3 +305,54 @@ class RuntimeDataConnector(DataConnector):
 appear among the configured batch identifiers.
                     """
                 )
+
+    def self_check(self, pretty_print=True, max_examples=3):
+        """
+        Overrides the self_check method for RuntimeDataConnector. Normally the `self_check()` method will check
+        the configuration of the DataConnector by doing the following :
+
+        1. refresh or create data_reference_cache
+        2. print batch_definition_count and example_data_references for each data_asset_names
+        3. also print unmatched data_references, and allow the user to modify the regex or glob configuration if necessary
+
+        However, in the case of the RuntimeDataConnector there is no example data_asset_names until the data is passed
+        in through the RuntimeBatchRequest. Therefore, there will be a
+        Args:
+            pretty_print (bool): should the output be printed?
+            max_examples (int): how many data_references should be printed?
+
+        """
+        if pretty_print:
+            print("\t" + self.name, ":", self.__class__.__name__)
+            print()
+        asset_names = self.get_available_data_asset_names()
+        asset_names.sort()
+        len_asset_names = len(asset_names)
+
+        report_obj = {
+            "class_name": self.__class__.__name__,
+            "data_asset_count": len_asset_names,
+            "example_data_asset_names": asset_names[:max_examples],
+            "data_assets": {},
+            "note": "RuntimeDataConnector will not have data asset until passed in through RuntimeBatchRequest"
+            # "data_reference_count": self.
+        }
+        if pretty_print:
+            print(
+                f"\tAvailable data_asset_names ({min(len_asset_names, max_examples)} of {len_asset_names}):"
+            )
+        if pretty_print:
+            print(
+                "\t\t"
+                + "Note : RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest"
+            )
+
+        unmatched_data_references = self.get_unmatched_data_references()
+        len_unmatched_data_references = len(unmatched_data_references)
+        if pretty_print:
+            print(
+                f"\n\tUnmatched data_references ({min(len_unmatched_data_references, max_examples)} of {len_unmatched_data_references}):",
+                unmatched_data_references[:max_examples],
+            )
+            print()
+        return report_obj

--- a/tests/data_context/test_data_context_test_yaml_config.py
+++ b/tests/data_context/test_data_context_test_yaml_config.py
@@ -1101,7 +1101,14 @@ def test_golden_path_runtime_data_connector_pandas_datasource_configuration(
     mock_emit, empty_data_context_stats_enabled, test_df, tmp_path_factory
 ):
     """
-    Tests output of RuntimeDataConnector
+    Tests output of test_yaml_config() for a Datacontext configured with a Datasource with
+    RuntimeDataConnector. Even though the test directory contains multiple files that can be read-in
+    by GE, the RuntimeDataConnector will output 0 data_assets, and return a "note" to the user.
+
+    This is because the RuntimeDataConnector is not aware of data_assets until they are passed in
+    through the RuntimeBatchRequest.
+
+    The test asserts that the proper number of data_asset_names are returned and note is returned to the user.
     """
     base_directory = str(
         tmp_path_factory.mktemp("test_golden_path_pandas_datasource_configuration")
@@ -1153,6 +1160,15 @@ def test_golden_path_runtime_data_connector_pandas_datasource_configuration(
         "boto3_options": {},
     }
     assert report_object["data_connectors"]["count"] == 1
+
+    # checking the correct number of data_assets have come back
+    assert (
+        report_object["data_connectors"]["default_runtime_data_connector_name"][
+            "data_asset_count"
+        ]
+        == 0
+    )
+
     # checking that note has come back
     assert (
         report_object["data_connectors"]["default_runtime_data_connector_name"]["note"]
@@ -1167,7 +1183,16 @@ def test_golden_path_runtime_data_connector_and_inferred_data_connector_pandas_d
     mock_emit, empty_data_context_stats_enabled, test_df, tmp_path_factory
 ):
     """
-    Tests the default configuration that we get for
+    Tests output of test_yaml_config() for a Datacontext configured with a Datasource with InferredAssetDataConnector
+    and RuntimeDataConnector.
+
+    1. The InferredAssetDataConnector will output 4 data_assets, which correspond to the files in the test_dir_charlie folder
+
+    2.  RuntimeDataConnector will output 0 data_assets, and return a "note" to the user. This is because the
+        RuntimeDataConnector is not aware of data_assets until they are passed in through the RuntimeBatchRequest.
+
+    The test asserts that the proper number of data_asset_names are returned for both DataConnectors, and in the case of
+    the RuntimeDataConnetor, the proper note is returned to the user.
     """
     base_directory = str(
         tmp_path_factory.mktemp("test_golden_path_pandas_datasource_configuration")

--- a/tests/data_context/test_data_context_test_yaml_config.py
+++ b/tests/data_context/test_data_context_test_yaml_config.py
@@ -1242,9 +1242,12 @@ def test_golden_path_runtime_data_connector_and_inferred_data_connector_pandas_d
     assert report_object["data_connectors"]["default_runtime_data_connector_name"] == {
         "class_name": "RuntimeDataConnector",
         "data_asset_count": 0,
-        "example_data_asset_names": [],
         "data_assets": {},
-        "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
+        "example_data_asset_names": [],
+        "example_unmatched_data_references": [],
+        "note": "RuntimeDataConnector will not have data_asset_names until they are "
+        "passed in through RuntimeBatchRequest",
+        "unmatched_data_reference_count": 0,
     }
     assert report_object["data_connectors"]["default_inferred_data_connector_name"] == {
         "class_name": "InferredAssetFilesystemDataConnector",

--- a/tests/data_context/test_data_context_test_yaml_config.py
+++ b/tests/data_context/test_data_context_test_yaml_config.py
@@ -1156,7 +1156,7 @@ def test_golden_path_runtime_data_connector_pandas_datasource_configuration(
     # checking that note has come back
     assert (
         report_object["data_connectors"]["default_runtime_data_connector_name"]["note"]
-        == "Note : RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest"
+        == "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest"
     )
 
 
@@ -1244,7 +1244,7 @@ def test_golden_path_runtime_data_connector_and_inferred_data_connector_pandas_d
         "data_asset_count": 0,
         "example_data_asset_names": [],
         "data_assets": {},
-        "note": "RuntimeDataConnector will not have data asset until passed in through RuntimeBatchRequest",
+        "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
     }
     assert report_object["data_connectors"]["default_inferred_data_connector_name"] == {
         "class_name": "InferredAssetFilesystemDataConnector",

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -30,11 +30,10 @@ def test_self_check(basic_datasource):
     assert test_runtime_data_connector.self_check() == {
         "class_name": "RuntimeDataConnector",
         "data_asset_count": 0,
-        "example_data_asset_names": [],
         "data_assets": {},
-        "unmatched_data_reference_count": 0,
-        "example_unmatched_data_references": [],
-        "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
+        "example_data_asset_names": [],
+        "note": "RuntimeDataConnector will not have data_asset_names until they are "
+        "passed in through RuntimeBatchRequest",
     }
 
 

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -32,8 +32,10 @@ def test_self_check(basic_datasource):
         "data_asset_count": 0,
         "data_assets": {},
         "example_data_asset_names": [],
+        "example_unmatched_data_references": [],
         "note": "RuntimeDataConnector will not have data_asset_names until they are "
         "passed in through RuntimeBatchRequest",
+        "unmatched_data_reference_count": 0,
     }
 
 

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -34,6 +34,7 @@ def test_self_check(basic_datasource):
         "data_assets": {},
         "unmatched_data_reference_count": 0,
         "example_unmatched_data_references": [],
+        "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
     }
 
 

--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -258,6 +258,8 @@ def test_basic_spark_datasource_self_check(basic_spark_datasource):
                 "example_data_asset_names": [],
                 "data_assets": {},
                 "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
+                "unmatched_data_reference_count": 0,
+                "example_unmatched_data_references": [],
             },
         },
         "execution_engine": {

--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -196,37 +196,37 @@ data_connectors:
 
 def test_basic_pandas_datasource_v013_self_check(basic_pandas_datasource_v013):
     report = basic_pandas_datasource_v013.self_check()
+    print(report)
     assert report == {
+        "execution_engine": {
+            "caching": True,
+            "module_name": "great_expectations.execution_engine.pandas_execution_engine",
+            "class_name": "PandasExecutionEngine",
+            "discard_subset_failing_expectations": False,
+            "boto3_options": {},
+        },
         "data_connectors": {
             "count": 2,
             "my_filesystem_data_connector": {
                 "class_name": "ConfiguredAssetFilesystemDataConnector",
                 "data_asset_count": 1,
+                "example_data_asset_names": ["Titanic"],
                 "data_assets": {
                     "Titanic": {
                         "batch_definition_count": 0,
                         "example_data_references": [],
                     }
                 },
-                "example_data_asset_names": ["Titanic"],
-                "example_unmatched_data_references": [],
                 "unmatched_data_reference_count": 0,
+                "example_unmatched_data_references": [],
             },
             "test_runtime_data_connector": {
                 "class_name": "RuntimeDataConnector",
                 "data_asset_count": 0,
-                "data_assets": {},
                 "example_data_asset_names": [],
-                "example_unmatched_data_references": [],
-                "unmatched_data_reference_count": 0,
+                "data_assets": {},
+                "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
             },
-        },
-        "execution_engine": {
-            "boto3_options": {},
-            "caching": True,
-            "class_name": "PandasExecutionEngine",
-            "discard_subset_failing_expectations": False,
-            "module_name": "great_expectations.execution_engine.pandas_execution_engine",
         },
     }
 
@@ -254,10 +254,9 @@ def test_basic_spark_datasource_self_check(basic_spark_datasource):
             "test_runtime_data_connector": {
                 "class_name": "RuntimeDataConnector",
                 "data_asset_count": 0,
-                "data_assets": {},
                 "example_data_asset_names": [],
-                "example_unmatched_data_references": [],
-                "unmatched_data_reference_count": 0,
+                "data_assets": {},
+                "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
             },
         },
         "execution_engine": {

--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -196,7 +196,6 @@ data_connectors:
 
 def test_basic_pandas_datasource_v013_self_check(basic_pandas_datasource_v013):
     report = basic_pandas_datasource_v013.self_check()
-    print(report)
     assert report == {
         "execution_engine": {
             "caching": True,
@@ -226,6 +225,8 @@ def test_basic_pandas_datasource_v013_self_check(basic_pandas_datasource_v013):
                 "example_data_asset_names": [],
                 "data_assets": {},
                 "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
+                "unmatched_data_reference_count": 0,
+                "example_unmatched_data_references": [],
             },
         },
     }

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector.py
@@ -47,6 +47,7 @@ def test_basic_datasource_runtime_data_connector_self_check(
     basic_datasource_with_runtime_data_connector,
 ):
     report = basic_datasource_with_runtime_data_connector.self_check()
+    print(report)
     assert report == {
         "execution_engine": {
             "caching": True,
@@ -62,8 +63,6 @@ def test_basic_datasource_runtime_data_connector_self_check(
                 "data_asset_count": 0,
                 "example_data_asset_names": [],
                 "data_assets": {},
-                "unmatched_data_reference_count": 0,
-                "example_unmatched_data_references": [],
                 "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
             },
         },

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector.py
@@ -64,6 +64,7 @@ def test_basic_datasource_runtime_data_connector_self_check(
                 "data_assets": {},
                 "unmatched_data_reference_count": 0,
                 "example_unmatched_data_references": [],
+                "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
             },
         },
     }

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector.py
@@ -47,7 +47,6 @@ def test_basic_datasource_runtime_data_connector_self_check(
     basic_datasource_with_runtime_data_connector,
 ):
     report = basic_datasource_with_runtime_data_connector.self_check()
-    print(report)
     assert report == {
         "execution_engine": {
             "caching": True,

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector.py
@@ -56,13 +56,7 @@ def test_basic_datasource_runtime_data_connector_self_check(
                 "data_assets": {},
                 "example_data_asset_names": [],
                 "example_unmatched_data_references": [],
-                "note": "RuntimeDataConnector "
-                "will not have "
-                "data_asset_names "
-                "until they are "
-                "passed in "
-                "through "
-                "RuntimeBatchRequest",
+                "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
                 "unmatched_data_reference_count": 0,
             },
         },

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector.py
@@ -48,22 +48,30 @@ def test_basic_datasource_runtime_data_connector_self_check(
 ):
     report = basic_datasource_with_runtime_data_connector.self_check()
     assert report == {
-        "execution_engine": {
-            "caching": True,
-            "module_name": "great_expectations.execution_engine.pandas_execution_engine",
-            "class_name": "PandasExecutionEngine",
-            "discard_subset_failing_expectations": False,
-            "boto3_options": {},
-        },
         "data_connectors": {
             "count": 1,
             "test_runtime_data_connector": {
                 "class_name": "RuntimeDataConnector",
                 "data_asset_count": 0,
-                "example_data_asset_names": [],
                 "data_assets": {},
-                "note": "RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest",
+                "example_data_asset_names": [],
+                "example_unmatched_data_references": [],
+                "note": "RuntimeDataConnector "
+                "will not have "
+                "data_asset_names "
+                "until they are "
+                "passed in "
+                "through "
+                "RuntimeBatchRequest",
+                "unmatched_data_reference_count": 0,
             },
+        },
+        "execution_engine": {
+            "boto3_options": {},
+            "caching": True,
+            "class_name": "PandasExecutionEngine",
+            "discard_subset_failing_expectations": False,
+            "module_name": "great_expectations.execution_engine.pandas_execution_engine",
         },
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- When running `test_yaml_config()` with a `RuntimeDataConnector`, provide user with more informative output. 
- Added corresponding test for configurations that include `RuntimeDataConnector` to `tests/data_context/test_data_context_test_yaml_config.py`, which was missing
- Addresses GDOC-87

## What has changed? 
**Previous Output**

```
	Instantiating as a Datasource, since class_name is Datasource
	Successfully instantiated Datasource


ExecutionEngine class name: PandasExecutionEngine
Data Connectors:
	default_runtime_data_connector_name : RuntimeDataConnector

	Available data_asset_names (0 of 0):

	Unmatched data_references (0 of 0): []

```

**Proposed Output**

```
	Instantiating as a Datasource, since class_name is Datasource
	Successfully instantiated Datasource

ExecutionEngine class name: PandasExecutionEngine
Data Connectors:
	default_runtime_data_connector_name : RuntimeDataConnector

	Available data_asset_names (0 of 0):
		Note : RuntimeDataConnector will not have data_asset_names until they are passed in through RuntimeBatchRequest

	Unmatched data_references (0 of 0): []

```


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.