### PR TITLE
[MAINTENANCE] Datasource and ExecutionEngine Anonymizers handle missing module_name

### DIFF
--- a/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
@@ -1,6 +1,10 @@
 # isort:skip_file
 
 from great_expectations.core.usage_statistics.anonymizers.anonymizer import Anonymizer
+from great_expectations.data_context.types.base import (
+    DataConnectorConfig,
+    dataConnectorConfigSchema,
+)
 
 from great_expectations.datasource.data_connector import (
     DataConnector,
@@ -54,10 +58,18 @@ class DataConnectorAnonymizer(Anonymizer):
             "anonymized_name": self.anonymize(name),
         }
 
+        # Roundtrip through schema validation to add any missing fields
+        data_connector_config: DataConnectorConfig = dataConnectorConfigSchema.load(
+            config
+        )
+        data_connector_config_dict: dict = dataConnectorConfigSchema.dump(
+            data_connector_config
+        )
+
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
             ge_classes=self._ge_classes,
-            object_config=config,
+            object_config=data_connector_config_dict,
         )
 
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/execution_engine_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/execution_engine_anonymizer.py
@@ -1,4 +1,8 @@
 from great_expectations.core.usage_statistics.anonymizers.anonymizer import Anonymizer
+from great_expectations.data_context.types.base import (
+    ExecutionEngineConfig,
+    executionEngineConfigSchema,
+)
 from great_expectations.execution_engine import (
     ExecutionEngine,
     PandasExecutionEngine,
@@ -23,10 +27,18 @@ class ExecutionEngineAnonymizer(Anonymizer):
         anonymized_info_dict = {}
         anonymized_info_dict["anonymized_name"] = self.anonymize(name)
 
+        # Roundtrip through schema validation to add any missing fields
+        execution_engine_config: ExecutionEngineConfig = (
+            executionEngineConfigSchema.load(config)
+        )
+        execution_engine_config_dict: dict = executionEngineConfigSchema.dump(
+            execution_engine_config
+        )
+
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
             ge_classes=self._ge_classes,
-            object_config=config,
+            object_config=execution_engine_config_dict,
         )
 
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/usage_statistics.py
+++ b/great_expectations/core/usage_statistics/usage_statistics.py
@@ -471,9 +471,9 @@ def add_datasource_usage_statistics(data_context, name, **kwargs):
     # noinspection PyBroadException
     try:
         payload = datasource_anonymizer.anonymize_datasource_info(name, kwargs)
-    except Exception:
+    except Exception as e:
         logger.debug(
-            "add_datasource_usage_statistics: Unable to create add_datasource_usage_statistics payload field"
+            f"{UsageStatsExceptionPrefix.EMIT_EXCEPTION.value}: {e} type: {type(e)}, add_datasource_usage_statistics: Unable to create add_datasource_usage_statistics payload field"
         )
 
     return payload

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2428,6 +2428,7 @@ class CheckpointValidationConfigSchema(Schema):
 dataContextConfigSchema = DataContextConfigSchema()
 datasourceConfigSchema = DatasourceConfigSchema()
 dataConnectorConfigSchema = DataConnectorConfigSchema()
+executionEngineConfigSchema = ExecutionEngineConfigSchema()
 assetConfigSchema = AssetConfigSchema()
 sorterConfigSchema = SorterConfigSchema()
 # noinspection SpellCheckingInspection

--- a/tests/core/usage_statistics/README.md
+++ b/tests/core/usage_statistics/README.md
@@ -27,5 +27,8 @@ We ensure:
 - Anonymizers work as expected
   - tests/core/usage_statistics/test_usage_statistics.py
   - tests/core/usage_statistics/test_anonymizer.py
+  - tests/datasource/test_datasource_anonymizer.py
+  - tests/execution_engine/test_execution_engine_anonymizer.py - TODO: implement
+  - TODO: Other anonymizer tests
 - Graceful failure with no internet
   - tests/integration/usage_statistics/test_integration_usage_statistics.py

--- a/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
+++ b/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
@@ -94,17 +94,18 @@ def test_common_usage_stats_are_sent_no_mocking(
     assert context.anonymous_usage_statistics.enabled
     assert context.anonymous_usage_statistics.data_context_id == DATA_CONTEXT_ID
 
-    # context.add_datasource() is decorated, was not sending usage stats events in v0.13.43-46 (possibly earlier)
+    # Note module_name fields are omitted purposely to ensure we are still able to send events
     datasource_yaml = f"""
     name: example_datasource
     class_name: Datasource
     module_name: great_expectations.datasource
     execution_engine:
-      module_name: great_expectations.execution_engine
+      # module_name: great_expectations.execution_engine
       class_name: PandasExecutionEngine
     data_connectors:
         default_runtime_data_connector_name:
             class_name: RuntimeDataConnector
+            # module_name: great_expectations.datasource.data_connector
             batch_identifiers:
                 - default_identifier_name
     """
@@ -114,8 +115,7 @@ def test_common_usage_stats_are_sent_no_mocking(
     expected_events: List[str] = ["data_context.test_yaml_config"]
 
     context.add_datasource(**yaml.load(datasource_yaml))
-    # TODO: AJB `data_context.add_datasource` is not being emitted, though it should be. See GREAT-448
-    # expected_events.append("data_context.add_datasource")
+    expected_events.append("data_context.add_datasource")
 
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed first usage stats exception logged in `test_common_usage_stats_are_sent_no_mocking`, caused by a missing `module_name` in the config (which is acceptable, so must be handled by our anonymizers).

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
