### PR TITLE
[BUGFIX] Recursion error when passing RuntimeBatchRequest with query into Checkpoint using validations

### DIFF
--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -411,6 +411,9 @@ class RuntimeBatchRequest(BatchRequest):
             cp._runtime_parameters["batch_data"] = batch_data
             self._runtime_parameters["batch_data"] = batch_data
             return cp
+        else:
+            # Don't use custom deepcopy if batch_data isn't found
+            self.__deepcopy__ = None
         return copy.deepcopy(self, memo)
 
     def to_json_dict(self) -> dict:

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -1507,6 +1507,140 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
         raise pytest.fail(f"EXCEPTION: {exception}")
 
 
+def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_query_in_validations(
+    data_context_with_datasource_sqlalchemy_engine,
+):
+    context: DataContext = data_context_with_datasource_sqlalchemy_engine
+
+    # create expectation suite
+    context.create_expectation_suite("my_expectation_suite")
+
+    # RuntimeBatchRequest with a query
+    batch_request = RuntimeBatchRequest(
+        **{
+            "datasource_name": "my_datasource",
+            "data_connector_name": "default_runtime_data_connector_name",
+            "data_asset_name": "default_data_asset_name",
+            "batch_identifiers": {"default_identifier_name": "test_identifier"},
+            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+        }
+    )
+
+    # add checkpoint config
+    checkpoint = Checkpoint(
+        name="my_checkpoint",
+        data_context=context,
+        config_version=1,
+        run_name_template="%Y-%M-foo-bar-template",
+        expectation_suite_name="my_expectation_suite",
+        action_list=[
+            {
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction",
+                },
+            },
+            {
+                "name": "store_evaluation_params",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction",
+                },
+            },
+            {
+                "name": "update_data_docs",
+                "action": {
+                    "class_name": "UpdateDataDocsAction",
+                },
+            },
+        ],
+        validations=[
+            {"batch_request": batch_request}
+        ],
+    )
+
+    results = checkpoint.run()
+
+    assert len(context.validations_store.list_keys()) == 1
+    assert results["success"] == True
+    try:
+        print(results)
+    except Exception as exception:
+        raise pytest.fail(f"EXCEPTION: {exception}")
+
+
+def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_multiple_runtime_batch_request_query_in_validations(
+    data_context_with_datasource_sqlalchemy_engine,
+):
+    context: DataContext = data_context_with_datasource_sqlalchemy_engine
+
+    # create expectation suite
+    context.create_expectation_suite("my_expectation_suite")
+
+    # RuntimeBatchRequest with a query 1
+    batch_request_1 = RuntimeBatchRequest(
+        **{
+            "datasource_name": "my_datasource",
+            "data_connector_name": "default_runtime_data_connector_name",
+            "data_asset_name": "default_data_asset_name",
+            "batch_identifiers": {"default_identifier_name": "test_identifier"},
+            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+        }
+    )
+
+    # RuntimeBatchRequest with a query 2
+    batch_request_2 = RuntimeBatchRequest(
+        **{
+            "datasource_name": "my_datasource",
+            "data_connector_name": "default_runtime_data_connector_name",
+            "data_asset_name": "default_data_asset_name",
+            "batch_identifiers": {"default_identifier_name": "test_identifier"},
+            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 5"},
+        }
+    )
+
+    # add checkpoint config
+    checkpoint = Checkpoint(
+        name="my_checkpoint",
+        data_context=context,
+        config_version=1,
+        run_name_template="%Y-%M-foo-bar-template",
+        expectation_suite_name="my_expectation_suite",
+        action_list=[
+            {
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction",
+                },
+            },
+            {
+                "name": "store_evaluation_params",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction",
+                },
+            },
+            {
+                "name": "update_data_docs",
+                "action": {
+                    "class_name": "UpdateDataDocsAction",
+                },
+            },
+        ],
+        validations=[
+            {"batch_request": batch_request_1},
+            {"batch_request": batch_request_2}
+        ],
+    )
+
+    results = checkpoint.run()
+
+    assert len(context.validations_store.list_keys()) == 1
+    assert results["success"] == True
+    try:
+        print(results)
+    except Exception as exception:
+        raise pytest.fail(f"EXCEPTION: {exception}")
+
+
 def test_newstyle_checkpoint_config_substitution_simple(
     titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates,
     monkeypatch,

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -1508,7 +1508,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_query_in_validations(
-    data_context_with_datasource_sqlalchemy_engine,
+    data_context_with_datasource_sqlalchemy_engine, sa
 ):
     context: DataContext = data_context_with_datasource_sqlalchemy_engine
 
@@ -1569,7 +1569,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
 
 
 def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_multiple_runtime_batch_request_query_in_validations(
-    data_context_with_datasource_sqlalchemy_engine,
+    data_context_with_datasource_sqlalchemy_engine, sa
 ):
     context: DataContext = data_context_with_datasource_sqlalchemy_engine
 

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -1522,7 +1522,9 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "default_data_asset_name",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"
+            },
         }
     )
 
