### PR TITLE
[MAINTENANCE] Lint codebase with `black` and `isort`

### DIFF
--- a/tests/integration/fixtures/gcp_deployment/ge_checkpoint_bigquery.py
+++ b/tests/integration/fixtures/gcp_deployment/ge_checkpoint_bigquery.py
@@ -24,5 +24,5 @@ t1 = BashOperator(
     bash_command="(cd /home/airflow/gcsfuse/great_expectations/ ; great_expectations --v3-api checkpoint run bigquery_checkpoint ) ",
     dag=dag,
     depends_on_past=False,
-    priority_weight=2**31 - 1,
+    priority_weight=2 ** 31 - 1,
 )

--- a/tests/integration/fixtures/gcp_deployment/ge_checkpoint_gcs.py
+++ b/tests/integration/fixtures/gcp_deployment/ge_checkpoint_gcs.py
@@ -24,5 +24,5 @@ t1 = BashOperator(
     bash_command="(cd /home/airflow/gcsfuse/great_expectations/ ; great_expectations --v3-api checkpoint run gcs_checkpoint ) ",
     dag=dag,
     depends_on_past=False,
-    priority_weight=2**31 - 1,
+    priority_weight=2 ** 31 - 1,
 )


### PR DESCRIPTION
Changes proposed in this pull request:
- Manually run linting tools after bumping up `black` version



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code


Thank you for submitting!
