### PR TITLE
[MAINTENANCE] Change schedule for `packaging_and_installation` pipeline to run at off-hours

### DIFF
--- a/azure-pipelines-packaging.yml
+++ b/azure-pipelines-packaging.yml
@@ -13,7 +13,7 @@
 #  * User and developer workflows
 
 schedules:
-- cron: 0 0 * * *
+- cron: 0 8 * * *
   displayName: Scheduled Runs
   branches:
     include:


### PR DESCRIPTION
Changes proposed in this pull request:
- Forgot that cron works on UTC - let's change this so it now runs at 12am PST or 3am EST
