### PR TITLE
[MAINTENANCE] Refactor Anonymizer base class to implicitly determine whether or not an object is a core GE class

### DIFF
--- a/great_expectations/core/usage_statistics/anonymizers/action_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/action_anonymizer.py
@@ -38,7 +38,6 @@ class ActionAnonymizer(Anonymizer):
             object_=action_obj,
             object_config=action_config,
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             runtime_environment={"module_name": "great_expectations.checkpoint"},
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -95,10 +95,10 @@ class Anonymizer:
 
     @staticmethod
     def _is_parent_class_recognized(
-        classes_to_check,
-        object_=None,
-        object_class=None,
-        object_config=None,
+        object_: Optional[object] = None,
+        object_class: Optional[type] = None,
+        object_config: Optional[dict] = None,
+        parent_module_prefix: str = "great_expectations",
     ) -> Optional[str]:
         """
         Check if the parent class is a subclass of any core GE class.
@@ -117,11 +117,16 @@ class Anonymizer:
                 object_module_name = object_config.get("module_name")
                 object_class = load_class(object_class_name, object_module_name)
 
-            for class_to_check in classes_to_check:
-                if issubclass(object_class, class_to_check):
-                    return class_to_check.__name__
+            bases: Tuple[type, ...] = object_class.__bases__
+            if len(bases) == 0:
+                return None
 
-            return None
+            parent: type
+            for parent in bases:
+                if parent.__module__.startswith(parent_module_prefix):
+                    return parent.__name__
 
         except AttributeError:
-            return None
+            pass
+
+        return None

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -94,7 +94,7 @@ class Anonymizer:
         return anonymized_info_dict
 
     @staticmethod
-    def _is_parent_class_recognized(
+    def _get_parent_class(
         object_: Optional[object] = None,
         object_class: Optional[type] = None,
         object_config: Optional[dict] = None,
@@ -102,7 +102,7 @@ class Anonymizer:
     ) -> Optional[str]:
         """
         Check if the parent class is a subclass of any core GE class.
