### PR TITLE
[DOCS] fix formatting in configuration details block of Getting Started

### DIFF
--- a/docs/tutorials/getting_started/tutorial_connect_to_data.md
+++ b/docs/tutorials/getting_started/tutorial_connect_to_data.md
@@ -133,10 +133,10 @@ Please note that due to how data is serialized, the entry in your ```great_expec
   <summary>What does the configuration contain?</summary>
   <div>
     <p>
-        <b>ExecutionEngine</b> : The <code>ExecutionEngine</code> provides backend-specific computing resources that are used to read-in and perform validation on data.  For more information on `ExecutionEngines`, please refer to the following [Core Concepts document on ExecutionEngines](/docs/reference/execution_engine)
+        <b>ExecutionEngine</b> : The <code>ExecutionEngine</code> provides backend-specific computing resources that are used to read-in and perform validation on data.  For more information on <code>ExecutionEngines</code>, please refer to the following <a href="/docs/reference/execution_engine">Core Concepts document on ExecutionEngines</a>
     </p>
     <p>
-        <b>DataConnectors</b> :  <code>DataConnectors</code> facilitate access to external data stores, such as filesystems, databases, and cloud storage. The current configuration contains both an <code>InferredAssetFilesystemDataConnector</code>, which allows you to retrieve a batch of data by naming a data asset (which is the filename in our case), and a <code>RuntimeDataConnector</code>, which allows you to retrieve a batch of data by defining a filepath.  In this tutorial we will only be using the <code>InferredAssetFilesystemDataConnector</code>.  For more information on <code>DataConnectors</code>, please refer to the <a href="https://docs.greatexpectations.io/docs/reference/datasources">Core Concepts document on Datasources</a>.
+        <b>DataConnectors</b> :  <code>DataConnectors</code> facilitate access to external data stores, such as filesystems, databases, and cloud storage. The current configuration contains both an <code>InferredAssetFilesystemDataConnector</code>, which allows you to retrieve a batch of data by naming a data asset (which is the filename in our case), and a <code>RuntimeDataConnector</code>, which allows you to retrieve a batch of data by defining a filepath.  In this tutorial we will only be using the <code>InferredAssetFilesystemDataConnector</code>.  For more information on <code>DataConnectors</code>, please refer to the <a href="/docs/reference/datasources">Core Concepts document on Datasources</a>.
     </p>
     <p>
         This Datasource does not require any credentials. However, if you were to connect to a database that requires connection credentials, those would be stored in <code>great_expectations/uncommitted/config_variables.yml</code>.


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixing a couple of things that were formatted with Markdown but needed to be HTML, including a link and inline code

### Definition of Done

- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation