### PR TITLE
convert unexpected_list contents to hashable type

### DIFF
--- a/tests/expectations/test_format_map_output.py
+++ b/tests/expectations/test_format_map_output.py
@@ -1,0 +1,154 @@
+from great_expectations.expectations.expectation import _format_map_output
+
+
+def test_format_map_output_with_numbers():
+    success = False
+    element_count = 5
+    nonnull_count = 5
+    success_count = 0
+    unexpected_list = [
+        {"foreign_key_1": 1, "foreign_key_2": 2},
+        {"foreign_key_1": 1, "foreign_key_2": 2},
+        {"foreign_key_1": 1, "foreign_key_2": 2},
+    ]
+    unexpected_index_list = [1, 2, 3]
+    assert _format_map_output(
+        result_format={
+            "result_format": "COMPLETE",
+            "partial_unexpected_count": 20,
+            "include_unexpected_rows": False,
+        },
+        success=success,
+        element_count=element_count,
+        nonnull_count=nonnull_count,
+        unexpected_count=len(unexpected_list),
+        unexpected_list=unexpected_list,
+        unexpected_index_list=unexpected_index_list,
+    ) == {
+        "success": False,
+        "result": {
+            "element_count": 5,
+            "missing_count": 0,
+            "missing_percent": 0.0,
+            "partial_unexpected_list": [
+                {"foreign_key_1": 1, "foreign_key_2": 2},
+                {"foreign_key_1": 1, "foreign_key_2": 2},
+                {"foreign_key_1": 1, "foreign_key_2": 2},
+            ],
+            "unexpected_count": 3,
+            "unexpected_percent": 60.0,
+            "unexpected_percent_total": 60.0,
+            "unexpected_percent_nonmissing": 60.0,
+            "partial_unexpected_counts": [{"value": (1, 2), "count": 3}],
+            "partial_unexpected_index_list": [1, 2, 3],
+            "unexpected_list": [
+                {"foreign_key_1": 1, "foreign_key_2": 2},
+                {"foreign_key_1": 1, "foreign_key_2": 2},
+                {"foreign_key_1": 1, "foreign_key_2": 2},
+            ],
+            "unexpected_index_list": [1, 2, 3],
+        },
+    }
+
+
+def test_format_map_output_with_strings():
+    success = False
+    element_count = 5
+    nonnull_count = 5
+    success_count = 0
+    unexpected_list = [
+        {"foreign_key_1": "a", "foreign_key_2": 2},
+        {"foreign_key_1": "a", "foreign_key_2": 2},
+        {"foreign_key_1": "a", "foreign_key_2": 2},
+    ]
+    unexpected_index_list = [1, 2, 3]
+    assert _format_map_output(
+        result_format={
+            "result_format": "COMPLETE",
+            "partial_unexpected_count": 20,
+            "include_unexpected_rows": False,
+        },
+        success=success,
+        element_count=element_count,
+        nonnull_count=nonnull_count,
+        unexpected_count=len(unexpected_list),
+        unexpected_list=unexpected_list,
+        unexpected_index_list=unexpected_index_list,
+    ) == {
+        "success": False,
+        "result": {
+            "element_count": 5,
+            "missing_count": 0,
+            "missing_percent": 0.0,
+            "partial_unexpected_list": [
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+            ],
+            "unexpected_count": 3,
+            "unexpected_percent": 60.0,
+            "unexpected_percent_total": 60.0,
+            "unexpected_percent_nonmissing": 60.0,
+            "partial_unexpected_counts": [{"value": ("a", 2), "count": 3}],
+            "partial_unexpected_index_list": [1, 2, 3],
+            "unexpected_list": [
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+            ],
+            "unexpected_index_list": [1, 2, 3],
+        },
+    }
+
+
+def test_format_map_output_with_strings_two_matches():
+    success = False
+    element_count = 5
+    nonnull_count = 5
+    success_count = 0
+    unexpected_list = [
+        {"foreign_key_1": "a", "foreign_key_2": 2},
+        {"foreign_key_1": "a", "foreign_key_2": 2},
+        {"foreign_key_1": "b", "foreign_key_2": 3},
+    ]
+    unexpected_index_list = [1, 3]
+    assert _format_map_output(
+        result_format={
+            "result_format": "COMPLETE",
+            "partial_unexpected_count": 20,
+            "include_unexpected_rows": False,
+        },
+        success=success,
+        element_count=element_count,
+        nonnull_count=nonnull_count,
+        unexpected_count=len(unexpected_list),
+        unexpected_list=unexpected_list,
+        unexpected_index_list=unexpected_index_list,
+    ) == {
+        "success": False,
+        "result": {
+            "element_count": 5,
+            "missing_count": 0,
+            "missing_percent": 0.0,
+            "partial_unexpected_list": [
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "b", "foreign_key_2": 3},
+            ],
+            "unexpected_count": 3,
+            "unexpected_percent": 60.0,
+            "unexpected_percent_total": 60.0,
+            "unexpected_percent_nonmissing": 60.0,
+            "partial_unexpected_counts": [
+                {"value": ("a", 2), "count": 2},
+                {"value": ("b", 3), "count": 1},
+            ],
+            "partial_unexpected_index_list": [1, 3],
+            "unexpected_list": [
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "a", "foreign_key_2": 2},
+                {"foreign_key_1": "b", "foreign_key_2": 3},
+            ],
+            "unexpected_index_list": [1, 3],
+        },
+    }


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- when handling `unexpected_list` while formatting the results of an expectation validation, an exception was being thrown if the unexpected_list contained dicts. This PR updates that logic to transform the dicts to an immutable data type, if present.
- DEVREL-1445
- closes ISS #4295 

After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