-        This private method is intended to be used by anonymizers in a public `is_parent_class_recognized()` method. These anonymizers define and provide the core GE classes_to_check.
+        This private method is intended to be used by anonymizers in a public `get_parent_class()` method. These anonymizers define and provide the core GE classes_to_check.
         Returns:
             The name of the parent class found, or None if no parent class was found
         """

--- a/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
@@ -25,7 +25,6 @@ class CheckpointAnonymizer(Anonymizer):
 
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=checkpoint_config_dict,
         )
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from ruamel.yaml.comments import CommentedMap
 
-from great_expectations.checkpoint import Checkpoint, SimpleCheckpoint
 from great_expectations.core.usage_statistics.anonymizers.anonymizer import Anonymizer
 from great_expectations.data_context.types.base import checkpointConfigSchema
 
@@ -10,9 +9,6 @@ from great_expectations.data_context.types.base import checkpointConfigSchema
 class CheckpointAnonymizer(Anonymizer):
     def __init__(self, salt=None):
         super().__init__(salt=salt)
-
-        # ordered bottom up in terms of inheritance order
-        self._ge_classes = [SimpleCheckpoint, Checkpoint]
 
     def anonymize_checkpoint_info(self, name: str, config: dict) -> dict:
         anonymized_info_dict: dict = {
@@ -31,6 +27,5 @@ class CheckpointAnonymizer(Anonymizer):
 
     def is_parent_class_recognized(self, config) -> Optional[str]:
         return self._is_parent_class_recognized(
-            classes_to_check=self._ge_classes,
             object_config=config,
         )

--- a/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
@@ -25,7 +25,7 @@ class CheckpointAnonymizer(Anonymizer):
         )
         return anonymized_info_dict
 
-    def is_parent_class_recognized(self, config) -> Optional[str]:
-        return self._is_parent_class_recognized(
+    def get_parent_class(self, config) -> Optional[str]:
+        return self._get_parent_class(
             object_config=config,
         )

--- a/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
@@ -68,7 +68,6 @@ class DataConnectorAnonymizer(Anonymizer):
 
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=data_connector_config_dict,
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
@@ -73,8 +73,8 @@ class DataConnectorAnonymizer(Anonymizer):
 
         return anonymized_info_dict
 
-    def is_parent_class_recognized(self, config):
-        return self._is_parent_class_recognized(
+    def get_parent_class(self, config):
+        return self._get_parent_class(
             classes_to_check=self._ge_classes,
             object_config=config,
         )

--- a/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
@@ -48,14 +48,12 @@ class DatasourceAnonymizer(Anonymizer):
         if self.is_parent_class_recognized_v2_api(config=config) is not None:
             self.anonymize_object_info(
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._legacy_ge_classes,
                 object_config=config,
             )
         # Datasources (>= v0.13 v3 BatchRequest API), and custom v2 BatchKwargs API
         elif self.is_parent_class_recognized_v3_api(config=config) is not None:
             self.anonymize_object_info(
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
                 object_config=config,
             )
             execution_engine_config = config.get("execution_engine")
@@ -85,7 +83,6 @@ class DatasourceAnonymizer(Anonymizer):
             config["module_name"] = "great_expectations.datasource"
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=config,
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
@@ -144,18 +144,15 @@ class DatasourceAnonymizer(Anonymizer):
 
     def is_parent_class_recognized(self, config) -> Optional[str]:
         return self._is_parent_class_recognized(
-            classes_to_check=self._ge_classes + self._legacy_ge_classes,
             object_config=config,
         )
 
     def is_parent_class_recognized_v2_api(self, config) -> Optional[str]:
         return self._is_parent_class_recognized(
-            classes_to_check=self._legacy_ge_classes,
             object_config=config,
         )
 
     def is_parent_class_recognized_v3_api(self, config) -> Optional[str]:
         return self._is_parent_class_recognized(
-            classes_to_check=self._ge_classes,
             object_config=config,
         )

--- a/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
@@ -45,13 +45,13 @@ class DatasourceAnonymizer(Anonymizer):
         anonymized_info_dict["anonymized_name"] = self.anonymize(name)
 
         # Legacy Datasources (<= v0.12 v2 BatchKwargs API)
-        if self.is_parent_class_recognized_v2_api(config=config) is not None:
+        if self.get_parent_class_v2_api(config=config) is not None:
             self.anonymize_object_info(
                 anonymized_info_dict=anonymized_info_dict,
                 object_config=config,
             )
         # Datasources (>= v0.13 v3 BatchRequest API), and custom v2 BatchKwargs API
-        elif self.is_parent_class_recognized_v3_api(config=config) is not None:
+        elif self.get_parent_class_v3_api(config=config) is not None:
             self.anonymize_object_info(
                 anonymized_info_dict=anonymized_info_dict,
                 object_config=config,
@@ -142,17 +142,17 @@ class DatasourceAnonymizer(Anonymizer):
 
         return anonymized_info_dict
 
-    def is_parent_class_recognized(self, config) -> Optional[str]:
-        return self._is_parent_class_recognized(
+    def get_parent_class(self, config) -> Optional[str]:
+        return self._get_parent_class(
             object_config=config,
         )
 
-    def is_parent_class_recognized_v2_api(self, config) -> Optional[str]:
-        return self._is_parent_class_recognized(
+    def get_parent_class_v2_api(self, config) -> Optional[str]:
+        return self._get_parent_class(
             object_config=config,
         )
 
-    def is_parent_class_recognized_v3_api(self, config) -> Optional[str]:
-        return self._is_parent_class_recognized(
+    def get_parent_class_v3_api(self, config) -> Optional[str]:
+        return self._get_parent_class(
             object_config=config,
         )

--- a/great_expectations/core/usage_statistics/anonymizers/execution_engine_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/execution_engine_anonymizer.py
@@ -37,7 +37,6 @@ class ExecutionEngineAnonymizer(Anonymizer):
 
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=execution_engine_config_dict,
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
@@ -21,8 +21,8 @@ class ProfilerAnonymizer(Anonymizer):
         )
         return anonymized_info_dict
 
-    def is_parent_class_recognized(self, config) -> Optional[str]:
-        return self._is_parent_class_recognized(
+    def get_parent_class(self, config) -> Optional[str]:
+        return self._get_parent_class(
             classes_to_check=self._ge_classes,
             object_config=config,
         )

--- a/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
@@ -17,7 +17,6 @@ class ProfilerAnonymizer(Anonymizer):
         }
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=config,
         )
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/site_builder_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/site_builder_anonymizer.py
@@ -25,7 +25,6 @@ class SiteBuilderAnonymizer(Anonymizer):
         self.anonymize_object_info(
             object_config={"class_name": class_name, "module_name": module_name},
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
         )
 
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/store_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/store_anonymizer.py
@@ -40,7 +40,6 @@ class StoreAnonymizer(Anonymizer):
         self.anonymize_object_info(
             object_=store_obj,
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
         )
 
         anonymized_info_dict[

--- a/great_expectations/core/usage_statistics/anonymizers/store_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/store_anonymizer.py
@@ -50,7 +50,7 @@ class StoreAnonymizer(Anonymizer):
 
         return anonymized_info_dict
 
-    def is_parent_class_recognized(self, store_obj):
-        return self._is_parent_class_recognized(
+    def get_parent_class(self, store_obj):
+        return self._get_parent_class(
             classes_to_check=self._ge_classes, object_=store_obj
         )

--- a/great_expectations/core/usage_statistics/anonymizers/store_backend_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/store_backend_anonymizer.py
@@ -36,7 +36,6 @@ class StoreBackendAnonymizer(Anonymizer):
             self.anonymize_object_info(
                 object_=store_backend_obj,
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
             )
         else:
             class_name = store_backend_object_config.get("class_name")
@@ -46,6 +45,5 @@ class StoreBackendAnonymizer(Anonymizer):
             self.anonymize_object_info(
                 object_config={"class_name": class_name, "module_name": module_name},
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
             )
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/validation_operator_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/validation_operator_anonymizer.py
@@ -32,7 +32,6 @@ class ValidationOperatorAnonymizer(Anonymizer):
             self.anonymize_object_info(
                 object_=validation_operator_obj,
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
             )
         )
 

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -3813,20 +3813,15 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         data_connector_anonymizer: DataConnectorAnonymizer = DataConnectorAnonymizer(
             self.data_context_id
         )
-        if (
-            store_anonymizer.is_parent_class_recognized(store_obj=instantiated_class)
-            is not None
-        ):
+        if store_anonymizer.get_parent_class(store_obj=instantiated_class) is not None:
             store_name: str = name or config.get("name") or "my_temp_store"
             store_name = instantiated_class.store_name or store_name
             usage_stats_event_payload = store_anonymizer.anonymize_store_info(
                 store_name=store_name, store_obj=instantiated_class
             )
-        elif (
-            datasource_anonymizer.is_parent_class_recognized(config=config) is not None
-        ):
+        elif datasource_anonymizer.get_parent_class(config=config) is not None:
             datasource_name: str = name or config.get("name") or "my_temp_datasource"
-            if datasource_anonymizer.is_parent_class_recognized_v3_api(config=config):
+            if datasource_anonymizer.get_parent_class_v3_api(config=config):
                 # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
                 datasource_config = datasourceConfigSchema.load(
                     instantiated_class.config
@@ -3835,9 +3830,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
             else:
                 # for v2 api
                 full_datasource_config = config
-            parent_class_name = datasource_anonymizer.is_parent_class_recognized(
-                config=config
-            )
+            parent_class_name = datasource_anonymizer.get_parent_class(config=config)
             if parent_class_name == "SimpleSqlalchemyDatasource":
                 # Use the raw config here, defaults will be added in the anonymizer
                 usage_stats_event_payload = (
@@ -3852,9 +3845,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
                     )
                 )
 
-        elif (
-            checkpoint_anonymizer.is_parent_class_recognized(config=config) is not None
-        ):
+        elif checkpoint_anonymizer.get_parent_class(config=config) is not None:
             checkpoint_name: str = name or config.get("name") or "my_temp_checkpoint"
             # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
             checkpoint_config: Union[CheckpointConfig, dict]
@@ -3867,10 +3858,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
                 name=checkpoint_name, config=checkpoint_config
             )
 
-        elif (
-            data_connector_anonymizer.is_parent_class_recognized(config=config)
-            is not None
-        ):
+        elif data_connector_anonymizer.get_parent_class(config=config) is not None:
             data_connector_name: str = (
                 name or config.get("name") or "my_temp_data_connector"
             )

--- a/tests/core/usage_statistics/test_anonymizer.py
+++ b/tests/core/usage_statistics/test_anonymizer.py
@@ -45,7 +45,7 @@ def test_anonymizer_consistent_salt():
 
 
 # The following empty classes are used in this test module only.
-# They are used to ensure class hierarchy is appropriately processed by Anonymizer._is_parent_class_recognized()
+# They are used to ensure class hierarchy is appropriately processed by Anonymizer._get_parent_class()
 
 
 class BaseTestClass:
@@ -64,10 +64,10 @@ class SomeOtherClass:
     pass
 
 
-def test_anonymizer__is_parent_class_recognized():
+def test_anonymizer__get_parent_class():
     """
     What does this test and why?
