### PR TITLE
[BUGFIX] Fix TupleS3StoreBackend remove_key bug

### DIFF
--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -680,7 +680,6 @@ class TupleS3StoreBackend(TupleStoreBackend):
         return public_url
 
     def remove_key(self, key):
-        from botocore.exceptions import ClientError
 
         if not isinstance(key, tuple):
             key = key.to_tuple()
@@ -688,27 +687,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
         s3 = self._create_resource()
         s3_object_key = self._build_s3_object_key(key)
         s3.Object(self.bucket, s3_object_key).delete()
-        if s3_object_key:
-            try:
-                #
-                objects_to_delete = s3.meta.client.list_objects_v2(
-                    Bucket=self.bucket, Prefix=self.prefix
-                )
-
-                delete_keys = {
-                    "Objects": [
-                        {"Key": k}
-                        for k in [
-                            obj["Key"] for obj in objects_to_delete.get("Contents", [])
-                        ]
-                    ]
-                }
-                s3.meta.client.delete_objects(Bucket=self.bucket, Delete=delete_keys)
-                return True
-            except ClientError as e:
-                return False
-        else:
-            return False
+        return True
 
     def _has_key(self, key):
         all_keys = self.list_keys()

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -686,8 +686,14 @@ class TupleS3StoreBackend(TupleStoreBackend):
 
         s3 = self._create_resource()
         s3_object_key = self._build_s3_object_key(key)
-        s3.Object(self.bucket, s3_object_key).delete()
-        return True
+
+        # Check if the object exists
+        if self.has_key(key):
+            # This implementation deletes the object if non-versioned or adds a delete marker if versioned
+            s3.Object(self.bucket, s3_object_key).delete()
+            return True
+        else:
+            return False
 
     def _has_key(self, key):
         all_keys = self.list_keys()

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -603,6 +603,32 @@ def test_TupleS3StoreBackend_with_prefix():
         "this_is_a_test_prefix/my_file_AAA",
     }
 
+    # Call remove_key on an already deleted object
+    assert not my_store.remove_key(("BBB",))
+    # Check that the rest of the keys still exist in the bucket
+    assert {
+        s3_object_info["Key"]
+        for s3_object_info in boto3.client("s3").list_objects_v2(
+            Bucket=bucket, Prefix=prefix
+        )["Contents"]
+    } == {
+        "this_is_a_test_prefix/.ge_store_backend_id",
+        "this_is_a_test_prefix/my_file_AAA",
+    }
+
+    # Call remove_key on a non-existent key
+    assert not my_store.remove_key(("NON_EXISTENT_KEY",))
+    # Check that the rest of the keys still exist in the bucket
+    assert {
+        s3_object_info["Key"]
+        for s3_object_info in boto3.client("s3").list_objects_v2(
+            Bucket=bucket, Prefix=prefix
+        )["Contents"]
+    } == {
+        "this_is_a_test_prefix/.ge_store_backend_id",
+        "this_is_a_test_prefix/my_file_AAA",
+    }
+
     # testing base_public_path
     my_new_store = TupleS3StoreBackend(
         filepath_template="my_file_{0}",

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -589,9 +589,19 @@ def test_TupleS3StoreBackend_with_prefix():
         == f"https://s3.amazonaws.com/{bucket}/{prefix}/my_file_BBB"
     )
 
-    my_store.remove_key(("BBB",))
+    assert my_store.remove_key(("BBB",))
     with pytest.raises(InvalidKeyError):
         my_store.get(("BBB",))
+    # Check that the rest of the keys still exist in the bucket
+    assert {
+        s3_object_info["Key"]
+        for s3_object_info in boto3.client("s3").list_objects_v2(
+            Bucket=bucket, Prefix=prefix
+        )["Contents"]
+    } == {
+        "this_is_a_test_prefix/.ge_store_backend_id",
+        "this_is_a_test_prefix/my_file_AAA",
+    }
 
     # testing base_public_path
     my_new_store = TupleS3StoreBackend(


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix a bug encountered with TupleS3StoreBackend remove_key() method where the objects at the given prefix were getting removed.
- Also tested successfully with a real s3 bucket and the original configuration where the bug was discovered.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
