### PR TITLE
[FEATURE] Introduce Top-Level Abstract "ConfigPeer" class for handling configuration output for Marshmallo Schema validated Config objects

### DIFF
--- a/docs/reference/checkpoints_and_actions.md
+++ b/docs/reference/checkpoints_and_actions.md
@@ -108,14 +108,14 @@ redefined.
 :::caution API note
 
 If the use case calls for instantiating the Checkpoint explicitly, then it is crucial to ensure that only serializable
-values are passed as arguments to the constructor.  Specifically, if batch_request is specified at any level of the
+values are passed as arguments to the constructor.  Specifically, if `batch_request` is specified at any level of the
 hierarchy of the Checkpoint configuration (at the top level and/or as part of the validators list structure), then no
-runtime batch_request can contain batch_data, only a database query.  This is because batch_data is used to specify
-dataframes (Pandas, Spark), which are not serializable (while database queries are plain text, which is serialiable).
+runtime `batch_request` can contain `batch_data`, only a database query.  This is because `batch_data` is used to specify
+dataframes (Pandas, Spark), which are not serializable (while database queries are plain text, which is serializable).
 
-The proper mechanism for specifying non-serializable parameters is to pass them dynamically to the Checkpoint run()
+The proper mechanism for specifying non-serializable parameters is to pass them dynamically to the Checkpoint `run()`
 method.  Hence, in a typical scenario, one would instantiate the Checkpoint class with serializable parameters only,
-while specifying any non-serializable parameters, commonly dataframes, as arguments to the Checkpoint run() method.
+while specifying any non-serializable parameters, commonly dataframes, as arguments to the Checkpoint `run()` method.
 :::
 
 ## SimpleCheckpoint class

--- a/docs/reference/checkpoints_and_actions.md
+++ b/docs/reference/checkpoints_and_actions.md
@@ -105,6 +105,19 @@ redefined.
 * `action_list`: actions that share the same user-defined name will be updated, otherwise a new action will be appended
 * `validations`
 
+:::caution API note
+
+If the use case calls for instantiating the Checkpoint explicitly, then it is crucial to ensure that only serializable
+values are passed as arguments to the constructor.  Specifically, if batch_request is specified at any level of the
+hierarchy of the Checkpoint configuration (at the top level and/or as part of the validators list structure), then no
+runtime batch_request can contain batch_data, only a database query.  This is because batch_data is used to specify
+dataframes (Pandas, Spark), which are not serializable (while database queries are plain text, which is serialiable).
+
+The proper mechnism for specifying non-serializable parameters is to pass them dynamically to the Checkpoint run()
+method.  Hence, in a typical scenario, one would instantiate the Checkpoint class with serializable parameters only,
+while specifying any non-serializable parameters, commonly dataframes, as arguments to the Checkpoint run() method.
+:::
+
 ## SimpleCheckpoint class
 
 For many use cases, the SimpleCheckpoint class can be used to simplify the process of specifying a Checkpoint

