### PR TITLE
[MAINTENANCE] Revert `dependency_graph` pipeline changes to ensure `usage_stats` runs in parallel

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -186,6 +186,39 @@ stages:
               summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
+  - stage: usage_stats_integration
+    dependsOn: [scope_check, lint]
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    jobs:
+      - job: test_usage_stats_messages
+        condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
+        variables:
+          python.version: '3.8'
+
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '$(python.version)'
+            displayName: 'Use Python $(python.version)'
+
+          - bash: python -m pip install --upgrade pip==20.2.4
+            displayName: 'Update pip'
+
+          - script: |
+              pip install --requirement requirements-dev-base.txt
+              pip install --requirement requirements.txt
+              pip install .
+            displayName: 'Install dependencies'
+
+          # Due to the relatively small number of usage_stats tests, we deem it appropriate to test them in their entirely through pytest
+          - script: |
+              pip install pytest pytest-azurepipelines
+              pytest --no-spark --no-sqlalchemy --aws-integration -v tests/integration/usage_statistics
+
+            displayName: 'pytest'
+
   - stage: db_integration
     pool:
       vmImage: 'ubuntu-latest'
@@ -327,36 +360,3 @@ stages:
               dgtest run great_expectations --filter 'tests/cli' --aws-integration -v
 
             displayName: 'dgtest'
-
-  - stage: usage_stats_integration
-    dependsOn: [scope_check, lint, required, db_integration, cli_integration]
-    pool:
-      vmImage: 'ubuntu-latest'
-
-    jobs:
-      - job: test_usage_stats_messages
-        condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
-        variables:
-          python.version: '3.8'
-
-        steps:
-          - task: UsePythonVersion@0
-            inputs:
-              versionSpec: '$(python.version)'
-            displayName: 'Use Python $(python.version)'
-
-          - bash: python -m pip install --upgrade pip==20.2.4
-            displayName: 'Update pip'
-
-          - script: |
-              pip install --requirement requirements-dev-base.txt
-              pip install --requirement requirements.txt
-              pip install .
-            displayName: 'Install dependencies'
-
-          # Due to the relatively small number of usage_stats tests, we deem it appropriate to test them in their entirely through pytest
-          - script: |
-              pip install pytest pytest-azurepipelines
-              pytest --no-spark --no-sqlalchemy --aws-integration -v tests/integration/usage_statistics
-
-            displayName: 'pytest'

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -1,4 +1,3 @@
-# Test change
 import copy
 import uuid
 from typing import Any, Dict, List, Optional, Union


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Accidentally pushed some changes; these should be reverted
- https://github.com/great-expectations/great_expectations/pull/4187/files

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
