### PR TITLE
[BUGFIX] `CheckDocsDependenciesChanges` to only handle `.py` files

### DIFF
--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -1,4 +1,3 @@
-import json
 import random
 import uuid
 from typing import Dict

--- a/scripts/trace_docs_deps.py
+++ b/scripts/trace_docs_deps.py
@@ -46,7 +46,8 @@ def find_docusaurus_refs(dir: str) -> List[str]:
             if re.search(pattern, line):
                 file: str = _parse_file_from_docusaurus_link(line)
                 path: str = os.path.join(os.path.dirname(doc), file)
-                linked_files.add(path)
+                if path[-3:] == ".py":
+                    linked_files.add(path)
 
     return [file for file in linked_files]
 

--- a/scripts/trace_docs_deps.py
+++ b/scripts/trace_docs_deps.py
@@ -46,6 +46,7 @@ def find_docusaurus_refs(dir: str) -> List[str]:
             if re.search(pattern, line):
                 file: str = _parse_file_from_docusaurus_link(line)
                 path: str = os.path.join(os.path.dirname(doc), file)
+                # only interested in looking at .py files for now (excludes .yml files)
                 if path[-3:] == ".py":
                     linked_files.add(path)
 


### PR DESCRIPTION
Changes proposed in this pull request:
- `CheckDocsDependenciesChanges` to only handle `.py` files

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

Thank you for submitting!
