### PR TITLE
[FEATURE] TableColumnTypesColumnDomainBuilder

### DIFF
--- a/great_expectations/rule_based_profiler/domain_builder/__init__.py
+++ b/great_expectations/rule_based_profiler/domain_builder/__init__.py
@@ -16,6 +16,9 @@ from great_expectations.rule_based_profiler.domain_builder.categorical_column_do
 from great_expectations.rule_based_profiler.domain_builder.map_metric_column_domain_builder import (
     MapMetricColumnDomainBuilder,
 )
+from great_expectations.rule_based_profiler.domain_builder.table_column_types_column_domain_builder import (
+    TableColumnTypesColumnDomainBuilder,
+)
 
 from great_expectations.rule_based_profiler.domain_builder.simple_semantic_type_domain_builder import (  # isort:skip
     SimpleSemanticTypeColumnDomainBuilder,

--- a/great_expectations/rule_based_profiler/domain_builder/table_column_types_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/table_column_types_column_domain_builder.py
@@ -1,0 +1,173 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
+from great_expectations.rule_based_profiler.domain_builder import ColumnDomainBuilder
+from great_expectations.rule_based_profiler.helpers.util import (
+    build_simple_domains_from_column_names,
+    get_parameter_value_and_validate_return_type,
+    get_resolved_metrics_by_key,
+)
+from great_expectations.rule_based_profiler.types import Domain, ParameterContainer
+from great_expectations.validator.metric_configuration import MetricConfiguration
+
+
+class TableColumnTypesColumnDomainBuilder(ColumnDomainBuilder):
+    """
+    This DomainBuilder uses execution engine column type metadata to identify domains.
+    """
+
+    def __init__(
+        self,
+        column_type: Any,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        data_context: Optional["DataContext"] = None,  # noqa: F821
+        column_names: Optional[Union[str, Optional[List[str]]]] = None,
+    ):
+        """
+        Create column domains using .
+
+        Args:
+            column_type: the column type you wish to return domains for
+            batch_list: explicitly specified Batch objects for use in DomainBuilder
+            batch_request: BatchRequest to be optionally used to define batches to consider for this domain builder
+            data_context: DataContext associated with this profiler
+            column_names: Explicitly specified column_names list desired (if None, it is computed based on active Batch)
+        """
+        super().__init__(
+            batch_list=batch_list,
+            batch_request=batch_request,
+            data_context=data_context,
+            column_names=column_names,
+        )
+
+        self._column_type = column_type
+
+    @property
+    def column_type(self) -> str:
+        return self._column_type
+
+    def _get_domains(
+        self,
+        variables: Optional[ParameterContainer] = None,
+    ) -> List[Domain]:
+        """Return domains matching the column type.
+
+        Args:
+            variables: Optional variables to substitute when evaluating.
+
+        Returns:
+            List of domains that match the column type.
+        """
+        # Obtain column_type from "rule state" (i.e., variables and parameters); from instance variable otherwise.
+        column_type: Any = get_parameter_value_and_validate_return_type(
+            domain=None,
+            parameter_reference=self.column_type,
+            expected_return_type=None,
+            variables=variables,
+            parameters=None,
+        )
+
+        table_column_names: List[str] = self.get_effective_column_names(
+            include_columns=self.column_names,
+            exclude_columns=None,
+            variables=variables,
+        )
+
+        validator: "Validator" = self.get_validator(variables=variables)  # noqa: F821
+
+        batch_ids: List[str] = self.get_batch_ids(variables=variables)
+
+        metric_configurations: Dict[
+            str, List[MetricConfiguration]
+        ] = self._generate_metric_configurations(
+            batch_ids=batch_ids,
+        )
+
+        candidate_column_names: List[
+            str
+        ] = self._get_column_names_satisfying_column_type(
+            validator=validator,
+            metric_configurations=metric_configurations,
+            column_type=column_type,
+        )
+
+        return build_simple_domains_from_column_names(
+            column_names=candidate_column_names,
+            domain_type=self.domain_type,
+        )
+
+    @staticmethod
+    def _generate_metric_configurations(
+        batch_ids: List[str],
+    ) -> Dict[str, List[MetricConfiguration]]:
+        """
+        Generate metric configurations used to get table column types.
+
+        Args:
+            batch_ids: List of batch_ids used to create metric configurations.
+
+        Returns:
+            Dictionary of the form {
+                table: List[MetricConfiguration],
+            }
+        """
+        batch_id: str
+        metric_configurations: Dict[str, List[MetricConfiguration]] = {
+            "table": [
+                MetricConfiguration(
+                    metric_name=f"table.column_types",
+                    metric_domain_kwargs={
+                        "batch_id": batch_id,
+                    },
+                    metric_value_kwargs=None,
+                    metric_dependencies=None,
+                )
+                for batch_id in batch_ids
+            ]
+        }
+
+        return metric_configurations
+
+    @staticmethod
+    def _get_column_names_satisfying_column_type(
+        validator: "Validator",  # noqa: F821
+        metric_configurations: Dict[str, List[MetricConfiguration]],
+        column_type: Any,
+    ) -> List[str]:
+        """
+        Get table column types and return columns matching the provided type.
+
+        Args:
+            validator: Validator used to compute column cardinality.
+            metric_configurations: metric configurations used to compute column types.
+
+        Returns:
+            List of column names satisfying column type.
+        """
+        column_name: str
+        resolved_metrics: Dict[Tuple[str, str, str], Any]
+
+        resolved_metrics: Dict[
+            str, Dict[Tuple[str, str, str], Any]
+        ] = get_resolved_metrics_by_key(
+            validator=validator,
+            metric_configurations_by_key=metric_configurations,
+        )
+
+        resolved_metric: Dict
+        table: List
+        column: Tuple
+        table_column_types_by_column_name: Dict[str, List[Any]] = {}
+        for resolved_metric in resolved_metrics.values():
+            for table in resolved_metric.values():
+                for column in table:
+                    table_column_types_by_column_name[column["name"]] = column["type"]
+
+        candidate_column_names: List[str] = [
+            name
+            for name, table_column_type in table_column_types_by_column_name.items()
+            if table_column_type == column_type
+        ]
+
+        return candidate_column_names

--- a/tests/rule_based_profiler/domain_builder/test_table_column_types_column_domain_builder.py
+++ b/tests/rule_based_profiler/domain_builder/test_table_column_types_column_domain_builder.py
@@ -1,0 +1,199 @@
+from typing import List
+
+import numpy as np
+
+from great_expectations import DataContext
+from great_expectations.core.batch import BatchRequest
+from great_expectations.execution_engine.execution_engine import MetricDomainTypes
+from great_expectations.rule_based_profiler.domain_builder import (
+    TableColumnTypesColumnDomainBuilder,
+)
+from great_expectations.rule_based_profiler.types import Domain
+
+
+def test_table_column_types_int_pandas_single_batch(
+    alice_columnar_table_single_batch_context,
+):
+    data_context: DataContext = alice_columnar_table_single_batch_context
+
+    batch_request: BatchRequest = BatchRequest(
+        datasource_name="alice_columnar_table_single_batch_datasource",
+        data_connector_name="alice_columnar_table_single_batch_data_connector",
+        data_asset_name="alice_columnar_table_single_batch_data_asset",
+    )
+
+    domain_builder: TableColumnTypesColumnDomainBuilder = (
+        TableColumnTypesColumnDomainBuilder(
+            column_type=np.int64,
+            batch_request=batch_request,
+            data_context=data_context,
+        )
+    )
+    domains: List[Domain] = domain_builder.get_domains()
+    domains = sorted(domains, key=lambda x: x.domain_kwargs["column"])
+
+    alice_compliant_column_names: List[str] = [
+        "event_type",
+        "user_id",
+    ]
+
+    column_name: str
+    alice_expected_column_domains: List[Domain] = [
+        Domain(
+            domain_type=MetricDomainTypes.COLUMN,
+            domain_kwargs={
+                "column": column_name,
+            },
+        )
+        for column_name in alice_compliant_column_names
+    ]
+    alice_expected_column_domains = sorted(
+        alice_expected_column_domains, key=lambda x: x.domain_kwargs["column"]
+    )
+
+    assert len(domains) == 2
+    assert domains == alice_expected_column_domains
+
+
+def test_table_column_types_object_pandas_single_batch(
+    alice_columnar_table_single_batch_context,
+):
+    data_context: DataContext = alice_columnar_table_single_batch_context
+
+    batch_request: BatchRequest = BatchRequest(
+        datasource_name="alice_columnar_table_single_batch_datasource",
+        data_connector_name="alice_columnar_table_single_batch_data_connector",
+        data_asset_name="alice_columnar_table_single_batch_data_asset",
+    )
+
+    domain_builder: TableColumnTypesColumnDomainBuilder = (
+        TableColumnTypesColumnDomainBuilder(
+            column_type=np.object,
+            batch_request=batch_request,
+            data_context=data_context,
+        )
+    )
+    domains: List[Domain] = domain_builder.get_domains()
+    domains = sorted(domains, key=lambda x: x.domain_kwargs["column"])
+
+    alice_compliant_column_names: List[str] = [
+        "device_ts",
+        "event_ts",
+        "id",
+        "server_ts",
+        "user_agent",
+    ]
+
+    column_name: str
+    alice_expected_column_domains: List[Domain] = [
+        Domain(
+            domain_type=MetricDomainTypes.COLUMN,
+            domain_kwargs={
+                "column": column_name,
+            },
+        )
+        for column_name in alice_compliant_column_names
+    ]
+    alice_expected_column_domains = sorted(
+        alice_expected_column_domains, key=lambda x: x.domain_kwargs["column"]
+    )
+
+    assert len(domains) == 5
+    assert domains == alice_expected_column_domains
+
+
+def test_table_column_types_int_pandas_multi_batch(
+    bobby_columnar_table_multi_batch_deterministic_data_context,
+):
+    data_context: DataContext = (
+        bobby_columnar_table_multi_batch_deterministic_data_context
+    )
+
+    batch_request: BatchRequest = BatchRequest(
+        datasource_name="taxi_pandas",
+        data_connector_name="monthly",
+        data_asset_name="my_reports",
+    )
+
+    domain_builder: TableColumnTypesColumnDomainBuilder = (
+        TableColumnTypesColumnDomainBuilder(
+            column_type=np.int64,
+            batch_request=batch_request,
+            data_context=data_context,
+        )
+    )
+    domains: List[Domain] = domain_builder.get_domains()
+    domains = sorted(domains, key=lambda x: x.domain_kwargs["column"])
+
+    bobby_compliant_column_names: List[str] = [
+        "DOLocationID",
+        "PULocationID",
+        "RatecodeID",
+        "VendorID",
+        "passenger_count",
+        "payment_type",
+    ]
+
+    column_name: str
+    bobby_expected_column_domains: List[Domain] = [
+        Domain(
+            domain_type=MetricDomainTypes.COLUMN,
+            domain_kwargs={
+                "column": column_name,
+            },
+        )
+        for column_name in bobby_compliant_column_names
+    ]
+    bobby_expected_column_domains = sorted(
+        bobby_expected_column_domains, key=lambda x: x.domain_kwargs["column"]
+    )
+
+    assert len(domains) == 6
+    assert domains == bobby_expected_column_domains
+
+
+def test_table_column_types_object_pandas_multi_batch(
+    bobby_columnar_table_multi_batch_deterministic_data_context,
+):
+    data_context: DataContext = (
+        bobby_columnar_table_multi_batch_deterministic_data_context
+    )
+
+    batch_request: BatchRequest = BatchRequest(
+        datasource_name="taxi_pandas",
+        data_connector_name="monthly",
+        data_asset_name="my_reports",
+    )
+
+    domain_builder: TableColumnTypesColumnDomainBuilder = (
+        TableColumnTypesColumnDomainBuilder(
+            column_type=np.object,
+            batch_request=batch_request,
+            data_context=data_context,
+        )
+    )
+    domains: List[Domain] = domain_builder.get_domains()
+    domains = sorted(domains, key=lambda x: x.domain_kwargs["column"])
+
+    bobby_compliant_column_names: List[str] = [
+        "dropoff_datetime",
+        "pickup_datetime",
+        "store_and_fwd_flag",
+    ]
+
+    column_name: str
+    bobby_expected_column_domains: List[Domain] = [
+        Domain(
+            domain_type=MetricDomainTypes.COLUMN,
+            domain_kwargs={
+                "column": column_name,
+            },
+        )
+        for column_name in bobby_compliant_column_names
+    ]
+    bobby_expected_column_domains = sorted(
+        bobby_expected_column_domains, key=lambda x: x.domain_kwargs["column"]
+    )
+
+    assert len(domains) == 3
+    assert domains == bobby_expected_column_domains


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-669
- Add a new domain builder that detects column types based on `ExecutionEngine` metadata, as opposed to scanning an entire column

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.