### PR TITLE
[BUGFIX] Fixed missing dependency in latest release 0.14.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ ruamel.yaml>=0.16,<0.17.18  # package
 scipy>=0.19.0  # package
 termcolor>=1.1.0  # package
 tqdm>=4.59.0
+typing_extensions>=4.0.1
 tzlocal>=1.2  # package


### PR DESCRIPTION
Running latest release 0.14.3, you end up with `ModuleNotFoundError: No module named 'typing_extensions'`. 
This fixes it.


