### PR TITLE
[MAINTENANCE] Update `RuleBasedProfiler` Example Notebook to have clean up

### DIFF
--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb
@@ -19,10 +19,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/work/Development/great_expectations/great_expectations/expectations/metrics/util.py:78: DeprecationWarning: The pybigquery package is obsolete, please use sqlalchemy-bigquery\n",
-      "  warnings.warn(\n",
-      "/Users/work/Development/great_expectations/great_expectations/expectations/core/expect_column_values_to_be_of_type.py:73: DeprecationWarning: The pybigquery package is obsolete, please use sqlalchemy-bigquery\n",
-      "  warnings.warn(\n"
+      "/Users/work/Development/ENVs/bugbash/lib/python3.8/site-packages/snowflake/connector/options.py:94: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<3.1.0,>=3.0.0; extra == \"pandas\"'\n",
+      "  warn_incompatible_dep(\n"
      ]
     }
    ],
@@ -52,16 +50,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/ipykernel/ipkernel.py:287: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
-      "  and should_run_async(code)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data_context: ge.DataContext = ge.get_context()"
    ]
@@ -110,7 +99,7 @@
     {
      "data": {
       "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x7f9fff55f940>"
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7f92603c43d0>"
       ]
      },
      "execution_count": 3,
@@ -149,8 +138,20 @@
     "    },\n",
     "}\n",
     "\n",
-    "data_context.test_yaml_config(yaml.dump(datasource_config))\n",
-    "data_context.add_datasource(**datasource_config)"
+    "data_context.test_yaml_config(yaml.dump(datasource_config))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_datasource only if it doesn't already exist in our configuration\n",
+    "try:\n",
+    "    data_context.get_datasource(datasource_config[\"name\"])\n",
+    "except ValueError:\n",
+    "    data_context.add_datasource(**datasource_config)"
    ]
   },
   {
@@ -171,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,13 +232,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fc6a05b4af0b4000aebd949f9a45eaba",
+       "model_id": "88b5e6f250a74f878b6d8d6c96fdc0ab",
        "version_major": 2,
        "version_minor": 0
       },
@@ -251,7 +252,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bf25b99e827141498e5387e0e031fa18",
+       "model_id": "820cfa73b834436794433ccef130ddc7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -274,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,13 +369,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0d47befd8004471b8a8dec6c462a5dde",
+       "model_id": "e78a412ce37a4dbe82ceb964a00470f8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -388,7 +389,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e0ea577f79b343378205b6cacf8493a6",
+       "model_id": "5ffb8f5e1c544b74a9a58ff2184560cc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -406,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,19 +416,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"fare_amount\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"tip_amount\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"tolls_amount\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"total_amount\"}}]"
+       "[{\"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\", \"kwargs\": {\"column\": \"fare_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\", \"kwargs\": {\"column\": \"tip_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\", \"kwargs\": {\"column\": \"tolls_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\", \"kwargs\": {\"column\": \"total_amount\"}}]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,13 +461,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9e087e559b8e4192a22c5029c581e5d3",
+       "model_id": "a85e008cdc6740199d43b8c5af997336",
        "version_major": 2,
        "version_minor": 0
       },
@@ -480,7 +481,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9060125baea7413fb114a66c0e10e765",
+       "model_id": "b44c87d4ac314d6fa91616bbf101acf8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -503,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -535,7 +536,7 @@
        " }]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -578,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,13 +680,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4f660f6a424245c7b9eff79e6e847637",
+       "model_id": "729dde39f7d64b86ad3e228e44f22b2d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -699,7 +700,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36da596195ed473d85d2a3627e05b16d",
+       "model_id": "ab984dab0e974175abbbc51cfe3edd01",
        "version_major": 2,
        "version_minor": 0
       },
@@ -713,7 +714,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d722e98fb91d417d814650f08ffed997",
+       "model_id": "2328f233ccf044449a728442286392f2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -727,7 +728,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2972499f9cd5473e99c3cddc79bc15eb",
+       "model_id": "6f096646ab454d4ab15e26a59e241a69",
        "version_major": 2,
        "version_minor": 0
       },
@@ -741,7 +742,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7254d5d3334f44c9bbf3acfc7954a864",
+       "model_id": "3ea452de6607468385eee7867041f455",
        "version_major": 2,
        "version_minor": 0
       },
