### PR TITLE
[DOCS] add Config section

### DIFF
--- a/docs/reference/expectations/result_format.md
+++ b/docs/reference/expectations/result_format.md
@@ -18,6 +18,44 @@ The `result_format` parameter may be either a string or a dictionary which speci
   unwieldy amount of data.
   :::
 
+## Configure Result Format
+Result Format can be applied to either a single Expectation or a complete Checkpoint.
+### Expectation Level Config
+To apply `result_format` to an Expectation, pass it into the Expectation's configuration:
+```python
+# first obtain a validator object, for instance by running the `$ great_expectations suite new` notebook.
+validation_result = validator.expect_column_values_to_be_between(
+    column="pickup_location_id",
+    min_value=0,
+    max_value=100,
+    result_format="COMPLETE",
+    include_unexpected_rows=True
+)
+unexpected_index_list = validation_result["result"]["unexpected_index_list"]
+unexpected_list = validation_result["result"]["unexpected_list"]
+```
+When configured at the Expectation level, the `unexpected_index_list` and `unexpected_list` won't be passed through to the final Expectation Suite Validation Result object.
+In order to see those values at the Suite level, configure `result_format` in your Checkpoint configuration.
+### Checkpoint Level Config
+To apply `result_format` to every Expectation in a Suite, define it in your Checkpoint configuration under the `runtime_configuration` key.
+```python
+checkpoint_config = {
+    "class_name": "SimpleCheckpoint", # or Checkpoint
+    "validations": [
+        # omitted for brevity
+    ],
+    "runtime_configuration": {
+        "result_format": {
+            "result_format": "COMPLETE",
+            "include_unexpected_rows": True
+        }
+    }
+}
+```
+The results will then be stored in the Validation result after running the Checkpoint.
+:::note
+Regardless of where Result Format is configured, `unexpected_list` and `unexpected_index_list` are never rendered in Data Docs, as they are expected to be used for debugging purposes only.
+:::
 
 ## result_format values
 
@@ -32,7 +70,7 @@ cases for working with Great Expectations, including interactive exploratory wor
 |    missing_count                      |no              |yes             |yes             |yes             |
 |    missing_percent                    |no              |yes             |yes             |yes             |
 |    details (dictionary)               |Defined on a per-expectation basis                                 |
-| Fields defined for `column_map_expectation` type expectations:                                            |
+### Fields defined for `column_map_expectation` type expectations:                                            |
 |    unexpected_count                   |no              |yes             |yes             |yes             |
 |    unexpected_percent                 |no              |yes             |yes             |yes             |
 |    unexpected_percent_nonmissing      |no              |yes             |yes             |yes             |
@@ -41,7 +79,7 @@ cases for working with Great Expectations, including interactive exploratory wor
 |    partial_unexpected_counts          |no              |no              |yes             |yes             |
 |    unexpected_index_list              |no              |no              |no              |yes             |
 |    unexpected_list                    |no              |no              |no              |yes             |
-| Fields defined for `column_aggregate_expectation` type expectations:                                      |
+### Fields defined for `column_aggregate_expectation` type expectations:                                      |
 |    observed_value                     |no              |yes             |yes             |yes             |
 |    details (e.g. statistical details) |no              |no              |yes             |yes             |
 

--- a/docs/reference/expectations/result_format.md
+++ b/docs/reference/expectations/result_format.md
@@ -70,7 +70,7 @@ cases for working with Great Expectations, including interactive exploratory wor
 |    missing_count                      |no              |yes             |yes             |yes             |
 |    missing_percent                    |no              |yes             |yes             |yes             |
 |    details (dictionary)               |Defined on a per-expectation basis                                 |
-### Fields defined for `column_map_expectation` type expectations:                                            |
+### Fields defined for `column_map_expectation` type expectations:                                            
 |    unexpected_count                   |no              |yes             |yes             |yes             |
 |    unexpected_percent                 |no              |yes             |yes             |yes             |
 |    unexpected_percent_nonmissing      |no              |yes             |yes             |yes             |
@@ -79,7 +79,7 @@ cases for working with Great Expectations, including interactive exploratory wor
 |    partial_unexpected_counts          |no              |no              |yes             |yes             |
 |    unexpected_index_list              |no              |no              |no              |yes             |
 |    unexpected_list                    |no              |no              |no              |yes             |
-### Fields defined for `column_aggregate_expectation` type expectations:                                      |
+### Fields defined for `column_aggregate_expectation` type expectations:                                     
 |    observed_value                     |no              |yes             |yes             |yes             |
 |    details (e.g. statistical details) |no              |no              |yes             |yes             |
 

