### PR TITLE
[BUGFIX] Fix Data asset name rendering

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,6 @@ title: Changelog
 
 ### Develop
 * [BUGFIX] Addresses issue #2993 (#3054) by using configuration over list keys when possible.
-* [BUGFIX] Display data asset name in notifications following checkpoint run.
 
 
 ### 0.13.34

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ title: Changelog
 
 ### Develop
 * [BUGFIX] Addresses issue #2993 (#3054) by using configuration over list keys when possible.
+* [BUGFIX] Display data asset name in notifications following checkpoint run.
 
 
 ### 0.13.34

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 
 develop
 -----------------
+* [BUGFIX] Display data asset name in notifications following checkpoint run.
+
 
 0.13.34
 -----------------

--- a/great_expectations/render/renderer/email_renderer.py
+++ b/great_expectations/render/renderer/email_renderer.py
@@ -31,7 +31,11 @@ class EmailRenderer(Renderer):
                     "data_asset_name", "__no_data_asset_name__"
                 )
             elif "active_batch_definition" in validation_result.meta:
-                data_asset_name = validation_result.meta["active_batch_definition"].data_asset_name
+                data_asset_name = (
+                    validation_result.meta["active_batch_definition"].data_asset_name
+                    if validation_result.meta["active_batch_definition"].data_asset_name
+                    else "__no_data_asset_name__"
+                )
             else:
                 data_asset_name = "__no_data_asset_name__"
 

--- a/great_expectations/render/renderer/email_renderer.py
+++ b/great_expectations/render/renderer/email_renderer.py
@@ -30,6 +30,8 @@ class EmailRenderer(Renderer):
                 data_asset_name = validation_result.meta["batch_kwargs"].get(
                     "data_asset_name", "__no_data_asset_name__"
                 )
+            elif "active_batch_definition" in validation_result.meta:
+                data_asset_name = validation_result.meta["active_batch_definition"].data_asset_name
             else:
                 data_asset_name = "__no_data_asset_name__"
 

--- a/great_expectations/render/renderer/opsgenie_renderer.py
+++ b/great_expectations/render/renderer/opsgenie_renderer.py
@@ -34,7 +34,11 @@ class OpsgenieRenderer(Renderer):
                     "data_asset_name", "__no_data_asset_name__"
                 )
             elif "active_batch_definition" in validation_result.meta:
-                data_asset_name = validation_result.meta["active_batch_definition"].data_asset_name
+                data_asset_name = (
+                    validation_result.meta["active_batch_definition"].data_asset_name
+                    if validation_result.meta["active_batch_definition"].data_asset_name
+                    else "__no_data_asset_name__"
+                )
             else:
                 data_asset_name = "__no_data_asset_name__"
 

--- a/great_expectations/render/renderer/opsgenie_renderer.py
+++ b/great_expectations/render/renderer/opsgenie_renderer.py
@@ -33,6 +33,8 @@ class OpsgenieRenderer(Renderer):
                 data_asset_name = validation_result.meta["batch_kwargs"].get(
                     "data_asset_name", "__no_data_asset_name__"
                 )
+            elif "active_batch_definition" in validation_result.meta:
+                data_asset_name = validation_result.meta["active_batch_definition"].data_asset_name
             else:
                 data_asset_name = "__no_data_asset_name__"
 

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -47,7 +47,11 @@ class SlackRenderer(Renderer):
                     "data_asset_name", "__no_data_asset_name__"
                 )
             elif "active_batch_definition" in validation_result.meta:
-                data_asset_name = validation_result.meta["active_batch_definition"].data_asset_name
+                data_asset_name = (
+                    validation_result.meta["active_batch_definition"].data_asset_name
+                    if validation_result.meta["active_batch_definition"].data_asset_name
+                    else "__no_data_asset_name__"
+                )
             else:
                 data_asset_name = "__no_data_asset_name__"
 

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -46,6 +46,8 @@ class SlackRenderer(Renderer):
                 data_asset_name = validation_result.meta["batch_kwargs"].get(
                     "data_asset_name", "__no_data_asset_name__"
                 )
