### PR TITLE
[BUGFIX] Azure CI/CD Python3.9 suddenly fails for existing tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,6 +155,7 @@ stages:
 
           - script: |
               pip install pytest pytest-cov pytest-azurepipelines
+              pip freeze
               pytest $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
             displayName: 'pytest'
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Hot fix for Azure pipeline failing at Python3.9 `pytest`

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have run any local integration tests and made sure that nothing is broken.