### PR TITLE
[BUGFIX] Update ExpectColumnValuesToMatchRegex to support parameterized expectations

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -90,6 +90,7 @@ class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
         "result_format": "BASIC",
         "include_config": True,
         "catch_exceptions": True,
+        "regex": "(?s).*",
     }
     args_keys = (
         "column",
@@ -102,14 +103,18 @@ class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration
+
+        # supports extensibility by allowing value_set to not be provided in config but captured via child-class default_kwarg_values, e.g. parameterized expectations
+        regex = configuration.kwargs.get("regex") or self.default_kwarg_values.get(
+            "regex"
+        )
+
         try:
-            assert "regex" in configuration.kwargs, "regex is required"
-            assert isinstance(
-                configuration.kwargs["regex"], (str, dict)
-            ), "regex must be a string"
-            if isinstance(configuration.kwargs["regex"], dict):
+            assert "regex" in configuration.kwargs or regex, "regex is required"
+            assert isinstance(regex, (str, dict)), "regex must be a string"
+            if isinstance(regex, dict):
                 assert (
-                    "$PARAMETER" in configuration.kwargs["regex"]
+                    "$PARAMETER" in regex
                 ), 'Evaluation Parameter dict for regex kwarg must have "$PARAMETER" key.'
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))

--- a/tests/expectations/core/test_expect_column_values_to_match_regex_parameterized.py
+++ b/tests/expectations/core/test_expect_column_values_to_match_regex_parameterized.py
@@ -1,0 +1,69 @@
+from typing import Optional
+
+from great_expectations.core import ExpectationConfiguration
+from great_expectations.expectations.core import ExpectColumnValuesToMatchRegex
+
+
+class ExpectColumnValuesAsStringToBePositiveInteger(ExpectColumnValuesToMatchRegex):
+    default_kwarg_values = {
+        "regex": "^\\d+$",
+    }
+
+    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+        super().validate_configuration(configuration)
+        assert "regex" not in configuration.kwargs, "regex cannot be altered"
+
+
+import pandas as pd
+import pytest
+
+from great_expectations.core.batch import RuntimeBatchRequest
+from great_expectations.data_context import DataContext
+
+
+def test_expect_column_values_as_string_to_be_positive_integers_pass(
+    data_context_with_datasource_pandas_engine,
+):
+    context: DataContext = data_context_with_datasource_pandas_engine
+
+    df = pd.DataFrame({"a": ["1", "2", "3", "4", "5"]})
+
+    batch_request = RuntimeBatchRequest(
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
+        runtime_parameters={"batch_data": df},
+        batch_identifiers={"default_identifier_name": "my_identifier"},
+    )
+    validator = context.get_validator(
+        batch_request=batch_request,
+        create_expectation_suite_with_name="test",
+    )
+
+    assert validator.expect_column_values_as_string_to_be_positive_integer(
+        column="a"
+    ).success
+
+
+def test_expect_column_values_as_string_to_be_positive_integers_fail(
+    data_context_with_datasource_pandas_engine,
+):
+    context: DataContext = data_context_with_datasource_pandas_engine
+
+    df = pd.DataFrame({"a": ["1", "2", "3", "4", "a"]})
+
+    batch_request = RuntimeBatchRequest(
+        datasource_name="my_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name="my_data_asset",
+        runtime_parameters={"batch_data": df},
+        batch_identifiers={"default_identifier_name": "my_identifier"},
+    )
+    validator = context.get_validator(
+        batch_request=batch_request,
+        create_expectation_suite_with_name="test",
+    )
+
+    assert not validator.expect_column_values_as_string_to_be_positive_integer(
+        column="a"
+    ).success


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Allows overriding of default_kwargs to support parameterized expectations
- Updates default_kwargs to maintain current behavior of vacuously passing on empty regex
- Updates tests


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- closes #4445 


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
