### PR TITLE
[FEATURE] Add support for named groups in data asset regex

### DIFF
--- a/great_expectations/datasource/data_connector/util.py
+++ b/great_expectations/datasource/data_connector/util.py
@@ -137,18 +137,39 @@ def convert_data_reference_string_to_batch_identifiers_using_regex(
     group_names: List[str],
 ) -> Optional[Tuple[str, IDDict]]:
     # noinspection PyUnresolvedReferences
-    matches: Optional[re.Match] = re.match(regex_pattern, data_reference)
+    pattern = re.compile(regex_pattern)
+    matches: Optional[re.Match] = pattern.match(data_reference)
     if matches is None:
         return None
-    groups: list = list(matches.groups())
-    batch_identifiers: IDDict = IDDict(dict(zip(group_names, groups)))
+
+    # Check for `(?P<name>)` named group syntax
+    match_dict = matches.groupdict()
+    if match_dict:
+        batch_identifiers = _determine_batch_identifiers_using_named_groups(
+            match_dict, group_names
+        )
+    else:
+        groups: list = list(matches.groups())
+        batch_identifiers: IDDict = IDDict(dict(zip(group_names, groups)))
 
     # TODO: <Alex>Accommodating "data_asset_name" inside batch_identifiers (e.g., via "group_names") is problematic; we need a better mechanism.</Alex>
     # TODO: <Alex>Update: Approach -- we can differentiate "def map_data_reference_string_to_batch_definition_list_using_regex(()" methods between ConfiguredAssetFilesystemDataConnector and InferredAssetFilesystemDataConnector so that IDDict never needs to include data_asset_name. (ref: https://superconductivedata.slack.com/archives/C01C0BVPL5Q/p1603843413329400?thread_ts=1603842470.326800&cid=C01C0BVPL5Q)</Alex>
-    data_asset_name: str = DEFAULT_DATA_ASSET_NAME
-    if "data_asset_name" in batch_identifiers:
-        data_asset_name = batch_identifiers.pop("data_asset_name")
+    data_asset_name = batch_identifiers.pop("data_asset_name", DEFAULT_DATA_ASSET_NAME)
     return data_asset_name, batch_identifiers
