### PR TITLE
[MAINTENANCE] Use f-string to prevent string concat issue in Evaluation Parameters

### DIFF
--- a/great_expectations/core/evaluation_parameters.py
+++ b/great_expectations/core/evaluation_parameters.py
@@ -219,7 +219,7 @@ def build_evaluation_parameters(
 
             # First, check to see whether an argument was supplied at runtime
             # If it was, use that one, but remove it from the stored config
-            param_key = f'"$PARAMETER."{value["$PARAMETER"]}'
+            param_key = f"$PARAMETER.{value['$PARAMETER']}"
             if param_key in value:
                 evaluation_args[key] = evaluation_args[key][param_key]
                 del expectation_args[key][param_key]

--- a/great_expectations/core/evaluation_parameters.py
+++ b/great_expectations/core/evaluation_parameters.py
@@ -5,7 +5,7 @@ import math
 import operator
 import traceback
 from collections import namedtuple
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from pyparsing import (
     CaselessKeyword,
@@ -197,11 +197,11 @@ class EvaluationParameterParser:
 
 
 def build_evaluation_parameters(
-    expectation_args,
-    evaluation_parameters=None,
-    interactive_evaluation=True,
+    expectation_args: dict,
+    evaluation_parameters: Optional[dict] = None,
+    interactive_evaluation: bool = True,
     data_context=None,
-):
+) -> Tuple[dict, dict]:
     """Build a dictionary of parameters to evaluate, using the provided evaluation_parameters,
     AND mutate expectation_args by removing any parameter values passed in as temporary values during
     exploratory work.
@@ -219,11 +219,10 @@ def build_evaluation_parameters(
 
             # First, check to see whether an argument was supplied at runtime
             # If it was, use that one, but remove it from the stored config
-            if "$PARAMETER." + value["$PARAMETER"] in value:
-                evaluation_args[key] = evaluation_args[key][
-                    "$PARAMETER." + value["$PARAMETER"]
-                ]
-                del expectation_args[key]["$PARAMETER." + value["$PARAMETER"]]
+            param_key = f'"$PARAMETER."{value["$PARAMETER"]}'
+            if param_key in value:
+                evaluation_args[key] = evaluation_args[key][param_key]
+                del expectation_args[key][param_key]
 
             # If not, try to parse the evaluation parameter and substitute, which will raise
             # an exception if we do not have a value


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Minor fix to prevent issue with string + numeric value concatenation
- https://github.com/great-expectations/great_expectations/issues/3816




### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
