### PR TITLE
[DOCS] Connecting to BigQuery Doc line references fix

### DIFF
--- a/docs/guides/connecting_to_your_data/database/bigquery.md
+++ b/docs/guides/connecting_to_your_data/database/bigquery.md
@@ -112,7 +112,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
 </TabItem>
 <TabItem value="python">
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py#L41
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py#L40
 ```
 
 </TabItem>
@@ -149,7 +149,7 @@ Here is an example of loading data by specifying an existing table name.
 Currently BigQuery does not allow for the creation of temporary tables as the result of a query.  As a workaround, Great Expectations allows for a named permanent table to be used as a "temporary" table, with the name passed in as a `batch_spec_passthrough` parameter. In the following example we are using a table named `ge_temp`.
 :::
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py#L67-L81
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py#L66-L80
 ```
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed line references for connecting to BigQuery Doc (python example)
- GREAT-405
-