### PR TITLE
Add a clear error message if ExecutionEngine configuration is missing

### DIFF
--- a/great_expectations/datasource/new_datasource.py
+++ b/great_expectations/datasource/new_datasource.py
@@ -45,6 +45,10 @@ class BaseDatasource:
         self._name = name
 
         self._data_context_root_directory = data_context_root_directory
+        if execution_engine is None:
+            raise ge_exceptions.ExecutionEngineError(
+                message="No ExecutionEngine configuration provided."
+            )
 
         try:
             self._execution_engine = instantiate_class_from_config(

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -68,6 +68,7 @@ class ExpectColumnToExist(TableExpectation):
         "column": None,
         "column_index": None,
     }
+    args_keys = (*success_keys,)
 
     def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
         """

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -138,6 +138,7 @@ class Expectation(metaclass=MetaExpectation):
         "catch_exceptions": False,
         "result_format": "BASIC",
     }
+    args_keys = None
     legacy_method_parameters = legacy_method_parameters
 
     def __init__(self, configuration: Optional[ExpectationConfiguration] = None):
@@ -838,44 +839,6 @@ class Expectation(metaclass=MetaExpectation):
                 "cannot access configuration: expectation has not yet been configured"
             )
         return self._configuration
-
-    @classmethod
-    def build_configuration(cls, *args, **kwargs):
-        # Combine all arguments into a single new "all_args" dictionary to name positional parameters
-        all_args = dict(zip(cls.validation_kwargs, args))
-        all_args.update(kwargs)
-
-        # Unpack display parameters; remove them from all_args if appropriate
-        if "include_config" in kwargs:
-            include_config = kwargs["include_config"]
-            del all_args["include_config"]
-        else:
-            include_config = cls.default_expectation_args["include_config"]
-
-        if "catch_exceptions" in kwargs:
-            catch_exceptions = kwargs["catch_exceptions"]
-            del all_args["catch_exceptions"]
-        else:
-            catch_exceptions = cls.default_expectation_args["catch_exceptions"]
-
-        if "result_format" in kwargs:
-            result_format = kwargs["result_format"]
-        else:
-            result_format = cls.default_expectation_args["result_format"]
-
-        # Extract the meta object for use as a top-level expectation_config holder
-        if "meta" in kwargs:
-            meta = kwargs["meta"]
-            del all_args["meta"]
-        else:
-            meta = None
-
-        # Construct the expectation_config object
-        return ExpectationConfiguration(
-            expectation_type=cls.expectation_type,
-            kwargs=convert_to_json_serializable(deepcopy(all_args)),
-            meta=meta,
-        )
 
     def run_diagnostics(self, pretty_print=True):
         """

--- a/great_expectations/expectations/util.py
+++ b/great_expectations/expectations/util.py
@@ -223,14 +223,6 @@ legacy_method_parameters = {
         "catch_exceptions",
         "meta",
     ),
-    "expect_column_to_exist": (
-        "column",
-        "column_index",
-        "result_format",
-        "include_config",
-        "catch_exceptions",
-        "meta",
-    ),
     "expect_column_unique_value_count_to_be_between": (
         "column",
         "min_value",

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -249,6 +249,10 @@ class Validator:
 
         def inst_expectation(*args, **kwargs):
             # this is used so that exceptions are caught appropriately when they occur in expectation config
+
+            # TODO: JPC - THIS LOGIC DOES NOT RESPECT DEFAULTS SET BY USERS IN THE VALIDATOR VS IN THE EXPECTATION
+            # DEVREL has action to develop a new plan in coordination with MarioPod
+
             basic_default_expectation_args = {
                 k: v
                 for k, v in self.default_expectation_args.items()
@@ -264,19 +268,23 @@ class Validator:
 
             expectation_kwargs = recursively_convert_to_json_serializable(kwargs)
 
-            meta = None
+            meta = expectation_kwargs.pop("meta", None)
 
-            # This section uses Expectation class' legacy_method_parameters attribute to maintain support for passing
-            # positional arguments to expectation methods
-            legacy_arg_names = expectation_impl.legacy_method_parameters.get(
-                name, tuple()
-            )
+            args_keys = expectation_impl.args_keys
+            if args_keys is None:
+                # This section uses Expectation class' legacy_method_parameters attribute to maintain support for passing
+                # positional arguments to expectation methods
+                args_keys = expectation_impl.legacy_method_parameters.get(name, tuple())
+
             for idx, arg in enumerate(args):
                 try:
-                    arg_name = legacy_arg_names[idx]
+                    arg_name = args_keys[idx]
                     if arg_name in allowed_config_keys:
                         expectation_kwargs[arg_name] = arg
                     if arg_name == "meta":
+                        logger.warning(
+                            "Setting meta via args could be ambiguous; please use a kwarg instead."
+                        )
                         meta = arg
                 except IndexError:
                     raise InvalidExpectationConfigurationError(


### PR DESCRIPTION
I hit this when using instructions from our "configure a data context without yml" guide.

I think this is a solid improvement, though I don't know why it's even possible to create a "New Datasource" without an execution engine configuration. Is it perhaps because of the case for SimpleSqlAlchemy Execution Engine?