### PR TITLE
[BUGFIX] Upper bound pyathena to <2.5.0

### DIFF
--- a/requirements-dev-sqlalchemy.txt
+++ b/requirements-dev-sqlalchemy.txt
@@ -4,11 +4,9 @@
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
 psycopg2-binary>=2.7.6  # sqlalchemy_tests
-pyathena>=1.11
-sqlalchemy-bigquery>=1.3.0  # sqlalchemy_tests
+pyathena>=1.11,<2.5.0
 PyMySQL>=0.9.3,<0.10  # sqlalchemy_tests
 pyodbc>=4.0.30  # sqlalchemy_tests
-sqlalchemy-dremio>=1.2.1
 
 # NOTE - 20200825
 # snowflake-connector-python is implied by snowflake-sqlalchemy, but has produced multiple
@@ -22,5 +20,7 @@ snowflake-connector-python==2.5.0  # sqlalchemy_tests
 snowflake-sqlalchemy>=1.2.3  # sqlalchemy_tests
 # NOTE - 20210421 sqlalchemy pinned temporarily due to 1.4.10 breaking mssql tests
 sqlalchemy>=1.3.18,<1.4.10 # sqlalchemy_tests
+sqlalchemy-bigquery>=1.3.0  # sqlalchemy_tests
+sqlalchemy-dremio>=1.2.1
 sqlalchemy-redshift>=0.7.7  # sqlalchemy_tests
 teradatasqlalchemy==17.0.0.1

--- a/requirements-dev-sqlalchemy.txt
+++ b/requirements-dev-sqlalchemy.txt
@@ -4,7 +4,7 @@
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
 psycopg2-binary>=2.7.6  # sqlalchemy_tests
-pyathena>=1.11
+pyathena>=1.11,<2.5.0
 PyMySQL>=0.9.3,<0.10  # sqlalchemy_tests
 pyodbc>=4.0.30  # sqlalchemy_tests
 

--- a/requirements-dev-sqlalchemy.txt
+++ b/requirements-dev-sqlalchemy.txt
@@ -4,7 +4,7 @@
 # Otherwise (i.e., if/when you are not concerned with running tests), please ignore these comments.
 
 psycopg2-binary>=2.7.6  # sqlalchemy_tests
-pyathena>=1.11,<2.5.0
+pyathena>=1.11
 PyMySQL>=0.9.3,<0.10  # sqlalchemy_tests
 pyodbc>=4.0.30  # sqlalchemy_tests
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Upper bound pin on pyathena due to regression introduced in latest release

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
