### PR TITLE
[MAINTENANCE] Implicitly anonymize object based on __module__

### DIFF
--- a/great_expectations/core/usage_statistics/anonymizers/action_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/action_anonymizer.py
@@ -38,7 +38,6 @@ class ActionAnonymizer(Anonymizer):
             object_=action_obj,
             object_config=action_config,
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             runtime_environment={"module_name": "great_expectations.checkpoint"},
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -76,6 +76,7 @@ class Anonymizer:
             if Anonymizer._is_core_great_expectations_class(object_module_name):
                 anonymized_info_dict["parent_class"] = object_class_name
             elif len(parents) != 1:
+                # __bases__ provides us with the inheritance hierarchy - all GE core objects subclass exactly ONE parent class
                 if len(parents) == 0:
                     logger.info(
                         "Could not find any parent classes when anonymizing payload"

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -76,6 +76,14 @@ class Anonymizer:
             if Anonymizer._is_core_great_expectations_class(object_module_name):
                 anonymized_info_dict["parent_class"] = object_class_name
             else:
+
+                # Chetan - 20220311 - If we can't identify the class in question, we iterate through the
+                # parents. While GE does not utilize multiple inheritance when defining core objects (as of v0.14.10),
+                # it is important to recognize that this approach will select the FIRST valid parent and ignore the rest.
+                #
+                # As the alternative would be to default to __not_recognized__ in the face of ambiguity, we deem it approrpriate
+                # to select the first valid result, even if it doesn't convey the full picture of the object's inheritance hierarchy.
+
                 parent_class: type
                 for parent_class in parents:
                     parent_module_name: str = parent_class.__module__

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -44,7 +44,6 @@ class Anonymizer:
     def anonymize_object_info(
         self,
         anonymized_info_dict: dict,
-        ge_classes,
         object_: Optional[object] = None,
         object_class: Optional[type] = None,
         object_config: Optional[dict] = None,

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -92,6 +92,9 @@ class Anonymizer:
                 parent_module_name: str = parent_class.__module__
                 if parent_module_name.startswith("great_expectations"):
                     anonymized_info_dict["parent_class"] = parent_class.__name__
+                    anonymized_info_dict["anonymized_class"] = self.anonymize(
+                        object_class_name
+                    )
                 else:
                     self._anonymize_class_with_unrecognized_parent(
                         anonymized_info_dict=anonymized_info_dict,

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 class Anonymizer:
     """Anonymize string names in an optionally-consistent way."""
 
-    CORE_OBJECT_PREFIX = "great_expectations"
+    # Any class that starts with this __module__ is considered a "core" object
+    CORE_GE_OBJECT_MODULE_PREFIX = "great_expectations"
 
     def __init__(self, salt: Optional[str] = None) -> None:
         if salt is not None and not isinstance(salt, str):
@@ -76,9 +77,11 @@ class Anonymizer:
                 anonymized_info_dict["parent_class"] = object_class_name
             elif len(parents) != 1:
                 if len(parents) == 0:
-                    logger.debug("Could not find parent class when anonymizing payload")
+                    logger.info(
+                        "Could not find any parent classes when anonymizing payload"
+                    )
                 else:
-                    logger.debug(
+                    logger.info(
                         "Due to the ambiguity brought on by multiple inheritance, short-circuiting anonymization of payload"
                     )
                 anonymized_info_dict["parent_class"] = "__not_recognized__"
@@ -113,7 +116,7 @@ class Anonymizer:
 
     @staticmethod
     def _is_core_great_expectations_class(class_name: str) -> bool:
-        return class_name.startswith(Anonymizer.CORE_OBJECT_PREFIX)
+        return class_name.startswith(Anonymizer.CORE_GE_OBJECT_MODULE_PREFIX)
 
     @staticmethod
     def _is_parent_class_recognized(

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 class Anonymizer:
     """Anonymize string names in an optionally-consistent way."""
 
+    CORE_OBJECT_PREFIX = "great_expectations"
+
     def __init__(self, salt: Optional[str] = None) -> None:
         if salt is not None and not isinstance(salt, str):
             logger.error("invalid salt: must provide a string. Setting a random salt.")
@@ -69,56 +71,50 @@ class Anonymizer:
 
             object_class_name = object_class.__name__
             object_module_name = object_class.__module__
-            bases: Tuple[type, ...] = object_class.__bases__
+            parents: Tuple[type, ...] = object_class.__bases__
 
-            if object_module_name.startswith("great_expectations"):
+            if Anonymizer._is_core_great_expectations_class(object_module_name):
                 anonymized_info_dict["parent_class"] = object_class_name
-            elif len(bases) == 0:
-                logger.warning("Could not find parent class when anonymizing payload")
-                self._anonymize_class_with_unrecognized_parent(
-                    anonymized_info_dict=anonymized_info_dict,
-                    class_name=object_class_name,
-                )
-            elif len(bases) > 1:
-                logger.warning(
-                    "Due to the ambiguity brought on by multiple inheritance, short-circuiting anonymization of payload"
-                )
-                self._anonymize_class_with_unrecognized_parent(
-                    anonymized_info_dict=anonymized_info_dict,
-                    class_name=object_class_name,
+            elif len(parents) != 1:
+                if len(parents) == 0:
+                    logger.debug("Could not find parent class when anonymizing payload")
+                else:
+                    logger.debug(
+                        "Due to the ambiguity brought on by multiple inheritance, short-circuiting anonymization of payload"
+                    )
+                anonymized_info_dict["parent_class"] = "__not_recognized__"
+                anonymized_info_dict["anonymized_class"] = self.anonymize(
+                    object_class_name
                 )
             else:
-                parent_class: type = bases[0]
+                parent_class: type = parents[0]
                 parent_module_name: str = parent_class.__module__
-                if parent_module_name.startswith("great_expectations"):
+                if Anonymizer._is_core_great_expectations_class(parent_module_name):
                     anonymized_info_dict["parent_class"] = parent_class.__name__
                     anonymized_info_dict["anonymized_class"] = self.anonymize(
                         object_class_name
                     )
                 else:
-                    self._anonymize_class_with_unrecognized_parent(
-                        anonymized_info_dict=anonymized_info_dict,
-                        class_name=object_class_name,
+                    anonymized_info_dict["parent_class"] = "__not_recognized__"
+                    anonymized_info_dict["anonymized_class"] = self.anonymize(
+                        object_class_name
                     )
 
             if not anonymized_info_dict.get("parent_class"):
-                self._anonymize_class_with_unrecognized_parent(
-                    anonymized_info_dict=anonymized_info_dict,
-                    class_name=object_class_name,
+                anonymized_info_dict["parent_class"] = "__not_recognized__"
+                anonymized_info_dict["anonymized_class"] = self.anonymize(
+                    object_class_name
                 )
 
         except AttributeError:
-            self._anonymize_class_with_unrecognized_parent(
-                anonymized_info_dict=anonymized_info_dict, class_name=object_class_name
-            )
+            anonymized_info_dict["parent_class"] = "__not_recognized__"
+            anonymized_info_dict["anonymized_class"] = self.anonymize(object_class_name)
 
         return anonymized_info_dict
 
-    def _anonymize_class_with_unrecognized_parent(
-        self, anonymized_info_dict: dict, class_name: Optional[str]
-    ) -> None:
-        anonymized_info_dict["parent_class"] = "__not_recognized__"
-        anonymized_info_dict["anonymized_class"] = self.anonymize(class_name)
+    @staticmethod
+    def _is_core_great_expectations_class(class_name: str) -> bool:
+        return class_name.startswith(Anonymizer.CORE_OBJECT_PREFIX)
 
     @staticmethod
     def _is_parent_class_recognized(

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -81,8 +81,9 @@ class Anonymizer:
                 # parents. While GE does not utilize multiple inheritance when defining core objects (as of v0.14.10),
                 # it is important to recognize that this approach will select the FIRST valid parent and ignore the rest.
                 #
-                # As the alternative would be to default to __not_recognized__ in the face of ambiguity, we deem it approrpriate
+                # As the alternative would be to default to "__not_recognized__" in the face of ambiguity, we deem it appropriate
                 # to select the first valid result, even if it doesn't convey the full picture of the object's inheritance hierarchy.
+                # Some information is better than no information.
 
                 parent_class: type
                 for parent_class in parents:

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -75,34 +75,18 @@ class Anonymizer:
 
             if Anonymizer._is_core_great_expectations_class(object_module_name):
                 anonymized_info_dict["parent_class"] = object_class_name
-            elif len(parents) != 1:
-                # __bases__ provides us with the inheritance hierarchy - all GE core objects subclass exactly ONE parent class
-                if len(parents) == 0:
-                    logger.info(
-                        "Could not find any parent classes when anonymizing payload"
-                    )
-                else:
-                    logger.info(
-                        "Due to the ambiguity brought on by multiple inheritance, short-circuiting anonymization of payload"
-                    )
-                anonymized_info_dict["parent_class"] = "__not_recognized__"
-                anonymized_info_dict["anonymized_class"] = self.anonymize(
-                    object_class_name
-                )
             else:
-                parent_class: type = parents[0]
-                parent_module_name: str = parent_class.__module__
-                if Anonymizer._is_core_great_expectations_class(parent_module_name):
-                    anonymized_info_dict["parent_class"] = parent_class.__name__
-                    anonymized_info_dict["anonymized_class"] = self.anonymize(
-                        object_class_name
-                    )
-                else:
-                    anonymized_info_dict["parent_class"] = "__not_recognized__"
-                    anonymized_info_dict["anonymized_class"] = self.anonymize(
-                        object_class_name
-                    )
+                parent_class: type
+                for parent_class in parents:
+                    parent_module_name: str = parent_class.__module__
+                    if Anonymizer._is_core_great_expectations_class(parent_module_name):
+                        anonymized_info_dict["parent_class"] = parent_class.__name__
+                        anonymized_info_dict["anonymized_class"] = self.anonymize(
+                            object_class_name
+                        )
+                        break
 
+            # Catch-all to prevent edge cases from slipping past
             if not anonymized_info_dict.get("parent_class"):
                 anonymized_info_dict["parent_class"] = "__not_recognized__"
                 anonymized_info_dict["anonymized_class"] = self.anonymize(

--- a/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
@@ -25,7 +25,6 @@ class CheckpointAnonymizer(Anonymizer):
 
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=checkpoint_config_dict,
         )
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/data_connector_anonymizer.py
@@ -68,7 +68,6 @@ class DataConnectorAnonymizer(Anonymizer):
 
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=data_connector_config_dict,
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/datasource_anonymizer.py
@@ -48,14 +48,12 @@ class DatasourceAnonymizer(Anonymizer):
         if self.is_parent_class_recognized_v2_api(config=config) is not None:
             self.anonymize_object_info(
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._legacy_ge_classes,
                 object_config=config,
             )
         # Datasources (>= v0.13 v3 BatchRequest API), and custom v2 BatchKwargs API
         elif self.is_parent_class_recognized_v3_api(config=config) is not None:
             self.anonymize_object_info(
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
                 object_config=config,
             )
             execution_engine_config = config.get("execution_engine")
@@ -85,7 +83,6 @@ class DatasourceAnonymizer(Anonymizer):
             config["module_name"] = "great_expectations.datasource"
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=config,
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/execution_engine_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/execution_engine_anonymizer.py
@@ -37,7 +37,6 @@ class ExecutionEngineAnonymizer(Anonymizer):
 
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=execution_engine_config_dict,
         )
 

--- a/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
@@ -17,7 +17,6 @@ class ProfilerAnonymizer(Anonymizer):
         }
         self.anonymize_object_info(
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
             object_config=config,
         )
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/profiler_run_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/profiler_run_anonymizer.py
@@ -172,7 +172,6 @@ class ProfilerRunAnonymizer(Anonymizer):
         anonymized_domain_builder: dict = self.anonymize_object_info(
             object_config=domain_builder,
             anonymized_info_dict={},
-            ge_classes=self._ge_domain_builders,
             runtime_environment={
                 "module_name": "great_expectations.rule_based_profiler.domain_builder"
             },
@@ -207,7 +206,6 @@ class ProfilerRunAnonymizer(Anonymizer):
         anonymized_parameter_builder: dict = self.anonymize_object_info(
             object_config=parameter_builder,
             anonymized_info_dict={},
-            ge_classes=self._ge_parameter_builders,
             runtime_environment={
                 "module_name": "great_expectations.rule_based_profiler.parameter_builder"
             },
@@ -252,7 +250,6 @@ class ProfilerRunAnonymizer(Anonymizer):
         anonymized_expectation_configuration_builder: dict = self.anonymize_object_info(
             object_config=expectation_configuration_builder,
             anonymized_info_dict={},
-            ge_classes=self._ge_expectation_configuration_builders,
             runtime_environment={
                 "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder"
             },

--- a/great_expectations/core/usage_statistics/anonymizers/site_builder_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/site_builder_anonymizer.py
@@ -25,7 +25,6 @@ class SiteBuilderAnonymizer(Anonymizer):
         self.anonymize_object_info(
             object_config={"class_name": class_name, "module_name": module_name},
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
         )
 
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/store_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/store_anonymizer.py
@@ -40,7 +40,6 @@ class StoreAnonymizer(Anonymizer):
         self.anonymize_object_info(
             object_=store_obj,
             anonymized_info_dict=anonymized_info_dict,
-            ge_classes=self._ge_classes,
         )
 
         anonymized_info_dict[

--- a/great_expectations/core/usage_statistics/anonymizers/store_backend_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/store_backend_anonymizer.py
@@ -36,7 +36,6 @@ class StoreBackendAnonymizer(Anonymizer):
             self.anonymize_object_info(
                 object_=store_backend_obj,
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
             )
         else:
             class_name = store_backend_object_config.get("class_name")
@@ -46,6 +45,5 @@ class StoreBackendAnonymizer(Anonymizer):
             self.anonymize_object_info(
                 object_config={"class_name": class_name, "module_name": module_name},
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
             )
         return anonymized_info_dict

--- a/great_expectations/core/usage_statistics/anonymizers/validation_operator_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/validation_operator_anonymizer.py
@@ -32,7 +32,6 @@ class ValidationOperatorAnonymizer(Anonymizer):
             self.anonymize_object_info(
                 object_=validation_operator_obj,
                 anonymized_info_dict=anonymized_info_dict,
-                ge_classes=self._ge_classes,
             )
         )
 

--- a/tests/core/usage_statistics/test_anonymizer.py
+++ b/tests/core/usage_statistics/test_anonymizer.py
@@ -217,9 +217,11 @@ def test_anonymize_object_info_with_custom_user_defined_object_with_multiple_par
         object_=MyCustomMultipleInheritanceClass(expectation_suite_name="my_name"),
     )
 
+    # Because we iterate through parents sequentially, the ExpectationSuite is the class
+    # that is picked up and stored in the payload.
     assert anonymized_result == {
         "anonymized_class": "1e1716661acfa73d538a191ed13efcfd",
-        "parent_class": "__not_recognized__",
+        "parent_class": "ExpectationSuite",
     }
 
 

--- a/tests/core/usage_statistics/test_anonymizer.py
+++ b/tests/core/usage_statistics/test_anonymizer.py
@@ -217,11 +217,9 @@ def test_anonymize_object_info_with_custom_user_defined_object_with_multiple_par
         object_=MyCustomMultipleInheritanceClass(expectation_suite_name="my_name"),
     )
 
-    # Because we iterate through parents sequentially, the ExpectationSuite is the class
-    # that is picked up and stored in the payload.
     assert anonymized_result == {
         "anonymized_class": "1e1716661acfa73d538a191ed13efcfd",
-        "parent_class": "ExpectationSuite",
+        "parent_class": "ExpectationSuite,BatchRequest",
     }
 
 

--- a/tests/core/usage_statistics/test_anonymizer.py
+++ b/tests/core/usage_statistics/test_anonymizer.py
@@ -1,6 +1,44 @@
 import uuid
 
+import pytest
+
+from great_expectations.core.batch import BatchRequest
+from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.usage_statistics.anonymizers.anonymizer import Anonymizer
+
+
+@pytest.fixture
+def anonymizer_with_consistent_salt() -> Anonymizer:
+    anonymizer: Anonymizer = Anonymizer(salt="00000000-0000-0000-0000-00000000a004")
+    return anonymizer
+
+
+# The following empty classes are used in this test module only.
+# They are used to ensure class hierarchy is appropriately processed by Anonymizer._is_parent_class_recognized()
+
+
+class BaseTestClass:
+    pass
+
+
+class TestClass(BaseTestClass):
+    pass
+
+
+class MyCustomTestClass(TestClass):
+    pass
+
+
+class SomeOtherClass:
+    pass
+
+
+class MyCustomExpectationSuite(ExpectationSuite):
+    pass
+
+
+class MyCustomMultipleInheritanceClass(ExpectationSuite, BatchRequest):
+    pass
 
 
 def test_anonymizer_no_salt():
@@ -42,26 +80,6 @@ def test_anonymizer_consistent_salt():
     assert anon_name_1 == anon_name_2
     assert len(anon_name_1) == 32
     assert len(anon_name_2) == 32
-
-
-# The following empty classes are used in this test module only.
-# They are used to ensure class hierarchy is appropriately processed by Anonymizer._is_parent_class_recognized()
-
-
-class BaseTestClass:
-    pass
-
-
-class TestClass(BaseTestClass):
-    pass
-
-
-class MyCustomTestClass(TestClass):
-    pass
-
-
-class SomeOtherClass:
-    pass
 
 
 def test_anonymizer__is_parent_class_recognized():
@@ -151,3 +169,69 @@ def test_anonymizer__is_parent_class_recognized():
         )
         == "BaseTestClass"
     )
+
+
+def test_anonymize_object_info_with_core_ge_object(
+    anonymizer_with_consistent_salt: Anonymizer,
+):
+    anonymized_result: dict = anonymizer_with_consistent_salt.anonymize_object_info(
+        anonymized_info_dict={},
+        object_=ExpectationSuite(expectation_suite_name="my_suite"),
+    )
+
+    assert anonymized_result == {"parent_class": "ExpectationSuite"}
+
+
+def test_anonymize_object_info_with_custom_user_defined_object_with_single_parent(
+    anonymizer_with_consistent_salt: Anonymizer,
+):
+    anonymized_result: dict = anonymizer_with_consistent_salt.anonymize_object_info(
+        anonymized_info_dict={},
+        object_=MyCustomExpectationSuite(expectation_suite_name="my_suite"),
+    )
+
+    assert anonymized_result == {
+        "anonymized_class": "54ab2657b855f8075e5d1f28e81ca7cd",
+        "parent_class": "ExpectationSuite",
+    }
+
+
+def test_anonymize_object_info_with_custom_user_defined_object_with_no_parent(
+    anonymizer_with_consistent_salt: Anonymizer,
+):
+    anonymized_result: dict = anonymizer_with_consistent_salt.anonymize_object_info(
+        anonymized_info_dict={}, object_=BaseTestClass()
+    )
+
+    assert anonymized_result == {
+        "anonymized_class": "760bfe8b56356bcd56012edfd512019b",
+        "parent_class": "__not_recognized__",
+    }
+
+
+def test_anonymize_object_info_with_custom_user_defined_object_with_multiple_parents(
+    anonymizer_with_consistent_salt: Anonymizer,
+):
+    anonymized_result: dict = anonymizer_with_consistent_salt.anonymize_object_info(
+        anonymized_info_dict={},
+        object_=MyCustomMultipleInheritanceClass(expectation_suite_name="my_name"),
+    )
+
+    assert anonymized_result == {
+        "anonymized_class": "1e1716661acfa73d538a191ed13efcfd",
+        "parent_class": "__not_recognized__",
+    }
+
+
+def test_anonymize_object_info_with_missing_args_raises_error(
+    anonymizer_with_consistent_salt: Anonymizer,
+):
+    with pytest.raises(AssertionError) as e:
+        anonymizer_with_consistent_salt.anonymize_object_info(
+            anonymized_info_dict={},
+            object_=None,
+            object_class=None,
+            object_config=None,
+        )
+
+    assert "Must pass either" in str(e.value)

--- a/tests/core/usage_statistics/test_anonymizer.py
+++ b/tests/core/usage_statistics/test_anonymizer.py
@@ -14,7 +14,7 @@ def anonymizer_with_consistent_salt() -> Anonymizer:
 
 
 # The following empty classes are used in this test module only.
-# They are used to ensure class hierarchy is appropriately processed by Anonymizer._is_parent_class_recognized()
+# They are used to ensure class hierarchy is appropriately processed by Anonymizer utilities.
 
 
 class BaseTestClass:


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactor usage stats so we don't need to declare `self._ge_classes` in each Anonymizer subclass.
- This is PR 1 of 2 - the feature in question is very susceptible to breakage so we're focusing on simply removing the reliance here and then refactoring out the actually attributes in a subsequent PR.
- Various unit tests to demonstrate the different code paths we can take through the Anonymizer.
- An interesting dilemma around multiple-inheritance - I've opted to get information on the first parent available but an argument can be made to panic and exit early in the face of ambiguous parents.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
