### PR TITLE
[BUGFIX] Update validate_configuration for core Expectations that don't return…

### DIFF
--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -361,7 +361,9 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnExpectation):
 
         return new_block
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """Validating that user has inputted a value set and that configuration has been initialized"""
         super().validate_configuration(configuration)
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -53,7 +53,9 @@ class ExpectColumnDistinctValuesToContainSet(ColumnExpectation):
         "value_set",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """Validating that user has inputted a value set and that configuration has been initialized"""
         super().validate_configuration(configuration)
 

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -53,7 +53,9 @@ class ExpectColumnDistinctValuesToEqualSet(ColumnExpectation):
         "value_set",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """Validating that user has inputted a value set and that configuration has been initialized"""
         super().validate_configuration(configuration)
         if configuration is None:

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -115,7 +115,9 @@ class ExpectColumnMaxToBeBetween(ColumnExpectation):
 
     """ A Column Map MetricProvider Decorator for the Maximum"""
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -129,6 +129,8 @@ class ExpectColumnMaxToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -169,6 +169,8 @@ class ExpectColumnMeanToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -155,7 +155,9 @@ class ExpectColumnMeanToBeBetween(ColumnExpectation):
         "required": ["column"],
     }
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -104,7 +104,9 @@ class ExpectColumnMedianToBeBetween(ColumnExpectation):
         "strict_max",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -118,6 +118,8 @@ class ExpectColumnMedianToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -112,7 +112,9 @@ class ExpectColumnMinToBeBetween(ColumnExpectation):
         "strict_max",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -126,6 +126,8 @@ class ExpectColumnMinToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration=configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -99,7 +99,9 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnExpectation):
         "value_set",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """Validating that user has inputted a value set and that configuration has been initialized"""
         super().validate_configuration(configuration)
         if configuration is None:

--- a/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
@@ -85,7 +85,9 @@ class ExpectColumnPairValuesAToBeGreaterThanB(ColumnPairMapExpectation):
         "or_equal",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -77,7 +77,9 @@ class ExpectColumnPairValuesToBeEqual(ColumnPairMapExpectation):
         "column_B",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
@@ -65,7 +65,9 @@ class ExpectColumnPairValuesToBeInSet(ColumnPairMapExpectation):
         "value_pairs_set",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -108,7 +108,9 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnExpectation):
 
     """ A Column Aggregate MetricProvider Decorator for the Unique Proportion"""
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -122,6 +122,8 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -148,7 +148,9 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
         "allow_relative_error",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert (

--- a/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
@@ -121,6 +121,8 @@ class ExpectColumnStdevToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
@@ -107,7 +107,9 @@ class ExpectColumnStdevToBeBetween(ColumnExpectation):
         "strict_max",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -100,7 +100,9 @@ class ExpectColumnSumToBeBetween(ColumnExpectation):
 
     """ A Column Map Metric Decorator for the Sum"""
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -114,6 +114,8 @@ class ExpectColumnSumToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -72,7 +72,9 @@ class ExpectColumnToExist(TableExpectation):
     }
     args_keys = ("column", "column_index")
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -116,6 +116,8 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -102,7 +102,9 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnExpectation):
 
     """ A Column Aggregate Metric Decorator for the Unique Value Count"""
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -116,7 +116,9 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
         "max_value",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
 
         if configuration is None:

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
@@ -88,7 +88,9 @@ class ExpectColumnValueLengthsToEqual(ColumnMapExpectation):
         "value",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -81,7 +81,9 @@ class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
     }
     args_keys = ("column", "threshold")
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -142,6 +142,7 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
         ), "min_value and max_value cannot both be None"
 
         self.validate_metric_value_between_configuration(configuration=configuration)
+        return True
 
     @classmethod
     def _atomic_prescriptive_template(

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -116,7 +116,9 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
         "strict_max",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
@@ -72,7 +72,9 @@ class ExpectColumnValuesToBeDateutilParseable(ColumnMapExpectation):
     }
     args_keys = ("column",)
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         return True
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
@@ -92,7 +92,9 @@ class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):
     }
     args_keys = ("column",)
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         return super().validate_configuration(configuration)
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_set.py
@@ -355,7 +355,9 @@ class ExpectColumnValuesToBeInSet(ColumnMapExpectation):
 
         return new_block
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         if not super().validate_configuration(configuration):
             return False
         try:

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -124,7 +124,9 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         "type_list",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert "type_list" in configuration.kwargs, "type_list is required"

--- a/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
@@ -91,7 +91,9 @@ class ExpectColumnValuesToBeIncreasing(ColumnMapExpectation):
     }
     args_keys = ("column",)
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         return super().validate_configuration(configuration)
 
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
@@ -81,7 +81,9 @@ class ExpectColumnValuesToBeJsonParseable(ColumnMapExpectation):
     }
     args_keys = ("column",)
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         return True
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -173,7 +173,9 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
         "type_",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert "type_" in configuration.kwargs, "type_ is required"

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -85,7 +85,9 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
     }
     args_keys = ("column",)
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert (

--- a/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
@@ -93,7 +93,9 @@ class ExpectColumnValuesToMatchJsonSchema(ColumnMapExpectation):
         "json_schema",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
 
         return True

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
@@ -45,7 +45,9 @@ class ExpectColumnValuesToMatchLikePattern(ColumnMapExpectation):
         "like_pattern",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert "like_pattern" in configuration.kwargs, "Must provide like_pattern"

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -38,7 +38,9 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
         "like_pattern_list",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert (

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -96,7 +96,9 @@ class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
         "regex",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -101,7 +101,9 @@ class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):
         "regex_list",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
@@ -84,7 +84,9 @@ class ExpectColumnValuesToMatchStrftimeFormat(ColumnMapExpectation):
         "strftime_format",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -116,7 +116,9 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
         "value_set",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -86,7 +86,9 @@ class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):
         "like_pattern",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert "like_pattern" in configuration.kwargs, "Must provide like_pattern"

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -86,7 +86,9 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
         "like_pattern_list",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         try:
             assert (

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -98,7 +98,9 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
         "regex",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -92,7 +92,9 @@ class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):
         "regex_list",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -86,7 +86,9 @@ class ExpectTableColumnCountToBeBetween(TableExpectation):
 
     """ A Metric Decorator for the Column Count"""
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -100,6 +100,8 @@ class ExpectTableColumnCountToBeBetween(TableExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -70,7 +70,9 @@ class ExpectTableColumnCountToEqual(TableExpectation):
 
     """ A Metric Decorator for the Column Count"""
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -80,7 +80,9 @@ class ExpectTableColumnsToMatchOrderedList(TableExpectation):
     }
     args_keys = ("column_list",)
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -72,7 +72,9 @@ class ExpectTableColumnsToMatchSet(TableExpectation):
         "exact_match",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -85,7 +85,9 @@ class ExpectTableRowCountToBeBetween(TableExpectation):
         "max_value",
     )
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -101,6 +101,8 @@ class ExpectTableRowCountToBeBetween(TableExpectation):
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)
 
+        return True
+
     @classmethod
     def _atomic_prescriptive_template(
         cls,

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -71,7 +71,9 @@ class ExpectTableRowCountToEqual(TableExpectation):
     }
     args_keys = ("value",)
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> bool:
         """
         Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
         necessary configuration arguments have been provided for the validation of the expectation.


### PR DESCRIPTION
The `validate_configuration` methods defined on several Expectations do not `return True` at the end, as specified in their docstrings. Exceptions should be raised if there is anything wrong with provided configs (before `return True`).

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/en/latest/contributing/style_guide.html?highlight=style%20guide)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html?highlight=checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.