### PR TITLE
[MAINTENANCE] Remove `class_name` as mandatory field from `RuleBasedProfiler`

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -3273,8 +3273,6 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         name: str,
         config_version: float,
         rules: Dict[str, dict],
-        class_name: str,
-        module_name: Optional[str] = None,
         variables: Optional[dict] = None,
         ge_cloud_id: Optional[str] = None,
     ):
@@ -3282,8 +3280,6 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
             "name": name,
             "config_version": config_version,
             "rules": rules,
-            "class_name": class_name,
-            "module_name": module_name,
             "variables": variables,
         }
 
@@ -3713,7 +3709,10 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         instantiated_class = instantiate_class_from_config(
             config=profiler_config,
             runtime_environment={"data_context": self},
-            config_defaults={"module_name": "great_expectations.rule_based_profiler"},
+            config_defaults={
+                "module_name": "great_expectations.rule_based_profiler",
+                "class_name": "RuleBasedProfiler",
+            },
         )
 
         profiler_anonymizer: ProfilerAnonymizer = ProfilerAnonymizer(

--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -89,7 +89,7 @@ class NotNullSchema(Schema):
 class DomainBuilderConfig(DictDot):
     def __init__(
         self,
-        class_name: str,  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        class_name: Optional[str] = None,
         module_name: Optional[str] = None,
         batch_request: Optional[Union[dict, str]] = None,
         **kwargs,
@@ -111,8 +111,10 @@ class DomainBuilderConfigSchema(NotNullSchema):
     __config_class__ = DomainBuilderConfig
 
     class_name = fields.String(
-        required=True
-    )  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        required=False,
+        all_none=True,
+        missing="DomainBuilder",
+    )
     module_name = fields.String(
         required=False,
         all_none=True,
@@ -125,13 +127,13 @@ class ParameterBuilderConfig(DictDot):
     def __init__(
         self,
         name: str,
-        class_name: str,  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        class_name: Optional[str] = None,
         module_name: Optional[str] = None,
         batch_request: Optional[Union[dict, str]] = None,
         **kwargs,
     ):
         self.name = name
-        self.class_name = class_name  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        self.class_name = class_name
         self.module_name = module_name
         self.batch_request = batch_request
         for k, v in kwargs.items():
@@ -149,8 +151,10 @@ class ParameterBuilderConfigSchema(NotNullSchema):
 
     name = fields.String(required=True)
     class_name = fields.String(
-        required=True
-    )  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        required=False,
+        all_none=True,
+        missing="ParameterBuilder",
+    )
     module_name = fields.String(
         required=False,
         all_none=True,
@@ -163,7 +167,7 @@ class ExpectationConfigurationBuilderConfig(DictDot):
     def __init__(
         self,
         expectation_type: str,
-        class_name: str,  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        class_name: Optional[str] = None,
         module_name: Optional[str] = None,
         **kwargs,
     ):
@@ -184,8 +188,10 @@ class ExpectationConfigurationBuilderConfigSchema(NotNullSchema):
     __config_class__ = ExpectationConfigurationBuilderConfig
 
     class_name = fields.String(
-        required=True
-    )  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        required=False,
+        all_none=True,
+        missing="ExpectationConfigurationBuilder",
+    )
     module_name = fields.String(
         required=False,
         all_none=True,
@@ -237,7 +243,7 @@ class RuleBasedProfilerConfig(BaseYamlConfig):
         name: str,
         config_version: float,
         rules: Dict[str, dict],  # see RuleConfig
-        class_name: str,  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        class_name: Optional[str] = None,
         module_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
         commented_map: Optional[CommentedMap] = None,
@@ -271,8 +277,11 @@ class RuleBasedProfilerConfigSchema(Schema):
 
     name = fields.String(required=True, allow_none=False)
     class_name = fields.String(
-        required=True, allow_none=False
-    )  # Chetan - 20220204 - class_name to be made optional in a subsequent PR
+        required=False,
+        all_none=True,
+        allow_none=True,
+        missing="RuleBasedProfiler",
+    )
     module_name = fields.String(
         required=False,
         all_none=True,

--- a/great_expectations/rule_based_profiler/toolkit.py
+++ b/great_expectations/rule_based_profiler/toolkit.py
@@ -34,7 +34,7 @@ def add_profiler(
         },
         config_defaults={
             "module_name": "great_expectations.rule_based_profiler",
-            # Chetan - 20220204 - class_name to be provided here in subsequent PR
+            "class_name": "RuleBasedProfiler",
         },
     )
 
@@ -111,6 +111,7 @@ def get_profiler(
         },
         config_defaults={
             "module_name": "great_expectations.rule_based_profiler",
+            "class_name": "RuleBasedProfiler",
         },
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5041,8 +5041,6 @@ def profiler_config_with_placeholder_args(
 
     return RuleBasedProfilerConfig(
         name=profiler_name,
-        class_name="RuleBasedProfiler",
-        module_name="great_expectations.rule_based_profiler",
         config_version=1.0,
         variables={
             "false_positive_threshold": 1.0e-2,

--- a/tests/data_context/test_data_context_profilers.py
+++ b/tests/data_context/test_data_context_profilers.py
@@ -25,6 +25,9 @@ def test_add_profiler(
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
     args = profiler_config_with_placeholder_args.to_json_dict()
+    for attr in ("class_name", "module_name"):
+        args.pop(attr, None)
+
     profiler = empty_data_context.add_profiler(**args)
     assert isinstance(profiler, RuleBasedProfiler)
 
@@ -34,6 +37,8 @@ def test_add_profiler_with_invalid_config_raises_error(
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
     args = profiler_config_with_placeholder_args.to_json_dict()
+    for attr in ("class_name", "module_name"):
+        args.pop(attr, None)
 
     # Setting invalid configuration to check that it is caught by DataContext wrapper method
     args["config_version"] = -1

--- a/tests/rule_based_profiler/config/test_base.py
+++ b/tests/rule_based_profiler/config/test_base.py
@@ -64,16 +64,6 @@ def test_domain_builder_config_successfully_loads_with_optional_args():
     assert all(getattr(config, k) == v for k, v in data.items())
 
 
-def test_domain_builder_config_unsuccessfully_loads_with_missing_required_fields():
-    data = {}
-    schema = DomainBuilderConfigSchema()
-
-    with pytest.raises(ValidationError) as e:
-        schema.load(data)
-
-    assert "'class_name': ['Missing data for required field.']" in str(e.value)
-
-
 def test_parameter_builder_config_successfully_loads_with_required_args():
     data = {"class_name": "ParameterBuilder", "name": "my_parameter_builder"}
     schema = ParameterBuilderConfigSchema()
@@ -105,10 +95,7 @@ def test_parameter_builder_config_unsuccessfully_loads_with_missing_required_fie
     with pytest.raises(ValidationError) as e:
         schema.load(data)
 
-    assert all(
-        f"'{attr}': ['Missing data for required field.']" in str(e.value)
-        for attr in ("class_name", "name")
-    )
+    assert "'name': ['Missing data for required field.']" in str(e.value)
 
 
 def test_expectation_configuration_builder_config_successfully_loads_with_required_args():
@@ -147,10 +134,7 @@ def test_expectation_configuration_builder_config_unsuccessfully_loads_with_miss
     with pytest.raises(ValidationError) as e:
         schema.load(data)
 
-    assert all(
-        f"'{attr}': ['Missing data for required field.']" in str(e.value)
-        for attr in ("class_name", "expectation_type")
-    )
+    assert "'expectation_type': ['Missing data for required field.']" in str(e.value)
 
 
 def test_rule_config_successfully_loads_with_required_args():


### PR DESCRIPTION
Changes proposed in this pull request:
- Removal of `class_name` as mandatory field in schema and config.
- Refactoring of usages to adhere to new pattern.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
