### PR TITLE
[DOCS] Standardize capitalization of "Python" in "Connecting to your data" section of new docs

### DIFF
--- a/docs/guides/connecting_to_your_data/cloud/s3/pandas.md
+++ b/docs/guides/connecting_to_your_data/cloud/s3/pandas.md
@@ -45,7 +45,7 @@ Using this example configuration, add in your S3 bucket and path to a directory 
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -84,7 +84,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/cloud/s3/spark.md
+++ b/docs/guides/connecting_to_your_data/cloud/s3/spark.md
@@ -47,7 +47,7 @@ Using this example configuration, add in your S3 bucket and path to a directory 
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -86,7 +86,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/database/bigquery.md
+++ b/docs/guides/connecting_to_your_data/database/bigquery.md
@@ -62,7 +62,7 @@ Load your DataContext into memory using the `get_context()` method.
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -102,7 +102,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/database/mysql.md
+++ b/docs/guides/connecting_to_your_data/database/mysql.md
@@ -63,7 +63,7 @@ Load your DataContext into memory using the `get_context()` method.
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -102,7 +102,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/database/postgres.md
+++ b/docs/guides/connecting_to_your_data/database/postgres.md
@@ -61,7 +61,7 @@ Load your DataContext into memory using the `get_context()` method.
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -100,7 +100,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/database/redshift.md
+++ b/docs/guides/connecting_to_your_data/database/redshift.md
@@ -67,7 +67,7 @@ Load your DataContext into memory using the `get_context()` method.
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -106,7 +106,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/database/snowflake.md
+++ b/docs/guides/connecting_to_your_data/database/snowflake.md
@@ -63,7 +63,7 @@ Load your DataContext into memory using the `get_context()` method.
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -102,7 +102,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/database/sqlite.md
+++ b/docs/guides/connecting_to_your_data/database/sqlite.md
@@ -64,7 +64,7 @@ Load your DataContext into memory using the `get_context()` method.
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -103,7 +103,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/filesystem/pandas.md
+++ b/docs/guides/connecting_to_your_data/filesystem/pandas.md
@@ -44,7 +44,7 @@ Using this example configuration add in the path to a directory that contains so
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -83,7 +83,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/filesystem/spark.md
+++ b/docs/guides/connecting_to_your_data/filesystem/spark.md
@@ -47,7 +47,7 @@ Using this example configuration, add in your path to a directory that contains 
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -86,7 +86,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/in_memory/pandas.md
+++ b/docs/guides/connecting_to_your_data/in_memory/pandas.md
@@ -46,7 +46,7 @@ Using this example configuration we configure a `RuntimeDataConnector` as part o
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -86,7 +86,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/connecting_to_your_data/in_memory/spark.md
+++ b/docs/guides/connecting_to_your_data/in_memory/spark.md
@@ -43,7 +43,7 @@ Using this example configuration add in the path to a directory that contains so
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 
@@ -80,7 +80,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
   defaultValue='yaml'
   values={[
   {label: 'YAML', value:'yaml'},
-  {label: 'python', value:'python'},
+  {label: 'Python', value:'python'},
   ]}>
   <TabItem value="yaml">
 

--- a/docs/guides/miscellaneous/how_to_template.md
+++ b/docs/guides/miscellaneous/how_to_template.md
@@ -54,7 +54,7 @@ Next, do {concise description of what the user is going to do} using either {cho
   defaultValue='tab1'
   values={[
   {label: 'Using the CLI', value:'cli'},
-  {label: 'Using python', value:'python'},
+  {label: 'Using Python', value:'python'},
   ]}>
   <TabItem value="cli">
 
@@ -67,7 +67,7 @@ great_expectations --v3-api suite new
   </TabItem>
 <TabItem value="python">
 
-Run this code in python.
+Run this code in Python.
 
 ```python file=../../../tests/integration/docusaurus/template/script_example.py#L1-L3
 ```

--- a/docs/guides/temp
+++ b/docs/guides/temp
@@ -1,0 +1,2 @@
+connecting_to_your_data/database/snowflake.md:  {label: 'python', value:'python'},
+connecting_to_your_data/database/snowflake.md:  {label: 'python', value:'python'},

--- a/docs/guides/temp
+++ b/docs/guides/temp
@@ -1,2 +1,0 @@
-connecting_to_your_data/database/snowflake.md:  {label: 'python', value:'python'},
-connecting_to_your_data/database/snowflake.md:  {label: 'python', value:'python'},

--- a/docs/guides/validation/how_to_add_a_validation_operator.md
+++ b/docs/guides/validation/how_to_add_a_validation_operator.md
@@ -79,7 +79,7 @@ validation_operators:
    Test that your new Validation Operator is configured correctly:
 
       1. Open the configuration file of a Checkpoint you created earlier and replace the value of ``validation_operator_name`` with the value from Step 2 above. The details of Checkpoint configuration can be found in [How to add validations data or suites to a Checkpoint](../../../guides/validation/checkpoints/how_to_add_validations_data_or_suites_to_a_checkpoint).
-      2. Run the Checkpoint and verify that no errors are thrown. You can run the Checkpoint from the CLI as explained in [How to run a Checkpoint in terminal](../guides/validation/checkpoints/how_to_run_a_checkpoint_in_terminal) or from Python, as explained in [How to run a Checkpoint in python](./checkpoints/how_to_run_a_checkpoint_in_python).
+      2. Run the Checkpoint and verify that no errors are thrown. You can run the Checkpoint from the CLI as explained in [How to run a Checkpoint in terminal](../guides/validation/checkpoints/how_to_run_a_checkpoint_in_terminal) or from Python, as explained in [How to run a Checkpoint in Python](./checkpoints/how_to_run_a_checkpoint_in_python).
 
 
 Additional notes


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Continuing off of a previous PR, this is a small fix to standardize capitalization of Python in our docs. This specific change revolves around the Docusaurus tabs we use in "Connecting to your data"

### Definition of Done
Please delete options that are not relevant.

- [x] I have made corresponding changes to the documentation