### PR TITLE
[BUGFIX] Fix pyfakefs boto / GCS incompatibility

### DIFF
--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -139,7 +139,7 @@ Notes:
                         info=info
                     )
                 self._gcs = storage.Client(credentials=credentials, **gcs_options)
-            except (TypeError, AttributeError):
+            except (TypeError, AttributeError, DefaultCredentialsError):
                 self._gcs = None
 
         super().__init__(*args, **kwargs)

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -139,7 +139,7 @@ Notes:
                         info=info
                     )
                 self._gcs = storage.Client(credentials=credentials, **gcs_options)
-            except (TypeError, AttributeError, DefaultCredentialsError):
+            except (TypeError, AttributeError):
                 self._gcs = None
 
         super().__init__(*args, **kwargs)

--- a/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from typing import List
 
@@ -28,9 +29,15 @@ def test__get_full_file_path_for_asset_pandas(fs):
     when preparing the PathBatchSpec for the PandasExecutionEngine.
     """
 
+    # Copy boto modules into fake filesystem (see https://github.com/spulec/moto/issues/1682#issuecomment-645016188)
     for module in [boto3, botocore]:
         module_dir = pathlib.Path(module.__file__).parent
         fs.add_real_directory(module_dir, lazy_read=False)
+
+    # Copy google credentials into fake filesystem if they exist on your filesystem
+    google_cred_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if google_cred_file:
+        fs.add_real_file(google_cred_file)
 
     base_directory: str = "/dbfs/great_expectations"
     fs.create_dir(base_directory)

--- a/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
@@ -1,5 +1,8 @@
+import pathlib
 from typing import List
 
+import boto3
+import botocore
 from ruamel.yaml import YAML
 
 from great_expectations.core.batch import BatchDefinition, BatchRequest
@@ -24,6 +27,10 @@ def test__get_full_file_path_for_asset_pandas(fs):
     This test verifies that a config using a `/dbfs/` path is NOT translated to `dbfs:/`
     when preparing the PathBatchSpec for the PandasExecutionEngine.
     """
+
+    for module in [boto3, botocore]:
+        module_dir = pathlib.Path(module.__file__).parent
+        fs.add_real_directory(module_dir, lazy_read=False)
 
     base_directory: str = "/dbfs/great_expectations"
     fs.create_dir(base_directory)

--- a/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
@@ -1,4 +1,8 @@
+import pathlib
 from typing import List
+
+import boto3
+import botocore
 
 from great_expectations.core.batch import BatchDefinition, BatchRequest
 from great_expectations.core.batch_spec import PathBatchSpec
@@ -17,6 +21,9 @@ def test__get_full_file_path_pandas(fs):
     This test verifies that a config using a `/dbfs/` path is NOT translated to `dbfs:/`
     when preparing the PathBatchSpec for the PandasExecutionEngine.
     """
+    for module in [boto3, botocore]:
+        module_dir = pathlib.Path(module.__file__).parent
+        fs.add_real_directory(module_dir, lazy_read=False)
 
     base_directory: str = "/dbfs/great_expectations"
     base_directory_colon: str = "dbfs:/great_expectations"

--- a/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_dbfs_data_connector.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from typing import List
 
@@ -21,9 +22,15 @@ def test__get_full_file_path_pandas(fs):
     This test verifies that a config using a `/dbfs/` path is NOT translated to `dbfs:/`
     when preparing the PathBatchSpec for the PandasExecutionEngine.
     """
+    # Copy boto modules into fake filesystem (see https://github.com/spulec/moto/issues/1682#issuecomment-645016188)
     for module in [boto3, botocore]:
         module_dir = pathlib.Path(module.__file__).parent
         fs.add_real_directory(module_dir, lazy_read=False)
+
+    # Copy google credentials into fake filesystem if they exist on your filesystem
+    google_cred_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if google_cred_file:
+        fs.add_real_file(google_cred_file)
 
     base_directory: str = "/dbfs/great_expectations"
     base_directory_colon: str = "dbfs:/great_expectations"


### PR DESCRIPTION
Changes proposed in this pull request:
- Copy files required by `PandasExecutionEngine` to the pyfakefs when running tests
- Files copied include boto3, botocore packages (see here https://github.com/spulec/moto/issues/1682#issuecomment-645016188) and google credentials if they exist

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
