### PR TITLE
Patch for atomic renderer snapshot tests

### DIFF
--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -1,3 +1,4 @@
+import re
 from pprint import pprint
 from typing import Callable, Dict, Union
 
@@ -180,11 +181,7 @@ def test_atomic_prescriptive_summary_expect_column_kl_divergence_to_be_less_than
     pprint(res)
 
     # replace version of vega-lite in res to match snapshot test
-    current_graph_string = res["value"]["graph"]
-    start_index = current_graph_string.index("vega-lite/") + len("vega-lite/")
-    end_index = current_graph_string.index(".json")
-    modified_graph_string = current_graph_string[:start_index] + "v4.8.1" + current_graph_string[end_index:]
-    res["value"]["graph"] = modified_graph_string
+    res["value"]["graph"] = re.sub(r"v\d*\.\d*\.\d*", "v4.8.1", res["value"]["graph"])
 
     snapshot.assert_match(res)
 

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -225,6 +225,7 @@ def test_atomic_diagnostic_observed_value_expect_column_kl_divergence_to_be_less
     res = rendered_content.to_json_dict()
     pprint(res)
 
+    # replace version of vega-lite in res to match snapshot test
     res["value"]["graph"] = re.sub(r"v\d*\.\d*\.\d*", "v4.8.1", res["value"]["graph"])
     snapshot.assert_match(res)
 

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -178,6 +178,14 @@ def test_atomic_prescriptive_summary_expect_column_kl_divergence_to_be_less_than
 
     res = rendered_content.to_json_dict()
     pprint(res)
+
+    # replace version of vega-lite in res to match snapshot test
+    current_graph_string = res["value"]["graph"]
+    start_index = current_graph_string.index("vega-lite/") + len("vega-lite/")
+    end_index = current_graph_string.index(".json")
+    modified_graph_string = current_graph_string[:start_index] + "v4.8.1" + current_graph_string[end_index:]
+    res["value"]["graph"] = modified_graph_string
+
     snapshot.assert_match(res)
 
 

--- a/tests/expectations/test_expectation_atomic_renderers.py
+++ b/tests/expectations/test_expectation_atomic_renderers.py
@@ -224,6 +224,8 @@ def test_atomic_diagnostic_observed_value_expect_column_kl_divergence_to_be_less
 
     res = rendered_content.to_json_dict()
     pprint(res)
+
+    res["value"]["graph"] = re.sub(r"v\d*\.\d*\.\d*", "v4.8.1", res["value"]["graph"])
     snapshot.assert_match(res)
 
 

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -541,8 +541,13 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_end(
     import pprint
 
     pprint.pprint(rendered_validation_results["sections"])
-    content_block = rendered_validation_results["sections"][5]["content_blocks"][1]["table"][10][2]["content_blocks"][1]
+
+    # replace version of vega-lite in res to match snapshot test
+    content_block = rendered_validation_results["sections"][5]["content_blocks"][1][
+        "table"
+    ][10][2]["content_blocks"][1]
     content_block["graph"] = re.sub(r"v\d*\.\d*\.\d*", "v4.8.1", content_block["graph"])
+
     # with open(file_relative_path(__file__, "./fixtures/ValidationResultsPageRenderer_render_with_run_info_at_end_nc.json"), "w") as f:
     #     json.dump(rendered_validation_results, f, indent=2)
     pprint.pprint(ValidationResultsPageRenderer_render_with_run_info_at_end)
@@ -564,7 +569,10 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_start(
     ).to_json_dict()
     print(rendered_validation_results)
 
-    content_block = rendered_validation_results["sections"][5]["content_blocks"][1]["table"][10][2]["content_blocks"][1]
+    # replace version of vega-lite in res to match snapshot test
+    content_block = rendered_validation_results["sections"][5]["content_blocks"][1][
+        "table"
+    ][10][2]["content_blocks"][1]
     content_block["graph"] = re.sub(r"v\d*\.\d*\.\d*", "v4.8.1", content_block["graph"])
 
     # with open(file_relative_path(__file__, "./fixtures/ValidationResultsPageRenderer_render_with_run_info_at_start_nc.json"), "w") as f:

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from collections import OrderedDict
 
 import mistune
@@ -540,6 +541,8 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_end(
     import pprint
 
     pprint.pprint(rendered_validation_results["sections"])
+    content_block = rendered_validation_results["sections"][5]["content_blocks"][1]["table"][10][2]["content_blocks"][1]
+    content_block["graph"] = re.sub(r"v\d*\.\d*\.\d*", "v4.8.1", content_block["graph"])
     # with open(file_relative_path(__file__, "./fixtures/ValidationResultsPageRenderer_render_with_run_info_at_end_nc.json"), "w") as f:
     #     json.dump(rendered_validation_results, f, indent=2)
     pprint.pprint(ValidationResultsPageRenderer_render_with_run_info_at_end)
@@ -560,6 +563,10 @@ def test_snapshot_ValidationResultsPageRenderer_render_with_run_info_at_start(
         titanic_profiled_evrs_1
     ).to_json_dict()
     print(rendered_validation_results)
+
+    content_block = rendered_validation_results["sections"][5]["content_blocks"][1]["table"][10][2]["content_blocks"][1]
+    content_block["graph"] = re.sub(r"v\d*\.\d*\.\d*", "v4.8.1", content_block["graph"])
+
     # with open(file_relative_path(__file__, "./fixtures/ValidationResultsPageRenderer_render_with_run_info_at_start_nc.json"), "w") as f:
     #     json.dump(rendered_validation_results, f, indent=2)
 


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- This address failures that are currently occurring in our Azure pipelines due to the version of vega-lite in the cdn not matching existing snapshots tests. This is currently a hard-coded patch, but in the future, we need to understand why we are not getting consistent versions from the cdn.
- We could also pin a more specific version of vega-lite, though it doesn't make sense to do this in order to pass a snapshot test.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
