### PR TITLE
[MAINTENANCE] Raising exceptions for misconfigured datasources in cloud mode

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -457,7 +457,12 @@ class BaseDataContext:
                 # this error will happen if our configuration contains datasources that GE can no longer connect to.
                 # this is ok, as long as we don't use it to retrieve a batch. If we try to do that, the error will be
                 # caught at the context.get_batch() step. So we just pass here.
-                pass
+                if self._ge_cloud_mode:
+                    # when running in cloud mode, we want to know if a datasource has been improperly configured at
+                    # init time.
+                    raise
+                else:
+                    pass
 
     def _apply_global_config_overrides(self):
         # check for global usage statistics opt out


### PR DESCRIPTION
Changes proposed in this pull request:
- Default behavior in GE is to swallow exceptions from misconfigured datasources, with the idea that if that datasource isn't used, it should not break GE (errors to result from trying to use the misconfigured datasource
- In Cloud Mode, we want to identify these datasource configuration issues early, and raise an error at the time of initialization
- Therefore, if the DataContext is in cloud mode, exceptions rising from datasource initialization are no longer swallowed

We currently lack the fixtures to bring this code (and this scenario) explicitly under test, but we do know that existing tests will ensure GE's continued operation. A subsequent PR will introduce a test suite for DataContext in Cloud Mode.

- [ x ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [ x ] I have run any local integration tests and made sure that nothing is broken.
