### PR TITLE
Make BigQuery SqlAlchemy dialect conform to "dialect" attribute convention and dataset cleanup

### DIFF
--- a/docs/contributing/contributing_test.md
+++ b/docs/contributing/contributing_test.md
@@ -37,6 +37,8 @@ After setting up authentication, you can run with your project using the environ
     pytest tests/test_definitions/test_expectations_cfe.py --bigquery --no-spark --no-postgresql
 ```
 
+Note that if you prefer to use a different dataset besides "test_ci", you can specify a different dataset with `GE_TEST_BIGQUERY_DATASET`.
+
 ### Writing unit and integration tests
 
 Production code in Great Expectations must be thoroughly tested. In general, we insist on unit tests for all branches of every method, including likely error states. Most new feature contributions should include several unit tests. Contributions that modify or extend existing features should include a test of the new behavior.

--- a/docs_rtd/contributing/testing.rst
+++ b/docs_rtd/contributing/testing.rst
@@ -54,6 +54,8 @@ After setting up authentication, you can run with your project using the environ
 
     GE_TEST_BIGQUERY_PROJECT=<YOUR_GOOGLE_CLOUD_PROJECT> pytest tests/test_definitions/test_expectations_cfe.py --bigquery --no-spark --no-postgresql -k bigquery
 
+Note that if you prefer to use a different dataset besides "test_ci", you can specify a different dataset with `GE_TEST_BIGQUERY_DATASET`.
+
 Writing unit and integration tests
 ----------------------------------
 

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -93,6 +93,16 @@ except (ImportError, KeyError, AttributeError):
 try:
     import pybigquery.sqlalchemy_bigquery
 
+    ###
+    # NOTE: 20210816 - jdimatteo: A convention we rely on is for SqlAlchemy dialects
+    # to define an attribute "dialect". A PR has been submitted to fix this upstream
+    # with https://github.com/googleapis/python-bigquery-sqlalchemy/pull/251. If that
+    # fix isn't present, add this "dialect" attribute here:
+    if not hasattr(pybigquery.sqlalchemy_bigquery, "dialect"):
+        pybigquery.sqlalchemy_bigquery.dialect = (
+            pybigquery.sqlalchemy_bigquery.BigQueryDialect
+        )
+
     # Sometimes "pybigquery.sqlalchemy_bigquery" fails to self-register in certain environments, so we do it explicitly.
     # (see https://stackoverflow.com/questions/53284762/nosuchmoduleerror-cant-load-plugin-sqlalchemy-dialectssnowflake)
     registry.register("bigquery", "pybigquery.sqlalchemy_bigquery", "BigQueryDialect")

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
@@ -62,21 +62,20 @@ class ColumnValuesUnique(ColumnMapMetricProvider):
         # the column we will be performing the expectation on, and the query is performed against it.
         dialect = kwargs.get("_dialect", None)
         sql_engine = kwargs.get("_sqlalchemy_engine", None)
-        if sql_engine and dialect:
-            if hasattr(dialect, "dialect") and dialect.dialect.name == "mysql":
-                temp_table_name = f"ge_tmp_{str(uuid.uuid4())[:8]}"
-                temp_table_stmt = "CREATE TEMPORARY TABLE {new_temp_table} AS SELECT tmp.{column_name} FROM {source_table} tmp".format(
-                    new_temp_table=temp_table_name,
-                    source_table=_table,
-                    column_name=column.name,
-                )
-                sql_engine.execute(temp_table_stmt)
-                dup_query = (
-                    sa.select([column])
-                    .select_from(sa.text(temp_table_name))
-                    .group_by(column)
-                    .having(sa.func.count(column) > 1)
-                )
+        if sql_engine and dialect and dialect.dialect.name == "mysql":
+            temp_table_name = f"ge_tmp_{str(uuid.uuid4())[:8]}"
+            temp_table_stmt = "CREATE TEMPORARY TABLE {new_temp_table} AS SELECT tmp.{column_name} FROM {source_table} tmp".format(
+                new_temp_table=temp_table_name,
+                source_table=_table,
+                column_name=column.name,
+            )
+            sql_engine.execute(temp_table_stmt)
+            dup_query = (
+                sa.select([column])
+                .select_from(sa.text(temp_table_name))
+                .group_by(column)
+                .having(sa.func.count(column) > 1)
+            )
         return column.notin_(dup_query)
 
     @column_condition_partial(

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -330,15 +330,13 @@ def get_dialect_like_pattern_expression(column, dialect, like_pattern, positive=
     ):  # TypeError can occur if the driver was not installed and so is None
         pass
 
-    if hasattr(dialect, "dialect") and (
-        issubclass(
-            dialect.dialect,
-            (
-                sa.dialects.sqlite.dialect,
-                sa.dialects.postgresql.dialect,
-                sa.dialects.mysql.dialect,
-                sa.dialects.mssql.dialect,
-            ),
+    if issubclass(
+        dialect.dialect,
+        (
+            sa.dialects.sqlite.dialect,
+            sa.dialects.postgresql.dialect,
+            sa.dialects.mysql.dialect,
+            sa.dialects.mssql.dialect,
         ),
     ):
         dialect_supported = True

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -529,8 +529,7 @@ def get_dataset(
             index=False,
             if_exists="replace",
         )
-        bigquery_dataset = os.getenv("GE_TEST_BIGQUERY_DATASET", "test_ci")
-        custom_sql = "SELECT * FROM " + bigquery_dataset + "." + table_name
+        custom_sql = f"SELECT * FROM {_bigquery_dataset()}.{table_name}"
         return SqlAlchemyDataset(
             custom_sql=custom_sql, engine=engine, profiler=profiler, caching=caching
         )
@@ -1970,13 +1969,13 @@ def generate_test_table_name(
 
 
 def _create_bigquery_engine() -> Engine:
-
-    # The following environment variables will need to be
     gcp_project = os.getenv("GE_TEST_BIGQUERY_PROJECT")
-    bigquery_dataset = os.getenv("GE_TEST_BIGQUERY_DATASET")
-
-    if not gcp_project or not bigquery_dataset:
+    if not gcp_project:
         raise ValueError(
-            "Environment Variables GE_TEST_BIGQUERY_PROJECT and GE_TEST_BIGQUERY_DATASET are required to run expectation tests"
+            "Environment Variable GE_TEST_BIGQUERY_PROJECT is required to run expectation tests"
         )
-    return create_engine(f"bigquery://{gcp_project}/{bigquery_dataset}")
+    return create_engine(f"bigquery://{gcp_project}/{_bigquery_dataset()}")
+
+
+def _bigquery_dataset() -> str:
+    return os.getenv("GE_TEST_BIGQUERY_DATASET", "test_ci")


### PR DESCRIPTION
Changes proposed in this pull request:
- Make BigQuery SqlAlchemy dialect conform to "dialect" attribute convention
- remove duplicate inconsistent logic around BigQuery dataset used in tests
- document how to override the BigQuery dataset name used in tests