### PR TITLE
[MAINTENANCE] type hints for Batch Request to be string (which leverages parameter/variable resolution)

### DIFF
--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -109,9 +109,15 @@ class DomainBuilderConfig(DictDot):
         batch_request: Optional[Union[dict, str]] = None,
         **kwargs,
     ):
-        self.class_name = class_name
-        self.module_name = module_name
-        self.batch_request = batch_request
+        if module_name is not None:
+            self.module_name = module_name
+
+        if class_name is not None:
+            self.class_name = class_name
+
+        if batch_request is not None:
+            self.batch_request = batch_request
+
         for k, v in kwargs.items():
             setattr(self, k, v)
             logger.debug(
@@ -150,12 +156,23 @@ class ParameterBuilderConfig(DictDot):
         class_name: str,
         module_name: Optional[str] = None,
         batch_request: Optional[Union[dict, str]] = None,
+        parameter_builders: Optional[dict] = None,
         **kwargs,
     ):
         self.name = name
-        self.class_name = class_name
-        self.module_name = module_name
-        self.batch_request = batch_request
+
+        if module_name is not None:
+            self.module_name = module_name
+
+        if class_name is not None:
+            self.class_name = class_name
+
+        if batch_request is not None:
+            self.batch_request = batch_request
+
+        if parameter_builders:
+            self.parameter_builders = parameter_builders
+
         for k, v in kwargs.items():
             setattr(self, k, v)
             logger.debug(
@@ -195,6 +212,20 @@ class ParameterBuilderConfigSchema(NotNullSchema):
         allow_none=True,
     )
 
+    parameter_builders = fields.Dict(
+        keys=fields.String(
+            required=True,
+            allow_none=False,
+        ),
+        values=fields.Nested(
+            lambda: ParameterBuilderConfigSchema(),
+            required=True,
+            allow_none=False,
+        ),
+        required=False,
+        allow_none=True,
+    )
+
 
 class ExpectationConfigurationBuilderConfig(DictDot):
     def __init__(
@@ -203,12 +234,27 @@ class ExpectationConfigurationBuilderConfig(DictDot):
         class_name: str,
         module_name: Optional[str] = None,
         meta: Optional[dict] = None,
+        batch_request: Optional[Union[dict, str]] = None,
+        parameter_builders: Optional[dict] = None,
         **kwargs,
     ):
         self.expectation_type = expectation_type
-        self.class_name = class_name
-        self.module_name = module_name
-        self.meta = meta
+
+        if module_name is not None:
+            self.module_name = module_name
+
+        if class_name is not None:
+            self.class_name = class_name
+
+        if meta is not None:
+            self.meta = meta
+
+        if batch_request is not None:
+            self.batch_request = batch_request
+
+        if parameter_builders:
+            self.parameter_builders = parameter_builders
+
         for k, v in kwargs.items():
             setattr(self, k, v)
             logger.debug(
@@ -242,6 +288,24 @@ class ExpectationConfigurationBuilderConfigSchema(NotNullSchema):
     )
     meta = fields.Dict(
         keys=fields.String(
+            required=True,
+            allow_none=False,
+        ),
+        required=False,
+        allow_none=True,
+    )
+    batch_request = fields.Raw(
+        required=False,
+        allow_none=True,
+    )
+
+    parameter_builders = fields.Dict(
+        keys=fields.String(
+            required=True,
+            allow_none=False,
+        ),
+        values=fields.Nested(
+            lambda: ParameterBuilderConfigSchema(),
             required=True,
             allow_none=False,
         ),

--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -195,6 +195,16 @@ class ParameterBuilderConfigSchema(NotNullSchema):
         allow_none=True,
     )
 
