### PR TITLE
[BUGFIX] Make ExpectationContext optional and remove when null to ensure backwards compatability

### DIFF
--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1382,7 +1382,9 @@ class ExpectationConfigurationSchema(Schema):
     kwargs = fields.Dict()
     meta = fields.Dict()
     ge_cloud_id = fields.UUID(required=False, allow_none=True)
-    expectation_context = fields.Nested(lambda: ExpectationContextSchema)
+    expectation_context = fields.Nested(
+        lambda: ExpectationContextSchema, required=False, allow_none=True
+    )
 
     REMOVE_KEYS_IF_NONE = ["ge_cloud_id"]
 

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1386,7 +1386,7 @@ class ExpectationConfigurationSchema(Schema):
         lambda: ExpectationContextSchema, required=False, allow_none=True
     )
 
-    REMOVE_KEYS_IF_NONE = ["ge_cloud_id"]
+    REMOVE_KEYS_IF_NONE = ["ge_cloud_id", "expectation_context"]
 
     @post_dump
     def clean_null_attrs(self, data: dict, **kwargs):

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -969,9 +969,6 @@ class ExpectationConfiguration(SerializableDictDot):
         self.meta = meta
         self.success_on_last_run = success_on_last_run
         self._ge_cloud_id = ge_cloud_id