+            elif "active_batch_definition" in validation_result.meta:
+                data_asset_name = validation_result.meta["active_batch_definition"].data_asset_name
             else:
                 data_asset_name = "__no_data_asset_name__"
 

--- a/tests/render/test_EmailRenderer.py
+++ b/tests/render/test_EmailRenderer.py
@@ -6,7 +6,6 @@ from great_expectations.core.batch import BatchDefinition
 from great_expectations.core import IDDict
 
 
-
 def test_EmailRenderer_validation_results_with_datadocs():
 
     validation_result_suite = ExpectationSuiteValidationResult(
@@ -64,11 +63,12 @@ def test_EmailRenderer_validation_results_with_datadocs():
 
     assert rendered_output == expected_output
 
+
 def test_EmailRenderer_checkpoint_validation_results_with_datadocs():
     batch_definition = BatchDefinition(
         datasource_name="test_datasource",
         data_connector_name="test_dataconnector",
-        data_asset_name = "test_data_asset",
+        data_asset_name="test_data_asset",
         batch_identifiers=IDDict({"id": "my_id"}),
     )
 
@@ -83,7 +83,7 @@ def test_EmailRenderer_checkpoint_validation_results_with_datadocs():
         },
         meta={
             "great_expectations_version": "v0.8.0__develop",
-            "active_batch_definition":batch_definition,
+            "active_batch_definition": batch_definition,
             "expectation_suite_name": "default",
             "run_id": "2019-09-25T060538.829112Z",
         },
@@ -121,7 +121,6 @@ def test_EmailRenderer_checkpoint_validation_results_with_datadocs():
     )
 
     assert rendered_output == expected_output
-
 
 
 def test_EmailRenderer_get_report_element():

--- a/tests/render/test_EmailRenderer.py
+++ b/tests/render/test_EmailRenderer.py
@@ -2,6 +2,9 @@ from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
 from great_expectations.render.renderer import EmailRenderer
+from great_expectations.core.batch import BatchDefinition
+from great_expectations.core import IDDict
+
 
 
 def test_EmailRenderer_validation_results_with_datadocs():
@@ -60,6 +63,65 @@ def test_EmailRenderer_validation_results_with_datadocs():
     )
 
     assert rendered_output == expected_output
