### PR TITLE
[MAINTENANCE] Move builder instantiation methods to utility module for broader usage among sub-components within Rule-Based Profiler

### DIFF
--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
@@ -56,22 +56,36 @@ class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
     ExpectationConfigurations can be optionally filtered if a supplied condition is met.
     """
 
-    exclude_field_names: Set[str] = {
+    exclude_field_names: Set[
+        str
+    ] = ExpectationConfigurationBuilder.exclude_field_names | {
         "kwargs",
     }
 
     def __init__(
         self,
         expectation_type: str,
+        meta: Optional[Dict[str, Any]] = None,
+        condition: Optional[str] = None,
         batch_list: Optional[List[Batch]] = None,
         batch_request: Optional[
             Union[str, BatchRequest, RuntimeBatchRequest, dict]
         ] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
-        condition: Optional[str] = None,
-        meta: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
+        """
+        Args:
+            expectation_type: the "expectation_type" argument of "ExpectationConfiguration" object to be emitted.
+            meta: the "meta" argument of "ExpectationConfiguration" object to be emitted.
+            condition: Boolean statement (expressed as string and following specified grammar), which controls whether
+            or not underlying logic should be executed and thus resulting "ExpectationConfiguration" emitted.
+            batch_list: explicitly passed Batch objects for parameter computation (take precedence over batch_request).
+            batch_request: specified in ParameterBuilder configuration to get Batch objects for parameter computation.
+            data_context: DataContext
+            kwargs: additional arguments
+        """
+
         super().__init__(
             expectation_type=expectation_type,
             batch_list=batch_list,
@@ -80,10 +94,10 @@ class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
             **kwargs,
         )
 
-        self._kwargs = kwargs
-
         if meta is None:
             meta = {}
+
+        self._meta = meta
 
         if not isinstance(meta, dict):
             raise ge_exceptions.ProfilerExecutionError(
@@ -100,7 +114,8 @@ class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
             )
 
         self._condition = condition
-        self._meta = meta
+
+        self._kwargs = kwargs
 
     @property
     def expectation_type(self) -> str:

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
@@ -25,6 +25,17 @@ class ExpectationConfigurationBuilder(Builder, ABC):
         data_context: Optional["DataContext"] = None,  # noqa: F821
         **kwargs
     ):
+        """
+        The ExpectationConfigurationBuilder will build ExpectationConfiguration objects for a Domain from the Rule.
+
+        Args:
+            expectation_type: the "expectation_type" argument of "ExpectationConfiguration" object to be emitted.
+            batch_list: explicitly passed Batch objects for parameter computation (take precedence over batch_request).
+            batch_request: specified in ParameterBuilder configuration to get Batch objects for parameter computation.
+            data_context: DataContext
+            kwargs: additional arguments
+        """
+
         super().__init__(
             batch_list=batch_list,
             batch_request=batch_request,
@@ -49,6 +60,7 @@ class ExpectationConfigurationBuilder(Builder, ABC):
 
     def build_expectation_configuration(
         self,
+        parameter_container: ParameterContainer,
         domain: Domain,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -16,9 +16,11 @@ from great_expectations.core.batch import (
     RuntimeBatchRequest,
     materialize_batch_request,
 )
+from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
 from great_expectations.rule_based_profiler.types import (
     VARIABLES_PREFIX,
+    Builder,
     Domain,
     ParameterContainer,
     get_parameter_value_by_fully_qualified_parameter_name,
@@ -390,6 +392,88 @@ def convert_variables_to_dict(
     return variables or {}
 
 
+def init_rule_parameter_builders(
+    parameter_builder_configs: Optional[List[dict]] = None,
+    data_context: Optional["DataContext"] = None,  # noqa: F821
+) -> Optional[List["ParameterBuilder"]]:  # noqa: F821
+    if parameter_builder_configs is None:
+        return None
+
+    return [
+        init_parameter_builder(
+            parameter_builder_config=parameter_builder_config,
+            data_context=data_context,
+        )
+        for parameter_builder_config in parameter_builder_configs
+    ]
+
+
+def init_parameter_builder(
+    parameter_builder_config: Union["ParameterBuilderConfig", dict],  # noqa: F821
+    data_context: Optional["DataContext"] = None,  # noqa: F821
+) -> "ParameterBuilder":  # noqa: F821
+    if not isinstance(parameter_builder_config, dict):
+        parameter_builder_config = parameter_builder_config.to_dict()
+
+    parameter_builder: "ParameterBuilder" = instantiate_class_from_config(  # noqa: F821
+        config=parameter_builder_config,
+        runtime_environment={"data_context": data_context},
+        config_defaults={
+            "module_name": "great_expectations.rule_based_profiler.parameter_builder"
+        },
+    )
+    return parameter_builder
+
+
+def init_rule_expectation_configuration_builders(
+    expectation_configuration_builder_configs: List[dict],
+    data_context: Optional["DataContext"] = None,  # noqa: F821
+) -> List["ExpectationConfigurationBuilder"]:  # noqa: F821
+    expectation_configuration_builder_config: dict
+    return [
+        init_expectation_configuration_builder(
+            expectation_configuration_builder_config=expectation_configuration_builder_config,
+            data_context=data_context,
+        )
+        for expectation_configuration_builder_config in expectation_configuration_builder_configs
+    ]
+
+
+def init_expectation_configuration_builder(
+    expectation_configuration_builder_config: Union[
+        "ExpectationConfigurationBuilder", dict  # noqa: F821
+    ],
+    data_context: Optional["DataContext"] = None,  # noqa: F821
+) -> "ExpectationConfigurationBuilder":  # noqa: F821
+    if not isinstance(expectation_configuration_builder_config, dict):
+        expectation_configuration_builder_config = (
+            expectation_configuration_builder_config.to_dict()
+        )
+
+    expectation_configuration_builder: "ExpectationConfigurationBuilder" = instantiate_class_from_config(  # noqa: F821
+        config=expectation_configuration_builder_config,
+        runtime_environment={"data_context": data_context},
+        config_defaults={
+            "class_name": "DefaultExpectationConfigurationBuilder",
+            "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder",
+        },
+    )
+    return expectation_configuration_builder
+
+
+def set_batch_list_or_batch_request_on_builder(
+    builder: Builder,
+    batch_list: Optional[List[Batch]] = None,
+    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+    force_batch_data: bool = False,
+) -> None:
+    if force_batch_data or builder.batch_request is None:
+        builder.set_batch_data(
+            batch_list=batch_list,
+            batch_request=batch_request,
+        )
+
+
 def compute_quantiles(
     metric_values: np.ndarray,
     false_positive_rate: np.float64,
@@ -528,8 +612,8 @@ def _compute_bootstrap_quantiles_point_estimate_custom_bias_corrected_method(
     lower_quantile_pct: float = false_positive_rate / 2
     upper_quantile_pct: float = 1.0 - false_positive_rate / 2
 
-    sample_lower_quantile: Number = np.quantile(metric_values, q=lower_quantile_pct)
-    sample_upper_quantile: Number = np.quantile(metric_values, q=upper_quantile_pct)
+    sample_lower_quantile: np.ndarray = np.quantile(metric_values, q=lower_quantile_pct)
+    sample_upper_quantile: np.ndarray = np.quantile(metric_values, q=upper_quantile_pct)
 
     if random_seed:
         random_state: np.random.Generator = np.random.Generator(
@@ -548,9 +632,9 @@ def _compute_bootstrap_quantiles_point_estimate_custom_bias_corrected_method(
         q=lower_quantile_pct,
         axis=1,
     )
-    bootstrap_lower_quantile_point_estimate: Number = np.mean(bootstrap_lower_quantiles)
-    bootstrap_lower_quantile_standard_error: Number = np.std(bootstrap_lower_quantiles)
-    bootstrap_lower_quantile_bias: Number = (
+    bootstrap_lower_quantile_point_estimate: float = np.mean(bootstrap_lower_quantiles)
+    bootstrap_lower_quantile_standard_error: float = np.std(bootstrap_lower_quantiles)
+    bootstrap_lower_quantile_bias: float = (
         bootstrap_lower_quantile_point_estimate - sample_lower_quantile
     )
 
@@ -573,9 +657,13 @@ def _compute_bootstrap_quantiles_point_estimate_custom_bias_corrected_method(
         q=upper_quantile_pct,
         axis=1,
     )
-    bootstrap_upper_quantile_point_estimate: Number = np.mean(bootstrap_upper_quantiles)
-    bootstrap_upper_quantile_standard_error: Number = np.std(bootstrap_upper_quantiles)
-    bootstrap_upper_quantile_bias: Number = (
+    bootstrap_upper_quantile_point_estimate: np.ndarray = np.mean(
+        bootstrap_upper_quantiles
+    )
+    bootstrap_upper_quantile_standard_error: np.ndarray = np.std(
+        bootstrap_upper_quantiles
+    )
+    bootstrap_upper_quantile_bias: float = (
         bootstrap_upper_quantile_point_estimate - sample_upper_quantile
     )
 

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -45,6 +45,9 @@ from great_expectations.rule_based_profiler.expectation_configuration_builder.ex
 )
 from great_expectations.rule_based_profiler.helpers.util import (
     convert_variables_to_dict,
+    init_rule_expectation_configuration_builders,
+    init_rule_parameter_builders,
+    set_batch_list_or_batch_request_on_builder,
 )
 from great_expectations.rule_based_profiler.parameter_builder.parameter_builder import (
     ParameterBuilder,
@@ -194,16 +197,17 @@ class BaseRuleBasedProfiler(ConfigPeer):
         )
         parameter_builders: Optional[
             List[ParameterBuilder]
-        ] = RuleBasedProfiler._init_rule_parameter_builders(
+        ] = init_rule_parameter_builders(
             parameter_builder_configs=rule_config.get("parameter_builders"),
             data_context=self._data_context,
         )
         expectation_configuration_builders: List[
             ExpectationConfigurationBuilder
-        ] = RuleBasedProfiler._init_rule_expectation_configuration_builders(
+        ] = init_rule_expectation_configuration_builders(
             expectation_configuration_builder_configs=rule_config[
                 "expectation_configuration_builders"
-            ]
+            ],
+            data_context=self._data_context,
         )
 
         # Compile previous steps and package into a Rule object
@@ -228,73 +232,6 @@ class BaseRuleBasedProfiler(ConfigPeer):
         )
 
         return domain_builder
-
-    @staticmethod
-    def _init_rule_parameter_builders(
-        parameter_builder_configs: Optional[List[dict]] = None,
-        data_context: Optional["DataContext"] = None,  # noqa: F821
-    ) -> Optional[List[ParameterBuilder]]:
-        if parameter_builder_configs is None:
-            return None
-
-        parameter_builders: List[ParameterBuilder] = []
-
-        parameter_builder_config: dict
-        for parameter_builder_config in parameter_builder_configs:
-            parameter_builder: ParameterBuilder = (
-                RuleBasedProfiler._init_parameter_builder(
-                    parameter_builder_config=parameter_builder_config,
-                    data_context=data_context,
-                )
-            )
-            parameter_builders.append(parameter_builder)
-
-        return parameter_builders
-
-    @staticmethod
-    def _init_parameter_builder(
-        parameter_builder_config: dict,
-        data_context: Optional["DataContext"] = None,  # noqa: F821
-    ) -> ParameterBuilder:
-        parameter_builder: ParameterBuilder = instantiate_class_from_config(
-            config=parameter_builder_config,
-            runtime_environment={"data_context": data_context},
-            config_defaults={
-                "module_name": "great_expectations.rule_based_profiler.parameter_builder"
-            },
-        )
-        return parameter_builder
-
-    @staticmethod
-    def _init_rule_expectation_configuration_builders(
-        expectation_configuration_builder_configs: List[dict],
-    ) -> List[ExpectationConfigurationBuilder]:
-        expectation_configuration_builders: List[ExpectationConfigurationBuilder] = []
-
-        expectation_configuration_builder_config: dict
-        for (
-            expectation_configuration_builder_config
-        ) in expectation_configuration_builder_configs:
-            expectation_configuration_builder: ExpectationConfigurationBuilder = RuleBasedProfiler._init_expectation_configuration_builder(
-                expectation_configuration_builder_config=expectation_configuration_builder_config,
-            )
-            expectation_configuration_builders.append(expectation_configuration_builder)
-
-        return expectation_configuration_builders
-
-    @staticmethod
-    def _init_expectation_configuration_builder(
-        expectation_configuration_builder_config: dict,
-    ) -> ExpectationConfigurationBuilder:
-        expectation_configuration_builder: ExpectationConfigurationBuilder = instantiate_class_from_config(
-            config=expectation_configuration_builder_config,
-            runtime_environment={},
-            config_defaults={
-                "class_name": "DefaultExpectationConfigurationBuilder",
-                "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder",
-            },
-        )
-        return expectation_configuration_builder
 
     @usage_statistics_enabled_method(
         event_name="profiler.run",
@@ -898,27 +835,38 @@ class BaseRuleBasedProfiler(ConfigPeer):
         domain_builder: DomainBuilder
         parameter_builders: Optional[List[ParameterBuilder]]
         parameter_builder: ParameterBuilder
+        expectation_configuration_builders: Optional[
+            List[ExpectationConfigurationBuilder]
+        ]
+        expectation_configuration_builder: ExpectationConfigurationBuilder
         for rule in rules:
             domain_builder = rule.domain_builder
-            if force_batch_data or domain_builder.batch_request is None:
-                domain_builder.set_batch_data(
+            set_batch_list_or_batch_request_on_builder(
+                builder=domain_builder,
+                batch_list=batch_list,
+                batch_request=batch_request,
+                force_batch_data=force_batch_data,
+            )
+
+            parameter_builders = rule.parameter_builders or []
+            for parameter_builder in parameter_builders:
+                set_batch_list_or_batch_request_on_builder(
+                    builder=parameter_builder,
                     batch_list=batch_list,
                     batch_request=batch_request,
+                    force_batch_data=force_batch_data,
                 )
 
-            """
-            Despite potentially having access to all loaded Batch objects, in general, a ParameterBuilder should
-            exclude using active Batch (in order to avoid estimation bias).  However, when ParameterBuilder is part
-            of RuleBasedProfiler used to estimate arguments of an Expectation class, all Batch objects must be used.
-            """
-            parameter_builders = rule.parameter_builders
-            if parameter_builders:
-                for parameter_builder in parameter_builders:
-                    if force_batch_data or parameter_builder.batch_request is None:
-                        parameter_builder.set_batch_data(
-                            batch_list=batch_list,
-                            batch_request=batch_request,
-                        )
+            expectation_configuration_builders = (
+                rule.expectation_configuration_builders or []
+            )
+            for expectation_configuration_builder in expectation_configuration_builders:
+                set_batch_list_or_batch_request_on_builder(
+                    builder=expectation_configuration_builder,
+                    batch_list=batch_list,
+                    batch_request=batch_request,
+                    force_batch_data=force_batch_data,
+                )
 
             resulting_rules.append(rule)
 

--- a/great_expectations/rule_based_profiler/types/builder.py
+++ b/great_expectations/rule_based_profiler/types/builder.py
@@ -19,8 +19,8 @@ class Builder(SerializableDictDot):
     """
 
     exclude_field_names: Set[str] = {
-        "data_context",
         "batch_list",
+        "data_context",
     }
 
     def __init__(

--- a/great_expectations/rule_based_profiler/types/parameter_container.py
+++ b/great_expectations/rule_based_profiler/types/parameter_container.py
@@ -541,7 +541,7 @@ def get_fully_qualified_parameter_names(
     parameters: Optional[Dict[str, ParameterContainer]] = None,
 ) -> List[str]:
     fully_qualified_parameter_names: List[str] = []
-    if variables is not None:
+    if not (variables is None or variables.parameter_nodes is None):
         fully_qualified_parameter_names.extend(
             _get_parameter_node_attribute_names(
                 parameter_name_root=PARAMETER_NAME_ROOT_FOR_VARIABLES,
@@ -554,18 +554,21 @@ def get_fully_qualified_parameter_names(
     if parameters is not None:
         parameter_container: ParameterContainer = parameters[domain.id]
 
-        parameter_name_root: str
-        parameter_node: ParameterNode
-        for (
-            parameter_name_root,
-            parameter_node,
-        ) in parameter_container.parameter_nodes.items():
-            fully_qualified_parameter_names.extend(
-                _get_parameter_node_attribute_names(
-                    parameter_name_root=PARAMETER_NAME_ROOT_FOR_PARAMETERS,
-                    parameter_node=parameter_node,
+        if not (
+            parameter_container is None or parameter_container.parameter_nodes is None
+        ):
+            parameter_name_root: str
+            parameter_node: ParameterNode
+            for (
+                parameter_name_root,
+                parameter_node,
+            ) in parameter_container.parameter_nodes.items():
+                fully_qualified_parameter_names.extend(
+                    _get_parameter_node_attribute_names(
+                        parameter_name_root=PARAMETER_NAME_ROOT_FOR_PARAMETERS,
+                        parameter_node=parameter_node,
+                    )
                 )
-            )
 
     return fully_qualified_parameter_names
 

--- a/tests/rule_based_profiler/expectation_configuration_builder/test_default_expectation_configuration_builder.py
+++ b/tests/rule_based_profiler/expectation_configuration_builder/test_default_expectation_configuration_builder.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 import pytest
 
@@ -165,11 +165,15 @@ def test_default_expectation_configuration_builder_alice_null_condition(
         parameter_container=parameter_container, domain=domain
     )
 
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
+
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id"
     value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition = None
@@ -185,7 +189,9 @@ def test_default_expectation_configuration_builder_alice_null_condition(
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}
+        parameter_container=parameter_container,
+        domain=domain,
+        parameters=parameters,
     )
 
     assert expectation_configuration.kwargs["min_value"] == 397433
@@ -223,11 +229,15 @@ def test_default_expectation_configuration_builder_alice_single_term_parameter_c
         parameter_container=parameter_container, domain=domain
     )
 
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
+
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id"
     value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$parameter.my_min_user_id.value[0]>0"
@@ -243,7 +253,9 @@ def test_default_expectation_configuration_builder_alice_single_term_parameter_c
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}
+        parameter_container=parameter_container,
+        domain=domain,
+        parameters=parameters,
     )
 
     assert expectation_configuration.kwargs["min_value"] == 397433
@@ -282,11 +294,15 @@ def test_default_expectation_configuration_builder_alice_single_term_parameter_c
         parameter_container=parameter_container, domain=domain
     )
 
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
+
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id"
     value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$parameter.my_min_user_id.value[0]<0"
