### PR TITLE
[FEATURE] Enable the passing of an existing suite to `RuleBasedProfiler.run()`

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -3417,7 +3417,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         expectation_suite_name: Optional[str] = None,
         include_citation: bool = True,
     ) -> ExpectationSuite:
-        """Retrieve a RuleBasedProfiler from a ProfilerStore and run it with rules/variables supplied at runtime.
+        """Retrieve a RuleBasedProfiler from a ProfilerStore and run it with a batch request supplied at runtime.
 
         Args:
             batch_request: The batch request used to supply arguments at runtime.

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -3375,6 +3375,24 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         expectation_suite_name: Optional[str] = None,
         include_citation: bool = True,
     ) -> ExpectationSuite:
+        """Retrieve a RuleBasedProfiler from a ProfilerStore and run it with rules/variables supplied at runtime.
+
+        Args:
+            name: Identifier used to retrieve the profiler from a store.
+            ge_cloud_id: Identifier used to retrieve the profiler from a store (GE Cloud specific).
+            variables: Attribute name/value pairs (overrides)
+            rules: Key-value pairs of name/configuration-dictionary (overrides)
+            expectation_suite: An existing ExpectationSuite to update.
+            expectation_suite_name: A name for returned ExpectationSuite.
+            include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler.
+
+        Returns:
+            Set of rule evaluation results in the form of an ExpectationSuite.
+
+        Raises:
+            AssertionError if both a `name` and `ge_cloud_id` are provided.
+            AssertionError if both an `expectation_suite` and `expectation_suite_name` are provided.
+        """
         return RuleBasedProfiler.run_profiler(
             data_context=self,
             profiler_store=self.profiler_store,
@@ -3399,6 +3417,23 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         expectation_suite_name: Optional[str] = None,
         include_citation: bool = True,
     ) -> ExpectationSuite:
+        """Retrieve a RuleBasedProfiler from a ProfilerStore and run it with rules/variables supplied at runtime.
+
+        Args:
+            batch_request: The batch request used to supply arguments at runtime.
+            name: Identifier used to retrieve the profiler from a store.
+            ge_cloud_id: Identifier used to retrieve the profiler from a store (GE Cloud specific).
+            expectation_suite: An existing ExpectationSuite to update.
+            expectation_suite_name: A name for returned ExpectationSuite.
+            include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler.
+
+        Returns:
+            Set of rule evaluation results in the form of an ExpectationSuite.
+
+        Raises:
+            AssertionError if both a `name` and `ge_cloud_id` are provided.
+            AssertionError if both an `expectation_suite` and `expectation_suite_name` are provided.
+        """
         return RuleBasedProfiler.run_profiler_on_data(
             data_context=self,
             profiler_store=self.profiler_store,

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -3371,6 +3371,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         ge_cloud_id: Optional[str] = None,
         variables: Optional[dict] = None,
         rules: Optional[dict] = None,
+        expectation_suite: Optional[ExpectationSuite] = None,
         expectation_suite_name: Optional[str] = None,
         include_citation: bool = True,
     ) -> ExpectationSuite:
@@ -3381,6 +3382,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
             ge_cloud_id=ge_cloud_id,
             variables=variables,
             rules=rules,
+            expectation_suite=expectation_suite,
             expectation_suite_name=expectation_suite_name,
             include_citation=include_citation,
         )
@@ -3393,6 +3395,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         batch_request: Union[dict, BatchRequest, RuntimeBatchRequest],
         name: Optional[str] = None,
         ge_cloud_id: Optional[str] = None,
+        expectation_suite: Optional[ExpectationSuite] = None,
         expectation_suite_name: Optional[str] = None,
         include_citation: bool = True,
     ) -> ExpectationSuite:
@@ -3402,6 +3405,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
             batch_request=batch_request,
             name=name,
             ge_cloud_id=ge_cloud_id,
+            expectation_suite=expectation_suite,
             expectation_suite_name=expectation_suite_name,
             include_citation=include_citation,
         )