@@ -1553,9 +1555,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
                 },
             },
         ],
-        validations=[
-            {"batch_request": batch_request}
-        ],
+        validations=[{"batch_request": batch_request}],
     )
 
     results = checkpoint.run()
@@ -1583,7 +1583,9 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "default_data_asset_name",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"
+            },
         }
     )
 
@@ -1594,7 +1596,9 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "default_data_asset_name",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 5"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 5"
+            },
         }
     )
 
@@ -1627,7 +1631,7 @@ def test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_
         ],
         validations=[
             {"batch_request": batch_request_1},
-            {"batch_request": batch_request_2}
+            {"batch_request": batch_request_2},
         ],
     )
 

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -990,7 +990,9 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "default_data_asset_name",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"
+            },
         }
     )
 
@@ -1021,9 +1023,7 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
                 },
             },
         ],
-        validations=[
-            {"batch_request": batch_request}
-        ],
+        validations=[{"batch_request": batch_request}],
     )
 
     results = checkpoint.run()
@@ -1051,7 +1051,9 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "default_data_asset_name",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"
+            },
         }
     )
 
@@ -1062,7 +1064,9 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
             "data_connector_name": "default_runtime_data_connector_name",
             "data_asset_name": "default_data_asset_name",
             "batch_identifiers": {"default_identifier_name": "test_identifier"},
-            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 5"},
+            "runtime_parameters": {
+                "query": "SELECT * from table_partitioned_by_date_column__A LIMIT 5"
+            },
         }
     )
 
@@ -1095,7 +1099,7 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
         ],
         validations=[
             {"batch_request": batch_request_1},
-            {"batch_request": batch_request_2}
+            {"batch_request": batch_request_2},
         ],
     )
 

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -976,7 +976,7 @@ def test_simple_checkpoint_with_runtime_batch_request_and_runtime_data_connector
 
 
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_query_in_validations(
-    data_context_with_datasource_sqlalchemy_engine,
+    data_context_with_datasource_sqlalchemy_engine, sa
 ):
     context: DataContext = data_context_with_datasource_sqlalchemy_engine
 
@@ -1037,7 +1037,7 @@ def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_ru
 
 
 def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_multiple_runtime_batch_request_query_in_validations(
-    data_context_with_datasource_sqlalchemy_engine,
+    data_context_with_datasource_sqlalchemy_engine, sa
 ):
     context: DataContext = data_context_with_datasource_sqlalchemy_engine
 

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -973,3 +973,137 @@ def test_simple_checkpoint_with_runtime_batch_request_and_runtime_data_connector
     assert checkpoint_config.evaluation_parameters == {}
     assert checkpoint_config.runtime_configuration == {}
     assert checkpoint_config.validations == []
