### PR TITLE
[BUGFIX] Ensure that test result for `RegexPatternStringParameterBuilder` is deterministic

### DIFF
--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -182,14 +182,15 @@ def test_regex_pattern_string_parameter_builder_bobby_multiple_matches(
         },
     }
 
-    assert (
-        get_parameter_value_by_fully_qualified_parameter_name(
-            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
-            domain=domain,
-            parameters={domain.id: parameter_container},
-        )
-        == expected_value
+    results = get_parameter_value_by_fully_qualified_parameter_name(
+        fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+        domain=domain,
+        parameters={domain.id: parameter_container},
     )
+
+    assert results is not None
+    assert sorted(results["value"]) == sorted(expected_value["value"])
+    assert results["details"] == expected_value["details"]
 
 
 def test_regex_pattern_string_parameter_builder_bobby_no_match(
@@ -249,6 +250,7 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
     )
 
 
+# Chetan - 20220219 - This needs to be renamed to prevent a namespace collision
 def test_regex_pattern_string_parameter_builder_bobby_no_match(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix to ensure consistent test results


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
