### PR TITLE
[BUGFIX] Fix for `expect_column_values_to_be_unique` that was not compatible with BigQuery

### DIFF
--- a/tests/integration/docusaurus/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py
+++ b/tests/integration/docusaurus/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_gcs.py
@@ -31,7 +31,7 @@ create_data_docs_directory = create_data_docs_directory.replace(
     "<YOUR GCP PROJECT NAME>", "ge-oss-ci-cd"
 )
 create_data_docs_directory = create_data_docs_directory.replace(
-    "<YOUR GCS BUCKET NAME>", "superconductive-integration-tests-data-docs" 
+    "<YOUR GCS BUCKET NAME>", "superconductive-integration-tests-data-docs"
 )
 
 result = subprocess.run(

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
@@ -9,9 +9,7 @@
       "n" : [null, null, 2, null],
       "unique" : [1, 2, 3, null],
       "null": [null, null, null, null],
-      "mult_dup": ["1", "1", "2", "2"],
-      "0": [1, 2, 3, 4],
-      "_c0": [1, 2, 3, 4]
+      "mult_dup": ["1", "1", "2", "2"]
     },
     "schemas": {
       "spark": {
@@ -22,9 +20,7 @@
         "n": "IntegerType",
         "unique": "IntegerType",
         "null": "NullType",
-        "mult_dup": "StringType",
-        "0": "IntegerType",
-        "_c0": "IntegerType"
+        "mult_dup": "StringType"
       },
       "mssql": {
         "a": "VARCHAR",
@@ -34,9 +30,7 @@
         "n": "INTEGER",
         "unique": "INTEGER",
         "null": "NVARCHAR",
-        "mult_dup": "VARCHAR",
-        "0": "INTEGER",
-        "_c0": "INTEGER"
+        "mult_dup": "VARCHAR"
       },
       "mysql": {
         "a": "CHAR",
@@ -46,9 +40,17 @@
         "n": "INTEGER",
         "unique": "INTEGER",
         "null": "CHAR",
-        "mult_dup": "CHAR",
-        "0": "INTEGER",
-        "_c0": "INTEGER"
+        "mult_dup": "CHAR"
+      },
+      "bigquery": {
+        "a": "STRING",
+        "b": "STRING",
+        "c": "NUMERIC",
+        "d": "STRING",
+        "n": "NUMERIC",
+        "unique": "NUMERIC",
+        "null": "STRING",
+        "mult_dup": "STRING"
       }
     },
     "tests" : [
@@ -155,9 +157,25 @@
           "unexpected_list": ["1", "1", "2", "2"],
           "unexpected_index_list": [0, 1, 2, 3]
         }
