### PR TITLE
[BUGFIX] Rule-Based Profiler: Only primitive type based BatchRequest is allowed for Builder classes

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 from uuid import UUID
 
 import great_expectations.exceptions as ge_exceptions
@@ -20,6 +20,7 @@ from great_expectations.core import RunIdentifier
 from great_expectations.core.async_executor import AsyncExecutor, AsyncResult
 from great_expectations.core.batch import (
     BatchRequest,
+    BatchRequestBase,
     RuntimeBatchRequest,
     batch_request_contains_batch_data,
     get_batch_request_as_dict,
@@ -84,7 +85,7 @@ class BaseCheckpoint(ConfigPeer):
         template_name: Optional[str] = None,
         run_name_template: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         action_list: Optional[List[dict]] = None,
         evaluation_parameters: Optional[dict] = None,
         runtime_configuration: Optional[dict] = None,
@@ -499,7 +500,7 @@ class Checkpoint(BaseCheckpoint):
         template_name: Optional[str] = None,
         run_name_template: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         action_list: Optional[List[dict]] = None,
         evaluation_parameters: Optional[dict] = None,
         runtime_configuration: Optional[dict] = None,
@@ -552,7 +553,7 @@ constructor arguments.
         template_name: Optional[str] = None,
         run_name_template: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         action_list: Optional[List[dict]] = None,
         evaluation_parameters: Optional[dict] = None,
         runtime_configuration: Optional[dict] = None,
@@ -565,7 +566,9 @@ constructor arguments.
         expectation_suite_ge_cloud_id: Optional[str] = None,
         **kwargs,
     ) -> CheckpointResult:
