### PR TITLE
[MAINTENANCE] Refactor ValidationParameter computation (to be more elegant/compact) and fix a type hint in SimpleDateFormatStringParameterBuilder

### DIFF
--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -105,27 +105,27 @@ class ExpectationConfigurationBuilder(Builder, ABC):
         Returns:
             ExpectationConfiguration object.
         """
-        self.set_batch_list_or_batch_request(
-            batch_list=batch_list,
-            batch_request=batch_request,
-            force_batch_data=force_batch_data,
-        )
-
-        self._resolve_validation_dependencies(
+        self.resolve_validation_dependencies(
             domain=domain,
             variables=variables,
             parameters=parameters,
+            batch_list=batch_list,
+            batch_request=batch_request,
+            force_batch_data=force_batch_data,
         )
 
         return self._build_expectation_configuration(
             domain=domain, variables=variables, parameters=parameters
         )
 
-    def _resolve_validation_dependencies(
+    def resolve_validation_dependencies(
         self,
         domain: Domain,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
     ) -> None:
         validation_parameter_builders: List[ParameterBuilder] = (
             self.validation_parameter_builders or []
@@ -133,15 +133,15 @@ class ExpectationConfigurationBuilder(Builder, ABC):
 
         validation_parameter_builder: ParameterBuilder
         for validation_parameter_builder in validation_parameter_builders:
-            validation_parameter_builder.set_batch_list_or_batch_request(
-                batch_list=self.batch_list,
-                batch_request=self.batch_request,
-                force_batch_data=False,
-            )
             validation_parameter_builder.build_parameters(
                 domain=domain,
                 variables=variables,
                 parameters=parameters,
+                parameter_computation_impl=None,
+                json_serialize=None,
+                batch_list=batch_list,
+                batch_request=batch_request,
+                force_batch_data=force_batch_data,
             )
 
     @abstractmethod

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -160,7 +160,7 @@ class ParameterBuilder(Builder, ABC):
             variables: attribute name/value pairs
             parameters: Dictionary of ParameterContainer objects corresponding to all Domain context in memory.
             parameter_computation_impl: Object containing desired ParameterBuilder implementation.
-            json_serialize: If True (default), convert computed value to JSON prior to saving results.
+            json_serialize: If absent, use property value (in standard way, supporting variables look-up).
             batch_list: Explicit list of Batch objects to supply data at runtime.
             batch_request: Explicit batch_request used to supply data at runtime.
             force_batch_data: Whether or not to overwrite existing batch_request value in ParameterBuilder components.

--- a/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
@@ -98,7 +98,7 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
         threshold: Union[str, float] = 1.0,
         candidate_strings: Optional[Union[Iterable[str], str]] = None,
         evaluation_parameter_builder_configs: Optional[List[dict]] = None,
-        json_serialize: bool = True,
+        json_serialize: Union[str, bool] = True,
         batch_list: Optional[List[Batch]] = None,
         batch_request: Optional[
             Union[str, BatchRequest, RuntimeBatchRequest, dict]


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-464/GREAT-766
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