--- a/docs/reference/checkpoints_and_actions.md
+++ b/docs/reference/checkpoints_and_actions.md
@@ -113,7 +113,7 @@ hierarchy of the Checkpoint configuration (at the top level and/or as part of th
 runtime batch_request can contain batch_data, only a database query.  This is because batch_data is used to specify
 dataframes (Pandas, Spark), which are not serializable (while database queries are plain text, which is serialiable).
 
-The proper mechnism for specifying non-serializable parameters is to pass them dynamically to the Checkpoint run()
+The proper mechanism for specifying non-serializable parameters is to pass them dynamically to the Checkpoint run()
 method.  Hence, in a typical scenario, one would instantiate the Checkpoint class with serializable parameters only,
 while specifying any non-serializable parameters, commonly dataframes, as arguments to the Checkpoint run() method.
 :::

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -24,7 +24,7 @@ from great_expectations.core.batch import (
     batch_request_contains_batch_data,
     get_batch_request_as_dict,
 )
-from great_expectations.core.config_peer import ConfigPeer
+from great_expectations.core.config_peer import ConfigOutputModes, ConfigPeer
 from great_expectations.core.usage_statistics.usage_statistics import (
     get_checkpoint_run_usage_statistics,
     usage_statistics_enabled_method,
@@ -186,7 +186,7 @@ class BaseCheckpoint(ConfigPeer):
         if runtime_kwargs is None:
             runtime_kwargs = {}
 
-        config_kwargs: dict = self.get_config(mode="json_dict")
+        config_kwargs: dict = self.get_config(mode=ConfigOutputModes.JSON_DICT)
 
         template_name: Optional[str] = runtime_kwargs.get("template_name")
         if template_name:

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -24,6 +24,7 @@ from great_expectations.core.batch import (
     batch_request_contains_batch_data,
     get_batch_request_as_dict,
 )
+from great_expectations.core.config_peer import ConfigPeer
 from great_expectations.core.usage_statistics.usage_statistics import (
     get_checkpoint_run_usage_statistics,
     usage_statistics_enabled_method,
@@ -33,7 +34,6 @@ from great_expectations.data_asset import DataAsset
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 from great_expectations.data_context.util import substitute_all_config_variables
-from great_expectations.util import filter_properties_dict
 from great_expectations.validation_operators import ActionListValidationOperator
 from great_expectations.validation_operators.types.validation_operator_result import (
     ValidationOperatorResult,
@@ -43,9 +43,9 @@ from great_expectations.validator.validator import Validator
 logger = logging.getLogger(__name__)
 
 
-class CheckpointBase:
+class BaseCheckpoint(ConfigPeer):
     """
-    CheckpointBase class is initialized from CheckpointConfig typed object and contains all functionality
+    BaseCheckpoint class is initialized from CheckpointConfig typed object and contains all functionality
     in the form of interface methods (which can be overwritten by subclasses) and their reference implementation.
     """
 
@@ -176,7 +176,7 @@ class CheckpointBase:
         return CheckpointResult(
             run_id=run_id,
             run_results=run_results,
-            checkpoint_config=self.checkpoint_config,
+            checkpoint_config=self.config,
         )
 
     def get_substituted_config(
@@ -212,7 +212,7 @@ class CheckpointBase:
             checkpoint: Checkpoint = self.data_context.get_checkpoint(
                 name=template_name
             )
-            template_config: dict = checkpoint.checkpoint_config.to_json_dict()
+            template_config: dict = checkpoint.config.to_json_dict()
 
             if template_config["config_version"] != source_config["config_version"]:
                 raise ge_exceptions.CheckpointError(
@@ -370,7 +370,7 @@ class CheckpointBase:
 
     def self_check(self, pretty_print=True) -> dict:
         # Provide visibility into parameters that Checkpoint was instantiated with.
-        report_object: dict = {"config": self.checkpoint_config.to_json_dict()}
+        report_object: dict = {"config": self.config.to_json_dict()}
 
         if pretty_print:
             print(f"\nCheckpoint class name: {self.__class__.__name__}")
@@ -416,87 +416,42 @@ is run), with each validation having its own defined "action_list" attribute.
 
         return report_object
 
-    # noinspection PyShadowingBuiltins
-    def get_config(
-        self,
-        mode: str = "typed",
-        clean_falsy: bool = False,
-    ) -> Union[CheckpointConfig, dict, str]:
-        config: CheckpointConfig = self.checkpoint_config
-
-        if mode == "typed":
-            return config
-
-        if mode == "commented_map":
-            return config.commented_map
-
-        if mode == "dict":
-            config_kwargs: dict = config.to_dict()
-            if clean_falsy:
-                filter_properties_dict(
-                    properties=config_kwargs,
-                    clean_falsy=True,
-                    inplace=True,
-                )
-
-            return config_kwargs
-
-        if mode == "json_dict":
-            config_kwargs: dict = config.to_json_dict()
-            if clean_falsy:
-                filter_properties_dict(
-                    properties=config_kwargs,
-                    clean_falsy=True,
-                    inplace=True,
-                )
-
-            return config_kwargs
-
-        if mode == "yaml":
-            return config.to_yaml_str()
-
-        raise ValueError(f'Unknown mode {mode} in "CheckpointBase.get_config()".')
-
     @property
-    def checkpoint_config(self) -> CheckpointConfig:
+    def config(self) -> CheckpointConfig:
         return self._checkpoint_config
-
-    @checkpoint_config.setter
-    def checkpoint_config(self, value: CheckpointConfig):
-        self._checkpoint_config = value
 
     @property
     def name(self) -> Optional[str]:
         try:
-            return self.checkpoint_config.name
+            return self.config.name
         except AttributeError:
             return None
 
     @property
     def config_version(self) -> Optional[float]:
         try:
-            return self.checkpoint_config.config_version
+            return self.config.config_version
         except AttributeError:
             return None
 
     @property
     def action_list(self) -> List[Dict]:
         try:
-            return self.checkpoint_config.action_list
+            return self.config.action_list
         except AttributeError:
             return []
 
     @property
     def validations(self) -> List[Dict]:
         try:
-            return self.checkpoint_config.validations
+            return self.config.validations
         except AttributeError:
             return []
 
     @property
     def ge_cloud_id(self) -> Optional[UUID]:
         try:
-            return self.checkpoint_config.ge_cloud_id
+            return self.config.ge_cloud_id
         except AttributeError:
             return None
 
@@ -508,7 +463,7 @@ is run), with each validation having its own defined "action_list" attribute.
         return str(self.get_config())
 
 
-class Checkpoint(CheckpointBase):
+class Checkpoint(BaseCheckpoint):
     """
     --ge-feature-maturity-info--
 

--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -1,11 +1,23 @@
 import logging
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Union
 
 from great_expectations.data_context.types.base import BaseYamlConfig
 from great_expectations.util import filter_properties_dict
 
 logger = logging.getLogger(__name__)
+
+
+class ConfigOutputModes(Enum):
+    TYPED = "typed"
+    COMMENTED_MAP = "commented_map"
+    YAML = "yaml"
+    DICT = "dict"
+    JSON_DICT = "json_dict"
+
+
+ConfigOutputModeType = Union[ConfigOutputModes, str]
 
 
 class ConfigPeer(ABC):
@@ -25,23 +37,26 @@ class ConfigPeer(ABC):
 
     def get_config(
         self,
-        mode: str = "typed",
+        mode: ConfigOutputModeType = ConfigOutputModes.TYPED,
         **kwargs,
     ) -> Union[BaseYamlConfig, dict, str]:
+        if isinstance(mode, str):
+            mode = ConfigOutputModes[mode]
+
         config: BaseYamlConfig = self.config
 
-        if mode == "typed":
+        if mode == ConfigOutputModes.TYPED:
             return config
 
-        if mode == "commented_map":
+        if mode == ConfigOutputModes.COMMENTED_MAP:
             return config.commented_map
 
-        if mode == "yaml":
+        if mode == ConfigOutputModes.YAML:
             return config.to_yaml_str()
 
-        if mode == "dict":
+        if mode == ConfigOutputModes.DICT:
             config_kwargs: dict = config.to_dict()
-        elif mode == "json_dict":
+        elif mode == ConfigOutputModes.JSON_DICT:
             config_kwargs: dict = config.to_json_dict()
         else:
             raise ValueError(f'Unknown mode {mode} in "BaseCheckpoint.get_config()".')

--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -34,7 +34,7 @@ class ConfigPeer(ABC):
     any form of serialization (YAML, JSON, SQL Database Tables, Pickle, etc.) will apply as peers, independent of the
     configuration classes themselves.  Hence, as part of this change, ConfigPeer will cease being the superclass of
     business objects (such as BaseDataContext, BaseCheckpoint, and BaseRuleBasedProfiler).  Instead, every persitable
-    business object will contain a referencing to its corresponding peer class, supporting the ConfigPeer interfaces.
+    business object will contain a reference to its corresponding peer class, supporting the ConfigPeer interfaces.
     """
 
     @property

--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -1,0 +1,58 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Union
+
+from great_expectations.data_context.types.base import BaseYamlConfig
+from great_expectations.util import filter_properties_dict
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigPeer(ABC):
+    """
+    A ConfigPeer is an object, whose subclasses can be instantiated using the "instantiate_class_from_config()" method
+    (located in "great_expectations/util.py").  Its immediate descendant subclass must use a subclass of
+    "BaseYamlConfig" as an argument to its constructor, and the subsequent descentants must use only primitive types as
+    their constructor arguments, whereever keys correspond to the keys of the "BaseYamlConfig" immutable configuration
+    object counterpart. The name, "ConfigPeer", denotes the fact that every immediate descendant subclass must have an
+    immutable, Marshmallow Schema validated, configuration class as its peer.
+    """
+
+    @property
+    @abstractmethod
+    def config(self) -> BaseYamlConfig:
+        pass
+
+    def get_config(
+        self,
+        mode: str = "typed",
+        **kwargs,
+    ) -> Union[BaseYamlConfig, dict, str]:
+        config: BaseYamlConfig = self.config
+
+        if mode == "typed":
+            return config
+
+        if mode == "commented_map":
+            return config.commented_map
+
+        if mode == "yaml":
+            return config.to_yaml_str()
+
+        if mode == "dict":
+            config_kwargs: dict = config.to_dict()
+        elif mode == "json_dict":
+            config_kwargs: dict = config.to_json_dict()
+        else:
+            raise ValueError(f'Unknown mode {mode} in "BaseCheckpoint.get_config()".')
+
+        kwargs["inplace"] = True
+        filter_properties_dict(
+            properties=config_kwargs,
+            **kwargs,
+        )
+
+        return config_kwargs
+
+    def __repr__(self) -> str:
+        return str(self.get_config())

--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -22,12 +22,11 @@ ConfigOutputModeType = Union[ConfigOutputModes, str]
 
 class ConfigPeer(ABC):
     """
-    A ConfigPeer is an object, whose subclasses can be instantiated using the "instantiate_class_from_config()" method
-    (located in "great_expectations/util.py").  Its immediate descendant subclass must use a subclass of
-    "BaseYamlConfig" as an argument to its constructor, and the subsequent descentants must use only primitive types as
-    their constructor arguments, whereever keys correspond to the keys of the "BaseYamlConfig" immutable configuration
-    object counterpart. The name, "ConfigPeer", denotes the fact that every immediate descendant subclass must have an
-    immutable, Marshmallow Schema validated, configuration class as its peer.
+    A ConfigPeer is an object, whose subclasses can be instantiated using instantiate_class_from_config() (located in
+    great_expectations/util.py).  Its immediate descendant subclass must use a subclass of BaseYamlConfig as an argument
+    to its constructor, and the subsequent descentants must use only primitive types as their constructor arguments,
+    whereever keys correspond to the keys of the "BaseYamlConfig" configuration object counterpart. The name ConfigPeer
+    means: Every immediate descendant subclass must have Marshmallow Schema validated configuration class as its peer.
     """
 
     @property

--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -27,6 +27,14 @@ class ConfigPeer(ABC):
     to its constructor, and the subsequent descentants must use only primitive types as their constructor arguments,
     whereever keys correspond to the keys of the "BaseYamlConfig" configuration object counterpart. The name ConfigPeer
     means: Every immediate descendant subclass must have Marshmallow Schema validated configuration class as its peer.
+
+    # TODO: <Alex>2/11/2022</Alex>
+    When -- as part of a potential future architecture update -- serialization is decoupled from configuration, the
+    configuration objects, persitable as YAML files, will no longer inherit from the BaseYamlConfig class.  Rather,
+    any form of serialization (YAML, JSON, SQL Database Tables, Pickle, etc.) will apply as peers, independent of the
+    configuration classes themselves.  Hence, as part of this change, ConfigPeer will cease being the superclass of
+    business objects (such as BaseDataContext, BaseCheckpoint, and BaseRuleBasedProfiler).  Instead, every persitable
+    business object will contain a referencing to its corresponding peer class, supporting the ConfigPeer interfaces.
     """
 
     @property

--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -41,7 +41,7 @@ class ConfigPeer(ABC):
         **kwargs,
     ) -> Union[BaseYamlConfig, dict, str]:
         if isinstance(mode, str):
-            mode = ConfigOutputModes[mode]
+            mode = ConfigOutputModes(mode.lower())
 
         config: BaseYamlConfig = self.config
 

--- a/great_expectations/core/usage_statistics/anonymizers/checkpoint_run_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/checkpoint_run_anonymizer.py
@@ -59,9 +59,9 @@ class CheckpointRunAnonymizer(Anonymizer):
         name: Optional[str] = kwargs.get("name")
         anonymized_name: Optional[str] = self.anonymize(name)
 
-        config_version: Optional[Number, str] = kwargs.get("config_version")
+        config_version: Optional[Union[Number, str]] = kwargs.get("config_version")
         if config_version is None:
-            config_version = 1
+            config_version = 1.0
 
         template_name: Optional[str] = kwargs.get("template_name")
         anonymized_template_name: Optional[str] = self.anonymize(template_name)

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML, YAMLError
 from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.constructor import DuplicateKeyError
 
+from great_expectations.core.config_peer import ConfigPeer
 from great_expectations.rule_based_profiler.config.base import (
     ruleBasedProfilerConfigSchema,
 )
@@ -143,7 +144,7 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 yaml.default_flow_style = False
 
 
-class BaseDataContext:
+class BaseDataContext(ConfigPeer):
     """
         This class implements most of the functionality of DataContext, with a few exceptions.
 
@@ -385,9 +386,7 @@ class BaseDataContext:
         self._data_context_id = self._construct_data_context_id()
 
         # Override the project_config data_context_id if an expectations_store was already set up
-        self._project_config.anonymous_usage_statistics.data_context_id = (
-            self._data_context_id
-        )
+        self.config.anonymous_usage_statistics.data_context_id = self._data_context_id
         self._initialize_usage_statistics(
             self.project_config_with_variables_substituted.anonymous_usage_statistics
         )
@@ -406,12 +405,12 @@ class BaseDataContext:
         # NOTE - 20210112 - Alex Sherstinsky - Validation Operators are planned to be deprecated.
         if (
             "validation_operators" in self.get_config().commented_map
-            and self._project_config.validation_operators
+            and self.config.validation_operators
         ):
             for (
                 validation_operator_name,
                 validation_operator_config,
-            ) in self._project_config.validation_operators.items():
+            ) in self.config.validation_operators.items():
                 self.add_validation_operator(
                     validation_operator_name,
                     validation_operator_config,
@@ -501,7 +500,7 @@ class BaseDataContext:
             logger.info(
                 "Usage statistics is disabled globally. Applying override to project_config."
             )
-            self._project_config.anonymous_usage_statistics.enabled = False
+            self.config.anonymous_usage_statistics.enabled = False
 
         # check for global data_context_id
         global_data_context_id = self._get_global_config_value(
@@ -517,7 +516,7 @@ class BaseDataContext:
                 logger.info(
                     "data_context_id is defined globally. Applying override to project_config."
                 )
-                self._project_config.anonymous_usage_statistics.data_context_id = (
+                self.config.anonymous_usage_statistics.data_context_id = (
                     global_data_context_id
                 )
             else:
@@ -536,7 +535,7 @@ class BaseDataContext:
                 logger.info(
                     "usage_statistics_url is defined globally. Applying override to project_config."
                 )
-                self._project_config.anonymous_usage_statistics.usage_statistics_url = (
+                self.config.anonymous_usage_statistics.usage_statistics_url = (
                     global_usage_statistics_url
                 )
             else:
@@ -649,7 +648,7 @@ class BaseDataContext:
             store (Store)
         """
 
-        self._project_config["stores"][store_name] = store_config
+        self.config["stores"][store_name] = store_config
         return self._build_store_from_config(store_name, store_config)
 
     def add_validation_operator(
@@ -665,7 +664,7 @@ class BaseDataContext:
             validation_operator (ValidationOperator)
         """
 
-        self._project_config["validation_operators"][
+        self.config["validation_operators"][
             validation_operator_name
         ] = validation_operator_config
         config = self.project_config_with_variables_substituted.validation_operators[
@@ -971,6 +970,10 @@ class BaseDataContext:
         # Note Abe 20121114 : We should probably cache config_variables instead of loading them from disk every time.
         return dict(self._load_config_variables_file())
 
+    @property
+    def config(self) -> DataContextConfig:
+        return self._project_config
+
     #####
     #
     # Internal helper methods
@@ -984,7 +987,9 @@ class BaseDataContext:
         """
         if self.ge_cloud_mode:
             return {}
-        config_variables_file_path = self.get_config().config_variables_file_path
+        config_variables_file_path = cast(
+            DataContextConfig, self.get_config()
+        ).config_variables_file_path
         if config_variables_file_path:
             try:
                 # If the user specifies the config variable path with an environment variable, we want to substitute it
@@ -1016,7 +1021,7 @@ class BaseDataContext:
         be optional in GE Cloud mode).
         """
         if not config:
-            config = self._project_config
+            config = self.config
 
         substituted_config_variables = substitute_all_config_variables(
             self.config_variables,
@@ -1118,7 +1123,9 @@ class BaseDataContext:
             skip_if_substitution_variable=skip_if_substitution_variable,
         )
         config_variables[config_variable_name] = value
-        config_variables_filepath = self.get_config().config_variables_file_path
+        config_variables_filepath = cast(
+            DataContextConfig, self.get_config()
+        ).config_variables_file_path
         if not config_variables_filepath:
             raise ge_exceptions.InvalidConfigError(
                 "'config_variables_file_path' property is not found in config - setting it is required to use this feature"
@@ -1157,7 +1164,7 @@ class BaseDataContext:
                 # remove key until we have a delete method on project_config
                 # self.project_config_with_variables_substituted.datasources[
                 # datasource_name].remove()
-                del self._project_config["datasources"][datasource_name]
+                del self.config["datasources"][datasource_name]
                 del self._cached_datasources[datasource_name]
             else:
                 raise ValueError(f"Datasource {datasource_name} not found")
@@ -1904,7 +1911,7 @@ class BaseDataContext:
         datasource_config: DatasourceConfig = datasourceConfigSchema.load(
             CommentedMap(**config)
         )
-        self._project_config["datasources"][name] = datasource_config
+        self.config["datasources"][name] = datasource_config
         datasource_config = self.project_config_with_variables_substituted.datasources[
             name
         ]
@@ -1918,7 +1925,7 @@ class BaseDataContext:
                 self._cached_datasources[name] = datasource
             except ge_exceptions.DatasourceInitializationError as e:
                 # Do not keep configuration that could not be instantiated.
-                del self._project_config["datasources"][name]
+                del self.config["datasources"][name]
                 raise e
         else:
             datasource = None
@@ -1973,25 +1980,6 @@ class BaseDataContext:
 
     def set_config(self, project_config: DataContextConfig):
         self._project_config = project_config
-
-    def get_config(
-        self, mode="typed"
-    ) -> Union[DataContextConfig, CommentedMap, dict, str]:
-        config: DataContextConfig = self._project_config
-
-        if mode == "typed":
-            return config
-
-        if mode == "commented_map":
-            return config.commented_map
-
-        if mode == "dict":
-            return config.to_json_dict()
-
-        if mode == "yaml":
-            return config.to_yaml_str()
-
-        raise ValueError(f"Unknown config mode {mode}")
 
     def _build_datasource_from_config(
         self, name: str, config: Union[dict, DatasourceConfig]
@@ -3593,7 +3581,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
             ),
         )
         store_name = instantiated_class.store_name or store_name
-        self._project_config["stores"][store_name] = config
+        self.config["stores"][store_name] = config
 
         store_anonymizer = StoreAnonymizer(self.data_context_id)
         usage_stats_event_payload = store_anonymizer.anonymize_store_info(
@@ -4193,7 +4181,7 @@ class DataContext(BaseDataContext):
         project_config_dict = dataContextConfigSchema.dump(project_config)
         if (
             project_config.anonymous_usage_statistics.explicit_id is False
-            or project_config_dict != dataContextConfigSchema.dump(self._project_config)
+            or project_config_dict != dataContextConfigSchema.dump(self.config)
         ):
             self._save_project_config()
 
@@ -4277,7 +4265,7 @@ class DataContext(BaseDataContext):
 
         config_filepath = os.path.join(self.root_directory, self.GE_YML)
         with open(config_filepath, "w") as outfile:
-            self._project_config.to_yaml(outfile)
+            self.config.to_yaml(outfile)
 
     def add_store(self, store_name, store_config):
         logger.debug("Starting DataContext.add_store for store %s" % store_name)

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -900,6 +900,7 @@ sqlalchemy data source (your data source is "{data['class_name']}").  Please upd
 class AnonymizedUsageStatisticsConfig(DictDot):
     def __init__(self, enabled=True, data_context_id=None, usage_statistics_url=None):
         self._enabled = enabled
+
         if data_context_id is None:
             data_context_id = str(uuid.uuid4())
             self._explicit_id = False
@@ -907,11 +908,13 @@ class AnonymizedUsageStatisticsConfig(DictDot):
             self._explicit_id = True
 
         self._data_context_id = data_context_id
+
         if usage_statistics_url is None:
             usage_statistics_url = DEFAULT_USAGE_STATISTICS_URL
             self._explicit_url = False
         else:
             self._explicit_url = True
+
         self._usage_statistics_url = usage_statistics_url
 
     @property
@@ -922,6 +925,7 @@ class AnonymizedUsageStatisticsConfig(DictDot):
     def enabled(self, enabled):
         if not isinstance(enabled, bool):
             raise ValueError("usage statistics enabled property must be boolean")
+
         self._enabled = enabled
 
     @property
@@ -936,12 +940,17 @@ class AnonymizedUsageStatisticsConfig(DictDot):
             raise ge_exceptions.InvalidConfigError(
                 "data_context_id must be a valid uuid"
             )
+
         self._data_context_id = data_context_id
         self._explicit_id = True
 
     @property
     def explicit_id(self):
         return self._explicit_id
+
+    @property
+    def explicit_url(self):
+        return self._explicit_url
 
     @property
     def usage_statistics_url(self):
@@ -2020,6 +2029,49 @@ class DataContextConfig(BaseYamlConfig):
     @property
     def config_version(self):
         return self._config_version
+
+    def to_json_dict(self) -> dict:
+        """
+        # TODO: <Alex>2/4/2022</Alex>
+        This implementation of "SerializableDictDot.to_json_dict() occurs frequently and should ideally serve as the
+        reference implementation in the "SerializableDictDot" class itself.  However, the circular import dependencies,
+        due to the location of the "great_expectations/types/__init__.py" and "great_expectations/core/util.py" modules
+        make this refactoring infeasible at the present time.
+        """
+        dict_obj: dict = self.to_dict()
+        serializeable_dict: dict = convert_to_json_serializable(data=dict_obj)
+        return serializeable_dict
+
+    def __repr__(self) -> str:
+        """
+        # TODO: <Alex>2/4/2022</Alex>
+        This implementation of a custom "__repr__()" occurs frequently and should ideally serve as the reference
+        implementation in the "SerializableDictDot" class.  However, the circular import dependencies, due to the
+        location of the "great_expectations/types/__init__.py" and "great_expectations/core/util.py" modules make this
+        refactoring infeasible at the present time.
+        """
+        json_dict: dict = self.to_json_dict()
+        deep_filter_properties_iterable(
+            properties=json_dict,
+            inplace=True,
+        )
+
+        keys: List[str] = sorted(list(json_dict.keys()))
+
+        key: str
+        sorted_json_dict: dict = {key: json_dict[key] for key in keys}
+
+        return json.dumps(sorted_json_dict, indent=2)
+
+    def __str__(self) -> str:
+        """
+        # TODO: <Alex>2/4/2022</Alex>
+        This implementation of a custom "__str__()" occurs frequently and should ideally serve as the reference
+        implementation in the "SerializableDictDot" class.  However, the circular import dependencies, due to the
+        location of the "great_expectations/types/__init__.py" and "great_expectations/core/util.py" modules make this
+        refactoring infeasible at the present time.
+        """
+        return self.__repr__()
 
 
 class CheckpointConfigSchema(Schema):

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -918,22 +918,22 @@ class AnonymizedUsageStatisticsConfig(DictDot):
         self._usage_statistics_url = usage_statistics_url
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         return self._enabled
 
     @enabled.setter
-    def enabled(self, enabled):
+    def enabled(self, enabled) -> None:
         if not isinstance(enabled, bool):
             raise ValueError("usage statistics enabled property must be boolean")
 
         self._enabled = enabled
 
     @property
-    def data_context_id(self):
+    def data_context_id(self) -> str:
         return self._data_context_id
 
     @data_context_id.setter
-    def data_context_id(self, data_context_id):
+    def data_context_id(self, data_context_id) -> None:
         try:
             uuid.UUID(data_context_id)
         except ValueError:
@@ -945,19 +945,19 @@ class AnonymizedUsageStatisticsConfig(DictDot):
         self._explicit_id = True
 
     @property
-    def explicit_id(self):
+    def explicit_id(self) -> bool:
         return self._explicit_id
 
     @property
-    def explicit_url(self):
+    def explicit_url(self) -> bool:
         return self._explicit_url
 
     @property
-    def usage_statistics_url(self):
+    def usage_statistics_url(self) -> str:
         return self._usage_statistics_url
 
     @usage_statistics_url.setter
-    def usage_statistics_url(self, usage_statistics_url):
+    def usage_statistics_url(self, usage_statistics_url) -> None:
         self._usage_statistics_url = usage_statistics_url
         self._explicit_url = True
 

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -69,7 +69,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         These will be used to define profiler computation patterns.
 
         Args:
-            profiler_config: RuleBasedProfilerConfig -- formal typed object containing configuration (immutable)
+            profiler_config: RuleBasedProfilerConfig -- formal typed object containing configuration
             data_context: DataContext object that defines a full runtime environment (data access, etc.)
         """
         name: str = profiler_config.name

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 import great_expectations.exceptions as ge_exceptions
+from great_expectations.core.config_peer import ConfigPeer
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.util import nested_update
@@ -49,9 +50,9 @@ def _validate_builder_override_config(builder_config: dict):
         )
 
 
-class RuleBasedProfilerBase:
+class BaseRuleBasedProfiler(ConfigPeer):
     """
-    RuleBasedProfilerBase class is initialized from RuleBasedProfilerConfig typed object and contains all functionality
+    BaseRuleBasedProfiler class is initialized from RuleBasedProfilerConfig typed object and contains all functionality
     in the form of interface methods (which can be overwritten by subclasses) and their reference implementation.
     """
 
@@ -78,6 +79,8 @@ class RuleBasedProfilerBase:
 
         self._name = name
         self._config_version = config_version
+
+        self._profiler_config = profiler_config
 
         if variables is None:
             variables = {}
@@ -640,6 +643,10 @@ class RuleBasedProfilerBase:
         return report_object
 
     @property
+    def config(self) -> RuleBasedProfilerConfig:
+        return self._profiler_config
+
+    @property
     def name(self) -> str:
         return self._name
 
@@ -661,7 +668,7 @@ class RuleBasedProfilerBase:
         self._rules = value
 
 
-class RuleBasedProfiler(RuleBasedProfilerBase):
+class RuleBasedProfiler(BaseRuleBasedProfiler):
     """
     RuleBasedProfiler object serves to profile, or automatically evaluate a set of rules, upon a given
     batch / multiple batches of data.

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -15,6 +15,7 @@ import great_expectations.exceptions as ge_exceptions
 from great_expectations.checkpoint import Checkpoint, LegacyCheckpoint
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
 from great_expectations.core.batch import RuntimeBatchRequest
+from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.core.util import get_or_create_spark_application
 from great_expectations.data_context.data_context import DataContext
 from great_expectations.data_context.types.base import CheckpointConfig
@@ -308,7 +309,7 @@ def test_basic_checkpoint_config_validation(
     )
     assert (
         filter_properties_dict(
-            properties=checkpoint.get_config(mode="dict"),
+            properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
             clean_falsy=True,
         )
         == expected_checkpoint_config
@@ -327,7 +328,7 @@ def test_basic_checkpoint_config_validation(
     )
     assert (
         filter_properties_dict(
-            properties=checkpoint.get_config(mode="dict"),
+            properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
             clean_falsy=True,
         )
         == expected_checkpoint_config
@@ -505,7 +506,7 @@ def test_checkpoint_configuration_no_nesting_using_test_yaml_config(
         name="my_fancy_checkpoint",
     )
     assert filter_properties_dict(
-        properties=checkpoint.get_config(mode="dict"),
+        properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == filter_properties_dict(
         properties=expected_checkpoint_config,
@@ -660,7 +661,7 @@ def test_checkpoint_configuration_nesting_provides_defaults_for_most_elements_te
         name="my_fancy_checkpoint",
     )
     assert filter_properties_dict(
-        properties=checkpoint.get_config(mode="dict"),
+        properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == filter_properties_dict(
         properties=expected_checkpoint_config,
@@ -758,7 +759,7 @@ def test_checkpoint_configuration_using_RuntimeDataConnector_with_Airflow_test_y
         name="airflow_checkpoint",
     )
     assert filter_properties_dict(
-        properties=checkpoint.get_config(mode="dict"),
+        properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == filter_properties_dict(
         properties=expected_checkpoint_config,
@@ -1027,7 +1028,7 @@ def test_checkpoint_configuration_warning_error_quarantine_test_yaml_config(
         name="airflow_users_node_3",
     )
     assert filter_properties_dict(
-        properties=checkpoint.get_config(mode="dict"),
+        properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == filter_properties_dict(
         properties=expected_checkpoint_config,
@@ -1126,7 +1127,7 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
         name="my_base_checkpoint",
     )
     assert filter_properties_dict(
-        properties=checkpoint.get_config(mode="dict"),
+        properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == filter_properties_dict(
         properties=expected_checkpoint_config,
@@ -1242,7 +1243,7 @@ def test_checkpoint_configuration_template_parsing_and_usage_test_yaml_config(
         name="my_fancy_checkpoint",
     )
     assert filter_properties_dict(
-        properties=checkpoint.get_config(mode="dict"),
+        properties=checkpoint.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == filter_properties_dict(
         properties=expected_checkpoint_config,

--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -1278,13 +1278,13 @@ def test_legacy_checkpoint_instantiates_and_produces_a_validation_result_when_ru
     base_directory = rad_datasource["batch_kwargs_generators"]["subdir_reader"][
         "base_directory"
     ]
-    batch_kwargs = {
+    batch_kwargs: dict = {
         "path": base_directory + "/f1.csv",
         "datasource": "rad_datasource",
         "reader_method": "read_csv",
     }
 
-    checkpoint_config_dict = {
+    checkpoint_config_dict: dict = {
         "name": "my_checkpoint",
         "validation_operator_name": "action_list_operator",
         "batches": [

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -3370,7 +3370,7 @@ def test_simple_checkpoint_does_not_pass_dataframes_via_batch_request_into_check
     )
 
     # add checkpoint config
-    checkpoint_config = {
+    checkpoint_config: dict = {
         "class_name": "SimpleCheckpoint",
         "name": "my_checkpoint",
         "config_version": 1,
@@ -3427,7 +3427,7 @@ def test_simple_checkpoint_does_not_pass_dataframes_via_validations_into_checkpo
     )
 
     # add checkpoint config
-    checkpoint_config = {
+    checkpoint_config: dict = {
         "class_name": "SimpleCheckpoint",
         "name": "my_checkpoint",
         "config_version": 1,

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -14,6 +14,7 @@ from great_expectations.checkpoint.checkpoint import (
     SimpleCheckpoint,
 )
 from great_expectations.core.batch import RuntimeBatchRequest
+from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.util import deep_filter_properties_iterable
 
@@ -140,7 +141,7 @@ def test_simple_checkpoint_default_properties_with_no_optional_arguments(
     checkpoint_from_store = titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates.get_checkpoint(
         "my_minimal_simple_checkpoint"
     )
-    checkpoint_config = checkpoint_from_store.get_config(mode="dict")
+    checkpoint_config = checkpoint_from_store.get_config(mode=ConfigOutputModes.DICT)
     assert checkpoint_config["name"] == "my_minimal_simple_checkpoint"
     assert checkpoint_config["action_list"] == [
         store_validation_result_action,
@@ -185,7 +186,7 @@ def test_simple_checkpoint_has_slack_action_with_defaults_when_slack_webhook_is_
     checkpoint_from_store = titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates.get_checkpoint(
         "my_simple_checkpoint_with_slack"
     )
-    checkpoint_config = checkpoint_from_store.get_config(mode="dict")
+    checkpoint_config = checkpoint_from_store.get_config(mode=ConfigOutputModes.DICT)
     assert checkpoint_config["name"] == "my_simple_checkpoint_with_slack"
     assert checkpoint_config["action_list"] == expected
 
@@ -252,7 +253,7 @@ def test_simple_checkpoint_notify_with_all_has_data_docs_action_with_none_specif
     checkpoint_from_store: Checkpoint = titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates.get_checkpoint(
         "my_simple_checkpoint_with_slack_and_notify_with_all"
     )
-    checkpoint_config = checkpoint_from_store.get_config(mode="dict")
+    checkpoint_config = checkpoint_from_store.get_config(mode=ConfigOutputModes.DICT)
     assert slack_notification_action in checkpoint_config["action_list"]
 
 
@@ -368,7 +369,7 @@ def test_simple_checkpoint_has_update_data_docs_action_that_should_update_select
     checkpoint_from_store = titanic_pandas_data_context_with_v013_datasource_stats_enabled_with_checkpoints_v1_with_templates.get_checkpoint(
         "my_simple_checkpoint_with_site_names"
     )
-    checkpoint_config = checkpoint_from_store.get_config(mode="dict")
+    checkpoint_config = checkpoint_from_store.get_config(mode=ConfigOutputModes.DICT)
     assert checkpoint_config["action_list"] == [
         store_validation_result_action,
         store_eval_parameter_action,
@@ -415,8 +416,10 @@ def test_simple_checkpoint_persisted_to_store(
         context_with_data_source_and_empty_suite.get_checkpoint(name="foo")
     )
     assert isinstance(checkpoint, Checkpoint)
-    assert isinstance(checkpoint.get_config(mode="dict"), dict)
-    checkpoint_config: dict = checkpoint.get_config(mode="json_dict", clean_nulls=False)
+    assert isinstance(checkpoint.get_config(mode=ConfigOutputModes.DICT), dict)
+    checkpoint_config: dict = checkpoint.get_config(
+        mode=ConfigOutputModes.JSON_DICT, clean_nulls=False
+    )
     assert checkpoint_config == {
         "action_list": [
             {
@@ -944,7 +947,7 @@ def test_simple_checkpoint_defaults_run_multiple_validations_with_persisted_chec
 
     # persist to store
     checkpoint_class_args: dict = simple_checkpoint_defaults.get_config(
-        mode="json_dict"
+        mode=ConfigOutputModes.JSON_DICT
     )
     context.add_checkpoint(**checkpoint_class_args)
     checkpoint_name = simple_checkpoint_defaults.name
@@ -982,7 +985,7 @@ def test_simple_checkpoint_with_runtime_batch_request_and_runtime_data_connector
     checkpoint: SimpleCheckpoint = SimpleCheckpoint(
         name="my_checkpoint", data_context=context, batch_request=runtime_batch_request
     )
-    checkpoint_config: dict = checkpoint.get_config(mode="json_dict")
+    checkpoint_config: dict = checkpoint.get_config(mode=ConfigOutputModes.JSON_DICT)
 
     assert isinstance(checkpoint_config, dict)
     assert checkpoint_config["name"] == "my_checkpoint"

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -416,7 +416,7 @@ def test_simple_checkpoint_persisted_to_store(
     )
     assert isinstance(checkpoint, Checkpoint)
     assert isinstance(checkpoint.get_config(mode="dict"), dict)
-    checkpoint_config: dict = checkpoint.get_config(mode="json_dict")
+    checkpoint_config: dict = checkpoint.get_config(mode="json_dict", clean_nulls=False)
     assert checkpoint_config == {
         "action_list": [
             {

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -12,6 +12,7 @@ import great_expectations.exceptions as ge_exceptions
 from great_expectations.checkpoint import Checkpoint
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
 from great_expectations.core import ExpectationConfiguration, expectationSuiteSchema
+from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_context import (
@@ -1432,7 +1433,7 @@ def test_get_checkpoint(empty_context_with_checkpoint):
     context = empty_context_with_checkpoint
     obs = context.get_checkpoint("my_checkpoint")
     assert isinstance(obs, Checkpoint)
-    config = obs.get_config(mode="json_dict")
+    config = obs.get_config(mode=ConfigOutputModes.JSON_DICT)
     assert isinstance(config, dict)
     assert config == {
         "name": "my_checkpoint",
@@ -1893,9 +1894,12 @@ expectation_suite_ge_cloud_id:
         checkpoint_from_disk = cf.read()
 
     assert checkpoint_from_disk == expected_checkpoint_yaml
-    assert checkpoint_from_yaml.get_config(mode="yaml") == expected_checkpoint_yaml
+    assert (
+        checkpoint_from_yaml.get_config(mode=ConfigOutputModes.YAML)
+        == expected_checkpoint_yaml
+    )
     assert deep_filter_properties_iterable(
-        properties=checkpoint_from_yaml.get_config(mode="dict"),
+        properties=checkpoint_from_yaml.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == deep_filter_properties_iterable(
         properties=dict(yaml.load(expected_checkpoint_yaml)),
@@ -1903,9 +1907,12 @@ expectation_suite_ge_cloud_id:
     )
 
     checkpoint_from_store = context.get_checkpoint(name=checkpoint_name)
-    assert checkpoint_from_store.get_config(mode="yaml") == expected_checkpoint_yaml
+    assert (
+        checkpoint_from_store.get_config(mode=ConfigOutputModes.YAML)
+        == expected_checkpoint_yaml
+    )
     assert deep_filter_properties_iterable(
-        properties=checkpoint_from_store.get_config(mode="dict"),
+        properties=checkpoint_from_store.get_config(mode=ConfigOutputModes.DICT),
         clean_falsy=True,
     ) == deep_filter_properties_iterable(
         properties=dict(yaml.load(expected_checkpoint_yaml)),
@@ -1938,7 +1945,9 @@ expectation_suite_ge_cloud_id:
     )
 
     assert checkpoint_from_yaml.name == checkpoint_name
-    assert checkpoint_from_yaml.get_config(mode="json_dict", clean_falsy=True) == {
+    assert checkpoint_from_yaml.get_config(
+        mode=ConfigOutputModes.JSON_DICT, clean_falsy=True
+    ) == {
         "name": "my_new_checkpoint",
         "config_version": 1.0,
         "class_name": "Checkpoint",

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1436,7 +1436,6 @@ def test_get_checkpoint(empty_context_with_checkpoint):
     assert isinstance(config, dict)
     assert config == {
         "name": "my_checkpoint",
-        "config_version": None,
         "class_name": "LegacyCheckpoint",
         "module_name": "great_expectations.checkpoint",
         "batches": [

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -8,6 +8,7 @@ from ruamel.yaml import YAML
 from great_expectations import DataContext
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import Batch, RuntimeBatchRequest
+from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
@@ -171,16 +172,16 @@ def test_get_config(empty_data_context):
 
     # We can call get_config in several different modes
     assert type(context.get_config()) == DataContextConfig
-    assert type(context.get_config(mode="typed")) == DataContextConfig
-    assert type(context.get_config(mode="dict")) == dict
-    assert type(context.get_config(mode="yaml")) == str
+    assert type(context.get_config(mode=ConfigOutputModes.TYPED)) == DataContextConfig
+    assert type(context.get_config(mode=ConfigOutputModes.DICT)) == dict
+    assert type(context.get_config(mode=ConfigOutputModes.YAML)) == str
     with pytest.raises(ValueError):
         context.get_config(mode="foobar")
 
-    print(context.get_config(mode="yaml"))
-    print(context.get_config(mode="dict").keys())
+    print(context.get_config(mode=ConfigOutputModes.YAML))
+    print(context.get_config(mode=ConfigOutputModes.DICT).keys())
 
-    assert set(context.get_config(mode="dict").keys()) == {
+    assert set(context.get_config(mode=ConfigOutputModes.DICT).keys()) == {
         "config_version",
         "datasources",
         "config_variables_file_path",
@@ -460,7 +461,7 @@ def test_in_memory_data_context_configuration(
     titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled,
 ):
     project_config_dict: dict = titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled.get_config(
-        mode="dict"
+        mode=ConfigOutputModes.DICT
     )
     project_config_dict["plugins_directory"] = None
     project_config_dict["validation_operators"] = {

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -175,6 +175,7 @@ def test_get_config(empty_data_context):
     assert type(context.get_config(mode=ConfigOutputModes.TYPED)) == DataContextConfig
     assert type(context.get_config(mode=ConfigOutputModes.DICT)) == dict
     assert type(context.get_config(mode=ConfigOutputModes.YAML)) == str
+    assert type(context.get_config(mode="yaml")) == str
     with pytest.raises(ValueError):
         context.get_config(mode="foobar")
 

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -9,7 +9,10 @@ from great_expectations import DataContext
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import Batch, RuntimeBatchRequest
 from great_expectations.data_context import BaseDataContext
-from great_expectations.data_context.types.base import DataContextConfig
+from great_expectations.data_context.types.base import (
+    DataContextConfig,
+    dataContextConfigSchema,
+)
 from great_expectations.exceptions import ExecutionEngineError
 from great_expectations.execution_engine.pandas_batch_data import PandasBatchData
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
@@ -175,9 +178,9 @@ def test_get_config(empty_data_context):
         context.get_config(mode="foobar")
 
     print(context.get_config(mode="yaml"))
-    print(context.get_config("dict").keys())
+    print(context.get_config(mode="dict").keys())
 
-    assert set(context.get_config("dict").keys()) == {
+    assert set(context.get_config(mode="dict").keys()) == {
         "config_version",
         "datasources",
         "config_variables_file_path",
@@ -189,7 +192,6 @@ def test_get_config(empty_data_context):
         "checkpoint_store_name",
         "data_docs_sites",
         "anonymous_usage_statistics",
-        "notebooks",
     }
 
 
@@ -480,6 +482,11 @@ def test_in_memory_data_context_configuration(
             ],
         }
     }
+
+    # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
+    project_config_dict = dataContextConfigSchema.dump(project_config_dict)
+    project_config_dict = dataContextConfigSchema.load(project_config_dict)
+
     project_config: DataContextConfig = DataContextConfig(**project_config_dict)
     data_context = BaseDataContext(
         project_config=project_config,


### PR DESCRIPTION
### Scope
* Introduce `ConfigPeer` abstract base class, which declares the `config` return property as the interface and provides a general `get_config()` method to be used by subclasses.
* Utilizes an `Enum` containing the available configuration output modes (which works generically with the `str` equivalents when passed to the `get_config()` method as the mode.
* Extended the mechanism to all YAML-Configurable objects: `BaseDataContext`, `BaseCheckpoint`, and `BaseRuleBasedProfiler`.
* Updated unit tests throughout.

### Future Work
When -- as part of a potential future architecture update -- serialization is decoupled from configuration, the
configuration objects, persitable as YAML files, will no longer inherit from the BaseYamlConfig class.  Rather,
any form of serialization (YAML, JSON, SQL Database Tables, Pickle, etc.) will apply as peers, independent of the
configuration classes themselves.  Hence, as part of this change, ConfigPeer will cease being the superclass of
business objects (such as BaseDataContext, BaseCheckpoint, and BaseRuleBasedProfiler).  Instead, every persitable
business object will contain a reference to its corresponding peer class, supporting the ConfigPeer interfaces.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-564
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/en/latest/contributing/testing.html#contributing-testing-writing-unit-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
