### PR TITLE
[FEATURE] DataContext registry

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import configparser
 import copy
 import datetime
@@ -3792,11 +3790,15 @@ class DataContext(BaseDataContext):
     _data_context = None
 
     @classmethod
-    def get_data_context(cls) -> DataContext:
+    def get_data_context(cls) -> "DataContext":
+        if cls._data_context is None:
+            raise DataContextError(
+                f"Could not retrieve DataContext from empty registry. Please instantiate DataContext before calling get_data_context()."
+            )
         return cls._data_context
 
     @classmethod
-    def set_data_context(cls, data_context: DataContext):
+    def set_data_context(cls, data_context: "DataContext"):
         cls._data_context = data_context
 
     @classmethod

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import copy
 import datetime
@@ -3787,6 +3789,16 @@ class DataContext(BaseDataContext):
     Similarly, if no expectation suite name is provided, the DataContext will assume the name "default".
     """
 
+    _data_context = None
+
+    @classmethod
+    def get_data_context(cls) -> DataContext:
+        return cls._data_context
+
+    @classmethod
+    def set_data_context(cls, data_context: DataContext):
+        cls._data_context = data_context
+
     @classmethod
     def create(
         cls,
@@ -4048,6 +4060,7 @@ class DataContext(BaseDataContext):
             or project_config_dict != dataContextConfigSchema.dump(self._project_config)
         ):
             self._save_project_config()
+        DataContext.set_data_context(self)
 
     def _retrieve_data_context_config_from_ge_cloud(self) -> DataContextConfig:
         """

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -72,8 +72,13 @@ def test_get_data_context_no_context_instantiated():
     This test tests whether the correct error is raised if we try to retrieve a DataContext from a registry that has not been instantiated (set to None)
     """
     DataContext.set_data_context(None)
-    with pytest.raises(ge_exceptions.DataContextError):
+    with pytest.raises(ge_exceptions.DataContextError) as e:
         DataContext.get_data_context()
+
+    assert (
+        "Could not retrieve DataContext from empty registry. Please instantiate DataContext before calling "
+        "get_data_context()" in str(e.value)
+    )
 
 
 def test_get_data_context(titanic_data_context):
@@ -82,7 +87,7 @@ def test_get_data_context(titanic_data_context):
     """
     my_data_context: DataContext = DataContext.get_data_context()
     assert my_data_context is not None
