### PR TITLE
removing commented requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
 altair>=4.0.0,<5  # package
-# black==21.8b0  # package optional dependency, please install manually if desired
 Click>=7.1.2  # package
 importlib-metadata>=1.7.0 # package (included in Python 3.8 by default.)
 ipywidgets>=7.5.1  # package


### PR DESCRIPTION
super-tiny change to remove commented out requirement (and it is already in requirements-dev where it is likely to be used)