### PR TITLE
[BUGFIX] Ensure that Jupyter Notebook cells convert JSON strings to Python-compliant syntax

### DIFF
--- a/great_expectations/render/renderer/notebook_renderer.py
+++ b/great_expectations/render/renderer/notebook_renderer.py
@@ -4,7 +4,10 @@ import nbformat
 
 from great_expectations import DataContext
 from great_expectations.render.renderer.renderer import Renderer
-from great_expectations.util import convert_nulls_to_None, lint_code
+from great_expectations.util import (
+    convert_json_string_to_be_python_compliant,
+    lint_code,
+)
 
 
 class BaseNotebookRenderer(Renderer):
@@ -20,7 +23,7 @@ class BaseNotebookRenderer(Renderer):
         self._notebook: Optional[nbformat.NotebookNode] = None
 
     def add_code_cell(
-        self, code: str, lint: bool = False, sanitize_nulls: bool = True
+        self, code: str, lint: bool = False, enforce_py_syntax: bool = True
     ) -> None:
         """
         Add the given code as a new code cell.
@@ -31,8 +34,8 @@ class BaseNotebookRenderer(Renderer):
         Returns:
             Nothing, adds a cell to the class instance notebook
         """
-        if sanitize_nulls:
-            code = convert_nulls_to_None(code)
+        if enforce_py_syntax:
+            code = convert_json_string_to_be_python_compliant(code)
 
         if lint:
             code = lint_code(code).rstrip("\n")

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -946,12 +946,25 @@ def lint_code(code: str) -> str:
         return code
 
 
-def convert_nulls_to_None(code: str) -> str:
-    """
-    Substitute instances of 'null' with 'None' in string representations of Python dictionaries.
+def convert_json_string_to_be_python_compliant(code: str) -> str:
+    """Cleans JSON-formatted string to adhere to Python syntax
 
-    Designed to provide security when serializing GE objects and writing them to Jupyter Notebooks.
+    Substitute instances of 'null' with 'None' in string representations of Python dictionaries.
+    Additionally, substitutes instances of 'true' or 'false' with their Python equivalents.
+
+    Args:
+        code: JSON string to update
+
+    Returns:
+        Clean, Python-compliant string
+
     """
+    code = _convert_nulls_to_None(code)
+    code = _convert_json_bools_to_python_bools(code)
+    return code
+
+
+def _convert_nulls_to_None(code: str) -> str:
     pattern = r'"([a-zA-Z0-9_]+)": null'
     result = re.findall(pattern, code)
     for match in result:
@@ -959,6 +972,18 @@ def convert_nulls_to_None(code: str) -> str:
         logger.info(
             f"Replaced '{match}: null' with '{match}: None' before writing to file"
         )
+    return code
+
+
+def _convert_json_bools_to_python_bools(code: str) -> str:
+    pattern = r'"([a-zA-Z0-9_]+)": (true|false)'
+    result = re.findall(pattern, code)
+    for match in result:
+        identifier, boolean = match
+        curr = f'"{identifier}": {boolean}'
+        updated = f'"{identifier}": {boolean.title()}'  # true -> True | false -> False
+        code = code.replace(curr, updated)
+        logger.info(f"Replaced '{curr}' with '{updated}' before writing to file")
     return code
 
 

--- a/tests/test_ge_utils.py
+++ b/tests/test_ge_utils.py
@@ -7,7 +7,7 @@ import pytest
 import great_expectations as ge
 from great_expectations.core.util import nested_update
 from great_expectations.util import (
-    convert_nulls_to_None,
+    convert_json_string_to_be_python_compliant,
     deep_filter_properties_iterable,
     filter_properties_dict,
     get_currently_executing_function_call_arguments,
@@ -248,17 +248,7 @@ def test_linter_leaves_clean_code():
     assert lint_code(code) == "foo = [1, 2, 3]\n"
 
 
-def test_convert_nulls_to_None_no_match():
-    text = """
-    "kwargs": {"max_value": 10000, "min_value": 10000},
-    "expectation_type": "expect_table_row_count_to_be_between",
-    "meta": {},
-    """
-    res = convert_nulls_to_None(text)
-    assert res == text
-
-
-def test_convert_nulls_to_None_with_match(caplog):
+def test_convert_json_string_to_be_python_compliant_null_replacement(caplog):
     text = """
     "ge_cloud_id": null,
     "expectation_context": {"description": null},
@@ -269,7 +259,7 @@ def test_convert_nulls_to_None_with_match(caplog):
     """
 
     with caplog.at_level(logging.INFO):
-        res = convert_nulls_to_None(text)
+        res = convert_json_string_to_be_python_compliant(text)
 
     assert res == expected
     assert (
@@ -280,6 +270,52 @@ def test_convert_nulls_to_None_with_match(caplog):
         "Replaced 'description: null' with 'description: None' before writing to file"
         in caplog.text
     )
+
+
+def test_convert_json_string_to_be_python_compliant_bool_replacement(caplog):
+    text = """
+    "meta": {},
+    "kwargs": {
+        "column": "input_date",
+        "max_value": "2027-09-03 00:00:00",
+        "min_value": "2015-01-01 00:00:00",
+        "parse_strings_as_datetimes": true,
+        "catch_exceptions": false
+    },
+    """
+    expected = """
+    "meta": {},
+    "kwargs": {
+        "column": "input_date",
+        "max_value": "2027-09-03 00:00:00",
+        "min_value": "2015-01-01 00:00:00",
+        "parse_strings_as_datetimes": True,
+        "catch_exceptions": False
+    },
+    """
+
+    with caplog.at_level(logging.INFO):
+        res = convert_json_string_to_be_python_compliant(text)
+
+    assert res == expected
+    assert (
+        "Replaced '\"parse_strings_as_datetimes\": true' with '\"parse_strings_as_datetimes\": True' before writing to file"
+        in caplog.text
+    )
+    assert (
+        "Replaced '\"catch_exceptions\": false' with '\"catch_exceptions\": False' before writing to file"
+        in caplog.text
+    )
+
+
+def test_convert_json_string_to_be_python_compliant_no_replacement():
+    text = """
+    "kwargs": {"max_value": 10000, "min_value": 10000},
+    "expectation_type": "expect_table_row_count_to_be_between",
+    "meta": {},
+    """
+    res = convert_json_string_to_be_python_compliant(text)
+    assert res == text
 
 
 def test_get_currently_executing_function_call_arguments(a=None, *args, **kwargs):


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- https://github.com/great-expectations/great_expectations/issues/3894
- This fix aligns with our current solution but will need to be part of a larger conversation around serialization between JSON and Python (specifically in the context of notebooks)


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