@@ -302,7 +318,9 @@ def test_default_expectation_configuration_builder_alice_single_term_parameter_c
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}
+        parameter_container=parameter_container,
+        domain=domain,
+        parameters=parameters,
     )
 
     assert expectation_configuration is None
@@ -343,12 +361,15 @@ def test_default_expectation_configuration_builder_alice_single_term_variable_co
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id>0"
@@ -364,7 +385,10 @@ def test_default_expectation_configuration_builder_alice_single_term_variable_co
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration.kwargs["min_value"] == 397433
@@ -405,12 +429,15 @@ def test_default_expectation_configuration_builder_alice_single_term_variable_co
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id<0"
@@ -426,7 +453,10 @@ def test_default_expectation_configuration_builder_alice_single_term_variable_co
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration is None
@@ -467,12 +497,15 @@ def test_default_expectation_configuration_builder_alice_two_term_and_parameter_
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id>0 & $parameter.my_min_user_id.value[0]>0"
@@ -488,7 +521,10 @@ def test_default_expectation_configuration_builder_alice_two_term_and_parameter_
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration.kwargs["min_value"] == 397433
@@ -529,12 +565,15 @@ def test_default_expectation_configuration_builder_alice_two_term_and_parameter_
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id<0 & $parameter.my_min_user_id.value[0]<0"
@@ -550,7 +589,10 @@ def test_default_expectation_configuration_builder_alice_two_term_and_parameter_
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration is None
@@ -591,12 +633,15 @@ def test_default_expectation_configuration_builder_alice_two_term_or_parameter_v
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id>0 | $parameter.my_min_user_id.value[0]<0"
@@ -612,7 +657,10 @@ def test_default_expectation_configuration_builder_alice_two_term_or_parameter_v
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration.kwargs["min_value"] == 397433
@@ -653,12 +701,15 @@ def test_default_expectation_configuration_builder_alice_two_term_or_parameter_v
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id<0 | $parameter.my_min_user_id.value[0]<0"
@@ -674,7 +725,10 @@ def test_default_expectation_configuration_builder_alice_two_term_or_parameter_v
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration is None
@@ -715,12 +769,15 @@ def test_default_expectation_configuration_builder_alice_more_than_two_term_para
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999, "answer": 42}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id>0 & $variables.answer==42 | $parameter.my_min_user_id.value[0]<0"
@@ -736,7 +793,10 @@ def test_default_expectation_configuration_builder_alice_more_than_two_term_para
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration.kwargs["min_value"] == 397433
@@ -777,12 +837,15 @@ def test_default_expectation_configuration_builder_alice_more_than_two_term_para
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999, "answer": 42}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "$variables.max_user_id<0 | $variables.answer!=42 | $parameter.my_min_user_id.value[0]<0"
@@ -798,7 +861,10 @@ def test_default_expectation_configuration_builder_alice_more_than_two_term_para
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration is None
@@ -839,12 +905,15 @@ def test_default_expectation_configuration_builder_alice_parentheses_parameter_v
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999, "answer": 42}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "($variables.max_user_id>0 & $variables.answer==42) | $parameter.my_min_user_id.value[0]<0"
@@ -860,7 +929,10 @@ def test_default_expectation_configuration_builder_alice_parentheses_parameter_v
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration.kwargs["min_value"] == 397433
@@ -901,12 +973,15 @@ def test_default_expectation_configuration_builder_alice_parentheses_parameter_v
     variables: ParameterContainer = build_parameter_container_for_variables(
         {"max_user_id": 999999999999, "answer": 42}
     )