+
+
+def _determine_batch_identifiers_using_named_groups(
+    match_dict: dict, group_names: List[str]
+) -> IDDict:
+    batch_identifiers = IDDict()
+    for key, value in match_dict.items():
+        if key in group_names:
+            batch_identifiers[key] = value
+        else:
+            logger.warn(
+                f"The named group '{key}' must explicitly be stated in group_names to be parsed"
+            )
+    return batch_identifiers
 
 
 def map_batch_definition_to_data_reference_string_using_regex(

--- a/great_expectations/datasource/data_connector/util.py
+++ b/great_expectations/datasource/data_connector/util.py
@@ -144,7 +144,7 @@ def convert_data_reference_string_to_batch_identifiers_using_regex(
 
     # Check for `(?P<name>)` named group syntax
     match_dict = matches.groupdict()
-    if match_dict:
+    if match_dict:  # Only named groups will populate this dict
         batch_identifiers = _determine_batch_identifiers_using_named_groups(
             match_dict, group_names
         )
@@ -154,7 +154,9 @@ def convert_data_reference_string_to_batch_identifiers_using_regex(
 
     # TODO: <Alex>Accommodating "data_asset_name" inside batch_identifiers (e.g., via "group_names") is problematic; we need a better mechanism.</Alex>
     # TODO: <Alex>Update: Approach -- we can differentiate "def map_data_reference_string_to_batch_definition_list_using_regex(()" methods between ConfiguredAssetFilesystemDataConnector and InferredAssetFilesystemDataConnector so that IDDict never needs to include data_asset_name. (ref: https://superconductivedata.slack.com/archives/C01C0BVPL5Q/p1603843413329400?thread_ts=1603842470.326800&cid=C01C0BVPL5Q)</Alex>
-    data_asset_name = batch_identifiers.pop("data_asset_name", DEFAULT_DATA_ASSET_NAME)
+    data_asset_name: str = batch_identifiers.pop(
+        "data_asset_name", DEFAULT_DATA_ASSET_NAME
+    )
     return data_asset_name, batch_identifiers
 
 

--- a/tests/datasource/data_connector/test_data_connector_util.py
+++ b/tests/datasource/data_connector/test_data_connector_util.py
@@ -231,6 +231,42 @@ def test_convert_data_reference_string_to_batch_identifiers_using_regex():
     )
 
 
+def test_convert_data_reference_string_to_batch_identifiers_using_regex_with_named_groups(
+    caplog,
+):
+    data_reference = "alex_20200809_1000.csv"
+    pattern = r"^(?P<name>.+)_(?P<timestamp>\d+)_(?P<price>\d+)\.csv$"
+    group_names = ["name", "timestamp", "price"]
+    assert convert_data_reference_string_to_batch_identifiers_using_regex(
+        data_reference=data_reference, regex_pattern=pattern, group_names=group_names
+    ) == (
+        "DEFAULT_ASSET_NAME",
+        IDDict(
+            {
+                "name": "alex",
+                "timestamp": "20200809",
+                "price": "1000",
+            }
+        ),
+    )
+
+    data_reference = "alex_20200809_1000.csv"
+    pattern = r"^(?P<name>.+)_(?P<timestamp>\d+)_(?P<cost>\d+)\.csv$"
+    group_names = ["name", "timestamp", "price"]  # Mismatch between "price" and "cost"!
+    assert convert_data_reference_string_to_batch_identifiers_using_regex(
+        data_reference=data_reference, regex_pattern=pattern, group_names=group_names
+    ) == (
+        "DEFAULT_ASSET_NAME",
+        IDDict(
+            {
+                "name": "alex",
+                "timestamp": "20200809",
+            }
+        ),
+    )
+    assert "The named group 'cost' must explicitly be stated" in caplog.text
+
+
 def test_map_batch_definition_to_data_reference_string_using_regex():
     # not BatchDefinition
     my_batch_definition = "I_am_a_string"

--- a/tests/datasource/data_connector/test_data_connector_util.py
+++ b/tests/datasource/data_connector/test_data_connector_util.py
@@ -236,6 +236,7 @@ def test_convert_data_reference_string_to_batch_identifiers_using_regex_with_nam
 ):
     data_reference = "alex_20200809_1000.csv"
     pattern = r"^(?P<name>.+)_(?P<timestamp>\d+)_(?P<price>\d+)\.csv$"
+
     group_names = ["name", "timestamp", "price"]
     assert convert_data_reference_string_to_batch_identifiers_using_regex(
         data_reference=data_reference, regex_pattern=pattern, group_names=group_names
@@ -250,9 +251,7 @@ def test_convert_data_reference_string_to_batch_identifiers_using_regex_with_nam
         ),
     )
 
-    data_reference = "alex_20200809_1000.csv"
-    pattern = r"^(?P<name>.+)_(?P<timestamp>\d+)_(?P<cost>\d+)\.csv$"
-    group_names = ["name", "timestamp", "price"]  # Mismatch between "price" and "cost"!
+    group_names = ["name", "timestamp", "cost"]  # Mismatch between "price" and "cost"!
     assert convert_data_reference_string_to_batch_identifiers_using_regex(
         data_reference=data_reference, regex_pattern=pattern, group_names=group_names
     ) == (
@@ -264,7 +263,7 @@ def test_convert_data_reference_string_to_batch_identifiers_using_regex_with_nam
             }
         ),
     )
-    assert "The named group 'cost' must explicitly be stated" in caplog.text
+    assert "The named group 'price' must explicitly be stated" in caplog.text
 
 
 def test_map_batch_definition_to_data_reference_string_using_regex():


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- https://github.com/great-expectations/great_expectations/issues/3829


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
