### PR TITLE
[MAINTENANCE] BaseDataContext registry (change from DataContext registry)

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -293,6 +293,20 @@ class BaseDataContext:
         + TEST_YAML_CONFIG_SUPPORTED_CHECKPOINT_TYPES
     )
 
+    _data_context = None
+
+    @classmethod
+    def get_data_context(cls) -> "BaseDataContext":
+        if cls._data_context is None:
+            raise DataContextError(
+                f"Could not retrieve DataContext from empty registry. Please instantiate DataContext before calling get_data_context()."
+            )
+        return cls._data_context
+
+    @classmethod
+    def set_data_context(cls, data_context: "BaseDataContext"):
+        cls._data_context = data_context
+
     @classmethod
     def validate_config(cls, project_config):
         if isinstance(project_config, DataContextConfig):
@@ -393,6 +407,7 @@ class BaseDataContext:
 
         self._evaluation_parameter_dependencies_compiled = False
         self._evaluation_parameter_dependencies = {}
+        BaseDataContext.set_data_context(self)
 
     @property
     def ge_cloud_config(self):
@@ -3787,20 +3802,6 @@ class DataContext(BaseDataContext):
     Similarly, if no expectation suite name is provided, the DataContext will assume the name "default".
     """
 
-    _data_context = None
-
-    @classmethod
-    def get_data_context(cls) -> "DataContext":
-        if cls._data_context is None:
-            raise DataContextError(
-                f"Could not retrieve DataContext from empty registry. Please instantiate DataContext before calling get_data_context()."
-            )
-        return cls._data_context
-
-    @classmethod
-    def set_data_context(cls, data_context: "DataContext"):
-        cls._data_context = data_context
-
     @classmethod
     def create(
         cls,
@@ -4062,7 +4063,6 @@ class DataContext(BaseDataContext):
             or project_config_dict != dataContextConfigSchema.dump(self._project_config)
         ):
             self._save_project_config()
-        DataContext.set_data_context(self)
 
     def _retrieve_data_context_config_from_ge_cloud(self) -> DataContextConfig:
         """

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -66,14 +66,14 @@ def test_get_data_context_no_context_instantiated():
     """
     What does this test and why?
 
-    The get_data_context() and set_data_context() methods were added as part of PR #3812 which introduces a registry
-    for DataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE. The next 3 tests test this functionality.
+    The get_data_context() and set_data_context() methods were added as part of PR #3812 and which introduces a registry
+    for BaseDataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE. The next 3 tests test this functionality.
 
-    This test tests whether the correct error is raised if we try to retrieve a DataContext from a registry that has not been instantiated (set to None)
+    This test tests whether the correct error is raised if we try to retrieve a BaseDataContext from a registry that has not been instantiated (set to None)
     """
-    DataContext.set_data_context(None)
+    BaseDataContext.set_data_context(None)
     with pytest.raises(ge_exceptions.DataContextError) as e:
-        DataContext.get_data_context()
+        BaseDataContext.get_data_context()
 
     assert (
         "Could not retrieve DataContext from empty registry. Please instantiate DataContext before calling "
@@ -85,7 +85,7 @@ def test_get_data_context(titanic_data_context):
     """
     This test tests whether the registry contains the identical data_context to the only that was passed in as a param.
     """
-    my_data_context: DataContext = DataContext.get_data_context()
+    my_data_context: BaseDataContext = BaseDataContext.get_data_context()
     assert my_data_context is not None
     assert my_data_context is titanic_data_context
 
@@ -96,12 +96,12 @@ def test_set_data_context(
     """
     This test tests whether the registry contains only the most recent data_context object.
     """
-    my_data_context: DataContext = DataContext.get_data_context()
+    my_data_context: BaseDataContext = BaseDataContext.get_data_context()
     assert my_data_context is empty_data_context_with_config_variables
 
     # set as previous context
     DataContext.set_data_context(titanic_data_context)
-    my_data_context: DataContext = DataContext.get_data_context()
+    my_data_context: BaseDataContext = DataContext.get_data_context()
     assert my_data_context is titanic_data_context
 
 

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -66,7 +66,7 @@ def test_get_data_context_no_context_instantiated():
     """
     What does this test and why?
 
-    The get_data_context() and set_data_context() methods were added as part of PR #3812 and which introduces a registry
+    The get_data_context() and set_data_context() methods were added as part of PR #3812 and #3819 which introduces a registry
     for BaseDataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE. The next 3 tests test this functionality.
 
     This test tests whether the correct error is raised if we try to retrieve a BaseDataContext from a registry that has not been instantiated (set to None)


### PR DESCRIPTION
Changes proposed in this pull request:
- Follow up PR to #3812
- PR #3812 introduced a registry for `DataContext`, which is now being converted to be `BaseDataContext`. 
- `BaseDataContext` is used by both paths of instantiating a `DataContext`, namely through the `great_expectations.yml` and in-memory instantiation through the construction
- `DataContext` as it is known now, is only used when instantiating the object through the `.yml` file.
- This PR moves the registry from `DataContext` to `BaseDataContext` and adjusts the tests and typing accordingly 
- ANT-29

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

