### PR TITLE
[DOCS] Ensure consistent usage of Markdown reference in docs

### DIFF
--- a/docs/guides/miscellaneous/how_to_write_a_how_to_guide.md
+++ b/docs/guides/miscellaneous/how_to_write_a_how_to_guide.md
@@ -103,7 +103,7 @@ If the user has data in Mongo and wants to configure a Datasource, no additional
 
 - Most steps will include inline code, such as a bash command, or an example yml snippet or two. These can be referenced in the how-to-guide itself using relative imports.
 
-- The following snippet displays line 1- line 7 of the `script_example.py` file.  
+- The following snippet displays line 1- line 7 of the `script_example.py` file.
 
 ```markdown
   ```python file=../../../tests/integration/docusaurus/template/script_example.py#L1-L7```
@@ -128,7 +128,7 @@ Once a draft of your guide is written, you can see it rendered on a `localhost` 
 
 ## Steps
 
-1. Ensure that your dev environment is set up according to the guide on <a href="../../contributing/contributing_setup">Setting up your dev environment</a>
+1. Ensure that your dev environment is set up according to the guide on [Setting up your dev environment](../../contributing/contributing_setup.md)
 
 2. Copy the How-to guide template file to the appropriate subdirectory of `docs/guides/`, and rename it.
 
@@ -136,16 +136,16 @@ Once a draft of your guide is written, you can see it rendered on a `localhost` 
 
 4. Decide whether you’re writing a code-heavy or process-heavy guide, and adjust your formatting appropriately.
 
-5. Fill out the Prerequisites info box (see <a href="how_to_template">How-to guide template file</a>). The header of the info box says: “This how-to guide assumes you have already:”. Place each prerequisite under its own bullet and phrase it using the style in the template: “done something” (e.g. "Configured a Datasource").
+5. Fill out the Prerequisites info box (see [How-to guide template file](./how_to_template.md)). The header of the info box says: “This how-to guide assumes you have already:”. Place each prerequisite under its own bullet and phrase it using the style in the template: “done something” (e.g. "Configured a Datasource").
 
 6. Fill in the Steps section, making sure to include bash, yml, and code snippets as appropriate.
-    - These will typically be included in a separate file that is in the `great_expectations/test/integrations` folder and can be referenced in the how-to-doc. For additional details, please see the "Structure of a How-to-guide" section below.  
+    - These will typically be included in a separate file that is in the `great_expectations/test/integrations` folder and can be referenced in the how-to-doc. For additional details, please see the "Structure of a How-to-guide" section below.
 
 7. If needed, add content to Additional Notes and/or Additional Resources. These sections supplement the article with information that would be distracting to include in Steps. It’s fine for them to be empty.
 
-8. Scan your article to make sure it follows the <a href="../../contributing/style_guides/docs_style">Style guide</a>. If you’re not familiar with the Style Guide, that’s okay: your PR reviewer will also check for style and let you know if we find any issues.
+8. Scan your article to make sure it follows the [Style guide](../../contributing/style_guides/docs_style.md). If you’re not familiar with the Style Guide, that’s okay: your PR reviewer will also check for style and let you know if we find any issues.
 
-9. Locally run integration tests for any code that was included as part of the guide. Also see our guide on <a href="../../contributing/contributing_test">Testing</a>
+9. Locally run integration tests for any code that was included as part of the guide. Also see our guide on [Testing](../../contributing/contributing_test.md)
 
 10. Submit your PR! If there are any additional integrations that need to be run, then please add this to your PR message.
 
@@ -203,4 +203,4 @@ import TabItem from '@theme/TabItem'
   <TabItem value="great">This is Great!</TabItem>
   <TabItem value="expectations">These are Expectations</TabItem>
 </Tabs>
-```
+`


### PR DESCRIPTION
Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