--- a/docs/reference/expectations/result_format.md
+++ b/docs/reference/expectations/result_format.md
@@ -63,14 +63,14 @@ Great Expectations supports four values for `result_format`: `BOOLEAN_ONLY`, `BA
 out-of-the-box default is `BASIC`. Each successive value includes more detail and so can support different use 
 cases for working with Great Expectations, including interactive exploratory work and automatic validation.
 
-
+## Fields defined for all Expectations
 | Fields within `result`                |BOOLEAN_ONLY    |BASIC           |SUMMARY         |COMPLETE        |
 ----------------------------------------|----------------|----------------|----------------|-----------------
 |    element_count                      |no              |yes             |yes             |yes             |
 |    missing_count                      |no              |yes             |yes             |yes             |
 |    missing_percent                    |no              |yes             |yes             |yes             |
 |    details (dictionary)               |Defined on a per-expectation basis                                 |
-### Fields defined for `column_map_expectation` type expectations:  
+### Fields defined for `column_map_expectation` type Expectations
 | Fields within `result`                |BOOLEAN_ONLY    |BASIC           |SUMMARY         |COMPLETE        |
 ----------------------------------------|----------------|----------------|----------------|-----------------
 |    unexpected_count                   |no              |yes             |yes             |yes             |
@@ -81,7 +81,7 @@ cases for working with Great Expectations, including interactive exploratory wor
 |    partial_unexpected_counts          |no              |no              |yes             |yes             |
 |    unexpected_index_list              |no              |no              |no              |yes             |
 |    unexpected_list                    |no              |no              |no              |yes             |
-### Fields defined for `column_aggregate_expectation` type expectations:           
+### Fields defined for `column_aggregate_expectation` type Expectations
 | Fields within `result`                |BOOLEAN_ONLY    |BASIC           |SUMMARY         |COMPLETE        |
 ----------------------------------------|----------------|----------------|----------------|-----------------
 |    observed_value                     |no              |yes             |yes             |yes             |

--- a/docs/reference/expectations/result_format.md
+++ b/docs/reference/expectations/result_format.md
@@ -19,7 +19,7 @@ The `result_format` parameter may be either a string or a dictionary which speci
   :::
 
 ## Configure Result Format
-Result Format can be applied to either a single Expectation or a complete Checkpoint.
+Result Format can be applied to either a single Expectation or an entire Checkpoint.
 ### Expectation Level Config
 To apply `result_format` to an Expectation, pass it into the Expectation's configuration:
 ```python
@@ -34,7 +34,7 @@ validation_result = validator.expect_column_values_to_be_between(
 unexpected_index_list = validation_result["result"]["unexpected_index_list"]
 unexpected_list = validation_result["result"]["unexpected_list"]
 ```
-When configured at the Expectation level, the `unexpected_index_list` and `unexpected_list` won't be passed through to the final Expectation Suite Validation Result object.
+When configured at the Expectation level, the `unexpected_index_list` and `unexpected_list` won't be passed through to the final Validation Result object.
 In order to see those values at the Suite level, configure `result_format` in your Checkpoint configuration.
 ### Checkpoint Level Config
 To apply `result_format` to every Expectation in a Suite, define it in your Checkpoint configuration under the `runtime_configuration` key.
@@ -52,9 +52,9 @@ checkpoint_config = {
     }
 }
 ```
-The results will then be stored in the Validation result after running the Checkpoint.
+The results will then be stored in the Validation Result after running the Checkpoint.
 :::note
-Regardless of where Result Format is configured, `unexpected_list` and `unexpected_index_list` are never rendered in Data Docs, as they are expected to be used for debugging purposes only.
+Regardless of where Result Format is configured, `unexpected_list` and `unexpected_index_list` are never rendered in Data Docs.
 :::
 
 ## result_format values

--- a/docs/reference/expectations/result_format.md
+++ b/docs/reference/expectations/result_format.md
@@ -70,7 +70,9 @@ cases for working with Great Expectations, including interactive exploratory wor
 |    missing_count                      |no              |yes             |yes             |yes             |
 |    missing_percent                    |no              |yes             |yes             |yes             |
 |    details (dictionary)               |Defined on a per-expectation basis                                 |
-### Fields defined for `column_map_expectation` type expectations:                                            
+### Fields defined for `column_map_expectation` type expectations:  
+| Fields within `result`                |BOOLEAN_ONLY    |BASIC           |SUMMARY         |COMPLETE        |
+----------------------------------------|----------------|----------------|----------------|-----------------
 |    unexpected_count                   |no              |yes             |yes             |yes             |
 |    unexpected_percent                 |no              |yes             |yes             |yes             |
 |    unexpected_percent_nonmissing      |no              |yes             |yes             |yes             |
@@ -79,7 +81,9 @@ cases for working with Great Expectations, including interactive exploratory wor
 |    partial_unexpected_counts          |no              |no              |yes             |yes             |
 |    unexpected_index_list              |no              |no              |no              |yes             |
 |    unexpected_list                    |no              |no              |no              |yes             |
-### Fields defined for `column_aggregate_expectation` type expectations:                                     
+### Fields defined for `column_aggregate_expectation` type expectations:           
+| Fields within `result`                |BOOLEAN_ONLY    |BASIC           |SUMMARY         |COMPLETE        |
+----------------------------------------|----------------|----------------|----------------|-----------------
 |    observed_value                     |no              |yes             |yes             |yes             |
 |    details (e.g. statistical details) |no              |no              |yes             |yes             |
 


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- add a section clarifying the two ways to configure `result_format` and where it will (or won't) show up.

After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).



### Definition of Done
Please delete options that are not relevant.

- [x] I have made corresponding changes to the documentation


Thank you for submitting!
