### PR TITLE
Draft overview for custom_expectations

### DIFF
--- a/docs/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
+++ b/docs/guides/expectations/creating_custom_expectations/components/prerequisites.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+
+/**
+ * A flexible Prerequisites admonition block.
+ * Styling/structure was copied over directly from docusaurus :::info admonition.
+ *
+ * Usage with only defaults
+ *
+ * <Prerequisites>
+ *
+ * Usage with additional list items
+ *
+ * <Prerequisites>
+ *
+ * - Have access to data on a filesystem
+ *
+ * </Prerequisites>
+ */
+export default class Prerequisites extends React.Component {
+  extractMarkdownListItems () {
+    try {
+      const children = React.Children.toArray(this.props.children).map((item) => (item.props.children))
+      const listItems = React.Children.toArray(children).map((item) => (item.props.children))
+      return listItems
+    } catch (error) {
+      const message = '🚨 The Prerequisites component only accepts markdown list items 🚨'
+      console.error(message, error)
+      window.alert(message)
+      return [message]
+    }
+  }
+
+  defaultPrerequisiteItems () {
+    return [
+      <li key={0.1}>Either: Completed the <a href='/docs/tutorials/getting_started/intro'>Getting Started Tutorial</a></li>,
+      <li key={0.2}>Or: <a href='/docs/contributing/contributing_setup'>Set up your dev environment</a></li>,
+    ]
+  }
+
+  render () {
+    return (
+      <div className='admonition admonition-note alert alert--secondary'>
+        <div className='admonition-heading'>
+          <h5>
+            <span className='admonition-icon'><svg xmlns='http://www.w3.org/2000/svg' width='14' height='16' viewBox='0 0 14 16'><path fillRule='evenodd' d='M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z' /></svg></span>
+            Prerequisites: This how-to guide assumes you have:
+          </h5>
+        </div>
+        <div className='admonition-content'>
+          <ul>
+            {this.defaultPrerequisiteItems()}
+            {this.extractMarkdownListItems().map((prereq, i) => (<li key={i}>{prereq}</li>))}
+          </ul>
+        </div>
+      </div>
+    )
+  }
+}

--- a/docs/guides/expectations/creating_custom_expectations/overview.md
+++ b/docs/guides/expectations/creating_custom_expectations/overview.md
@@ -71,6 +71,6 @@ Beyond the first four steps, additional features are generally similar across al
 
 ## Publishing your Expectation as an open source contribution
 
-(Add this later; possibly in a different location in the TOC)
+You can find more detailed instructions in the [Contributing](/docs/contributing/contributing) section of the docs.
 
 ## Wrapping up

--- a/docs/guides/expectations/creating_custom_expectations/overview.md
+++ b/docs/guides/expectations/creating_custom_expectations/overview.md
@@ -1,18 +1,76 @@
 ---
-title: Creating custom Expectations
+title: Overview
 ---
-import Prerequisites from '../../connecting_to_your_data/components/prerequisites.jsx'
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Prerequisites from './components/prerequisites.jsx'
 
+You can extend the functionality of Great Expectations by creating your own custom Expectations. You can also enrich Great Expectations as a shared standard for data quality by contributing new Expectations to the open source project.
 
-(Text goes here)
+Both processes follow the same streamlined steps. This section will teach you how.
 
-<Prerequisites>
+<Prerequisites></Prerequisites>
 
-- [Set up a working deployment of Great Expectations](../../../tutorials/getting_started/intro.md)
-OR
-- [Set up a working deployment of Great Expectations](../../../tutorials/getting_started/intro.md)
-    
-</Prerequisites>
+## Steps to create a custom Expectation
 