+    evaluation_parameter_builders = fields.List(
+        cls_or_instance=fields.Nested(
+            lambda: ParameterBuilderConfigSchema(),
+            required=True,
+            allow_none=False,
+        ),
+        required=False,
+        allow_none=True,
+    )
+
 
 class ExpectationConfigurationBuilderConfig(DictDot):
     def __init__(
@@ -242,6 +252,16 @@ class ExpectationConfigurationBuilderConfigSchema(NotNullSchema):
     )
     meta = fields.Dict(
         keys=fields.String(
+            required=True,
+            allow_none=False,
+        ),
+        required=False,
+        allow_none=True,
+    )
+
+    validation_parameter_builders = fields.List(
+        cls_or_instance=fields.Nested(
+            ParameterBuilderConfigSchema,
             required=True,
             allow_none=False,
         ),

--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -156,7 +156,6 @@ class ParameterBuilderConfig(DictDot):
         class_name: str,
         module_name: Optional[str] = None,
         batch_request: Optional[Union[dict, str]] = None,
-        parameter_builders: Optional[dict] = None,
         **kwargs,
     ):
         self.name = name
@@ -169,9 +168,6 @@ class ParameterBuilderConfig(DictDot):
 
         if batch_request is not None:
             self.batch_request = batch_request
-
-        if parameter_builders:
-            self.parameter_builders = parameter_builders
 
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -212,20 +208,6 @@ class ParameterBuilderConfigSchema(NotNullSchema):
         allow_none=True,
     )
 
-    parameter_builders = fields.Dict(
-        keys=fields.String(
-            required=True,
-            allow_none=False,
-        ),
-        values=fields.Nested(
-            lambda: ParameterBuilderConfigSchema(),
-            required=True,
-            allow_none=False,
-        ),
-        required=False,
-        allow_none=True,
-    )
-
 
 class ExpectationConfigurationBuilderConfig(DictDot):
     def __init__(
@@ -235,7 +217,6 @@ class ExpectationConfigurationBuilderConfig(DictDot):
         module_name: Optional[str] = None,
         meta: Optional[dict] = None,
         batch_request: Optional[Union[dict, str]] = None,
-        parameter_builders: Optional[dict] = None,
         **kwargs,
     ):
         self.expectation_type = expectation_type
@@ -251,9 +232,6 @@ class ExpectationConfigurationBuilderConfig(DictDot):
 
         if batch_request is not None:
             self.batch_request = batch_request
-
-        if parameter_builders:
-            self.parameter_builders = parameter_builders
 
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -295,20 +273,6 @@ class ExpectationConfigurationBuilderConfigSchema(NotNullSchema):
         allow_none=True,
     )
     batch_request = fields.Raw(
-        required=False,
-        allow_none=True,
-    )
-
-    parameter_builders = fields.Dict(
-        keys=fields.String(
-            required=True,
-            allow_none=False,
-        ),
-        values=fields.Nested(
-            lambda: ParameterBuilderConfigSchema(),
-            required=True,
-            allow_none=False,
-        ),
         required=False,
         allow_none=True,
     )

--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -195,16 +195,6 @@ class ParameterBuilderConfigSchema(NotNullSchema):
         allow_none=True,
     )
 
