### PR TITLE
[BUGFIX] Insure Proper Indexing of Metric Computation Results in ParameterBuilder

### DIFF
--- a/great_expectations/rule_based_profiler/parameter_builder/__init__.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/__init__.py
@@ -1,4 +1,5 @@
 from great_expectations.rule_based_profiler.parameter_builder.parameter_builder import (  # isort:skip
+    AttributedResolvedMetrics,
     ParameterBuilder,
     MetricComputationResult,
     MetricValues,

--- a/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -8,8 +8,6 @@ from great_expectations.rule_based_profiler.helpers.util import (
 )
 from great_expectations.rule_based_profiler.parameter_builder import (
     MetricMultiBatchParameterBuilder,
-)
-from great_expectations.rule_based_profiler.parameter_builder.parameter_builder import (
     MetricValues,
 )
 from great_expectations.rule_based_profiler.types import (

--- a/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
@@ -6,7 +6,7 @@ from great_expectations.rule_based_profiler.helpers.util import (
 )
 from great_expectations.rule_based_profiler.types import Domain, ParameterContainer
 
-from great_expectations.rule_based_profiler.parameter_builder.parameter_builder import (  # isort:skip
+from great_expectations.rule_based_profiler.parameter_builder import (  # isort:skip
     MetricComputationResult,
     MetricValues,
     MetricComputationDetails,
@@ -140,8 +140,12 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         )
 
         # As a simplification, apply reduction to scalar in case of one-dimensional metric (for convenience).
-        if reduce_scalar_metric and metric_values.shape[1] == 1:
-            metric_values = metric_values[:, 0]
+        if (
+            reduce_scalar_metric
+            and len(metric_values) == 1
+            and metric_values[0].metric_values.shape[1] == 1
+        ):
+            metric_values = metric_values[0].metric_values[:, 0]
 
         return (
             metric_values,

--- a/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
@@ -4,14 +4,14 @@ from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchReque
 from great_expectations.rule_based_profiler.helpers.util import (
     get_parameter_value_and_validate_return_type,
 )
-from great_expectations.rule_based_profiler.types import Domain, ParameterContainer
-
-from great_expectations.rule_based_profiler.parameter_builder import (  # isort:skip
+from great_expectations.rule_based_profiler.parameter_builder import (
+    AttributedResolvedMetrics,
+    MetricComputationDetails,
     MetricComputationResult,
     MetricValues,
-    MetricComputationDetails,
     ParameterBuilder,
 )
+from great_expectations.rule_based_profiler.types import Domain, ParameterContainer
 
 
 class MetricMultiBatchParameterBuilder(ParameterBuilder):
@@ -142,7 +142,9 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         # As a simplification, apply reduction to scalar in case of one-dimensional metric (for convenience).
         if (
             reduce_scalar_metric
+            and isinstance(metric_values, list)
             and len(metric_values) == 1
+            and isinstance(metric_values[0], AttributedResolvedMetrics)
             and metric_values[0].metric_values.shape[1] == 1
         ):
             metric_values = metric_values[0].metric_values[:, 0]

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -13,7 +13,9 @@ from great_expectations.rule_based_profiler.helpers.util import (
     get_parameter_value_and_validate_return_type,
 )
 from great_expectations.rule_based_profiler.parameter_builder import (
+    AttributedResolvedMetrics,
     MetricMultiBatchParameterBuilder,
+    MetricValues,
 )
 from great_expectations.rule_based_profiler.types import (
     Domain,
@@ -240,16 +242,16 @@ detected.
 """
             )
 
-        estimator: Callable
+        estimator_func: Callable
         etimator_kwargs: dict
         if estimator == "bootstrap":
-            estimator = self._get_bootstrap_estimate
+            estimator_func = self._get_bootstrap_estimate
             estimator_kwargs = {
                 "false_positive_rate": false_positive_rate,
                 "num_bootstrap_samples": self.num_bootstrap_samples,
             }
         else:
-            estimator = self._get_deterministic_estimate
+            estimator_func = self._get_deterministic_estimate
             estimator_kwargs = {
                 "false_positive_rate": false_positive_rate,
             }
@@ -272,10 +274,24 @@ detected.
             variables=variables,
             parameters=parameters,
         )
+        metric_values: MetricValues
+        if isinstance(parameter_node.value, list):
+            num_parameter_node_value_elements: int = len(parameter_node.value)
+            if num_parameter_node_value_elements != 1:
+                raise ge_exceptions.ProfilerExecutionError(
+                    message=f'Length of "AttributedResolvedMetrics" list for {self.__class__.__name__} must be exactly 1 ({num_parameter_node_value_elements} elements found).'
+                )
+
+            attributed_resolved_metrics: AttributedResolvedMetrics = (
+                parameter_node.value[0]
+            )
+            metric_values = attributed_resolved_metrics.metric_values
+        else:
+            metric_values = parameter_node.value
 
         metric_value_range: np.ndarray = self._estimate_metric_value_range(
-            metric_values=cast(np.ndarray, parameter_node.value),
-            estimator=estimator,
+            metric_values=metric_values,
+            estimator_func=estimator_func,
             domain=domain,
             variables=variables,
             parameters=parameters,
@@ -292,7 +308,7 @@ detected.
     def _estimate_metric_value_range(
         self,
         metric_values: np.ndarray,
-        estimator: Callable,
+        estimator_func: Callable,
         domain: Optional[Domain] = None,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
@@ -363,7 +379,7 @@ detected.
                 lower_quantile = upper_quantile = metric_value_vector[0]
             else:
                 # Compute low and high estimates for vector of samples for given element of multi-dimensional metric.
-                lower_quantile, upper_quantile = estimator(
+                lower_quantile, upper_quantile = estimator_func(
                     metric_values=metric_value_vector,
                     domain=domain,
                     variables=variables,

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -420,11 +420,7 @@ class ParameterBuilder(Builder, ABC):
 
         # Nineth: Compose and return result to receiver (apply simplications to cases of single "metric_value_kwargs").
         return MetricComputationResult(
-            metric_values=list(attributed_resolved_metrics_map.values())[
-                0
-            ].metric_values
-            if len(metric_value_kwargs) == 1
-            else attributed_resolved_metrics_map.values(),
+            list(attributed_resolved_metrics_map.values()),
             details={
                 "metric_configuration": {
                     "metric_name": metric_name,

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -5,7 +5,7 @@ from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchReque
 from great_expectations.rule_based_profiler.helpers.util import (
     get_parameter_value_and_validate_return_type,
 )
-from great_expectations.rule_based_profiler.parameter_builder.parameter_builder import (
+from great_expectations.rule_based_profiler.parameter_builder import (
     AttributedResolvedMetrics,
     MetricComputationResult,
     MetricValues,
@@ -136,7 +136,7 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
 
         metric_values: MetricValues
 
-        metric_values = metric_computation_result.metric_values
+        metric_values = metric_computation_result.metric_values[0].metric_values
 
         # Now obtain 1-dimensional vector of values of computed metric (each element corresponds to a Batch ID).
         metric_values = metric_values[:, 0]

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
+import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
 from great_expectations.rule_based_profiler.helpers.util import (
     get_parameter_value_and_validate_return_type,
@@ -134,9 +135,21 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
             parameters=parameters,
         )
 
+        if not (
+            isinstance(metric_computation_result.metric_values, list)
+            and len(metric_computation_result.metric_values) == 1
+        ):
+            raise ge_exceptions.ProfilerExecutionError(
+                message=f'Result of metric computations for {self.__class__.__name__} must be a list with exactly 1 element of type "AttributedResolvedMetrics" ({metric_computation_result.metric_values} found).'
+            )
+
+        attributed_resolved_metrics: AttributedResolvedMetrics
+
+        attributed_resolved_metrics = metric_computation_result.metric_values[0]
+
         metric_values: MetricValues
 
-        metric_values = metric_computation_result.metric_values[0].metric_values
+        metric_values = attributed_resolved_metrics.metric_values
 
         # Now obtain 1-dimensional vector of values of computed metric (each element corresponds to a Batch ID).
         metric_values = metric_values[:, 0]
@@ -177,7 +190,7 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
             match_regex_metric_value_kwargs_list.append(match_regex_metric_value_kwargs)
 
         # Obtain resolved metrics and metadata for all metric configurations and available Batch objects simultaneously.
-        metric_computation_result: MetricComputationResult = self.get_metrics(
+        metric_computation_result = self.get_metrics(
             metric_name="column_values.match_regex.unexpected_count",
             metric_domain_kwargs=self.metric_domain_kwargs,
             metric_value_kwargs=match_regex_metric_value_kwargs_list,
@@ -188,7 +201,6 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
 
         regex_string_success_ratios: dict = {}
 
-        attributed_resolved_metrics: AttributedResolvedMetrics
         for attributed_resolved_metrics in metric_computation_result.metric_values:
             # Now obtain 1-dimensional vector of values of computed metric (each element corresponds to a Batch ID).
             metric_values = attributed_resolved_metrics.metric_values[:, 0]

--- a/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
@@ -5,7 +5,7 @@ from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchReque
 from great_expectations.rule_based_profiler.helpers.util import (
     get_parameter_value_and_validate_return_type,
 )
-from great_expectations.rule_based_profiler.parameter_builder.parameter_builder import (
+from great_expectations.rule_based_profiler.parameter_builder import (
     AttributedResolvedMetrics,
     MetricComputationResult,
     MetricValues,
@@ -186,7 +186,7 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
 
         metric_values: MetricValues
 
-        metric_values = metric_computation_result.metric_values
+        metric_values = metric_computation_result.metric_values[0].metric_values
 
         # Now obtain 1-dimensional vector of values of computed metric (each element corresponds to a Batch ID).
         metric_values = metric_values[:, 0]

--- a/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
@@ -111,7 +111,7 @@ class ValueSetMultiBatchParameterBuilder(MetricMultiBatchParameterBuilder):
 
         return (
             _get_unique_values_from_nested_collection_of_sets(
-                collection=parameter_node.value
+                collection=parameter_node.value[0].metric_values
             ),
             parameter_node.details,
         )

--- a/great_expectations/rule_based_profiler/types/parameter_container.py
+++ b/great_expectations/rule_based_profiler/types/parameter_container.py
@@ -207,6 +207,15 @@ class ParameterContainer(SerializableDictDot):
                 source[key] = self._convert_dictionaries_to_parameter_nodes(
                     source=value
                 )
+        elif isinstance(source, (list, tuple, set)):
+            source_type: type = type(source)
+            value: Any
+            return source_type(
+                [
+                    self._convert_dictionaries_to_parameter_nodes(source=value)
+                    for value in source
+                ]
+            )
 
         return source
 

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -33,7 +33,7 @@ def test_regex_pattern_string_parameter_builder_instantiation_with_defaults(
 
     regex_pattern_string_parameter: RegexPatternStringParameterBuilder = (
         RegexPatternStringParameterBuilder(
-            name="my_simple_regex_string_parameter_builder",
+            name="my_regex_pattern_string_parameter_builder",
             data_context=data_context,
             candidate_regexes=candidate_regexes,
         )
@@ -54,7 +54,7 @@ def test_regex_pattern_string_parameter_builder_instantiation_override_defaults(
     }
     regex_pattern_string_parameter: RegexPatternStringParameterBuilder = (
         RegexPatternStringParameterBuilder(
-            name="my_simple_regex_string_parameter_builder",
+            name="my_regex_pattern_string_parameter_builder",
             candidate_regexes=candidate_regexes,
             threshold=0.5,
             data_context=data_context,
@@ -85,7 +85,7 @@ def test_regex_pattern_string_parameter_builder_alice(
 
     regex_pattern_string_parameter: RegexPatternStringParameterBuilder = (
         RegexPatternStringParameterBuilder(
-            name="my_regex",
+            name="my_regex_pattern_string_parameter_builder",
             metric_domain_kwargs=metric_domain_kwargs,
             candidate_regexes=candidate_regexes,
             batch_request=batch_request,
@@ -102,7 +102,9 @@ def test_regex_pattern_string_parameter_builder_alice(
     regex_pattern_string_parameter.build_parameters(
         parameter_container=parameter_container, domain=domain
     )
-    fully_qualified_parameter_name_for_value: str = "$parameter.my_regex"
+    fully_qualified_parameter_name_for_value: str = (
+        "$parameter.my_regex_pattern_string_parameter_builder"
+    )
     expected_value: dict = {
         "value": [r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$"],
         "details": {
@@ -262,6 +264,125 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
                 r"\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-5][0-9a-fA-F]{3}-[089ab][0-9a-fA-F]{3}-\b[0-9a-fA-F]{12}\b ": 0,
             },
             "threshold": 0.9,
+        },
+    }
+
+    assert (
+        get_parameter_value_by_fully_qualified_parameter_name(
+            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            domain=domain,
+            parameters={domain.id: parameter_container},
+        )
+        == expected_value
+    )
+
+
+def test_regex_pattern_string_parameter_builder_alice_single_regex_pattern(
+    alice_columnar_table_single_batch_context,
+):
+    data_context: DataContext = alice_columnar_table_single_batch_context
+
+    batch_request: dict = {
+        "datasource_name": "alice_columnar_table_single_batch_datasource",
+        "data_connector_name": "alice_columnar_table_single_batch_data_connector",
+        "data_asset_name": "alice_columnar_table_single_batch_data_asset",
+    }
+
+    metric_domain_kwargs = {"column": "id"}
+    candidate_regexes: List[str] = [
+        r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$",
+    ]
+
+    regex_pattern_string_parameter_builder: RegexPatternStringParameterBuilder = (
+        RegexPatternStringParameterBuilder(
+            name="my_regex_pattern_string_parameter_builder",
+            metric_domain_kwargs=metric_domain_kwargs,
+            candidate_regexes=candidate_regexes,
+            batch_request=batch_request,
+            data_context=data_context,
+        )
+    )
+
+    parameter_container: ParameterContainer = ParameterContainer(parameter_nodes=None)
+    domain: Domain = Domain(
+        domain_type=MetricDomainTypes.COLUMN, domain_kwargs=metric_domain_kwargs
+    )
+    assert parameter_container.parameter_nodes is None
+
+    regex_pattern_string_parameter_builder.build_parameters(
+        parameter_container=parameter_container, domain=domain
+    )
+    fully_qualified_parameter_name_for_value: str = (
+        "$parameter.my_regex_pattern_string_parameter_builder"
+    )
+    expected_value: dict = {
+        "value": [r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$"],
+        "details": {
+            "evaluated_regexes": {
+                r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$": 1.0,
+            },
+            "threshold": 1.0,
+        },
+    }
+
+    assert (
+        get_parameter_value_by_fully_qualified_parameter_name(
+            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            domain=domain,
+            parameters={domain.id: parameter_container},
+        )
+        == expected_value
+    )
+
+
+def test_regex_pattern_string_parameter_builder_alice_two_regex_patterns(
+    alice_columnar_table_single_batch_context,
+):
+    data_context: DataContext = alice_columnar_table_single_batch_context
+
+    batch_request: dict = {
+        "datasource_name": "alice_columnar_table_single_batch_datasource",
+        "data_connector_name": "alice_columnar_table_single_batch_data_connector",
+        "data_asset_name": "alice_columnar_table_single_batch_data_asset",
+    }
+
+    metric_domain_kwargs = {"column": "id"}
+    candidate_regexes: List[str] = [
+        r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$",
+        r"^\d{1}$",
+    ]
+
+    regex_pattern_string_parameter_builder: RegexPatternStringParameterBuilder = (
+        RegexPatternStringParameterBuilder(
+            name="my_regex_pattern_string_parameter_builder",
+            metric_domain_kwargs=metric_domain_kwargs,
+            candidate_regexes=candidate_regexes,
+            batch_request=batch_request,
+            data_context=data_context,
+        )
+    )
+
+    parameter_container: ParameterContainer = ParameterContainer(parameter_nodes=None)
+    domain: Domain = Domain(
+        domain_type=MetricDomainTypes.COLUMN, domain_kwargs=metric_domain_kwargs
+    )
+    assert parameter_container.parameter_nodes is None
+
+    regex_pattern_string_parameter_builder.build_parameters(
+        parameter_container=parameter_container, domain=domain
+    )
+
+    fully_qualified_parameter_name_for_value: str = (
+        "$parameter.my_regex_pattern_string_parameter_builder"
+    )
+    expected_value: dict = {
+        "value": [r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$"],
+        "details": {
+            "evaluated_regexes": {
+                r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$": 1.0,
+                r"^\d{1}$": 0,
+            },
+            "threshold": 1.0,
         },
     }
 


### PR DESCRIPTION
### Scope
We return results from `get_metrics()` as list, even if the length of list is 1 (previous simplification introduced inconsistencies in the way results are interpreted).  Now, different `ParameterBuilder` implementations interpret the results according to their own logic, often depending on whether or not the number of `metric_value_kwargs` is greater than 1.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- JIRA: GREAT-464/GREAT-498/GREAT-674
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
