### PR TITLE
[BUGFIX] Add redirect for removed Spark EMR page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -174,6 +174,7 @@
 # Redirects for consolidated pages
 /docs/why_use_ge https://docs.greatexpectations.io/docs
 /docs/community https://docs.greatexpectations.io/docs
+/docs/guides/setup/installation/spark_emr https://docs.greatexpectations.io/docs/guides/setup/installation/hosted_environment
 
 # Redirects for Universal Map getting started tutorial
 /docs/tutorials/getting_started/intro https://docs.greatexpectations.io/docs/tutorials/getting_started/tutorial_overview


### PR DESCRIPTION
Changes proposed in this pull request:
- Add redirect for removed Spark EMR page

### Definition of Done
- [X] I have made corresponding changes to the documentation