### PR TITLE
[BUGFIX] Serialization of alternate configurations when passing RuntimeBatchRequest into Checkpoint

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -250,7 +250,8 @@ class Checkpoint:
         )
         run_name_template: Optional[str] = substituted_runtime_config.run_name_template
         validations: list = substituted_runtime_config.validations
-        if len(validations) == 0:
+        batch_request: BatchRequest = substituted_runtime_config.batch_request
+        if len(validations) == 0 and batch_request is None:
             raise ge_exceptions.CheckpointError(
                 f'Checkpoint "{self.name}" does not contain any validations.'
             )

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -253,7 +253,7 @@ class Checkpoint:
         batch_request: BatchRequest = substituted_runtime_config.batch_request
         if len(validations) == 0 and batch_request is None:
             raise ge_exceptions.CheckpointError(
-                f'Checkpoint "{self.name}" does not contain any validations.'
+                f'Checkpoint "{self.name}" must contain either a batch_request or validations.'
             )
 
         if run_name is None and run_name_template is not None:

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -411,6 +411,8 @@ class RuntimeBatchRequest(BatchRequest):
             cp._runtime_parameters["batch_data"] = batch_data
             self._runtime_parameters["batch_data"] = batch_data
             return cp
+        else:
+            self.__deepcopy__ = None
         return copy.deepcopy(self, memo)
 
     def to_json_dict(self) -> dict:

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -1355,7 +1355,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
         raise pytest.fail(f"EXCEPTION: {exception}")
 
 
-def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_object_top_level_batch_request(
+def test_newstyle_checkpoint_instantiates_and_produces_a_result_when_run_runtime_batch_request_object_top_level_batch_request(
     data_context_with_datasource_spark_engine,
 ):
     context: DataContext = data_context_with_datasource_spark_engine
@@ -1405,7 +1405,6 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
     # noinspection PyUnusedLocal
     results = checkpoint.run()
 
-    assert len(context.validations_store.list_keys()) == 1
     assert results["success"] == True
     try:
         print(results)

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -1576,7 +1576,9 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "test_df",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"
+            },
         }
     )
     checkpoint = Checkpoint(

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -1355,6 +1355,64 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
         raise pytest.fail(f"EXCEPTION: {exception}")
 
 
+def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_runtime_batch_request_object_top_level_batch_request(
+    data_context_with_datasource_spark_engine,
+):
+    context: DataContext = data_context_with_datasource_spark_engine
+    spark = SparkSession.builder.getOrCreate()
+    pandas_df: pd.DataFrame = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
+    test_df = spark.createDataFrame(pandas_df)
+    # add checkpoint config
+    batch_request = RuntimeBatchRequest(
+        **{
+            "datasource_name": "my_datasource",
+            "data_connector_name": "default_runtime_data_connector_name",
+            "data_asset_name": "test_df",
+            "batch_identifiers": {"default_identifier_name": "test_identifier"},
+            "runtime_parameters": {"batch_data": test_df},
+        }
+    )
+    checkpoint = Checkpoint(
+        name="my_checkpoint",
+        data_context=context,
+        config_version=1,
+        run_name_template="%Y-%M-foo-bar-template",
+        expectation_suite_name="my_expectation_suite",
+        action_list=[
+            {
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction",
+                },
+            },
+            {
+                "name": "store_evaluation_params",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction",
+                },
+            },
+            {
+                "name": "update_data_docs",
+                "action": {
+                    "class_name": "UpdateDataDocsAction",
+                },
+            },
+        ],
+        batch_request=batch_request,
+    )
+
+    context.create_expectation_suite("my_expectation_suite")
+    # noinspection PyUnusedLocal
+    results = checkpoint.run()
+
+    assert len(context.validations_store.list_keys()) == 1
+    assert results["success"] == True
+    try:
+        print(results)
+    except Exception as exception:
+        raise pytest.fail(f"EXCEPTION: {exception}")
+
+
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_object_multi_validation_pandasdf(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
 ):

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -22,6 +22,7 @@ except ImportError:
     pyspark = None
     SparkSession = None
 
+
 @pytest.fixture
 def update_data_docs_action():
     return {
@@ -1057,7 +1058,9 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "test_df",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"
+            },
         }
     )
     checkpoint = SimpleCheckpoint(


### PR DESCRIPTION
Changes proposed in this pull request:
- DEVREL-259
- DEVREL-346
- DEVREL-401

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.