-    The method Anonymizer._is_parent_class_recognized() should return the name of the parent class if it is or is a subclass of one of the classes_to_check. If not, it should return None. It should do so regardless of the parameter used to pass in the object definition (object_, object_class, object_config). It should also return the first matching class in classes_to_check, even if a later class also matches.
+    The method Anonymizer._get_parent_class() should return the name of the parent class if it is or is a subclass of one of the classes_to_check. If not, it should return None. It should do so regardless of the parameter used to pass in the object definition (object_, object_class, object_config). It should also return the first matching class in classes_to_check, even if a later class also matches.
     """
     anonymizer = Anonymizer()
 
@@ -76,19 +76,19 @@ def test_anonymizer__is_parent_class_recognized():
     parent_module_prefix: str = "tests"
 
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_class=MyCustomTestClass, parent_module_prefix=parent_module_prefix
         )
         == "TestClass"
     )
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_class=SomeOtherClass, parent_module_prefix=parent_module_prefix
         )
         is None
     )
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_class=TestClass, parent_module_prefix=parent_module_prefix
         )
         == "BaseTestClass"
@@ -99,19 +99,19 @@ def test_anonymizer__is_parent_class_recognized():
     test_class = TestClass()
     some_other_class = SomeOtherClass()
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_=my_custom_test_class, parent_module_prefix=parent_module_prefix
         )
         == "TestClass"
     )
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_=some_other_class, parent_module_prefix=parent_module_prefix
         )
         is None
     )
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_=test_class, parent_module_prefix=parent_module_prefix
         )
         == "BaseTestClass"
@@ -131,21 +131,21 @@ def test_anonymizer__is_parent_class_recognized():
         "module_name": "tests.core.usage_statistics.test_anonymizer",
     }
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_config=my_custom_test_class_config,
             parent_module_prefix=parent_module_prefix,
         )
         == "TestClass"
     )
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_config=some_other_class_config,
             parent_module_prefix=parent_module_prefix,
         )
         is None
     )
     assert (
-        anonymizer._is_parent_class_recognized(
+        anonymizer._get_parent_class(
             object_config=test_class_config, parent_module_prefix=parent_module_prefix
         )
         == "BaseTestClass"

--- a/tests/core/usage_statistics/test_anonymizer.py
+++ b/tests/core/usage_statistics/test_anonymizer.py
@@ -71,24 +71,25 @@ def test_anonymizer__is_parent_class_recognized():
     """
     anonymizer = Anonymizer()
 
