### PR TITLE
[MAINTENANCE] Minor Cleanup -- remove unnecessary default arguments from dictionary cleaner

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -491,7 +491,6 @@ is run), with each validation having its own defined "action_list" attribute.
             filter_properties_dict(
                 properties=config_kwargs,
                 clean_falsy=True,
-                keep_falsy_numerics=True,
                 inplace=True,
             )
 
@@ -502,7 +501,6 @@ is run), with each validation having its own defined "action_list" attribute.
             json_dict: dict = convert_to_json_serializable(data=config_kwargs)
             deep_filter_properties_iterable(
                 properties=json_dict,
-                keep_falsy_numerics=True,
                 inplace=True,
             )
             return json.dumps(json_dict, indent=2)
@@ -544,7 +542,6 @@ is run), with each validation having its own defined "action_list" attribute.
         json_dict: dict = convert_to_json_serializable(data=self.get_config())
         deep_filter_properties_iterable(
             properties=json_dict,
-            keep_falsy_numerics=True,
             inplace=True,
         )
         return json.dumps(json_dict, indent=2)

--- a/great_expectations/checkpoint/toolkit.py
+++ b/great_expectations/checkpoint/toolkit.py
@@ -116,7 +116,6 @@ def add_checkpoint(
     checkpoint_config = deep_filter_properties_iterable(
         properties=checkpoint_config,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
     new_checkpoint: Union[
         Checkpoint, SimpleCheckpoint, LegacyCheckpoint
@@ -336,7 +335,6 @@ def run_checkpoint(
     filter_properties_dict(
         properties=checkpoint_run_arguments,
         clean_falsy=True,
-        keep_falsy_numerics=True,
         inplace=True,
     )
 

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -272,7 +272,6 @@ class BatchRequestBase(SerializableDictDot):
         json_dict: dict = self.to_json_dict()
         deep_filter_properties_iterable(
             properties=json_dict,
-            keep_falsy_numerics=True,
             inplace=True,
         )
         return json.dumps(json_dict, indent=2)
@@ -567,7 +566,6 @@ class Batch(SerializableDictDot):
         json_dict: dict = self.to_dict()
         deep_filter_properties_iterable(
             properties=json_dict["batch_request"],
-            keep_falsy_numerics=True,
             inplace=True,
         )
         return json_dict
@@ -790,7 +788,6 @@ def get_batch_request_from_acceptable_arguments(
 
     deep_filter_properties_iterable(
         properties=batch_request_as_dict,
-        keep_falsy_numerics=True,
         inplace=True,
     )
 

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2349,7 +2349,6 @@ class CheckpointConfig(BaseYamlConfig):
         json_dict: dict = self.to_json_dict()
         deep_filter_properties_iterable(
             properties=json_dict,
-            keep_falsy_numerics=True,
             inplace=True,
         )
         return json.dumps(json_dict, indent=2)

--- a/great_expectations/render/renderer/v3/suite_edit_notebook_renderer.py
+++ b/great_expectations/render/renderer/v3/suite_edit_notebook_renderer.py
@@ -408,7 +408,6 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         """
         deep_filter_properties_iterable(
             properties=batch_request,
-            keep_falsy_numerics=True,
             inplace=True,
         )
         self.render(

--- a/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
+++ b/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
@@ -27,7 +27,6 @@ class SuiteProfileNotebookRenderer(SuiteEditNotebookRenderer):
 
         deep_filter_properties_iterable(
             properties=batch_request,
-            keep_falsy_numerics=True,
             inplace=True,
         )
         batch_request = standardize_batch_request_display_ordering(

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -2519,7 +2519,6 @@ def test_newstyle_checkpoint_config_substitution_simple(
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_only,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -2527,14 +2526,12 @@ def test_newstyle_checkpoint_config_substitution_simple(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
     # make sure operation is idempotent
     simplified_checkpoint.get_substituted_config()
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_only,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -2542,7 +2539,6 @@ def test_newstyle_checkpoint_config_substitution_simple(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
     # template and runtime kwargs
@@ -2690,7 +2686,6 @@ def test_newstyle_checkpoint_config_substitution_simple(
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_and_runtime_kwargs,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -2698,7 +2693,6 @@ def test_newstyle_checkpoint_config_substitution_simple(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
 
@@ -2820,7 +2814,6 @@ def test_newstyle_checkpoint_config_substitution_nested(
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_only,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -2828,14 +2821,12 @@ def test_newstyle_checkpoint_config_substitution_nested(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
     # make sure operation is idempotent
     nested_checkpoint.get_substituted_config()
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_only,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -2843,7 +2834,6 @@ def test_newstyle_checkpoint_config_substitution_nested(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
     # runtime kwargs with new checkpoint template name passed at runtime
@@ -3007,7 +2997,6 @@ def test_newstyle_checkpoint_config_substitution_nested(
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_and_runtime_kwargs,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -3015,7 +3004,6 @@ def test_newstyle_checkpoint_config_substitution_nested(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
 

--- a/tests/checkpoint/test_checkpoint_config.py
+++ b/tests/checkpoint/test_checkpoint_config.py
@@ -137,7 +137,6 @@ def test_checkpoint_config_repr_after_substitution(checkpoint):
     json_dict: dict = convert_to_json_serializable(data=resolved_runtime_kwargs)
     deep_filter_properties_iterable(
         properties=json_dict,
-        keep_falsy_numerics=True,
         inplace=True,
     )
     checkpoint_config_repr: str = json.dumps(json_dict, indent=2)

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -535,11 +535,9 @@ def test_simple_checkpoint_runtime_kwargs_processing_site_names_only_without_per
     assert deep_filter_properties_iterable(
         properties=substituted_runtime_config,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties=expected_runtime_kwargs,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
 
@@ -617,11 +615,9 @@ def test_simple_checkpoint_runtime_kwargs_processing_slack_webhook_only_without_
     assert deep_filter_properties_iterable(
         properties=substituted_runtime_config,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties=expected_runtime_kwargs,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
 
@@ -705,11 +701,9 @@ def test_simple_checkpoint_runtime_kwargs_processing_all_special_kwargs_without_
     assert deep_filter_properties_iterable(
         properties=substituted_runtime_config,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties=expected_runtime_kwargs,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
 
@@ -824,11 +818,9 @@ def test_simple_checkpoint_runtime_kwargs_processing_all_kwargs(
     assert deep_filter_properties_iterable(
         properties=substituted_runtime_config,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties=expected_runtime_kwargs,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
 
@@ -991,7 +983,6 @@ def test_simple_checkpoint_with_runtime_batch_request_and_runtime_data_connector
     assert deep_filter_properties_iterable(
         properties=checkpoint_config["batch_request"].to_json_dict(),
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == {
         "batch_identifiers": {"pipeline_stage_name": "first"},
         "data_asset_name": "users",

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -790,7 +790,6 @@ def test_suite_new_interactive_valid_batch_request_from_json_file_in_notebook_ru
     batch_request_obj: BatchRequest = BatchRequest(**batch_request)
     batch_request = deep_filter_properties_iterable(
         properties=batch_request_obj.to_json_dict(),
-        keep_falsy_numerics=True,
     )
     batch_request = standardize_batch_request_display_ordering(
         batch_request=batch_request
@@ -1214,7 +1213,6 @@ def test_suite_edit_multiple_datasources_with_no_additional_args_without_citatio
     batch_request_obj: BatchRequest = BatchRequest(**batch_request)
     batch_request = deep_filter_properties_iterable(
         properties=batch_request_obj.to_json_dict(),
-        keep_falsy_numerics=True,
     )
     batch_request = standardize_batch_request_display_ordering(
         batch_request=batch_request
@@ -1469,7 +1467,6 @@ def test_suite_edit_multiple_datasources_with_no_additional_args_with_citations_
     batch_request_obj: BatchRequest = BatchRequest(**batch_request)
     batch_request = deep_filter_properties_iterable(
         properties=batch_request_obj.to_json_dict(),
-        keep_falsy_numerics=True,
     )
     batch_request = standardize_batch_request_display_ordering(
         batch_request=batch_request
@@ -1707,7 +1704,6 @@ def test_suite_edit_multiple_datasources_with_sql_with_no_additional_args_withou
     batch_request_obj: BatchRequest = BatchRequest(**batch_request)
     batch_request = deep_filter_properties_iterable(
         properties=batch_request_obj.to_json_dict(),
-        keep_falsy_numerics=True,
     )
     batch_request = standardize_batch_request_display_ordering(
         batch_request=batch_request
@@ -1965,7 +1961,6 @@ def test_suite_edit_multiple_datasources_with_sql_with_no_additional_args_with_c
     batch_request_obj: BatchRequest = BatchRequest(**batch_request)
     batch_request = deep_filter_properties_iterable(
         properties=batch_request_obj.to_json_dict(),
-        keep_falsy_numerics=True,
     )
     batch_request = standardize_batch_request_display_ordering(
         batch_request=batch_request
@@ -3087,7 +3082,6 @@ def test_suite_new_profile_runs_notebook_no_jupyter(
     batch_request_obj: BatchRequest = BatchRequest(**batch_request)
     batch_request = deep_filter_properties_iterable(
         properties=batch_request_obj.to_json_dict(),
-        keep_falsy_numerics=True,
     )
     batch_request = standardize_batch_request_display_ordering(
         batch_request=batch_request
@@ -3329,7 +3323,6 @@ def test_suite_new_profile_runs_notebook_opens_jupyter(
     batch_request_obj: BatchRequest = BatchRequest(**batch_request)
     batch_request = deep_filter_properties_iterable(
         properties=batch_request_obj.to_json_dict(),
-        keep_falsy_numerics=True,
     )
     batch_request = standardize_batch_request_display_ordering(
         batch_request=batch_request

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -444,7 +444,6 @@ def test_checkpoint_config_print(
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_and_runtime_kwargs,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -452,7 +451,6 @@ def test_checkpoint_config_print(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
     substituted_config_template_and_runtime_kwargs_json_dict: dict = (
@@ -463,7 +461,6 @@ def test_checkpoint_config_print(
     assert deep_filter_properties_iterable(
         properties=substituted_config_template_and_runtime_kwargs_json_dict,
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -471,5 +468,4 @@ def test_checkpoint_config_print(
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1903,7 +1903,6 @@ expectation_suite_ge_cloud_id:
     assert deep_filter_properties_iterable(
         properties=checkpoint_from_yaml.get_config(),
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -1911,14 +1910,12 @@ expectation_suite_ge_cloud_id:
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
     checkpoint_from_store = context.get_checkpoint(name=checkpoint_name)
     assert deep_filter_properties_iterable(
         properties=checkpoint_from_store.get_config(),
         clean_falsy=True,
-        keep_falsy_numerics=True,
     ) == deep_filter_properties_iterable(
         properties={
             key: value
@@ -1926,7 +1923,6 @@ expectation_suite_ge_cloud_id:
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
-        keep_falsy_numerics=True,
     )
 
     expected_action_list = [


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-560
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