+
+def test_EmailRenderer_checkpoint_validation_results_with_datadocs():
+    batch_definition = BatchDefinition(
+        datasource_name="test_datasource",
+        data_connector_name="test_dataconnector",
+        data_asset_name = "test_data_asset",
+        batch_identifiers=IDDict({"id": "my_id"}),
+    )
+
+    validation_result_suite = ExpectationSuiteValidationResult(
+        results=[],
+        success=True,
+        statistics={
+            "evaluated_expectations": 0,
+            "successful_expectations": 0,
+            "unsuccessful_expectations": 0,
+            "success_percent": None,
+        },
+        meta={
+            "great_expectations_version": "v0.8.0__develop",
+            "active_batch_definition":batch_definition,
+            "expectation_suite_name": "default",
+            "run_id": "2019-09-25T060538.829112Z",
+        },
+    )
+
+    rendered_output = EmailRenderer().render(validation_result_suite)
+
+    expected_output = (
+        "default: Success 🎉",
+        '<p><strong>Batch Validation Status</strong>: Success 🎉</p>\n<p><strong>Expectation suite name</strong>: default</p>\n<p><strong>Data asset name</strong>: test_data_asset</p>\n<p><strong>Run ID</strong>: 2019-09-25T060538.829112Z</p>\n<p><strong>Batch ID</strong>: ()</p>\n<p><strong>Summary</strong>: <strong>0</strong> of <strong>0</strong> expectations were met</p><p>Learn <a href="https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html">here</a> how to review validation results in Data Docs</p>',
+    )
+    assert rendered_output == expected_output
+
+    data_docs_pages = {"local_site": "file:///localsite/index.html"}
+    notify_with = ["local_site"]
+    rendered_output = EmailRenderer().render(
+        validation_result_suite, data_docs_pages, notify_with
+    )
+
+    expected_output = (
+        "default: Success 🎉",
+        '<p><strong>Batch Validation Status</strong>: Success 🎉</p>\n<p><strong>Expectation suite name</strong>: default</p>\n<p><strong>Data asset name</strong>: test_data_asset</p>\n<p><strong>Run ID</strong>: 2019-09-25T060538.829112Z</p>\n<p><strong>Batch ID</strong>: ()</p>\n<p><strong>Summary</strong>: <strong>0</strong> of <strong>0</strong> expectations were met</p><p><strong>DataDocs</strong> can be found here: <a href="file:///localsite/index.html">file:///localsite/index.html</a>.</br>(Please copy and paste link into a browser to view)</p><p>Learn <a href="https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html">here</a> how to review validation results in Data Docs</p>',
+    )
+    assert rendered_output == expected_output
+
+    # not configured
+    notify_with = ["fake_site"]
+    rendered_output = EmailRenderer().render(
+        validation_result_suite, data_docs_pages, notify_with
+    )
+
+    expected_output = (
+        "default: Success 🎉",
+        '<p><strong>Batch Validation Status</strong>: Success 🎉</p>\n<p><strong>Expectation suite name</strong>: default</p>\n<p><strong>Data asset name</strong>: test_data_asset</p>\n<p><strong>Run ID</strong>: 2019-09-25T060538.829112Z</p>\n<p><strong>Batch ID</strong>: ()</p>\n<p><strong>Summary</strong>: <strong>0</strong> of <strong>0</strong> expectations were met</p><strong>ERROR</strong>: The email is trying to provide a link to the following DataDocs: `fake_site`, but it is not configured under data_docs_sites in the great_expectations.yml</br><p>Learn <a href="https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html">here</a> how to review validation results in Data Docs</p>',
+    )
+
+    assert rendered_output == expected_output
+
 
 
 def test_EmailRenderer_get_report_element():

--- a/tests/render/test_EmailRenderer.py
+++ b/tests/render/test_EmailRenderer.py
@@ -1,9 +1,8 @@
+from great_expectations.core.batch import BatchDefinition, IDDict
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
 from great_expectations.render.renderer import EmailRenderer
-from great_expectations.core.batch import BatchDefinition
-from great_expectations.core import IDDict
 
 
 def test_EmailRenderer_validation_results_with_datadocs():

--- a/tests/render/test_OpsgenieRenderer.py
+++ b/tests/render/test_OpsgenieRenderer.py
@@ -1,7 +1,8 @@
-from great_expectations.core import ExpectationSuiteValidationResult
+from great_expectations.core.batch import BatchDefinition, IDDict
+from great_expectations.core.expectation_validation_result import (
+    ExpectationSuiteValidationResult,
+)
 from great_expectations.render.renderer import OpsgenieRenderer
-from great_expectations.core.batch import BatchDefinition
-from great_expectations.core import IDDict
 
 
 def test_OpsgenieRenderer_validation_results_success():

--- a/tests/render/test_OpsgenieRenderer.py
+++ b/tests/render/test_OpsgenieRenderer.py
@@ -3,6 +3,7 @@ from great_expectations.render.renderer import OpsgenieRenderer
 from great_expectations.core.batch import BatchDefinition
 from great_expectations.core import IDDict
 
