### PR TITLE
[DOCS] minor fix to syntax highlighting in how_to_contribute_a_new_expectation…

### DIFF
--- a/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
+++ b/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
@@ -170,7 +170,7 @@ Run `run_diagnostics` again. The newly added examples will appear in the output.
 
 When you define data in your examples, we will mostly guess the type of the columns. Sometimes you need to specify the precise type of the columns for each backend. Then you use schema attribute (on the same level as data and tests in the dictionary):
 
-````console
+````python
 "schemas": {
   "spark": {
     "mostly_threes": "IntegerType",

--- a/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
+++ b/docs/guides/expectations/contributing/how_to_contribute_a_new_expectation_to_great_expectations.md
@@ -74,7 +74,7 @@ Recently we introduced a fast-track release process for community contributed Ex
 
 Expectations contain a self diagnostic tool that will help you during development. The simplest way to run it is to execute the file as a standalone script. Note: if you prefer, you can also run it within a notebook or IDE.
 
-````python
+````console
 python expect_column_values_to_equal_three.py
 ````
 
@@ -241,7 +241,7 @@ If you have never used Python Decorators and don’t know what they are and how 
 
 Find the following code snippet in your Metric Provider class:
 
-````console
+````python
 @column_condition_partial(engine=PandasExecutionPandasExecutionEngineEngine)
 def _pandas(cls, column, **kwargs):
     return column == 3
@@ -261,13 +261,13 @@ Here is how you could modify expect_column_values_to_equal_three to expect_colum
 
 Find the snippet success_keys = ("mostly",) in the class that implements your Expectation. Add your arguments to success_keys
 
-````console
+````python
 success_keys = ("integer", "mostly")
 ````
 Success keys are arguments that determine the values of the Expectation’s metrics and when the Expectation will succeed.
 
 In the class that implements Metric Provider set the variable condition_value_keys to a tuple of your arguments:
-````console
+````python
 condition_value_keys = ("integer",)
 ````
 
@@ -279,7 +279,7 @@ For a map Metric producing a yes/no question answer, you use condition_value_key
 
 * Add named arguments to the methods that compute the Metric for each backend in your Metric Provider class:
 
-````console
+````python
 @column_condition_partial(engine=PandasExecutionEngine)
 def _pandas(cls, column, integer=None, **kwargs):
     return column == integer
@@ -300,7 +300,7 @@ The Expectation declares “column_values.z_score.under_threshold” as its `con
 
 The `ColumnValuesZScore` Metric Provider class that computes this Metric declares an additional metric:
 
-````console
+````python
 function_metric_name = "column_values.z_score"
 ````
 
@@ -393,7 +393,7 @@ Implement this method to compute your Metric.
 
 Find this code snippet in your file and edit tags and contributors:
 
-````console
+````python
 library_metadata = {
     "maturity": "experimental",  # "experimental", "beta", or "production"
     "tags": [  # Tags for this Expectation in the gallery


### PR DESCRIPTION
minor fix to syntax highlighting in how_to_contribute_a_new_expectation.md, python commands listed as console and vice versa