-    assert my_data_context == titanic_data_context
+    assert my_data_context is titanic_data_context
 
 
 def test_set_data_context(

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -62,11 +62,22 @@ def parameterized_expectation_suite():
         return json.load(suite)
 
 
-def test_get_data_context(titanic_data_context):
+def test_get_data_context_no_context_instantiated():
     """
     What does this test and why?
 
-    The get_data_context() and set_data_context() methods were added as part of PR
+    The get_data_context() and set_data_context() methods were added as part of PR #3812 which introduces a registry
+    for DataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE. The next 3 tests test this functionality.
+
+    This test tests whether the correct error is raised if we try to retrieve a DataContext from a registry that has not been instantiated.
+    """
+    with pytest.raises(ge_exceptions.DataContextError):
+        DataContext.get_data_context()
+
+
+def test_get_data_context(titanic_data_context):
+    """
+    This test tests whether the registry contains the identical data_context to the only that was passed in as a param.
     """
     my_data_context: DataContext = DataContext.get_data_context()
     assert my_data_context is not None
@@ -77,14 +88,12 @@ def test_set_data_context(
     titanic_data_context, empty_data_context_with_config_variables
 ):
     """
-    What does this test and why?
-
-    This file will hold various tests to ensure that the UI functions as expected when creating a DataContextConfig object. It will ensure that the appropriate defaults are used, including when the store_backend_defaults parameter is set.
+    This test tests whether the registry contains only the most recent data_context object.
     """
     my_data_context: DataContext = DataContext.get_data_context()
     assert my_data_context is empty_data_context_with_config_variables
 
-    # set as first one
+    # set as previous context
     DataContext.set_data_context(titanic_data_context)
     my_data_context: DataContext = DataContext.get_data_context()
     assert my_data_context is titanic_data_context

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -62,21 +62,13 @@ def parameterized_expectation_suite():
         return json.load(suite)
 
 
-def test_get_data_context_no_context_instantiated():
+def test_get_data_context(titanic_data_context):
     """
     What does this test and why?
 
     The get_data_context() and set_data_context() methods were added as part of PR #3812 which introduces a registry
-    for DataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE. The next 3 tests test this functionality.
+    for DataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE.
 
-    This test tests whether the correct error is raised if we try to retrieve a DataContext from a registry that has not been instantiated.
-    """
-    with pytest.raises(ge_exceptions.DataContextError):
-        DataContext.get_data_context()
-
-
-def test_get_data_context(titanic_data_context):
-    """
     This test tests whether the registry contains the identical data_context to the only that was passed in as a param.
     """
     my_data_context: DataContext = DataContext.get_data_context()

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -62,13 +62,22 @@ def parameterized_expectation_suite():
         return json.load(suite)
 
 
-def test_get_data_context(titanic_data_context):
+def test_get_data_context_no_context_instantiated():
     """
     What does this test and why?
 
     The get_data_context() and set_data_context() methods were added as part of PR #3812 which introduces a registry
-    for DataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE.
+    for DataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE. The next 3 tests test this functionality.
 
+    This test tests whether the correct error is raised if we try to retrieve a DataContext from a registry that has not been instantiated (set to None)
+    """
+    DataContext.set_data_context(None)
+    with pytest.raises(ge_exceptions.DataContextError):
+        DataContext.get_data_context()
+
+
+def test_get_data_context(titanic_data_context):
+    """
     This test tests whether the registry contains the identical data_context to the only that was passed in as a param.
     """
     my_data_context: DataContext = DataContext.get_data_context()

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -62,6 +62,34 @@ def parameterized_expectation_suite():
         return json.load(suite)
 
 
+def test_get_data_context(titanic_data_context):
+    """
+    What does this test and why?
+
+    The get_data_context() and set_data_context() methods were added as part of PR
+    """
+    my_data_context: DataContext = DataContext.get_data_context()
+    assert my_data_context is not None
+    assert my_data_context == titanic_data_context
+
+
+def test_set_data_context(
+    titanic_data_context, empty_data_context_with_config_variables
+):
+    """
+    What does this test and why?
+
+    This file will hold various tests to ensure that the UI functions as expected when creating a DataContextConfig object. It will ensure that the appropriate defaults are used, including when the store_backend_defaults parameter is set.
+    """
+    my_data_context: DataContext = DataContext.get_data_context()
+    assert my_data_context is empty_data_context_with_config_variables
+
+    # set as first one
+    DataContext.set_data_context(titanic_data_context)
+    my_data_context: DataContext = DataContext.get_data_context()
+    assert my_data_context is titanic_data_context
+
+
 def test_create_duplicate_expectation_suite(titanic_data_context):
     # create new expectation suite
     assert titanic_data_context.create_expectation_suite(


### PR DESCRIPTION
Changes proposed in this pull request:

This PR introduces a registry for `DataContext` so that it is accessible throughout GE by using `DataContext.get_data_context()` command. The registry is populated as part of the `__init__` process of `DataContext`, and uses the `DataContext.set_data_context(data_context)` method. 

The work was originally motivated by the need to instrument the `ExpectationSuite`(specifically the `add_expectation()` method) for usage statistics. Usage statistics are mediated by the `UsageStatisticsHandler`, which is a `DataContext`-level attribute, and `ExpectationSuite` had no way of accessing the `DataContext`'s `UsageStatisticsHandler`

An alternate considered was to pass the `DataContext` along as a reference when creating `ExpectationSuite` objects, but we ran into trouble with `Store`. Which are used to which retrieve and instantiate GE objects like `ExpectationSuite` `ValidationResults` etc. In the current codebase, these are only instantiated from configurations and never directly from their constructors, and allowing the `DataContext` to be accessible from `Stores` would have required changes that we were uncomfortable with. 

This PR allows for all classes to retrieve the most recently instantiated `DataContext` using `DataContext.get_data_context()`, although is must be emphasized that in most cases, we would only have one instance (ie. effectively a Singleton object, although no explicitly so).

This PR will also enable follow-up work that involves the actual instrumentation
Previous Design Review notes:
- closes ANT-63
- enables ANT-64 / ANT-29

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
