### PR TITLE
[MAINTENANCE] Rule-Based Profiler: Allow ExpectationConfigurationBuilder to be Optional

### DIFF
--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -295,11 +295,11 @@ class ExpectationConfigurationBuilderConfigSchema(NotNullSchema):
 class RuleConfig(SerializableDictDot):
     def __init__(
         self,
-        expectation_configuration_builders: List[
-            dict
-        ],  # see ExpectationConfigurationBuilderConfig
         domain_builder: Optional[dict] = None,  # see DomainBuilderConfig
         parameter_builders: Optional[List[dict]] = None,  # see ParameterBuilderConfig
+        expectation_configuration_builders: Optional[
+            List[dict]
+        ] = None,  # see ExpectationConfigurationBuilderConfig
     ):
         self.domain_builder = domain_builder
         self.parameter_builders = parameter_builders
@@ -375,8 +375,8 @@ class RuleConfigSchema(NotNullSchema):
             required=True,
             allow_none=False,
         ),
-        required=True,
-        allow_none=False,
+        required=False,
+        allow_none=True,
     )
 
 

--- a/great_expectations/rule_based_profiler/rule/rule.py
+++ b/great_expectations/rule_based_profiler/rule/rule.py
@@ -25,8 +25,10 @@ class Rule(SerializableDictDot):
         self,
         name: str,
         domain_builder: DomainBuilder,
-        expectation_configuration_builders: List[ExpectationConfigurationBuilder],
         parameter_builders: Optional[List[ParameterBuilder]] = None,
+        expectation_configuration_builders: Optional[
+            List[ExpectationConfigurationBuilder]
+        ] = None,
     ):
         """
         Sets Profiler rule name, domain builders, parameters builders, configuration builders,
@@ -130,7 +132,7 @@ class Rule(SerializableDictDot):
     @property
     def expectation_configuration_builders(
         self,
-    ) -> List[ExpectationConfigurationBuilder]:
+    ) -> Optional[List[ExpectationConfigurationBuilder]]:
         return self._expectation_configuration_builders
 
     @property
@@ -225,8 +227,14 @@ class Rule(SerializableDictDot):
     def _get_expectation_configuration_builders_as_dict(
         self,
     ) -> Dict[str, ExpectationConfigurationBuilder]:
+        expectation_configuration_builders: List[
+            ExpectationConfigurationBuilder
+        ] = self.expectation_configuration_builders
+        if expectation_configuration_builders is None:
+            expectation_configuration_builders = []
+
         expectation_configuration_builder: ExpectationConfigurationBuilder
         return {
             expectation_configuration_builder.expectation_type: expectation_configuration_builder
-            for expectation_configuration_builder in self.expectation_configuration_builders
+            for expectation_configuration_builder in expectation_configuration_builders
         }

--- a/tests/rule_based_profiler/config/test_base.py
+++ b/tests/rule_based_profiler/config/test_base.py
@@ -178,13 +178,12 @@ def test_rule_config_unsuccessfully_loads_with_missing_required_fields():
     data = {}
     schema = RuleConfigSchema()
 
-    with pytest.raises(ValidationError) as e:
-        schema.load(data)
+    config = schema.load(data)
 
-    assert (
-        "'expectation_configuration_builders': ['Missing data for required field.']"
-        in str(e.value)
-    )
+    assert isinstance(config, RuleConfig)
+    assert config.domain_builder is None
+    assert config.parameter_builders is None
+    assert config.expectation_configuration_builders is None
 
 
 def test_rule_based_profiler_config_successfully_loads_with_required_args():

--- a/tests/rule_based_profiler/conftest.py
+++ b/tests/rule_based_profiler/conftest.py
@@ -117,8 +117,6 @@ def column_Description_domain():
 # noinspection PyPep8Naming
 @pytest.fixture
 def column_pair_Age_Date_domain():
-    skip_if_python_below_minimum_version()
-
     return Domain(
         domain_type=MetricDomainTypes.COLUMN_PAIR,
         domain_kwargs={
@@ -132,8 +130,6 @@ def column_pair_Age_Date_domain():
 # noinspection PyPep8Naming
 @pytest.fixture
 def multi_column_Age_Date_Description_domain():
-    skip_if_python_below_minimum_version()
-
     return Domain(
         domain_type=MetricDomainTypes.MULTICOLUMN,
         domain_kwargs={


### PR DESCRIPTION
### Scope
* Rationale: For `DataAssistant` use cases, emitting ExpectationConfiguration objects is only one of the outputs.
* Updated existing tests.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-735/GREAT-780
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
