### PR TITLE
[BUGFIX] Run batch_request dictionary through util function convert_to_json_serializable

### DIFF
--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 develop
 -----------------
 * [BUGFIX] Allow for RuntimeDataConnector to accept custom query while suppressing temp table creation (#3335)
+* [BUGFIX] Run batch_request dictionary through util function convert_to_json_serializable for datetimes (#3349)
 
 0.13.32
 -----------------

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -5,6 +5,7 @@ import json
 from typing import Dict, Optional, Union
 
 from great_expectations.core.id_dict import BatchKwargs, BatchSpec, IDDict
+from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.exceptions import InvalidBatchIdError
 from great_expectations.types import DictDot, SerializableDictDot
 from great_expectations.util import filter_properties_dict
@@ -122,12 +123,14 @@ class BatchDefinition(SerializableDictDot):
         self._batch_spec_passthrough = batch_spec_passthrough
 
     def get_json_dict(self) -> dict:
-        return {
-            "datasource_name": self.datasource_name,
-            "data_connector_name": self.data_connector_name,
-            "data_asset_name": self.data_asset_name,
-            "batch_identifiers": self.batch_identifiers,
-        }
+        return convert_to_json_serializable(
+            {
+                "datasource_name": self.datasource_name,
+                "data_connector_name": self.data_connector_name,
+                "data_asset_name": self.data_asset_name,
+                "batch_identifiers": self.batch_identifiers,
+            }
+        )
 
     @property
     def id(self) -> str:

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -677,7 +677,7 @@ def test__get_data_reference_name(basic_datasource):
     )
 
 
-def test_batch_identifiers_and_batch_identifiers_datetime(
+def test_batch_identifiers_datetime(
     basic_datasource,
 ):
     test_df: pd.DataFrame = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -1,6 +1,5 @@
-from typing import List
-
 import datetime
+from typing import List
 
 import pandas as pd
 import pytest
@@ -705,14 +704,17 @@ def test_expectation_with_batch_identifiers_datetime(
     }
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
 
-    batch_definition = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
-        batch_request=batch_request
-    )[0]
+    batch_definition = (
+        test_runtime_data_connector.get_batch_definition_list_from_batch_request(
+            batch_request=batch_request
+        )[0]
+    )
 
-    batch = Batch(data=test_df, batch_request=batch_request, batch_definition=batch_definition)
+    batch = Batch(
+        data=test_df, batch_request=batch_request, batch_definition=batch_definition
+    )
 
     try:
         batch.id
     except TypeError:
         pytest.fail()
-

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -1,11 +1,14 @@
 from typing import List
 
+import datetime
+
 import pandas as pd
 import pytest
 from ruamel.yaml import YAML
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import (
+    Batch,
     BatchDefinition,
     BatchRequest,
     BatchSpec,
@@ -673,3 +676,43 @@ def test__get_data_reference_name(basic_datasource):
         test_runtime_data_connector._get_data_reference_name(batch_identifiers)
         == "1234567890-1111111111"
     )
+
+
+def test_expectation_with_batch_identifiers_datetime(
+    basic_datasource,
+):
+    test_df: pd.DataFrame = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
+
+    batch_identifiers: dict
+
+    batch_identifiers = {
+        "pipeline_stage_name": "core_processing",
+        "airflow_run_id": 1234567890,
+        "custom_key_0": datetime.datetime.utcnow(),
+    }
+
+    test_runtime_data_connector: RuntimeDataConnector = (
+        basic_datasource.data_connectors["test_runtime_data_connector"]
+    )
+
+    # Verify that all keys in batch_identifiers are acceptable as batch_identifiers
+    batch_request: dict = {
+        "datasource_name": basic_datasource.name,
+        "data_connector_name": test_runtime_data_connector.name,
+        "data_asset_name": "IN_MEMORY_DATA_ASSET",
+        "runtime_parameters": {"batch_data": test_df},
+        "batch_identifiers": batch_identifiers,
+    }
+    batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
+
+    batch_definition = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
+        batch_request=batch_request
+    )[0]
+
+    batch = Batch(data=test_df, batch_request=batch_request, batch_definition=batch_definition)
+
+    try:
+        batch.id
+    except TypeError:
+        pytest.fail()
+

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -677,7 +677,7 @@ def test__get_data_reference_name(basic_datasource):
     )
 
 
-def test_expectation_with_batch_identifiers_datetime(
+def test_batch_identifiers_and_batch_identifiers_datetime(
     basic_datasource,
 ):
     test_df: pd.DataFrame = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})


### PR DESCRIPTION

Changes proposed in this pull request:
- https://github.com/great-expectations/great_expectations/issues/3299
- JIRA: DEVREL-125

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
