### PR TITLE
[BUGFIX] Remove `pytest-azurepiplines` usage from `test_cli` stages in Azure pipelines

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -352,7 +352,7 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install pytest pytest-azurepipelines
+              pip install pytest
               git clone https://github.com/superconductive/dgtest.git
               pip install -e dgtest
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -384,7 +384,7 @@ stages:
             displayName: 'Install dependencies'
 
           - script: |
-              pip install pytest pytest-azurepipelines
+              pip install pytest
               pytest --postgresql --spark --aws-integration -v tests/cli
             displayName: 'pytest'
 

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -1,3 +1,4 @@
+# test change
 import copy
 import os
 import sys

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -1,4 +1,3 @@
-# test change
 import copy
 import os
 import sys


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove `pytest-azurepipelines` plugin to prevent blocking `test_cli` stage in Azure.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
