### PR TITLE
[DOCS] GDOC-216 Fix broken links

### DIFF
--- a/docs/contributing/contributing_github.md
+++ b/docs/contributing/contributing_github.md
@@ -8,15 +8,15 @@ If you want to change documentation, but not code, we suggest using the GitHub m
 
 ### Start editing
 
-#### 1A. Edit from https://knoxpod.netlify.app/docs/
+#### 1A. Edit from https://docs.greatexpectations.io/docs/
 
-* Go to the [Great Expectations docs](https://knoxpod.netlify.app/docs/).
+* Go to the [Great Expectations docs](https://docs.greatexpectations.io/docs/).
 
 * On each page, you’ll see an `Edit` button in the lower left. Click this to go to the source file in the Great Expectations GitHub repo.
 
 #### 1B. Edit from Github
 
-* If you’re already on GitHub, the docs are located in `great_expectations > docs`. You can directly navigate to the respective page you want to edit (but getting there from https://knoxpod.netlify.app/docs/ is a little easier).
+* If you’re already on GitHub, the docs are located in `great_expectations > docs`. You can directly navigate to the respective page you want to edit (but getting there from https://docs.greatexpectations.io/docs/ is a little easier).
 
 * In the top right of the grey header bar of the actual file, click the pencil icon to get into edit mode on GitHub.
 

--- a/docs/reference/expectations/expectations.md
+++ b/docs/reference/expectations/expectations.md
@@ -16,11 +16,11 @@ Great Expectations' built-in library includes more than 50 common Expectations, 
 * `expect_table_row_count_to_be_between`
 * `expect_column_median_to_be_between`
 
-For a full list of available Expectations, please check out the [Expectation Glossary](./). Please note that not all
+For a full list of available Expectations, please check out the [Expectation Glossary](../glossary_of_expectations). Please note that not all
 Expectations are implemented on all Execution Engines yet. You can see the grid of supported
-Expectations [here](./implemented_expectations). We welcome [contributions](./) to fill in the gaps.
+Expectations [here](./implemented_expectations). We welcome [contributions](../../contributing/contributing) to fill in the gaps.
 
-You can also extend Great Expectations by [creating your own custom Expectations](./).
+You can also extend Great Expectations by [creating your own custom Expectations](../../guides/expectations/creating_custom_expectations/how_to_create_custom_expectations).
 
 Expectations *enhance communication* about your data and *improve quality* for data applications. Using Expectations
 helps reduce trips to domain experts and avoids leaving insights about data on the "cutting room floor."


### PR DESCRIPTION
GDOC-216 Fix some broken doc links


### Definition of Done
Please delete options that are not relevant.

- [ x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ x] I have run any local integration tests and made sure that nothing is broken.
