### PR TITLE
[MAINTENANCE] Replacing uses of `yaml.load()` with `yaml.safe_load()`

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -319,7 +319,7 @@ data_connectors:
     class_name: InferredAssetFilesystemDataConnector
     base_directory: {self.base_path}
     default_regex:
-      group_names: 
+      group_names:
         - data_asset_name
       pattern: (.*)
   default_runtime_data_connector_name:
@@ -785,7 +785,7 @@ def sanitize_yaml_and_save_datasource(
         raise ValueError("Please verify the yaml and try again.")
     if not isinstance(datasource_yaml, str):
         raise TypeError("Please pass in a valid yaml string.")
-    config = yaml.load(datasource_yaml)
+    config = yaml.safe_load(datasource_yaml)
     try:
         datasource_name = config.pop("name")
     except KeyError:

--- a/great_expectations/cli/v012/checkpoint.py
+++ b/great_expectations/cli/v012/checkpoint.py
@@ -168,7 +168,7 @@ def _load_checkpoint_yml_template() -> dict:
         __file__, os.path.join("..", "data_context", "checkpoint_template.yml")
     )
     with open(template_file) as f:
-        template = yaml.load(f)
+        template = yaml.safe_load(f)
     return template
 
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -996,7 +996,7 @@ class BaseDataContext:
                     root_directory = ""
                 var_path = os.path.join(root_directory, defined_path)
                 with open(var_path) as config_variables_file:
-                    return yaml.load(config_variables_file) or {}
+                    return yaml.safe_load(config_variables_file) or {}
             except OSError as e:
                 if e.errno != errno.ENOENT:
                     raise
@@ -3536,7 +3536,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
             raise e
 
         try:
-            config: CommentedMap = yaml.load(config_str_with_substituted_variables)
+            config: CommentedMap = yaml.safe_load(config_str_with_substituted_variables)
             return config
 
         except Exception as e:
@@ -3950,7 +3950,7 @@ class DataContext(BaseDataContext):
 
         # TODO this is so brittle and gross
         with open(path_to_yml) as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
         config_var_path = config.get("config_variables_file_path")
         config_var_path = os.path.join(ge_dir, config_var_path)
         return os.path.isfile(config_var_path)
@@ -4187,7 +4187,7 @@ class DataContext(BaseDataContext):
         path_to_yml = os.path.join(self.root_directory, self.GE_YML)
         try:
             with open(path_to_yml) as data:
