### PR TITLE
[BUGFIX] Use `pip==20.2.4` for usage statistics stage of CI/CD

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -261,7 +261,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip==21.3.1
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - script: |

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -120,7 +120,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # --upgrade pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - bash: pip install numpy
@@ -192,7 +192,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -261,7 +261,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -311,7 +311,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -356,7 +356,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -261,7 +261,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip==21.3.1
+          - bash: python -m pip install --upgrade pip==20.2.4
             displayName: 'Update pip'
 
           - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,7 +127,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # --upgrade pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - bash: pip install numpy
@@ -204,7 +204,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -261,7 +261,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -297,7 +297,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -340,7 +340,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -378,7 +378,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -416,7 +416,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |
@@ -468,7 +468,7 @@ stages:
               versionSpec: '$(python.version)'
             displayName: 'Use Python $(python.version)'
 
-          - bash: python -m pip install --upgrade pip  # pip==20.2.4
+          - bash: python -m pip install --upgrade pip==21.3.1
             displayName: 'Update pip'
 
           - script: |

--- a/great_expectations/rule_based_profiler/rule/rule.py
+++ b/great_expectations/rule_based_profiler/rule/rule.py
@@ -1,3 +1,4 @@
+# Test change to trigger pipeline
 import copy
 from typing import Dict, List, Optional
 

--- a/great_expectations/rule_based_profiler/rule/rule.py
+++ b/great_expectations/rule_based_profiler/rule/rule.py
@@ -1,4 +1,3 @@
-# Test change to trigger pipeline
 import copy
 from typing import Dict, List, Optional
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Usage stats require an older version of pip for proper dependency resolution (see the version of the YAML from before the hotfix PR (https://github.com/great-expectations/great_expectations/pull/4100), where this was working as intended).

### Definition of Done
Please delete options that are not relevant.

- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.