### PR TITLE
[MAINTENANCE] Refactor relative imports

### DIFF
--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -5,6 +5,11 @@ import tempfile
 from mimetypes import guess_type
 from zipfile import ZipFile, is_zipfile
 
+from great_expectations.core.data_context_key import DataContextKey
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudStoreBackend,
+)
+from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     SiteSectionIdentifier,
@@ -20,10 +25,6 @@ from great_expectations.util import (
     filter_properties_dict,
     verify_dynamic_loading_support,
 )
-
-from ...core.data_context_key import DataContextKey
-from .ge_cloud_store_backend import GeCloudStoreBackend
-from .tuple_store_backend import TupleStoreBackend
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -16,13 +16,12 @@ from scipy import stats
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import DocInherit, parse_result_format
+from great_expectations.dataset.dataset import Dataset
 from great_expectations.dataset.util import (
     _scipy_distribution_positional_args_from_dict,
     is_valid_continuous_partition_object,
     validate_distribution_parameters,
 )
-
-from .dataset import Dataset
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -15,8 +15,9 @@ from dateutil.parser import parse
 
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import DocInherit, parse_result_format
-from great_expectations.dataset import Dataset
-from great_expectations.dataset.pandas_dataset import PandasDataset
+
+from .dataset import Dataset
+from .pandas_dataset import PandasDataset
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -15,9 +15,8 @@ from dateutil.parser import parse
 
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import DocInherit, parse_result_format
-
-from .dataset import Dataset
-from .pandas_dataset import PandasDataset
+from great_expectations.dataset import Dataset
+from great_expectations.dataset.pandas_dataset import PandasDataset
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -15,9 +15,8 @@ from dateutil.parser import parse
 
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import DocInherit, parse_result_format
-
-from .dataset import Dataset
-from .pandas_dataset import PandasDataset
+from great_expectations.dataset.dataset import Dataset
+from great_expectations.dataset.pandas_dataset import PandasDataset
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -17,6 +17,8 @@ from great_expectations.core.util import (
 )
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import DocInherit, parse_result_format
+from great_expectations.dataset.dataset import Dataset
+from great_expectations.dataset.pandas_dataset import PandasDataset
 from great_expectations.dataset.util import (
     check_sql_engine_dialect,
     get_approximate_percentile_disc_sql,
@@ -26,9 +28,6 @@ from great_expectations.util import (
     get_sqlalchemy_inspector,
     import_library_module,
 )
-
-from .dataset import Dataset
-from .pandas_dataset import PandasDataset
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/datasource/batch_kwargs_generator/query_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/query_batch_kwargs_generator.py
@@ -2,11 +2,12 @@ import logging
 import os
 import warnings
 
+from great_expectations.data_context.util import instantiate_class_from_config
+from great_expectations.datasource.batch_kwargs_generator.batch_kwargs_generator import (
+    BatchKwargsGenerator,
+)
 from great_expectations.datasource.types import SqlAlchemyDatasourceQueryBatchKwargs
 from great_expectations.exceptions import BatchKwargsError, ClassInstantiationError
-
-from ...data_context.util import instantiate_class_from_config
-from .batch_kwargs_generator import BatchKwargsGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/datasource/batch_kwargs_generator/table_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/table_batch_kwargs_generator.py
@@ -2,6 +2,9 @@ import logging
 import warnings
 from string import Template
 
+from great_expectations.datasource.batch_kwargs_generator.batch_kwargs_generator import (
+    BatchKwargsGenerator,
+)
 from great_expectations.datasource.types import SqlAlchemyDatasourceTableBatchKwargs
 from great_expectations.exceptions import BatchKwargsError, GreatExpectationsError
 from great_expectations.marshmallow__shade import (
@@ -10,8 +13,6 @@ from great_expectations.marshmallow__shade import (
     fields,
     post_load,
 )
-
-from .batch_kwargs_generator import BatchKwargsGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -9,13 +9,14 @@ from io import BytesIO
 import pandas as pd
 
 from great_expectations.core.batch import Batch, BatchMarkers
+from great_expectations.core.util import S3Url
+from great_expectations.datasource.datasource import LegacyDatasource
 from great_expectations.exceptions import BatchKwargsError
+from great_expectations.execution_engine.pandas_execution_engine import (
+    hash_pandas_dataframe,
+)
 from great_expectations.types import ClassConfig
-
-from ..core.util import S3Url
-from ..execution_engine.pandas_execution_engine import hash_pandas_dataframe
-from ..types.configurations import classConfigSchema
-from .datasource import LegacyDatasource
+from great_expectations.types.configurations import classConfigSchema
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/datasource/sparkdf_datasource.py
+++ b/great_expectations/datasource/sparkdf_datasource.py
@@ -3,14 +3,13 @@ import logging
 import uuid
 import warnings
 
+from great_expectations.core.batch import Batch, BatchMarkers
+from great_expectations.core.util import get_or_create_spark_application
+from great_expectations.dataset import SparkDFDataset
+from great_expectations.datasource.datasource import LegacyDatasource
+from great_expectations.exceptions import BatchKwargsError
 from great_expectations.types import ClassConfig
-
-from ..core.batch import Batch, BatchMarkers
-from ..core.util import get_or_create_spark_application
-from ..dataset import SparkDFDataset
-from ..exceptions import BatchKwargsError
-from ..types.configurations import classConfigSchema
-from .datasource import LegacyDatasource
+from great_expectations.types.configurations import classConfigSchema
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -18,19 +18,18 @@ from great_expectations.core.batch_spec import (
 )
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.util import AzureUrl, get_or_create_spark_application
-from great_expectations.exceptions import exceptions as ge_exceptions
-from great_expectations.execution_engine import ExecutionEngine
-from great_expectations.execution_engine.execution_engine import MetricDomainTypes
-from great_expectations.validator.metric_configuration import MetricConfiguration
-
-from ..exceptions import (
+from great_expectations.exceptions import (
     BatchSpecError,
     ExecutionEngineError,
     GreatExpectationsError,
     ValidationError,
 )
-from ..expectations.row_conditions import parse_condition_to_spark
-from .sparkdf_batch_data import SparkDFBatchData
+from great_expectations.exceptions import exceptions as ge_exceptions
+from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.execution_engine.execution_engine import MetricDomainTypes
+from great_expectations.execution_engine.sparkdf_batch_data import SparkDFBatchData
+from great_expectations.expectations.row_conditions import parse_condition_to_spark
+from great_expectations.validator.metric_configuration import MetricConfiguration
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -5,19 +5,24 @@ import pandas as pd
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    ColumnExpectation,
+    InvalidExpectationConfigurationError,
+)
+from great_expectations.expectations.metrics.util import parse_value_set
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedGraphContent, RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import (
+    RenderedGraphContent,
+    RenderedStringTemplateContent,
+)
+from great_expectations.render.util import (
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
-from ..metrics.util import parse_value_set
 
 
 class ExpectColumnDistinctValuesToBeInSet(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -5,19 +5,21 @@ import pandas as pd
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    ColumnExpectation,
+    InvalidExpectationConfigurationError,
+)
+from great_expectations.expectations.metrics.util import parse_value_set
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
-from ..metrics.util import parse_value_set
 
 
 class ExpectColumnDistinctValuesToContainSet(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -2,19 +2,21 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    ColumnExpectation,
+    InvalidExpectationConfigurationError,
+)
+from great_expectations.expectations.metrics.util import parse_value_set
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
-from ..metrics.util import parse_value_set
 
 
 class ExpectColumnDistinctValuesToEqualSet(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -3,9 +3,8 @@ from typing import Dict, Optional
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
@@ -17,8 +16,8 @@ except ImportError:
     pass
 
 
-from ...render.renderer.renderer import renderer
-from ..expectation import ColumnExpectation
+from great_expectations.expectations.expectation import ColumnExpectation
+from great_expectations.render.renderer.renderer import renderer
 
 
 class ExpectColumnMaxToBeBetween(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -2,16 +2,15 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation
 
 
 class ExpectColumnMeanToBeBetween(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -2,16 +2,15 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation
 
 
 class ExpectColumnMedianToBeBetween(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -2,16 +2,15 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation
 
 
 class ExpectColumnMinToBeBetween(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -2,18 +2,20 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    ColumnExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnMostCommonValueToBeInSet(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
@@ -1,16 +1,18 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnPairMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnPairMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnPairValuesAToBeGreaterThanB(ColumnPairMapExpectation):

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -2,14 +2,14 @@ from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
+
 from ..expectation import ColumnPairMapExpectation, InvalidExpectationConfigurationError
 
 

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -2,14 +2,14 @@ from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.expectations.util import render_evaluation_parameter_string
-from great_expectations.render.renderer import renderer
-from great_expectations.render.types import RenderedStringTemplateContent
-from great_expectations.render.util import (
+
+from ...render.renderer.renderer import renderer
+from ...render.types import RenderedStringTemplateContent
+from ...render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-
 from ..expectation import ColumnPairMapExpectation, InvalidExpectationConfigurationError
 
 

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -1,16 +1,18 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnPairMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnPairMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnPairValuesToBeEqual(ColumnPairMapExpectation):

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
@@ -1,8 +1,10 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
-
-from ..expectation import ColumnPairMapExpectation, InvalidExpectationConfigurationError
+from great_expectations.expectations.expectation import (
+    ColumnPairMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 
 
 class ExpectColumnPairValuesToBeInSet(ColumnPairMapExpectation):

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -2,16 +2,15 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation
 
 
 class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -2,16 +2,15 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation
 
 
 class ExpectColumnSumToBeBetween(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -2,12 +2,14 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    InvalidExpectationConfigurationError,
+    TableExpectation,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import ordinal, substitute_none_for_missing
-from ..expectation import InvalidExpectationConfigurationError, TableExpectation
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import ordinal, substitute_none_for_missing
 
 
 class ExpectColumnToExist(TableExpectation):

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -2,17 +2,16 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnExpectation
 
 
 class ExpectColumnUniqueValueCountToBeBetween(ColumnExpectation):

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -1,23 +1,22 @@
 from typing import Any, List, Optional, Union
 
+from great_expectations.core import ExpectationValidationResult
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
-
-from ...core import ExpectationValidationResult
-from ...exceptions import InvalidExpectationConfigurationError
-from ...render.renderer.renderer import renderer
-from ...render.types import (
+from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.expectations.expectation import ColumnMapExpectation
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import (
     RenderedBulletListContent,
     RenderedGraphContent,
     RenderedStringTemplateContent,
     RenderedTableContent,
 )
-from ...render.util import (
+from great_expectations.render.util import (
     handle_strict_min_max,
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation
 
 try:
     import sqlalchemy as sa

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
@@ -1,16 +1,18 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnValueLengthsToEqual(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -1,8 +1,10 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
-
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 
 
 class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -1,10 +1,8 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
-from great_expectations.expectations.expectation import (
-    ColumnMapExpectation,
-    InvalidExpectationConfigurationError,
-)
+
+from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -1,17 +1,16 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import ColumnMapExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation
 
 
 class ExpectColumnValuesToBeBetween(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
@@ -1,16 +1,15 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import ColumnMapExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation
 
 
 class ExpectColumnValuesToBeDateutilParseable(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
@@ -1,16 +1,15 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import ColumnMapExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation
 
 
 class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -1,19 +1,21 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
-
-from ...render.renderer.renderer import renderer
-from ...render.types import (
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import (
     RenderedBulletListContent,
     RenderedStringTemplateContent,
     ValueListContent,
 )
-from ...render.util import (
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 try:
     import sqlalchemy as sa

--- a/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
@@ -2,16 +2,15 @@ import logging
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import ColumnMapExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
@@ -1,16 +1,15 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import ColumnMapExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation
 
 try:
     import sqlalchemy as sa

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -1,16 +1,18 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 try:
     import sqlalchemy as sa

--- a/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
@@ -2,16 +2,15 @@ import json
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import ColumnMapExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation
 
 try:
     import sqlalchemy as sa

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.util import substitute_none_for_missing
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.util import substitute_none_for_missing
 
 try:
     import sqlalchemy as sa

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.util import substitute_none_for_missing
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -1,16 +1,18 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -1,19 +1,21 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
@@ -2,16 +2,18 @@ from datetime import datetime
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnValuesToMatchStrftimeFormat(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -5,19 +5,21 @@ import pandas as pd
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import PandasExecutionEngine
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.util import substitute_none_for_missing
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.util import substitute_none_for_missing
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -1,16 +1,18 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 try:
     import sqlalchemy as sa

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -1,19 +1,21 @@
 from typing import Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    InvalidExpectationConfigurationError,
+)
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     num_to_str,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
 
 
 class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -2,12 +2,14 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import TableExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import handle_strict_min_max, substitute_none_for_missing
-from ..expectation import TableExpectation
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
+    handle_strict_min_max,
+    substitute_none_for_missing,
+)
 
 
 class ExpectTableColumnCountToBeBetween(TableExpectation):

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -2,12 +2,14 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    InvalidExpectationConfigurationError,
+    TableExpectation,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import substitute_none_for_missing
-from ..expectation import InvalidExpectationConfigurationError, TableExpectation
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectTableColumnCountToEqual(TableExpectation):

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -3,15 +3,17 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    InvalidExpectationConfigurationError,
+    TableExpectation,
+)
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import substitute_none_for_missing
-from ..expectation import InvalidExpectationConfigurationError, TableExpectation
+from great_expectations.render.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectTableColumnsToMatchOrderedList(TableExpectation):

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -3,17 +3,15 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
-from great_expectations.expectations.expectation import (
-    InvalidExpectationConfigurationError,
-    TableExpectation,
-)
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-from great_expectations.render.renderer import renderer
-from great_expectations.render.types import RenderedStringTemplateContent
-from great_expectations.render.util import substitute_none_for_missing
+
+from ...render.renderer.renderer import renderer
+from ...render.types import RenderedStringTemplateContent
+from ...render.util import substitute_none_for_missing
+from ..expectation import InvalidExpectationConfigurationError, TableExpectation
 
 
 class ExpectTableColumnsToMatchOrderedList(TableExpectation):

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -3,15 +3,17 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    InvalidExpectationConfigurationError,
+    TableExpectation,
+)
 from great_expectations.expectations.util import (
     add_values_with_json_schema_from_list_in_params,
     render_evaluation_parameter_string,
 )
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import substitute_none_for_missing
-from ..expectation import InvalidExpectationConfigurationError, TableExpectation
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectTableColumnsToMatchOrderedList(TableExpectation):

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -2,16 +2,15 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import TableExpectation
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     handle_strict_min_max,
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import TableExpectation
 
 
 class ExpectTableRowCountToBeBetween(TableExpectation):

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -2,15 +2,17 @@ from typing import Dict, Optional
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.expectations.expectation import (
+    InvalidExpectationConfigurationError,
+    TableExpectation,
+)
 from great_expectations.expectations.util import render_evaluation_parameter_string
-
-from ...render.renderer.renderer import renderer
-from ...render.types import RenderedStringTemplateContent
-from ...render.util import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
-from ..expectation import InvalidExpectationConfigurationError, TableExpectation
 
 
 class ExpectTableRowCountToEqual(TableExpectation):

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -20,11 +20,14 @@ from great_expectations.core.expectation_configuration import (
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
+from great_expectations.core.util import nested_update
 from great_expectations.exceptions import (
     GreatExpectationsError,
     InvalidExpectationConfigurationError,
     InvalidExpectationKwargsError,
 )
+from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
+from great_expectations.execution_engine.execution_engine import MetricDomainTypes
 from great_expectations.expectations.registry import (
     _registered_metrics,
     _registered_renderers,
@@ -33,26 +36,22 @@ from great_expectations.expectations.registry import (
     register_renderer,
 )
 from great_expectations.expectations.util import render_evaluation_parameter_string
-from great_expectations.self_check.util import (
-    evaluate_json_test_cfe,
-    generate_expectation_tests,
-)
-from great_expectations.validator.metric_configuration import MetricConfiguration
-from great_expectations.validator.validator import Validator
-
-from ..core.util import nested_update
-from ..execution_engine import ExecutionEngine, PandasExecutionEngine
-from ..execution_engine.execution_engine import MetricDomainTypes
-from ..render.renderer.renderer import renderer
-from ..render.types import (
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import (
     CollapseContent,
     RenderedAtomicContent,
     RenderedStringTemplateContent,
     RenderedTableContent,
     renderedAtomicValueSchema,
 )
-from ..render.util import num_to_str
-from ..util import is_parseable_date
+from great_expectations.render.util import num_to_str
+from great_expectations.self_check.util import (
+    evaluate_json_test_cfe,
+    generate_expectation_tests,
+)
+from great_expectations.util import is_parseable_date
+from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.validator import Validator
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/expectations/metrics/column_aggregate_metric.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metric.py
@@ -1,7 +1,7 @@
 import warnings
 
 # noinspection PyUnresolvedReferences
-from .column_aggregate_metric_provider import *
+from great_expectations.expectations.metrics.column_aggregate_metric_provider import *
 
 warnings.warn(
     f"""The module "{__name__}" has been renamed to "{__name__}_provider" -- the alias "{__name__}" will be deprecated \

--- a/great_expectations/expectations/metrics/map_metric.py
+++ b/great_expectations/expectations/metrics/map_metric.py
@@ -1,7 +1,7 @@
 import warnings
 
 # noinspection PyUnresolvedReferences
-from .map_metric_provider import *
+from great_expectations.expectations.metrics.map_metric_provider import *
 
 warnings.warn(
     f"""The module "{__name__}" has been renamed to "{__name__}_provider" -- the alias "{__name__}" will be deprecated \

--- a/great_expectations/expectations/metrics/table_metric.py
+++ b/great_expectations/expectations/metrics/table_metric.py
@@ -1,7 +1,7 @@
 import warnings
 
 # noinspection PyUnresolvedReferences
-from .table_metric_provider import *
+from great_expectations.expectations.metrics.table_metric_provider import *
 
 warnings.warn(
     f"""The module "{__name__}" has been renamed to "{__name__}_provider" -- the alias "{__name__}" will be deprecated \

--- a/great_expectations/profile/columns_exist.py
+++ b/great_expectations/profile/columns_exist.py
@@ -1,7 +1,7 @@
 import warnings
 
-from ..dataset.util import create_multiple_expectations
-from .base import DatasetProfiler
+from great_expectations.dataset.util import create_multiple_expectations
+from great_expectations.profile.base import DatasetProfiler
 
 
 # This particular file should be immune to the new changes

--- a/great_expectations/render/exceptions.py
+++ b/great_expectations/render/exceptions.py
@@ -1,4 +1,4 @@
-from ..exceptions import GreatExpectationsTypeError
+from great_expectations.exceptions import GreatExpectationsTypeError
 
 
 class InvalidRenderedContentError(GreatExpectationsTypeError):

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -10,14 +10,13 @@ from great_expectations.expectations.registry import (
     _registered_renderers,
     get_renderer_impl,
 )
+from great_expectations.render.renderer.renderer import Renderer
 from great_expectations.render.types import (
     CollapseContent,
     RenderedMarkdownContent,
     RenderedStringTemplateContent,
     TextContent,
 )
-
-from ..renderer import Renderer
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/render/renderer/content_block/exception_list_content_block.py
+++ b/great_expectations/render/renderer/content_block/exception_list_content_block.py
@@ -1,9 +1,10 @@
+from great_expectations.render.renderer.content_block.content_block import (
+    ContentBlockRenderer,
+)
 from great_expectations.render.types import (
     RenderedBulletListContent,
     RenderedStringTemplateContent,
 )
-
-from .content_block import ContentBlockRenderer
 
 
 class ExceptionListContentBlockRenderer(ContentBlockRenderer):

--- a/great_expectations/render/renderer/content_block/profiling_column_properties_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/profiling_column_properties_table_content_block.py
@@ -1,10 +1,11 @@
 from great_expectations.expectations.registry import get_renderer_impl
+from great_expectations.render.renderer.content_block.content_block import (
+    ContentBlockRenderer,
+)
 from great_expectations.render.types import (
     RenderedStringTemplateContent,
     RenderedTableContent,
 )
-
-from .content_block import ContentBlockRenderer
 
 
 class ProfilingColumnPropertiesTableContentBlockRenderer(ContentBlockRenderer):

--- a/great_expectations/render/renderer/email_renderer.py
+++ b/great_expectations/render/renderer/email_renderer.py
@@ -3,8 +3,8 @@ import textwrap
 
 logger = logging.getLogger(__name__)
 
-from ...core.id_dict import BatchKwargs
-from .renderer import Renderer
+from great_expectations.core.id_dict import BatchKwargs
+from great_expectations.render.renderer.renderer import Renderer
 
 
 class EmailRenderer(Renderer):

--- a/great_expectations/render/renderer/microsoft_teams_renderer.py
+++ b/great_expectations/render/renderer/microsoft_teams_renderer.py
@@ -1,11 +1,11 @@
 import logging
 
-from ...core import RunIdentifier
-from ...data_context.types.resource_identifiers import BatchIdentifier
+from great_expectations.core import RunIdentifier
+from great_expectations.data_context.types.resource_identifiers import BatchIdentifier
 
 logger = logging.getLogger(__name__)
 
-from .renderer import Renderer
+from great_expectations.render.renderer.renderer import Renderer
 
 
 class MicrosoftTeamsRenderer(Renderer):

--- a/great_expectations/render/renderer/opsgenie_renderer.py
+++ b/great_expectations/render/renderer/opsgenie_renderer.py
@@ -2,8 +2,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from ...core.id_dict import BatchKwargs
-from .renderer import Renderer
+from great_expectations.core.id_dict import BatchKwargs
+from great_expectations.render.renderer.renderer import Renderer
 
 
 class OpsgenieRenderer(Renderer):

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -5,17 +5,15 @@ from typing import Dict, List, Tuple, Union
 
 from dateutil.parser import parse
 
+from great_expectations.core import ExpectationSuite
+from great_expectations.core.expectation_validation_result import (
+    ExpectationSuiteValidationResult,
+)
+from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.exceptions import ClassInstantiationError
-from great_expectations.render.util import num_to_str
-
-from ...core import ExpectationSuite
-from ...core.expectation_validation_result import ExpectationSuiteValidationResult
-from ...core.run_identifier import RunIdentifier
-from ...validation_operators.types.validation_operator_result import (
-    ValidationOperatorResult,
-)
-from ..types import (
+from great_expectations.render.renderer.renderer import Renderer
+from great_expectations.render.types import (
     CollapseContent,
     RenderedComponentContent,
     RenderedDocumentContent,
@@ -26,7 +24,10 @@ from ..types import (
     RenderedTableContent,
     TextContent,
 )
-from .renderer import Renderer
+from great_expectations.render.util import num_to_str
+from great_expectations.validation_operators.types.validation_operator_result import (
+    ValidationOperatorResult,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/render/renderer/profiling_results_overview_section_renderer.py
+++ b/great_expectations/render/renderer/profiling_results_overview_section_renderer.py
@@ -2,6 +2,7 @@ import warnings
 from collections import Counter, defaultdict
 
 from great_expectations.profile.base import ProfilerTypeMapping
+from great_expectations.render.renderer.renderer import Renderer
 from great_expectations.render.types import (
     CollapseContent,
     RenderedBulletListContent,
@@ -10,8 +11,6 @@ from great_expectations.render.types import (
     RenderedStringTemplateContent,
     RenderedTableContent,
 )
-
-from .renderer import Renderer
 
 
 class ProfilingResultsOverviewSectionRenderer(Renderer):

--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -6,6 +6,10 @@ import traceback
 import tzlocal
 from dateutil.parser import parse
 
+from great_expectations.render.renderer.call_to_action_renderer import (
+    CallToActionRenderer,
+)
+from great_expectations.render.renderer.renderer import Renderer
 from great_expectations.render.types import (
     RenderedBootstrapTableContent,
     RenderedDocumentContent,
@@ -14,9 +18,6 @@ from great_expectations.render.types import (
     RenderedStringTemplateContent,
     RenderedTabsContent,
 )
-
-from .call_to_action_renderer import CallToActionRenderer
-from .renderer import Renderer
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -2,8 +2,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from ...core.id_dict import BatchKwargs
-from .renderer import Renderer
+from great_expectations.core.id_dict import BatchKwargs
+from great_expectations.render.renderer.renderer import Renderer
 
 
 class SlackRenderer(Renderer):

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -9,6 +9,7 @@ import great_expectations.exceptions as ge_exceptions
 from great_expectations.checkpoint.util import send_slack_notification
 from great_expectations.core.async_executor import AsyncExecutor
 from great_expectations.core.batch import Batch
+from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import parse_result_format
 from great_expectations.data_context.types.resource_identifiers import (
@@ -20,8 +21,6 @@ from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.validation_operators.types.validation_operator_result import (
     ValidationOperatorResult,
 )
-
-from ..core.run_identifier import RunIdentifier
 
 logger = logging.getLogger(__name__)
 

--- a/temp
+++ b/temp
@@ -1,0 +1,207 @@
+great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py:from ...core import ExpectationValidationResult
+great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py:from ...exceptions import InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py:from ...render.types import (
+great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py:from ..expectation import ColumnMapExpectation
+great_expectations/expectations/core/expect_column_min_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_min_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_min_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_min_to_be_between.py:from ..expectation import ColumnExpectation
+great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py:from ...render.util import substitute_none_for_missing
+great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_table_column_count_to_equal.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_table_column_count_to_equal.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_table_column_count_to_equal.py:from ...render.util import substitute_none_for_missing
+great_expectations/expectations/core/expect_table_column_count_to_equal.py:from ..expectation import InvalidExpectationConfigurationError, TableExpectation
+great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py:from ...render.util import substitute_none_for_missing
+great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py:from ...render.util import substitute_none_for_missing
+great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_value_lengths_to_equal.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_value_lengths_to_equal.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_value_lengths_to_equal.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_value_lengths_to_equal.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py:from ..expectation import ColumnMapExpectation
+great_expectations/expectations/core/expect_column_values_to_match_regex.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_match_regex.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_match_regex.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_match_regex.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_sum_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_sum_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_sum_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_sum_to_be_between.py:from ..expectation import ColumnExpectation
+great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py:from ..expectation import ColumnExpectation
+great_expectations/expectations/core/expect_column_values_to_be_in_set.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_be_in_set.py:from ...render.types import (
+great_expectations/expectations/core/expect_column_values_to_be_in_set.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_be_in_set.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_median_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_median_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_median_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_median_to_be_between.py:from ..expectation import ColumnExpectation
+great_expectations/expectations/core/expect_table_column_count_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_table_column_count_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_table_column_count_to_be_between.py:from ...render.util import handle_strict_min_max, substitute_none_for_missing
+great_expectations/expectations/core/expect_table_column_count_to_be_between.py:from ..expectation import TableExpectation
+great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py:from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_values_to_match_regex_list.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_match_regex_list.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_match_regex_list.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_match_regex_list.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_max_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_max_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_max_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_max_to_be_between.py:from ..expectation import ColumnExpectation
+great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py:from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py:from ..metrics.util import parse_value_set
+great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_values_to_match_json_schema.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_match_json_schema.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_match_json_schema.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_match_json_schema.py:from ..expectation import ColumnMapExpectation
+great_expectations/expectations/core/expect_column_values_to_be_decreasing.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_be_decreasing.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_be_decreasing.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_be_decreasing.py:from ..expectation import ColumnMapExpectation
+great_expectations/expectations/core/expect_table_row_count_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_table_row_count_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_table_row_count_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_table_row_count_to_be_between.py:from ..expectation import TableExpectation
+great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py:from ...render.util import substitute_none_for_missing
+great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py:from ...render.types import RenderedGraphContent, RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py:from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py:from ..metrics.util import parse_value_set
+great_expectations/expectations/core/expect_column_to_exist.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_to_exist.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_to_exist.py:from ...render.util import ordinal, substitute_none_for_missing
+great_expectations/expectations/core/expect_column_to_exist.py:from ..expectation import InvalidExpectationConfigurationError, TableExpectation
+great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py:from ..expectation import ColumnMapExpectation
+great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py:from ..expectation import ColumnPairMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py:from ..expectation import ColumnExpectation
+great_expectations/expectations/core/expect_column_values_to_be_increasing.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_be_increasing.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_be_increasing.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_be_increasing.py:from ..expectation import ColumnMapExpectation
+great_expectations/expectations/core/expect_column_values_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_be_between.py:from ..expectation import ColumnMapExpectation
+great_expectations/expectations/core/expect_table_row_count_to_equal.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_table_row_count_to_equal.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_table_row_count_to_equal.py:from ...render.util import (
+great_expectations/expectations/core/expect_table_row_count_to_equal.py:from ..expectation import InvalidExpectationConfigurationError, TableExpectation
+great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py:from ..expectation import ColumnPairMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py:from ..expectation import ColumnExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py:from ..metrics.util import parse_value_set
+great_expectations/expectations/core/expect_column_values_to_not_match_regex.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_not_match_regex.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_not_match_regex.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_not_match_regex.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_mean_to_be_between.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_mean_to_be_between.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_mean_to_be_between.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_mean_to_be_between.py:from ..expectation import ColumnExpectation
+great_expectations/expectations/core/expect_column_values_to_be_unique.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_be_unique.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_be_unique.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_be_unique.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py:from ...render.renderer.renderer import renderer
+great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py:from ...render.types import RenderedStringTemplateContent
+great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py:from ...render.util import (
+great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py:from ..expectation import ColumnMapExpectation, InvalidExpectationConfigurationError
+great_expectations/data_context/store/html_site_store.py:from ...core.data_context_key import DataContextKey
+great_expectations/data_context/store/html_site_store.py:from .ge_cloud_store_backend import GeCloudStoreBackend
+great_expectations/data_context/store/html_site_store.py:from .tuple_store_backend import TupleStoreBackend
+great_expectations/validation_operators/validation_operators.py:from ..core.run_identifier import RunIdentifier
+great_expectations/expectations/expectation.py:from ..core.util import nested_update
+great_expectations/expectations/expectation.py:from ..execution_engine import ExecutionEngine, PandasExecutionEngine
+great_expectations/expectations/expectation.py:from ..execution_engine.execution_engine import MetricDomainTypes
+great_expectations/expectations/expectation.py:from ..render.renderer.renderer import renderer
+great_expectations/expectations/expectation.py:from ..render.types import (
+great_expectations/expectations/expectation.py:from ..render.util import num_to_str
+great_expectations/expectations/expectation.py:from ..util import is_parseable_date
+great_expectations/expectations/metrics/column_aggregate_metric.py:from .column_aggregate_metric_provider import *
+great_expectations/expectations/metrics/map_metric.py:from .map_metric_provider import *
+great_expectations/expectations/metrics/table_metric.py:from .table_metric_provider import *
+great_expectations/profile/columns_exist.py:from ..dataset.util import create_multiple_expectations
+great_expectations/profile/columns_exist.py:from .base import DatasetProfiler
+great_expectations/execution_engine/sparkdf_execution_engine.py:from ..exceptions import (
+great_expectations/execution_engine/sparkdf_execution_engine.py:from ..expectations.row_conditions import parse_condition_to_spark
+great_expectations/execution_engine/sparkdf_execution_engine.py:from .sparkdf_batch_data import SparkDFBatchData
+great_expectations/render/exceptions.py:from ..exceptions import GreatExpectationsTypeError
+great_expectations/render/renderer/email_renderer.py:from ...core.id_dict import BatchKwargs
+great_expectations/render/renderer/email_renderer.py:from .renderer import Renderer
+great_expectations/render/renderer/slack_renderer.py:from ...core.id_dict import BatchKwargs
+great_expectations/render/renderer/slack_renderer.py:from .renderer import Renderer
+great_expectations/render/renderer/site_index_page_renderer.py:from .call_to_action_renderer import CallToActionRenderer
+great_expectations/render/renderer/site_index_page_renderer.py:from .renderer import Renderer
+great_expectations/render/renderer/profiling_results_overview_section_renderer.py:from .renderer import Renderer
+great_expectations/render/renderer/page_renderer.py:from ...core import ExpectationSuite
+great_expectations/render/renderer/page_renderer.py:from ...core.expectation_validation_result import ExpectationSuiteValidationResult
+great_expectations/render/renderer/page_renderer.py:from ...core.run_identifier import RunIdentifier
+great_expectations/render/renderer/page_renderer.py:from ...validation_operators.types.validation_operator_result import (
+great_expectations/render/renderer/page_renderer.py:from ..types import (
+great_expectations/render/renderer/page_renderer.py:from .renderer import Renderer
+great_expectations/render/renderer/microsoft_teams_renderer.py:from ...core import RunIdentifier
+great_expectations/render/renderer/microsoft_teams_renderer.py:from ...data_context.types.resource_identifiers import BatchIdentifier
+great_expectations/render/renderer/microsoft_teams_renderer.py:from .renderer import Renderer
+great_expectations/render/renderer/opsgenie_renderer.py:from ...core.id_dict import BatchKwargs
+great_expectations/render/renderer/opsgenie_renderer.py:from .renderer import Renderer
+great_expectations/render/renderer/content_block/profiling_column_properties_table_content_block.py:from .content_block import ContentBlockRenderer
+great_expectations/render/renderer/content_block/content_block.py:from ..renderer import Renderer
+great_expectations/render/renderer/content_block/exception_list_content_block.py:from .content_block import ContentBlockRenderer
+great_expectations/dataset/pandas_dataset.py:from .dataset import Dataset
+great_expectations/datasource/sparkdf_datasource.py:from ..core.batch import Batch, BatchMarkers
+great_expectations/datasource/sparkdf_datasource.py:from ..core.util import get_or_create_spark_application
+great_expectations/datasource/sparkdf_datasource.py:from ..dataset import SparkDFDataset
+great_expectations/datasource/sparkdf_datasource.py:from ..exceptions import BatchKwargsError
+great_expectations/datasource/sparkdf_datasource.py:from ..types.configurations import classConfigSchema
+great_expectations/datasource/sparkdf_datasource.py:from .datasource import LegacyDatasource
+great_expectations/datasource/pandas_datasource.py:from ..core.util import S3Url
+great_expectations/datasource/pandas_datasource.py:from ..execution_engine.pandas_execution_engine import hash_pandas_dataframe
+great_expectations/datasource/pandas_datasource.py:from ..types.configurations import classConfigSchema
+great_expectations/datasource/pandas_datasource.py:from .datasource import LegacyDatasource
+great_expectations/dataset/sqlalchemy_dataset.py:from .dataset import Dataset
+great_expectations/dataset/sqlalchemy_dataset.py:from .pandas_dataset import PandasDataset
+great_expectations/datasource/batch_kwargs_generator/query_batch_kwargs_generator.py:from ...data_context.util import instantiate_class_from_config
+great_expectations/datasource/batch_kwargs_generator/query_batch_kwargs_generator.py:from .batch_kwargs_generator import BatchKwargsGenerator
+great_expectations/datasource/batch_kwargs_generator/table_batch_kwargs_generator.py:from .batch_kwargs_generator import BatchKwargsGenerator

--- a/tests/data_context/test_data_context_datasource_non_sql_methods.py
+++ b/tests/data_context/test_data_context_datasource_non_sql_methods.py
@@ -7,8 +7,7 @@ from ruamel.yaml import YAML
 
 from great_expectations.core.batch import Batch, BatchRequest
 from great_expectations.data_context.util import file_relative_path
-
-from ..test_utils import create_files_in_directory
+from tests.test_utils import create_files_in_directory
 
 yaml = YAML()
 

--- a/tests/execution_engine/test_sqlalchemy_batch_data.py
+++ b/tests/execution_engine/test_sqlalchemy_batch_data.py
@@ -1,6 +1,5 @@
 import pytest
 
-from great_expectations.core.batch import BatchSpec
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 
@@ -12,8 +11,7 @@ except ImportError:
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
-
-from ..test_utils import get_sqlite_temp_table_names
+from tests.test_utils import get_sqlite_temp_table_names
 
 
 def test_instantiation_with_table_name(sqlite_view_engine):

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -21,8 +21,7 @@ from great_expectations.self_check.util import (
     postgresqlDialect,
     sqliteDialect,
 )
-
-from ..conftest import build_test_backends_list
+from tests.conftest import build_test_backends_list
 
 logger = logging.getLogger(__name__)
 tmp_dir = str(tempfile.mkdtemp())


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactor relative imports to adhere to Superconductive style guide
- `find great_expectations -name "*.py" | xargs absolufy-imports `
  - But ignore `__init__.py` (the one place we're saying we're okay with relative imports)

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
