### PR TITLE
<!!!DO_NOT_MERGE!!!>[PROTOTYPE/DEMO] multi-batch quantile ranges profiler example<!!!DO_NOT_MERGE!!!>

### DIFF
--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -236,12 +236,11 @@ detected.
                 message=f"The confidence level for {self.__class__.__name__} is outside of [0.0, 1.0] closed interval."
             )
 
-        metric_values = np.array(metric_values, dtype=np.float64)
-
         lower_quantile: Union[Number, float]
         upper_quantile: Union[Number, float]
 
-        if len(metric_values.shape) > 1 and metric_values.shape[1] > 1:
+        if isinstance(metric_values[0], list):
+            metric_values = np.array(metric_values, dtype=np.float64)
             metric_values = np.transpose(metric_values)
 
             value_ranges: List[List[float]] = []
@@ -290,6 +289,8 @@ detected.
                 variables=variables,
                 parameters=parameters,
             )
+
+            metric_values = np.array(metric_values, dtype=np.float64)
 
             if np.all(np.isclose(metric_values, metric_values[0])):
                 # Computation is unnecessary if distribution is degenerate.

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -241,7 +241,7 @@ detected.
         lower_quantile: Union[Number, float]
         upper_quantile: Union[Number, float]
 
-        if metric_values.shape[1] > 1:
+        if len(metric_values.shape) > 1 and metric_values.shape[1] > 1:
             metric_values = np.transpose(metric_values)
 
             value_ranges: List[List[float]] = []

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -110,6 +110,35 @@ def test_stdev_metric_pd():
     assert results == {desired_metric.id: 1}
 
 
+def test_quantiles_metric_pd():
+    engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 3, 4]}))
+
+    metrics: dict = {}
+
+    table_columns_metric: MetricConfiguration
+    results: dict
+
+    table_columns_metric, results = get_table_columns_metric(engine=engine)
+    metrics.update(results)
+
+    desired_metric = MetricConfiguration(
+        metric_name="column.quantile_values",
+        metric_domain_kwargs={"column": "a"},
+        metric_value_kwargs={
+            "quantiles": [2.5e-1, 5.0e-1, 7.5e-1],
+            "allow_relative_error": "linear",
+        },
+        metric_dependencies={
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(desired_metric,), metrics=metrics
+    )
+    metrics.update(results)
+    assert results == {desired_metric.id: [1.75, 2.5, 3.25]}
+
+
 def test_max_metric_column_exists_pd():
     df = pd.DataFrame({"a": [1, 2, 3, 3, None]})
     batch = Batch(data=df)

--- a/tests/rule_based_profiler/quentin_user_workflow_fixture.py
+++ b/tests/rule_based_profiler/quentin_user_workflow_fixture.py
@@ -1,0 +1,25 @@
+import pytest
+
+# TODO: Move these fixtures to integration tests
+from great_expectations.data_context.util import file_relative_path
+
+
+@pytest.fixture
+def quentin_columnar_table_multi_batch():
+    verbose_profiler_config_file_path: str = file_relative_path(
+        __file__, "quentin_user_workflow_verbose_profiler_config.yml"
+    )
+    verbose_profiler_config: str
+    with open(verbose_profiler_config_file_path) as f:
+        verbose_profiler_config = f.read()
+
+    expectation_suite_name_bootstrap_sampling_method: str = (
+        "quentin_columnar_table_multi_batch"
+    )
+
+    return {
+        "profiler_config": verbose_profiler_config,
+        "test_configuration": {
+            "expectation_suite_name": expectation_suite_name_bootstrap_sampling_method,
+        },
+    }

--- a/tests/rule_based_profiler/quentin_user_workflow_verbose_profiler_config.yml
+++ b/tests/rule_based_profiler/quentin_user_workflow_verbose_profiler_config.yml
@@ -1,0 +1,50 @@
+# This profiler is meant to be used on the NYC taxi data:
+# tests/test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_20(18|19|20)-*.csv
+variables:
+  quantiles:
+    - 2.5e-1
+    - 5.0e-1
+    - 7.5e-1
+
+  # BatchRequest yielding thirty five (35) batches (January, 2018 -- November, 2020 trip data)
+  jan_2018_thru_nov_2020_monthly_tripdata_batch_request:
+    datasource_name: taxi_pandas
+    data_connector_name: monthly
+    data_asset_name: my_reports
+    data_connector_query:
+      index: ":-1"
+
+  false_positive_rate: 5.0e-2
+
+rules:
+  column_quantiles_rule:
+    domain_builder:
+      class_name: SimpleColumnSuffixDomainBuilder
+      # BatchRequest yielding exactly one batch (November, 2020 trip data)
+      batch_request:
+        datasource_name: taxi_pandas
+        data_connector_name: monthly
+        data_asset_name: my_reports
+        data_connector_query:
+          index: -1
+      column_name_suffixes:
+        - _amount
+    parameter_builders:
+      - parameter_name: quantile_value_ranges
+        class_name: NumericMetricRangeMultiBatchParameterBuilder
+        batch_request: $variables.jan_2018_thru_nov_2020_monthly_tripdata_batch_request
+        metric_name: column.quantile_values
+        metric_domain_kwargs: $domain.domain_kwargs
+        metric_value_kwargs:
+          quantiles: $variables.quantiles
+          allow_relative_error: linear
+        false_positive_rate: $variables.false_positive_rate
+    expectation_configuration_builders:
+      - expectation_type: expect_column_quantile_values_to_be_between
+        class_name: DefaultExpectationConfigurationBuilder
+        module_name: great_expectations.rule_based_profiler.expectation_configuration_builder
+        column: $domain.domain_kwargs.column
+        quantiles: $variables.quantiles
+        value_ranges: $parameter.quantile_value_ranges.value.value_ranges
+        meta:
+          profiler_details: $parameter.quantile_value_ranges.details

--- a/tests/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/rule_based_profiler/test_profiler_user_workflows.py
@@ -275,3 +275,35 @@ def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstr
             "test_configuration_bootstrap_sampling_method"
         ]["expect_table_row_count_to_be_between_max_value_mean_value"]
     )
