### PR TITLE
[MAINTENANCE] Provide cardinality limit modes from CategoricalColumnDomainBuilder

### DIFF
--- a/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
@@ -31,6 +31,7 @@ class CategoricalColumnDomainBuilder(ColumnDomainBuilder):
     exclude_field_names: Set[str] = ColumnDomainBuilder.exclude_field_names | {
         "cardinality_checker",
     }
+    cardinality_limit_modes: CardinalityLimitMode = CardinalityLimitMode
 
     def __init__(
         self,
@@ -89,6 +90,8 @@ class CategoricalColumnDomainBuilder(ColumnDomainBuilder):
             limit_mode: CardinalityLimitMode or string name of the mode
                 defining the maximum allowable cardinality to use when
                 filtering columns.
+                Accessible for convenience via CategoricalColumnDomainBuilder.cardinality_limit_modes e.g.:
+                limit_mode=CategoricalColumnDomainBuilder.cardinality_limit_modes.VERY_FEW,
             max_unique_values: number of max unique rows for a custom
                 cardinality limit to use when filtering columns.
             max_proportion_unique: proportion of unique values for a

--- a/great_expectations/rule_based_profiler/helpers/cardinality_checker.py
+++ b/great_expectations/rule_based_profiler/helpers/cardinality_checker.py
@@ -3,24 +3,44 @@ import enum
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
+from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.exceptions import ProfilerConfigurationError
+from great_expectations.types import SerializableDictDot
 
 
-@dataclass
-class CardinalityLimit(abc.ABC):
+@dataclass(frozen=True)
+class CardinalityLimit(abc.ABC, SerializableDictDot):
     name: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class RelativeCardinalityLimit(CardinalityLimit):
     max_proportion_unique: float
     metric_name_defining_limit: str = "column.unique_proportion"
 
+    def to_json_dict(self) -> dict:
+        return convert_to_json_serializable(
+            {
+                "name": self.name,
+                "max_proportion_unique": self.max_proportion_unique,
+                "metric_name_defining_limit": self.metric_name_defining_limit,
+            }
+        )
 
-@dataclass
+
+@dataclass(frozen=True)
 class AbsoluteCardinalityLimit(CardinalityLimit):
     max_unique_values: int
     metric_name_defining_limit: str = "column.distinct_values.count"
+
+    def to_json_dict(self) -> dict:
+        return convert_to_json_serializable(
+            {
+                "name": self.name,
+                "max_proportion_unique": self.max_unique_values,
+                "metric_name_defining_limit": self.metric_name_defining_limit,
+            }
+        )
 
 
 class CardinalityLimitMode(enum.Enum):

--- a/tests/rule_based_profiler/domain_builder/test_categorical_column_domain_builder.py
+++ b/tests/rule_based_profiler/domain_builder/test_categorical_column_domain_builder.py
@@ -13,6 +13,27 @@ from great_expectations.rule_based_profiler.domain_builder.categorical_column_do
 from great_expectations.rule_based_profiler.types import Domain
 
 
+def test_instantiate_with_cardinality_limit_modes(
+    alice_columnar_table_single_batch_context,
+):
+    data_context: DataContext = alice_columnar_table_single_batch_context
+
+    batch_request: BatchRequest = BatchRequest(
+        datasource_name="alice_columnar_table_single_batch_datasource",
+        data_connector_name="alice_columnar_table_single_batch_data_connector",
+        data_asset_name="alice_columnar_table_single_batch_data_asset",
+    )
+
+    domain_builder: DomainBuilder = CategoricalColumnDomainBuilder(
+        exclude_column_name_suffixes="_id",
+        limit_mode=CategoricalColumnDomainBuilder.cardinality_limit_modes.VERY_FEW,
+        batch_request=batch_request,
+        data_context=data_context,
+    )
+
+    domain_builder.get_domains()
+
+
 def test_single_batch_very_few_cardinality(alice_columnar_table_single_batch_context):
     data_context: DataContext = alice_columnar_table_single_batch_context
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Access the cardinality limit modes from CategoricalColumnDomainBuilder to eliminate a second import when using it. For example using a class attribute `CategoricalColumnDomainBuilder.cardinality_limit_modes`:
```
domain_builder: DomainBuilder = CategoricalColumnDomainBuilder(
        exclude_column_name_suffixes="_id",
        limit_mode=CategoricalColumnDomainBuilder.cardinality_limit_modes.VERY_FEW,
        batch_request=batch_request,
        data_context=data_context,
    )
```

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