+
 def test_OpsgenieRenderer_validation_results_success():
 
     validation_result_suite = ExpectationSuiteValidationResult(
@@ -33,11 +34,12 @@ def test_OpsgenieRenderer_validation_results_success():
 
     assert rendered_output == expected_output
 
+
 def test_OpsgenieRenderer_checkpoint_validation_results_success():
     batch_definition = BatchDefinition(
         datasource_name="test_datasource",
         data_connector_name="test_dataconnector",
-        data_asset_name = "test_data_asset",
+        data_asset_name="test_data_asset",
         batch_identifiers=IDDict({"id": "my_id"}),
     )
     validation_result_suite = ExpectationSuiteValidationResult(
@@ -51,7 +53,7 @@ def test_OpsgenieRenderer_checkpoint_validation_results_success():
         },
         meta={
             "great_expectations_version": "v0.12.2__develop",
-            "active_batch_definition":batch_definition,
+            "active_batch_definition": batch_definition,
             "expectation_suite_name": "default",
             "run_id": "2021-01-01T000000.000000Z",
         },
@@ -62,8 +64,6 @@ def test_OpsgenieRenderer_checkpoint_validation_results_success():
     expected_output = "Batch Validation Status: Success 🎉\nExpectation suite name: default\nData asset name: test_data_asset\nRun ID: 2021-01-01T000000.000000Z\nBatch ID: ()\nSummary: 0 of 0 expectations were met"
 
     assert rendered_output == expected_output
-
-
 
 
 def test_OpsgenieRenderer_validation_results_failure():

--- a/tests/render/test_OpsgenieRenderer.py
+++ b/tests/render/test_OpsgenieRenderer.py
@@ -1,6 +1,7 @@
 from great_expectations.core import ExpectationSuiteValidationResult
 from great_expectations.render.renderer import OpsgenieRenderer
-
+from great_expectations.core.batch import BatchDefinition
+from great_expectations.core import IDDict
 
 def test_OpsgenieRenderer_validation_results_success():
 
@@ -31,6 +32,38 @@ def test_OpsgenieRenderer_validation_results_success():
     expected_output = "Batch Validation Status: Success 🎉\nExpectation suite name: default\nData asset name: x/y/z\nRun ID: 2021-01-01T000000.000000Z\nBatch ID: data_asset_name=x/y/z\nSummary: 0 of 0 expectations were met"
 
     assert rendered_output == expected_output
+
+def test_OpsgenieRenderer_checkpoint_validation_results_success():
+    batch_definition = BatchDefinition(
+        datasource_name="test_datasource",
+        data_connector_name="test_dataconnector",
+        data_asset_name = "test_data_asset",
+        batch_identifiers=IDDict({"id": "my_id"}),
+    )
+    validation_result_suite = ExpectationSuiteValidationResult(
+        results=[],
+        success=True,
+        statistics={
+            "evaluated_expectations": 0,
+            "successful_expectations": 0,
+            "unsuccessful_expectations": 0,
+            "success_percent": None,
+        },
+        meta={
+            "great_expectations_version": "v0.12.2__develop",
+            "active_batch_definition":batch_definition,
+            "expectation_suite_name": "default",
+            "run_id": "2021-01-01T000000.000000Z",
+        },
+    )
+
+    rendered_output = OpsgenieRenderer().render(validation_result_suite)
+
+    expected_output = "Batch Validation Status: Success 🎉\nExpectation suite name: default\nData asset name: test_data_asset\nRun ID: 2021-01-01T000000.000000Z\nBatch ID: ()\nSummary: 0 of 0 expectations were met"
+
+    assert rendered_output == expected_output
+
+
 
 
 def test_OpsgenieRenderer_validation_results_failure():

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -1,9 +1,8 @@
+from great_expectations.core.batch import BatchDefinition, IDDict
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
-from great_expectations.core.batch import BatchDefinition
 from great_expectations.render.renderer import SlackRenderer
-from great_expectations.core import IDDict
 
 
 def test_SlackRenderer_validation_results_with_datadocs():

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -1,7 +1,9 @@
 from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
 )
+from great_expectations.core.batch import BatchDefinition
 from great_expectations.render.renderer import SlackRenderer
+from great_expectations.core import IDDict
 
 
 def test_SlackRenderer_validation_results_with_datadocs():
