### PR TITLE
[MAINTENANCE] Remove DataContext registry

### DIFF
--- a/great_expectations/core/usage_statistics/util.py
+++ b/great_expectations/core/usage_statistics/util.py
@@ -16,9 +16,6 @@ def send_usage_message(
     api_version: str = "v3",
     success: bool = False,
 ):
-    if data_context is None:
-        data_context = BaseDataContext.get_data_context()
-
     if not event:
         event = None
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -395,7 +395,6 @@ class BaseDataContext:
 
         self._evaluation_parameter_dependencies_compiled = False
         self._evaluation_parameter_dependencies = {}
-        BaseDataContext.set_data_context(self)
 
     @property
     def ge_cloud_config(self):

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -296,18 +296,6 @@ class BaseDataContext:
     _data_context = None
 
     @classmethod
-    def get_data_context(cls) -> "BaseDataContext":
-        if cls._data_context is None:
-            raise DataContextError(
-                f"Could not retrieve DataContext from empty registry. Please instantiate DataContext before calling get_data_context()."
-            )
-        return cls._data_context
-
-    @classmethod
-    def set_data_context(cls, data_context: "BaseDataContext"):
-        cls._data_context = data_context
-
-    @classmethod
     def validate_config(cls, project_config):
         if isinstance(project_config, DataContextConfig):
             return True

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -62,49 +62,6 @@ def parameterized_expectation_suite():
         return json.load(suite)
 
 
-def test_get_data_context_no_context_instantiated():
-    """
-    What does this test and why?
-
-    The get_data_context() and set_data_context() methods were added as part of PR #3812 and #3819 which introduces a registry
-    for BaseDataContext. This PR introduces a registry for DataContext so that it is accessible throughout GE. The next 3 tests test this functionality.
-
-    This test tests whether the correct error is raised if we try to retrieve a BaseDataContext from a registry that has not been instantiated (set to None)
-    """
-    BaseDataContext.set_data_context(None)
-    with pytest.raises(ge_exceptions.DataContextError) as e:
-        BaseDataContext.get_data_context()
-
-    assert (
-        "Could not retrieve DataContext from empty registry. Please instantiate DataContext before calling "
-        "get_data_context()" in str(e.value)
-    )
-
-
-def test_get_data_context(titanic_data_context):
-    """
-    This test tests whether the registry contains the identical data_context to the only that was passed in as a param.
-    """
-    my_data_context: BaseDataContext = BaseDataContext.get_data_context()
-    assert my_data_context is not None
-    assert my_data_context is titanic_data_context
-
-
-def test_set_data_context(
-    titanic_data_context, empty_data_context_with_config_variables
-):
-    """
-    This test tests whether the registry contains only the most recent data_context object.
-    """
-    my_data_context: BaseDataContext = BaseDataContext.get_data_context()
-    assert my_data_context is empty_data_context_with_config_variables
-
-    # set as previous context
-    DataContext.set_data_context(titanic_data_context)
-    my_data_context: BaseDataContext = DataContext.get_data_context()
-    assert my_data_context is titanic_data_context
-
-
 def test_create_duplicate_expectation_suite(titanic_data_context):
     # create new expectation suite
     assert titanic_data_context.create_expectation_suite(


### PR DESCRIPTION
### Scope
The `DataContext` registry is not being used; hence it is removed -- a better alternative is work in progress.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: ANT-20/ANT-24/ANT-94
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
