### PR TITLE
[BUGFIX] Only validate row_condition if not None

### DIFF
--- a/great_expectations/data_asset/util.py
+++ b/great_expectations/data_asset/util.py
@@ -115,7 +115,7 @@ def recursively_convert_to_json_serializable(test_obj):
     elif isinstance(test_obj, dict):
         new_dict = {}
         for key in test_obj:
-            if key == "row_condition":
+            if key == "row_condition" and test_obj[key] is not None:
                 ensure_row_condition_is_correct(test_obj[key])
             # A pandas index can be numeric, and a dict key can be numeric, but a json key must be a string
             new_dict[str(key)] = recursively_convert_to_json_serializable(test_obj[key])


### PR DESCRIPTION
Changes proposed in this pull request:
- `row_condition` validation should only occur if not `None`, otherwise exception is thrown and serialization fails (`TypeError: argument of type 'NoneType' is not iterable `)
