### PR TITLE
[FEATURE] Add schema validation for different GCS auth methods

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -562,8 +562,8 @@ continue.
             "InferredAssetGCSDataConnector",
             "ConfiguredAssetGCSDataConnector",
         ]:
-            azure_options = data["gcs_options"]
-            if "filename" in azure_options and "info" in azure_options:
+            gcs_options = data["gcs_options"]
+            if "filename" in gcs_options and "info" in gcs_options:
                 raise ge_exceptions.InvalidConfigError(
                     f"""Your current configuration can only use a single method of authentication for the GCS type of data connector.
                     You must only select one between `filename` (from_service_account_file) and `info` (from_service_account_info). Please update your configuration to continue.

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -558,6 +558,17 @@ GCS type of the data connector (your data connector is "{data['class_name']}"). 
 continue.
                     """
             )
+        if "gcs_options" in data and data["class_name"] in [
+            "InferredAssetGCSDataConnector",
+            "ConfiguredAssetGCSDataConnector",
+        ]:
+            azure_options = data["gcs_options"]
+            if "filename" in azure_options and "info" in azure_options:
+                raise ge_exceptions.InvalidConfigError(
+                    f"""Your current configuration can only use a single method of authentication for the GCS type of data connector.
+                    You must only select one between `filename` (from_service_account_file) and `info` (from_service_account_info). Please update your configuration to continue.
+                    """
+                )
         if (
             "data_asset_name_prefix" in data
             or "data_asset_name_suffix" in data


### PR DESCRIPTION
Changes proposed in this pull request:
- https://superconductive.atlassian.net/secure/RapidBoard.jspa?rapidView=24&projectKey=GREAT&modal=detail&selectedIssue=GREAT-101
- Ensures that we are supporting both `from_service_account_file` and `from_service_account_info` helper methods from the Google SDK: https://google-auth.readthedocs.io/en/master/reference/google.oauth2.service_account.html
- If a user decides to manually pass a `Credential` to the connection object's constructor, it must be done one of these two supported ways.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
