### PR TITLE
[DOCS] swap of old uri for new in data docs generated

### DIFF
--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -673,8 +673,7 @@ class DefaultSiteIndexBuilder:
         """
         create_expectations = CallToActionButton(
             "How to Create Expectations",
-            # TODO update this link to a proper tutorial
-            "https://docs.greatexpectations.io/en/latest/guides/how_to_guides/creating_and_editing_expectations.html",
+            "https://docs.greatexpectations.io/docs/tutorials/getting_started/tutorial_create_expectations",
         )
         see_glossary = CallToActionButton(
             "See More Kinds of Expectations",
@@ -682,16 +681,15 @@ class DefaultSiteIndexBuilder:
         )
         validation_playground = CallToActionButton(
             "How to Validate Data",
-            # TODO update this link to a proper tutorial
-            "https://docs.greatexpectations.io/en/latest/guides/how_to_guides/validation.html",
+            "https://docs.greatexpectations.io/docs/tutorials/getting_started/tutorial_validate_data",
         )
         customize_data_docs = CallToActionButton(
             "How to Customize Data Docs",
-            "https://docs.greatexpectations.io/en/latest/reference/core_concepts.html#data-docs",
+            "https://docs.greatexpectations.io/docs/reference/data_docs#customizing-html-documentation",
         )
         team_site = CallToActionButton(
             "How to Set Up a Team Site",
-            "https://docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_docs.html",
+            "https://docs.greatexpectations.io/docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_a_filesystem"
         )
         # TODO gallery does not yet exist
         # gallery = CallToActionButton(

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -673,7 +673,7 @@ class DefaultSiteIndexBuilder:
         """
         create_expectations = CallToActionButton(
             "How to Create Expectations",
-            "https://docs.greatexpectations.io/docs/tutorials/getting_started/tutorial_create_expectations",
+            "https://docs.greatexpectations.io/docs/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data",
         )
         see_glossary = CallToActionButton(
             "See More Kinds of Expectations",

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -689,7 +689,7 @@ class DefaultSiteIndexBuilder:
         )
         team_site = CallToActionButton(
             "How to Set Up a Team Site",
-            "https://docs.greatexpectations.io/docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_a_filesystem"
+            "https://docs.greatexpectations.io/docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_a_filesystem",
         )
         # TODO gallery does not yet exist
         # gallery = CallToActionButton(

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -681,7 +681,7 @@ class DefaultSiteIndexBuilder:
         )
         validation_playground = CallToActionButton(
             "How to Validate Data",
-            "https://docs.greatexpectations.io/docs/tutorials/getting_started/tutorial_validate_data",
+            "https://docs.greatexpectations.io/docs/guides/validation/checkpoints/how_to_create_a_new_checkpoint",
         )
         customize_data_docs = CallToActionButton(
             "How to Customize Data Docs",


### PR DESCRIPTION
May require feedback to find best applicable resources.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Change old documentation references with new, old 404 etc.

After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