+
+
+@pytest.mark.skipif(
+    version.parse(np.version.version) < version.parse("1.21.0"),
+    reason="requires numpy version 1.21.0 or newer",
+)
+def test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule(
+    quentin_columnar_table_multi_batch_data_context,
+    quentin_columnar_table_multi_batch,
+):
+    # Load data context
+    data_context: DataContext = quentin_columnar_table_multi_batch_data_context
+
+    # Load profiler configs & loop (run tests for each one)
+    yaml_config: str = quentin_columnar_table_multi_batch["profiler_config"]
+
+    # Instantiate Profiler
+    profiler_config: dict = yaml.load(yaml_config)
+
+    profiler: Profiler = Profiler(
+        profiler_config=profiler_config,
+        data_context=data_context,
+    )
+
+    expectation_suite: ExpectationSuite = profiler.profile(
+        expectation_suite_name=quentin_columnar_table_multi_batch["test_configuration"][
+            "expectation_suite_name"
+        ],
+    )
+    print(
+        f"\n[ALEX_TEST] [TEST_PROFILER_USER_WORKFLOWS.QUENTIN] EXPECTATION_SUITE:\n{expectation_suite}"
+    )


### PR DESCRIPTION
## WARNING
Please *DO NOT* merge this Draft Pull Request

### Synopsis
* Rule Based Profiler Configuration `tests/rule_based_profiler/quentin_user_workflow_verbose_profiler_config.yml` presents a fully-functional multi-batch profiler that emits the `expect_column_quantile_values_to_be_between` expectation for every column of the taxi tripdata dataset that matches the `_amount` suffix (in other words, the different fare amounts).
* Please run the following command to see the `ExpectationSuite`, emitted by this profiler:

```
pytest tests/rule_based_profiler/test_profiler_user_workflows.py::test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule -svv
```

* Note that the parameter estimation for the `value_range` argument of the expectation is performed on a 35-batch sample using the `bootstrap` estimator.
* A new unit test was added in `tests/expectations/metrics/test_core.py` for the `column.quantile_values` metric.
* It was necessary to modify the core modules `great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py` and `great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py` of the Rule Based Profiler in order to support the quantiles type of an expectation.  Refactoring and enhancement is in order.
* The complete list of changes is:

```
git diff develop --name-only
great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
tests/expectations/metrics/test_core.py
tests/rule_based_profiler/conftest.py
tests/rule_based_profiler/quentin_user_workflow_fixture.py
tests/rule_based_profiler/quentin_user_workflow_verbose_profiler_config.yml
tests/rule_based_profiler/test_profiler_user_workflows.py
```

### Next steps
* Porting this prototype to the proper repository.
* Plans to improve the design for a more elegant support of the various numeric parameter estimators.
* Plans to productize Rule Based Profiler (ultimately so that it can be accessed from `DataContext` as the entry point).

Thank you.



Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