-
-        if expectation_context is None:
-            expectation_context = ExpectationContext()
         self._expectation_context = expectation_context
 
     def process_evaluation_parameters(
@@ -1048,7 +1045,7 @@ class ExpectationConfiguration(SerializableDictDot):
         self._ge_cloud_id = value
 
     @property
-    def expectation_context(self) -> ExpectationContext:
+    def expectation_context(self) -> Optional[ExpectationContext]:
         return self._expectation_context
 
     @expectation_context.setter

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1283,9 +1283,12 @@ class ExpectationConfiguration(SerializableDictDot):
         # NOTE - JPC - 20191031: migrate to expectation-specific schemas that subclass result with properly-typed
         # schemas to get serialization all-the-way down via dump
         myself["kwargs"] = convert_to_json_serializable(myself["kwargs"])
-        myself["expectation_context"] = convert_to_json_serializable(
-            myself["expectation_context"]
-        )
+
+        # Post dump hook removes this value if null so we need to ensure applicability before conversion
+        if "expectation_context" in myself:
+            myself["expectation_context"] = convert_to_json_serializable(
+                myself["expectation_context"]
+            )
         return myself
 
     def get_evaluation_parameter_dependencies(self) -> dict:

--- a/tests/expectations/test_expectation_arguments.py
+++ b/tests/expectations/test_expectation_arguments.py
@@ -630,7 +630,6 @@ def test_result_format_configured_no_set_default_override(
             },
             "expectation_type": "expect_column_values_to_not_be_null",
             "meta": {"Notes": "Some notes"},
-            "expectation_context": {"description": None},
         },
         "meta": {},
         "exception_info": {
@@ -659,7 +658,6 @@ def test_result_format_configured_no_set_default_override(
         "expectation_config": {
             "expectation_type": "expect_column_values_to_not_be_null",
             "meta": {},
-            "expectation_context": {"description": None},
             "kwargs": {
                 "catch_exceptions": False,
                 "result_format": {
@@ -771,7 +769,6 @@ def test_result_format_configured_with_set_default_override(
             },
             "meta": {"Notes": "Some notes"},
             "expectation_type": "expect_column_values_to_not_be_null",
-            "expectation_context": {"description": None},
         },
         "success": True,
         "meta": {},
@@ -839,7 +836,6 @@ def test_result_format_configured_with_set_default_override(
             },
             "meta": {},
             "expectation_type": "expect_column_values_to_not_be_null",
-            "expectation_context": {"description": None},
         },
         "success": True,
         "meta": {},

--- a/tests/profile/test_jsonschema_profiler.py
+++ b/tests/profile/test_jsonschema_profiler.py
@@ -286,13 +286,11 @@ def test_profile_simple_schema(empty_data_context, simple_schema):
     assert obs.expectation_suite_name == "simple_suite"
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "first_name"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "first_name",
@@ -314,19 +312,16 @@ def test_profile_simple_schema(empty_data_context, simple_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "first_name"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "age"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "age",
@@ -357,7 +352,6 @@ def test_profile_simple_schema(empty_data_context, simple_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "age"},
             "meta": {},
@@ -374,13 +368,11 @@ def test_profile_boolean_schema(empty_data_context, boolean_types_schema):
     assert obs.expectation_suite_name == "bools"
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "active"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "active",
@@ -397,25 +389,21 @@ def test_profile_boolean_schema(empty_data_context, boolean_types_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_set",
             "kwargs": {"column": "active", "value_set": [True, False]},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "active"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "optional"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "optional",
@@ -432,7 +420,6 @@ def test_profile_boolean_schema(empty_data_context, boolean_types_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_set",
             "kwargs": {"column": "optional", "value_set": [True, False]},
             "meta": {},
@@ -449,13 +436,11 @@ def test_profile_enum_schema(empty_data_context, enum_types_schema):
     assert obs.expectation_suite_name == "enums"
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "shirt-size"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_set",
             "kwargs": {
                 "column": "shirt-size",
@@ -464,19 +449,16 @@ def test_profile_enum_schema(empty_data_context, enum_types_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "shirt-size"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "optional-color"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_set",
             "kwargs": {
                 "column": "optional-color",
@@ -485,13 +467,11 @@ def test_profile_enum_schema(empty_data_context, enum_types_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "optional-hat"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "optional-hat",
@@ -513,19 +493,16 @@ def test_profile_enum_schema(empty_data_context, enum_types_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_set",
             "kwargs": {"column": "optional-hat", "value_set": ["red", "green", "blue"]},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "optional-answer"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_set",
             "kwargs": {"column": "optional-answer", "value_set": ["yes", "no"]},
             "meta": {},
@@ -542,13 +519,11 @@ def test_profile_string_lengths_schema(empty_data_context, string_lengths_schema
     assert obs.expectation_suite_name == "lengths"
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "comments-no-constraints"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "comments-no-constraints",
@@ -570,19 +545,16 @@ def test_profile_string_lengths_schema(empty_data_context, string_lengths_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "comments-no-constraints"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "state-abbreviation-equal-min-max"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "state-abbreviation-equal-min-max",
@@ -604,25 +576,21 @@ def test_profile_string_lengths_schema(empty_data_context, string_lengths_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_value_lengths_to_equal",
             "kwargs": {"column": "state-abbreviation-equal-min-max", "value": 2},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "state-abbreviation-equal-min-max"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "ICD10-code-3-7"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "ICD10-code-3-7",
@@ -644,25 +612,21 @@ def test_profile_string_lengths_schema(empty_data_context, string_lengths_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_value_lengths_to_be_between",
             "kwargs": {"column": "ICD10-code-3-7", "max_value": 7, "min_value": 3},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "ICD10-code-3-7"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "name-no-max"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "name-no-max",
@@ -684,25 +648,21 @@ def test_profile_string_lengths_schema(empty_data_context, string_lengths_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_value_lengths_to_be_between",
             "kwargs": {"column": "name-no-max", "min_value": 1},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "name-no-max"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "password-max-33"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "password-max-33",
@@ -724,25 +684,21 @@ def test_profile_string_lengths_schema(empty_data_context, string_lengths_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_value_lengths_to_be_between",
             "kwargs": {"column": "password-max-33", "max_value": 33},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "password-max-33"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "optional-min-1"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "optional-min-1",
@@ -764,7 +720,6 @@ def test_profile_string_lengths_schema(empty_data_context, string_lengths_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_value_lengths_to_be_between",
             "kwargs": {"column": "optional-min-1", "min_value": 1},
             "meta": {},
@@ -781,13 +736,11 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
     assert obs.expectation_suite_name == "integer_ranges"
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "favorite-number"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "favorite-number",
@@ -818,19 +771,16 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "favorite-number"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "age-0-130"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "age-0-130",
@@ -861,25 +811,21 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "age-0-130", "max_value": 130, "min_value": 0},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "age-0-130"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "wheel-count-0-plus"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "wheel-count-0-plus",
@@ -910,25 +856,21 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "wheel-count-0-plus", "min_value": 0},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "wheel-count-0-plus"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "rpm-max-7000"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "rpm-max-7000",
@@ -959,25 +901,21 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "rpm-max-7000", "max_value": 7000},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "rpm-max-7000"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "lake-depth-max-minus-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "lake-depth-max-minus-100",
@@ -1008,25 +946,21 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "lake-depth-max-minus-100", "max_value": -100},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "lake-depth-max-minus-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "floor-exclusive-min-0"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "floor-exclusive-min-0",
@@ -1057,7 +991,6 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {
                 "column": "floor-exclusive-min-0",
@@ -1067,19 +1000,16 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "floor-exclusive-min-0"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "floor-exclusive-max-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "floor-exclusive-max-100",
@@ -1110,7 +1040,6 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {
                 "column": "floor-exclusive-max-100",
@@ -1120,19 +1049,16 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "floor-exclusive-max-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "gear-exclusive-0-6"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "gear-exclusive-0-6",
@@ -1163,7 +1089,6 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {
                 "column": "gear-exclusive-0-6",
@@ -1175,19 +1100,16 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "gear-exclusive-0-6"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "optional-min-1"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "optional-min-1",
@@ -1218,7 +1140,6 @@ def test_profile_integer_ranges_schema(empty_data_context, integer_ranges_schema
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "optional-min-1", "min_value": 1},
             "meta": {},
@@ -1235,13 +1156,11 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
     assert obs.expectation_suite_name == "number_ranges"
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "favorite-number"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "favorite-number",
@@ -1268,19 +1187,16 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "favorite-number"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "age-0-130"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "age-0-130",
@@ -1307,25 +1223,21 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "age-0-130", "max_value": 130.5, "min_value": 0.5},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "age-0-130"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "wheel-count-0-plus"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "wheel-count-0-plus",
@@ -1352,25 +1264,21 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "wheel-count-0-plus", "min_value": 0.5},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "wheel-count-0-plus"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "rpm-max-7000"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "rpm-max-7000",
@@ -1397,25 +1305,21 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "rpm-max-7000", "max_value": 7000.5},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "rpm-max-7000"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "lake-depth-max-minus-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "lake-depth-max-minus-100",
@@ -1442,25 +1346,21 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "lake-depth-max-minus-100", "max_value": -100.5},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "lake-depth-max-minus-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "floor-exclusive-min-0"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "floor-exclusive-min-0",
@@ -1487,7 +1387,6 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {
                 "column": "floor-exclusive-min-0",
@@ -1497,19 +1396,16 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "floor-exclusive-min-0"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "floor-exclusive-max-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "floor-exclusive-max-100",
@@ -1536,7 +1432,6 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {
                 "column": "floor-exclusive-max-100",
@@ -1546,19 +1441,16 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "floor-exclusive-max-100"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "gear-exclusive-0-6"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "gear-exclusive-0-6",
@@ -1585,7 +1477,6 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {
                 "column": "gear-exclusive-0-6",
@@ -1597,19 +1488,16 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "gear-exclusive-0-6"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "optional-min-half"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "optional-min-half",
@@ -1636,7 +1524,6 @@ def test_profile_number_ranges_schema(empty_data_context, number_ranges_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_between",
             "kwargs": {"column": "optional-min-half", "min_value": 0.5},
             "meta": {},
@@ -1660,13 +1547,11 @@ def test_has_profile_create_expectations_from_complex_schema(
 
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "post-office-box"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "post-office-box",
@@ -1688,19 +1573,16 @@ def test_has_profile_create_expectations_from_complex_schema(
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "post-office-box"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "street-name"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "street-name",
@@ -1722,13 +1604,11 @@ def test_has_profile_create_expectations_from_complex_schema(
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "street-name"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "street-number"},
             "meta": {
@@ -1739,7 +1619,6 @@ def test_has_profile_create_expectations_from_complex_schema(
             },
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "street-number",
@@ -1770,19 +1649,16 @@ def test_has_profile_create_expectations_from_complex_schema(
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "street-number"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "locality"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "locality",
@@ -1804,19 +1680,16 @@ def test_has_profile_create_expectations_from_complex_schema(
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "locality"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "region"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "region",
@@ -1838,19 +1711,16 @@ def test_has_profile_create_expectations_from_complex_schema(
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "region"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "postal-code"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "postal-code",
@@ -1872,19 +1742,16 @@ def test_has_profile_create_expectations_from_complex_schema(
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "postal-code"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "country-name"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "country-name",
@@ -1906,7 +1773,6 @@ def test_has_profile_create_expectations_from_complex_schema(
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_not_be_null",
             "kwargs": {"column": "country-name"},
             "meta": {},
@@ -1923,25 +1789,21 @@ def test_null_fields_schema(empty_data_context, null_fields_schema):
     assert obs.expectation_suite_name == "null_fields"
     assert [e.to_json_dict() for e in obs.expectations] == [
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "null"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_null",
             "kwargs": {"column": "null"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "string-or-null"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "string-or-null",
@@ -1963,13 +1825,11 @@ def test_null_fields_schema(empty_data_context, null_fields_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "int-or-null"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "int-or-null",
@@ -2000,13 +1860,11 @@ def test_null_fields_schema(empty_data_context, null_fields_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "number-or-null"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_type_list",
             "kwargs": {
                 "column": "number-or-null",
@@ -2033,13 +1891,11 @@ def test_null_fields_schema(empty_data_context, null_fields_schema):
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_to_exist",
             "kwargs": {"column": "enum-or-null"},
             "meta": {},
         },
         {
-            "expectation_context": {"description": None},
             "expectation_type": "expect_column_values_to_be_in_set",
             "kwargs": {"column": "enum-or-null", "value_set": ["a", "b", "c"]},
             "meta": {},


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Hotfix PR for incompatible change made to ExpectationSuite schema


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
