### PR TITLE
[MAINTENANCE] Remove dataclasses from required dependencies for py3.6 EOL

### DIFF
--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -36,7 +36,6 @@ class GEDependencies:
             "Click",
             "colorama",
             "cryptography",
-            "dataclasses",
             "importlib-metadata",
             "Ipython",
             "jinja2",


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove dataclass from required dependencies