### PR TITLE
[BUGFIX] Check for pandas>=024 not pandas>=24

### DIFF
--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1624,7 +1624,7 @@ def generate_expectation_tests(
                             or "pandas_023" in test["only_for"]
                         ) and int(pd.__version__.split(".")[1]) in [22, 23]:
                             generate_test = True
-                        if ("pandas>=24" in test["only_for"]) and int(
+                        if ("pandas>=024" in test["only_for"]) and int(
                             pd.__version__.split(".")[1]
                         ) > 24:
                             generate_test = True

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -173,7 +173,7 @@ def pytest_generate_tests(metafunc):
                                     and minor in ["22", "23"]
                                 ):
                                     generate_test = True
-                                if ("pandas>=24" in only_for) and (
+                                if ("pandas>=024" in only_for) and (
                                     (major == "0" and int(minor) >= 24)
                                     or int(major) >= 1
                                 ):

--- a/tests/test_definitions/test_expectations_cfe.py
+++ b/tests/test_definitions/test_expectations_cfe.py
@@ -185,7 +185,7 @@ def pytest_generate_tests(metafunc):
                                     and minor in ["22", "23"]
                                 ):
                                     generate_test = True
-                                if ("pandas>=24" in only_for) and (
+                                if ("pandas>=024" in only_for) and (
                                     (major == "0" and int(minor) >= 24)
                                     or int(major) >= 1
                                 ):


### PR DESCRIPTION
In a fast follow to [#4248](https://github.com/great-expectations/great_expectations/pull/4248) it appears that the `test_expectations[_cfe].py` files were always wrong since [expect_column_values_to_be_of_type](https://github.com/great-expectations/great_expectations/blob/7fb3877c5a342bf4a55863cb9880677619c34525/tests/test_definitions/column_map_expectations/expect_column_values_to_be_of_type.json#L401) always specified that one test was `"only_for": ["pandas>=024"]` (not `pandas>=24`)