@@ -106,6 +108,134 @@ def test_SlackRenderer_validation_results_with_datadocs():
                 "text": {
                     "type": "mrkdwn",
                     "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `x/y/z`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `data_asset_name=x/y/z`\n*Summary*: *0* of *0* expectations were met",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*ERROR*: Slack is trying to provide a link to the following DataDocs: `fake_site`, but it is not configured under `data_docs_sites` in the `great_expectations.yml`\n",
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "Learn how to review validation results in Data Docs: https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html",
+                    }
+                ],
+            },
+        ],
+        "text": "default: Success :tada:",
+    }
+
+    assert rendered_output == expected_output
+
+def test_SlackRenderer_checkpoint_validation_results_with_datadocs():
+
+    batch_definition = BatchDefinition(
+        datasource_name="test_datasource",
+        data_connector_name="test_dataconnector",
+        data_asset_name = "test_data_asset",
+        batch_identifiers=IDDict({"id": "my_id"}),
+    )
+    validation_result_suite = ExpectationSuiteValidationResult(
+        results=[],
+        success=True,
+        statistics={
+            "evaluated_expectations": 0,
+            "successful_expectations": 0,
+            "unsuccessful_expectations": 0,
+            "success_percent": None,
+        },
+        meta={
+            "great_expectations_version": "v0.8.0__develop",
+            "active_batch_definition": batch_definition,
+            "expectation_suite_name": "default",
+            "run_id": "2019-09-25T060538.829112Z",
+        },
+    )
+
+    rendered_output = SlackRenderer().render(validation_result_suite)
+
+    expected_output = {
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `test_data_asset`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `()`\n*Summary*: *0* of *0* expectations were met",
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "Learn how to review validation results in Data Docs: https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html",
+                    }
+                ],
+            },
+        ],
+        "text": "default: Success :tada:",
+    }
+    print(rendered_output)
+    print(expected_output)
+    assert rendered_output == expected_output
+
+    data_docs_pages = {"local_site": "file:///localsite/index.html"}
+    notify_with = ["local_site"]
+    rendered_output = SlackRenderer().render(
+        validation_result_suite, data_docs_pages, notify_with
+    )
+
+    expected_output = {
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `test_data_asset`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `()`\n*Summary*: *0* of *0* expectations were met",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*DataDocs* can be found here: `file:///localsite/index.html` \n (Please copy and paste link into a browser to view)\n",
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": "Learn how to review validation results in Data Docs: https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/set_up_data_docs.html",
+                    }
+                ],
+            },
+        ],
+        "text": "default: Success :tada:",
+    }
+    assert rendered_output == expected_output
+
+    # not configured
+    notify_with = ["fake_site"]
+    rendered_output = SlackRenderer().render(
+        validation_result_suite, data_docs_pages, notify_with
+    )
+
+    expected_output = {
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Batch Validation Status*: Success :tada:\n*Expectation suite name*: `default`\n*Data asset name*: `test_data_asset`\n*Run ID*: `2019-09-25T060538.829112Z`\n*Batch ID*: `()`\n*Summary*: *0* of *0* expectations were met",
                 },
             },
             {

--- a/tests/render/test_SlackRenderer.py
+++ b/tests/render/test_SlackRenderer.py
@@ -133,12 +133,13 @@ def test_SlackRenderer_validation_results_with_datadocs():
 
     assert rendered_output == expected_output
 
+
 def test_SlackRenderer_checkpoint_validation_results_with_datadocs():
 
     batch_definition = BatchDefinition(
         datasource_name="test_datasource",
         data_connector_name="test_dataconnector",
-        data_asset_name = "test_data_asset",
+        data_asset_name="test_data_asset",
         batch_identifiers=IDDict({"id": "my_id"}),
     )
     validation_result_suite = ExpectationSuiteValidationResult(


### PR DESCRIPTION
Resolves #3430 

Updated code to look for data_asset_name in `active_batch_definition` section of validation results.



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
