### PR TITLE
[BUGFIX] Adding `--spark` flag back to `azure-pipelines.yml` compatibility_matrix stage. 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -220,7 +220,7 @@ stages:
 
           - script: |
               pip install pytest pytest-cov pytest-azurepipelines==1.0.1
-              pytest $(GE_pytest_opts) --postgresql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+              pytest $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
             displayName: 'pytest'
 
           - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ stages:
       - job: compatibility_matrix
         condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
         variables:
-          GE_pytest_opts: '--no-sqlalchemy'
+          GE_pytest_opts: '--no-sqlalchemy --spark'
         strategy:
           matrix:
             Python36-Pandas023:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ stages:
       - job: compatibility_matrix
         condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
         variables:
-          GE_pytest_opts: '--no-sqlalchemy --spark'
+          GE_pytest_opts: '--no-sqlalchemy'
         strategy:
           matrix:
             Python36-Pandas023:
@@ -168,7 +168,7 @@ stages:
           postgres: postgres
 
         variables:
-          GE_pytest_opts: ''
+          GE_pytest_opts: '--postgresql --spark'
 
         strategy:
           matrix:


### PR DESCRIPTION

Changes proposed in this pull request:
- Follow-up to PR #4309 
- Adding `--spark` flag back to `compatibility_matrix stage of main `azure-pipelines.yml`
