### PR TITLE
[DOCS] Corrected typo 'virutal' corrected to 'virtual'

### DIFF
--- a/docs/guides/setup/installation/local.md
+++ b/docs/guides/setup/installation/local.md
@@ -47,7 +47,7 @@ You can use either pip or Anaconda to install Great Expectations.
   ]}>
 <TabItem value="pip">
 
-Once you have confirmed that Python 3 is installed locally, you can create a virutal environment with venv.
+Once you have confirmed that Python 3 is installed locally, you can create a virtual environment with venv.
 
 <details>
 <summary>Python Virtual Environments</summary>


### PR DESCRIPTION
Corrected typo 'virutal' corrected to 'virtual'

Changes proposed in this pull request:
- Correction of typo in one word

### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code

Thank you for submitting!