-    evaluation_parameter_builders = fields.List(
-        cls_or_instance=fields.Nested(
-            lambda: ParameterBuilderConfigSchema(),
-            required=True,
-            allow_none=False,
-        ),
-        required=False,
-        allow_none=True,
-    )
-
 
 class ExpectationConfigurationBuilderConfig(DictDot):
     def __init__(
@@ -252,16 +242,6 @@ class ExpectationConfigurationBuilderConfigSchema(NotNullSchema):
     )
     meta = fields.Dict(
         keys=fields.String(
-            required=True,
-            allow_none=False,
-        ),
-        required=False,
-        allow_none=True,
-    )
-
-    validation_parameter_builders = fields.List(
-        cls_or_instance=fields.Nested(
-            ParameterBuilderConfigSchema,
             required=True,
             allow_none=False,
         ),

--- a/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
@@ -35,7 +35,9 @@ class CategoricalColumnDomainBuilder(ColumnDomainBuilder):
     def __init__(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
         include_column_names: Optional[Union[str, Optional[List[str]]]] = None,
         exclude_column_names: Optional[Union[str, Optional[List[str]]]] = None,

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -28,7 +28,9 @@ class ColumnDomainBuilder(DomainBuilder):
     def __init__(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
         include_column_names: Optional[Union[str, Optional[List[str]]]] = None,
         exclude_column_names: Optional[Union[str, Optional[List[str]]]] = None,

--- a/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
@@ -29,7 +29,7 @@ class DomainBuilder(Builder, ABC):
         self,
         batch_list: Optional[List[Batch]] = None,
         batch_request: Optional[
-            Union[BatchRequest, RuntimeBatchRequest, dict, str]
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
         ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):

--- a/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
@@ -28,7 +28,9 @@ class DomainBuilder(Builder, ABC):
     def __init__(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[BatchRequest, RuntimeBatchRequest, dict, str]
+        ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
         """

--- a/great_expectations/rule_based_profiler/domain_builder/map_metric_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/map_metric_column_domain_builder.py
@@ -24,7 +24,9 @@ class MapMetricColumnDomainBuilder(ColumnDomainBuilder):
         self,
         map_metric_name: str,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
         include_column_names: Optional[Union[str, Optional[List[str]]]] = None,
         exclude_column_names: Optional[Union[str, Optional[List[str]]]] = None,

--- a/great_expectations/rule_based_profiler/domain_builder/table_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/table_domain_builder.py
@@ -10,7 +10,9 @@ class TableDomainBuilder(DomainBuilder):
     def __init__(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
         """

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
@@ -16,6 +16,7 @@ from pyparsing import (
 )
 
 import great_expectations.exceptions as ge_exceptions
+from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.rule_based_profiler.expectation_configuration_builder import (
     ExpectationConfigurationBuilder,
@@ -62,11 +63,24 @@ class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
     def __init__(
         self,
         expectation_type: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
+        data_context: Optional["DataContext"] = None,  # noqa: F821
         condition: Optional[str] = None,
         meta: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
-        super().__init__(expectation_type=expectation_type, **kwargs)
+        super().__init__(
+            expectation_type=expectation_type,
+            parameter_builders=parameter_builders,
+            batch_list=batch_list,
+            batch_request=batch_request,
+            data_context=data_context,
+            **kwargs,
+        )
 
         self._kwargs = kwargs
 

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
@@ -63,7 +63,6 @@ class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
     def __init__(
         self,
         expectation_type: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
         batch_request: Optional[
             Union[str, BatchRequest, RuntimeBatchRequest, dict]
@@ -75,7 +74,6 @@ class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
     ):
         super().__init__(
             expectation_type=expectation_type,
-            parameter_builders=parameter_builders,
             batch_list=batch_list,
             batch_request=batch_request,
             data_context=data_context,

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -18,8 +18,11 @@ class ExpectationConfigurationBuilder(Builder, ABC):
     def __init__(
         self,
         expectation_type: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
         **kwargs
     ):

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -18,7 +18,6 @@ class ExpectationConfigurationBuilder(Builder, ABC):
     def __init__(
         self,
         expectation_type: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
         batch_request: Optional[
             Union[str, BatchRequest, RuntimeBatchRequest, dict]

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -37,7 +37,7 @@ def get_validator(
     *,
     data_context: Optional["DataContext"] = None,  # noqa: F821
     batch_list: Optional[List[Batch]] = None,
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict, str]] = None,
+    batch_request: Optional[Union[str, BatchRequest, RuntimeBatchRequest, dict]] = None,
     domain: Optional[Domain] = None,
     variables: Optional[ParameterContainer] = None,
     parameters: Optional[Dict[str, ParameterContainer]] = None,
@@ -92,7 +92,7 @@ def get_validator(
 def get_batch_ids(
     data_context: Optional["DataContext"] = None,  # noqa: F821
     batch_list: Optional[List[Batch]] = None,
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict, str]] = None,
+    batch_request: Optional[Union[str, BatchRequest, RuntimeBatchRequest, dict]] = None,
     domain: Optional[Domain] = None,
     variables: Optional[ParameterContainer] = None,
     parameters: Optional[Dict[str, ParameterContainer]] = None,
@@ -124,7 +124,7 @@ def get_batch_ids(
 
 
 def build_batch_request(
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict, str]] = None,
+    batch_request: Optional[Union[str, BatchRequest, RuntimeBatchRequest, dict]] = None,
     domain: Optional[Domain] = None,
     variables: Optional[ParameterContainer] = None,
     parameters: Optional[Dict[str, ParameterContainer]] = None,

--- a/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -40,7 +40,6 @@ class MeanUnexpectedMapMetricMultiBatchParameterBuilder(
         map_metric_name: str,
         total_count_parameter_builder_name: str,
         null_count_parameter_builder_name: Optional[str] = None,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
@@ -69,7 +68,6 @@ class MeanUnexpectedMapMetricMultiBatchParameterBuilder(
         super().__init__(
             name=name,
             metric_name=f"{map_metric_name}.unexpected_count",
-            parameter_builders=parameter_builders,
             metric_domain_kwargs=metric_domain_kwargs,
             metric_value_kwargs=metric_value_kwargs,
             enforce_numeric_metric=True,

--- a/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -40,10 +40,13 @@ class MeanUnexpectedMapMetricMultiBatchParameterBuilder(
         map_metric_name: str,
         total_count_parameter_builder_name: str,
         null_count_parameter_builder_name: Optional[str] = None,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
@@ -66,6 +69,7 @@ class MeanUnexpectedMapMetricMultiBatchParameterBuilder(
         super().__init__(
             name=name,
             metric_name=f"{map_metric_name}.unexpected_count",
+            parameter_builders=parameter_builders,
             metric_domain_kwargs=metric_domain_kwargs,
             metric_value_kwargs=metric_value_kwargs,
             enforce_numeric_metric=True,

--- a/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
@@ -28,7 +28,6 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         self,
         name: str,
         metric_name: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         enforce_numeric_metric: Union[str, bool] = False,
@@ -60,7 +59,6 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         """
         super().__init__(
             name=name,
-            parameter_builders=parameter_builders,
             batch_list=batch_list,
             batch_request=batch_request,
             json_serialize=json_serialize,

--- a/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
@@ -28,13 +28,16 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         self,
         name: str,
         metric_name: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         enforce_numeric_metric: Union[str, bool] = False,
         replace_nan_with_zero: Union[str, bool] = False,
         reduce_scalar_metric: Union[str, bool] = True,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
@@ -57,6 +60,7 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         """
         super().__init__(
             name=name,
+            parameter_builders=parameter_builders,
             batch_list=batch_list,
             batch_request=batch_request,
             json_serialize=json_serialize,

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -58,6 +58,7 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
         self,
         name: str,
         metric_name: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         enforce_numeric_metric: Union[str, bool] = True,
@@ -72,7 +73,9 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
             Union[str, Dict[str, Union[Optional[int], Optional[float]]]]
         ] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
@@ -106,6 +109,7 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
         super().__init__(
             name=name,
             metric_name=metric_name,
+            parameter_builders=parameter_builders,
             metric_domain_kwargs=metric_domain_kwargs,
             metric_value_kwargs=metric_value_kwargs,
             enforce_numeric_metric=enforce_numeric_metric,

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -58,7 +58,6 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
         self,
         name: str,
         metric_name: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         enforce_numeric_metric: Union[str, bool] = True,
@@ -109,7 +108,6 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
         super().__init__(
             name=name,
             metric_name=metric_name,
-            parameter_builders=parameter_builders,
             metric_domain_kwargs=metric_domain_kwargs,
             metric_value_kwargs=metric_value_kwargs,
             enforce_numeric_metric=enforce_numeric_metric,

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -90,7 +90,6 @@ class ParameterBuilder(Builder, ABC):
     def __init__(
         self,
         name: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
         batch_request: Optional[
             Union[str, BatchRequest, RuntimeBatchRequest, dict]

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -90,8 +90,11 @@ class ParameterBuilder(Builder, ABC):
     def __init__(
         self,
         name: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -48,12 +48,15 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
     def __init__(
         self,
         name: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         threshold: Union[float, str] = 1.0,
         candidate_regexes: Optional[Union[Iterable[str], str]] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
@@ -72,6 +75,7 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
         """
         super().__init__(
             name=name,
+            parameter_builders=parameter_builders,
             batch_list=batch_list,
             batch_request=batch_request,
             json_serialize=json_serialize,

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -48,7 +48,6 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
     def __init__(
         self,
         name: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         threshold: Union[float, str] = 1.0,
@@ -75,7 +74,6 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
         """
         super().__init__(
             name=name,
-            parameter_builders=parameter_builders,
             batch_list=batch_list,
             batch_request=batch_request,
             json_serialize=json_serialize,

--- a/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
@@ -93,12 +93,15 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
     def __init__(
         self,
         name: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         threshold: Union[str, float] = 1.0,
         candidate_strings: Optional[Union[Iterable[str], str]] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         json_serialize: bool = True,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
@@ -119,6 +122,7 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
         """
         super().__init__(
             name=name,
+            parameter_builders=parameter_builders,
             batch_list=batch_list,
             batch_request=batch_request,
             json_serialize=json_serialize,

--- a/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
@@ -93,7 +93,6 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
     def __init__(
         self,
         name: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         threshold: Union[str, float] = 1.0,
@@ -122,7 +121,6 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
         """
         super().__init__(
             name=name,
-            parameter_builders=parameter_builders,
             batch_list=batch_list,
             batch_request=batch_request,
             json_serialize=json_serialize,

--- a/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
@@ -49,10 +49,13 @@ class ValueSetMultiBatchParameterBuilder(MetricMultiBatchParameterBuilder):
     def __init__(
         self,
         name: str,
+        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
@@ -71,6 +74,7 @@ class ValueSetMultiBatchParameterBuilder(MetricMultiBatchParameterBuilder):
         super().__init__(
             name=name,
             metric_name="column.distinct_values",
+            parameter_builders=parameter_builders,
             metric_domain_kwargs=metric_domain_kwargs,
             metric_value_kwargs=metric_value_kwargs,
             enforce_numeric_metric=False,

--- a/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
@@ -49,7 +49,6 @@ class ValueSetMultiBatchParameterBuilder(MetricMultiBatchParameterBuilder):
     def __init__(
         self,
         name: str,
-        parameter_builders: Optional[Dict[str, dict]] = None,
         metric_domain_kwargs: Optional[Union[str, dict]] = None,
         metric_value_kwargs: Optional[Union[str, dict]] = None,
         batch_list: Optional[List[Batch]] = None,
@@ -74,7 +73,6 @@ class ValueSetMultiBatchParameterBuilder(MetricMultiBatchParameterBuilder):
         super().__init__(
             name=name,
             metric_name="column.distinct_values",
-            parameter_builders=parameter_builders,
             metric_domain_kwargs=metric_domain_kwargs,
             metric_value_kwargs=metric_value_kwargs,
             enforce_numeric_metric=False,

--- a/great_expectations/rule_based_profiler/types/builder.py
+++ b/great_expectations/rule_based_profiler/types/builder.py
@@ -26,7 +26,9 @@ class Builder(SerializableDictDot):
     def __init__(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[
+            Union[str, BatchRequest, RuntimeBatchRequest, dict]
+        ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
         """


### PR DESCRIPTION
### Scope
We already use the `str` version of `batch_request` in Rule-Based Profiler configuration YAML/JSON-Dict versions — this is just making this usage explicit with the type-hint.



Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
