### PR TITLE
Insure consistency between implementation of overriding Python __hash__() and internal ID property value

### DIFF
--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -139,14 +139,7 @@ class BatchDefinition(SerializableDictDot):
 
     def __hash__(self) -> int:
         """Overrides the default implementation"""
-        _result_hash: int = (
-            hash(self.datasource_name)
-            ^ hash(self.data_connector_name)
-            ^ hash(self.data_asset_name)
-        )
-        if self.batch_identifiers is not None:
-            for key, value in self.batch_identifiers.items():
-                _result_hash = _result_hash ^ hash(key) ^ hash(str(value))
+        _result_hash: int = hash(self.id)
         return _result_hash
 
 

--- a/great_expectations/validator/exception_info.py
+++ b/great_expectations/validator/exception_info.py
@@ -65,9 +65,5 @@ class ExceptionInfo(SerializableDotDict):
 
     def __hash__(self) -> int:
         """Overrides the default implementation"""
-        _result_hash: int = (
-            hash(self.exception_traceback)
-            ^ hash(self.exception_message)
-            ^ hash(self.raised_exception)
-        )
+        _result_hash: int = hash(self.id)
         return _result_hash

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -461,7 +461,7 @@ class Validator:
                     result = ExpectationValidationResult(
                         success=False,
                         exception_info=exception_info,
-                        expectation_config=configuration,
+                        expectation_config=evaluated_config,
                     )
                     evrs.append(result)
                 else:


### PR DESCRIPTION
### Note
Making implementation somewhat more verbose for code clarity (two lines, instead of just one `return` line) to emphasize that the type of the `Python` `Hash` must be an integer (while internal IDs are often strings).

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-143/GREAT-270
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
