### PR TITLE
[DOCS] Fix broken links in how_to_create_a_new_expectation_suite_using_rule_based_profiler

### DIFF
--- a/docs/guides/expectations/advanced/how_to_create_a_new_expectation_suite_using_rule_based_profilers.md
+++ b/docs/guides/expectations/advanced/how_to_create_a_new_expectation_suite_using_rule_based_profilers.md
@@ -9,7 +9,7 @@ In this tutorial, you will develop hands-on experience with configuring a Rule-B
 
 - Have a basic understanding of [Metrics in Great Expectations](https://docs.greatexpectations.io/en/latest/reference/core_concepts/metrics.html)
 - Have a basic understanding of [Expectation Configurations in Great Expectations](https://docs.greatexpectations.io/en/latest/reference/core_concepts/expectations/expectations.html#expectation-concepts-domain-and-success-keys)
-- Have read the sections in Core Concepts on [Profilers](../../../../reference/profilers) and [Rule-Based Profilers](../../../../reference/profilers#rule-based-profilers)
+- Have read the sections in Core Concepts on [Profilers](../../../reference/profilers) and [Rule-Based Profilers](../../../reference/profilers#rule-based-profilers)
 
 </Prerequisites>
 

--- a/docs_rtd/changelog.rst
+++ b/docs_rtd/changelog.rst
@@ -18,7 +18,6 @@ develop
 * [BUGFIX] fixed typo and added CLA links (#3347)
 * [DOCS] Azure Data Connector Documentation for Pandas and Spark. (#3378)
 * [DOCS] Connecting to GCS using Spark (#3375)
-* [DOCS] Fixed broken links in how_to_create_a_new_expectation_suite_using_rule_based_profilers 
 * [DOCS] Docusaurus - Deploying Great Expectations in a hosted environment without file system or CLI (#3361)
 * [DOCS] How to get a batch from configured datasource (#3382)
 * [MAINTENANCE] Add Flyte to README (#3387) (Thanks @samhita-alla)


### PR DESCRIPTION
It seems PR #3410 actually did not fix these links. They were fine before and now they are broken.

### Definition of Done

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have run any local integration tests and made sure that nothing is broken.