-      },
+      }
+    ]
+  },
+   {
+    "data" : {
+      "0": [1, 2, 3, 4],
+      "_c0": [1, 2, 3, 4]
+    },
+    "schemas": {
+      "spark": {
+        "0": "IntegerType",
+        "_c0": "IntegerType"
+      }
+    },
+    "only_for": "spark",
+    "tests" : [
       {
         "title": "positive_integer_column_name",
+        "only_for": "spark",
         "exact_match_out": false,
         "in": {
           "column": "0"
@@ -168,6 +186,7 @@
       },
       {
         "title": "positive_spark_headerless_column_name",
+        "only_for": "spark",
         "exact_match_out": false,
         "in": {
           "column": "_c0"

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
@@ -171,7 +171,7 @@
         "_c0": "IntegerType"
       }
     },
-    "only_for": "spark",
+    "only_for": ["spark"],
     "tests" : [
       {
         "title": "positive_integer_column_name",

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
@@ -175,7 +175,6 @@
     "tests" : [
       {
         "title": "positive_integer_column_name",
-        "only_for": "spark",
         "exact_match_out": false,
         "in": {
           "column": "0"
@@ -186,7 +185,6 @@
       },
       {
         "title": "positive_spark_headerless_column_name",
-        "only_for": "spark",
         "exact_match_out": false,
         "in": {
           "column": "_c0"

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -53,11 +53,17 @@ def pytest_generate_tests(metafunc):
 
                 for d in test_configuration["datasets"]:
                     datasets = []
+                    # optional only_for flag that can prevent data being added to incompatible backends.
+                    # currently only used by expect_column_values_to_be_unique
+                    only_for = d.get("only_for", None)
                     if candidate_test_is_on_temporary_notimplemented_list(
                         c, test_configuration["expectation_type"]
                     ):
                         skip_expectation = True
                         schemas = data_asset = None
+                    elif only_for:
+                        if c is not only_for:
+                            continue
                     else:
                         skip_expectation = False
                         if isinstance(d["data"], list):

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -56,14 +56,18 @@ def pytest_generate_tests(metafunc):
                     # optional only_for flag that can prevent data being added to incompatible backends.
                     # currently only used by expect_column_values_to_be_unique
                     only_for = d.get("only_for", None)
+                    suppress_test_for = d.get("suppress_test_for", None)
                     if candidate_test_is_on_temporary_notimplemented_list(
                         c, test_configuration["expectation_type"]
                     ):
                         skip_expectation = True
                         schemas = data_asset = None
-                    elif only_for:
-                        if c is not only_for:
-                            continue
+                    elif suppress_test_for and (
+                        c is suppress_test_for or c in suppress_test_for
+                    ):
+                        continue
+                    elif only_for and (c is only_for or c in only_for):
+                        continue
                     else:
                         skip_expectation = False
                         if isinstance(d["data"], list):

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -61,6 +61,9 @@ def pytest_generate_tests(metafunc):
                     ):
                         skip_expectation = True
                         schemas = data_asset = None
+                    elif only_for:
+                        if c is not only_for:
+                            continue
                     else:
                         skip_expectation = False
                         if isinstance(d["data"], list):

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -53,10 +53,18 @@ def pytest_generate_tests(metafunc):
 
                 for d in test_configuration["datasets"]:
                     datasets = []
-                    # optional only_for flag that can prevent data being added to incompatible backends.
-                    # currently only used by expect_column_values_to_be_unique
+                    # optional only_for and suppress_test flag at the datasets-level that can prevent data being
+                    # added to incompatible backends. Currently only used by expect_column_values_to_be_unique
                     only_for = d.get("only_for", None)
+                    if only_for and not isinstance(only_for, list):
+                        raise ValueError(
+                            "Invalid test specification. 'only_for' should be passed in as a list"
+                        )
                     suppress_test_for = d.get("suppress_test_for", None)
+                    if suppress_test_for and not isinstance(suppress_test_for, list):
+                        raise ValueError(
+                            "Invalid test specification. 'suppress_test_for' should be passed in as a list"
+                        )
                     if candidate_test_is_on_temporary_notimplemented_list(
                         c, test_configuration["expectation_type"]
                     ):
@@ -108,7 +116,9 @@ def pytest_generate_tests(metafunc):
                             # if we're not on the "only_for" list, then never even generate the test
                             generate_test = False
                             if not isinstance(test["only_for"], list):
-                                raise ValueError("Invalid test specification.")
+                                raise ValueError(
+                                    "Invalid test specification. 'only_for' should be passed in as a list"
+                                )
 
                             if isinstance(data_asset, SqlAlchemyDataset):
                                 # Call out supported dialects
@@ -174,54 +184,65 @@ def pytest_generate_tests(metafunc):
                         if not generate_test:
                             continue
 
-                        if "suppress_test_for" in test and (
-                            (
+                        if "suppress_test_for" in test:
+                            if not isinstance(test["suppress_test_for"], list):
+                                raise ValueError(
+                                    "Invalid test specification. 'suppress_test_for' should be passed in as a list"
+                                )
+
+                            if (
                                 "sqlalchemy" in test["suppress_test_for"]
                                 and isinstance(data_asset, SqlAlchemyDataset)
-                            )
-                            or (
-                                "sqlite" in test["suppress_test_for"]
-                                and sqliteDialect is not None
-                                and isinstance(data_asset, SqlAlchemyDataset)
-                                and isinstance(data_asset.engine.dialect, sqliteDialect)
-                            )
-                            or (
-                                "postgresql" in test["suppress_test_for"]
-                                and postgresqlDialect is not None
-                                and isinstance(data_asset, SqlAlchemyDataset)
-                                and isinstance(
-                                    data_asset.engine.dialect, postgresqlDialect
+                                or (
+                                    "sqlite" in test["suppress_test_for"]
+                                    and sqliteDialect is not None
+                                    and isinstance(data_asset, SqlAlchemyDataset)
+                                    and isinstance(
+                                        data_asset.engine.dialect, sqliteDialect
+                                    )
                                 )
-                            )
-                            or (
-                                "mysql" in test["suppress_test_for"]
-                                and mysqlDialect is not None
-                                and isinstance(data_asset, SqlAlchemyDataset)
-                                and isinstance(data_asset.engine.dialect, mysqlDialect)
-                            )
-                            or (
-                                "mssql" in test["suppress_test_for"]
-                                and mssqlDialect is not None
-                                and isinstance(data_asset, SqlAlchemyDataset)
-                                and isinstance(data_asset.engine.dialect, mssqlDialect)
-                            )
-                            or (
-                                "bigquery" in test["suppress_test_for"]
-                                and BigQueryDialect is not None
-                                and isinstance(data_asset, SqlAlchemyDataset)
-                                and hasattr(data_asset.engine.dialect, "name")
-                                and data_asset.engine.dialect.name.lower() == "bigquery"
-                            )
-                            or (
-                                "pandas" in test["suppress_test_for"]
-                                and isinstance(data_asset, PandasDataset)
-                            )
-                            or (
-                                "spark" in test["suppress_test_for"]
-                                and isinstance(data_asset, SparkDFDataset)
-                            )
-                        ):
-                            skip_test = True
+                                or (
+                                    "postgresql" in test["suppress_test_for"]
+                                    and postgresqlDialect is not None
+                                    and isinstance(data_asset, SqlAlchemyDataset)
+                                    and isinstance(
+                                        data_asset.engine.dialect, postgresqlDialect
+                                    )
+                                )
+                                or (
+                                    "mysql" in test["suppress_test_for"]
+                                    and mysqlDialect is not None
+                                    and isinstance(data_asset, SqlAlchemyDataset)
+                                    and isinstance(
+                                        data_asset.engine.dialect, mysqlDialect
+                                    )
+                                )
+                                or (
+                                    "mssql" in test["suppress_test_for"]
+                                    and mssqlDialect is not None
+                                    and isinstance(data_asset, SqlAlchemyDataset)
+                                    and isinstance(
+                                        data_asset.engine.dialect, mssqlDialect
+                                    )
+                                )
+                                or (
+                                    "bigquery" in test["suppress_test_for"]
+                                    and BigQueryDialect is not None
+                                    and isinstance(data_asset, SqlAlchemyDataset)
+                                    and hasattr(data_asset.engine.dialect, "name")
+                                    and data_asset.engine.dialect.name.lower()
+                                    == "bigquery"
+                                )
+                                or (
+                                    "pandas" in test["suppress_test_for"]
+                                    and isinstance(data_asset, PandasDataset)
+                                )
+                                or (
+                                    "spark" in test["suppress_test_for"]
+                                    and isinstance(data_asset, SparkDFDataset)
+                                )
+                            ):
+                                skip_test = True
                         # Known condition: SqlAlchemy does not support allow_cross_type_comparisons
                         if "allow_cross_type_comparisons" in test["in"] and isinstance(
                             data_asset, SqlAlchemyDataset

--- a/tests/test_definitions/test_expectations_cfe.py
+++ b/tests/test_definitions/test_expectations_cfe.py
@@ -50,10 +50,16 @@ def pytest_generate_tests(metafunc):
 
                 for d in test_configuration["datasets"]:
                     datasets = []
+                    # optional only_for flag that can prevent data being added to incompatible backends.
+                    # currently only used by expect_column_values_to_be_unique
+                    only_for = d.get("only_for", None)
                     if candidate_test_is_on_temporary_notimplemented_list_cfe(
                         c, test_configuration["expectation_type"]
                     ):
                         skip_expectation = True
+                    elif only_for:
+                        if c is not only_for:
+                            continue
                     else:
                         skip_expectation = False
                         if isinstance(d["data"], list):

--- a/tests/test_definitions/test_expectations_cfe.py
+++ b/tests/test_definitions/test_expectations_cfe.py
@@ -57,6 +57,9 @@ def pytest_generate_tests(metafunc):
                         c, test_configuration["expectation_type"]
                     ):
                         skip_expectation = True
+                    elif only_for:
+                        if c is not only_for:
+                            continue
                     else:
                         skip_expectation = False
                         if isinstance(d["data"], list):

--- a/tests/test_definitions/test_expectations_cfe.py
+++ b/tests/test_definitions/test_expectations_cfe.py
@@ -53,13 +53,17 @@ def pytest_generate_tests(metafunc):
                     # optional only_for flag that can prevent data being added to incompatible backends.
                     # currently only used by expect_column_values_to_be_unique
                     only_for = d.get("only_for", None)
+                    suppress_test_for = d.get("suppress_test_for", None)
                     if candidate_test_is_on_temporary_notimplemented_list_cfe(
                         c, test_configuration["expectation_type"]
                     ):
                         skip_expectation = True
-                    elif only_for:
-                        if c is not only_for:
-                            continue
+                    elif suppress_test_for and (
+                        c is suppress_test_for or c in suppress_test_for
+                    ):
+                        continue
+                    elif only_for and (c is only_for or c in only_for):
+                        continue
                     else:
                         skip_expectation = False
                         if isinstance(d["data"], list):


### PR DESCRIPTION
Changes proposed in this pull request:
- Bugfix that was motivated by a change in #4004, which added fixes to the flow in `sparkdf_execution_engine.py` for Spark Nan filtering. 
- #4004 added columns (`"0"`, `"_c0"`) to the `expect_column_values_to_be_unique ` fixture, which are incompatible with `BigQuery` only (found using `azure-pipelines-cloud-db-integration.yml` pipeline, which is only run once a week). The `expect_column_values_to_be_unique` is the Expectation that fails. 
- Currently merging this PR into `MAINTENANCE/GREAT-503/GCP-testing-migration`, which is associated with the #4072 PR that is in progress

## How was it fixed? 
- Currently the Expectation tests are configured as `.json` files in the `test_definitions` directories, and each `.json` file contains 3 main fields : 
- 1. `data` : which defines the data to be loaded into the backend. 
- 2. `schema` : which defines backend-specific schemas for the `data`
- 3. `tests`: which define tests for `data` and `schema`. 

- We currently allow for  `tests` to be filtered by back-end either using the `only_for` or `suppress_test_for` lists (for example setting `only_for : ["spark"]` will make the test only run for the `spark` backend), but this is only after the `data` has been loaded to each backend (which is where we are running into a problem with `bigquery`)
- This PR first splits out the dataset with columns (`"0"`, `"_c0"`) and makes it into its own `data` field. 
- The PR then adds a `only_for` and `suppress_test_for` flag at the `data` level, and ensures the test only runs for the `spark` backend. 
- The PR also introduces some more-detailed error messages for the `only_for` and `suppress_test_for` flags, both at the `data` and `tests` level


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
