### PR TITLE
[BUGFIX] Add back `nbconvert` to dev dependencies

### DIFF
--- a/requirements-dev-lite.txt
+++ b/requirements-dev-lite.txt
@@ -2,6 +2,7 @@ boto3==1.17.106 # This should match the version in constraints-dev.txt
 flask>=1.0.0 # for s3 test only (with moto)
 freezegun>=0.3.15
 moto>=1.3.7,<2.0.0
+nbconvert>=5
 pyfakefs>=4.5.1
 pytest>=5.3.5
 pytest-benchmark>=3.4.1


### PR DESCRIPTION
Changes proposed in this pull request:
- `nbconvert` is a required dependency but was removed from requirements. This PR adds it back in.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
