### PR TITLE
[BUGFIX] Cloud-519/cloud notification action return type

### DIFF
--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -340,6 +340,6 @@ def send_cloud_notification(url: str, headers: dict):
         if response.status_code != 200:
             message = f"Cloud Notification request at {url} returned error {response.status_code}: {response.text}"
             logger.error(message)
-            return message
+            return {"cloud_notification_result": message}
         else:
-            return "Cloud notification succeeded."
+            return {"cloud_notification_result": "Cloud notification succeeded."}

--- a/tests/actions/test_core_actions.py
+++ b/tests/actions/test_core_actions.py
@@ -682,7 +682,7 @@ def test_cloud_notification_action(
             validation_result_suite_identifier=validation_result_suite_ge_cloud_identifier,
             data_asset=None,
         )
-        == "Cloud notification succeeded."
+        == {"cloud_notification_result": "Cloud notification succeeded."}
     )
     mock_post_method.assert_called_with(
         url=expected_ge_cloud_url, headers=expected_headers
@@ -711,7 +711,11 @@ def test_cloud_notification_action_bad_response(
         "Content-Type": "application/vnd.api+json",
         "Authorization": f"Bearer {ge_cloud_access_token}",
     }
-    expected_error_message = "Cloud Notification request at https://app.test.greatexpectations.io/accounts/bd20fead-2c31-4392-bcd1-f1e87ad5a79c/contracts/bfe7dc64-5320-49b0-91c1-2e8029e06c4d/suite-validation-results/bfe7dc64-5320-49b0-91c1-2e8029e06c4d/notification-actions returned error 418: test_text"
+    expected_result = {
+        "cloud_notification_result": "Cloud Notification request at "
+        "https://app.test.greatexpectations.io/accounts/bd20fead-2c31-4392-bcd1-f1e87ad5a79c/contracts/bfe7dc64-5320-49b0-91c1-2e8029e06c4d/suite-validation-results/bfe7dc64-5320-49b0-91c1-2e8029e06c4d/notification-actions "
+        "returned error 418: test_text"
+    }
 
     assert (
         cloud_action.run(
@@ -719,7 +723,7 @@ def test_cloud_notification_action_bad_response(
             validation_result_suite_identifier=validation_result_suite_ge_cloud_identifier,
             data_asset=None,
         )
-        == expected_error_message
+        == expected_result
     )
     mock_post_method.assert_called_with(
         url=expected_ge_cloud_url, headers=expected_headers


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Update cloud notification action to return a dictionary instead of str

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