-    # classes_to_check in order of inheritance hierarchy
-    classes_to_check = [TestClass, BaseTestClass]
+    # As these classes are declared within the "tests" module,
+    # we need to be explicit that they originate outside of "great_expectations"
+    parent_module_prefix: str = "tests"
+
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_class=MyCustomTestClass
+            object_class=MyCustomTestClass, parent_module_prefix=parent_module_prefix
         )
         == "TestClass"
     )
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_class=SomeOtherClass
+            object_class=SomeOtherClass, parent_module_prefix=parent_module_prefix
         )
         is None
     )
-    classes_to_check = [BaseTestClass]
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_class=TestClass
+            object_class=TestClass, parent_module_prefix=parent_module_prefix
         )
         == "BaseTestClass"
     )
@@ -97,23 +98,21 @@ def test_anonymizer__is_parent_class_recognized():
     my_custom_test_class = MyCustomTestClass()
     test_class = TestClass()
     some_other_class = SomeOtherClass()
-    classes_to_check = [TestClass, BaseTestClass]
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_=my_custom_test_class
+            object_=my_custom_test_class, parent_module_prefix=parent_module_prefix
         )
         == "TestClass"
     )
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_=some_other_class
+            object_=some_other_class, parent_module_prefix=parent_module_prefix
         )
         is None
     )
