### PR TITLE
[DOCS] adding the link checker to the build

### DIFF
--- a/azure-pipelines-docs-integration.yml
+++ b/azure-pipelines-docs-integration.yml
@@ -55,6 +55,14 @@ stages:
           - bash: ./scripts/check_for_docs_deps_changes
             name: CheckDocsDependenciesChanges
 
+  - stage: custom_checks
+    pool:
+      vmImage: 'ubuntu-latest'
+    jobs:
+    - job: link_checker
+      steps:
+      - bash: python scripts/docs_link_checker.py -p docs -r docs -s docs --skip-external
+
   - stage: docusaurus_tests
     pool:
       vmImage: 'ubuntu-latest'

--- a/azure-pipelines-docs-integration.yml
+++ b/azure-pipelines-docs-integration.yml
@@ -60,6 +60,7 @@ stages:
       vmImage: 'ubuntu-latest'
     jobs:
     - job: link_checker
+      condition: or(eq(stageDependencies.scope_check.changes.outputs['CheckDocsChanges.DocsChanged'], true), eq(variables.isMain, true))
       steps:
       - bash: python scripts/docs_link_checker.py -p docs -r docs -s docs --skip-external
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 Welcome to Great Expectations!
 
-Great Expectations is the leading tool for [validating](./reference/core_concepts.md#expectations), [documenting](./reference/core_concepts.md#data-docs), and [profiling](./reference/core_concepts.md#profiling) your data to maintain quality and improve communication between teams. Head over to our [getting started](./tutorials/getting_started/intro.md) tutorial.
+Great Expectations is the leading tool for [validating](./refeBROKENrence/core_concepts.md#expectations), [documenting](./reference/core_concepts.md#data-docs), and [profiling](./reference/core_concepts.md#profiling) your data to maintain quality and improve communication between teams. Head over to our [getting started](./tutorials/getting_started/intro.md) tutorial.
 
 Software developers have long known that automated testing is essential for managing complex codebases. Great Expectations brings the same discipline, confidence, and acceleration to data science and data engineering teams.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 Welcome to Great Expectations!
 
-Great Expectations is the leading tool for [validating](./refeBROKENrence/core_concepts.md#expectations), [documenting](./reference/core_concepts.md#data-docs), and [profiling](./reference/core_concepts.md#profiling) your data to maintain quality and improve communication between teams. Head over to our [getting started](./tutorials/getting_started/intro.md) tutorial.
+Great Expectations is the leading tool for [validating](./reference/core_concepts.md#expectations), [documenting](./reference/core_concepts.md#data-docs), and [profiling](./reference/core_concepts.md#profiling) your data to maintain quality and improve communication between teams. Head over to our [getting started](./tutorials/getting_started/intro.md) tutorial.
 
 Software developers have long known that automated testing is essential for managing complex codebases. Great Expectations brings the same discipline, confidence, and acceleration to data science and data engineering teams.
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Adding checking the internal links as part of the CI for docs; if a broken link is added to docs, the build will fail