@@ -755,7 +756,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "82f093db84174f81bb8d8f8315308f50",
+       "model_id": "b26b544bed18415f95b53570088ab30e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -773,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -782,19 +783,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"column\": \"fare_amount\", \"value\": -80.0, \"name\": \"my_column_min\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"column\": \"tip_amount\", \"value\": 0.0, \"name\": \"my_column_min\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"column\": \"tolls_amount\", \"value\": 0.0, \"name\": \"my_column_min\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"column\": \"total_amount\", \"value\": -80.3, \"name\": \"my_column_min\"}}]"
+       "[{\"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\", \"kwargs\": {\"name\": \"my_column_min\", \"value\": -80.0, \"column\": \"fare_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\", \"kwargs\": {\"name\": \"my_column_min\", \"value\": 0.0, \"column\": \"tip_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\", \"kwargs\": {\"name\": \"my_column_min\", \"value\": 0.0, \"column\": \"tolls_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\", \"kwargs\": {\"name\": \"my_column_min\", \"value\": -80.3, \"column\": \"total_amount\"}}]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -851,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -873,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -891,7 +892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -900,7 +901,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -928,7 +929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -937,7 +938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -954,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -992,7 +993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1006,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1049,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1057,13 +1058,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3717c446e0d04e61aed2f6a24a90fa7e",
+       "model_id": "af67c9a59e62402faa2381101737f889",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1077,7 +1078,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2cf666169b594494bbef9c38fc4678ae",
+       "model_id": "d1925ab5ae994931ad911049e3683965",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1091,7 +1092,29 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "544f92760d5f4914afe7244f4215daba",
+       "model_id": "a5fa2167437e436c8908f3d2a29c4b93",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/48 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:587: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "  if bootstrap_upper_quantile_bias / bootstrap_upper_quantile_standard_error <= 0.25:\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2b03ea40bef24f1b8224362b8230ffc4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1105,7 +1128,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c3912148cca4e42aad69d1b38ef7748",
+       "model_id": "4e12f10e7caa4aba831f7a6905a28a49",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1119,21 +1142,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b4e7363afa804720b61b17c8e6080ba8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculating Metrics:   0%|          | 0/48 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ffb0b5a072eb4d91af4d1dfb6b874078",
+       "model_id": "192748b09e15454a960a04f5898484cc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1151,19 +1160,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{\"expectation_type\": \"expect_column_min_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"tip_amount\", \"max_value\": 0.0, \"min_value\": -1.66025}},\n",
-       " {\"expectation_type\": \"expect_column_max_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"tip_amount\", \"max_value\": 156.454398615, \"min_value\": 34.4595}},\n",
-       " {\"expectation_type\": \"expect_column_min_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"fare_amount\", \"max_value\": -4.373247825, \"min_value\": -94.5}},\n",
-       " {\"expectation_type\": \"expect_column_max_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"fare_amount\", \"max_value\": 231796.417320982, \"min_value\": 167.375}}]"
+       "[{\"meta\": {}, \"expectation_type\": \"expect_column_min_to_be_between\", \"kwargs\": {\"max_value\": 0.0, \"min_value\": -1.66025, \"column\": \"tip_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_max_to_be_between\", \"kwargs\": {\"max_value\": 157.290239174, \"min_value\": 34.4595, \"column\": \"tip_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_min_to_be_between\", \"kwargs\": {\"max_value\": -4.36670117, \"min_value\": -94.5, \"column\": \"fare_amount\"}},\n",
+       " {\"meta\": {}, \"expectation_type\": \"expect_column_max_to_be_between\", \"kwargs\": {\"max_value\": 234103.847175468, \"min_value\": 167.375, \"column\": \"fare_amount\"}}]"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1211,7 +1220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,13 +1236,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6c0ac6bfbc6b4c43b429a5d1b4b64f99",
+       "model_id": "2fb6d0f33bff42f799eed5120d0ebffd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1247,7 +1256,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "35d507bb8743421db94dbe13d597945b",
+       "model_id": "fffaed55c1a044c0a5327f1b23517fb3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1277,13 +1286,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cfb4f47eabfc4ab1be833666484d93fb",
+       "model_id": "3d0c6bb09c344605a7088cbb55c53e80",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1297,7 +1306,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "121468b55685498daeea0135b58d4dec",
+       "model_id": "59d0b3a7770b44079ff45d4d9635b74e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1319,7 +1328,7 @@
        " }]"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1336,13 +1345,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b3c61766b73c49c6b916b95e73ad752d",
+       "model_id": "bde8fd1db88e437297f99f16853826c3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1356,7 +1365,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "290902d40ecc41ce9a26578c3a3ef9b9",
+       "model_id": "abb24e472e30410eb0273497f25efc68",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1387,7 +1396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1400,13 +1409,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1fd6e16a91f44a9586fb3b4f019c6f05",
+       "model_id": "5f9f62b593994af484c2f18729fac391",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1420,7 +1429,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e368bf580f6a4e55ba3961b33fb4e600",
+       "model_id": "de79a86f8f144b248b44923916631ad1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1447,7 +1456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1456,7 +1465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1467,7 +1476,7 @@
        " }]"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1497,7 +1506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1506,13 +1515,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c0d0b3e3fe7d44c5b1515114b2f1967e",
