### PR TITLE
[FEATURE] More package contrib info

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -394,7 +394,7 @@ stages:
             displayName: 'pytest'
 
   - stage: deploy_gallery
-    # condition: and(succeeded(), eq(variables.isMain, true))
+    condition: and(succeeded(), eq(variables.isMain, true))
     pool:
       vmImage: 'ubuntu-18.04'
     dependsOn: [required, lint, db_integration, usage_stats_integration, cli_integration]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -394,7 +394,7 @@ stages:
             displayName: 'pytest'
 
   - stage: deploy_gallery
-    condition: and(succeeded(), eq(variables.isMain, true))
+    # condition: and(succeeded(), eq(variables.isMain, true))
     pool:
       vmImage: 'ubuntu-18.04'
     dependsOn: [required, lint, db_integration, usage_stats_integration, cli_integration]

--- a/contrib/capitalone_dataprofiler_expectations/package_info.yml
+++ b/contrib/capitalone_dataprofiler_expectations/package_info.yml
@@ -15,12 +15,16 @@
 general:
   package_name: CapitalOne DataProfiler Expectations
   icon: assets/logo.png
-  description: Data Profiler is an [open source solution](https://www.capitalone.com/tech/open-source/) from Capital One that uses [machine learning](https://www.capitalone.com/tech/machine-learning/)
-    to help companies monitor big data and detect private customer information so that it can be protected. [Data Profiler](https://www.capitalone.com/tech/open-source/basics-of-data-profiler/)
-    provides a pre-trained deep learning model to efficiently identify sensitive information, components to conduct statistical analysis of the dataset, and an API to build data labelers.
-    Data Profiler can accept a wide range of data formats including csv, avro, parquet, json, text, and pandas DataFrames.
-    Whether the data is structured, semi-structured or unstructured, the library is able to identify the schema, statistics, entities from the data.
-    Versatility of the data labeler allows models to be modified as needed and it’s possible to run multiple models on the same dataset with just a few lines of code.
+  description: |
+    Data Profiler is an [open source solution](https://www.capitalone.com/tech/open-source/) from Capital One that uses [machine learning](https://www.capitalone.com/tech/machine-learning/) to help companies monitor big data and detect private customer information so that it can be protected. [Data Profiler](https://www.capitalone.com/tech/open-source/basics-of-data-profiler/) provides a pre-trained deep learning model to efficiently identify sensitive information, components to conduct statistical analysis of the dataset, and an API to build data labelers. Data Profiler can accept a wide range of data formats including csv, avro, parquet, json, text, and pandas DataFrames. Whether the data is structured, semi-structured or unstructured, the library is able to identify the schema, statistics, entities from the data. Versatility of the data labeler allows models to be modified as needed and it’s possible to run multiple models on the same dataset with just a few lines of code.
+
+    * [Data Profiler on GitHub](https://github.com/capitalone/dataprofiler)
+    * Website: [https://www.capitalone.com/tech](https://www.capitalone.com/tech/)
+    * Twitter: [@CapitalOneTech](https://twitter.com/CapitalOneTech)
+    * Articles:
+      *  [Data Profiler - An Open Source Solution to Explain Your Data](https://www.capitalone.com/tech/open-source/basics-of-data-profiler/)
+      *  [Detecting Sensitive Information in Data with Data Profiler](https://www.capitalone.com/tech/open-source/sensitive-data-detection-with-data-profiler/)
+      *  [Evaluating Data Quality for Machine Learning Models at Scale](https://www.capitalone.com/tech/open-source/data-profiler-evaluating-data-quality-at-scale/)
 
 # Please add more code owners as you see fit
 code_owners:

--- a/contrib/capitalone_dataprofiler_expectations/package_info.yml
+++ b/contrib/capitalone_dataprofiler_expectations/package_info.yml
@@ -35,11 +35,25 @@ code_owners:
 domain_experts:
   - full_name: Taylor Turner
     picture: assets/taylor.jpeg
+    title: Principal Machine Learning Engineer at Capital One
+    bio: Since joining Capital One in 2016, Taylor has worked on projects within the model lifecycle, consulted with other departments on their ML projects, and taken new ideas and made them reusable tools internal and external to Capital One. He developed the profiler validator, null data flag, and data quantile reporting features for Data Profiler. Prior to Capital One, Taylor worked as a lead engineer for a hedge fund focused on using deep learning to glean tradable datapoints from a corpus of niche data streams of high-profile market commentators.
+    social_links:
+      - account_type: GITHUB
+        identifier: https://github.com/taylorfturner
+      - account_type: LINKEDIN
+        identifier: https://www.linkedin.com/in/taylorfturner
 
   - full_name: Jeremy Goodsitt
     picture: assets/jeremy.png
+    title: Lead Machine Learning Engineer at Capital One
+    bio: Since joining Capital One in 2017, Jeremy has worked on machine learning optimization infrastructure, NLP model development such as the sensitive data labeler within the Data Profiler, and the engineering design behind the open source library, Data Profiler. His doctoral studies were at the University of Illinois where he worked on improving medical diagnostic techniques through computer vision and optimization techniques.
+    social_links:
+      - account_type: GITHUB
+        identifier: https://github.com/JGSweets
+      - account_type: LINKEDIN
+        identifier: https://www.linkedin.com/in/jeremy-goodsitt
 
     # social_links:
-    #   - account_type: ~ # May be one of TWITTER | INSTAGRAM | LINKEDIN | MEDIUM
+    #   - account_type: ~ # May be one of TWITTER | GITHUB | LINKEDIN | MEDIUM | WEBSITE
     #     identifier: ~
     # picture: ~ # May be a relative path to `assets/` or a URL

--- a/contrib/capitalone_dataprofiler_expectations/requirements.txt
+++ b/contrib/capitalone_dataprofiler_expectations/requirements.txt
@@ -1,4 +1,5 @@
 dataprofiler
 great_expectations
 numpy
+scikit-learn
 tensorflow

--- a/contrib/cli/great_expectations_contrib/package.py
+++ b/contrib/cli/great_expectations_contrib/package.py
@@ -46,9 +46,10 @@ class GitHubUser(SerializableDictDot):
 
 class SocialLinkType(str, Enum):
     TWITTER = "TWITTER"
-    INSTAGRAM = "INSTAGRAM"
+    GITHUB = "GITHUB"
     LINKEDIN = "LINKEDIN"
     MEDIUM = "MEDIUM"
+    WEBSITE = "WEBSITE"
 
 
 @dataclass

--- a/contrib/cli/great_expectations_contrib/package.py
+++ b/contrib/cli/great_expectations_contrib/package.py
@@ -127,7 +127,22 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
         general = data.get("general")
         if general:
             for attr in ("package_name", "icon", "description"):
-                self[attr] = general.get(attr)
+                if attr == "icon":
+                    # If the user has provided an icon, we need to check if it is a relative URL.
+                    # If it is, we need to convert to the HTTPS path that will show up when merged into `develop`.
+                    icon: Optional[str] = general.get(attr)
+                    if icon and os.path.exists(icon):
+                        package_name: str = os.path.basename(os.getcwd())
+                        url: str = os.path.join(
+                            "https://raw.githubusercontent.com/great-expectations/great_expectations/develop/contrib",
+                            package_name,
+                            icon,
+                        )
+                        self["icon"] = url
+                    else:
+                        self["icon"] = icon
+                else:
+                    self[attr] = general.get(attr)
 
         # Assign code owners
         code_owners = data.get("code_owners")

--- a/contrib/cli/great_expectations_contrib/package.py
+++ b/contrib/cli/great_expectations_contrib/package.py
@@ -63,6 +63,8 @@ class DomainExpert(SerializableDictDot):
     full_name: str
     social_links: Optional[List[SocialLink]] = None
     picture: Optional[str] = None
+    title: Optional[str] = None
+    bio: Optional[str] = None
 
 
 class Maturity(str, Enum):


### PR DESCRIPTION

Changes proposed in this pull request:
- Remove INSTAGRAM from SocialLinkType and add GITHUB and WEBSITE
- Add title and bio to DomainExpert class
- Update description for CapitalOne package to be a multi-line markdown string
- Add title and bio info for the 2 CapitalOne experts

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
