### PR TITLE
[MAINTENANCE] Add DevRel team to GitHub auto-label action

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,8 +1,17 @@
 core-team:
-  - '@NathanFarmer'
-  - '@Shinnyshinshin'
-  - '@Super-Tanner'
-  - '@alexsherstinsky'
-  - '@anthonyburdi'
-  - '@cdkini'
-  - '@donaldheppner'
+  - '@NathanFarmer'    # Nathan Farmer
+  - '@Shinnyshinshin'  # Will Shin
+  - '@Super-Tanner'    # Tanner Beam
+  - '@alexsherstinsky' # Alex Sherstinsky
+  - '@anthonyburdi'    # Anthony Burdi
+  - '@cdkini'          # Chetan Kini
+  - '@donaldheppner'   # Don Heppner
+
+devrel:
+  - '@AFineDayFor'     # Hannah Stokes
+  - '@Rachel-Reverie'  # Rachel Reverie
+  - '@austiezr'        # Austin Robinson
+  - '@kenwade4'        # Ken Wade
+  - '@kyleaton'        # Kyle Eaton
+  - '@rdodev'          # Ruben Orduz
+  - '@talagluck'       # Tal Gluck


### PR DESCRIPTION
Changes proposed in this pull request:
- All PR's with individuals in this list will have their PR's auto-labeled as `devrel`
- We can leverage these labels to conditionally run other actions.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
