### PR TITLE
[MAINTENANCE] Run PEP273 checks on a schedule or release cut

### DIFF
--- a/.github/workflows/test-pep273-compatibility.yml
+++ b/.github/workflows/test-pep273-compatibility.yml
@@ -1,7 +1,13 @@
 name: Test PEP 273 compatibility
 
 on:
-  - push
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - 'main'
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   run:


### PR DESCRIPTION
Changes proposed in this pull request:
- PEP273 is a very niche requirement and doesn't necessarily need to be checked on each commit - instead, let's run on a schedule and also check when trying to merge into `main`.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