--- a/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
+++ b/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
@@ -211,7 +211,7 @@ validator.head(n_rows=5, fetch_all=False)
             code=f"""\
 suite = context.run_profiler_with_dynamic_arguments(
     name="{self._profiler_name}",
-    expectation_suite_name=expectation_suite_name,
+    expectation_suite=validator.expectation_suite
 )
 """,
             lint=True,

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -320,8 +320,8 @@ class BaseRuleBasedProfiler(ConfigPeer):
             :param include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler
         :return: Set of rule evaluation results in the form of an ExpectationSuite
         """
-        assert bool(expectation_suite) ^ bool(
-            expectation_suite_name
+        assert not (
+            expectation_suite and expectation_suite_name
         ), "Ambiguous arguments provided; you may pass in an ExpectationSuite or provide a name to instantiate a new one (but you may not do both)."
 
         effective_variables: Optional[

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -974,6 +974,7 @@ class RuleBasedProfiler(BaseRuleBasedProfiler):
         ge_cloud_id: Optional[str] = None,
         variables: Optional[dict] = None,
         rules: Optional[dict] = None,
+        expectation_suite: Optional[ExpectationSuite] = None,
         expectation_suite_name: Optional[str] = None,
         include_citation: bool = True,
     ) -> ExpectationSuite:
@@ -988,6 +989,7 @@ class RuleBasedProfiler(BaseRuleBasedProfiler):
         result: ExpectationSuite = profiler.run(
             variables=variables,
             rules=rules,
+            expectation_suite=expectation_suite,
             expectation_suite_name=expectation_suite_name,
             include_citation=include_citation,
         )
@@ -1001,6 +1003,7 @@ class RuleBasedProfiler(BaseRuleBasedProfiler):
         batch_request: Union[BatchRequest, RuntimeBatchRequest, dict],
         name: Optional[str] = None,
         ge_cloud_id: Optional[str] = None,
+        expectation_suite: Optional[ExpectationSuite] = None,
         expectation_suite_name: Optional[str] = None,
         include_citation: bool = True,
     ) -> ExpectationSuite:
@@ -1019,6 +1022,7 @@ class RuleBasedProfiler(BaseRuleBasedProfiler):
 
         result: ExpectationSuite = profiler.run(
             rules=rules,
+            expectation_suite=expectation_suite,
             expectation_suite_name=expectation_suite_name,
             include_citation=include_citation,
         )

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -312,7 +312,7 @@ class Validator:
 
             if self.interactive_evaluation:
                 configuration.process_evaluation_parameters(
-                    self._expectation_suite.evaluation_parameters,
+                    self.expectation_suite.evaluation_parameters,
                     True,
                     self._data_context,
                 )
@@ -328,7 +328,7 @@ class Validator:
                 else:
                     validation_result = expectation.validate(
                         validator=self,
-                        evaluation_parameters=self._expectation_suite.evaluation_parameters,
+                        evaluation_parameters=self.expectation_suite.evaluation_parameters,
                         data_context=self._data_context,
                         runtime_configuration=basic_runtime_configuration,
                     )
@@ -339,7 +339,7 @@ class Validator:
                     stored_config = configuration.get_raw_configuration()
                 else:
                     # Append the expectation to the config.
-                    stored_config = self._expectation_suite._add_expectation(
+                    stored_config = self.expectation_suite._add_expectation(
                         expectation_configuration=configuration.get_raw_configuration(),
                         send_usage_event=False,
                     )
@@ -1175,7 +1175,7 @@ aborting graph resolution.
             + "Please use ExpectationSuite.add_expectation instead.",
             DeprecationWarning,
         )
-        self._expectation_suite.append_expectation(expectation_config)
+        self.expectation_suite.append_expectation(expectation_config)
 
     def find_expectation_indexes(
         self,
@@ -1188,7 +1188,7 @@ aborting graph resolution.
             + "Please use ExpectationSuite.find_expectation_indexes instead.",
             DeprecationWarning,
         )
-        return self._expectation_suite.find_expectation_indexes(
+        return self.expectation_suite.find_expectation_indexes(
             expectation_configuration=expectation_configuration, match_type=match_type
         )
 
@@ -1204,7 +1204,7 @@ aborting graph resolution.
             + "Please use ExpectationSuite.find_expectation_indexes instead.",
             DeprecationWarning,
         )
-        return self._expectation_suite.find_expectations(
+        return self.expectation_suite.find_expectations(
             expectation_configuration=expectation_configuration,
             match_type=match_type,
             ge_cloud_id=ge_cloud_id,
@@ -1218,7 +1218,7 @@ aborting graph resolution.
         ge_cloud_id: Optional[str] = None,
     ) -> List[ExpectationConfiguration]:
 
-        return self._expectation_suite.remove_expectation(
+        return self.expectation_suite.remove_expectation(
             expectation_configuration=expectation_configuration,
             match_type=match_type,
             remove_multiple_matches=remove_multiple_matches,
@@ -1425,7 +1425,7 @@ set as active.
              copy of _expectation_suite, not the original object.
         """
 
