### PR TITLE
[DOCS] adjust lines for py reference

### DIFF
--- a/docs/guides/connecting_to_your_data/database/postgres.md
+++ b/docs/guides/connecting_to_your_data/database/postgres.md
@@ -78,10 +78,10 @@ Run this code to test your configuration.
 
 Put your connection string in this template:
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L19-L36
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L18-L35
 ```
 Run this code to test your configuration.
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L37-L40
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L41-L43
 ```
 
 </TabItem>

--- a/docs/guides/connecting_to_your_data/database/postgres.md
+++ b/docs/guides/connecting_to_your_data/database/postgres.md
@@ -67,7 +67,7 @@ Load your DataContext into memory using the `get_context()` method.
 
 Put your connection string in this template:
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py#L18-L35
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py#L19-L33
 ```
 Run this code to test your configuration.
 ```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py#L42
@@ -81,7 +81,7 @@ Put your connection string in this template:
 ```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L18-L35
 ```
 Run this code to test your configuration.
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L41-L43
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L41
 ```
 
 </TabItem>
@@ -110,7 +110,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
 </TabItem>
 <TabItem value="python">
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L44
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L43
 ```
 
 </TabItem>

--- a/docs/guides/connecting_to_your_data/database/postgres.md
+++ b/docs/guides/connecting_to_your_data/database/postgres.md
@@ -40,7 +40,7 @@ For this guide we will use a `connection_string` like this:
 
 ```
 postgresql+psycopg2://<USERNAME>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>
-```   
+```
 
 ### 4. Instantiate your project's DataContext
 
@@ -67,7 +67,7 @@ Load your DataContext into memory using the `get_context()` method.
 
 Put your connection string in this template:
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py#L19-L33
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py#L18-L35
 ```
 Run this code to test your configuration.
 ```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py#L42
@@ -81,7 +81,7 @@ Put your connection string in this template:
 ```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L19-L36
 ```
 Run this code to test your configuration.
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L42
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L37-L40
 ```
 
 </TabItem>
@@ -154,6 +154,6 @@ To view the full scripts used in this page, see them on GitHub:
 - [postgres_yaml_example.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/connecting_to_your_data/database/postgres_yaml_example.py)
 - [postgres_python_example.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py)
 
-## Next Steps	
+## Next Steps
 
-<NextSteps />	
+<NextSteps />

--- a/docs/guides/connecting_to_your_data/database/postgres.md
+++ b/docs/guides/connecting_to_your_data/database/postgres.md
@@ -78,10 +78,10 @@ Run this code to test your configuration.
 
 Put your connection string in this template:
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L18-L35
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L21-L37
 ```
 Run this code to test your configuration.
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L41
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L45
 ```
 
 </TabItem>
@@ -110,7 +110,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
 </TabItem>
 <TabItem value="python">
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L43
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L49
 ```
 
 </TabItem>

--- a/docs/guides/connecting_to_your_data/database/postgres.md
+++ b/docs/guides/connecting_to_your_data/database/postgres.md
@@ -110,7 +110,7 @@ Save the configuration into your `DataContext` by using the `add_datasource()` f
 </TabItem>
 <TabItem value="python">
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L49
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L50
 ```
 
 </TabItem>

--- a/docs/guides/connecting_to_your_data/database/postgres.md
+++ b/docs/guides/connecting_to_your_data/database/postgres.md
@@ -78,10 +78,10 @@ Run this code to test your configuration.
 
 Put your connection string in this template:
 
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L21-L37
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L21-L38
 ```
 Run this code to test your configuration.
-```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L45
+```python file=../../../../tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L46
 ```
 
 </TabItem>

--- a/tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py
@@ -13,8 +13,11 @@ load_data_into_test_database(
     connection_string=CONNECTION_STRING,
 )
 
+# <snippet>
 context = ge.get_context()
+# </snippet>
 
+# <snippet>
 datasource_config = {
     "name": "my_postgres_datasource",
     "class_name": "Datasource",
@@ -33,14 +36,19 @@ datasource_config = {
         },
     },
 }
+# </snippet>
 
 # Please note this override is only to provide good UX for docs and tests.
 # In normal usage you'd set your path directly in the yaml above.
 datasource_config["execution_engine"]["connection_string"] = CONNECTION_STRING
 
+# <snippet>
 context.test_yaml_config(yaml.dump(datasource_config))
+# </snippet>
 
+# <snippet>
 context.add_datasource(**datasource_config)
+# </snippet>
 
 # Here is a RuntimeBatchRequest using a query
 batch_request = RuntimeBatchRequest(


### PR DESCRIPTION
Changes proposed in this pull request:
- Change reference lines used in example [tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L18-L35
](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/connecting_to_your_data/database/postgres_python_example.py#L18-L35
)


### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