-        checkpoint_config_from_store: CheckpointConfig = self.get_config()
+        checkpoint_config_from_store: CheckpointConfig = cast(
+            CheckpointConfig, self.get_config()
+        )
 
         if (
             "runtime_configuration" in checkpoint_config_from_store
@@ -713,7 +716,7 @@ constructor arguments.
     @staticmethod
     def instantiate_from_config_with_runtime_args(
         checkpoint_config: CheckpointConfig,
-        data_context: "DataContext",
+        data_context: "DataContext",  # noqa: F821
         **runtime_kwargs,
     ) -> "Checkpoint":
         config: dict = checkpoint_config.to_json_dict()
@@ -1022,7 +1025,7 @@ class SimpleCheckpoint(Checkpoint):
         template_name: Optional[str] = None,
         run_name_template: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         action_list: Optional[List[dict]] = None,
         evaluation_parameters: Optional[dict] = None,
         runtime_configuration: Optional[dict] = None,
@@ -1080,7 +1083,7 @@ class SimpleCheckpoint(Checkpoint):
         template_name: Optional[str] = None,
         run_name_template: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         action_list: Optional[List[dict]] = None,
         evaluation_parameters: Optional[dict] = None,
         runtime_configuration: Optional[dict] = None,

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -12,6 +12,7 @@ import requests
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import (
     BatchRequest,
+    BatchRequestBase,
     RuntimeBatchRequest,
     get_batch_request_as_dict,
     materialize_batch_request,
@@ -215,9 +216,7 @@ def get_substituted_validation_dict(
 # TODO: <Alex>A common utility function should be factored out from DataContext.get_batch_list() for any purpose.</Alex>
 def get_substituted_batch_request(
     substituted_runtime_config: dict,
-    validation_batch_request: Optional[
-        Union[BatchRequest, RuntimeBatchRequest, dict]
-    ] = None,
+    validation_batch_request: Optional[Union[BatchRequestBase, dict]] = None,
 ) -> Optional[Union[BatchRequest, RuntimeBatchRequest]]:
     substituted_runtime_batch_request = substituted_runtime_config.get("batch_request")
 

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -434,6 +434,7 @@ def batch_request_in_validations_contains_batch_data(
         for idx, val in enumerate(validations):
             if (
                 val.get("batch_request") is not None
+                and isinstance(val.get("batch_request"), (dict, DictDot))
                 and val["batch_request"].get("runtime_parameters") is not None
                 and val["batch_request"]["runtime_parameters"].get("batch_data")
                 is not None

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -17,6 +17,7 @@ from great_expectations.core.batch import (
     materialize_batch_request,
 )
 from great_expectations.core.util import nested_update
+from great_expectations.types import DictDot
 
 try:
     import boto3

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -7,7 +7,7 @@ import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.id_dict import BatchKwargs, BatchSpec, IDDict
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.exceptions import InvalidBatchIdError
-from great_expectations.types import SerializableDictDot, safe_deep_copy
+from great_expectations.types import DictDot, SerializableDictDot, safe_deep_copy
 from great_expectations.util import deep_filter_properties_iterable
 from great_expectations.validator.metric_configuration import MetricConfiguration
 
@@ -648,7 +648,7 @@ def materialize_batch_request(
 
 
 def batch_request_contains_batch_data(
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None
+    batch_request: Optional[Union[BatchRequestBase, dict]] = None
 ) -> bool:
     return (
         batch_request_contains_runtime_parameters(batch_request=batch_request)
@@ -661,6 +661,7 @@ def batch_request_contains_runtime_parameters(
 ) -> bool:
     return (
         batch_request is not None
+        and isinstance(batch_request, (dict, DictDot))
         and batch_request.get("runtime_parameters") is not None
     )
 

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -273,14 +273,14 @@ class BatchRequestBase(SerializableDictDot):
         # str placeholder before calling convert_to_json_serializable so that
         # batch_data is not serialized
         if batch_request_contains_batch_data(batch_request=self):
-            batch_data: Union[
-                BatchRequest, RuntimeBatchRequest, dict
-            ] = self.runtime_parameters["batch_data"]
+            batch_data: Union[BatchRequestBase, dict] = self.runtime_parameters[
+                "batch_data"
+            ]
             self.runtime_parameters["batch_data"]: str = str(type(batch_data))
             serializeable_dict: dict = convert_to_json_serializable(data=self.to_dict())
             # after getting serializable_dict, restore original batch_data
             self.runtime_parameters["batch_data"]: Union[
-                BatchRequest, RuntimeBatchRequest, dict
+                BatchRequestBase, dict
             ] = batch_data
         else:
             serializeable_dict: dict = convert_to_json_serializable(data=self.to_dict())
@@ -503,7 +503,7 @@ class Batch(SerializableDictDot):
     def __init__(
         self,
         data,
-        batch_request: Union[BatchRequest, RuntimeBatchRequest] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         batch_definition: BatchDefinition = None,
         batch_spec: BatchSpec = None,
         batch_markers: BatchMarkers = None,
@@ -629,7 +629,7 @@ class Batch(SerializableDictDot):
 
 
 def materialize_batch_request(
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None
+    batch_request: Optional[Union[BatchRequestBase, dict]] = None,
 ) -> Optional[Union[BatchRequest, RuntimeBatchRequest]]:
     effective_batch_request: dict = get_batch_request_as_dict(
         batch_request=batch_request
@@ -657,7 +657,7 @@ def batch_request_contains_batch_data(
 
 
 def batch_request_contains_runtime_parameters(
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None
+    batch_request: Optional[Union[BatchRequestBase, dict]] = None
 ) -> bool:
     return (
         batch_request is not None
@@ -667,7 +667,7 @@ def batch_request_contains_runtime_parameters(
 
 
 def get_batch_request_as_dict(
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None
+    batch_request: Optional[Union[BatchRequestBase, dict]] = None
 ) -> Optional[dict]:
     if batch_request is None:
         return None
@@ -683,7 +683,7 @@ def get_batch_request_from_acceptable_arguments(
     data_connector_name: Optional[str] = None,
     data_asset_name: Optional[str] = None,
     *,
-    batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest]] = None,
+    batch_request: Optional[BatchRequestBase] = None,
     batch_data: Optional[Any] = None,
     data_connector_query: Optional[dict] = None,
     batch_identifiers: Optional[dict] = None,
@@ -700,7 +700,7 @@ def get_batch_request_from_acceptable_arguments(
     path: Optional[str] = None,
     batch_filter_parameters: Optional[dict] = None,
     **kwargs,
-) -> BatchRequest:
+) -> Union[BatchRequest, RuntimeBatchRequest]:
     """Obtain formal BatchRequest typed object from allowed attributes (supplied as arguments).
     This method applies only to the new (V3) Datasource schema.
 
@@ -733,7 +733,7 @@ def get_batch_request_from_acceptable_arguments(
         **kwargs
 
     Returns:
-        (BatchRequest) The formal BatchRequest object
+        (BatchRequest or RuntimeBatchRequest) The formal BatchRequest or RuntimeBatchRequest object
     """
 
     if batch_request:

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -3405,8 +3405,8 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         """Retrieve a RuleBasedProfiler from a ProfilerStore and run it with a batch request supplied at runtime.
 
         Args:
-            batch_list: List of Batch objects used to supply arguments at runtime.
-            batch_request: The batch_request used to supply arguments at runtime.
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
             name: Identifier used to retrieve the profiler from a store.
             ge_cloud_id: Identifier used to retrieve the profiler from a store (GE Cloud specific).
             expectation_suite: An existing ExpectationSuite to update.

--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -38,9 +38,8 @@ from great_expectations.checkpoint.types.checkpoint_result import CheckpointResu
 from great_expectations.core.batch import (
     Batch,
     BatchDefinition,
-    BatchRequest,
+    BatchRequestBase,
     IDDict,
-    RuntimeBatchRequest,
     get_batch_request_from_acceptable_arguments,
 )
 from great_expectations.core.expectation_suite import ExpectationSuite
@@ -883,7 +882,7 @@ class BaseDataContext(ConfigPeer):
             raise ge_exceptions.InvalidTopLevelConfigKeyError(error_message)
 
     @property
-    def checkpoint_store(self) -> "CheckpointStore":
+    def checkpoint_store(self) -> "CheckpointStore":  # noqa: F821
         checkpoint_store_name: str = self.checkpoint_store_name
         try:
             return self.stores[checkpoint_store_name]
@@ -1358,7 +1357,7 @@ class BaseDataContext(ConfigPeer):
         data_connector_name: Optional[str] = None,
         data_asset_name: Optional[str] = None,
         *,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest]] = None,
+        batch_request: Optional[BatchRequestBase] = None,
         batch_data: Optional[Any] = None,
         data_connector_query: Optional[Union[IDDict, dict]] = None,
         batch_identifiers: Optional[dict] = None,
@@ -1661,7 +1660,7 @@ class BaseDataContext(ConfigPeer):
         data_connector_name: Optional[str] = None,
         data_asset_name: Optional[str] = None,
         *,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest]] = None,
+        batch_request: Optional[BatchRequestBase] = None,
         batch_data: Optional[Any] = None,
         data_connector_query: Optional[dict] = None,
         batch_identifiers: Optional[dict] = None,
@@ -1760,10 +1759,8 @@ class BaseDataContext(ConfigPeer):
         data_connector_name: Optional[str] = None,
         data_asset_name: Optional[str] = None,
         *,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest]] = None,
-        batch_request_list: List[
-            Optional[Union[BatchRequest, RuntimeBatchRequest]]
-        ] = None,
+        batch_request: Optional[BatchRequestBase] = None,
+        batch_request_list: List[Optional[BatchRequestBase]] = None,
         batch_data: Optional[Any] = None,
         data_connector_query: Optional[Union[IDDict, dict]] = None,
         batch_identifiers: Optional[dict] = None,
@@ -2268,7 +2265,9 @@ class BaseDataContext(ConfigPeer):
             )
 
         if self.expectations_store.has_key(key):
-            expectations_schema_dict: dict = self.expectations_store.get(key)
+            expectations_schema_dict: dict = cast(
+                dict, self.expectations_store.get(key)
+            )
             # create the ExpectationSuite from constructor
             return ExpectationSuite(**expectations_schema_dict, data_context=self)
 
@@ -2461,7 +2460,7 @@ class BaseDataContext(ConfigPeer):
         # NOTE: Chetan - 20211118: This iteration is reverting the behavior performed here: https://github.com/great-expectations/great_expectations/pull/3377
         # This revision was necessary due to breaking changes but will need to be brought back in a future ticket.
         for key in self.expectations_store.list_keys():
-            expectation_suite_dict: dict = self.expectations_store.get(key)
+            expectation_suite_dict: dict = cast(dict, self.expectations_store.get(key))
             if not expectation_suite_dict:
                 continue
             expectation_suite: ExpectationSuite = ExpectationSuite(
@@ -3097,6 +3096,7 @@ class BaseDataContext(ConfigPeer):
 
         self.save_expectation_suite(expectation_suite)
         duration = (datetime.datetime.now() - start_time).total_seconds()
+        # noinspection PyUnboundLocalVariable
         logger.info(
             "\tProfiled %d columns using %d rows from %s (%.3f sec)"
             % (new_column_count, row_count, name, duration)
@@ -3214,7 +3214,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         template_name: Optional[str] = None,
         run_name_template: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[BatchRequestBase] = None,
         action_list: Optional[List[dict]] = None,
         evaluation_parameters: Optional[dict] = None,
         runtime_configuration: Optional[dict] = None,
@@ -3395,7 +3395,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
     def run_profiler_on_data(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[BatchRequestBase] = None,
         name: Optional[str] = None,
         ge_cloud_id: Optional[str] = None,
         expectation_suite: Optional[ExpectationSuite] = None,

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -13,11 +13,7 @@ from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.compat import StringIO
 
 import great_expectations.exceptions as ge_exceptions
-from great_expectations.core.batch import (
-    BatchRequest,
-    RuntimeBatchRequest,
-    get_batch_request_as_dict,
-)
+from great_expectations.core.batch import BatchRequestBase, get_batch_request_as_dict
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.core.util import (
     convert_to_json_serializable,
@@ -543,9 +539,9 @@ configuration to continue.
         ):
             raise ge_exceptions.InvalidConfigError(
                 f"""Your current configuration uses one or more keys in a data connector that are required only by an
-S3/Azure type of the data connector (your data connector is "{data['class_name']}").  Please update your configuration to
-continue.
-                """
+S3/Azure type of the data connector (your data connector is "{data['class_name']}").  Please update your configuration \
+to continue.
+"""
             )
         if ("prefix" in data) and not (
             data["class_name"]
@@ -597,9 +593,10 @@ continue.
             azure_options = data["azure_options"]
             if not (("conn_str" in azure_options) ^ ("account_url" in azure_options)):
                 raise ge_exceptions.InvalidConfigError(
-                    """Your current configuration is either missing methods of authentication or is using too many for the Azure type of data connector.
-                    You must only select one between `conn_str` or `account_url`. Please update your configuration to continue.
-                    """
+                    """Your current configuration is either missing methods of authentication or is using too many for \
+the Azure type of data connector. You must only select one between `conn_str` or `account_url`. Please update your \
+configuration to continue.
+"""
                 )
         if (
             "gcs_options" in data or "bucket_or_name" in data or "max_results" in data
@@ -623,9 +620,10 @@ continue.
             gcs_options = data["gcs_options"]
             if "filename" in gcs_options and "info" in gcs_options:
                 raise ge_exceptions.InvalidConfigError(
-                    """Your current configuration can only use a single method of authentication for the GCS type of data connector.
-                    You must only select one between `filename` (from_service_account_file) and `info` (from_service_account_info). Please update your configuration to continue.
-                    """
+                    """Your current configuration can only use a single method of authentication for the GCS type of \
+data connector. You must only select one between `filename` (from_service_account_file) and `info` \
+(from_service_account_info). Please update your configuration to continue.
+"""
                 )
         if (
             "data_asset_name_prefix" in data
@@ -2577,7 +2575,7 @@ class CheckpointConfig(BaseYamlConfig):
         template_name: Optional[str] = None,
         run_name_template: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         action_list: Optional[List[dict]] = None,
         evaluation_parameters: Optional[dict] = None,
         runtime_configuration: Optional[dict] = None,
@@ -2653,9 +2651,9 @@ class CheckpointConfig(BaseYamlConfig):
                 substituted_runtime_config=substituted_runtime_config,
                 validation_dict=validation_dict,
             )
-            validation_batch_request: Union[
-                BatchRequest, RuntimeBatchRequest
-            ] = substituted_validation_dict.get("batch_request")
+            validation_batch_request: BatchRequestBase = (
+                substituted_validation_dict.get("batch_request")
+            )
             validation_dict["batch_request"] = validation_batch_request
             validation_expectation_suite_name: str = substituted_validation_dict.get(
                 "expectation_suite_name"

--- a/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
@@ -1,7 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
+from great_expectations.core.batch import (
+    Batch,
+    BatchRequest,
+    BatchRequestBase,
+    RuntimeBatchRequest,
+)
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
 from great_expectations.rule_based_profiler.helpers.util import (
     get_batch_ids as get_batch_ids_from_batch_list_or_batch_request,
@@ -48,11 +53,29 @@ class DomainBuilder(Builder, ABC):
     def get_domains(
         self,
         variables: Optional[ParameterContainer] = None,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
     ) -> List[Domain]:
         """
+        Args:
+            variables: attribute name/value pairs
+            batch_list: Explicit list of Batch objects used as data to supply arguments at runtime.
+            batch_request: batch_request used to override builder attributes to get runtime data.
+            force_batch_data: Whether or not to overwrite existing batch_request value in DomainBuilder components.
+
+        Returns:
+            List of Domain objects.
+
         Note: Please do not overwrite the public "get_domains()" method.  If a child class needs to check parameters,
         then please do so in its implementation of the (private) "_get_domains()" method, or in a utility method.
         """
+        self.set_batch_list_or_batch_request(
+            batch_list=batch_list,
+            batch_request=batch_request,
+            force_batch_data=force_batch_data,
+        )
+
         return self._get_domains(variables=variables)
 
     @property

--- a/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
@@ -60,8 +60,8 @@ class DomainBuilder(Builder, ABC):
         """
         Args:
             variables: attribute name/value pairs
-            batch_list: Explicit list of Batch objects used as data to supply arguments at runtime.
-            batch_request: batch_request used to override builder attributes to get runtime data.
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
             force_batch_data: Whether or not to overwrite existing batch_request value in DomainBuilder components.
 
         Returns:

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -100,8 +100,8 @@ class ExpectationConfigurationBuilder(Builder, ABC):
             domain: Domain object that is context for execution of this ParameterBuilder object.
             variables: attribute name/value pairs
             parameters: Dictionary of ParameterContainer objects corresponding to all Domain context in memory.
-            batch_list: Explicit list of Batch objects used as data to supply arguments at runtime.
-            batch_request: batch_request used to override builder attributes to get runtime data.
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
             force_batch_data: Whether or not to overwrite existing batch_request value in ParameterBuilder components.
 
         Returns:

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -2,7 +2,12 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Set, Union
 
-from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
+from great_expectations.core.batch import (
+    Batch,
+    BatchRequest,
+    BatchRequestBase,
+    RuntimeBatchRequest,
+)
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.rule_based_profiler.config import ParameterBuilderConfig
@@ -85,7 +90,29 @@ class ExpectationConfigurationBuilder(Builder, ABC):
         domain: Domain,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
     ) -> ExpectationConfiguration:
+        """
+        Args:
+            parameter_container: Storage for parameters, computed by this ParameterBuilder object.
+            domain: Domain object that is context for execution of this ParameterBuilder object.
+            variables: attribute name/value pairs
+            parameters: Dictionary of ParameterContainer objects corresponding to all Domain context in memory.
+            batch_list: Explicit list of Batch objects used as data to supply arguments at runtime.
+            batch_request: batch_request used to override builder attributes to get runtime data.
+            force_batch_data: Whether or not to overwrite existing batch_request value in ParameterBuilder components.
+
+        Returns:
+            ExpectationConfiguration object.
+        """
+        self.set_batch_list_or_batch_request(
+            batch_list=batch_list,
+            batch_request=batch_request,
+            force_batch_data=force_batch_data,
+        )
+
         self._resolve_validation_dependencies(
             parameter_container=parameter_container,
             domain=domain,

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -13,6 +13,7 @@ from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import (
     Batch,
     BatchRequest,
+    BatchRequestBase,
     RuntimeBatchRequest,
     materialize_batch_request,
 )
@@ -38,7 +39,7 @@ def get_validator(
     *,
     data_context: Optional["DataContext"] = None,  # noqa: F821
     batch_list: Optional[List[Batch]] = None,
-    batch_request: Optional[Union[str, BatchRequest, RuntimeBatchRequest, dict]] = None,
+    batch_request: Optional[Union[str, BatchRequestBase, dict]] = None,
     domain: Optional[Domain] = None,
     variables: Optional[ParameterContainer] = None,
     parameters: Optional[Dict[str, ParameterContainer]] = None,
@@ -93,7 +94,7 @@ def get_validator(
 def get_batch_ids(
     data_context: Optional["DataContext"] = None,  # noqa: F821
     batch_list: Optional[List[Batch]] = None,
-    batch_request: Optional[Union[str, BatchRequest, RuntimeBatchRequest, dict]] = None,
+    batch_request: Optional[Union[str, BatchRequestBase, dict]] = None,
     domain: Optional[Domain] = None,
     variables: Optional[ParameterContainer] = None,
     parameters: Optional[Dict[str, ParameterContainer]] = None,

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -227,6 +227,20 @@ def get_parameter_value(
                 variables=variables,
                 parameters=parameters,
             )
+    elif isinstance(parameter_reference, (list, set, tuple)):
+        parameter_reference_type: type = type(parameter_reference)
+        element: Any
+        return parameter_reference_type(
+            [
+                get_parameter_value(
+                    domain=domain,
+                    parameter_reference=element,
+                    variables=variables,
+                    parameters=parameters,
+                )
+                for element in parameter_reference
+            ]
+        )
     elif isinstance(
         parameter_reference, str
     ) and is_fully_qualified_parameter_name_literal_string_format(

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -7,7 +7,12 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import numpy as np
 
 import great_expectations.exceptions as ge_exceptions
-from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
+from great_expectations.core.batch import (
+    Batch,
+    BatchRequest,
+    BatchRequestBase,
+    RuntimeBatchRequest,
+)
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.rule_based_profiler.config import ParameterBuilderConfig
@@ -146,7 +151,28 @@ class ParameterBuilder(Builder, ABC):
         parameters: Optional[Dict[str, ParameterContainer]] = None,
         parameter_computation_impl: Optional[Callable] = None,
         json_serialize: Optional[bool] = None,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
     ) -> None:
+        """
+        Args:
+            parameter_container: Storage for parameters, computed by this ParameterBuilder object.
+            domain: Domain object that is context for execution of this ParameterBuilder object.
+            variables: attribute name/value pairs
+            parameters: Dictionary of ParameterContainer objects corresponding to all Domain context in memory.
+            parameter_computation_impl: Object containing desired ParameterBuilder implementation.
+            json_serialize: If True (default), convert computed value to JSON prior to saving results.
+            batch_list: Explicit list of Batch objects used as data to supply arguments at runtime.
+            batch_request: batch_request used to override builder attributes to get runtime data.
+            force_batch_data: Whether or not to overwrite existing batch_request value in ParameterBuilder components.
+        """
+        self.set_batch_list_or_batch_request(
+            batch_list=batch_list,
+            batch_request=batch_request,
+            force_batch_data=force_batch_data,
+        )
+
         resolve_evaluation_dependencies(
             parameter_builder=self,
             parameter_container=parameter_container,

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -163,8 +163,8 @@ class ParameterBuilder(Builder, ABC):
             parameters: Dictionary of ParameterContainer objects corresponding to all Domain context in memory.
             parameter_computation_impl: Object containing desired ParameterBuilder implementation.
             json_serialize: If True (default), convert computed value to JSON prior to saving results.
-            batch_list: Explicit list of Batch objects used as data to supply arguments at runtime.
-            batch_request: batch_request used to override builder attributes to get runtime data.
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
             force_batch_data: Whether or not to overwrite existing batch_request value in ParameterBuilder components.
         """
         self.set_batch_list_or_batch_request(
@@ -609,6 +609,7 @@ class ParameterBuilder(Builder, ABC):
 
         Returns sorted dict of candidate as key and ratio as value
         """
+        # noinspection PyTypeChecker
         return dict(
             sorted(
                 candidate_ratio_dict.items(),

--- a/great_expectations/rule_based_profiler/rule/rule.py
+++ b/great_expectations/rule_based_profiler/rule/rule.py
@@ -1,8 +1,9 @@
 import copy
 import json
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from great_expectations.core import ExpectationConfiguration
+from great_expectations.core.batch import Batch, BatchRequestBase
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.rule_based_profiler.config.base import (
     domainBuilderConfigSchema,
@@ -46,16 +47,29 @@ class Rule(SerializableDictDot):
     def generate(
         self,
         variables: Optional[ParameterContainer] = None,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
     ) -> List[ExpectationConfiguration]:
         """
         Builds a list of Expectation Configurations, returning a single Expectation Configuration entry for every
         ConfigurationBuilder available based on the instantiation.
+        Args:
+            :param variables attribute name/value pairs (overrides)
+            :param batch_list: List of Batch objects used to supply arguments at runtime.
+            :param batch_request: batch_request used to supply arguments at runtime.
+            :param force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
 
         :return: List of Corresponding Expectation Configurations representing every configured rule
         """
         expectation_configurations: List[ExpectationConfiguration] = []
 
-        domains: List[Domain] = self.domain_builder.get_domains(variables=variables)
+        domains: List[Domain] = self.domain_builder.get_domains(
+            variables=variables,
+            batch_list=batch_list,
+            batch_request=batch_request,
+            force_batch_data=force_batch_data,
+        )
 
         domain: Domain
         for domain in domains:
@@ -72,6 +86,11 @@ class Rule(SerializableDictDot):
                     domain=domain,
                     variables=variables,
                     parameters=self._parameters,
+                    parameter_computation_impl=None,
+                    json_serialize=None,
+                    batch_list=batch_list,
+                    batch_request=batch_request,
+                    force_batch_data=force_batch_data,
                 )
 
             expectation_configuration_builders: List[
@@ -85,6 +104,9 @@ class Rule(SerializableDictDot):
                         domain=domain,
                         variables=variables,
                         parameters=self._parameters,
+                        batch_list=batch_list,
+                        batch_request=batch_request,
+                        force_batch_data=force_batch_data,
                     )
                 )
 

--- a/great_expectations/rule_based_profiler/rule/rule.py
+++ b/great_expectations/rule_based_profiler/rule/rule.py
@@ -55,12 +55,13 @@ class Rule(SerializableDictDot):
         Builds a list of Expectation Configurations, returning a single Expectation Configuration entry for every
         ConfigurationBuilder available based on the instantiation.
         Args:
-            :param variables attribute name/value pairs (overrides)
-            :param batch_list: List of Batch objects used to supply arguments at runtime.
-            :param batch_request: batch_request used to supply arguments at runtime.
-            :param force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
+            variables: attribute name/value pairs, commonly-used in Builder objects.
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
+            force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
 
-        :return: List of Corresponding Expectation Configurations representing every configured rule
+        Returns:
+            List of Corresponding Expectation Configurations representing every configured rule
         """
         expectation_configurations: List[ExpectationConfiguration] = []
 

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -258,6 +258,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
             :param expectation_suite: An existing ExpectationSuite to update.
             :param expectation_suite_name: A name for returned ExpectationSuite.
             :param include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler
+
         :return: Set of rule evaluation results in the form of an ExpectationSuite
         """
         assert not (

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -854,7 +854,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
                     batch_requests.append(parameter_builder["batch_request"])
 
         # DataFrames shouldn't be saved to ProfilerStore
-        batch_request: Optional[Union[BatchRequestBase, dict]]
+        batch_request: Union[BatchRequestBase, dict]
         for batch_request in batch_requests:
             if batch_request_contains_batch_data(batch_request=batch_request):
                 return False

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -249,17 +249,18 @@ class BaseRuleBasedProfiler(ConfigPeer):
     ) -> ExpectationSuite:
         """
         Args:
-            :param variables attribute name/value pairs (overrides)
-            :param rules name/(configuration-dictionary) (overrides)
-            :param batch_list: List of Batch objects used to supply arguments at runtime.
-            :param batch_request: batch_request used to supply arguments at runtime.
-            :param force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
-            :param reconciliation_directives directives for how each rule component should be overwritten
-            :param expectation_suite: An existing ExpectationSuite to update.
-            :param expectation_suite_name: A name for returned ExpectationSuite.
-            :param include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler
+            variables: attribute name/value pairs (overrides), commonly-used in Builder objects.
+            rules: name/(configuration-dictionary) (overrides)
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
+            force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
+            reconciliation_directives: directives for how each rule component should be overwritten
+            expectation_suite: An existing ExpectationSuite to update.
+            expectation_suite_name: A name for returned ExpectationSuite.
+            include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler
 
-        :return: Set of rule evaluation results in the form of an ExpectationSuite
+        Returns:
+            Set of rule evaluation results in the form of an ExpectationSuite
         """
         assert not (
             expectation_suite and expectation_suite_name

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -914,7 +914,6 @@ class BaseRuleBasedProfiler(ConfigPeer):
         batch_requests: List[Union[BatchRequest, RuntimeBatchRequest, dict]] = []
         rule: dict
         for rule in config.rules.values():
-
             domain_builder: dict = rule["domain_builder"]
             if "batch_request" in domain_builder:
                 batch_requests.append(domain_builder["batch_request"])

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -9,8 +9,7 @@ from typing import Any, Dict, List, Optional, Set, Union
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import (
     Batch,
-    BatchRequest,
-    RuntimeBatchRequest,
+    BatchRequestBase,
     batch_request_contains_batch_data,
 )
 from great_expectations.core.config_peer import ConfigPeer
@@ -241,7 +240,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         force_batch_data: bool = False,
         reconciliation_directives: ReconciliationDirectives = DEFAULT_RECONCILATION_DIRECTIVES,
         expectation_suite: Optional[ExpectationSuite] = None,
@@ -768,7 +767,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         data_context: "DataContext",  # noqa: F821
         profiler_store: ProfilerStore,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         name: Optional[str] = None,
         ge_cloud_id: Optional[str] = None,
         expectation_suite: Optional[ExpectationSuite] = None,
@@ -803,7 +802,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
     def generate_rule_overrides_from_batch_request(
         rules: List[Rule],
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         force_batch_data: bool = False,
     ) -> List[Rule]:
         """Iterates through the profiler's builder attributes and generates a set of
@@ -911,7 +910,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         config: RuleBasedProfilerConfig,
     ) -> bool:
         # Evaluate nested types in RuleConfig to parse out BatchRequests
-        batch_requests: List[Union[BatchRequest, RuntimeBatchRequest, dict]] = []
+        batch_requests: List[Union[BatchRequestBase, dict]] = []
         rule: dict
         for rule in config.rules.values():
             domain_builder: dict = rule["domain_builder"]
@@ -925,7 +924,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
                     batch_requests.append(parameter_builder["batch_request"])
 
         # DataFrames shouldn't be saved to ProfilerStore
-        batch_request: Union[BatchRequest, RuntimeBatchRequest, dict]
+        batch_request: Optional[Union[BatchRequestBase, dict]]
         for batch_request in batch_requests:
             if batch_request_contains_batch_data(batch_request=batch_request):
                 return False

--- a/great_expectations/rule_based_profiler/types/builder.py
+++ b/great_expectations/rule_based_profiler/types/builder.py
@@ -116,6 +116,10 @@ class Builder(SerializableDictDot):
         dict_obj: dict = super().to_dict()
         dict_obj["class_name"] = self.__class__.__name__
         dict_obj["module_name"] = self.__class__.__module__
+
+        if batch_request_contains_batch_data(batch_request=self.batch_request):
+            dict_obj.pop("batch_request", None)
+
         return dict_obj
 
     def to_json_dict(self) -> dict:

--- a/great_expectations/rule_based_profiler/types/builder.py
+++ b/great_expectations/rule_based_profiler/types/builder.py
@@ -4,8 +4,7 @@ from typing import Any, List, Optional, Set, Union
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import (
     Batch,
-    BatchRequest,
-    RuntimeBatchRequest,
+    BatchRequestBase,
     batch_request_contains_batch_data,
     get_batch_request_as_dict,
 )
@@ -27,9 +26,7 @@ class Builder(SerializableDictDot):
     def __init__(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[
-            Union[str, BatchRequest, RuntimeBatchRequest, dict]
-        ] = None,
+        batch_request: Optional[Union[str, BatchRequestBase, dict]] = None,
         data_context: Optional["DataContext"] = None,  # noqa: F821
     ):
         """
@@ -64,13 +61,11 @@ class Builder(SerializableDictDot):
         self._batch_list = value
 
     @property
-    def batch_request(self) -> Optional[Union[BatchRequest, RuntimeBatchRequest, dict]]:
+    def batch_request(self) -> Optional[Union[BatchRequestBase, dict]]:
         return self._batch_request
 
     @batch_request.setter
-    def batch_request(
-        self, value: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]]
-    ) -> None:
+    def batch_request(self, value: Optional[Union[BatchRequestBase, dict]]) -> None:
         if not (value is None or isinstance(value, dict)):
             value = get_batch_request_as_dict(batch_request=value)
 
@@ -83,7 +78,7 @@ class Builder(SerializableDictDot):
     def set_batch_list_or_batch_request(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         force_batch_data: bool = False,
     ) -> None:
         if force_batch_data or self.batch_request is None:
@@ -95,7 +90,7 @@ class Builder(SerializableDictDot):
     def set_batch_data(
         self,
         batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequest, RuntimeBatchRequest, dict]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
     ) -> None:
         arg: Any
         num_supplied_batch_specification_args: int = sum(

--- a/great_expectations/rule_based_profiler/types/builder.py
+++ b/great_expectations/rule_based_profiler/types/builder.py
@@ -6,6 +6,7 @@ from great_expectations.core.batch import (
     Batch,
     BatchRequest,
     RuntimeBatchRequest,
+    batch_request_contains_batch_data,
     get_batch_request_as_dict,
 )
 from great_expectations.core.util import convert_to_json_serializable
@@ -38,7 +39,16 @@ class Builder(SerializableDictDot):
             batch_request: specified in DomainBuilder configuration to get Batch objects for domain computation.
         """
         self._batch_list = batch_list
+
+        if batch_request_contains_batch_data(batch_request=batch_request):
+            raise ValueError(
+                f"""Error: batch_data found in batch_request -- only primitive types are allowed as part of \
+{self.__class__.__name__} instance attributes.
+"""
+            )
+
         self._batch_request = batch_request
+
         self._data_context = data_context
 
     """

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -453,9 +453,17 @@ class Validator:
                 override_profiler_config=override_profiler_config,
             )
 
-            expectation_configurations: List[
-                ExpectationConfiguration
-            ] = profiler.run().expectations
+            expectation_configurations: List[ExpectationConfiguration] = profiler.run(
+                variables=None,
+                rules=None,
+                batch_list=list(self.batches.values()),
+                batch_request=None,
+                force_batch_data=False,
+                reconciliation_directives=BaseRuleBasedProfiler.DEFAULT_RECONCILATION_DIRECTIVES,
+                expectation_suite=None,
+                expectation_suite_name=None,
+                include_citation=True,
+            ).expectations
 
             configuration = expectation_configurations[0]
 
@@ -524,7 +532,10 @@ class Validator:
 
         effective_variables: Optional[
             ParameterContainer
-        ] = profiler.reconcile_profiler_variables(variables=override_variables)
+        ] = profiler.reconcile_profiler_variables(
+            variables=override_variables,
+            reconciliation_strategy=ReconciliationStrategy.UPDATE,
+        )
         profiler.variables = effective_variables
 
         override_rules: Optional[
@@ -571,13 +582,6 @@ class Validator:
             rule.expectation_configuration_builders[0].expectation_type
             == expectation_type
         ), "ExpectationConfigurationBuilder in profiler used to build an ExpectationConfiguration must have the same expectation_type as the expectation being invoked."
-
-        rule = profiler.generate_rule_overrides_from_batch_request(
-            rules=[rule],
-            batch_list=list(self.batches.values()),
-            batch_request=None,
-            force_batch_data=False,
-        )[0]
 
         # TODO: <Alex>Add "metric_domain_kwargs_override" when "Expectation" defines "domain_keys" separately.</Alex>
         key: str

--- a/tests/rule_based_profiler/domain_builder/test_domain_builder.py
+++ b/tests/rule_based_profiler/domain_builder/test_domain_builder.py
@@ -51,25 +51,12 @@ def test_table_domain_builder(
     assert domain.kwargs is None
 
 
-def test_builder_with_runtime_batch_request(
+def test_builder_instantiated_with_runtime_batch_request_raises_error(
     data_context_with_datasource_pandas_engine,
-    alice_columnar_table_single_batch,
 ):
     data_context: DataContext = data_context_with_datasource_pandas_engine
 
-    profiler_config: str = alice_columnar_table_single_batch["profiler_config"]
-
-    full_profiler_config_dict: dict = yaml.load(profiler_config)
-
-    variables_configs: dict = full_profiler_config_dict.get("variables")
-    if variables_configs is None:
-        variables_configs = {}
-
-    variables: ParameterContainer = build_parameter_container_for_variables(
-        variables_configs=variables_configs
-    )
-
-    df = pd.DataFrame(
+    df: pd.DataFrame = pd.DataFrame(
         {
             "a": [
                 "2021-01-01",
@@ -106,6 +93,70 @@ def test_builder_with_runtime_batch_request(
         "Error: batch_data found in batch_request -- only primitive types are allowed as part of ColumnDomainBuilder instance attributes."
         in str(excinfo.value)
     )
+
+
+def test_builder_executed_with_runtime_batch_request_does_not_raise_error(
+    data_context_with_datasource_pandas_engine,
+    alice_columnar_table_single_batch,
+):
+    data_context: DataContext = data_context_with_datasource_pandas_engine
+
+    profiler_config: str = alice_columnar_table_single_batch["profiler_config"]
+
+    full_profiler_config_dict: dict = yaml.load(profiler_config)
+
+    variables_configs: dict = full_profiler_config_dict.get("variables")
+    if variables_configs is None:
+        variables_configs = {}
+
+    variables: ParameterContainer = build_parameter_container_for_variables(
+        variables_configs=variables_configs
+    )
+
+    df: pd.DataFrame = pd.DataFrame(
+        {
+            "a": [
+                "2021-01-01",
+                "2021-01-31",
+                "2021-02-28",
+                "2021-03-20",
+                "2021-02-21",
+                "2021-05-01",
+                "2021-06-18",
+            ]
+        }
+    )
+
+    batch_request: dict = {
+        "datasource_name": "my_datasource",
+        "data_connector_name": "default_runtime_data_connector_name",
+        "data_asset_name": "my_data_asset",
+        "runtime_parameters": {
+            "batch_data": df,
+        },
+        "batch_identifiers": {
+            "default_identifier_name": "my_identifier",
+        },
+    }
+
+    domain_builder: DomainBuilder = ColumnDomainBuilder(
+        data_context=data_context,
+    )
+    domains: List[Domain] = domain_builder.get_domains(
+        variables=variables,
+        batch_request=batch_request,
+    )
+
+    assert len(domains) == 1
+    assert domains == [
+        {
+            "domain_type": "column",
+            "domain_kwargs": {
+                "column": "a",
+            },
+            "details": {},
+        },
+    ]
 
 
 def test_column_domain_builder(

--- a/tests/rule_based_profiler/domain_builder/test_domain_builder.py
+++ b/tests/rule_based_profiler/domain_builder/test_domain_builder.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import pandas as pd
 import pytest
 from ruamel.yaml import YAML
 
@@ -48,6 +49,63 @@ def test_table_domain_builder(
     # Also test that the dot notation is supported properly throughout the dictionary fields of the Domain object.
     assert domain.domain_type.value == "table"
     assert domain.kwargs is None
+
+
+def test_builder_with_runtime_batch_request(
+    data_context_with_datasource_pandas_engine,
+    alice_columnar_table_single_batch,
+):
+    data_context: DataContext = data_context_with_datasource_pandas_engine
+
+    profiler_config: str = alice_columnar_table_single_batch["profiler_config"]
+
+    full_profiler_config_dict: dict = yaml.load(profiler_config)
+
+    variables_configs: dict = full_profiler_config_dict.get("variables")
+    if variables_configs is None:
+        variables_configs = {}
+
+    variables: ParameterContainer = build_parameter_container_for_variables(
+        variables_configs=variables_configs
+    )
+
+    df = pd.DataFrame(
+        {
+            "a": [
+                "2021-01-01",
+                "2021-01-31",
+                "2021-02-28",
+                "2021-03-20",
+                "2021-02-21",
+                "2021-05-01",
+                "2021-06-18",
+            ]
+        }
+    )
+
+    batch_request: dict = {
+        "datasource_name": "my_datasource",
+        "data_connector_name": "default_runtime_data_connector_name",
+        "data_asset_name": "my_data_asset",
+        "runtime_parameters": {
+            "batch_data": df,
+        },
+        "batch_identifiers": {
+            "default_identifier_name": "my_identifier",
+        },
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        # noinspection PyArgumentList
+        domain_builder: DomainBuilder = ColumnDomainBuilder(
+            batch_request=batch_request,
+            data_context=data_context,
+        )
+
+    assert (
+        "Error: batch_data found in batch_request -- only primitive types are allowed as part of ColumnDomainBuilder instance attributes."
+        in str(excinfo.value)
+    )
 
 
 def test_column_domain_builder(

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -958,13 +958,11 @@ def test_run_profiler_with_dynamic_args(
     )
 
 
-@mock.patch(
-    "great_expectations.rule_based_profiler.RuleBasedProfiler.generate_rule_overrides_from_batch_request"
-)
+@mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock.patch("great_expectations.data_context.data_context.DataContext")
 def test_run_profiler_on_data_creates_suite_with_dict_arg(
     mock_data_context: mock.MagicMock,
-    mock_generate_rule_overrides_from_batch_request: mock.MagicMock,
+    mock_rule_based_profiler_run: mock.MagicMock,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -981,21 +979,17 @@ def test_run_profiler_on_data_creates_suite_with_dict_arg(
         batch_request=batch_request,
     )
 
-    assert mock_generate_rule_overrides_from_batch_request.called
+    assert mock_rule_based_profiler_run.called
 
-    resulting_batch_request = mock_generate_rule_overrides_from_batch_request.call_args[
-        1
-    ]["batch_request"]
+    resulting_batch_request = mock_rule_based_profiler_run.call_args[1]["batch_request"]
     assert resulting_batch_request == batch_request
 
 
-@mock.patch(
-    "great_expectations.rule_based_profiler.RuleBasedProfiler.generate_rule_overrides_from_batch_request"
-)
+@mock.patch("great_expectations.rule_based_profiler.RuleBasedProfiler.run")
 @mock.patch("great_expectations.data_context.data_context.DataContext")
 def test_run_profiler_on_data_creates_suite_with_batch_request_arg(
     mock_data_context: mock.MagicMock,
-    mock_generate_rule_overrides_from_batch_request: mock.MagicMock,
+    mock_rule_based_profiler_run: mock.MagicMock,
     populated_profiler_store: ProfilerStore,
     profiler_name: str,
 ):
@@ -1012,13 +1006,11 @@ def test_run_profiler_on_data_creates_suite_with_batch_request_arg(
         batch_request=batch_request,
     )
 
-    assert mock_generate_rule_overrides_from_batch_request.called
+    assert mock_rule_based_profiler_run.called
 
-    resulting_batch_request: dict = (
-        mock_generate_rule_overrides_from_batch_request.call_args[1][
-            "batch_request"
-        ].to_json_dict()
-    )
+    resulting_batch_request: dict = mock_rule_based_profiler_run.call_args[1][
+        "batch_request"
+    ].to_json_dict()
     deep_filter_properties_iterable(resulting_batch_request, inplace=True)
     expected_batch_request: dict = batch_request.to_json_dict()
     deep_filter_properties_iterable(expected_batch_request, inplace=True)


### PR DESCRIPTION
### Scope
* Non-serializable batch requests (specifically, `RuntimeBatchRequest` containing `batch_data`) must not be passed to `Builder` class constructors.  Instead, such batch requests should be supplied at runtime.
* Error message is added when a non-serializable batch request is passed to a `Builder` class constructor.
* Unit test.
* Ability to supply `RuntimeBatchRequest` containing `batch_data` (e.g., Pandas or Spark `DataFrame`) at runtime.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-749
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