-        expectation_suite = copy.deepcopy(self._expectation_suite)
+        expectation_suite = copy.deepcopy(self.expectation_suite)
         expectations = expectation_suite.expectations
 
         discards = defaultdict(int)
@@ -1851,8 +1851,8 @@ set as active.
         Returns:
             The current value of the evaluation parameter.
         """
-        if parameter_name in self._expectation_suite.evaluation_parameters:
-            return self._expectation_suite.evaluation_parameters[parameter_name]
+        if parameter_name in self.expectation_suite.evaluation_parameters:
+            return self.expectation_suite.evaluation_parameters[parameter_name]
         else:
             return default_value
 
@@ -1865,7 +1865,7 @@ set as active.
             parameter_name (string): The name of the kwarg to be replaced at evaluation time
             parameter_value (any): The value to be used
         """
-        self._expectation_suite.evaluation_parameters.update(
+        self.expectation_suite.evaluation_parameters.update(
             {parameter_name: parameter_value}
         )
 
@@ -1884,7 +1884,7 @@ set as active.
             batch_markers = self.active_batch_markers
         if batch_definition is None:
             batch_definition = self.active_batch_definition
-        self._expectation_suite.add_citation(
+        self.expectation_suite.add_citation(
             comment,
             batch_spec=batch_spec,
             batch_markers=batch_markers,
@@ -1893,14 +1893,18 @@ set as active.
         )
 
     @property
+    def expectation_suite(self) -> ExpectationSuite:
+        return self._expectation_suite
+
+    @property
     def expectation_suite_name(self) -> str:
         """Gets the current expectation_suite name of this data_asset as stored in the expectations configuration."""
-        return self._expectation_suite.expectation_suite_name
+        return self.expectation_suite.expectation_suite_name
 
     @expectation_suite_name.setter
     def expectation_suite_name(self, expectation_suite_name: str) -> None:
         """Sets the expectation_suite name of this data_asset as stored in the expectations configuration."""
-        self._expectation_suite.expectation_suite_name = expectation_suite_name
+        self.expectation_suite.expectation_suite_name = expectation_suite_name
 
     def test_expectation_function(
         self, function: Callable, *args, **kwargs
@@ -2067,20 +2071,20 @@ set as active.
                 )
             else:
                 expectation_suite: ExpectationSuite = copy.deepcopy(expectation_suite)
-            self._expectation_suite = expectation_suite
+            self.expectation_suite = expectation_suite
 
             if expectation_suite_name is not None:
                 if (
-                    self._expectation_suite.expectation_suite_name
+                    self.expectation_suite.expectation_suite_name
                     != expectation_suite_name
                 ):
                     logger.warning(
                         "Overriding existing expectation_suite_name {n1} with new name {n2}".format(
-                            n1=self._expectation_suite.expectation_suite_name,
+                            n1=self.expectation_suite.expectation_suite_name,
                             n2=expectation_suite_name,
                         )
                     )
-                self._expectation_suite.expectation_suite_name = expectation_suite_name
+                self.expectation_suite.expectation_suite_name = expectation_suite_name
 
         else:
             if expectation_suite_name is None:
@@ -2090,7 +2094,7 @@ set as active.
                 data_context=self._data_context,
             )
 
-        self._expectation_suite.execution_engine_type = type(
+        self.expectation_suite.execution_engine_type = type(
             self.execution_engine
         ).__name__
 

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -2071,7 +2071,7 @@ set as active.
                 )
             else:
                 expectation_suite: ExpectationSuite = copy.deepcopy(expectation_suite)
-            self.expectation_suite = expectation_suite
+            self._expectation_suite = expectation_suite
 
             if expectation_suite_name is not None:
                 if (

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -312,7 +312,7 @@ class Validator:
 
             if self.interactive_evaluation:
                 configuration.process_evaluation_parameters(
-                    self.expectation_suite.evaluation_parameters,
+                    self._expectation_suite.evaluation_parameters,
                     True,
                     self._data_context,
                 )
@@ -328,7 +328,7 @@ class Validator:
                 else:
                     validation_result = expectation.validate(
                         validator=self,
-                        evaluation_parameters=self.expectation_suite.evaluation_parameters,
+                        evaluation_parameters=self._expectation_suite.evaluation_parameters,
                         data_context=self._data_context,
                         runtime_configuration=basic_runtime_configuration,
                     )
@@ -339,7 +339,7 @@ class Validator:
                     stored_config = configuration.get_raw_configuration()
                 else:
                     # Append the expectation to the config.
-                    stored_config = self.expectation_suite._add_expectation(
+                    stored_config = self._expectation_suite._add_expectation(
                         expectation_configuration=configuration.get_raw_configuration(),
                         send_usage_event=False,
                     )
@@ -1175,7 +1175,7 @@ aborting graph resolution.
             + "Please use ExpectationSuite.add_expectation instead.",
             DeprecationWarning,
         )
-        self.expectation_suite.append_expectation(expectation_config)
+        self._expectation_suite.append_expectation(expectation_config)
 
     def find_expectation_indexes(
         self,
@@ -1188,7 +1188,7 @@ aborting graph resolution.
             + "Please use ExpectationSuite.find_expectation_indexes instead.",
             DeprecationWarning,
         )
-        return self.expectation_suite.find_expectation_indexes(
+        return self._expectation_suite.find_expectation_indexes(
             expectation_configuration=expectation_configuration, match_type=match_type
         )
 
@@ -1204,7 +1204,7 @@ aborting graph resolution.
             + "Please use ExpectationSuite.find_expectation_indexes instead.",
             DeprecationWarning,
         )
-        return self.expectation_suite.find_expectations(
+        return self._expectation_suite.find_expectations(
             expectation_configuration=expectation_configuration,
             match_type=match_type,
             ge_cloud_id=ge_cloud_id,
@@ -1218,7 +1218,7 @@ aborting graph resolution.
         ge_cloud_id: Optional[str] = None,
     ) -> List[ExpectationConfiguration]:
 
-        return self.expectation_suite.remove_expectation(
+        return self._expectation_suite.remove_expectation(
             expectation_configuration=expectation_configuration,
             match_type=match_type,
             remove_multiple_matches=remove_multiple_matches,
@@ -1425,7 +1425,7 @@ set as active.
              copy of _expectation_suite, not the original object.
         """
 
-        expectation_suite = copy.deepcopy(self.expectation_suite)
+        expectation_suite = copy.deepcopy(self._expectation_suite)
         expectations = expectation_suite.expectations
 
         discards = defaultdict(int)
@@ -1851,8 +1851,8 @@ set as active.
         Returns:
             The current value of the evaluation parameter.
         """
-        if parameter_name in self.expectation_suite.evaluation_parameters:
-            return self.expectation_suite.evaluation_parameters[parameter_name]
+        if parameter_name in self._expectation_suite.evaluation_parameters:
+            return self._expectation_suite.evaluation_parameters[parameter_name]
         else:
             return default_value
 
@@ -1865,7 +1865,7 @@ set as active.
             parameter_name (string): The name of the kwarg to be replaced at evaluation time
             parameter_value (any): The value to be used
         """
-        self.expectation_suite.evaluation_parameters.update(
+        self._expectation_suite.evaluation_parameters.update(
             {parameter_name: parameter_value}
         )
 
@@ -1884,7 +1884,7 @@ set as active.
             batch_markers = self.active_batch_markers
         if batch_definition is None:
             batch_definition = self.active_batch_definition
-        self.expectation_suite.add_citation(
+        self._expectation_suite.add_citation(
             comment,
             batch_spec=batch_spec,
             batch_markers=batch_markers,
@@ -1899,12 +1899,12 @@ set as active.
     @property
     def expectation_suite_name(self) -> str:
         """Gets the current expectation_suite name of this data_asset as stored in the expectations configuration."""
-        return self.expectation_suite.expectation_suite_name
+        return self._expectation_suite.expectation_suite_name
 
     @expectation_suite_name.setter
     def expectation_suite_name(self, expectation_suite_name: str) -> None:
         """Sets the expectation_suite name of this data_asset as stored in the expectations configuration."""
-        self.expectation_suite.expectation_suite_name = expectation_suite_name
+        self._expectation_suite.expectation_suite_name = expectation_suite_name
 
     def test_expectation_function(
         self, function: Callable, *args, **kwargs
@@ -2075,16 +2075,16 @@ set as active.
 
             if expectation_suite_name is not None:
                 if (
-                    self.expectation_suite.expectation_suite_name
+                    self._expectation_suite.expectation_suite_name
                     != expectation_suite_name
                 ):
                     logger.warning(
                         "Overriding existing expectation_suite_name {n1} with new name {n2}".format(
-                            n1=self.expectation_suite.expectation_suite_name,
+                            n1=self._expectation_suite.expectation_suite_name,
                             n2=expectation_suite_name,
                         )
                     )
-                self.expectation_suite.expectation_suite_name = expectation_suite_name
+                self._expectation_suite.expectation_suite_name = expectation_suite_name
 
         else:
             if expectation_suite_name is None:
@@ -2094,7 +2094,7 @@ set as active.
                 data_context=self._data_context,
             )
 
-        self.expectation_suite.execution_engine_type = type(
+        self._expectation_suite.execution_engine_type = type(
             self.execution_engine
         ).__name__
 
@@ -2138,7 +2138,7 @@ class BridgeValidator:
             determined by the type of data within the given batch
         """
         self.batch = batch
-        self.expectation_suite = expectation_suite
+        self._expectation_suite = expectation_suite
 
         if isinstance(expectation_engine, dict):
             expectation_engine = ClassConfig(**expectation_engine)
@@ -2192,7 +2192,7 @@ class BridgeValidator:
 
             return self.expectation_engine(
                 self.batch.data,
-                expectation_suite=self.expectation_suite,
+                expectation_suite=self._expectation_suite,
                 batch_kwargs=self.batch.batch_kwargs,
                 batch_parameters=self.batch.batch_parameters,
                 batch_markers=self.batch.batch_markers,
@@ -2214,7 +2214,7 @@ class BridgeValidator:
                 batch_parameters=self.batch.batch_parameters,
                 batch_markers=self.batch.batch_markers,
                 data_context=self.batch.data_context,
-                expectation_suite=self.expectation_suite,
+                expectation_suite=self._expectation_suite,
                 **init_kwargs,
                 **self.batch.batch_kwargs.get("dataset_options", {}),
             )
@@ -2229,7 +2229,7 @@ class BridgeValidator:
 
             return self.expectation_engine(
                 spark_df=self.batch.data,
-                expectation_suite=self.expectation_suite,
+                expectation_suite=self._expectation_suite,
                 batch_kwargs=self.batch.batch_kwargs,
                 batch_parameters=self.batch.batch_parameters,
                 batch_markers=self.batch.batch_markers,

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -3606,7 +3606,7 @@ def test_suite_new_profile_with_named_arg_runs_notebook_no_jupyter(
     profiler_code_cell: str = f"""\
 suite = context.run_profiler_with_dynamic_arguments(
     name="{profiler_name}",
-    expectation_suite_name=expectation_suite_name,
+    expectation_suite=validator.expectation_suite
 )
 """
     profiler_code_cell = lint_code(code=profiler_code_cell).rstrip("\n")
@@ -3730,7 +3730,7 @@ def test_suite_new_profile_with_named_arg_runs_notebook_opens_jupyter(
     profiler_code_cell: str = f"""\
 suite = context.run_profiler_with_dynamic_arguments(
     name="{profiler_name}",
-    expectation_suite_name=expectation_suite_name,
+    expectation_suite=validator.expectation_suite
 )
 """
     profiler_code_cell = lint_code(code=profiler_code_cell).rstrip("\n")

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_basic_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_basic_workflows.py
@@ -354,4 +354,4 @@ def test_profiler_run_with_expectation_suite_arg(
 
     assert id(res) == id(basic_expectation_suite)
     assert len(res.expectations) == 8
-    assert basic_expectation_suite.expectations == existing_expectations
+    assert basic_expectation_suite.expectations[:4] == existing_expectations

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_basic_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_basic_workflows.py
@@ -1,14 +1,12 @@
-from unittest import mock
+from typing import List
 
 import pytest
 from ruamel import yaml
 
-import great_expectations as ge
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import BatchRequest
-from great_expectations.data_context.types.resource_identifiers import (
-    ConfigurationIdentifier,
-)
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.data_context import DataContext
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.rule_based_profiler.domain_builder import (
     DomainBuilder,
@@ -19,7 +17,6 @@ from great_expectations.rule_based_profiler.expectation_configuration_builder im
 )
 from great_expectations.rule_based_profiler.parameter_builder import (
     MetricMultiBatchParameterBuilder,
-    NumericMetricRangeMultiBatchParameterBuilder,
 )
 from great_expectations.rule_based_profiler.rule.rule import Rule
 from great_expectations.rule_based_profiler.rule_based_profiler import RuleBasedProfiler
@@ -27,7 +24,7 @@ from great_expectations.rule_based_profiler.rule_based_profiler import RuleBased
 
 @pytest.fixture
 def data_context_with_taxi_data(empty_data_context):
-    context: ge.DataContext = empty_data_context
+    context: DataContext = empty_data_context
 
     # finding path to taxi_data relative to current test file
     data_path: str = file_relative_path(
@@ -76,7 +73,7 @@ def test_domain_builder(data_context_with_taxi_data):
     will be run on.  This test will SimpleColumnSuffixDomainBuilder on the suffix "_amount", which
     returns 4 columns as the domain.
     """
-    context: ge.DataContext = data_context_with_taxi_data
+    context: DataContext = data_context_with_taxi_data
     batch_request: BatchRequest = BatchRequest(
         datasource_name="taxi_multibatch_datasource_other_possibility",
         data_connector_name="default_inferred_data_connector_name",
@@ -110,7 +107,7 @@ def test_add_rule_and_run_profiler(data_context_with_taxi_data):
     The test eventually asserts that the profiler return 4 Expectations, one per column in
     our domain.
     """
-    context: ge.DataContext = data_context_with_taxi_data
+    context: DataContext = data_context_with_taxi_data
     batch_request: BatchRequest = BatchRequest(
         datasource_name="taxi_multibatch_datasource_other_possibility",
         data_connector_name="default_inferred_data_connector_name",
@@ -147,7 +144,7 @@ def test_profiler_parameter_builder_added(data_context_with_taxi_data):
     we use a MetricMultiBatchParameterBuilder to pass in the min_value parameter to
     expect_column_values_to_be_greater_than.
     """
-    context: ge.DataContext = data_context_with_taxi_data
+    context: DataContext = data_context_with_taxi_data
     batch_request: BatchRequest = BatchRequest(
         datasource_name="taxi_multibatch_datasource_other_possibility",
         data_connector_name="default_inferred_data_connector_name",
@@ -197,7 +194,7 @@ def test_profiler_save_and_load(data_context_with_taxi_data):
 
     The test tests that context.save_profiler() and context.get_profiler() return the expected RBP.
     """
-    context: ge.DataContext = data_context_with_taxi_data
+    context: DataContext = data_context_with_taxi_data
     batch_request: BatchRequest = BatchRequest(
         datasource_name="taxi_multibatch_datasource_other_possibility",
         data_connector_name="default_inferred_data_connector_name",
@@ -302,3 +299,59 @@ def test_profiler_save_and_load(data_context_with_taxi_data):
         "config_version": 1.0,
         "name": "my_rbp",
     }
+
+
+def test_profiler_run_with_expectation_suite_arg(
+    data_context_with_taxi_data: DataContext, basic_expectation_suite: ExpectationSuite
+):
+    context: DataContext = data_context_with_taxi_data
+    batch_request: BatchRequest = BatchRequest(
+        datasource_name="taxi_multibatch_datasource_other_possibility",
+        data_connector_name="default_inferred_data_connector_name",
+        data_asset_name="yellow_tripdata_sample_2018",
+        data_connector_query={"index": -1},
+    )
+    domain_builder: DomainBuilder = SimpleColumnSuffixDomainBuilder(
+        data_context=context,
+        batch_request=batch_request,
+        column_name_suffixes=["_amount"],
+    )
+    default_expectation_configuration_builder = DefaultExpectationConfigurationBuilder(
+        expectation_type="expect_column_values_to_not_be_null",
+        column="$domain.domain_kwargs.column",
+    )
+    simple_rule: Rule = Rule(
+        name="rule_with_no_variables_no_parameters",
+        domain_builder=domain_builder,
+        expectation_configuration_builders=[default_expectation_configuration_builder],
+    )
+    my_rbp: RuleBasedProfiler = RuleBasedProfiler(
+        name="my_simple_rbp", data_context=context, config_version=1.0
+    )
+    my_rbp.add_rule(rule=simple_rule)
+
+    existing_expectations: List[ExpectationConfiguration] = [
+        ExpectationConfiguration(
+            expectation_type="expect_column_to_exist",
+            kwargs={"column": "infinities"},
+        ),
+        ExpectationConfiguration(
+            expectation_type="expect_column_to_exist", kwargs={"column": "nulls"}
+        ),
+        ExpectationConfiguration(
+            expectation_type="expect_column_to_exist", kwargs={"column": "naturals"}
+        ),
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_be_unique",
+            kwargs={"column": "naturals"},
+        ),
+    ]
+
+    assert len(basic_expectation_suite.expectations) == 4
+    assert basic_expectation_suite.expectations == existing_expectations
+
+    res: ExpectationSuite = my_rbp.run(expectation_suite=basic_expectation_suite)
+
+    assert id(res) == id(basic_expectation_suite)
+    assert len(res.expectations) == 8
+    assert basic_expectation_suite.expectations == existing_expectations

--- a/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
+++ b/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
@@ -311,7 +311,7 @@ from great_expectations.exceptions import DataContextError""",
         # Profiler instantiation/usage
         """suite = context.run_profiler_with_dynamic_arguments(
     name="my_profiler",
-    expectation_suite_name=expectation_suite_name,
+    expectation_suite=validator.expectation_suite,
 )""",
     ]
 

--- a/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
+++ b/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
@@ -310,8 +310,7 @@ from great_expectations.exceptions import DataContextError""",
 }""",
         # Profiler instantiation/usage
         """suite = context.run_profiler_with_dynamic_arguments(
-    name="my_profiler",
-    expectation_suite=validator.expectation_suite,
+    name="my_profiler", expectation_suite=validator.expectation_suite
 )""",
     ]
 

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -917,7 +917,11 @@ def test_run_profiler_without_dynamic_args(
 
     assert mock_profiler_run.called
     assert mock_profiler_run.call_args == mock.call(
-        variables=None, rules=None, expectation_suite_name=None, include_citation=True
+        variables=None,
+        rules=None,
+        expectation_suite=None,
+        expectation_suite_name=None,
+        include_citation=True,
     )
 
 
@@ -949,6 +953,7 @@ def test_run_profiler_with_dynamic_args(
     assert mock_profiler_run.call_args == mock.call(
         variables=variables,
         rules=rules,
+        expectation_suite=None,
         expectation_suite_name=expectation_suite_name,
         include_citation=include_citation,
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow users to pass in an existing suite to `run()`
- In enabling this, we can now pass the `Validator`'s suite attribute to the method (CLI flow to come in a subsequent PR).

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