+
+
+def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_single_runtime_batch_request_query_in_validations(
+    data_context_with_datasource_sqlalchemy_engine,
+):
+    context: DataContext = data_context_with_datasource_sqlalchemy_engine
+
+    # create expectation suite
+    context.create_expectation_suite("my_expectation_suite")
+
+    # RuntimeBatchRequest with a query
+    batch_request = RuntimeBatchRequest(
+        **{
+            "datasource_name": "my_datasource",
+            "data_connector_name": "default_runtime_data_connector_name",
+            "data_asset_name": "default_data_asset_name",
+            "batch_identifiers": {"default_identifier_name": "test_identifier"},
+            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+        }
+    )
+
+    # add checkpoint config
+    checkpoint = SimpleCheckpoint(
+        name="my_checkpoint",
+        data_context=context,
+        config_version=1,
+        run_name_template="%Y-%M-foo-bar-template",
+        expectation_suite_name="my_expectation_suite",
+        action_list=[
+            {
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction",
+                },
+            },
+            {
+                "name": "store_evaluation_params",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction",
+                },
+            },
+            {
+                "name": "update_data_docs",
+                "action": {
+                    "class_name": "UpdateDataDocsAction",
+                },
+            },
+        ],
+        validations=[
+            {"batch_request": batch_request}
+        ],
+    )
+
+    results = checkpoint.run()
+
+    assert len(context.validations_store.list_keys()) == 1
+    assert results["success"] == True
+    try:
+        print(results)
+    except Exception as exception:
+        raise pytest.fail(f"EXCEPTION: {exception}")
+
+
+def test_simple_checkpoint_instantiates_and_produces_a_validation_result_when_run_multiple_runtime_batch_request_query_in_validations(
+    data_context_with_datasource_sqlalchemy_engine,
+):
+    context: DataContext = data_context_with_datasource_sqlalchemy_engine
+
+    # create expectation suite
+    context.create_expectation_suite("my_expectation_suite")
+
+    # RuntimeBatchRequest with a query 1
+    batch_request_1 = RuntimeBatchRequest(
+        **{
+            "datasource_name": "my_datasource",
+            "data_connector_name": "default_runtime_data_connector_name",
+            "data_asset_name": "default_data_asset_name",
+            "batch_identifiers": {"default_identifier_name": "test_identifier"},
+            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 10"},
+        }
+    )
+
+    # RuntimeBatchRequest with a query 2
+    batch_request_2 = RuntimeBatchRequest(
+        **{
+            "datasource_name": "my_datasource",
+            "data_connector_name": "default_runtime_data_connector_name",
+            "data_asset_name": "default_data_asset_name",
+            "batch_identifiers": {"default_identifier_name": "test_identifier"},
+            "runtime_parameters": {"query": "SELECT * from table_partitioned_by_date_column__A LIMIT 5"},
+        }
+    )
+
+    # add checkpoint config
+    checkpoint = SimpleCheckpoint(
+        name="my_checkpoint",
+        data_context=context,
+        config_version=1,
+        run_name_template="%Y-%M-foo-bar-template",
+        expectation_suite_name="my_expectation_suite",
+        action_list=[
+            {
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction",
+                },
+            },
+            {
+                "name": "store_evaluation_params",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction",
+                },
+            },
+            {
+                "name": "update_data_docs",
+                "action": {
+                    "class_name": "UpdateDataDocsAction",
+                },
+            },
+        ],
+        validations=[
+            {"batch_request": batch_request_1},
+            {"batch_request": batch_request_2}
+        ],
+    )
+
+    results = checkpoint.run()
+
+    assert len(context.validations_store.list_keys()) == 1
+    assert results["success"] == True
+    try:
+        print(results)
+    except Exception as exception:
+        raise pytest.fail(f"EXCEPTION: {exception}")


### PR DESCRIPTION
Changes proposed in this pull request:
- Story: GREAT-358
- Subtasks: GREAT-360, GREAT-382
- Fix bug that occurs when running a Checkpoint or SimpleCheckpoint that uses a RuntimeBatchRequest with a custom query that has been passed into the Checkpoint validations parameter.

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.