+       "model_id": "186ea84706bc41f98b3d67362d70f883",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1526,7 +1535,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "49110013634d475f8712756abd3b0476",
+       "model_id": "381c9234384e49c68438983ff8a98236",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1540,7 +1549,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "510faf0f7ae64c7790da31cecd04486b",
+       "model_id": "0c303e22e1bb48eeb3eac9e643248657",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1554,7 +1563,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "63cf124d4c1644babfcb50fe3872bff9",
+       "model_id": "1e9185f5890446ce85fa44b32efc5153",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1571,7 +1580,7 @@
        "True"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1604,7 +1613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1613,7 +1622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1626,7 +1635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 52,
    "metadata": {
     "scrolled": true
    },
@@ -1634,7 +1643,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1596eda218254827bfe4d7fc5ca786bb",
+       "model_id": "4b3d952f60774a84850ae38a2a47cf53",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1648,7 +1657,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "56f76e531b5b46169758aac43394af31",
+       "model_id": "e8d996dadeed4af5a6cd456a7cf5c1d4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1662,7 +1671,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a01a56e39394f3f93ef3151cfa702ac",
+       "model_id": "2940942d54db46f8a058ea1960347b26",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1697,7 +1706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1708,7 +1717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,7 +1740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1740,7 +1749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1757,7 +1766,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1766,13 +1775,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "614063fb00464ee385028d90f0c0caa3",
+       "model_id": "fac9e094da5a42c99516b03200ea079f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1799,7 +1808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -1808,7 +1817,7 @@
        "-100.8"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1840,7 +1849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1849,7 +1858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1858,7 +1867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1868,7 +1877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1884,7 +1893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 64,
    "metadata": {
     "scrolled": true
    },
@@ -1892,7 +1901,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e0b72cddba0d4ed39fd8b7e76d19d32f",
+       "model_id": "a96ff72b4cfa48d5b1423ac48ba4fb38",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1914,7 +1923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -1952,7 +1961,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1961,7 +1970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1977,7 +1986,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1986,7 +1995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2002,13 +2011,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "69fee3cb8bcf45e78cf8d70da9f35321",
+       "model_id": "a6515c578975460594b8acf8125ea054",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2022,7 +2031,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3ae5571ef3734743a1fadd326b65e110",
+       "model_id": "e1b7567856344e17bf78d57758db3bf7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2037,8 +2046,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/pandas/core/strings/accessor.py:101: UserWarning: This pattern has match groups. To actually get the groups, use str.extract.\n",
-      "  return func(self, *args, **kwargs)\n"
+      "/Users/work/Development/great_expectations/great_expectations/expectations/metrics/column_map_metrics/column_values_match_regex.py:23: UserWarning: This pattern is interpreted as a regular expression, and has match groups. To actually get the groups, use str.extract.\n",
+      "  return column.astype(str).str.contains(regex)\n"
      ]
     }
    ],
@@ -2052,7 +2061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -2076,7 +2085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2093,13 +2102,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "998d135cb6814d16af439ac5a1cfcea3",
+       "model_id": "2651817a0e844d0e950a798d9f81727b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2113,7 +2122,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2897c03629e84971bca26249c19857de",
+       "model_id": "74cc650d6efb41d399c5843d5352ab8a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2135,7 +2144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
@@ -2173,7 +2182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2182,7 +2191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2191,7 +2200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2200,7 +2209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2216,13 +2225,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b296b286ed384353974036c48efd068a",
+       "model_id": "b41b86304c7148e7b272c00ad2aae184",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2236,7 +2245,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "97c1e7bde6444950abbfb365780088cf",
+       "model_id": "0221341b801840409fd3a5990958702d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2258,7 +2267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -2275,7 +2284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -2284,7 +2293,7 @@
        "'%Y-%m-%d %H:%M:%S'"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2320,7 +2329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2329,7 +2338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2338,7 +2347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2356,7 +2365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2365,13 +2374,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78bc33778fda4ad28c424fc7acc19610",
+       "model_id": "082772353dc8431fabe69823c40ebcd2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2393,7 +2402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -2414,11 +2423,39 @@
    "source": [
     "As we see, the mean value range for the `total_amount` column is `16.0` to `44.0`"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optional: Clean-up Directory\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As part of running this notebook, the `RuleBasedProfiler` will create a number of ExpectationSuite configurations in the `great_expectations/expectations/tmp` directory. Optionally run the following cell to clean up the directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import os\n",
+    "# import glob\n",
+    "\n",
+    "# files = glob.glob('great_expectations/expectations/tmp/*.json')\n",
+    "# for f in files:\n",
+    "#     os.remove(f)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION

Changes proposed in this pull request:
- Whenever the notebook was run, there would be some changes to the `great_expectations.yml` file and a long list of `ExpectationSuites` that were built from the Profiler. 
- This PR proposes to: 
   - Only add `datasource` if it doesn't exist already
   - Add an optional clean up cell at the end that will clean up the ExpectationSuites with an explanation of why the cell is there. 


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.