### PR TITLE
[FEATURE] Add data_context.run_checkpoint event to usage statistics

### DIFF
--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -553,7 +553,7 @@ usage_statistics_record_schema = {
         "init_payload": init_payload_schema,
         "run_validation_operator_payload": run_validation_operator_payload_schema,
         "anonymized_data_docs_site": anonymized_data_docs_site_schema,
-        "anonymized_batch_request_keys": anonymized_batch_request_schema,
+        "anonymized_batch_request": anonymized_batch_request_schema,
         "anonymized_batch": anonymized_batch_schema,
         "anonymized_expectation_suite": anonymized_expectation_suite_schema,
         "save_or_edit_expectation_suite_payload": save_or_edit_expectation_suite_payload_schema,
@@ -603,9 +603,7 @@ usage_statistics_record_schema = {
             "type": "object",
             "properties": {
                 "event": {"enum": ["data_context.get_batch_list"]},
-                "event_payload": {
-                    "$ref": "#/definitions/anonymized_batch_request_keys"
-                },
+                "event_payload": {"$ref": "#/definitions/anonymized_batch_request"},
             },
         },
         {
@@ -645,6 +643,7 @@ usage_statistics_record_schema = {
                     "enum": [
                         "data_context.build_data_docs",
                         "data_context.open_data_docs",
+                        "data_context.run_checkpoint",
                     ],
                 },
                 "event_payload": {"$ref": "#/definitions/empty_payload"},

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -3188,6 +3188,9 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         else:
             return [x.configuration_key for x in self.checkpoint_store.list_keys()]
 
+    @usage_statistics_enabled_method(
+        event_name="data_context.run_checkpoint",
+    )
     def run_checkpoint(
         self,
         checkpoint_name: Optional[str] = None,

--- a/tests/cli/test_checkpoint.py
+++ b/tests/cli/test_checkpoint.py
@@ -941,7 +941,7 @@ def test_checkpoint_run_on_checkpoint_with_not_found_suite_raises_error(
     stdout: str = result.stdout
     assert "expectation_suite suite_from_template_1 not found" in stdout
 
-    assert mock_emit.call_count == 3
+    assert mock_emit.call_count == 4
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -953,6 +953,13 @@ def test_checkpoint_run_on_checkpoint_with_not_found_suite_raises_error(
                 "event": "cli.checkpoint.run.begin",
                 "event_payload": {"api_version": "v3"},
                 "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
+                "success": False,
             }
         ),
         mock.call(
@@ -1065,7 +1072,7 @@ def test_checkpoint_run_on_checkpoint_with_batch_load_problem_raises_error(
     # assert "No such file or directory" in stdout
     assert ("No such file or directory" in stdout) or ("does not exist" in stdout)
 
-    assert mock_emit.call_count == 5
+    assert mock_emit.call_count == 6
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -1105,6 +1112,13 @@ def test_checkpoint_run_on_checkpoint_with_batch_load_problem_raises_error(
                     "runtime_parameters_keys": ["path"],
                     "batch_spec_passthrough_keys": ["reader_method"],
                 },
+                "success": False,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": False,
             }
         ),
@@ -1200,7 +1214,7 @@ def test_checkpoint_run_on_checkpoint_with_empty_suite_list_raises_error(
         in stdout
     )
 
-    assert mock_emit.call_count == 3
+    assert mock_emit.call_count == 4
     assert mock_emit.call_args_list == [
         mock.call(
             {"event_payload": {}, "event": "data_context.__init__", "success": True}
@@ -1210,6 +1224,13 @@ def test_checkpoint_run_on_checkpoint_with_empty_suite_list_raises_error(
                 "event": "cli.checkpoint.run.begin",
                 "event_payload": {"api_version": "v3"},
                 "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
+                "success": False,
             }
         ),
         mock.call(
@@ -1293,7 +1314,7 @@ def test_checkpoint_run_on_non_existent_validations(
         in stdout
     )
 
-    assert mock_emit.call_count == 3
+    assert mock_emit.call_count == 4
     assert mock_emit.call_args_list == [
         mock.call(
             {"event_payload": {}, "event": "data_context.__init__", "success": True}
@@ -1303,6 +1324,13 @@ def test_checkpoint_run_on_non_existent_validations(
                 "event": "cli.checkpoint.run.begin",
                 "event_payload": {"api_version": "v3"},
                 "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
+                "success": False,
             }
         ),
         mock.call(
@@ -1406,7 +1434,7 @@ def test_checkpoint_run_happy_path_with_successful_validation_pandas(
         ]
     )
 
-    assert mock_emit.call_count == 7
+    assert mock_emit.call_count == 8
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -1463,6 +1491,13 @@ def test_checkpoint_run_happy_path_with_successful_validation_pandas(
             {
                 "event": "data_context.build_data_docs",
                 "event_payload": {},
+                "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": True,
             }
         ),
@@ -1568,7 +1603,7 @@ def test_checkpoint_run_happy_path_with_successful_validation_sql(
         ]
     )
 
-    assert mock_emit.call_count == 7
+    assert mock_emit.call_count == 8
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -1623,6 +1658,13 @@ def test_checkpoint_run_happy_path_with_successful_validation_sql(
             {
                 "event_payload": {},
                 "event": "data_context.build_data_docs",
+                "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": True,
             }
         ),
@@ -1732,7 +1774,7 @@ def test_checkpoint_run_happy_path_with_successful_validation_spark(
         ]
     )
 
-    assert mock_emit.call_count == 7
+    assert mock_emit.call_count == 8
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -1789,6 +1831,13 @@ def test_checkpoint_run_happy_path_with_successful_validation_spark(
             {
                 "event": "data_context.build_data_docs",
                 "event_payload": {},
+                "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": True,
             }
         ),
@@ -1896,7 +1945,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_pandas(
     stdout: str = result.stdout
     assert "Validation failed!" in stdout
 
-    assert mock_emit.call_count == 7
+    assert mock_emit.call_count == 8
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -1953,6 +2002,13 @@ def test_checkpoint_run_happy_path_with_failed_validation_pandas(
             {
                 "event": "data_context.build_data_docs",
                 "event_payload": {},
+                "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": True,
             }
         ),
@@ -2048,7 +2104,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_sql(
     stdout: str = result.stdout
     assert "Validation failed!" in stdout
 
-    assert mock_emit.call_count == 7
+    assert mock_emit.call_count == 8
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -2103,6 +2159,13 @@ def test_checkpoint_run_happy_path_with_failed_validation_sql(
             {
                 "event_payload": {},
                 "event": "data_context.build_data_docs",
+                "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": True,
             }
         ),
@@ -2203,7 +2266,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_spark(
     stdout: str = result.stdout
     assert "Validation failed!" in stdout
 
-    assert mock_emit.call_count == 7
+    assert mock_emit.call_count == 8
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -2264,6 +2327,13 @@ def test_checkpoint_run_happy_path_with_failed_validation_spark(
             {
                 "event_payload": {},
                 "event": "data_context.build_data_docs",
+                "success": True,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": True,
             }
         ),
@@ -2371,7 +2441,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_pandas
     assert "Exception occurred while running Checkpoint." in stdout
     assert 'Error: The column "Name" in BatchData does not exist...' in stdout
 
-    assert mock_emit.call_count == 6
+    assert mock_emit.call_count == 7
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -2421,6 +2491,13 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_pandas
                     "anonymized_expectation_suite_name": "__not_found__",
                     "anonymized_datasource_name": "__not_found__",
                 },
+                "success": False,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": False,
             }
         ),
@@ -2519,7 +2596,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_sql(
     assert "Exception occurred while running Checkpoint." in stdout
     assert 'Error: The column "Name" in BatchData does not exist...' in stdout
 
-    assert mock_emit.call_count == 6
+    assert mock_emit.call_count == 7
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -2567,6 +2644,13 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_sql(
                     "anonymized_expectation_suite_name": "__not_found__",
                     "anonymized_datasource_name": "__not_found__",
                 },
+                "success": False,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": False,
             }
         ),
@@ -2676,7 +2760,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_spark(
     assert "Exception occurred while running Checkpoint." in stdout
     assert 'Error: The column "Name" in BatchData does not exist...' in stdout
 
-    assert mock_emit.call_count == 6
+    assert mock_emit.call_count == 7
 
     # noinspection PyUnresolvedReferences
     expected_events: List[unittest.mock._Call] = [
@@ -2730,6 +2814,13 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_spark(
                     "anonymized_expectation_suite_name": "__not_found__",
                     "anonymized_datasource_name": "__not_found__",
                 },
+                "success": False,
+            }
+        ),
+        mock.call(
+            {
+                "event_payload": {},
+                "event": "data_context.run_checkpoint",
                 "success": False,
             }
         ),

--- a/tests/core/usage_statistics/test_usage_stats_schema.py
+++ b/tests/core/usage_statistics/test_usage_stats_schema.py
@@ -235,6 +235,7 @@ def test_usage_stats_empty_payload_messages():
     usage_stats_records_messages = [
         "data_context.build_data_docs",
         "data_context.open_data_docs",
+        "data_context.run_checkpoint",
     ]
     for message_type in usage_stats_records_messages:
         for message in valid_usage_statistics_messages[message_type]:

--- a/tests/core/usage_statistics/test_usage_stats_schema.py
+++ b/tests/core/usage_statistics/test_usage_stats_schema.py
@@ -58,6 +58,7 @@ def test_comprehensive_list_of_messages():
         "data_context.get_batch_list",
         "data_context.build_data_docs",
         "data_context.open_data_docs",
+        "data_context.run_checkpoint",
         "data_context.save_expectation_suite",
         "data_context.test_yaml_config",
         "datasource.sqlalchemy.connect",

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -540,6 +540,19 @@ valid_usage_statistics_messages = {
             "x-forwarded-for": "00.000.00.000, 00.000.000.000",
         }
     ],
+    "data_context.run_checkpoint": [
+        {
+            "event_payload": {},
+            "event": "data_context.run_checkpoint",
+            "success": True,
+            "version": "1.0.0",
+            "event_time": "2020-06-25T16:08:28.070Z",
+            "data_context_id": "00000000-0000-0000-0000-000000000002",
+            "data_context_instance_id": "10000000-0000-0000-0000-000000000002",
+            "ge_version": "0.11.9.manual_testing",
+            "x-forwarded-for": "00.000.00.000, 00.000.000.000",
+        }
+    ],
     "data_context.save_expectation_suite": [
         {
             "event_payload": {


### PR DESCRIPTION
### Scope
* Adding the event "data_context.run_checkpoint" to usage statistics.
* No payload is needed -- only the fact that a checkpoint was run is needed.
* Updated schema and tests.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: ANT-20/ANT-25
-
-


After submitting your PR, CI checks will run and @tiny-tim-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