-    classes_to_check = [BaseTestClass]
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_=test_class
+            object_=test_class, parent_module_prefix=parent_module_prefix
         )
         == "BaseTestClass"
     )
@@ -131,23 +130,23 @@ def test_anonymizer__is_parent_class_recognized():
         "class_name": "SomeOtherClass",
         "module_name": "tests.core.usage_statistics.test_anonymizer",
     }
-    classes_to_check = [TestClass, BaseTestClass]
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_config=my_custom_test_class_config
+            object_config=my_custom_test_class_config,
+            parent_module_prefix=parent_module_prefix,
         )
         == "TestClass"
     )
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_config=some_other_class_config
+            object_config=some_other_class_config,
+            parent_module_prefix=parent_module_prefix,
         )
         is None
     )
-    classes_to_check = [BaseTestClass]
     assert (
         anonymizer._is_parent_class_recognized(
-            classes_to_check=classes_to_check, object_config=test_class_config
+            object_config=test_class_config, parent_module_prefix=parent_module_prefix
         )
         == "BaseTestClass"
     )

--- a/tests/datasource/test_datasource_anonymizer.py
+++ b/tests/datasource/test_datasource_anonymizer.py
@@ -254,7 +254,7 @@ introspection:
     }
 
 
-def test_is_parent_class_recognized_yes():
+def test_get_parent_class_yes():
 
     v2_batch_kwargs_api_datasources = [
         "PandasDatasource",
@@ -278,9 +278,7 @@ def test_is_parent_class_recognized_yes():
     ]
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     for idx in range(len(configs)):
-        parent_class = datasource_anonymizer.is_parent_class_recognized(
-            config=configs[idx]
-        )
+        parent_class = datasource_anonymizer.get_parent_class(config=configs[idx])
         assert parent_class == parent_classes[idx]
 
 
@@ -290,7 +288,7 @@ def test_is_custom_parent_class_recognized_yes():
         "class_name": "MyCustomV3ApiDatasource",
     }
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
-    parent_class = datasource_anonymizer.is_parent_class_recognized(config=config)
+    parent_class = datasource_anonymizer.get_parent_class(config=config)
     assert parent_class == "Datasource"
 
     config = {
@@ -298,11 +296,11 @@ def test_is_custom_parent_class_recognized_yes():
         "class_name": "MyCustomV2ApiDatasource",
     }
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
-    parent_class = datasource_anonymizer.is_parent_class_recognized(config=config)
+    parent_class = datasource_anonymizer.get_parent_class(config=config)
     assert parent_class == "PandasDatasource"
 
 