+    parameters: Dict[str, ParameterContainer] = {
+        domain.id: parameter_container,
+    }
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_min_user_id.value[0]"
     parameter_value = get_parameter_value_by_fully_qualified_parameter_name(
         fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
         domain=domain,
-        parameters={domain.id: parameter_container},
+        parameters=parameters,
     )
 
     condition: str = "($variables.max_user_id<0 | $variables.answer!=42) | $parameter.my_min_user_id.value[0]<0"
@@ -922,7 +997,10 @@ def test_default_expectation_configuration_builder_alice_parentheses_parameter_v
     expectation_configuration: Optional[
         ExpectationConfiguration
     ] = default_expectation_configuration_builder.build_expectation_configuration(
-        domain=domain, parameters={domain.id: parameter_container}, variables=variables
+        parameter_container=parameter_container,
+        domain=domain,
+        variables=variables,
+        parameters=parameters,
     )
 
     assert expectation_configuration is None


### PR DESCRIPTION
### Scope
* Refactor to clean up order of arguments and add docstrings.
* Fix type erros in `bootstrap` estimation algorithm implementation.
* Move `Rule` sub-component instantiation methods to `util.py` (they will be needed by other components).
* Update unit tests to fit new interfaces.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-464/GREAT-688/GREAT-690
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
