### PR TITLE
[BUGFIX] Update ExpectColumnValuesToMatchRegex to support parameterized expectations

### DIFF
--- a/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_set_based_column_map_expectations.md
+++ b/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_set_based_column_map_expectations.md
@@ -1,0 +1,265 @@
+---
+title: How to create a Custom Set-Based Column Map Expectation
+---
+import Prerequisites from '../creating_custom_expectations/components/prerequisites.jsx'
+import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
+
+**`SetBasedColumnMapExpectations`** are a sub-type of <TechnicalTag tag="expectation" text="ColumnMapExpectaion"/>. They are evaluated for a single column and ask whether each row in that column belongs to the specified set.
+
+Based on the result, they then calculate the percentage of rows that gave a positive answer. If that percentage meets a specified threshold (100% by default), the Expectation considers that data valid.  This threshold is configured via the `mostly` parameter, which can be passed as input to your Custom `SetBasedColumnMapExpectation` as a `float` between 0 and 1.
+
+This guide will walk you through the process of creating a Custom `SetBasedColumnMapExpectation`.
+
+<Prerequisites>
+
+- Read the [overview for creating Custom Expectations](./overview.md).
+
+</Prerequisites>
+
+## Steps
+
+### 1. Choose a name for your Expectation
+
+First, decide on a name for your own Expectation. By convention, all `ColumnMapExpectations`, including `SetBasedColumnMapExpectations`, start with `expect_column_values_`. You can see other naming conventions in the [Expectations section](/docs/contributing/style_guides/code_style#expectations)  of the code Style Guide.
+
+Your Expectation will have two versions of the same name: a `CamelCaseName` and a `snake_case_name`. For example, this tutorial will use:
+
+- `ExpectColumnValuesToBeInSolfegeScaleSet`
+- `expect_column_values_to_be_in_solfege_scale_set`
+
+### 2. Copy and rename the template file
+
+By convention, each Expectation is kept in its own python file, named with the snake_case version of the Expectation's name.
+
+You can find the template file for a custom [`SetBasedColumnMapExpectation` here](https://github.com/great-expectations/great_expectations/blob/develop/examples/expectations/set_based_column_map_expectation_template.py). Download the file, place it in the appropriate directory, and rename it to the appropriate name.
+
+```bash
+cp set_based_column_map_expectation_template.py /SOME_DIRECTORY/expect_column_values_to_be_in_solfege_scale_set.py
+```
+
+<details>
+  <summary>Where should I put my Expectation file?</summary>
+  <div>
+    <p>
+        During development, you don't actually need to put the file anywhere in particular. It's self-contained, and can be executed anywhere as long as <code>great_expectations</code> is installed.
+    </p>
+    <p>
+        But to use your new Expectation alongside the other components of Great Expectations, you'll need to make sure the file is in the right place. The right place depends on what you intend to use it for.
+    </p>
+    <p>
+        <ul>
+            <li>If you're building a Custom Expectation for personal use, you'll need to put it in the <code>great_expectations/plugins/expectations</code> folder of your Great Expectations deployment, and import your Custom Expectation from that directory whenever it will be used. When you instantiate the corresponding <code>DataContext</code>, it will automatically make all plugins in the directory available for use.</li>
+            <li>If you're building a Custom Expectation to contribute to the open source project, you'll need to put it in the repo for the Great Expectations library itself. Most likely, this will be within a package within <code>contrib/</code>: <code>great_expectations/contrib/SOME_PACKAGE/SOME_PACKAGE/expectations/</code>. To use these Expectations, you'll need to install the package.</li>
+        </ul>
+    </p>
+  </div>
+</details>
+
+### 3. Generate a diagnostic checklist for your Expectation
+
+Once you've copied and renamed the template file, you can execute it as follows.
+
+```bash
+python expect_column_values_to_be_in_solfege_scale_set.py
+```
+
+The template file is set up so that this will run the Expectation's `print_diagnostic_checklist()` method. This will run a diagnostic script on your new Expectation, and return a checklist of steps to get it to full production readiness.
+
+```
+Completeness checklist for ExpectColumnValuesToBeInSomeSet:
+  ✔ Has a library_metadata object
+    Has a docstring, including a one-line short description
+    Has at least one positive and negative example case, and all test cases pass
+    Has core logic and passes tests on at least one Execution Engine
+    Has basic input validation and type checking
+    Has both Statement Renderers: prescriptive and diagnostic
+    Has core logic that passes tests for all applicable Execution Engines
+    Passes all linting checks
+    Has a robust suite of tests, as determined by a code owner
+    Has passed a manual review by a code owner for code standards and style guides
+```
+
+When in doubt, the next step to implement is the first one that doesn't have a ✔ next to it. This guide covers the first four steps on the checklist.
+
+### 4. Change the Expectation class name and add a docstring
+
+Let's start by updating your Expectation's name and docstring.
+
+Replace the Expectation class name
+```python file=../../../../examples/expectations/regex_based_column_map_expectation_template.py#L21
+```
+
+with your real Expectation class name, in upper camel case:
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L14
+```
+
+You can also go ahead and write a new one-line docstring, replacing
+```python file=../../../../examples/expectations/regex_based_column_map_expectation_template.py#L22
+```
+
+with something like:
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L15
+```
+
+You'll also need to change the class name at the bottom of the file, by replacing this line:
+
+```python file=../../../../examples/expectations/regex_based_column_map_expectation_template.py#L81
+```
+
+with this one:
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L146
+```
+
+Later, you can go back and write a more thorough docstring.
+
+At this point you can re-run your diagnostic checklist. You should see something like this:
+```
+$ python expect_column_values_to_only_contain_vowels.py
+
+Completeness checklist for ExpectColumnValuesToOnlyContainVowels:
+  ✔ Has a library_metadata object
+  ✔ Has a docstring, including a one-line short description
+    Has at least one positive and negative example case, and all test cases pass
+    Has core logic and passes tests on at least one Execution Engine
+...
+```
+
+Congratulations! You're one step closer to implementing a Custom Expectation.
+
+### 5. Add example cases
+
+Next, we're going to search for `examples = []` in your file, and replace it with at least two test examples. These examples serve a dual purpose:
+
+1. They provide test fixtures that Great Expectations can execute automatically via pytest.
+
+2. They help users understand the logic of your Expectation by providing tidy examples of paired input and output. If you contribute your Expectation to open source, these examples will appear in the Gallery.
+
+Your examples will look something like this:
+
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L22-L111
+```
+
+Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
+
+* `data`: defines the input data of the example as a table/data frame. In this example the table has columns named `only_vowels`, `mixed`, `longer_vowels`, and `contains_vowels_but_also_other_stuff`. All of these columns have 7 rows. (Note: if you define multiple columns, make sure that they have the same number of rows.)
+* `tests`: a list of test cases to validate against the data frame defined in the corresponding `data`.
+	* `title` should be a descriptive name for the test case. Make sure to have no spaces.
+	* `include_in_gallery`: This must be set to `True` if you want this test case to be visible in the Gallery as an example.
+	* `in` contains exactly the parameters that you want to pass in to the Expectation. `"in": {"column": "mixed", "mostly": .1}` in the example above is equivalent to `expect_column_values_to_only_contain_vowels(column="mixed", mostly=0.6)`
+	* `out` is based on the Validation Result returned when executing the Expectation.
+	* `exact_match_out`: if you set `exact_match_out=False`, then you don’t need to include all the elements of the Validation Result object - only the ones that are important to test.
+
+
+If you run your Expectation file again, you won't see any new checkmarks, as the logic for your Custom Expectation hasn't been implemented yet. 
+However, you should see that the tests you've written are now being caught and reported in your checklist:
+
+```
+$ python expect_column_values_to_only_contain_vowels.py
+
+Completeness checklist for ExpectColumnValuesToOnlyContainVowels:
+  ✔ Has a library_metadata object
+  ✔ Has a docstring, including a one-line short description
+...
+	Has core logic that passes tests for all applicable Execution Engines and SQL dialects
+		  Only 0 / 2 tests for pandas are passing
+		  Only 0 / 2 tests for spark are passing
+		  Only 0 / 2 tests for sqlite are passing
+		  Failing: basic_positive_test, basic_negative_test
+...
+```
+
+:::note
+For more information on tests and example cases, <br/>
+see our guide on [how to create example cases for a Custom Expectation](../features_custom_expectations/how_to_add_example_cases_for_an_expectation.md).
+:::
+
+### 6. Define your regex and connect it to your Expectation
+
+This is the stage where you implement the actual business logic for your Expectation.   
+
+In the case of your Custom `RegexBasedColumnMapExpectation`, Great Expectations will handle the actual application of the regex to your data. 
+
+To do this, we replace these:
+
+```python file=../../../../examples/expectations/regex_based_column_map_expectation_template.py#L25-L27
+```
+
+with something like this:
+
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L17-L19
+```
+
+For more detail when rendering your Custom Expectation, you can optionally specify the plural form of a Semantic Type you're validating. 
+
+For example:
+
+```python file=../../../../examples/expectations/regex_based_column_map_expectation_template.py#L28
+```
+
+becomes:
+
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L20
+```
+
+Great Expectations will use these values to tell your Custom Expectation to apply your specified regex as a <TechnicalTag tag="metric" text="Metric"/> to be utilized in validating your data.
+
+This is all that you need to define for now. The `RegexBasedColumnMapExpectation` class has built-in logic to handle all the machinery of data validation, including standard parameters like `mostly`, generation of Validation Results, etc.
+
+<details>
+  <summary>Other parameters</summary>
+  <div>
+    <p>
+        <b>Expectation Success Keys</b> - A tuple consisting of values that must / could be provided by the user and defines how the Expectation evaluates success.
+    </p>
+    <p>
+        <b>Expectation Default Kwarg Values</b> (Optional) - Default values for success keys and the defined domain, among other values.
+    </p>
+  </div>
+</details>
+
+Running your diagnostic checklist at this point should return something like this:
+```
+$ python expect_column_values_to_only_contain_vowels.py
+
+Completeness checklist for ExpectColumnValuesToOnlyContainVowels:
+  ✔ Has a library_metadata object
+  ✔ Has a docstring, including a one-line short description
+  ✔ Has at least one positive and negative example case, and all test cases pass
+  ✔ Has core logic and passes tests on at least one Execution Engine
+...
+```
+
+<div style={{"text-align":"center"}}>  
+<p style={{"color":"#8784FF","font-size":"1.4em"}}><b>  
+Congratulations!<br/>&#127881; You've just built your first Custom Regex-Based Column Map Expectation! &#127881;  
+</b></p>  
+</div>
+
+:::note
+If you've already built a [Custom Expectation](./overview.md) of a different type,
+you may notice that we didn't explicitly implement a `_validate` method or Metric class here. While we have to explicitly create these for other types of Custom Expectations,
+the `RegexBasedColumnMapExpectation` class handles Metric creation and result validation implicitly; no extra work needed!
+:::
+
+### 7. Contribution (Optional)
+
+This guide will leave you with a Custom Expectation sufficient for [contribution](../contributing/how_to_contribute_a_custom_expectation_to_great_expectations.md) back to Great Expectations at an Experimental level.
+
+If you plan to contribute your Expectation to the public open source project, you should update the `library_metadata` object before submitting your [Pull Request](https://github.com/great-expectations/great_expectations/pulls). For example:
+
+```python file=../../../../examples/expectations/regex_based_column_map_expectation_template.py#L71-L76
+```
+
+would become
+
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py#L138-L141
+```
+
+This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!
+
+:::note
+For more information on our code standards and contribution, see our guide on [Levels of Maturity](../../../contributing/contributing_maturity.md#contributing-expectations) for Expectations.
+
+To view the full script used in this page, see it on GitHub:
+- [expect_column_values_to_only_contain_vowels.py](https://github.com/great-expectations/great_expectations/blob/hackathon-docs/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_only_contain_vowels.py)
+:::

--- a/examples/expectations/set_based_column_map_expectation_template.py
+++ b/examples/expectations/set_based_column_map_expectation_template.py
@@ -1,0 +1,46 @@
+"""
+This is a template for creating custom SetBasedColumnMapExpectations.
+For detailed instructions on how to use it, please see:
+    https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_seet_based_column_map_expectations
+"""
+
+from great_expectations.expectations.regex_based_column_map_expectation import (
+    SetBasedColumnMapExpectation,
+)
+
+
+# <snippet>
+# This class defines the Expectation itself
+class ExpectColumnValuesToBeInSomeSet(SetBasedColumnMapExpectation):
+    """TODO: Add a docstring here"""
+
+    # These values will be used to configure the metric created by your expectation
+    set_ = []
+    
+    set_snake_name = "regex_name"
+    set_camel_name = "RegexName"
+    set_semantic_name = None
+
+    # These examples will be shown in the public gallery.
+    # They will also be executed as unit tests for your Expectation.
+    examples = []
+
+    # Here your regex is used to create a custom metric for this expectation
+    map_metric = SetBasedColumnMapExpectation.register_metric(
+        regex_snake_name=regex_snake_name,
+        regex_camel_name=regex_camel_name,
+        set_=set_,
+    )
+
+    # This object contains metadata for display in the public Gallery
+    library_metadata = {
+        "tags": ["set-based"],  # Tags for this Expectation in the Gallery
+        "contributors": [  # Github handles for all contributors to this Expectation.
+            "@your_name_here",  # Don't forget to add your github handle here!
+        ],
+    }
+
+
+# </snippet>
+if __name__ == "__main__":
+    ExpectColumnValuesToBeInSomeSet().print_diagnostic_checklist()

--- a/examples/expectations/set_based_column_map_expectation_template.py
+++ b/examples/expectations/set_based_column_map_expectation_template.py
@@ -17,8 +17,8 @@ class ExpectColumnValuesToBeInSomeSet(SetBasedColumnMapExpectation):
     # These values will be used to configure the metric created by your expectation
     set_ = []
     
-    set_snake_name = "regex_name"
-    set_camel_name = "RegexName"
+    set_snake_name = "set_name"
+    set_camel_name = "SetName"
     set_semantic_name = None
 
     # These examples will be shown in the public gallery.
@@ -27,8 +27,8 @@ class ExpectColumnValuesToBeInSomeSet(SetBasedColumnMapExpectation):
 
     # Here your regex is used to create a custom metric for this expectation
     map_metric = SetBasedColumnMapExpectation.register_metric(
-        regex_snake_name=regex_snake_name,
-        regex_camel_name=regex_camel_name,
+        set_snake_name=set_snake_name,
+        set_camel_name=set_camel_name,
         set_=set_,
     )
 

--- a/great_expectations/expectations/set_based_column_map_expectation.py
+++ b/great_expectations/expectations/set_based_column_map_expectation.py
@@ -1,0 +1,298 @@
+import json
+import logging
+from abc import ABC
+from typing import Dict, Optional
+
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.exceptions.exceptions import (
+    InvalidExpectationConfigurationError,
+)
+from great_expectations.execution_engine import (
+    PandasExecutionEngine,
+    SparkDFExecutionEngine,
+    SqlAlchemyExecutionEngine,
+)
+from great_expectations.expectations.expectation import (
+    ColumnMapExpectation,
+    ExpectationConfiguration,
+)
+from great_expectations.expectations.metrics.map_metric_provider import (
+    ColumnMapMetricProvider,
+    column_condition_partial,
+)
+from great_expectations.expectations.metrics.util import get_dialect_regex_expression
+from great_expectations.expectations.util import render_evaluation_parameter_string
+from great_expectations.render.renderer.renderer import renderer
+from great_expectations.render.types import RenderedStringTemplateContent
+from great_expectations.render.util import (
+    handle_strict_min_max,
+    parse_row_condition_string_pandas_engine,
+    substitute_none_for_missing,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SetColumnMapMetricProvider(ColumnMapMetricProvider):
+    condition_value_keys = ()
+
+    @column_condition_partial(engine=PandasExecutionEngine)
+    def _pandas(cls, column, **kwargs):
+        return column.isin(cls.set_)
+
+    # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+    # def _sqlalchemy(cls, column, _dialect, **kwargs):
+    #     regex_expression = get_dialect_regex_expression(column, cls.regex, _dialect)
+
+    #     if regex_expression is None:
+    #         logger.warning(
+    #             "Regex is not supported for dialect %s" % str(_dialect.dialect.name)
+    #         )
+    #         raise NotImplementedError
+
+    #     return regex_expression
+
+    # @column_condition_partial(engine=SparkDFExecutionEngine)
+    # def _spark(cls, column, **kwargs):
+    #     return column.rlike(cls.regex)
+
+
+class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
+    @staticmethod
+    def register_metric(
+        set_snake_name: str,
+        set_camel_name: str,
+        set_: str,
+    ):
+        map_metric = "column_values.match_" + set_snake_name + "_set"
+
+        # Define the class using `type`. This allows us to name it dynamically.
+        new_column_set_metric_provider = type(
+            f"(ColumnValuesMatch{set_camel_name}Set",
+            (SetColumnMapMetricProvider,),
+            {
+                "condition_metric_name": map_metric,
+                "set_": set_,
+            },
+        )
+
+        return map_metric
+
+    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+        super().validate_configuration(configuration)
+        try:
+            assert (
+                getattr(self, "set_", None) is not None
+            ), "set_ is required for SetBasedColumnMap Expectations"
+            
+            assert (
+                "column" in configuration.kwargs
+            ), "'column' parameter is required for ColumnMap expectations"
+
+            if "mostly" in configuration.kwargs:
+                mostly = configuration.kwargs["mostly"]
+                assert isinstance(
+                    mostly, (int, float)
+                ), "'mostly' parameter must be an integer or float"
+                assert 0 <= mostly <= 1, "'mostly' parameter must be between 0 and 1"
+
+        except AssertionError as e:
+            raise InvalidExpectationConfigurationError(str(e))
+            
+        return True
+
+    # question, descriptive, prescriptive, diagnostic
+    @classmethod
+    @renderer(renderer_type="renderer.question")
+    def _question_renderer(
+        cls, configuration, result=None, language=None, runtime_configuration=None
+    ):
+        column = configuration.kwargs.get("column")
+        mostly = configuration.kwargs.get("mostly")
+        set_ = getattr(cls, "set_")
+        set_semantic_name = getattr(cls, "set_semantic_name", None)
+
+        if mostly == 1 or mostly is None:
+            if set_semantic_name is not None:
+                return f'Are all values in column "{column}" in {semantic_type_name_plural}: {str(set_)}?'
+            else:
+                return f'Are all values in column "{column}" in the set {str(set_)}?'
+        else:
+            if set_semantic_name is not None:
+                return f'Are at least {mostly * 100}% of values in column "{column}" in {semantic_type_name_plural}: {str(set_)}?'
+            else:
+                return f'Are at least {mostly * 100}% of values in column "{column}" in the set {str(set_)}?'
+
+    @classmethod
+    @renderer(renderer_type="renderer.answer")
+    def _answer_renderer(
+        cls, configuration=None, result=None, language=None, runtime_configuration=None
+    ):
+        column = result.expectation_config.kwargs.get("column")
+        mostly = result.expectation_config.kwargs.get("mostly")
+        regex = result.expectation_config.kwargs.get("regex")
+        semantic_type_name_plural = configuration.kwargs.get(
+            "semantic_type_name_plural"
+        )
+
+        if result.success:
+            if mostly == 1 or mostly is None:
+                if semantic_type_name_plural is not None:
+                    return f'All values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
+                else:
+                    return f'All values in column "{column}" match the regular expression {regex}.'
+            else:
+                if semantic_type_name_plural is not None:
+                    return f'At least {mostly * 100}% of values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
+                else:
+                    return f'At least {mostly * 100}% of values in column "{column}" match the regular expression {regex}.'
+        else:
+            if semantic_type_name_plural is not None:
+                return f' Less than {mostly * 100}% of values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
+            else:
+                return f'Less than {mostly * 100}% of values in column "{column}" match the regular expression {regex}.'
+
+    @classmethod
+    def _atomic_prescriptive_template(
+        cls,
+        configuration=None,
+        result=None,
+        language=None,
+        runtime_configuration=None,
+        **kwargs,
+    ):
+        runtime_configuration = runtime_configuration or {}
+        include_column_name = runtime_configuration.get("include_column_name", True)
+        include_column_name = (
+            include_column_name if include_column_name is not None else True
+        )
+        styling = runtime_configuration.get("styling")
+        params = substitute_none_for_missing(
+            configuration.kwargs,
+            ["column", "regex", "mostly", "row_condition", "condition_parser"],
+        )
+        params_with_json_schema = {
+            "column": {"schema": {"type": "string"}, "value": params.get("column")},
+            "mostly": {"schema": {"type": "number"}, "value": params.get("mostly")},
+            "mostly_pct": {
+                "schema": {"type": "number"},
+                "value": params.get("mostly_pct"),
+            },
+            "regex": {"schema": {"type": "string"}, "value": params.get("regex")},
+            "row_condition": {
+                "schema": {"type": "string"},
+                "value": params.get("row_condition"),
+            },
+            "condition_parser": {
+                "schema": {"type": "string"},
+                "value": params.get("condition_parser"),
+            },
+        }
+
+        if not params.get("regex"):
+            template_str = (
+                "values must match a regular expression but none was specified."
+            )
+        else:
+            template_str = "values must match this regular expression: $regex"
+            if params["mostly"] is not None:
+                params_with_json_schema["mostly_pct"]["value"] = num_to_str(
+                    params["mostly"] * 100, precision=15, no_scientific=True
+                )
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        if params["row_condition"] is not None:
+            (
+                conditional_template_str,
+                conditional_params,
+            ) = parse_row_condition_string_pandas_engine(
+                params["row_condition"], with_schema=True
+            )
+            template_str = conditional_template_str + ", then " + template_str
+            params_with_json_schema.update(conditional_params)
+
+        return (template_str, params_with_json_schema, styling)
+
+    @classmethod
+    @renderer(renderer_type="renderer.prescriptive")
+    @render_evaluation_parameter_string
+    def _prescriptive_renderer(
+        cls,
+        configuration=None,
+        result=None,
+        language=None,
+        runtime_configuration=None,
+        **kwargs,
+    ):
+        runtime_configuration = runtime_configuration or {}
+        include_column_name = runtime_configuration.get("include_column_name", True)
+        include_column_name = (
+            include_column_name if include_column_name is not None else True
+        )
+        styling = runtime_configuration.get("styling")
+        params = substitute_none_for_missing(
+            configuration.kwargs,
+            ["column", "regex", "mostly", "row_condition", "condition_parser"],
+        )
+
+        if not params.get("regex"):
+            template_str = (
+                "values must match a regular expression but none was specified."
+            )
+        else:
+            template_str = "values must match this regular expression: $regex"
+            if params["mostly"] is not None:
+                params["mostly_pct"] = num_to_str(
+                    params["mostly"] * 100, precision=15, no_scientific=True
+                )
+                # params["mostly_pct"] = "{:.14f}".format(params["mostly"]*100).rstrip("0").rstrip(".")
+                template_str += ", at least $mostly_pct % of the time."
+            else:
+                template_str += "."
+
+        if include_column_name:
+            template_str = "$column " + template_str
+
+        if params["row_condition"] is not None:
+            (
+                conditional_template_str,
+                conditional_params,
+            ) = parse_row_condition_string_pandas_engine(params["row_condition"])
+            template_str = conditional_template_str + ", then " + template_str
+            params.update(conditional_params)
+
+        params_with_json_schema = {
+            "column": {"schema": {"type": "string"}, "value": params.get("column")},
+            "mostly": {"schema": {"type": "number"}, "value": params.get("mostly")},
+            "mostly_pct": {
+                "schema": {"type": "number"},
+                "value": params.get("mostly_pct"),
+            },
+            "regex": {"schema": {"type": "string"}, "value": params.get("regex")},
+            "row_condition": {
+                "schema": {"type": "string"},
+                "value": params.get("row_condition"),
+            },
+            "condition_parser": {
+                "schema": {"type": "string"},
+                "value": params.get("condition_parser"),
+            },
+        }
+
+        return [
+            RenderedStringTemplateContent(
+                **{
+                    "content_block_type": "string_template",
+                    "string_template": {
+                        "template": template_str,
+                        "params": params,
+                        "styling": styling,
+                    },
+                }
+            )
+        ]

--- a/great_expectations/expectations/set_based_column_map_expectation.py
+++ b/great_expectations/expectations/set_based_column_map_expectation.py
@@ -98,7 +98,7 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
 
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
-            
+
         return True
 
     # question, descriptive, prescriptive, diagnostic
@@ -123,176 +123,176 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
             else:
                 return f'Are at least {mostly * 100}% of values in column "{column}" in the set {str(set_)}?'
 
-    @classmethod
-    @renderer(renderer_type="renderer.answer")
-    def _answer_renderer(
-        cls, configuration=None, result=None, language=None, runtime_configuration=None
-    ):
-        column = result.expectation_config.kwargs.get("column")
-        mostly = result.expectation_config.kwargs.get("mostly")
-        regex = result.expectation_config.kwargs.get("regex")
-        semantic_type_name_plural = configuration.kwargs.get(
-            "semantic_type_name_plural"
-        )
+    # @classmethod
+    # @renderer(renderer_type="renderer.answer")
+    # def _answer_renderer(
+    #     cls, configuration=None, result=None, language=None, runtime_configuration=None
+    # ):
+    #     column = result.expectation_config.kwargs.get("column")
+    #     mostly = result.expectation_config.kwargs.get("mostly")
+    #     regex = result.expectation_config.kwargs.get("regex")
+    #     semantic_type_name_plural = configuration.kwargs.get(
+    #         "semantic_type_name_plural"
+    #     )
 
-        if result.success:
-            if mostly == 1 or mostly is None:
-                if semantic_type_name_plural is not None:
-                    return f'All values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
-                else:
-                    return f'All values in column "{column}" match the regular expression {regex}.'
-            else:
-                if semantic_type_name_plural is not None:
-                    return f'At least {mostly * 100}% of values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
-                else:
-                    return f'At least {mostly * 100}% of values in column "{column}" match the regular expression {regex}.'
-        else:
-            if semantic_type_name_plural is not None:
-                return f' Less than {mostly * 100}% of values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
-            else:
-                return f'Less than {mostly * 100}% of values in column "{column}" match the regular expression {regex}.'
+    #     if result.success:
+    #         if mostly == 1 or mostly is None:
+    #             if semantic_type_name_plural is not None:
+    #                 return f'All values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
+    #             else:
+    #                 return f'All values in column "{column}" match the regular expression {regex}.'
+    #         else:
+    #             if semantic_type_name_plural is not None:
+    #                 return f'At least {mostly * 100}% of values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
+    #             else:
+    #                 return f'At least {mostly * 100}% of values in column "{column}" match the regular expression {regex}.'
+    #     else:
+    #         if semantic_type_name_plural is not None:
+    #             return f' Less than {mostly * 100}% of values in column "{column}" are valid {semantic_type_name_plural}, as judged by matching the regular expression {regex}.'
+    #         else:
+    #             return f'Less than {mostly * 100}% of values in column "{column}" match the regular expression {regex}.'
 
-    @classmethod
-    def _atomic_prescriptive_template(
-        cls,
-        configuration=None,
-        result=None,
-        language=None,
-        runtime_configuration=None,
-        **kwargs,
-    ):
-        runtime_configuration = runtime_configuration or {}
-        include_column_name = runtime_configuration.get("include_column_name", True)
-        include_column_name = (
-            include_column_name if include_column_name is not None else True
-        )
-        styling = runtime_configuration.get("styling")
-        params = substitute_none_for_missing(
-            configuration.kwargs,
-            ["column", "regex", "mostly", "row_condition", "condition_parser"],
-        )
-        params_with_json_schema = {
-            "column": {"schema": {"type": "string"}, "value": params.get("column")},
-            "mostly": {"schema": {"type": "number"}, "value": params.get("mostly")},
-            "mostly_pct": {
-                "schema": {"type": "number"},
-                "value": params.get("mostly_pct"),
-            },
-            "regex": {"schema": {"type": "string"}, "value": params.get("regex")},
-            "row_condition": {
-                "schema": {"type": "string"},
-                "value": params.get("row_condition"),
-            },
-            "condition_parser": {
-                "schema": {"type": "string"},
-                "value": params.get("condition_parser"),
-            },
-        }
+    # @classmethod
+    # def _atomic_prescriptive_template(
+    #     cls,
+    #     configuration=None,
+    #     result=None,
+    #     language=None,
+    #     runtime_configuration=None,
+    #     **kwargs,
+    # ):
+    #     runtime_configuration = runtime_configuration or {}
+    #     include_column_name = runtime_configuration.get("include_column_name", True)
+    #     include_column_name = (
+    #         include_column_name if include_column_name is not None else True
+    #     )
+    #     styling = runtime_configuration.get("styling")
+    #     params = substitute_none_for_missing(
+    #         configuration.kwargs,
+    #         ["column", "regex", "mostly", "row_condition", "condition_parser"],
+    #     )
+    #     params_with_json_schema = {
+    #         "column": {"schema": {"type": "string"}, "value": params.get("column")},
+    #         "mostly": {"schema": {"type": "number"}, "value": params.get("mostly")},
+    #         "mostly_pct": {
+    #             "schema": {"type": "number"},
+    #             "value": params.get("mostly_pct"),
+    #         },
+    #         "regex": {"schema": {"type": "string"}, "value": params.get("regex")},
+    #         "row_condition": {
+    #             "schema": {"type": "string"},
+    #             "value": params.get("row_condition"),
+    #         },
+    #         "condition_parser": {
+    #             "schema": {"type": "string"},
+    #             "value": params.get("condition_parser"),
+    #         },
+    #     }
 
-        if not params.get("regex"):
-            template_str = (
-                "values must match a regular expression but none was specified."
-            )
-        else:
-            template_str = "values must match this regular expression: $regex"
-            if params["mostly"] is not None:
-                params_with_json_schema["mostly_pct"]["value"] = num_to_str(
-                    params["mostly"] * 100, precision=15, no_scientific=True
-                )
-                template_str += ", at least $mostly_pct % of the time."
-            else:
-                template_str += "."
+    #     if not params.get("regex"):
+    #         template_str = (
+    #             "values must match a regular expression but none was specified."
+    #         )
+    #     else:
+    #         template_str = "values must match this regular expression: $regex"
+    #         if params["mostly"] is not None:
+    #             params_with_json_schema["mostly_pct"]["value"] = num_to_str(
+    #                 params["mostly"] * 100, precision=15, no_scientific=True
+    #             )
+    #             template_str += ", at least $mostly_pct % of the time."
+    #         else:
+    #             template_str += "."
 
-        if include_column_name:
-            template_str = "$column " + template_str
+    #     if include_column_name:
+    #         template_str = "$column " + template_str
 
-        if params["row_condition"] is not None:
-            (
-                conditional_template_str,
-                conditional_params,
-            ) = parse_row_condition_string_pandas_engine(
-                params["row_condition"], with_schema=True
-            )
-            template_str = conditional_template_str + ", then " + template_str
-            params_with_json_schema.update(conditional_params)
+    #     if params["row_condition"] is not None:
+    #         (
+    #             conditional_template_str,
+    #             conditional_params,
+    #         ) = parse_row_condition_string_pandas_engine(
+    #             params["row_condition"], with_schema=True
+    #         )
+    #         template_str = conditional_template_str + ", then " + template_str
+    #         params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+    #     return (template_str, params_with_json_schema, styling)
 
-    @classmethod
-    @renderer(renderer_type="renderer.prescriptive")
-    @render_evaluation_parameter_string
-    def _prescriptive_renderer(
-        cls,
-        configuration=None,
-        result=None,
-        language=None,
-        runtime_configuration=None,
-        **kwargs,
-    ):
-        runtime_configuration = runtime_configuration or {}
-        include_column_name = runtime_configuration.get("include_column_name", True)
-        include_column_name = (
-            include_column_name if include_column_name is not None else True
-        )
-        styling = runtime_configuration.get("styling")
-        params = substitute_none_for_missing(
-            configuration.kwargs,
-            ["column", "regex", "mostly", "row_condition", "condition_parser"],
-        )
+    # @classmethod
+    # @renderer(renderer_type="renderer.prescriptive")
+    # @render_evaluation_parameter_string
+    # def _prescriptive_renderer(
+    #     cls,
+    #     configuration=None,
+    #     result=None,
+    #     language=None,
+    #     runtime_configuration=None,
+    #     **kwargs,
+    # ):
+    #     runtime_configuration = runtime_configuration or {}
+    #     include_column_name = runtime_configuration.get("include_column_name", True)
+    #     include_column_name = (
+    #         include_column_name if include_column_name is not None else True
+    #     )
+    #     styling = runtime_configuration.get("styling")
+    #     params = substitute_none_for_missing(
+    #         configuration.kwargs,
+    #         ["column", "regex", "mostly", "row_condition", "condition_parser"],
+    #     )
 
-        if not params.get("regex"):
-            template_str = (
-                "values must match a regular expression but none was specified."
-            )
-        else:
-            template_str = "values must match this regular expression: $regex"
-            if params["mostly"] is not None:
-                params["mostly_pct"] = num_to_str(
-                    params["mostly"] * 100, precision=15, no_scientific=True
-                )
-                # params["mostly_pct"] = "{:.14f}".format(params["mostly"]*100).rstrip("0").rstrip(".")
-                template_str += ", at least $mostly_pct % of the time."
-            else:
-                template_str += "."
+    #     if not params.get("regex"):
+    #         template_str = (
+    #             "values must match a regular expression but none was specified."
+    #         )
+    #     else:
+    #         template_str = "values must match this regular expression: $regex"
+    #         if params["mostly"] is not None:
+    #             params["mostly_pct"] = num_to_str(
+    #                 params["mostly"] * 100, precision=15, no_scientific=True
+    #             )
+    #             # params["mostly_pct"] = "{:.14f}".format(params["mostly"]*100).rstrip("0").rstrip(".")
+    #             template_str += ", at least $mostly_pct % of the time."
+    #         else:
+    #             template_str += "."
 
-        if include_column_name:
-            template_str = "$column " + template_str
+    #     if include_column_name:
+    #         template_str = "$column " + template_str
 
-        if params["row_condition"] is not None:
-            (
-                conditional_template_str,
-                conditional_params,
-            ) = parse_row_condition_string_pandas_engine(params["row_condition"])
-            template_str = conditional_template_str + ", then " + template_str
-            params.update(conditional_params)
+    #     if params["row_condition"] is not None:
+    #         (
+    #             conditional_template_str,
+    #             conditional_params,
+    #         ) = parse_row_condition_string_pandas_engine(params["row_condition"])
+    #         template_str = conditional_template_str + ", then " + template_str
+    #         params.update(conditional_params)
 
-        params_with_json_schema = {
-            "column": {"schema": {"type": "string"}, "value": params.get("column")},
-            "mostly": {"schema": {"type": "number"}, "value": params.get("mostly")},
-            "mostly_pct": {
-                "schema": {"type": "number"},
-                "value": params.get("mostly_pct"),
-            },
-            "regex": {"schema": {"type": "string"}, "value": params.get("regex")},
-            "row_condition": {
-                "schema": {"type": "string"},
-                "value": params.get("row_condition"),
-            },
-            "condition_parser": {
-                "schema": {"type": "string"},
-                "value": params.get("condition_parser"),
-            },
-        }
+    #     params_with_json_schema = {
+    #         "column": {"schema": {"type": "string"}, "value": params.get("column")},
+    #         "mostly": {"schema": {"type": "number"}, "value": params.get("mostly")},
+    #         "mostly_pct": {
+    #             "schema": {"type": "number"},
+    #             "value": params.get("mostly_pct"),
+    #         },
+    #         "regex": {"schema": {"type": "string"}, "value": params.get("regex")},
+    #         "row_condition": {
+    #             "schema": {"type": "string"},
+    #             "value": params.get("row_condition"),
+    #         },
+    #         "condition_parser": {
+    #             "schema": {"type": "string"},
+    #             "value": params.get("condition_parser"),
+    #         },
+    #     }
 
-        return [
-            RenderedStringTemplateContent(
-                **{
-                    "content_block_type": "string_template",
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
-            )
-        ]
+    #     return [
+    #         RenderedStringTemplateContent(
+    #             **{
+    #                 "content_block_type": "string_template",
+    #                 "string_template": {
+    #                     "template": template_str,
+    #                     "params": params,
+    #                     "styling": styling,
+    #                 },
+    #             }
+    #         )
+    #     ]

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_be_in_solfege_scale_set.py
@@ -1,0 +1,112 @@
+from great_expectations.expectations.set_based_column_map_expectation import (
+    SetBasedColumnMapExpectation,
+)
+
+# <snippet>
+class ExpectColumnValuesToBeInSolfegeScaleSet(SetBasedColumnMapExpectation):
+    """Values in this column should be valid members of the Solfege scale: do, re, mi, etc."""
+
+    set_ = [
+        "do", "re", "mi", "fa", "so", "la", "ti",
+        "Do", "Re", "Mi", "Fa", "So", "La", "Ti",
+        "DO", "RE", "MI", "FA", "SO", "LA", "TI",
+    ]
+    set_snake_name = "solfege_scale"
+    set_camel_name = "SolfegeScale"
+    set_semantic_name = "the Solfege scale"
+
+    examples = [
+        {
+            "data": {
+                "lowercase_solfege_scale": ["do", "re", "mi", "fa", "so", "la", "ti", "do"],
+                "uppercase_solfege_scale": ["DO", "RE", "MI", "FA", "SO", "LA", "TI", "DO"],
+                "mixed": ["do", "od", "re", "er", "mi", "im", "fa", "af"],
+            },
+            "tests": [
+                {
+                    "title": "positive_test_lowercase",
+                    "exact_match_out": False,
+                    "in": {"column": "lowercase_solfege_scale"},
+                    "out": {
+                        "success": True,
+                    },
+                    "include_in_gallery": True,
+                },
+                {
+                    "title": "negative_test",
+                    "exact_match_out": False,
+                    "in": {"column": "mixed"},
+                    "out": {
+                        "success": False,
+                        "unexpected_index_list": [1, 3, 5, 7],
+                    },
+                    "include_in_gallery": True,
+                },
+                {
+                    "title": "postive_test_uppercase",
+                    "exact_match_out": False,
+                    "in": {"column": "uppercase_solfege_scale"},
+                    "out": {
+                        "success": True,
+                    },
+                    "include_in_gallery": True,
+                },
+                {
+                    "title": "positive_test_with_mostly",
+                    "exact_match_out": False,
+                    "in": {"column": "mixed", "mostly": 0.4},
+                    "out": {
+                        "success": True,
+                        "unexpected_index_list": [1, 3, 5, 7],
+                    },
+                    "include_in_gallery": True,
+                },
+            ],
+            "test_backends": [
+                {
+                    "backend": "pandas",
+                    "dialects": None,
+                },
+                # {
+                #     "backend": "sqlalchemy",
+                #     "dialects": ["sqlite", "postgresql"],
+                # },
+                # {
+                #     "backend": "spark",
+                #     "dialects": None,
+                # },
+            ],
+        }
+    ]
+
+    map_metric = SetBasedColumnMapExpectation.register_metric(
+        set_snake_name = set_snake_name,
+        set_camel_name = set_camel_name,
+        set_ = set_,
+    )
+
+    library_metadata = {
+        "tags": ["set-based"],
+        "contributors": ["@joegargery"],
+    }
+
+
+# </snippet>
+if __name__ == "__main__":
+    ExpectColumnValuesToBeInSolfegeScaleSet().print_diagnostic_checklist()
+
+# Note to users: code below this line is only for integration testing -- ignore!
+
+diagnostics = ExpectColumnValuesToBeInSolfegeScaleSet().run_diagnostics()
+
+for check in diagnostics["tests"]:
+    print(check)
+    assert check["test_passed"] is True
+    assert check["error_message"] is None
+    assert check["stack_trace"] is None
+
+for check in diagnostics["errors"]:
+    assert check is None
+
+for check in diagnostics["maturity_checklist"]["experimental"]:
+    assert check["passed"] is True


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Allows overriding of default_kwargs to support parameterized expectations
- Updates default_kwargs to maintain current behavior of vacuously passing on empty regex
- Updates tests


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- closes #4445 


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