-def test_is_parent_class_recognized_no():
+def test_get_parent_class_no():
     parent_classes = ["MyCustomNonDatasourceClass", "MyOtherCustomNonDatasourceClass"]
     configs = [
         {
@@ -314,14 +312,12 @@ def test_is_parent_class_recognized_no():
     ]
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     for idx in range(len(configs)):
-        parent_class = datasource_anonymizer.is_parent_class_recognized(
-            config=configs[idx]
-        )
+        parent_class = datasource_anonymizer.get_parent_class(config=configs[idx])
         assert parent_class != parent_classes[idx]
         assert parent_class is None
 
 
-def test_is_parent_class_recognized_v2_api_yes():
+def test_get_parent_class_v2_api_yes():
     v2_batch_kwargs_api_datasources = [
         "PandasDatasource",
         "SqlAlchemyDatasource",
@@ -339,7 +335,7 @@ def test_is_parent_class_recognized_v2_api_yes():
     ]
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     for idx in range(len(configs)):
-        parent_class = datasource_anonymizer.is_parent_class_recognized_v2_api(
+        parent_class = datasource_anonymizer.get_parent_class_v2_api(
             config=configs[idx]
         )
         assert parent_class == parent_classes[idx]
@@ -351,13 +347,11 @@ def test_is_custom_parent_class_recognized_v2_api_yes():
         "class_name": "MyCustomV2ApiDatasource",
     }
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
-    parent_class = datasource_anonymizer.is_parent_class_recognized_v2_api(
-        config=config
-    )
+    parent_class = datasource_anonymizer.get_parent_class_v2_api(config=config)
     assert parent_class == "PandasDatasource"
 
 
-def test_is_parent_class_recognized_v2_api_no():
+def test_get_parent_class_v2_api_no():
     v3_batch_request_api_datasources = [
         "SimpleSqlalchemyDatasource",
         "Datasource",
@@ -378,14 +372,14 @@ def test_is_parent_class_recognized_v2_api_no():
     ]
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     for idx in range(len(configs)):
-        parent_class = datasource_anonymizer.is_parent_class_recognized_v2_api(
+        parent_class = datasource_anonymizer.get_parent_class_v2_api(
             config=configs[idx]
         )
         assert parent_class != parent_classes[idx]
         assert parent_class is None
 
 
-def test_is_parent_class_recognized_v3_api_yes():
+def test_get_parent_class_v3_api_yes():
     v3_batch_request_api_datasources = [
         "SimpleSqlalchemyDatasource",
         "Datasource",
@@ -402,7 +396,7 @@ def test_is_parent_class_recognized_v3_api_yes():
     ]
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     for idx in range(len(configs)):
-        parent_class = datasource_anonymizer.is_parent_class_recognized_v3_api(
+        parent_class = datasource_anonymizer.get_parent_class_v3_api(
             config=configs[idx]
         )
         assert parent_class == parent_classes[idx]
@@ -414,13 +408,11 @@ def test_is_custom_parent_class_recognized_v3_api_yes():
         "class_name": "MyCustomV3ApiDatasource",
     }
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
-    parent_class = datasource_anonymizer.is_parent_class_recognized_v3_api(
-        config=config
-    )
+    parent_class = datasource_anonymizer.get_parent_class_v3_api(config=config)
     assert parent_class == "Datasource"
 
 
-def test_is_parent_class_recognized_v3_api_no():
+def test_get_parent_class_v3_api_no():
     v2_batch_kwargs_api_datasources = [
         "PandasDatasource",
         "SqlAlchemyDatasource",
@@ -442,7 +434,7 @@ def test_is_parent_class_recognized_v3_api_no():
     ]
     datasource_anonymizer = DatasourceAnonymizer(salt=CONSISTENT_SALT)
     for idx in range(len(configs)):
-        parent_class = datasource_anonymizer.is_parent_class_recognized_v3_api(
+        parent_class = datasource_anonymizer.get_parent_class_v3_api(
             config=configs[idx]
         )
         assert parent_class != parent_classes[idx]


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
