### PR TITLE
[BUGFIX] Revert change to `ExpectationSuite` constructor

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -590,11 +590,12 @@ class ExpectationSuite(SerializableDictDot):
     def send_usage_event(self, success: bool):
         usage_stats_event_name: str = "expectation_suite.add_expectation"
         usage_stats_event_payload: dict = {}
-        self._data_context.send_usage_message(
-            event=usage_stats_event_name,
-            event_payload=usage_stats_event_payload,
-            success=success,
-        )
+        if self._data_context is not None:
+            self._data_context.send_usage_message(
+                event=usage_stats_event_name,
+                event_payload=usage_stats_event_payload,
+                success=success,
+            )
 
     def add_expectation(
         self,

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -49,7 +49,7 @@ class ExpectationSuite(SerializableDictDot):
     def __init__(
         self,
         expectation_suite_name,
-        data_context,
+        data_context=None,
         expectations=None,
         evaluation_parameters=None,
         data_asset_type=None,


### PR DESCRIPTION
Changes proposed in this pull request:
- Reverting change to `ExpectationSuite` constructor that was introduced in #3824 
- `data_context` is now an Optional parameter

