### PR TITLE
[MAINTENANCE] Add retries to `requests` in usage stats integration tests

### DIFF
--- a/tests/integration/usage_statistics/conftest.py
+++ b/tests/integration/usage_statistics/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+
+@pytest.fixture(scope="session")
+def requests_session_with_retries():
+    # https://stackoverflow.com/a/35636367
+    session = requests.Session()
+    retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+    return session

--- a/tests/integration/usage_statistics/conftest.py
+++ b/tests/integration/usage_statistics/conftest.py
@@ -4,7 +4,7 @@ from requests.adapters import HTTPAdapter, Retry
 
 
 @pytest.fixture(scope="session")
-def requests_session_with_retries():
+def requests_session_with_retries() -> requests.Session:
     # https://stackoverflow.com/a/35636367
     session = requests.Session()
     retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])

--- a/tests/integration/usage_statistics/test_integration_usage_statistics.py
+++ b/tests/integration/usage_statistics/test_integration_usage_statistics.py
@@ -33,7 +33,7 @@ def aws_session():
 
 
 @pytest.fixture(scope="session")
-def valid_usage_statistics_message():
+def valid_usage_statistics_message() -> dict:
     return {
         "event_payload": {
             "platform.system": "Darwin",
@@ -129,7 +129,8 @@ def valid_usage_statistics_message():
 
 
 def test_send_malformed_data(
-    valid_usage_statistics_message, requests_session_with_retries: requests.Session
+    valid_usage_statistics_message: dict,
+    requests_session_with_retries: requests.Session,
 ):
     # We should be able to successfully send a valid message, but find that
     # a malformed message is not accepted

--- a/tests/integration/usage_statistics/test_integration_usage_statistics.py
+++ b/tests/integration/usage_statistics/test_integration_usage_statistics.py
@@ -128,14 +128,20 @@ def valid_usage_statistics_message():
     }
 
 
-def test_send_malformed_data(valid_usage_statistics_message):
+def test_send_malformed_data(
+    valid_usage_statistics_message, requests_session_with_retries: requests.Session
+):
     # We should be able to successfully send a valid message, but find that
     # a malformed message is not accepted
-    res = requests.post(USAGE_STATISTICS_QA_URL, json=valid_usage_statistics_message)
+    res = requests_session_with_retries.post(
+        USAGE_STATISTICS_QA_URL, json=valid_usage_statistics_message
+    )
     assert res.status_code == 201
     invalid_usage_statistics_message = copy.deepcopy(valid_usage_statistics_message)
     del invalid_usage_statistics_message["data_context_id"]
-    res = requests.post(USAGE_STATISTICS_QA_URL, json=invalid_usage_statistics_message)
+    res = requests_session_with_retries.post(
+        USAGE_STATISTICS_QA_URL, json=invalid_usage_statistics_message
+    )
     assert res.status_code == 400
 
 

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -2644,7 +2644,7 @@ for message_type, messages in valid_usage_statistics_messages.items():
 @pytest.mark.aws_integration
 @pytest.mark.parametrize("message", test_messages, ids=message_test_ids)
 def test_usage_statistics_message(
-    message, requests_session_with_retries: requests.Session
+    message: dict, requests_session_with_retries: requests.Session
 ):
     """known message formats should be valid"""
     res = requests_session_with_retries.post(

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -2643,8 +2643,12 @@ for message_type, messages in valid_usage_statistics_messages.items():
 
 @pytest.mark.aws_integration
 @pytest.mark.parametrize("message", test_messages, ids=message_test_ids)
-def test_usage_statistics_message(message):
+def test_usage_statistics_message(
+    message, requests_session_with_retries: requests.Session
+):
     """known message formats should be valid"""
-    res = requests.post(USAGE_STATISTICS_QA_URL, json=message, timeout=2)
+    res = requests_session_with_retries.post(
+        USAGE_STATISTICS_QA_URL, json=message, timeout=2
+    )
     assert res.status_code == 201
     assert res.json() == {"event_count": 1}


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Add fixture to automatically retry requests if they fail - this should alleviate issues with flaky usage stats tests.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
