### PR TITLE
[BUGFIX] Ensure `docs-integration` pipeline has access to appropriate AWS credentials

### DIFF
--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_create_a_batch_of_data_from_an_in_memory_pandas_dataframe.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_create_a_batch_of_data_from_an_in_memory_pandas_dataframe.py
@@ -32,7 +32,7 @@ data_connectors:
             - some_other_key_maybe_airflow_run_id
 """
 
-context.add_datasource(**yaml.load(datasource_yaml))
+context.add_datasource(**yaml.safe_load(datasource_yaml))
 
 # RuntimeBatchRequest with batch_data as Pandas Dataframe
 path_to_file: str = "some_path.csv"


### PR DESCRIPTION
Changes proposed in this pull request:
- PR to check if new `aws_creds` Secure File that is loaded into our Azure pipeline. 
- small change to test to ensure the tests run. 

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

Thank you for submitting!
