### PR TITLE
Feature/changes from novuum jan3 review

### DIFF
--- a/great_expectations/core/expectation_diagnostics/supporting_types.py
+++ b/great_expectations/core/expectation_diagnostics/supporting_types.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Union
+from typing import List, Union, Optional
 
 from great_expectations.core import ExpectationConfiguration
 from great_expectations.core.expectation_diagnostics.expectation_test_data_cases import (
@@ -27,6 +27,14 @@ class Maturity(Enum):
 
 
 @dataclass
+class Package:
+    """A package name, link to its pypi or Gallery page, and (optional) version number"""
+
+    text: str
+    link: str
+    version: Optional[str]
+
+@dataclass
 class AugmentedLibraryMetadata(SerializableDictDot):
     """An augmented version of the Expectation.library_metadata object, used within ExpectationDiagnostics"""
 
@@ -34,7 +42,7 @@ class AugmentedLibraryMetadata(SerializableDictDot):
     tags: List[str]
     contributors: List[str]
     library_metadata_passed_checks: bool
-    package: Union[str, None] = None
+    package: Optional[Package] = None
 
     legacy_maturity_level_substitutions = {
         "experimental": "EXPERIMENTAL",
@@ -160,6 +168,7 @@ class ExpectationDiagnosticCheckMessage(SerializableDictDot):
 
     message: str
     passed: bool
+    doc_url: Optional[str] = None
     sub_messages: List["ExpectationDiagnosticCheckMessage"] = field(
         default_factory=list
     )

--- a/great_expectations/core/expectation_diagnostics/supporting_types.py
+++ b/great_expectations/core/expectation_diagnostics/supporting_types.py
@@ -163,3 +163,13 @@ class ExpectationDiagnosticCheckMessage(SerializableDictDot):
     sub_messages: List["ExpectationDiagnosticCheckMessage"] = field(
         default_factory=list
     )
+
+
+@dataclass
+class ExpectationDiagnosticMaturityMessages(SerializableDictDot):
+    """A holder for ExpectationDiagnosticCheckMessages, grouping them by maturity level. Used within the ExpectationDiagnostic object."""
+
+    experimental: List[ExpectationDiagnosticCheckMessage]
+    beta: List[ExpectationDiagnosticCheckMessage]
+    production: List[ExpectationDiagnosticCheckMessage]
+

--- a/tests/expectations/test_expectation_diagnostics.py
+++ b/tests/expectations/test_expectation_diagnostics.py
@@ -13,6 +13,7 @@ from great_expectations.core.expectation_diagnostics.supporting_types import (
     AugmentedLibraryMetadata,
     ExpectationDescriptionDiagnostics,
     ExpectationDiagnosticCheckMessage,
+    ExpectationDiagnosticMaturityMessages,
     ExpectationExecutionEngineDiagnostics,
     ExpectationRendererDiagnostics,
     ExpectationTestDiagnostics,
@@ -112,35 +113,40 @@ def test_ExpectationDiagnosticReport():
 
 
 def test__convert_checks_into_output_message():
-    checks = [
-        ExpectationDiagnosticCheckMessage(
-            message="AAA",
-            passed=True,
-        ),
-        ExpectationDiagnosticCheckMessage(
-            message="BBB",
-            passed=False,
-        ),
-        ExpectationDiagnosticCheckMessage(
-            message="CCC",
-            passed=False,
-            sub_messages=[
-                ExpectationDiagnosticCheckMessage(
-                    message="ddd",
-                    passed=True,
-                ),
-                ExpectationDiagnosticCheckMessage(
-                    message="eee",
-                    passed=False,
-                ),
-            ],
-        ),
-    ]
+    checks = ExpectationDiagnosticMaturityMessages(
+        experimental= [
+            ExpectationDiagnosticCheckMessage(
+                message="AAA",
+                passed=True,
+            ),
+            ExpectationDiagnosticCheckMessage(
+                message="BBB",
+                passed=False,
+            ),
+        ],
+        beta = [],
+        production= [
+            ExpectationDiagnosticCheckMessage(
+                message="CCC",
+                passed=False,
+                sub_messages=[
+                    ExpectationDiagnosticCheckMessage(
+                        message="ddd",
+                        passed=True,
+                    ),
+                    ExpectationDiagnosticCheckMessage(
+                        message="eee",
+                        passed=False,
+                    ),
+                ],
+            ),
+        ]
+    )
 
     assert (
         edr._convert_checks_into_output_message(
             class_name="ExpectColumnValuesToEqualThree",
-            checks=checks,
+            maturity_messages=checks,
         )
         == """\
 Completeness checklist for ExpectColumnValuesToEqualThree:


### PR DESCRIPTION
Changes proposed in this pull request:

Three small changes to make this fit the updated front-end Gallery designs.
- Add a `ExpectationDiagnosticsMaturityMessages` class, that groups `CheckMessages` by maturity level for display.
- Add a `Package` class to enable display of links and versions for package dependencies.
- Add a `doc_url` parameter to `CheckMessages`, so they can link to docs.

