### PR TITLE
[BUGFIX] Minor Serialization Correction for MeanUnexpectedMapMetricMultiBatchParameterBuilder

### DIFF
--- a/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 
@@ -25,6 +25,15 @@ class MeanUnexpectedMapMetricMultiBatchParameterBuilder(
     """
     Compute mean unexpected count ratio (as a fraction) of a specified map-style metric across all specified batches.
     """
+
+    exclude_field_names: Set[
+        str
+    ] = MetricMultiBatchParameterBuilder.exclude_field_names | {
+        "metric_name",
+        "enforce_numeric_metric",
+        "replace_nan_with_zero",
+        "reduce_scalar_metric",
+    }
 
     def __init__(
         self,

--- a/tests/rule_based_profiler/parameter_builder/test_mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -279,7 +279,7 @@ def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_datetime
     )
 
 
-def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_serialization(
+def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_check_serialized_keys(
     bobby_columnar_table_multi_batch_deterministic_data_context,
 ):
     data_context: DataContext = (

--- a/tests/rule_based_profiler/parameter_builder/test_mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -41,6 +41,7 @@ def test_instantiation_mean_unexpected_map_metric_multi_batch_parameter_builder_
     )
 
     with pytest.raises(TypeError) as excinfo:
+        # noinspection PyArgumentList
         _: MeanUnexpectedMapMetricMultiBatchParameterBuilder = (
             MeanUnexpectedMapMetricMultiBatchParameterBuilder(
                 name="my_name",
@@ -55,6 +56,7 @@ def test_instantiation_mean_unexpected_map_metric_multi_batch_parameter_builder_
     )
 
     with pytest.raises(TypeError) as excinfo:
+        # noinspection PyArgumentList
         _: MeanUnexpectedMapMetricMultiBatchParameterBuilder = (
             MeanUnexpectedMapMetricMultiBatchParameterBuilder(
                 name="my_name",
@@ -275,3 +277,47 @@ def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_datetime
         atol=atol,
         err_msg=f"Actual value of {actual_parameter_value.value} differs from expected value of {expected_parameter_value} by more than {atol + rtol * abs(actual_parameter_value.value)} tolerance.",
     )
+
+
+def test_mean_unexpected_map_metric_multi_batch_parameter_builder_bobby_serialization(
+    bobby_columnar_table_multi_batch_deterministic_data_context,
+):
+    data_context: DataContext = (
+        bobby_columnar_table_multi_batch_deterministic_data_context
+    )
+
+    batch_request: dict = {
+        "datasource_name": "taxi_pandas",
+        "data_connector_name": "monthly",
+        "data_asset_name": "my_reports",
+    }
+
+    metric_domain_kwargs_for_parameter_builder: str = "$domain.domain_kwargs"
+
+    mean_unexpected_map_metric_multi_batch_parameter_builder: MeanUnexpectedMapMetricMultiBatchParameterBuilder = MeanUnexpectedMapMetricMultiBatchParameterBuilder(
+        name="my_pickup_datetime_count_values_unique_mean_unexpected_map_metric",
+        map_metric_name="column_values.unique",
+        total_count_parameter_builder_name="my_total_count",
+        null_count_parameter_builder_name="my_null_count",
+        metric_domain_kwargs=metric_domain_kwargs_for_parameter_builder,
+        metric_value_kwargs=None,
+        batch_list=None,
+        batch_request=batch_request,
+        json_serialize=False,
+        data_context=data_context,
+    )
+
+    assert set(
+        mean_unexpected_map_metric_multi_batch_parameter_builder.to_json_dict().keys()
+    ) == {
+        "class_name",
+        "module_name",
+        "name",
+        "map_metric_name",
+        "total_count_parameter_builder_name",
+        "null_count_parameter_builder_name",
+        "metric_domain_kwargs",
+        "metric_value_kwargs",
+        "batch_request",
+        "json_serialize",
+    }


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
