### PR TITLE
[MAINTENANCE] Remove unused `Exception as e` instances

### DIFF
--- a/great_expectations/cli/upgrade_helpers/upgrade_helper_v13.py
+++ b/great_expectations/cli/upgrade_helpers/upgrade_helper_v13.py
@@ -115,7 +115,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
 
             if len(self.upgrade_checklist["manual"]["checkpoints"]) == 0:
                 self.upgrade_log["skipped_checkpoint_config_upgrade"] = True
-        except ge_exceptions.InvalidTopLevelConfigKeyError as e:
+        except ge_exceptions.InvalidTopLevelConfigKeyError:
             self.upgrade_log["skipped_checkpoint_config_upgrade"] = True
 
     # noinspection SpellCheckingInspection

--- a/great_expectations/cli/v012/toolkit.py
+++ b/great_expectations/cli/v012/toolkit.py
@@ -332,7 +332,7 @@ def load_expectation_suite(
     try:
         suite = context.get_expectation_suite(suite_name)
         return suite
-    except ge_exceptions.DataContextError as e:
+    except ge_exceptions.DataContextError:
         exit_with_failure_message_and_stats(
             context,
             usage_event,

--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -101,7 +101,7 @@ class MetaDataset(DataAsset):
             row_condition=None,
             condition_parser=None,
             *args,
-            **kwargs
+            **kwargs,
         ):
             if result_format is None:
                 result_format = self.default_expectation_args["result_format"]
@@ -3523,7 +3523,9 @@ class Dataset(MetaDataset):
                     try:
                         min_value = parse(min_value)
                     except (ValueError, TypeError) as e:
-                        pass
+                        logger.debug(
+                            f"Something went wrong when parsing 'min_value': {e}"
+                        )
 
                 if strict_min:
                     above_min = column_min > min_value
@@ -3537,7 +3539,9 @@ class Dataset(MetaDataset):
                     try:
                         max_value = parse(max_value)
                     except (ValueError, TypeError) as e:
-                        pass
+                        logger.debug(
+                            f"Something went wrong when parsing 'max_value': {e}"
+                        )
 
                 if strict_max:
                     below_max = column_min < max_value
@@ -3654,7 +3658,9 @@ class Dataset(MetaDataset):
                     try:
                         min_value = parse(min_value)
                     except (ValueError, TypeError) as e:
-                        pass
+                        logger.debug(
+                            f"Something went wrong when parsing 'min_value': {e}"
+                        )
 
                 if strict_min:
                     above_min = column_max > min_value
@@ -3668,7 +3674,9 @@ class Dataset(MetaDataset):
                     try:
                         max_value = parse(max_value)
                     except (ValueError, TypeError) as e:
-                        pass
+                        logger.debug(
+                            f"Something went wrong when parsing 'max_value': {e}"
+                        )
 
                 if strict_max:
                     below_max = column_max < max_value

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -154,7 +154,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         batch_definition_list: List[BatchDefinition] = []
         try:
             sub_cache = self._data_references_cache[batch_request.data_asset_name]
-        except KeyError as e:
+        except KeyError:
             raise KeyError(
                 f"data_asset_name {batch_request.data_asset_name} is not recognized."
             )

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -766,7 +766,7 @@ Please check your config."""
         """Split on the hashed value of the named column"""
         try:
             getattr(hashlib, hash_function_name)
-        except (TypeError, AttributeError) as e:
+        except (TypeError, AttributeError):
             raise (
                 ge_exceptions.ExecutionEngineError(
                     f"""The splitting method used with SparkDFExecutionEngine has a reference to an invalid hash_function_name.
@@ -834,7 +834,7 @@ Please check your config."""
     ):
         try:
             getattr(hashlib, str(hash_function_name))
-        except (TypeError, AttributeError) as e:
+        except (TypeError, AttributeError):
             raise (
                 ge_exceptions.ExecutionEngineError(
                     f"""The sampling method used with SparkDFExecutionEngine has a reference to an invalid hash_function_name.

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1529,7 +1529,7 @@ set as active.
             )
 
             self._data_context = validation_data_context
-        except Exception as e:
+        except Exception:
             if getattr(data_context, "_usage_statistics_handler", None):
                 # noinspection PyProtectedMember
                 handler = data_context._usage_statistics_handler


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove unused `e` instances
- Add logging instead of simply passing

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
