### PR TITLE
[BUGFIX] ExpectationSuite: Make data_context arg optional

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -590,11 +590,12 @@ class ExpectationSuite(SerializableDictDot):
     def send_usage_event(self, success: bool):
         usage_stats_event_name: str = "expectation_suite.add_expectation"
         usage_stats_event_payload: dict = {}
-        self._data_context.send_usage_message(
-            event=usage_stats_event_name,
-            event_payload=usage_stats_event_payload,
-            success=success,
-        )
+        if self._data_context is not None:
+            self._data_context.send_usage_message(
+                event=usage_stats_event_name,
+                event_payload=usage_stats_event_payload,
+                success=success,
+            )
 
     def add_expectation(
         self,

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -49,7 +49,7 @@ class ExpectationSuite(SerializableDictDot):
     def __init__(
         self,
         expectation_suite_name,
-        data_context,
+        data_context=None,
         expectations=None,
         evaluation_parameters=None,
         data_asset_type=None,


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- make `data_context` an optional arg for ExpectationSuite
- only emit ExpectationSuite related usage stats messages if self._data_context exists
- this makes ExpectationSuite and DataContext less tightly coupled and allows ExpectationSuite objects to be used independently of a DataContext (necessary in GE Cloud)


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
