### PR TITLE
[BUGFIX] Add default BIGQUERY_TYPES

### DIFF
--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -146,10 +146,13 @@ try:
             "BigQueryTypes", sorted(pybigquery.sqlalchemy_bigquery._type_map)
         )
         bigquery_types_tuple = BigQueryTypes(**pybigquery.sqlalchemy_bigquery._type_map)
+        BIGQUERY_TYPES = {}
+
 except (ImportError, AttributeError):
     bigquery_types_tuple = None
     BigQueryDialect = None
     pybigquery = None
+    BIGQUERY_TYPES = {}
 
 
 try:


### PR DESCRIPTION
Changes proposed in this pull request:
- Similar to other sql backends, set a default when pybigquery is not importable

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