-                config_commented_map_from_yaml = yaml.load(data)
+                config_commented_map_from_yaml = yaml.safe_load(data)
 
         except YAMLError as err:
             raise ge_exceptions.InvalidConfigurationYamlError(
@@ -4277,7 +4277,7 @@ class DataContext(BaseDataContext):
             return
 
         with open(yml_path) as f:
-            config_commented_map_from_yaml = yaml.load(f)
+            config_commented_map_from_yaml = yaml.safe_load(f)
 
         config_version = config_commented_map_from_yaml.get("config_version")
         return float(config_version) if config_version else None
@@ -4310,7 +4310,7 @@ class DataContext(BaseDataContext):
             return False
 
         with open(yml_path) as f:
-            config_commented_map_from_yaml = yaml.load(f)
+            config_commented_map_from_yaml = yaml.safe_load(f)
             config_commented_map_from_yaml["config_version"] = float(config_version)
 
         with open(yml_path, "w") as f:

--- a/great_expectations/data_context/store/configuration_store.py
+++ b/great_expectations/data_context/store/configuration_store.py
@@ -99,7 +99,7 @@ class ConfigurationStore(Store):
     def deserialize(self, key, value):
         config = value
         if isinstance(value, str):
-            config: CommentedMap = yaml.load(value)
+            config: CommentedMap = yaml.safe_load(value)
         try:
             return self._configuration_class.from_commented_map(commented_map=config)
         except ge_exceptions.InvalidBaseYamlConfigError:

--- a/great_expectations/render/renderer/checkpoint_new_notebook_renderer.py
+++ b/great_expectations/render/renderer/checkpoint_new_notebook_renderer.py
@@ -161,7 +161,7 @@ You can run the following cell to print out the full yaml configuration. For exa
 Run the following cell to save this Checkpoint to your Checkpoint Store."""
         )
         self.add_code_cell(
-            f"context.add_checkpoint(**yaml.load(yaml_config))",
+            f"context.add_checkpoint(**yaml.safe_load(yaml_config))",
             lint=True,
         )
 

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -73,7 +73,7 @@ def test_basic_checkpoint_config_validation(
     name: misconfigured_checkpoint
     unexpected_property: UNKNOWN_PROPERTY_VALUE
     """
-    config_erroneous = yaml.load(yaml_config_erroneous)
+    config_erroneous = yaml.safe_load(yaml_config_erroneous)
     with pytest.raises(TypeError):
         # noinspection PyUnusedLocal
         checkpoint_config = CheckpointConfig(**config_erroneous)
@@ -106,7 +106,7 @@ def test_basic_checkpoint_config_validation(
     yaml_config_erroneous = f"""
     config_version: 1
     """
-    config_erroneous = yaml.load(yaml_config_erroneous)
+    config_erroneous = yaml.safe_load(yaml_config_erroneous)
     with pytest.raises(ge_exceptions.InvalidConfigError):
         # noinspection PyUnusedLocal
         checkpoint_config = CheckpointConfig.from_commented_map(
@@ -247,7 +247,7 @@ def test_basic_checkpoint_config_validation(
     assert actual_events == expected_events
 
     assert len(context.list_checkpoints()) == 0
-    context.add_checkpoint(**yaml.load(yaml_config_erroneous))
+    context.add_checkpoint(**yaml.safe_load(yaml_config_erroneous))
     assert len(context.list_checkpoints()) == 1
 
     yaml_config: str = f"""
@@ -286,7 +286,7 @@ def test_basic_checkpoint_config_validation(
         ],
     }
 
-    config: CommentedMap = yaml.load(yaml_config)
+    config: CommentedMap = yaml.safe_load(yaml_config)
     checkpoint_config = CheckpointConfig(**config)
     checkpoint = Checkpoint(
         data_context=context,
@@ -384,7 +384,7 @@ def test_basic_checkpoint_config_validation(
     assert actual_events == expected_events
 
     assert len(context.list_checkpoints()) == 1
-    context.add_checkpoint(**yaml.load(yaml_config))
+    context.add_checkpoint(**yaml.safe_load(yaml_config))
     assert len(context.list_checkpoints()) == 2
 
     context.create_expectation_suite(expectation_suite_name="my_expectation_suite")
@@ -533,7 +533,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
     assert actual_events == expected_events
 
     assert len(data_context.list_checkpoints()) == 0
-    data_context.add_checkpoint(**yaml.load(yaml_config))
+    data_context.add_checkpoint(**yaml.safe_load(yaml_config))
     assert len(data_context.list_checkpoints()) == 1
 
     data_context.create_expectation_suite(expectation_suite_name="users.delivery")
@@ -661,7 +661,7 @@ def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_te
     )
 
     assert len(data_context.list_checkpoints()) == 0
-    data_context.add_checkpoint(**yaml.load(yaml_config))
+    data_context.add_checkpoint(**yaml.safe_load(yaml_config))
     assert len(data_context.list_checkpoints()) == 1
 
     data_context.create_expectation_suite(expectation_suite_name="users.delivery")
@@ -757,7 +757,7 @@ def test_checkpoint_configuration_using_RuntimeDataConnector_with_Airflow_test_y
     )
 
     assert len(data_context.list_checkpoints()) == 0
-    data_context.add_checkpoint(**yaml.load(yaml_config))
+    data_context.add_checkpoint(**yaml.safe_load(yaml_config))
     assert len(data_context.list_checkpoints()) == 1
 
     data_context.create_expectation_suite(expectation_suite_name="users.delivery")
@@ -1024,7 +1024,7 @@ def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
     )
 
     assert len(data_context.list_checkpoints()) == 0
-    data_context.add_checkpoint(**yaml.load(yaml_config))
+    data_context.add_checkpoint(**yaml.safe_load(yaml_config))
     assert len(data_context.list_checkpoints()) == 1
 
     data_context.create_expectation_suite(expectation_suite_name="users.warning")
@@ -1121,7 +1121,7 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
     )
 
     assert len(data_context.list_checkpoints()) == 0
-    data_context.add_checkpoint(**yaml.load(yaml_config))
+    data_context.add_checkpoint(**yaml.safe_load(yaml_config))
     assert len(data_context.list_checkpoints()) == 1
 
     with pytest.raises(
@@ -1235,7 +1235,7 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
     )
 
     assert len(data_context.list_checkpoints()) == 1
-    data_context.add_checkpoint(**yaml.load(yaml_config))
+    data_context.add_checkpoint(**yaml.safe_load(yaml_config))
     assert len(data_context.list_checkpoints()) == 2
 
     result: CheckpointResult = data_context.run_checkpoint(

--- a/tests/cli/test_checkpoint.py
+++ b/tests/cli/test_checkpoint.py
@@ -76,7 +76,7 @@ introspection:
         my_sql_datasource: Optional[
             Union[SimpleSqlalchemyDatasource, LegacyDatasource]
         ] = context.add_datasource(
-            "test_sqlite_db_datasource", **yaml.load(datasource_config)
+            "test_sqlite_db_datasource", **yaml.safe_load(datasource_config)
         )
     except AttributeError:
         pytest.skip("SQL Database tests require sqlalchemy to be installed.")
@@ -1102,7 +1102,7 @@ def test_checkpoint_run_on_checkpoint_with_batch_load_problem_raises_error(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -1301,7 +1301,7 @@ def test_checkpoint_run_on_checkpoint_with_empty_suite_list_raises_error(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -1409,7 +1409,7 @@ def test_checkpoint_run_on_non_existent_validations(
           result_format: BASIC
           partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -1529,7 +1529,7 @@ def test_checkpoint_run_happy_path_with_successful_validation_pandas(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -1743,7 +1743,7 @@ def test_checkpoint_run_happy_path_with_successful_validation_sql(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -1958,7 +1958,7 @@ def test_checkpoint_run_happy_path_with_successful_validation_spark(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -2186,7 +2186,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_pandas(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -2389,7 +2389,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_sql(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -2595,7 +2595,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_spark(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -2817,7 +2817,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_pandas
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -3017,7 +3017,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_sql(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -3224,7 +3224,7 @@ def test_checkpoint_run_happy_path_with_failed_validation_due_to_bad_data_spark(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -3620,7 +3620,7 @@ def test_checkpoint_script_happy_path_executable_successful_validation_pandas(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -3744,7 +3744,7 @@ def test_checkpoint_script_happy_path_executable_failed_validation_pandas(
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )
@@ -3866,7 +3866,7 @@ def test_checkpoint_script_happy_path_executable_failed_validation_due_to_bad_da
         result_format: BASIC
         partial_unexpected_count: 20
     """
-    config: dict = dict(yaml.load(checkpoint_yaml_config))
+    config: dict = dict(yaml.safe_load(checkpoint_yaml_config))
     _write_checkpoint_dict_to_file(
         config=config, checkpoint_file_path=checkpoint_file_path
     )

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -65,7 +65,7 @@ def test_cli_init_on_new_project(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     assert config["datasources"] == {}
 
     obs_tree = gen_directory_tree_str(os.path.join(project_dir, "great_expectations"))

--- a/tests/cli/test_init_missing_libraries.py
+++ b/tests/cli/test_init_missing_libraries.py
@@ -66,7 +66,7 @@ but the package `{library_name}` containing this library is not installed.
     config_path = os.path.join(basedir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     assert config["datasources"] == {}
 
     obs_tree = gen_directory_tree_str(os.path.join(basedir, "great_expectations"))
@@ -298,7 +298,7 @@ but the package `pyspark` containing this library is not installed.
     config_path = os.path.join(basedir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     assert config["datasources"] == {}
 
     obs_tree = gen_directory_tree_str(os.path.join(basedir, "great_expectations"))

--- a/tests/cli/test_init_pandas.py
+++ b/tests/cli/test_init_pandas.py
@@ -80,7 +80,7 @@ def test_cli_init_on_new_project(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["data__dir"]["data_asset_type"][
         "class_name"
     ]
@@ -265,7 +265,7 @@ def _load_config_file(config_path):
 
     with open(config_path) as f:
         read = f.read()
-        config = yaml.load(read)
+        config = yaml.safe_load(read)
 
     assert isinstance(config, dict)
     return config
@@ -544,7 +544,7 @@ def test_cli_init_on_new_project_with_broken_excel_file_without_trying_again(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["data__dir"]["data_asset_type"][
         "class_name"
     ]
@@ -622,7 +622,7 @@ def test_cli_init_on_new_project_with_broken_excel_file_try_again_with_different
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["data__dir"]["data_asset_type"][
         "class_name"
     ]

--- a/tests/cli/test_init_sqlite.py
+++ b/tests/cli/test_init_sqlite.py
@@ -107,7 +107,7 @@ def test_cli_init_on_new_project(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["titanic"]["data_asset_type"][
         "class_name"
     ]
@@ -278,7 +278,7 @@ def test_cli_init_on_new_project_extra_whitespace_in_url(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["titanic"]["data_asset_type"][
         "class_name"
     ]
@@ -408,7 +408,7 @@ def _load_config_file(config_path):
 
     with open(config_path) as f:
         read = f.read()
-        config = yaml.load(read)
+        config = yaml.safe_load(read)
 
     assert isinstance(config, dict)
     return config

--- a/tests/cli/v012/test_datasource_pandas.py
+++ b/tests/cli/v012/test_datasource_pandas.py
@@ -106,7 +106,7 @@ def test_cli_datasource_new(caplog, empty_data_context, filesystem_csv_2):
     assert result.exit_code == 0
 
     config_path = os.path.join(project_root_dir, DataContext.GE_YML)
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     datasources = config["datasources"]
     assert "mynewsource" in datasources.keys()
     data_source_class = datasources["mynewsource"]["data_asset_type"]["class_name"]

--- a/tests/cli/v012/test_datasource_sqlite.py
+++ b/tests/cli/v012/test_datasource_sqlite.py
@@ -184,7 +184,7 @@ def test_cli_datasource_new_connection_string(
     assert result.exit_code == 0
 
     config_path = os.path.join(project_root_dir, DataContext.GE_YML)
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     datasources = config["datasources"]
     assert "mynewsource" in datasources.keys()
     data_source_class = datasources["mynewsource"]["data_asset_type"]["class_name"]

--- a/tests/cli/v012/test_init.py
+++ b/tests/cli/v012/test_init.py
@@ -200,7 +200,7 @@ def test_cli_init_connection_string_non_working_db_connection_instructs_user_and
         config_path = os.path.join(ge_dir, DataContext.GE_YML)
         assert os.path.isfile(config_path)
 
-        config = yaml.load(open(config_path))
+        config = yaml.safe_load(open(config_path))
         assert config["datasources"] == {
             "my_db": {
                 "data_asset_type": {
@@ -216,7 +216,7 @@ def test_cli_init_connection_string_non_working_db_connection_instructs_user_and
         config_path = os.path.join(
             ge_dir, DataContext.GE_UNCOMMITTED_DIR, "config_variables.yml"
         )
-        config = yaml.load(open(config_path))
+        config = yaml.safe_load(open(config_path))
         assert config["my_db"] == {
             "url": "sqlite:////subfolder_thats_not_real/not_a_real.db"
         }

--- a/tests/cli/v012/test_init_missing_libraries.py
+++ b/tests/cli/v012/test_init_missing_libraries.py
@@ -64,7 +64,7 @@ def _library_not_loaded_test(
         config_path = os.path.join(basedir, "great_expectations/great_expectations.yml")
         assert os.path.isfile(config_path)
 
-        config = yaml.load(open(config_path))
+        config = yaml.safe_load(open(config_path))
         assert config["datasources"] == {}
 
         obs_tree = gen_directory_tree_str(os.path.join(basedir, "great_expectations"))
@@ -251,7 +251,7 @@ def test_cli_init_spark_without_library_installed_instructs_user(
         config_path = os.path.join(basedir, "great_expectations/great_expectations.yml")
         assert os.path.isfile(config_path)
 
-        config = yaml.load(open(config_path))
+        config = yaml.safe_load(open(config_path))
         assert config["datasources"] == {}
 
         obs_tree = gen_directory_tree_str(os.path.join(basedir, "great_expectations"))

--- a/tests/cli/v012/test_init_pandas.py
+++ b/tests/cli/v012/test_init_pandas.py
@@ -79,7 +79,7 @@ def test_cli_init_on_new_project(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["data__dir"]["data_asset_type"][
         "class_name"
     ]
@@ -266,7 +266,7 @@ def _load_config_file(config_path):
 
     with open(config_path) as f:
         read = f.read()
-        config = yaml.load(read)
+        config = yaml.safe_load(read)
 
     assert isinstance(config, dict)
     return config
@@ -528,7 +528,7 @@ def test_cli_init_on_new_project_with_broken_excel_file_without_trying_again(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["data__dir"]["data_asset_type"][
         "class_name"
     ]
@@ -610,7 +610,7 @@ def test_cli_init_on_new_project_with_broken_excel_file_try_again_with_different
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["data__dir"]["data_asset_type"][
         "class_name"
     ]

--- a/tests/cli/v012/test_init_sqlite.py
+++ b/tests/cli/v012/test_init_sqlite.py
@@ -108,7 +108,7 @@ def test_cli_init_on_new_project(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["titanic"]["data_asset_type"][
         "class_name"
     ]
@@ -282,7 +282,7 @@ def test_cli_init_on_new_project_extra_whitespace_in_url(
     config_path = os.path.join(project_dir, "great_expectations/great_expectations.yml")
     assert os.path.isfile(config_path)
 
-    config = yaml.load(open(config_path))
+    config = yaml.safe_load(open(config_path))
     data_source_class = config["datasources"]["titanic"]["data_asset_type"][
         "class_name"
     ]
@@ -406,7 +406,7 @@ def _load_config_file(config_path):
 
     with open(config_path) as f:
         read = f.read()
-        config = yaml.load(read)
+        config = yaml.safe_load(read)
 
     assert isinstance(config, dict)
     return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2497,7 +2497,7 @@ def titanic_v013_multi_datasource_pandas_data_context_with_checkpoints_v1_with_e
 
     # noinspection PyUnusedLocal
     datasource: BaseDatasource = context.add_datasource(
-        "my_additional_datasource", **yaml.load(datasource_config)
+        "my_additional_datasource", **yaml.safe_load(datasource_config)
     )
 
     return context
@@ -2557,7 +2557,7 @@ def titanic_v013_multi_datasource_multi_execution_engine_data_context_with_check
 
         # noinspection PyUnusedLocal
         datasource: BaseDatasource = context.add_datasource(
-            "my_sqlite_db_datasource", **yaml.load(datasource_config)
+            "my_sqlite_db_datasource", **yaml.safe_load(datasource_config)
         )
 
     return context
@@ -4506,7 +4506,7 @@ def data_context_with_sql_data_connectors_including_schema_for_testing_get_batch
         my_sql_datasource: Optional[
             Union[SimpleSqlalchemyDatasource, LegacyDatasource]
         ] = context.add_datasource(
-            "test_sqlite_db_datasource", **yaml.load(datasource_config)
+            "test_sqlite_db_datasource", **yaml.safe_load(datasource_config)
         )
     except AttributeError:
         pytest.skip("SQL Database tests require sqlalchemy to be installed.")
@@ -4587,7 +4587,7 @@ introspection:
 """
 
     try:
-        context.add_datasource("my_sqlite_db", **yaml.load(datasource_config))
+        context.add_datasource("my_sqlite_db", **yaml.safe_load(datasource_config))
     except AttributeError:
         pytest.skip("SQL Database tests require sqlalchemy to be installed.")
 
@@ -4625,7 +4625,7 @@ def data_context_with_pandas_datasource_for_testing_get_batch(
         directory=base_directory, file_name_list=sample_file_names
     )
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
 class_name: Datasource
 execution_engine:
@@ -4657,7 +4657,7 @@ def basic_datasource(tmp_path_factory):
     )
 
     basic_datasource: Datasource = instantiate_class_from_config(
-        config=yaml.load(
+        config=yaml.safe_load(
             f"""
 class_name: Datasource
 
@@ -4789,7 +4789,7 @@ def db_file():
 @pytest.fixture
 def data_context_with_datasource_pandas_engine(empty_data_context):
     context = empty_data_context
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
     execution_engine:
@@ -4811,7 +4811,7 @@ def data_context_with_datasource_pandas_engine(empty_data_context):
 @pytest.fixture
 def data_context_with_datasource_spark_engine(empty_data_context, spark_session):
     context = empty_data_context
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
     execution_engine:
@@ -4835,7 +4835,7 @@ def data_context_with_datasource_spark_engine_batch_spec_passthrough(
     empty_data_context, spark_session
 ):
     context = empty_data_context
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
     execution_engine:
@@ -4861,7 +4861,7 @@ def data_context_with_datasource_spark_engine_batch_spec_passthrough(
 @pytest.fixture
 def data_context_with_datasource_sqlalchemy_engine(empty_data_context, db_file):
     context = empty_data_context
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
     execution_engine:
@@ -4952,7 +4952,7 @@ expectations_store_name: default_expectations_store
 validations_store_name: default_validations_store
 checkpoint_store_name: default_checkpoint_store
 """
-    data_context_config_dict = yaml.load(config_yaml_str)
+    data_context_config_dict = yaml.safe_load(config_yaml_str)
     return DataContextConfig(**data_context_config_dict)
 
 
@@ -4977,7 +4977,7 @@ def empty_cloud_data_context(
 @pytest.fixture
 def cloud_data_context_with_datasource_pandas_engine(empty_cloud_data_context):
     context = empty_cloud_data_context
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
     execution_engine:
@@ -5001,7 +5001,7 @@ def cloud_data_context_with_datasource_sqlalchemy_engine(
     empty_cloud_data_context, db_file
 ):
     context = empty_cloud_data_context
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
     execution_engine:

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -233,7 +233,7 @@ def profiler_config():
              profiler_details: $parameter.row_count_range.details
     """
     yaml = YAML()
-    return yaml.load(yaml_config)
+    return yaml.safe_load(yaml_config)
 
 
 def test_expectation_suite_equality(baseline_suite, identical_suite, equivalent_suite):

--- a/tests/data_context/store/test_configuration_store.py
+++ b/tests/data_context/store/test_configuration_store.py
@@ -122,7 +122,7 @@ def test_v3_configuration_store(tmp_path_factory):
 
     stored_file_name_0: str = Path(base_directory) / f"{configuration_name_0}.yml"
     with open(stored_file_name_0) as f:
-        config: CommentedMap = yaml.load(f)
+        config: CommentedMap = yaml.safe_load(f)
         expected_config: CommentedMap = CommentedMap(
             {"some_param_0": "test_str_0", "some_param_1": 65}
         )
@@ -190,7 +190,7 @@ def test_v3_configuration_store(tmp_path_factory):
 
     stored_file_name_1: str = Path(base_directory) / f"{configuration_name_1}.yml"
     with open(stored_file_name_1) as f:
-        config: CommentedMap = yaml.load(f)
+        config: CommentedMap = yaml.safe_load(f)
         expected_config: CommentedMap = CommentedMap(
             {"some_param_0": "test_str_1", "some_param_1": 26}
         )

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1665,7 +1665,7 @@ data_connectors:
             A:
 """
 
-    config = yaml.load(yaml_config)
+    config = yaml.safe_load(yaml_config)
     context.add_datasource(
         "my_directory_datasource",
         **config,
@@ -1719,7 +1719,7 @@ data_connectors:
             A:
 """
 
-    config = yaml.load(yaml_config)
+    config = yaml.safe_load(yaml_config)
     context.add_datasource(
         "my_directory_datasource",
         **config,
@@ -1856,7 +1856,7 @@ validations:
     assert len(context.list_checkpoints()) == 0
 
     checkpoint_from_yaml = context.add_checkpoint(
-        **yaml.load(checkpoint_yaml_config),
+        **yaml.safe_load(checkpoint_yaml_config),
     )
 
     expected_checkpoint_yaml: str = """name: my_new_checkpoint
@@ -1909,7 +1909,7 @@ expectation_suite_ge_cloud_id:
     ) == deep_filter_properties_iterable(
         properties={
             key: value
-            for key, value in dict(yaml.load(expected_checkpoint_yaml)).items()
+            for key, value in dict(yaml.safe_load(expected_checkpoint_yaml)).items()
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
@@ -1922,7 +1922,7 @@ expectation_suite_ge_cloud_id:
     ) == deep_filter_properties_iterable(
         properties={
             key: value
-            for key, value in dict(yaml.load(expected_checkpoint_yaml)).items()
+            for key, value in dict(yaml.safe_load(expected_checkpoint_yaml)).items()
             if key not in ["module_name", "class_name"]
         },
         clean_falsy=True,
@@ -2031,7 +2031,7 @@ validations:
 
     with pytest.raises(AttributeError):
         context.add_checkpoint(
-            **yaml.load(checkpoint_yaml_config),
+            **yaml.safe_load(checkpoint_yaml_config),
         )
 
     assert checkpoint_name not in context.list_checkpoints()
@@ -2117,7 +2117,7 @@ def test_add_datasource_from_yaml(mock_emit, empty_data_context_stats_enabled):
     assert mock_emit.call_args_list == expected_call_args_list
 
     datasource_from_yaml = context.add_datasource(
-        name=datasource_name, **yaml.load(example_yaml)
+        name=datasource_name, **yaml.safe_load(example_yaml)
     )
     assert mock_emit.call_count == 2
     expected_call_args_list.extend(
@@ -2253,7 +2253,7 @@ def test_add_datasource_from_yaml_sql_datasource(
     ]
     assert mock_emit.call_args_list == expected_call_args_list
     datasource_from_yaml = context.add_datasource(
-        name=datasource_name, **yaml.load(example_yaml)
+        name=datasource_name, **yaml.safe_load(example_yaml)
     )
     assert mock_emit.call_count == 2
     expected_call_args_list.extend(
@@ -2465,7 +2465,7 @@ def test_add_datasource_from_yaml_sql_datasource_with_credentials(
     ]
     assert mock_emit.call_args_list == expected_call_args_list
     datasource_from_yaml = context.add_datasource(
-        name=datasource_name, **yaml.load(example_yaml)
+        name=datasource_name, **yaml.safe_load(example_yaml)
     )
     assert mock_emit.call_count == 2
     expected_call_args_list.extend(
@@ -2646,7 +2646,7 @@ def test_add_datasource_from_yaml_with_substitution_variables(
     ]
     assert mock_emit.call_args_list == expected_call_args_list
     datasource_from_yaml = context.add_datasource(
-        name=datasource_name, **yaml.load(example_yaml)
+        name=datasource_name, **yaml.safe_load(example_yaml)
     )
     assert mock_emit.call_count == 2
     expected_call_args_list.extend(

--- a/tests/data_context/test_data_context_config_variables.py
+++ b/tests/data_context/test_data_context_config_variables.py
@@ -214,7 +214,7 @@ def test_substituted_config_variables_not_written_to_file(tmp_path_factory):
     )
     path_to_yml = file_relative_path(__file__, path_to_yml)
     with open(path_to_yml) as data:
-        config_commented_map_from_yaml = yaml.load(data)
+        config_commented_map_from_yaml = yaml.safe_load(data)
     expected_config = DataContextConfig.from_commented_map(
         config_commented_map_from_yaml
     )

--- a/tests/data_context/test_data_context_config_variables_pre_v013.py
+++ b/tests/data_context/test_data_context_config_variables_pre_v013.py
@@ -44,7 +44,7 @@ def test_substituted_config_variables_not_written_to_file(tmp_path_factory):
     )
     path_to_yml = file_relative_path(__file__, path_to_yml)
     with open(path_to_yml) as data:
-        config_commented_map_from_yaml = yaml.load(data)
+        config_commented_map_from_yaml = yaml.safe_load(data)
     expected_config = DataContextConfig.from_commented_map(
         config_commented_map_from_yaml
     )

--- a/tests/data_context/test_data_context_datasource_non_sql_methods.py
+++ b/tests/data_context/test_data_context_datasource_non_sql_methods.py
@@ -34,7 +34,7 @@ def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_in
         file_content_fn=lambda: "x,y,z\n1,2,3\n2,3,5",
     )
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
 class_name: Datasource
 
@@ -110,7 +110,7 @@ def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_co
     )
     shutil.copy(titanic_csv_source_file_path, titanic_csv_destination_file_path)
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
 class_name: Datasource
 
@@ -175,7 +175,7 @@ def test_get_batch_list_from_new_style_datasource_with_runtime_data_connector(
     empty_data_context, tmp_path_factory
 ):
     context = empty_data_context
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
 class_name: Datasource
 
@@ -246,7 +246,7 @@ def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_co
         file_content_fn=lambda: "x,y,z\n1,2,3\n2,3,5",
     )
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
 
@@ -339,7 +339,7 @@ def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_co
         file_content_fn=lambda: "x,y,z\n1,2,3\n2,3,5",
     )
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
 
@@ -436,7 +436,7 @@ def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_co
         file_content_fn=lambda: "x,y,z\n1,2,3\n2,3,5",
     )
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
 
@@ -541,7 +541,7 @@ def test_get_batch_list_from_new_style_datasource_with_file_system_datasource_co
         file_content_fn=lambda: "x,y,z\n1,2,3\n2,3,5",
     )
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
     class_name: Datasource
 

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -114,7 +114,7 @@ def ge_cloud_data_context_config(
       usage_statistics_url: https://dev.stats.greatexpectations.io/great_expectations/v1/usage_statistics
       data_context_id: {ge_cloud_data_context_config}
     """
-    config = yaml.load(DEFAULT_GE_CLOUD_DATA_CONTEXT_CONFIG)
+    config = yaml.safe_load(DEFAULT_GE_CLOUD_DATA_CONTEXT_CONFIG)
     return DataContextConfig(**config)
 
 

--- a/tests/datasource/data_connector/test_configured_asset_azure_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_azure_data_connector.py
@@ -623,7 +623,7 @@ def test_get_batch_definition_list_from_batch_request_with_nonexistent_datasourc
 def test_get_definition_list_from_batch_request_with_empty_args_raises_error(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetAzureDataConnector
            datasource_name: test_environment
@@ -689,7 +689,7 @@ def test_get_definition_list_from_batch_request_with_empty_args_raises_error(
 def test_get_definition_list_from_batch_request_with_unnamed_data_asset_name_raises_error(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetAzureDataConnector
            datasource_name: test_environment
@@ -749,7 +749,7 @@ def test_return_all_batch_definitions_unsorted_without_named_data_asset_name(
     empty_data_context_stats_enabled,
     expected_batch_definitions_unsorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetAzureDataConnector
            datasource_name: test_environment
@@ -830,7 +830,7 @@ def test_return_all_batch_definitions_unsorted_with_named_data_asset_name(
     empty_data_context_stats_enabled,
     expected_batch_definitions_unsorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetAzureDataConnector
            datasource_name: test_environment
@@ -911,7 +911,7 @@ def test_return_all_batch_definitions_basic_sorted(
     empty_data_context_stats_enabled,
     expected_batch_definitions_sorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetAzureDataConnector
        datasource_name: test_environment
@@ -999,7 +999,7 @@ def test_return_all_batch_definitions_basic_sorted(
 def test_return_all_batch_definitions_returns_specified_partition(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1117,7 +1117,7 @@ def test_return_all_batch_definitions_sorted_without_data_connector_query(
     empty_data_context_stats_enabled,
     expected_batch_definitions_sorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1205,7 +1205,7 @@ def test_return_all_batch_definitions_sorted_without_data_connector_query(
 def test_return_all_batch_definitions_raises_error_due_to_sorter_that_does_not_match_group(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1278,7 +1278,7 @@ def test_return_all_batch_definitions_raises_error_due_to_sorter_that_does_not_m
 def test_return_all_batch_definitions_too_many_sorters(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1372,7 +1372,7 @@ azure_options:
    account_url: my_account_url.blob.core.windows.net
    credential: my_credential
    """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     mock_list_keys.return_value = [  # Initial return value during instantiation
         "my_base_directory/alpha/files/go/here/alpha-202001.csv",
@@ -1511,7 +1511,7 @@ azure_options:
    account_url: my_account_url.blob.core.windows.net
    credential: my_credential
    """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     mock_list_keys.return_value = [
         "my_base_directory/alpha/files/go/here/alpha-202001.csv",

--- a/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_dbfs_data_connector.py
@@ -52,7 +52,7 @@ def test__get_full_file_path_for_asset_pandas(fs):
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             module_name: great_expectations.datasource.data_connector
             class_name: ConfiguredAssetDBFSDataConnector
@@ -156,7 +156,7 @@ def test__get_full_file_path_for_asset_spark(basic_spark_df_execution_engine, fs
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             module_name: great_expectations.datasource.data_connector
             class_name: ConfiguredAssetDBFSDataConnector

--- a/tests/datasource/data_connector/test_configured_asset_filesystem_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_filesystem_data_connector.py
@@ -274,7 +274,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             class_name: ConfiguredAssetFilesystemDataConnector
             datasource_name: test_environment
@@ -445,7 +445,7 @@ def test_return_all_batch_definitions_sorted(tmp_path_factory):
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         class_name: ConfiguredAssetFilesystemDataConnector
         datasource_name: test_environment
@@ -659,7 +659,7 @@ def test_alpha(tmp_path_factory):
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
                 module_name: great_expectations.datasource.data_connector
                 class_name: ConfiguredAssetFilesystemDataConnector
@@ -749,7 +749,7 @@ def test_foxtrot(tmp_path_factory):
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             module_name: great_expectations.datasource.data_connector
             class_name: ConfiguredAssetFilesystemDataConnector
@@ -856,7 +856,7 @@ def test_relative_asset_base_directory_path(tmp_path_factory):
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             module_name: great_expectations.datasource.data_connector
             class_name: ConfiguredAssetFilesystemDataConnector
@@ -948,7 +948,7 @@ def test_relative_default_and_relative_asset_base_directory_paths(tmp_path_facto
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             module_name: great_expectations.datasource.data_connector
             class_name: ConfiguredAssetFilesystemDataConnector
@@ -1048,7 +1048,7 @@ def test_return_all_batch_definitions_sorted_sorter_named_that_does_not_match_gr
             "alex_20200819_1300.csv",
         ],
     )
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         class_name: ConfiguredAssetFilesystemDataConnector
         datasource_name: test_environment
@@ -1113,7 +1113,7 @@ def test_return_all_batch_definitions_too_many_sorters(tmp_path_factory):
             "alex_20200819_1300.csv",
         ],
     )
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         class_name: ConfiguredAssetFilesystemDataConnector
         datasource_name: test_environment
@@ -1197,7 +1197,7 @@ assets:
         glob_directive: "*.csv"
 
     """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
     my_data_connector = instantiate_class_from_config(
         config,
         config_defaults={"module_name": "great_expectations.datasource.data_connector"},

--- a/tests/datasource/data_connector/test_configured_asset_gcs_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_gcs_data_connector.py
@@ -528,7 +528,7 @@ def test_get_batch_definition_list_from_batch_request_with_nonexistent_datasourc
 def test_get_definition_list_from_batch_request_with_empty_args_raises_error(
     mock_gcs_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetGCSDataConnector
            datasource_name: test_environment
@@ -587,7 +587,7 @@ def test_get_definition_list_from_batch_request_with_empty_args_raises_error(
 def test_get_definition_list_from_batch_request_with_unnamed_data_asset_name_raises_error(
     mock_gcs_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetGCSDataConnector
            datasource_name: test_environment
@@ -640,7 +640,7 @@ def test_return_all_batch_definitions_unsorted_without_named_data_asset_name(
     empty_data_context_stats_enabled,
     expected_batch_definitions_unsorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetGCSDataConnector
            datasource_name: test_environment
@@ -714,7 +714,7 @@ def test_return_all_batch_definitions_unsorted_with_named_data_asset_name(
     empty_data_context_stats_enabled,
     expected_batch_definitions_unsorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: ConfiguredAssetGCSDataConnector
            datasource_name: test_environment
@@ -788,7 +788,7 @@ def test_return_all_batch_definitions_basic_sorted(
     empty_data_context_stats_enabled,
     expected_batch_definitions_sorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetGCSDataConnector
        datasource_name: test_environment
@@ -869,7 +869,7 @@ def test_return_all_batch_definitions_basic_sorted(
 def test_return_all_batch_definitions_returns_specified_partition(
     mock_gcs_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetGCSDataConnector
        datasource_name: test_environment
@@ -980,7 +980,7 @@ def test_return_all_batch_definitions_sorted_without_data_connector_query(
     empty_data_context_stats_enabled,
     expected_batch_definitions_sorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetGCSDataConnector
        datasource_name: test_environment
@@ -1061,7 +1061,7 @@ def test_return_all_batch_definitions_sorted_without_data_connector_query(
 def test_return_all_batch_definitions_raises_error_due_to_sorter_that_does_not_match_group(
     mock_gcs_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetGCSDataConnector
        datasource_name: test_environment
@@ -1130,7 +1130,7 @@ def test_return_all_batch_definitions_raises_error_due_to_sorter_that_does_not_m
 def test_return_all_batch_definitions_too_many_sorters(
     mock_gcs_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: ConfiguredAssetGCSDataConnector
        datasource_name: test_environment
@@ -1216,7 +1216,7 @@ assets:
    gamma:
        pattern: ^(.+)-(\\d{{4}})(\\d{{2}})\\.csv$
    """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     mock_list_keys.return_value = [  # Initial return value during instantiation
         "my_base_directory/alpha/files/go/here/alpha-202001.csv",
@@ -1347,7 +1347,7 @@ assets:
    gamma:
        pattern: ^(.+)-(\\d{{4}})(\\d{{2}})\\.csv$
    """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     mock_list_keys.return_value = [
         "my_base_directory/alpha/files/go/here/alpha-202001.csv",

--- a/tests/datasource/data_connector/test_configured_asset_s3_data_connector.py
+++ b/tests/datasource/data_connector/test_configured_asset_s3_data_connector.py
@@ -301,7 +301,7 @@ def test_return_all_batch_definitions_unsorted():
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             class_name: ConfiguredAssetS3DataConnector
             datasource_name: test_environment
@@ -475,7 +475,7 @@ def test_return_all_batch_definitions_sorted():
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         class_name: ConfiguredAssetS3DataConnector
         datasource_name: test_environment
@@ -694,7 +694,7 @@ def test_alpha():
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
                 module_name: great_expectations.datasource.data_connector
                 class_name: ConfiguredAssetS3DataConnector
@@ -789,7 +789,7 @@ def test_foxtrot():
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             module_name: great_expectations.datasource.data_connector
             class_name: ConfiguredAssetS3DataConnector
@@ -904,7 +904,7 @@ def test_return_all_batch_definitions_sorted_sorter_named_that_does_not_match_gr
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         class_name: ConfiguredAssetS3DataConnector
         datasource_name: test_environment
@@ -976,7 +976,7 @@ def test_return_all_batch_definitions_too_many_sorters():
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         class_name: ConfiguredAssetS3DataConnector
         datasource_name: test_environment
@@ -1069,7 +1069,7 @@ assets:
         pattern: ^(.+)-(\\d{{4}})(\\d{{2}})\\.csv$
 
     """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
     my_data_connector = instantiate_class_from_config(
         config,
         config_defaults={"module_name": "great_expectations.datasource.data_connector"},

--- a/tests/datasource/data_connector/test_data_connector.py
+++ b/tests/datasource/data_connector/test_data_connector.py
@@ -29,7 +29,7 @@ def basic_data_connector(tmp_path_factory):
     )
 
     basic_data_connector = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
 class_name: ConfiguredAssetFilesystemDataConnector
 name: my_data_connector

--- a/tests/datasource/data_connector/test_data_connector_query.py
+++ b/tests/datasource/data_connector/test_data_connector_query.py
@@ -35,7 +35,7 @@ def create_files_and_instantiate_data_connector(tmp_path_factory):
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
             class_name: ConfiguredAssetFilesystemDataConnector
             datasource_name: test_environment

--- a/tests/datasource/data_connector/test_inferred_asset_azure_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_azure_data_connector.py
@@ -609,7 +609,7 @@ def test_get_batch_definition_list_from_batch_request_with_nonexistent_datasourc
 def test_get_definition_list_from_batch_request_with_empty_args_raises_error(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: InferredAssetAzureDataConnector
            datasource_name: test_environment
@@ -669,7 +669,7 @@ def test_get_definition_list_from_batch_request_with_empty_args_raises_error(
 def test_get_definition_list_from_batch_request_with_unnamed_data_asset_name_raises_error(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: InferredAssetAzureDataConnector
            datasource_name: test_environment
@@ -723,7 +723,7 @@ def test_return_all_batch_definitions_unsorted_without_named_data_asset_name(
     empty_data_context_stats_enabled,
     expected_batch_definitions_unsorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: InferredAssetAzureDataConnector
            datasource_name: test_environment
@@ -798,7 +798,7 @@ def test_return_all_batch_definitions_unsorted_with_named_data_asset_name(
     empty_data_context_stats_enabled,
     expected_batch_definitions_unsorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
            class_name: InferredAssetAzureDataConnector
            datasource_name: test_environment
@@ -873,7 +873,7 @@ def test_return_all_batch_definitions_basic_sorted(
     empty_data_context_stats_enabled,
     expected_batch_definitions_sorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: InferredAssetAzureDataConnector
        datasource_name: test_environment
@@ -958,7 +958,7 @@ def test_return_all_batch_definitions_basic_sorted(
 def test_return_all_batch_definitions_returns_specified_partition(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: InferredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1073,7 +1073,7 @@ def test_return_all_batch_definitions_sorted_without_data_connector_query(
     empty_data_context_stats_enabled,
     expected_batch_definitions_sorted,
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: InferredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1158,7 +1158,7 @@ def test_return_all_batch_definitions_sorted_without_data_connector_query(
 def test_return_all_batch_definitions_raises_error_due_to_sorter_that_does_not_match_group(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: InferredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1224,7 +1224,7 @@ def test_return_all_batch_definitions_raises_error_due_to_sorter_that_does_not_m
 def test_return_all_batch_definitions_too_many_sorters(
     mock_azure_conn, mock_list_keys, mock_emit, empty_data_context_stats_enabled
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
        class_name: InferredAssetAzureDataConnector
        datasource_name: test_environment
@@ -1306,7 +1306,7 @@ azure_options:
     account_url: my_account_url.blob.core.windows.net
     credential: my_credential
     """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     my_data_connector: InferredAssetAzureDataConnector = instantiate_class_from_config(
         config,
@@ -1384,7 +1384,7 @@ azure_options:
     account_url: my_account_url.blob.core.windows.net
     credential: my_credential
     """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     my_data_connector: InferredAssetAzureDataConnector = instantiate_class_from_config(
         config,
@@ -1458,7 +1458,7 @@ azure_options:
     account_url: my_account_url.blob.core.windows.net
     credential: my_credential
     """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     # Raises error due to a non-existent/unknown ExecutionEngine instance.
     with pytest.raises(ge_exceptions.DataConnectorError):

--- a/tests/datasource/data_connector/test_inferred_asset_filesystem_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_filesystem_data_connector.py
@@ -749,7 +749,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(tmp_path_facto
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
           module_name: great_expectations.datasource.data_connector
           class_name: InferredAssetFilesystemDataConnector
@@ -875,7 +875,7 @@ def test_redundant_information_in_naming_convention_bucket_sorter_does_not_match
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
           module_name: great_expectations.datasource.data_connector
           class_name: InferredAssetFilesystemDataConnector
@@ -933,7 +933,7 @@ def test_redundant_information_in_naming_convention_bucket_too_many_sorters(
         ],
     )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         module_name: great_expectations.datasource.data_connector
         class_name: InferredAssetFilesystemDataConnector

--- a/tests/datasource/data_connector/test_inferred_asset_gcs_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_gcs_data_connector.py
@@ -920,7 +920,7 @@ def test_redundant_information_in_naming_convention_bucket(
 def test_redundant_information_in_naming_convention_bucket_sorted(
     mock_gcs_conn, mock_list_keys, mock_emit
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
           module_name: great_expectations.datasource.data_connector
           class_name: InferredAssetGCSDataConnector
@@ -1044,7 +1044,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted(
 def test_redundant_information_in_naming_convention_bucket_sorter_does_not_match_group(
     mock_gcs_conn, mock_list_keys, mock_emit
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
           module_name: great_expectations.datasource.data_connector
           class_name: InferredAssetGCSDataConnector
@@ -1102,7 +1102,7 @@ def test_redundant_information_in_naming_convention_bucket_sorter_does_not_match
 def test_redundant_information_in_naming_convention_bucket_too_many_sorters(
     mock_gcs_conn, mock_list_keys, mock_emit
 ):
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         module_name: great_expectations.datasource.data_connector
         class_name: InferredAssetGCSDataConnector
@@ -1166,7 +1166,7 @@ default_regex:
        - year_dir
        - month_dir
    """
-    config = yaml.load(yaml_string)
+    config = yaml.safe_load(yaml_string)
 
     mock_list_keys.return_value = [
         "my_base_directory/alpha/files/go/here/alpha-202001.csv",

--- a/tests/datasource/data_connector/test_inferred_asset_s3_data_connector.py
+++ b/tests/datasource/data_connector/test_inferred_asset_s3_data_connector.py
@@ -821,7 +821,7 @@ def test_redundant_information_in_naming_convention_bucket_sorted():
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
           module_name: great_expectations.datasource.data_connector
           class_name: InferredAssetS3DataConnector
@@ -949,7 +949,7 @@ def test_redundant_information_in_naming_convention_bucket_sorter_does_not_match
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
           module_name: great_expectations.datasource.data_connector
           class_name: InferredAssetS3DataConnector
@@ -1011,7 +1011,7 @@ def test_redundant_information_in_naming_convention_bucket_too_many_sorters():
             Bucket=bucket, Body=test_df.to_csv(index=False).encode("utf-8"), Key=key
         )
 
-    my_data_connector_yaml = yaml.load(
+    my_data_connector_yaml = yaml.safe_load(
         f"""
         module_name: great_expectations.datasource.data_connector
         class_name: InferredAssetS3DataConnector

--- a/tests/datasource/data_connector/test_sql_data_connector.py
+++ b/tests/datasource/data_connector/test_sql_data_connector.py
@@ -23,7 +23,7 @@ def test_basic_self_check(test_cases_for_sql_data_connector_sqlite_execution_eng
     random.seed(0)
     execution_engine = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -79,7 +79,7 @@ def test_get_batch_definition_list_from_batch_request(
     random.seed(0)
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -178,7 +178,7 @@ def test_example_A(test_cases_for_sql_data_connector_sqlite_execution_engine):
     random.seed(0)
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -232,7 +232,7 @@ def test_example_B(test_cases_for_sql_data_connector_sqlite_execution_engine):
     random.seed(0)
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -285,7 +285,7 @@ def test_example_C(test_cases_for_sql_data_connector_sqlite_execution_engine):
     random.seed(0)
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -341,7 +341,7 @@ def test_example_E(test_cases_for_sql_data_connector_sqlite_execution_engine):
     random.seed(0)
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -394,7 +394,7 @@ def test_example_F(test_cases_for_sql_data_connector_sqlite_execution_engine):
     random.seed(0)
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -448,7 +448,7 @@ def test_example_G(test_cases_for_sql_data_connector_sqlite_execution_engine):
     random.seed(0)
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -513,7 +513,7 @@ def test_example_H(test_cases_for_sql_data_connector_sqlite_execution_engine):
 
     # db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    # config = yaml.load("""
+    # config = yaml.safe_load("""
     # name: my_sql_data_connector
     # datasource_name: FAKE_Datasource_NAME
 
@@ -738,7 +738,7 @@ def test_default_behavior_with_no_splitter(
 ):
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME
@@ -797,7 +797,7 @@ def test_behavior_with_whole_table_splitter(
 ):
     db = test_cases_for_sql_data_connector_sqlite_execution_engine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         """
     name: my_sql_data_connector
     datasource_name: FAKE_Datasource_NAME

--- a/tests/datasource/test_datasource_anonymizer.py
+++ b/tests/datasource/test_datasource_anonymizer.py
@@ -108,7 +108,7 @@ data_connectors:
         class_name: InferredAssetFilesystemDataConnector
         module_name: great_expectations.datasource.data_connector
 """
-    config: CommentedMap = yaml.load(yaml_config)
+    config: CommentedMap = yaml.safe_load(yaml_config)
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     anonymized_datasource = datasource_anonymizer.anonymize_datasource_info(
         name=name, config=config
@@ -141,7 +141,7 @@ def test_anonymize_datasource_info_v2_api_custom_subclass():
 module_name: tests.data_context.fixtures.plugins.my_custom_v2_api_datasource
 class_name: MyCustomV2ApiDatasource
 """
-    config: CommentedMap = yaml.load(yaml_config)
+    config: CommentedMap = yaml.safe_load(yaml_config)
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     anonymized_datasource = datasource_anonymizer.anonymize_datasource_info(
         name=name, config=config
@@ -168,7 +168,7 @@ data_connectors:
         class_name: InferredAssetFilesystemDataConnector
         module_name: great_expectations.datasource.data_connector
 """
-    config: CommentedMap = yaml.load(yaml_config)
+    config: CommentedMap = yaml.safe_load(yaml_config)
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     anonymized_datasource = datasource_anonymizer.anonymize_datasource_info(
         name=name, config=config
@@ -202,7 +202,7 @@ introspection:
         sampling_kwargs:
             n: 10
 """
-    config: CommentedMap = yaml.load(yaml_config)
+    config: CommentedMap = yaml.safe_load(yaml_config)
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     anonymized_datasource = (
         datasource_anonymizer.anonymize_simple_sqlalchemy_datasource(
@@ -233,7 +233,7 @@ introspection:
     my_custom_datasource_name:
         data_asset_name_suffix: some_suffix
 """
-    config: CommentedMap = yaml.load(yaml_config)
+    config: CommentedMap = yaml.safe_load(yaml_config)
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     anonymized_datasource = (
         datasource_anonymizer.anonymize_simple_sqlalchemy_datasource(

--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -45,7 +45,7 @@ def basic_pandas_datasource_v013(tmp_path_factory):
     )
 
     basic_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
 class_name: Datasource
 
@@ -92,7 +92,7 @@ def basic_spark_datasource(tmp_path_factory, spark_session):
     )
 
     basic_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
 class_name: Datasource
 
@@ -139,7 +139,7 @@ def sample_datasource_v013_with_single_partition_file_data_connector(
     )
 
     sample_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
 class_name: Datasource
 
@@ -823,7 +823,7 @@ x,y
         )
 
     my_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             rf"""
 class_name: Datasource
 
@@ -898,7 +898,7 @@ def test_spark_with_batch_spec_passthrough(tmp_path_factory, spark_session):
         ],
     )
     basic_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
         class_name: Datasource
 

--- a/tests/datasource/test_new_datasource_with_runtime_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_runtime_data_connector.py
@@ -33,7 +33,7 @@ yaml = YAML()
 @pytest.fixture
 def datasource_with_runtime_data_connector_and_pandas_execution_engine():
     basic_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
     class_name: Datasource
 
@@ -59,7 +59,7 @@ def datasource_with_runtime_data_connector_and_pandas_execution_engine():
 @pytest.fixture
 def datasource_with_runtime_data_connector_and_sparkdf_execution_engine(spark_session):
     basic_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
     class_name: Datasource
 
@@ -85,7 +85,7 @@ def datasource_with_runtime_data_connector_and_sparkdf_execution_engine(spark_se
 @pytest.fixture
 def datasource_with_runtime_data_connector_and_sqlalchemy_execution_engine(db_file, sa):
     basic_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
     class_name: Datasource
 
@@ -849,7 +849,7 @@ def test_sparkdf_execution_engine_get_batch_definitions_and_get_batch_basics(
 @pytest.fixture
 def datasource_with_runtime_data_connector_and_sqlalchemy_execution_engine(db_file, sa):
     basic_datasource: Datasource = instantiate_class_from_config(
-        yaml.load(
+        yaml.safe_load(
             f"""
     class_name: Datasource
 

--- a/tests/datasource/test_new_datasource_with_sql_data_connector.py
+++ b/tests/datasource/test_new_datasource_with_sql_data_connector.py
@@ -41,7 +41,7 @@ def test_basic_instantiation_with_ConfiguredAssetSqlDataConnector(sa):
     )
     # This is a basic integration test demonstrating an Datasource containing a SQL data_connector
     # It also shows how to instantiate a SQLite SqlAlchemyExecutionEngine
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
 class_name: Datasource
 
@@ -125,7 +125,7 @@ def test_basic_instantiation_with_InferredAssetSqlDataConnector(sa):
     # This is a basic integration test demonstrating an Datasource containing a SQL data_connector
     # It also shows how to instantiate a SQLite SqlAlchemyExecutionEngine
 
-    config = yaml.load(
+    config = yaml.safe_load(
         f"""
 class_name: Datasource
 

--- a/tests/datasource/test_pandas_datasource.py
+++ b/tests/datasource/test_pandas_datasource.py
@@ -92,7 +92,7 @@ def test_create_pandas_datasource(
             "great_expectations.yml",
         ),
     ) as data_context_config_file:
-        data_context_file_config = yaml.load(data_context_config_file)
+        data_context_file_config = yaml.safe_load(data_context_config_file)
 
     assert (
         data_context_file_config["datasources"][name]
@@ -137,7 +137,7 @@ def test_pandas_datasource_custom_data_asset(
             "great_expectations.yml",
         ),
     ) as data_context_config_file:
-        data_context_file_config = yaml.load(data_context_config_file)
+        data_context_file_config = yaml.safe_load(data_context_config_file)
 
     assert (
         data_context_file_config["datasources"][name]["data_asset_type"]["module_name"]

--- a/tests/datasource/test_sparkdf_datasource.py
+++ b/tests/datasource/test_sparkdf_datasource.py
@@ -68,7 +68,7 @@ def test_sparkdf_datasource_custom_data_asset(
             "great_expectations.yml",
         ),
     ) as data_context_config_file:
-        data_context_file_config = yaml.load(data_context_config_file)
+        data_context_file_config = yaml.safe_load(data_context_config_file)
 
     assert (
         data_context_file_config["datasources"][name]["data_asset_type"]["module_name"]

--- a/tests/datasource/test_sqlalchemy_datasource.py
+++ b/tests/datasource/test_sqlalchemy_datasource.py
@@ -49,7 +49,7 @@ def test_sqlalchemy_datasource_custom_data_asset(
             "great_expectations.yml",
         ),
     ) as data_context_config_file:
-        data_context_file_config = yaml.load(data_context_config_file)
+        data_context_file_config = yaml.safe_load(data_context_config_file)
 
     assert (
         data_context_file_config["datasources"][name]["data_asset_type"]["module_name"]
@@ -149,7 +149,7 @@ def test_create_sqlalchemy_datasource(data_context_parameterized_expectation_sui
             "uncommitted/config_variables.yml",
         ),
     ) as credentials_file:
-        substitution_variables = yaml.load(credentials_file)
+        substitution_variables = yaml.safe_load(credentials_file)
 
     assert substitution_variables == {
         var_name: dict(**connection_kwargs["credentials"])

--- a/tests/integration/db/awsathena.py
+++ b/tests/integration/db/awsathena.py
@@ -41,7 +41,7 @@ data_connectors:
     include_schema_name: true
 """
 context.test_yaml_config(datasource_yaml)
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # clean db
 clean_athena_db(connection_string, ATHENA_DB_NAME, "taxitable")

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/pandas/configured_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/pandas/configured_yaml_example.py
@@ -50,7 +50,7 @@ datasource_yaml = datasource_yaml.replace("<YOUR_CREDENTIAL>", CREDENTIAL)
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/pandas/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/pandas/inferred_and_runtime_yaml_example.py
@@ -51,7 +51,7 @@ datasource_yaml = datasource_yaml.replace("<YOUR_CREDENTIAL>", CREDENTIAL)
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/spark/configured_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/spark/configured_yaml_example.py
@@ -50,7 +50,7 @@ datasource_yaml = datasource_yaml.replace("<YOUR_CREDENTIAL>", CREDENTIAL)
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/spark/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/azure/spark/inferred_and_runtime_yaml_example.py
@@ -51,7 +51,7 @@ datasource_yaml = datasource_yaml.replace("<YOUR_CREDENTIAL>", CREDENTIAL)
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/pandas/configured_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/pandas/configured_yaml_example.py
@@ -35,7 +35,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a BatchRequest naming a data_asset
 batch_request = BatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/pandas/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/pandas/inferred_and_runtime_yaml_example.py
@@ -36,7 +36,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/spark/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/spark/inferred_and_runtime_yaml_example.py
@@ -49,7 +49,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/pandas/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/pandas/inferred_and_runtime_yaml_example.py
@@ -38,7 +38,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py
@@ -51,7 +51,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/database/bigquery_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/bigquery_yaml_example.py
@@ -44,7 +44,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Test for RuntimeBatchRequest using a query. bigquery_temp_table name is passed in as batch_spec_passthrough
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/database/mssql_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/mssql_yaml_example.py
@@ -44,7 +44,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/database/mysql_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/mysql_yaml_example.py
@@ -41,7 +41,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py
@@ -41,7 +41,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/database/redshift_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/redshift_yaml_example.py
@@ -50,7 +50,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # First test for RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/database/snowflake_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/snowflake_yaml_example.py
@@ -41,7 +41,7 @@ datasource_yaml = datasource_yaml.replace(
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # First test for RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/database/sqlite_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/sqlite_yaml_example.py
@@ -31,7 +31,7 @@ datasource_yaml = datasource_yaml.replace(
 )
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/filesystem/pandas_yaml_example.py
@@ -32,7 +32,7 @@ datasource_yaml = datasource_yaml.replace("<PATH_TO_YOUR_DATA_HERE>", "../data/"
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py
@@ -43,7 +43,7 @@ datasource_yaml = datasource_yaml.replace("<YOUR_PATH>", "data")
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a path to a single CSV file
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_create_a_batch_of_data_from_an_in_memory_pandas_dataframe.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_create_a_batch_of_data_from_an_in_memory_pandas_dataframe.py
@@ -32,7 +32,7 @@ data_connectors:
             - some_other_key_maybe_airflow_run_id
 """
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # RuntimeBatchRequest with batch_data as Pandas Dataframe
 path_to_file: str = "some_path.csv"

--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_create_a_batch_of_data_from_an_in_memory_spark_dataframe.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_create_a_batch_of_data_from_an_in_memory_spark_dataframe.py
@@ -36,7 +36,7 @@ data_connectors:
             - some_other_key_maybe_airflow_run_id
 """
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # RuntimeBatchRequest with batch_data as Spark Dataframe
 path_to_file: str = "some_path.csv"

--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_get_a_batch_of_data_from_a_configured_datasource.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_get_a_batch_of_data_from_a_configured_datasource.py
@@ -34,7 +34,7 @@ data_connectors:
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is an example BatchRequest for all batches associated with the specified DataAsset
 batch_request = BatchRequest(

--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/files/yaml_example_complete.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/files/yaml_example_complete.py
@@ -23,7 +23,7 @@ data_connectors:
           pattern: (.*)
           group_names:
             - data_asset_name
-            
+
     configured_data_connector_name:
         class_name: ConfiguredAssetFilesystemDataConnector
         base_directory: <PATH_TO_YOUR_DATA_HERE>
@@ -55,7 +55,7 @@ datasource_yaml = datasource_yaml.replace("<PATH_TO_YOUR_DATA_HERE>", data_dir_p
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(

--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/files/yaml_example_gradual.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/files/yaml_example_gradual.py
@@ -122,7 +122,7 @@ report = context.test_yaml_config(
     buggy_datasource_yaml, return_mode="report_object", shorten_tracebacks=True
 )
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(
@@ -212,7 +212,7 @@ datasource_yaml = datasource_yaml.replace("<PATH_TO_YOUR_DATA_HERE>", data_dir_p
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(data_connector_names="configured_data_connector_name")[
@@ -289,7 +289,7 @@ datasource_yaml = datasource_yaml.replace("<PATH_TO_YOUR_DATA_HERE>", data_dir_p
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(data_connector_names="configured_data_connector_name")[

--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/sql_database/yaml_example_complete.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/sql_database/yaml_example_complete.py
@@ -79,7 +79,7 @@ datasource_yaml = datasource_yaml.replace("<CONNECTION_STRING>", CONNECTION_STRI
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(data_connector_names="whole_table")["whole_table"]

--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/sql_database/yaml_example_gradual.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/sql_database/yaml_example_gradual.py
@@ -53,7 +53,7 @@ datasource_yaml = datasource_yaml.replace("<CONNECTION_STRING>", CONNECTION_STRI
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(data_connector_names="whole_table")["whole_table"]
@@ -92,7 +92,7 @@ datasource_yaml = datasource_yaml.replace("<CONNECTION_STRING>", CONNECTION_STRI
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(data_connector_names="whole_table")["whole_table"]

--- a/tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/in_memory/pandas_yaml_example.py
@@ -22,7 +22,7 @@ data_connectors:
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # creating our example Pandas dataframe
 df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["a", "b", "c"])

--- a/tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py
@@ -43,7 +43,7 @@ data_connectors:
 
 context.test_yaml_config(datasource_yaml)
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Here is a RuntimeBatchRequest using a dataframe
 batch_request = RuntimeBatchRequest(

--- a/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_dataframe_yaml_configs.py
+++ b/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_dataframe_yaml_configs.py
@@ -81,7 +81,7 @@ data_connectors:
 
 context.test_yaml_config(my_spark_datasource_config)
 
-context.add_datasource(**yaml.load(my_spark_datasource_config))
+context.add_datasource(**yaml.safe_load(my_spark_datasource_config))
 
 batch_request = RuntimeBatchRequest(
     datasource_name="insert_your_datasource_name_here",
@@ -149,7 +149,7 @@ run_name_template: "%Y%m%d-%H%M%S-my-run-name-template"
 
 my_checkpoint = context.test_yaml_config(my_checkpoint_config)
 
-context.add_checkpoint(**yaml.load(my_checkpoint_config))
+context.add_checkpoint(**yaml.safe_load(my_checkpoint_config))
 
 checkpoint_result = context.run_checkpoint(
     checkpoint_name=my_checkpoint_name,

--- a/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_file_yaml_configs.py
+++ b/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_file_yaml_configs.py
@@ -91,7 +91,7 @@ my_spark_datasource_config = my_spark_datasource_config.replace("*.csv.gz", "*.c
 
 context.test_yaml_config(my_spark_datasource_config)
 
-context.add_datasource(**yaml.load(my_spark_datasource_config))
+context.add_datasource(**yaml.safe_load(my_spark_datasource_config))
 
 batch_request = BatchRequest(
     datasource_name="insert_your_datasource_name_here",
@@ -206,7 +206,7 @@ checkpoint_config = checkpoint_config.replace(
 
 my_checkpoint = context.test_yaml_config(checkpoint_config)
 
-context.add_checkpoint(**yaml.load(checkpoint_config))
+context.add_checkpoint(**yaml.safe_load(checkpoint_config))
 
 checkpoint_result = context.run_checkpoint(
     checkpoint_name=my_checkpoint_name,

--- a/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
+++ b/tests/integration/docusaurus/expectations/advanced/multi_batch_rule_based_profiler_example.py
@@ -100,7 +100,7 @@ rules:
 data_context = DataContext()
 
 # Instantiate RuleBasedProfiler
-full_profiler_config_dict: dict = yaml.load(profiler_config)
+full_profiler_config_dict: dict = yaml.safe_load(profiler_config)
 rule_based_profiler: RuleBasedProfiler = RuleBasedProfiler(
     name=full_profiler_config_dict["name"],
     config_version=full_profiler_config_dict["config_version"],

--- a/tests/integration/docusaurus/reference/core_concepts/checkpoints_and_actions.py
+++ b/tests/integration/docusaurus/reference/core_concepts/checkpoints_and_actions.py
@@ -37,7 +37,7 @@ data_connectors:
       - default_identifier_name
 """
 context.test_yaml_config(datasource_yaml)
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 assert [ds["name"] for ds in context.list_datasources()] == ["taxi_datasource"]
 context.create_expectation_suite("my_expectation_suite")
 context.create_expectation_suite("my_other_expectation_suite")
@@ -65,14 +65,14 @@ validations:
         action:
           class_name: UpdateDataDocsAction
 """
-context.add_checkpoint(**yaml.load(checkpoint_yaml))
+context.add_checkpoint(**yaml.safe_load(checkpoint_yaml))
 assert context.list_checkpoints() == ["test_checkpoint"]
 
 results = context.run_checkpoint(checkpoint_name="test_checkpoint")
 assert results.success is True
 run_id_type = type(results.run_id)
 assert run_id_type == RunIdentifier
-validation_result_id_type_set = set(type(k) for k in results.run_results.keys())
+validation_result_id_type_set = {type(k) for k in results.run_results.keys()}
 assert len(validation_result_id_type_set) == 1
 validation_result_id_type = next(iter(validation_result_id_type_set))
 assert validation_result_id_type == ValidationResultIdentifier
@@ -170,7 +170,7 @@ runtime_configuration:
     result_format: BASIC
     partial_unexpected_count: 20
 """
-context.add_checkpoint(**yaml.load(no_nesting))
+context.add_checkpoint(**yaml.safe_load(no_nesting))
 results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 assert results.success is True
 assert (
@@ -219,7 +219,7 @@ runtime_configuration:
     result_format: BASIC
     partial_unexpected_count: 20
 """
-context.add_checkpoint(**yaml.load(nesting_with_defaults))
+context.add_checkpoint(**yaml.safe_load(nesting_with_defaults))
 results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 assert results.success is True
 first_validation_result = list(results.run_results.items())[0][1]["validation_result"]
@@ -275,7 +275,7 @@ runtime_configuration:
     result_format: BASIC
     partial_unexpected_count: 20
 """
-context.add_checkpoint(**yaml.load(keys_passed_at_runtime))
+context.add_checkpoint(**yaml.safe_load(keys_passed_at_runtime))
 results = context.run_checkpoint(
     checkpoint_name="my_base_checkpoint",
     validations=[
@@ -334,7 +334,7 @@ validations:
       data_asset_name: yellow_tripdata_sample_2019-02
     expectation_suite_name: my_other_expectation_suite
 """
-context.add_checkpoint(**yaml.load(using_template))
+context.add_checkpoint(**yaml.safe_load(using_template))
 results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 assert results.success is True
 first_validation_result = list(results.run_results.items())[0][1]["validation_result"]
@@ -371,7 +371,7 @@ notify_with: all
 using_simple_checkpoint = using_simple_checkpoint.replace(
     "<YOUR SLACK WEBHOOK URL>", "https://hooks.slack.com/foo/bar"
 )
-context.add_checkpoint(**yaml.load(using_simple_checkpoint))
+context.add_checkpoint(**yaml.safe_load(using_simple_checkpoint))
 results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 assert results.success is True
 
@@ -408,7 +408,7 @@ action_list:
 equivalent_using_checkpoint = equivalent_using_checkpoint.replace(
     "<YOUR SLACK WEBHOOK URL>", "https://hooks.slack.com/foo/bar"
 )
-context.add_checkpoint(**yaml.load(equivalent_using_checkpoint))
+context.add_checkpoint(**yaml.safe_load(equivalent_using_checkpoint))
 results = context.run_checkpoint(checkpoint_name="my_checkpoint")
 assert results.success is True
 validation_result = list(results.run_results.items())[0][1]["validation_result"]

--- a/tests/integration/docusaurus/tutorials/getting-started/getting_started.py
+++ b/tests/integration/docusaurus/tutorials/getting-started/getting_started.py
@@ -47,7 +47,7 @@ datasource_yaml = datasource_yaml.replace(
 )
 
 context.test_yaml_config(datasource_yaml)
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # Get Validator by creating ExpectationSuite and passing in BatchRequest
 batch_request = BatchRequest(
@@ -145,7 +145,7 @@ my_checkpoint_config = my_checkpoint_config.replace(
 )
 
 
-my_checkpoint_config = yaml.load(my_checkpoint_config)
+my_checkpoint_config = yaml.safe_load(my_checkpoint_config)
 
 # NOTE: The following code (up to and including the assert) is only for testing and can be ignored by users.
 # In the current test, site_names are set to None because we do not want to update and build data_docs
@@ -185,7 +185,7 @@ yaml_config = yaml_config.replace(
     GETTING_STARTED_EXPECTATION_SUITE_NAME,
 )
 
-my_new_checkpoint_config = yaml.load(yaml_config)
+my_new_checkpoint_config = yaml.safe_load(yaml_config)
 
 # NOTE: The following code (up to and including the assert) is only for testing and can be ignored by users.
 # In the current test, site_names are set to None because we do not want to update and build data_docs

--- a/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
+++ b/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
@@ -117,7 +117,7 @@ def test_common_usage_stats_are_sent_no_mocking(
     context.test_yaml_config(yaml_config=datasource_yaml)
     expected_events: List[str] = ["data_context.test_yaml_config"]
 
-    context.add_datasource(**yaml.load(datasource_yaml))
+    context.add_datasource(**yaml.safe_load(datasource_yaml))
     expected_events.append("data_context.add_datasource")
 
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})

--- a/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
+++ b/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
@@ -221,7 +221,7 @@ validations:
             "cell_type": "code",
             "metadata": {},
             "execution_count": None,
-            "source": f"context.add_checkpoint(**yaml.load(yaml_config))",
+            "source": f"context.add_checkpoint(**yaml.safe_load(yaml_config))",
             "outputs": [],
         },
     ]

--- a/tests/rule_based_profiler/alpha/test_profiler_user_workflows.py
+++ b/tests/rule_based_profiler/alpha/test_profiler_user_workflows.py
@@ -85,7 +85,7 @@ def test_alice_profiler_user_workflow_single_batch(
     yaml_config: str = alice_columnar_table_single_batch["profiler_config"]
 
     # Instantiate Profiler
-    profiler_config: CommentedMap = yaml.load(yaml_config)
+    profiler_config: CommentedMap = yaml.safe_load(yaml_config)
 
     # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
     deserialized_config: dict = ruleBasedProfilerConfigSchema.load(profiler_config)
@@ -201,7 +201,7 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
     yaml_config: str = bobby_columnar_table_multi_batch["profiler_config"]
 
     # Instantiate Profiler
-    profiler_config: dict = yaml.load(yaml_config)
+    profiler_config: dict = yaml.safe_load(yaml_config)
 
     # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
     deserialized_config: dict = ruleBasedProfilerConfigSchema.load(profiler_config)
@@ -251,7 +251,7 @@ def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstr
     ]
 
     # Instantiate Profiler
-    profiler_config: CommentedMap = yaml.load(yaml_config)
+    profiler_config: CommentedMap = yaml.safe_load(yaml_config)
 
     # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
     deserialized_config: dict = ruleBasedProfilerConfigSchema.load(profiler_config)

--- a/tests/rule_based_profiler/alpha/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/alpha/test_rule_based_profiler.py
@@ -136,7 +136,7 @@ def test_profile_includes_citations(
     yaml_config: str = alice_columnar_table_single_batch["profiler_config"]
 
     # Instantiate Profiler
-    profiler_config = yaml.load(yaml_config)
+    profiler_config = yaml.safe_load(yaml_config)
     # `class_name`/`module_name` are generally consumed through `instantiate_class_from_config`
     # so we need to manually remove those values if we wish to use the **kwargs instantiation pattern
     profiler_config.pop("class_name")
@@ -167,7 +167,7 @@ def test_profile_excludes_citations(
     yaml_config: str = alice_columnar_table_single_batch["profiler_config"]
 
     # Instantiate Profiler
-    profiler_config: dict = yaml.load(yaml_config)
+    profiler_config: dict = yaml.safe_load(yaml_config)
 
     # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
     deserialized_config: dict = ruleBasedProfilerConfigSchema.load(profiler_config)

--- a/tests/rule_based_profiler/conftest.py
+++ b/tests/rule_based_profiler/conftest.py
@@ -140,7 +140,7 @@ data_connectors:
     module_name: great_expectations.datasource.data_connector
         """
 
-    context.add_datasource(name=datasource_name, **yaml.load(datasource_config))
+    context.add_datasource(name=datasource_name, **yaml.safe_load(datasource_config))
 
     assert context.list_datasources() == [
         {
@@ -362,7 +362,7 @@ def alice_columnar_table_single_batch(empty_data_context):
     # because the device_ts is ahead of the event_ts for the latest event
     sample_data_relative_path: str = "alice_columnar_table_single_batch_data.csv"
 
-    profiler_config: dict = yaml.load(verbose_profiler_config)
+    profiler_config: dict = yaml.safe_load(verbose_profiler_config)
 
     # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
     deserialized_config: dict = ruleBasedProfilerConfigSchema.load(profiler_config)
@@ -444,7 +444,7 @@ data_connectors:
     module_name: great_expectations.datasource.data_connector
         """
 
-    context.add_datasource(name=datasource_name, **yaml.load(datasource_config))
+    context.add_datasource(name=datasource_name, **yaml.safe_load(datasource_config))
 
     assert context.list_datasources() == [
         {
@@ -1171,7 +1171,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
             expectation_configuration=expectation_configuration, send_usage_event=False
         )
 
-    profiler_config: dict = yaml.load(verbose_profiler_config)
+    profiler_config: dict = yaml.safe_load(verbose_profiler_config)
 
     # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
     deserialized_config: dict = ruleBasedProfilerConfigSchema.load(profiler_config)

--- a/tests/rule_based_profiler/domain_builder/test_domain_builder.py
+++ b/tests/rule_based_profiler/domain_builder/test_domain_builder.py
@@ -57,7 +57,7 @@ def test_column_domain_builder(
 
     profiler_config: str = alice_columnar_table_single_batch["profiler_config"]
 
-    full_profiler_config_dict: dict = yaml.load(profiler_config)
+    full_profiler_config_dict: dict = yaml.safe_load(profiler_config)
 
     variables_configs: dict = full_profiler_config_dict.get("variables")
     if variables_configs is None:
@@ -144,7 +144,7 @@ def test_simple_semantic_type_column_domain_builder(
 
     profiler_config: str = alice_columnar_table_single_batch["profiler_config"]
 
-    full_profiler_config_dict: dict = yaml.load(profiler_config)
+    full_profiler_config_dict: dict = yaml.safe_load(profiler_config)
 
     variables_configs: dict = full_profiler_config_dict.get("variables")
     if variables_configs is None:


### PR DESCRIPTION
Changes proposed in this pull request:
- As part of refactoring `test_script_runner.py`, I'm proposing that we perform this refactor across our codebase. 
- In general, the OSS GE codebase uses `yaml.load()` to load configurations into memory and  currently results in the following `warning` in the codebase. 

```bash
tests/integration/test_script_runner.py::test_docs[checkpoints_and_actions_core_concepts]
  /private/var/folders/ns/fx4x5_c119n_tt_8rk8nts900000gq/T/pytest-of-work/pytest-403/test_docs_checkpoints_and_acti0/test_script.py:278: UnsafeLoaderWarning:
  The default 'Loader' for 'load(stream)' without further arguments can be unsafe.
  Use 'load(stream, Loader=ruamel.yaml.Loader)' explicitly if that is OK.
  Alternatively include the following in your code:

    import warnings
    warnings.simplefilter('ignore', ruamel.yaml.error.UnsafeLoaderWarning)

  In most other cases you should consider using 'safe_load(stream)'
    context.add_checkpoint(**yaml.load(keys_passed_at_runtime))

```

### Why does this warning exist?
- As explained in the following link, the use of YAML configuration can result in an attacker imbedding malicious Python objects into an arbitrary string, which will then be loaded in a `yaml.load()` call.  This may provide an attacker with a method to execute code.
- Use of `safe_load()` is recommended over `load()` to avoid these dangers: https://security.openstack.org/guidelines/dg_avoid-dangerous-input-parsing-libraries.html
