### PR TITLE
[MAINTENANCE] Reduce tries to 2 for probabilistic tests

### DIFF
--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -447,7 +447,7 @@ def _compute_bootstrap_quantiles_point_estimate_scipy_confidence_interval_midpoi
     """
     bootstraps: tuple = (metric_values,)  # bootstrap samples must be in a sequence
 
-    lower_quantile_bootstrap_result: stats.bootstrap.BootstrapResult = stats.bootstrap(
+    lower_quantile_bootstrap_result: stats._bootstrap.BootstrapResult = stats.bootstrap(
         bootstraps,
         lambda data: np.quantile(
             data,
@@ -458,7 +458,7 @@ def _compute_bootstrap_quantiles_point_estimate_scipy_confidence_interval_midpoi
         n_resamples=n_resamples,
         method=method,
     )
-    upper_quantile_bootstrap_result: stats.bootstrap.BootstrapResult = stats.bootstrap(
+    upper_quantile_bootstrap_result: stats._bootstrap.BootstrapResult = stats.bootstrap(
         bootstraps,
         lambda data: np.quantile(
             data,
@@ -486,7 +486,7 @@ def _compute_bootstrap_quantiles_point_estimate_scipy_confidence_interval_midpoi
     #     Springer Science and Business Media Dordrecht. DOI 10.1007/978-1-4899-4541-9
     #
     # For an in-depth look at how the BCa interval is constructed and you will find the points made above on page 186.
-    lower_quantile_confidence_interval: stats.bootstrap.BootstrapResult.ConfidenceInterval = (
+    lower_quantile_confidence_interval: stats._bootstrap.BootstrapResult.ConfidenceInterval = (
         lower_quantile_bootstrap_result.confidence_interval
     )
     lower_quantile_point_estimate: np.float64 = np.mean(
@@ -495,7 +495,7 @@ def _compute_bootstrap_quantiles_point_estimate_scipy_confidence_interval_midpoi
             lower_quantile_confidence_interval.high,
         ]
     )
-    upper_quantile_confidence_interal: stats.bootstrap.BootstrapResult.ConfidenceInterval = (
+    upper_quantile_confidence_interal: stats._bootstrap.BootstrapResult.ConfidenceInterval = (
         upper_quantile_bootstrap_result.confidence_interval
     )
     upper_quantile_point_estimate: np.float64 = np.mean(

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -95,7 +95,7 @@ PLURAL_TO_SINGULAR_LOOKUP_DICT: dict = {
     "rendered_data_docs": "rendered_data_doc",
 }
 
-MAX_PROBABILISTIC_TEST_ASSERTION_RETRIES: int = 3
+MAX_PROBABILISTIC_TEST_ASSERTION_RETRIES: int = 2
 
 
 def pluralize(singular_ge_noun):


### PR DESCRIPTION
Changes proposed in this pull request:
- Only try probabilistic tests twice instead of thrice

It is preferable to start with a stricter tolerance and loosen the tolerance if necessary. Three tries leads to running multiple unnecessary test runs and can cover up poorly performing tests.

### Chance of two failures given the probability of a test succeeding:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/19361723/157155361-aa6f8b79-072a-406d-bba7-0e2fef410b4a.png">

### Same chart above zoomed into 90% - 100% test success:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/19361723/157155412-2a4f3fea-037a-4e24-8d38-3885f56ca879.png">

### Highlights that even poorly performing tests with low success ratios will pass the vast majority of the time with three tries:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/19361723/157155679-4f4c91ca-501e-43d3-9da3-20a7a0a4e76a.png">



### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have run any local integration tests and made sure that nothing is broken.
