### PR TITLE
[MAINTENANCE] Set upper bound on number of allowed warnings in snippet validation script

### DIFF
--- a/scripts/validate_docs_snippet_line_numbers.py
+++ b/scripts/validate_docs_snippet_line_numbers.py
@@ -195,6 +195,12 @@ if __name__ == "__main__":
     broken_refs: List[DocusaurusRef] = evaluate_snippet_validity(docusaurus_refs)
     if broken_refs:
         print_diagnostic_report(broken_refs)
-        # sys.exit(1) # TODO(cdkini): Enable once all errors are resolved
     else:
         print("[SUCCESS] All snippets are valid and referenced properly!")
+
+    # Chetan - 20220316 - While this number should be 0, getting the number of warnings down takes time
+    # and effort. In the meanwhile, we want to set an upper bound on warnings to ensure we're not introducing
+    # further regressions. As snippets are validated, developers should update this number.
+    assert (
+        len(broken_refs) <= 542
+    ), "A broken snippet reference was introduced; please resolve the matter before merging."


### PR DESCRIPTION
Changes proposed in this pull request:
- While we eventually want to get this number down to 0, this is a tedious process and takes time. To ensure we're headed in the right direction, let's confirm we don't introduce new regressions.
- As developers tackle these numbers, please make sure to update the script so we set a new upper bound.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