+A fully developed Expectation needs to do a lot of things:
+* Execute consistently across many types of data infrastructure
+* Render itself and its Validation Results into several different formats
+* Support Profiling against new data
+* Be maintainable, with good tests, documentation, linting, type hints, etc.
+
+In order to make development of Expectations as easy as possible, we've broken up the steps to create custom Expectations into a series of bite-sized steps. Each step can be completed in minutes. They can be completed (and contributed) incrementally, unlocking value at each step along the way.
+
+Grouped together, they constitute a Definition of Done for Expectations at each [Level of Maturity](/docs/contributing/contributing_maturity).
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+<i class="fas fa-circle" style={{color: "#dc3545"}}></i> An experimental Expectation...
+
+* Has a `library_metadata` object
+* Has a docstring, including a one-line short description
+* Has at least one positive and negative example case
+* Has core logic and passes tests on at least one `Execution Engine`
+
+<i class="fas fa-circle" style={{color: "#ffc107"}}></i> A beta Expectation...
+
+* Has basic input validation and type checking
+* Has all four statement `Renderers`: question, descriptive, prescriptive, diagnostic
+* Has default `Parameter Builders` and Domain hooks to support Profiling   
+* Has core logic exists and passes tests for all applicable `Execution Engines` and SQL dialects
+
+<i class="fas fa-check-circle" style={{color: "#28a745"}}></i> A production Expectation...
+
+* Passes all linting checks
+* Has all applicable Renderers, with fully typed and styled output
+* Has a full suite of tests, as determined by project code standards
+* Has passed a manual review by a code owner for code standards and style guides
+
+## How these docs are organized
+
+The docs in `Creating custom Expectations` focus on completing the four steps for experimental Expectations. Completing them will get to the point where your Expectation can be executed against one backend, with a couple tests to verify correctness, and a basic docstring and metadata to support diagonstics. Optionally, you can also publish experimental Expectations to the [Great Expectations open source gallery](https://greatexpectations.io/expectations) by following the steps [here](overview#publishing-your-expectation-as-an-open-source-contribution).
+
+These code to achieve the first four steps looks somewhat different depending on the class of Expectation you're developing. Accordingly, there are separate how-to guides and templates for each class of Expectation.
+
+| Guide: "How to create a custom..." |  Template |
+|-----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Column Map Expectation](how_to_create_custom_column_map_expectations)             | [column_map_expectation_template](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/column_map_expectation_template.py)       |
+| [Column Aggregate Expectation](how_to_create_custom_column_aggregate_expectations) | [column_aggregate_expectation_template](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/column_map_expectation_template.py) |
+
+Note: not all classes of Expectation currently have guides and templates. If you'd like to develop a different kind of Expectation, please reach out on [Slack](https://greatexpectations.io/slack).
+
+Beyond the first four steps, additional features are generally similar across all Expectation classes. Accordingly, each of the remaining steps has its own how-to guide in the `Adding features to Great Expectations` section of the table of contents.
+
+| Step | Guide |
+|------|-------|
+| Has basic input validation and type checking                                                     | [How to add configuration validation for an Expectation](../features_custom_expectations/how_to_add_input_validation_for_an_expectation) |
+| Has all four statement `Renderers`: question, descriptive, prescriptive, diagnostic              | [How to add text renderers for custom Expectations](../features_custom_expectations/how_to_add_text_renderers_for_an_expectation) |
+| Has default `Parameter Builders` and Domain hooks to support Profiling                           | |
+| Has core logic exists and passes tests for all applicable `Execution Engines` and SQL dialects   | [How to add SQLAlchemy support for custom Metrics](../features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation)<br/> [How to add Spark support for custom Metrics](../features_custom_expectations/how_to_add_spark_support_for_an_expectation)|
+| Passes all linting checks                                                                        | |
+| Has all applicable Renderers, with fully typed and styled output                                 | |
+| Has a full suite of tests, as determined by project code standards                               | |
+| Has passed a manual review by a code owner for code standards and style guides                   | |
+
+## Publishing your Expectation as an open source contribution
+
+(Add this later; possibly in a different location in the TOC)
+
+## Wrapping up

--- a/docs/guides/expectations/creating_custom_expectations/overview.md
+++ b/docs/guides/expectations/creating_custom_expectations/overview.md
@@ -5,7 +5,7 @@ import Prerequisites from './components/prerequisites.jsx'
 
 You can extend the functionality of Great Expectations by creating your own custom Expectations. You can also enrich Great Expectations as a shared standard for data quality by contributing new Expectations to the open source project.
 
-Both processes follow the same streamlined steps. This section will teach you how.
+These processes compliment each other and their steps are streamlined so that one flows into the other. Once you have created a custom Expectation, it is simple to contribute it to the open source project. This section will teach you how to do both.
 
 <Prerequisites></Prerequisites>
 

--- a/docs/guides/expectations/creating_custom_expectations/overview.md
+++ b/docs/guides/expectations/creating_custom_expectations/overview.md
@@ -47,7 +47,7 @@ Grouped together, they constitute a Definition of Done for Expectations at each 
 
 The docs in `Creating custom Expectations` focus on completing the four steps for experimental Expectations. Completing them will get to the point where your Expectation can be executed against one backend, with a couple tests to verify correctness, and a basic docstring and metadata to support diagonstics. Optionally, you can also publish experimental Expectations to the [Great Expectations open source gallery](https://greatexpectations.io/expectations) by following the steps [here](overview#publishing-your-expectation-as-an-open-source-contribution).
 
-These code to achieve the first four steps looks somewhat different depending on the class of Expectation you're developing. Accordingly, there are separate how-to guides and templates for each class of Expectation.
+The code to achieve the first four steps looks somewhat different depending on the class of Expectation you're developing. Accordingly, there are separate how-to guides and templates for each class of Expectation.
 
 | Guide: "How to create a custom..." |  Template |
 |-----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/guides/expectations/creating_custom_expectations/overview.md
+++ b/docs/guides/expectations/creating_custom_expectations/overview.md
@@ -34,7 +34,7 @@ Grouped together, they constitute a Definition of Done for Expectations at each 
 * Has basic input validation and type checking
 * Has all four statement `Renderers`: question, descriptive, prescriptive, diagnostic
 * Has default `Parameter Builders` and Domain hooks to support Profiling   
-* Has core logic exists and passes tests for all applicable `Execution Engines` and SQL dialects
+* Has core logic that passes tests for all applicable `Execution Engines` and SQL dialects
 
 <i class="fas fa-check-circle" style={{color: "#28a745"}}></i> A production Expectation...
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -197,6 +197,7 @@ module.exports = {
               type: 'category',
               label: 'Creating Custom Expectations',
               items: [
+                'guides/expectations/creating_custom_expectations/overview',
                 'guides/expectations/creating_custom_expectations/how_to_create_custom_column_aggregate_expectations',
                 'guides/expectations/creating_custom_expectations/how_to_create_custom_metrics',
                 'guides/expectations/creating_custom_expectations/how_to_create_example_cases_for_an_expectation',


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds an "Overview" section to the "creating custom expectations" part of the ToC
- Note that some content is unfinished, and will need to be either removed or completed before merging the `hacakthon-docs` branch into `develop`

@talagluck , can you please review for content?
@Rachel-Reverie  , can you please review for consistency with style guides and templates in other sections?