### PR TITLE
[FEATURE] GitHub action to auto label `core-team`

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,0 +1,8 @@
+core-team:
+  - '@NathanFarmer'
+  - '@Shinnyshinshin'
+  - '@Super-Tanner'
+  - '@alexsherstinsky'
+  - '@anthonyburdi'
+  - '@cdkini'
+  - '@donaldheppner'

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -1,0 +1,9 @@
+on: pull_request
+name: team-label
+jobs:
+  team-labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: JulienKode/team-labeler-action@v0.1.1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -4,6 +4,7 @@ jobs:
   team-labeler:
     runs-on: ubuntu-latest
     steps:
+    # https://github.com/JulienKode/team-labeler-action
     - uses: JulienKode/team-labeler-action@v0.1.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Changes proposed in this pull request:
- Automatically label using GitHub actions. Yay for open source!