### PR TITLE
[FEATURE] Introducing RuleState class and RuleOutput class for Rule-Based Profiler in support of richer use cases (such as DataAssistant).

### DIFF
--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -97,7 +97,7 @@ class ExpectationConfigurationBuilder(Builder, ABC):
         Args:
             domain: Domain object that is context for execution of this ParameterBuilder object.
             variables: attribute name/value pairs
-            parameters: Dictionary of ParameterContainer objects corresponding to all Domain context in memory.
+            parameters: Dictionary of ParameterContainer objects corresponding to all Domain objects in memory.
             batch_list: Explicit list of Batch objects to supply data at runtime.
             batch_request: Explicit batch_request used to supply data at runtime.
             force_batch_data: Whether or not to overwrite existing batch_request value in ParameterBuilder components.

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -158,7 +158,7 @@ class ParameterBuilder(Builder, ABC):
         Args:
             domain: Domain object that is context for execution of this ParameterBuilder object.
             variables: attribute name/value pairs
-            parameters: Dictionary of ParameterContainer objects corresponding to all Domain context in memory.
+            parameters: Dictionary of ParameterContainer objects corresponding to all Domain objects in memory.
             parameter_computation_impl: Object containing desired ParameterBuilder implementation.
             json_serialize: If absent, use property value (in standard way, supporting variables look-up).
             batch_list: Explicit list of Batch objects to supply data at runtime.

--- a/great_expectations/rule_based_profiler/rule/__init__.py
+++ b/great_expectations/rule_based_profiler/rule/__init__.py
@@ -1,1 +1,2 @@
 from .rule import Rule
+from .rule_output import RuleOutput

--- a/great_expectations/rule_based_profiler/rule/rule.py
+++ b/great_expectations/rule_based_profiler/rule/rule.py
@@ -74,9 +74,8 @@ class Rule(SerializableDictDot):
         rule_state: RuleState = RuleState(
             rule=self,
             variables=variables,
+            domains=domains,
         )
-        rule_state.domains = domains
-
         rule_state.reset_parameter_containers()
 
         domain: Domain

--- a/great_expectations/rule_based_profiler/rule/rule_output.py
+++ b/great_expectations/rule_based_profiler/rule/rule_output.py
@@ -27,12 +27,7 @@ class RuleOutput:
     def rule_state(self) -> RuleState:
         return self._rule_state
 
-    def expectation_configurations(
-        self,
-        batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
-        force_batch_data: bool = False,
-    ) -> List[ExpectationConfiguration]:
+    def expectation_configurations(self) -> List[ExpectationConfiguration]:
         expectation_configurations: List[ExpectationConfiguration] = []
 
         domains: List[Domain] = self.rule_state.domains
@@ -48,9 +43,6 @@ class RuleOutput:
                         domain=domain,
                         variables=self.rule_state.variables,
                         parameters=self.rule_state.parameters,
-                        batch_list=batch_list,
-                        batch_request=batch_request,
-                        force_batch_data=force_batch_data,
                     )
                 )
 

--- a/great_expectations/rule_based_profiler/rule/rule_output.py
+++ b/great_expectations/rule_based_profiler/rule/rule_output.py
@@ -1,0 +1,49 @@
+from typing import List, Optional, Union
+
+from great_expectations.core import ExpectationConfiguration
+from great_expectations.core.batch import Batch, BatchRequestBase
+from great_expectations.rule_based_profiler.expectation_configuration_builder import (
+    ExpectationConfigurationBuilder,
+)
+from great_expectations.rule_based_profiler.types import Domain, RuleState
+
+
+class RuleOutput:
+    def __init__(
+        self,
+        rule_state: RuleState,
+    ):
+        self._rule_state = rule_state
+
+    @property
+    def rule_state(self) -> RuleState:
+        return self._rule_state
+
+    def expectation_configurations(
+        self,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
+    ) -> List[ExpectationConfiguration]:
+        expectation_configurations: List[ExpectationConfiguration] = []
+
+        domains: List[Domain] = self.rule_state.domains
+
+        domain: Domain
+        expectation_configuration_builder: ExpectationConfigurationBuilder
+        for domain in domains:
+            for (
+                expectation_configuration_builder
+            ) in self.rule_state.rule.expectation_configuration_builders:
+                expectation_configurations.append(
+                    expectation_configuration_builder.build_expectation_configuration(
+                        domain=domain,
+                        variables=self.rule_state.variables,
+                        parameters=self.rule_state.parameters,
+                        batch_list=batch_list,
+                        batch_request=batch_request,
+                        force_batch_data=force_batch_data,
+                    )
+                )
+
+        return expectation_configurations

--- a/great_expectations/rule_based_profiler/rule/rule_output.py
+++ b/great_expectations/rule_based_profiler/rule/rule_output.py
@@ -9,10 +9,18 @@ from great_expectations.rule_based_profiler.types import Domain, RuleState
 
 
 class RuleOutput:
+    """
+    RuleOutput provides methods for extracting useful information from RuleState using directives and application logic.
+    """
+
     def __init__(
         self,
         rule_state: RuleState,
     ):
+        """
+        Args:
+            rule_state: RuleState object represented by "Domain" objects and parameters,.computed for one Rule object.
+        """
         self._rule_state = rule_state
 
     @property

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -50,9 +50,10 @@ from great_expectations.rule_based_profiler.parameter_builder import (
     ParameterBuilder,
     init_rule_parameter_builders,
 )
-from great_expectations.rule_based_profiler.rule.rule import Rule
+from great_expectations.rule_based_profiler.rule import Rule, RuleOutput
 from great_expectations.rule_based_profiler.types import (
     ParameterContainer,
+    RuleState,
     build_parameter_container_for_variables,
 )
 from great_expectations.types import SerializableDictDot
@@ -136,7 +137,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         self._usage_statistics_handler = usage_statistics_handler
 
-        # Necessary to annotate ExpectationSuite during `run()`
+        # Necessary to annotate ExpectationSuite during `expectation_suite()`
         self._citation = {
             "name": name,
             "config_version": config_version,
@@ -153,6 +154,8 @@ class BaseRuleBasedProfiler(ConfigPeer):
         self._data_context = data_context
 
         self._rules = self._init_profiler_rules(rules=rules)
+
+        self._rule_states = []
 
     def _init_profiler_rules(
         self,
@@ -243,10 +246,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         force_batch_data: bool = False,
         reconciliation_directives: ReconciliationDirectives = DEFAULT_RECONCILATION_DIRECTIVES,
-        expectation_suite: Optional[ExpectationSuite] = None,
-        expectation_suite_name: Optional[str] = None,
-        include_citation: bool = True,
-    ) -> ExpectationSuite:
+    ) -> None:
         """
         Args:
             variables: attribute name/value pairs (overrides), commonly-used in Builder objects.
@@ -255,17 +255,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
             batch_request: Explicit batch_request used to supply data at runtime.
             force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
             reconciliation_directives: directives for how each rule component should be overwritten
-            expectation_suite: An existing ExpectationSuite to update.
-            expectation_suite_name: A name for returned ExpectationSuite.
-            include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler
-
-        Returns:
-            Set of rule evaluation results in the form of an ExpectationSuite
         """
-        assert not (
-            expectation_suite and expectation_suite_name
-        ), "Ambiguous arguments provided; you may pass in an ExpectationSuite or provide a name to instantiate a new one (but you may not do both)."
-
         effective_variables: Optional[
             ParameterContainer
         ] = self.reconcile_profiler_variables(
@@ -276,6 +266,73 @@ class BaseRuleBasedProfiler(ConfigPeer):
         effective_rules: List[Rule] = self.reconcile_profiler_rules(
             rules=rules, reconciliation_directives=reconciliation_directives
         )
+
+        rule_state: RuleState
+        rule: Rule
+        for rule in effective_rules:
+            rule_state = rule.run(
+                variables=effective_variables,
+                batch_list=batch_list,
+                batch_request=batch_request,
+                force_batch_data=force_batch_data,
+            )
+            self.rule_states.append(rule_state)
+
+    def expectation_suite_meta(
+        self,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
+        expectation_suite: Optional[ExpectationSuite] = None,
+        expectation_suite_name: Optional[str] = None,
+        include_citation: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Args:
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
+            force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
+            expectation_suite: An existing ExpectationSuite to update.
+            expectation_suite_name: A name for returned ExpectationSuite.
+            include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler
+
+        Returns:
+            Dictionary corresponding to meta property of ExpectationSuite using ExpectationConfiguration objects, accumulated from RuleState of every Rule executed.
+        """
+        expectation_suite: ExpectationSuite = self.expectation_suite(
+            batch_list=batch_list,
+            batch_request=batch_request,
+            force_batch_data=force_batch_data,
+            expectation_suite=expectation_suite,
+            expectation_suite_name=expectation_suite_name,
+            include_citation=include_citation,
+        )
+        return expectation_suite.meta
+
+    def expectation_suite(
+        self,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
+        expectation_suite: Optional[ExpectationSuite] = None,
+        expectation_suite_name: Optional[str] = None,
+        include_citation: bool = True,
+    ) -> ExpectationSuite:
+        """
+        Args:
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
+            force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
+            expectation_suite: An existing ExpectationSuite to update.
+            expectation_suite_name: A name for returned ExpectationSuite.
+            include_citation: Whether or not to include the Profiler config in the metadata for the ExpectationSuite produced by the Profiler
+
+        Returns:
+            ExpectationSuite using ExpectationConfiguration objects, accumulated from RuleState of every Rule executed.
+        """
+        assert not (
+            expectation_suite and expectation_suite_name
+        ), "Ambiguous arguments provided; you may pass in an ExpectationSuite or provide a name to instantiate a new one (but you may not do both)."
 
         if expectation_suite is None:
             if expectation_suite_name is None:
@@ -292,24 +349,55 @@ class BaseRuleBasedProfiler(ConfigPeer):
                 profiler_config=self._citation,
             )
 
-        rule: Rule
-        for rule in effective_rules:
-            expectation_configurations: List[ExpectationConfiguration] = rule.run(
-                variables=effective_variables,
-                batch_list=batch_list,
-                batch_request=batch_request,
-                force_batch_data=force_batch_data,
+        expectation_configurations: List[
+            ExpectationConfiguration
+        ] = self.expectation_configurations(
+            batch_list=batch_list,
+            batch_request=batch_request,
+            force_batch_data=force_batch_data,
+        )
+
+        expectation_configuration: ExpectationConfiguration
+        for expectation_configuration in expectation_configurations:
+            expectation_suite._add_expectation(
+                expectation_configuration=expectation_configuration,
+                send_usage_event=False,
+                match_type="domain",
+                overwrite_existing=True,
             )
-            expectation_configuration: ExpectationConfiguration
-            for expectation_configuration in expectation_configurations:
-                expectation_suite._add_expectation(
-                    expectation_configuration=expectation_configuration,
-                    send_usage_event=False,
-                    match_type="domain",
-                    overwrite_existing=True,
-                )
 
         return expectation_suite
+
+    def expectation_configurations(
+        self,
+        batch_list: Optional[List[Batch]] = None,
+        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        force_batch_data: bool = False,
+    ) -> List[ExpectationConfiguration]:
+        """
+        Args:
+            batch_list: Explicit list of Batch objects to supply data at runtime.
+            batch_request: Explicit batch_request used to supply data at runtime.
+            force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
+
+        Returns:
+            List of ExpectationConfiguration objects, accumulated from RuleState of every Rule executed.
+        """
+        expectation_configurations: List[ExpectationConfiguration] = []
+
+        rule_state: RuleState
+        rule_output: RuleOutput
+        for rule_state in self.rule_states:
+            rule_output = RuleOutput(rule_state=rule_state)
+            expectation_configurations.extend(
+                rule_output.expectation_configurations(
+                    batch_list=batch_list,
+                    batch_request=batch_request,
+                    force_batch_data=force_batch_data,
+                )
+            )
+
+        return expectation_configurations
 
     def add_rule(self, rule: Rule) -> None:
         """
@@ -750,9 +838,19 @@ class BaseRuleBasedProfiler(ConfigPeer):
             ge_cloud_id=ge_cloud_id,
         )
 
-        result: ExpectationSuite = profiler.run(
+        profiler.run(
             variables=variables,
             rules=rules,
+            batch_list=None,
+            batch_request=None,
+            force_batch_data=False,
+            reconciliation_directives=BaseRuleBasedProfiler.DEFAULT_RECONCILATION_DIRECTIVES,
+            expectation_suite=expectation_suite,
+            expectation_suite_name=expectation_suite_name,
+            include_citation=include_citation,
+        )
+
+        result: ExpectationSuite = profiler.expectation_suite(
             expectation_suite=expectation_suite,
             expectation_suite_name=expectation_suite_name,
             include_citation=include_citation,
@@ -784,13 +882,19 @@ class BaseRuleBasedProfiler(ConfigPeer):
             rule.name: rule.to_json_dict() for rule in profiler.rules
         }
 
-        result: ExpectationSuite = profiler.run(
+        profiler.run(
             variables=None,
             rules=rules,
             batch_list=batch_list,
             batch_request=batch_request,
             force_batch_data=True,
             reconciliation_directives=BaseRuleBasedProfiler.DEFAULT_RECONCILATION_DIRECTIVES,
+            expectation_suite=expectation_suite,
+            expectation_suite_name=expectation_suite_name,
+            include_citation=include_citation,
+        )
+
+        result: ExpectationSuite = profiler.expectation_suite(
             expectation_suite=expectation_suite,
             expectation_suite_name=expectation_suite_name,
             include_citation=include_citation,
@@ -998,6 +1102,10 @@ class BaseRuleBasedProfiler(ConfigPeer):
     @rules.setter
     def rules(self, value: List[Rule]):
         self._rules = value
+
+    @property
+    def rule_states(self) -> List[RuleState]:
+        return self._rule_states
 
     def to_json_dict(self) -> dict:
         rule: Rule

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -351,11 +351,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         expectation_configurations: List[
             ExpectationConfiguration
-        ] = self.expectation_configurations(
-            batch_list=batch_list,
-            batch_request=batch_request,
-            force_batch_data=force_batch_data,
-        )
+        ] = self.expectation_configurations()
 
         expectation_configuration: ExpectationConfiguration
         for expectation_configuration in expectation_configurations:
@@ -368,18 +364,8 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         return expectation_suite
 
-    def expectation_configurations(
-        self,
-        batch_list: Optional[List[Batch]] = None,
-        batch_request: Optional[Union[BatchRequestBase, dict]] = None,
-        force_batch_data: bool = False,
-    ) -> List[ExpectationConfiguration]:
+    def expectation_configurations(self) -> List[ExpectationConfiguration]:
         """
-        Args:
-            batch_list: Explicit list of Batch objects to supply data at runtime.
-            batch_request: Explicit batch_request used to supply data at runtime.
-            force_batch_data: Whether or not to overwrite any existing batch_request value in Builder components.
-
         Returns:
             List of ExpectationConfiguration objects, accumulated from RuleState of every Rule executed.
         """
@@ -389,13 +375,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         rule_output: RuleOutput
         for rule_state in self.rule_states:
             rule_output = RuleOutput(rule_state=rule_state)
-            expectation_configurations.extend(
-                rule_output.expectation_configurations(
-                    batch_list=batch_list,
-                    batch_request=batch_request,
-                    force_batch_data=force_batch_data,
-                )
-            )
+            expectation_configurations.extend(rule_output.expectation_configurations())
 
         return expectation_configurations
 

--- a/great_expectations/rule_based_profiler/types/__init__.py
+++ b/great_expectations/rule_based_profiler/types/__init__.py
@@ -22,3 +22,4 @@ from .parameter_container import (  # isort:skip
     get_parameter_values_for_fully_qualified_parameter_names,
     get_fully_qualified_parameter_names,
 )
+from .rule_state import RuleState  # isort:skip

--- a/great_expectations/rule_based_profiler/types/rule_state.py
+++ b/great_expectations/rule_based_profiler/types/rule_state.py
@@ -1,0 +1,104 @@
+from typing import Dict, List, Optional
+
+import great_expectations.exceptions as ge_exceptions
+from great_expectations.rule_based_profiler.types import Domain, ParameterContainer
+
+
+class RuleState:
+    def __init__(
+        self,
+        rule: "Rule",  # noqa: F821
+        domains: Optional[List[Domain]] = None,
+        variables: Optional[ParameterContainer] = None,
+        parameters: Optional[Dict[str, ParameterContainer]] = None,
+    ):
+        self._rule = rule
+
+        if domains is None:
+            domains = []
+
+        self._domains = domains
+
+        self._variables = variables
+
+        if parameters is None:
+            parameters = {}
+
+        self._parameters = parameters
+
+    @property
+    def rule(self) -> "Rule":  # noqa: F821:
+        return self._rule
+
+    @property
+    def domains(self) -> List[Domain]:
+        return self._domains
+
+    @domains.setter
+    def domains(self, value: Optional[List[Domain]]) -> None:
+        self._domains = value
+
+    @property
+    def variables(self) -> Optional[ParameterContainer]:
+        return self._variables
+
+    @property
+    def parameters(self) -> Dict[str, ParameterContainer]:
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, value: Optional[Dict[str, ParameterContainer]]) -> None:
+        self._parameters = value
+
+    def reset(self) -> None:
+        self.reset_domains()
+        self.reset_parameter_containers()
+
+    def reset_domains(self) -> None:
+        self.domains = []
+
+    def reset_parameter_containers(self) -> None:
+        self.parameters = {}
+
+    def add_domain(
+        self,
+        domain: Domain,
+        allow_duplicates: bool = False,
+    ) -> None:
+        domain_cursor: Domain
+        if not allow_duplicates and domain.id in [
+            domain_cursor.id for domain_cursor in self.domains
+        ]:
+            raise ge_exceptions.ProfilerConfigurationError(
+                f"""Error: Domain\n{domain}\nalready exists.  In order to add it, either pass "allow_duplicates=True" \
+or call "RuleState.remove_domain_if_exists()" with Domain having ID equal to "{domain.id}" as argument first.
+"""
+            )
+        self.domains.append(domain)
+
+    def remove_domain_if_exists(self, domain: Domain) -> None:
+        domain_cursor: Domain
+        if domain.id in [domain_cursor.id for domain_cursor in self.domains]:
+            self.domains.remove(domain)
+            self.remove_domain_if_exists(domain=domain)
+
+    def initialize_parameter_container_for_domain(
+        self,
+        domain: Domain,
+        overwrite: bool = True,
+    ) -> None:
+        if not overwrite and domain.id in self.parameters:
+            raise ge_exceptions.ProfilerConfigurationError(
+                f"""Error: ParameterContainer for Domain\n{domain}\nalready exists.  In order to overwrite it, either \
+pass "overwrite=True" or call "RuleState.remove_parameter_container_from_domain()" with Domain having ID equal to \
+"{domain.id}" as argument first.
+"""
+            )
+
+        parameter_container: ParameterContainer = ParameterContainer(
+            parameter_nodes=None
+        )
+        self._parameters[domain.id] = parameter_container
+
+    def remove_parameter_container_from_domain_if_exists(self, domain: Domain) -> None:
+        self.parameters.pop(domain.id, None)

--- a/great_expectations/rule_based_profiler/types/rule_state.py
+++ b/great_expectations/rule_based_profiler/types/rule_state.py
@@ -15,25 +15,25 @@ class RuleState:
     def __init__(
         self,
         rule: "Rule",  # noqa: F821
-        domains: Optional[List[Domain]] = None,
         variables: Optional[ParameterContainer] = None,
+        domains: Optional[List[Domain]] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
     ):
         """
         Args:
             rule: Rule object for which present RuleState object corresponds (needed for various Rule properties).
-            domains: List of Domain objects, which DomainBuilder of associated Rule generated.
             variables: attribute name/value pairs (part of state, relevant for associated Rule).
+            domains: List of Domain objects, which DomainBuilder of associated Rule generated.
             parameters: Dictionary of ParameterContainer objects corresponding to all Domain objects in memory.
         """
         self._rule = rule
+
+        self._variables = variables
 
         if domains is None:
             domains = []
 
         self._domains = domains
-
-        self._variables = variables
 
         if parameters is None:
             parameters = {}
@@ -45,16 +45,16 @@ class RuleState:
         return self._rule
 
     @property
+    def variables(self) -> Optional[ParameterContainer]:
+        return self._variables
+
+    @property
     def domains(self) -> List[Domain]:
         return self._domains
 
     @domains.setter
     def domains(self, value: Optional[List[Domain]]) -> None:
         self._domains = value
-
-    @property
-    def variables(self) -> Optional[ParameterContainer]:
-        return self._variables
 
     @property
     def parameters(self) -> Dict[str, ParameterContainer]:

--- a/great_expectations/rule_based_profiler/types/rule_state.py
+++ b/great_expectations/rule_based_profiler/types/rule_state.py
@@ -5,6 +5,13 @@ from great_expectations.rule_based_profiler.types import Domain, ParameterContai
 
 
 class RuleState:
+    """
+    RuleState maintains state information, resulting from executing "Rule.run()" method by combining passed "Batch" data
+    with currently loaded configuration of "Rule" components ("DomainBuilder" object, "ParameterBuilder" objects, and
+    "ExpectationConfigurationBuilder" objects).  Using "RuleState" with correponding flags is sufficient for generating
+    outputs for different purposes (in raw and aggregated form) from available "Domain" objects and computed parameters.
+    """
+
     def __init__(
         self,
         rule: "Rule",  # noqa: F821
@@ -12,6 +19,13 @@ class RuleState:
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
     ):
+        """
+        Args:
+            rule: Rule object for which present RuleState object corresponds (needed for various Rule properties).
+            domains: List of Domain objects, which DomainBuilder of associated Rule generated.
+            variables: attribute name/value pairs (part of state, relevant for associated Rule).
+            parameters: Dictionary of ParameterContainer objects corresponding to all Domain objects in memory.
+        """
         self._rule = rule
 
         if domains is None:

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -463,11 +463,7 @@ class Validator:
             )
             expectation_configurations: List[
                 ExpectationConfiguration
-            ] = profiler.expectation_suite(
-                expectation_suite=None,
-                expectation_suite_name=None,
-                include_citation=True,
-            ).expectations
+            ] = profiler.expectation_configurations()
 
             configuration = expectation_configurations[0]
 

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -453,13 +453,20 @@ class Validator:
                 override_profiler_config=override_profiler_config,
             )
 
-            expectation_configurations: List[ExpectationConfiguration] = profiler.run(
+            profiler.run(
                 variables=None,
                 rules=None,
                 batch_list=list(self.batches.values()),
                 batch_request=None,
                 force_batch_data=False,
                 reconciliation_directives=BaseRuleBasedProfiler.DEFAULT_RECONCILATION_DIRECTIVES,
+            )
+            expectation_configurations: List[
+                ExpectationConfiguration
+            ] = profiler.expectation_suite(
+                batch_list=list(self.batches.values()),
+                batch_request=None,
+                force_batch_data=False,
                 expectation_suite=None,
                 expectation_suite_name=None,
                 include_citation=True,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -464,9 +464,6 @@ class Validator:
             expectation_configurations: List[
                 ExpectationConfiguration
             ] = profiler.expectation_suite(
-                batch_list=list(self.batches.values()),
-                batch_request=None,
-                force_batch_data=False,
                 expectation_suite=None,
                 expectation_suite_name=None,
                 include_citation=True,

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_basic_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_basic_workflows.py
@@ -134,7 +134,8 @@ def test_add_rule_and_run_profiler(data_context_with_taxi_data):
         data_context=context,
     )
     my_rbp.add_rule(rule=simple_rule)
-    res: ExpectationSuite = my_rbp.run()
+    my_rbp.run()
+    res: ExpectationSuite = my_rbp.expectation_suite()
     assert len(res.expectations) == 4
 
 
@@ -187,7 +188,8 @@ def test_profiler_parameter_builder_added(data_context_with_taxi_data):
         data_context=context,
     )
     my_rbp.add_rule(rule=simple_rule)
-    res: ExpectationSuite = my_rbp.run()
+    my_rbp.run()
+    res: ExpectationSuite = my_rbp.expectation_suite()
     assert len(res.expectations) == 4
 
 
@@ -367,7 +369,10 @@ def test_profiler_run_with_expectation_suite_arg(
     assert len(basic_expectation_suite.expectations) == 4
     assert basic_expectation_suite.expectations == existing_expectations
 
-    res: ExpectationSuite = my_rbp.run(expectation_suite=basic_expectation_suite)
+    my_rbp.run()
+    res: ExpectationSuite = my_rbp.expectation_suite(
+        expectation_suite=basic_expectation_suite
+    )
 
     assert id(res) == id(basic_expectation_suite)
     assert len(res.expectations) == 8

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
@@ -117,7 +117,8 @@ def test_alice_profiler_user_workflow_single_batch(
         data_context=data_context,
     )
 
-    expectation_suite: ExpectationSuite = profiler.run(
+    profiler.run()
+    expectation_suite: ExpectationSuite = profiler.expectation_suite(
         expectation_suite_name=alice_columnar_table_single_batch[
             "expected_expectation_suite_name"
         ],
@@ -444,7 +445,8 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
         data_context=data_context,
     )
 
-    profiled_expectation_suite: ExpectationSuite = profiler.run(
+    profiler.run()
+    profiled_expectation_suite: ExpectationSuite = profiler.expectation_suite(
         expectation_suite_name=bobby_columnar_table_multi_batch[
             "test_configuration_oneshot_estimator"
         ]["expectation_suite_name"],
@@ -1428,7 +1430,8 @@ def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstr
         data_context=data_context,
     )
 
-    expectation_suite: ExpectationSuite = profiler.run(
+    profiler.run()
+    expectation_suite: ExpectationSuite = profiler.expectation_suite(
         expectation_suite_name=bobster_columnar_table_multi_batch_normal_mean_5000_stdev_1000[
             "test_configuration_bootstrap_estimator"
         ][
@@ -1611,7 +1614,8 @@ def test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule(
         data_context=data_context,
     )
 
-    expectation_suite: ExpectationSuite = profiler.run(
+    profiler.run()
+    expectation_suite: ExpectationSuite = profiler.expectation_suite(
         expectation_suite_name=quentin_columnar_table_multi_batch["test_configuration"][
             "expectation_suite_name"
         ],

--- a/tests/integration/profiling/rule_based_profilers/test_rule_based_profiler.py
+++ b/tests/integration/profiling/rule_based_profilers/test_rule_based_profiler.py
@@ -151,7 +151,8 @@ def test_profile_includes_citations(
         data_context=data_context,
     )
 
-    expectation_suite: ExpectationSuite = profiler.run(
+    profiler.run()
+    expectation_suite: ExpectationSuite = profiler.expectation_suite(
         expectation_suite_name=alice_columnar_table_single_batch[
             "expected_expectation_suite_name"
         ],
@@ -199,7 +200,8 @@ def test_profile_excludes_citations(
         data_context=data_context,
     )
 
-    expectation_suite: ExpectationSuite = profiler.run(
+    profiler.run()
+    expectation_suite: ExpectationSuite = profiler.expectation_suite(
         expectation_suite_name=alice_columnar_table_single_batch[
             "expected_expectation_suite_name"
         ],

--- a/tests/rule_based_profiler/conftest.py
+++ b/tests/rule_based_profiler/conftest.py
@@ -17,6 +17,7 @@ from great_expectations.rule_based_profiler.types import (
     Domain,
     ParameterContainer,
     ParameterNode,
+    RuleState,
 )
 
 yaml = YAML()
@@ -477,12 +478,18 @@ def variables_multi_part_name_parameter_container():
     return variables
 
 
+# noinspection PyPep8Naming
 @pytest.fixture
-def rule_without_parameters(
+def rule_without_variables(
     empty_data_context,
+    column_Age_domain,
+    column_Date_domain,
+    variables_multi_part_name_parameter_container,
+    single_part_name_parameter_container,
+    multi_part_name_parameter_container,
 ):
     rule: Rule = Rule(
-        name="rule_with_no_variables_no_parameters",
+        name="rule_without_variables",
         domain_builder=ColumnDomainBuilder(data_context=empty_data_context),
         expectation_configuration_builders=[
             DefaultExpectationConfigurationBuilder(
@@ -495,28 +502,25 @@ def rule_without_parameters(
 
 # noinspection PyPep8Naming
 @pytest.fixture
-def rule_with_parameters(
-    empty_data_context,
+def rule_state_with_domains_and_parameters(
+    rule_without_variables,
     column_Age_domain,
     column_Date_domain,
-    variables_multi_part_name_parameter_container,
     single_part_name_parameter_container,
     multi_part_name_parameter_container,
 ):
-    rule: Rule = Rule(
-        name="rule_with_parameters",
-        domain_builder=ColumnDomainBuilder(data_context=empty_data_context),
-        expectation_configuration_builders=[
-            DefaultExpectationConfigurationBuilder(
-                expectation_type="expect_my_validation"
-            )
+    rule_state: RuleState = RuleState(
+        rule=rule_without_variables,
+        domains=[
+            column_Age_domain,
+            column_Date_domain,
         ],
+        parameters={
+            column_Age_domain.id: single_part_name_parameter_container,
+            column_Date_domain.id: multi_part_name_parameter_container,
+        },
     )
-    rule._parameters = {
-        column_Age_domain.id: single_part_name_parameter_container,
-        column_Date_domain.id: multi_part_name_parameter_container,
-    }
-    return rule
+    return rule_state
 
 
 @pytest.fixture

--- a/tests/rule_based_profiler/test_rule.py
+++ b/tests/rule_based_profiler/test_rule.py
@@ -12,7 +12,7 @@ from great_expectations.rule_based_profiler.types import (
 def test_get_parameter_value_by_fully_qualified_parameter_name_invalid_parameter_name(
     column_Age_domain,
     variables_multi_part_name_parameter_container,
-    rule_with_parameters,
+    rule_state_with_domains_and_parameters,
 ):
     with pytest.raises(
         ge_exceptions.ProfilerExecutionError, match=r".+start with \$.*"
@@ -22,7 +22,7 @@ def test_get_parameter_value_by_fully_qualified_parameter_name_invalid_parameter
             fully_qualified_parameter_name="mean",
             domain=column_Age_domain,
             variables=variables_multi_part_name_parameter_container,
-            parameters=rule_with_parameters.parameters,
+            parameters=rule_state_with_domains_and_parameters.parameters,
         )
 
 
@@ -293,7 +293,7 @@ def test_get_parameter_value_by_fully_qualified_parameter_name_invalid_parameter
 def test_get_parameter_value_by_fully_qualified_parameter_name_valid_parameter_name(
     column_Age_domain,
     column_Date_domain,
-    rule_with_parameters,
+    rule_state_with_domains_and_parameters,
     variables_multi_part_name_parameter_container,
     domain_name,
     fully_qualified_parameter_name,
@@ -329,7 +329,7 @@ def test_get_parameter_value_by_fully_qualified_parameter_name_valid_parameter_n
             fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
             domain=domain,
             variables=variables_multi_part_name_parameter_container,
-            parameters=rule_with_parameters.parameters,
+            parameters=rule_state_with_domains_and_parameters.parameters,
         )
         == value
     )
@@ -344,7 +344,7 @@ def test_get_parameter_value_by_fully_qualified_parameter_name_valid_parameter_n
                 fully_qualified_parameter_name=fully_qualified_parameter_name_for_details,
                 domain=domain,
                 variables=variables_multi_part_name_parameter_container,
-                parameters=rule_with_parameters.parameters,
+                parameters=rule_state_with_domains_and_parameters.parameters,
             )
             == details
         )

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -918,6 +918,15 @@ def test_run_profiler_without_dynamic_args(
     assert mock_profiler_run.call_args == mock.call(
         variables=None,
         rules=None,
+        batch_list=None,
+        batch_request=None,
+        force_batch_data=False,
+        reconciliation_directives=ReconciliationDirectives(
+            variables=ReconciliationStrategy.UPDATE,
+            domain_builder=ReconciliationStrategy.UPDATE,
+            parameter_builder=ReconciliationStrategy.UPDATE,
+            expectation_configuration_builder=ReconciliationStrategy.UPDATE,
+        ),
         expectation_suite=None,
         expectation_suite_name=None,
         include_citation=True,
@@ -952,6 +961,15 @@ def test_run_profiler_with_dynamic_args(
     assert mock_profiler_run.call_args == mock.call(
         variables=variables,
         rules=rules,
+        batch_list=None,
+        batch_request=None,
+        force_batch_data=False,
+        reconciliation_directives=ReconciliationDirectives(
+            variables=ReconciliationStrategy.UPDATE,
+            domain_builder=ReconciliationStrategy.UPDATE,
+            parameter_builder=ReconciliationStrategy.UPDATE,
+            expectation_configuration_builder=ReconciliationStrategy.UPDATE,
+        ),
         expectation_suite=None,
         expectation_suite_name=expectation_suite_name,
         include_citation=include_citation,
@@ -1349,7 +1367,8 @@ def test_run_with_expectation_suite_arg(mock_data_context: mock.MagicMock):
     suite: ExpectationSuite = ExpectationSuite(
         expectation_suite_name="my_expectation_suite"
     )
-    result_suite: ExpectationSuite = profiler.run(expectation_suite=suite)
+    profiler.run()
+    result_suite: ExpectationSuite = profiler.expectation_suite(expectation_suite=suite)
 
     assert id(suite) == id(result_suite)
 
@@ -1366,7 +1385,8 @@ def test_run_with_conflicting_expectation_suite_args_raises_error(
     )
 
     with pytest.raises(AssertionError) as e:
-        profiler.run(
+        profiler.run()
+        suite = profiler.expectation_suite(
             expectation_suite=suite, expectation_suite_name="my_expectation_suite"
         )
 

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb
@@ -103,7 +103,7 @@
     {
      "data": {
       "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x140448b80>"
+       "<great_expectations.datasource.new_datasource.Datasource at 0x133d5a370>"
       ]
      },
      "execution_count": 3,
@@ -242,7 +242,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "11cdfef5de0e4c04bf3bddfaafd64ad5",
+       "model_id": "83d950d908324acd981c9605eaa0bbc6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -256,7 +256,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e0c41734b39446b685f556692fae61fc",
+       "model_id": "c027e5c1961146e1bffdce0623187a7d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -373,13 +373,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f80363e75e5b46c7bab37c6c2f899d8b",
+       "model_id": "865068c640d44f468656083b4f93953b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -393,7 +393,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a45b0daba4ef4a00b3d62959cfae2383",
+       "model_id": "2f044a5521c148d3b5527db9d73dbdf7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -406,12 +406,21 @@
     }
    ],
    "source": [
-    "res: ExpectationSuite = my_rbp.run()"
+    "my_rbp.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res: ExpectationSuite = my_rbp.expectation_suite()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,19 +429,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"fare_amount\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"tip_amount\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"tolls_amount\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_not_be_null\", \"meta\": {}, \"kwargs\": {\"column\": \"total_amount\"}}]"
+       "[{\"kwargs\": {\"column\": \"fare_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\"},\n",
+       " {\"kwargs\": {\"column\": \"tip_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\"},\n",
+       " {\"kwargs\": {\"column\": \"tolls_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\"},\n",
+       " {\"kwargs\": {\"column\": \"total_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_not_be_null\"}]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,13 +474,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2be643d803de437b9a0b7eaa1892698b",
+       "model_id": "15785fa8779a4b2598def1c4cd12caeb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -485,7 +494,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c3eff516c6bb4758b9961125c395959b",
+       "model_id": "9699291270f14142a8d2b100ec271f02",
        "version_major": 2,
        "version_minor": 0
       },
@@ -508,7 +517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -540,7 +549,7 @@
        " }]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -583,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,12 +667,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_rbp = RuleBasedProfiler(name=\"my_rbp\", data_context=data_context\n",
-    "                           , config_version=1.0)\n"
+    "my_rbp = RuleBasedProfiler(name=\"my_rbp\", data_context=data_context, config_version=1.0)\n"
    ]
   },
   {
@@ -675,7 +683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,13 +692,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18a76d6314e64f79b09dbc4bdb09407a",
+       "model_id": "71aa8775d0644ad5ba514d2a59d0630d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -704,7 +712,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d50ce13e0a0a4f28a82a2a8a88363c65",
+       "model_id": "9664b8360c854a68a3c3f46aaed46199",
        "version_major": 2,
        "version_minor": 0
       },
@@ -718,7 +726,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "20568cc10b27415fb29774b8fab652c2",
+       "model_id": "b4298dff347d40de833920d96572ec9a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -732,7 +740,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6e45fd45db804663917cb7cb4ae8bb4d",
+       "model_id": "1b15f21d3802450d88653c2ef1248442",
        "version_major": 2,
        "version_minor": 0
       },
@@ -746,7 +754,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f0240523f35f4f5d97832d4dddaac31c",
+       "model_id": "db2faada794d4e2ca42576866dd35bad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -760,7 +768,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "96fd31c4afff404da8e38ddcf66d6b4e",
+       "model_id": "d932ff958e68463bafb9e500fa0d70b1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -773,12 +781,21 @@
     }
    ],
    "source": [
-    "res: ExpectationSuite = my_rbp.run()"
+    "my_rbp.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res: ExpectationSuite = my_rbp.expectation_suite()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,19 +804,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"value\": -80.0, \"column\": \"fare_amount\", \"name\": \"my_column_min\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"value\": 0.0, \"column\": \"tip_amount\", \"name\": \"my_column_min\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"value\": 0.0, \"column\": \"tolls_amount\", \"name\": \"my_column_min\"}},\n",
-       " {\"expectation_type\": \"expect_column_values_to_be_greater_than\", \"meta\": {}, \"kwargs\": {\"value\": -80.3, \"column\": \"total_amount\", \"name\": \"my_column_min\"}}]"
+       "[{\"kwargs\": {\"value\": -80.0, \"name\": \"my_column_min\", \"column\": \"fare_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\"},\n",
+       " {\"kwargs\": {\"value\": 0.0, \"name\": \"my_column_min\", \"column\": \"tip_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\"},\n",
+       " {\"kwargs\": {\"value\": 0.0, \"name\": \"my_column_min\", \"column\": \"tolls_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\"},\n",
+       " {\"kwargs\": {\"value\": -80.3, \"name\": \"my_column_min\", \"column\": \"total_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_values_to_be_greater_than\"}]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -856,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -878,7 +895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -896,7 +913,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -933,7 +950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,7 +959,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -959,7 +976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -997,7 +1014,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1011,7 +1028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1039,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1053,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1062,13 +1079,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe9e1e813443479a9432cfc8d6a487f0",
+       "model_id": "9afb0488a1ab4feb98bbcdb89dbe462e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1082,7 +1099,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "039b27967fed463ebb5696b13ebdc965",
+       "model_id": "0c936d7643d94397bc3a24a3e25717d2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1096,7 +1113,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "840360e0c5bd455e859328ed4fd8c979",
+       "model_id": "2411be93f1e24910ba01ce0467bd6f63",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1118,7 +1135,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c599c430b6e94e8496a2b832bdab6071",
+       "model_id": "2dc79cfa9a1849efbe0534e7582df853",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1132,7 +1149,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "70c1976b152e4ccb9130b4dcf32fbe25",
+       "model_id": "8747860f52494d248ad3caf221b83018",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1146,7 +1163,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "726f57edaae1483393c9f0e29069097d",
+       "model_id": "c818a1cc62384888ba8aa56c263c926f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1159,24 +1176,33 @@
     }
    ],
    "source": [
-    "res: ExpectationSuite = my_rbp.run()"
+    "my_rbp.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res: ExpectationSuite = my_rbp.expectation_suite()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{\"expectation_type\": \"expect_column_min_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"tip_amount\", \"max_value\": 0.0, \"min_value\": -1.66025}},\n",
-       " {\"expectation_type\": \"expect_column_max_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"tip_amount\", \"max_value\": 156.751423992, \"min_value\": 34.4595}},\n",
-       " {\"expectation_type\": \"expect_column_min_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"fare_amount\", \"max_value\": -4.326149365, \"min_value\": -94.5}},\n",
-       " {\"expectation_type\": \"expect_column_max_to_be_between\", \"meta\": {}, \"kwargs\": {\"column\": \"fare_amount\", \"max_value\": 235818.585662816, \"min_value\": 167.375}}]"
+       "[{\"kwargs\": {\"min_value\": -1.66025, \"max_value\": 0.0, \"column\": \"tip_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_min_to_be_between\"},\n",
+       " {\"kwargs\": {\"min_value\": 34.4595, \"max_value\": 156.302170192, \"column\": \"tip_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_max_to_be_between\"},\n",
+       " {\"kwargs\": {\"min_value\": -94.5, \"max_value\": -4.313232073, \"column\": \"fare_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_min_to_be_between\"},\n",
+       " {\"kwargs\": {\"min_value\": 167.375, \"max_value\": 233861.61819782, \"column\": \"fare_amount\"}, \"meta\": {}, \"expectation_type\": \"expect_column_max_to_be_between\"}]"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1224,7 +1250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1240,13 +1266,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0f07405977b44839a97537ce95c8fd6b",
+       "model_id": "8edfd315a33247bd8c9acda286034068",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1260,7 +1286,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a83604f9ddca4e7899b4958ccb816105",
+       "model_id": "44a499ad09354a76811848cc3ff3ed84",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1290,13 +1316,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9376d0b00e174b38b67a79c9fe1b9a05",
+       "model_id": "881f0e4186f348ad8f28dd3da4cc47bb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1310,7 +1336,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b2523303bc13463baddce119b33f056e",
+       "model_id": "f2583d125bfb472d95c997f35cd21c62",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1332,7 +1358,7 @@
        " }]"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1349,13 +1375,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "332e8b3608874a1fbd403b345c76e074",
+       "model_id": "316c8d52324d4704b024a33343c8427e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1369,7 +1395,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "257eb68de4c64ef5895800cba497c419",
+       "model_id": "2e6b1b82bbbf4e1ea253757ccbc4ab2d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1393,7 +1419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -1503,7 +1529,7 @@
        " }]"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1521,7 +1547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1534,13 +1560,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "32aa47e93f944bdebb26d3ea6a5f5a2f",
+       "model_id": "99ab341990f94a18af46962a2f9704e6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1554,7 +1580,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d544d780dc3540b6b046a4139dbb9b29",
+       "model_id": "95633d8bafde42f6ae108617554e3f08",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1582,7 +1608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1591,13 +1617,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e30a7802f0840769a7f8a6e527141fd",
+       "model_id": "723d15ac8765408ea9ae45335ebc7190",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1611,7 +1637,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d2c8afcc148f4644b76dc39bb4d230dd",
+       "model_id": "001d0b49dfd34b5499f15a90d5364e49",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1635,7 +1661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1644,11 +1670,91 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
     "assert domains[0][\"domain_kwargs\"][\"column_list\"] == expected_columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**`ColumnPairDomainBuilder`**\n",
+    "\n",
+    "This DomainBuilder outputs columnpair domains by taking in a column pair list in the include_column_names parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from great_expectations.rule_based_profiler.domain_builder import ColumnPairDomainBuilder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "07e1ea053f20443db26ab5c2a9035f0b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "91107073bf3148f9b756685a148129bb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "domain_builder: DomainBuilder = ColumnPairDomainBuilder(\n",
+    "    include_column_names=[\"vendor_id\", \"fare_amount\"],\n",
+    "    batch_request=single_batch_batch_request,\n",
+    "    data_context=data_context,\n",
+    ")\n",
+    "domains: list = domain_builder.get_domains()\n",
+    "assert len(domains) == 1 # 2 columns are part of a single multi-column domain. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expect_columns_dict: dict = {'column_A': 'fare_amount', 'column_B': 'vendor_id'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert domains[0][\"domain_kwargs\"] == expect_columns_dict"
    ]
   },
   {
@@ -1661,7 +1767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1670,7 +1776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -1681,7 +1787,7 @@
        " }]"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1711,7 +1817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1720,13 +1826,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8a0bb10b87984a2f9af834f0ad90711e",
+       "model_id": "44eb10eb254143e996adffb64ad752a4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1740,7 +1846,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b56c4801e84143458bcefb19d90272a5",
+       "model_id": "6b18c180bb4649a397ed025c01e8b3ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1754,7 +1860,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f963f6b6543743d28fe4cf9c9361864e",
+       "model_id": "1a49709cf0714f4db87853c47022f33b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1768,7 +1874,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1da850a8507943619f066351ec7c1759",
+       "model_id": "558e3238bfd24793971a984d4149d0e7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1785,7 +1891,7 @@
        "True"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1818,7 +1924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1827,7 +1933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1840,7 +1946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 63,
    "metadata": {
     "scrolled": true
    },
@@ -1848,7 +1954,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "21d991915d6a402fa0ca99603a589cdc",
+       "model_id": "85f01ea6931c4cf2b43469ae758e2b21",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1862,7 +1968,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5c97b163fbe546519953358b74d54c99",
+       "model_id": "590e088c88824b8496fa1379610e1e5b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1876,7 +1982,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a2c433b6c90c4ad69896edecf4ac9418",
+       "model_id": "25183fabc1fd423dad35b2eb8152cbdb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1911,7 +2017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1922,7 +2028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1945,7 +2051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1954,7 +2060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1971,7 +2077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1980,7 +2086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1991,13 +2097,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "69ff1d802bef461dbf2800b13682b8a3",
+       "model_id": "20deae2abf40415596c53d348786c04e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2027,7 +2133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -2036,7 +2142,7 @@
        "-100.8"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2121,7 +2227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 77,
    "metadata": {
     "scrolled": true
    },
@@ -2129,7 +2235,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "564e69c6ceee4ebd88303644c6e1efae",
+       "model_id": "0624da70f59043b0b117fd82768351dd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2150,7 +2256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -2188,7 +2294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2197,7 +2303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2213,7 +2319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2222,7 +2328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2231,7 +2337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2247,13 +2353,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "77cca963e7904082b3121aa2e8a82961",
+       "model_id": "c92899f41b6f47849c2db14914673ecf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2267,7 +2373,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f5a6c2fd748849e1bf5c44cbadc015dd",
+       "model_id": "b0fb97c5edd0436cb8c5dc413b7a82d3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2296,14 +2402,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'parameter': {'parameter': {'my_regex_set': {'value': None, 'details': {'success_ratio': 0.0, 'evaluated_regexes': {'\\\\s+/$': 0.0, '/[A-Za-z0-9\\\\.,;:!?()\\\\\"\\'%\\\\-]+/': 0.0, '/-?\\\\d+/': 0.0, '/-?\\\\d+(\\\\.\\\\d*)?/': 0.0, '\\\\b[0-9a-fA-F]{8}\\\\b-[0-9a-fA-F]{4}-[0-5][0-9a-fA-F]{3}-[089ab][0-9a-fA-F]{3}-\\\\b[0-9a-fA-F]{12}\\\\b ': 0.0, '^\\\\s+/': 0.0, '/https?:\\\\/\\\\/(www\\\\.)?[-a-zA-Z0-9@:%._\\\\+~#=]{2,256}\\\\.[a-z]{2,6}\\\\b([-a-zA-Z0-9@:%_\\\\+.~#()?&//=]*)/': 0.0, '/\\\\d+/': 0.0, '/(?:25[0-5]|2[0-4]\\\\d|[01]\\\\d{2}|\\\\d{1,2})(?:.(?:25[0-5]|2[0-4]\\\\d|[01]\\\\d{2}|\\\\d{1,2})){3}/': 0.0, '/(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}/': 0.0, '/<\\\\/?(?:p|a|b|img)(?: \\\\/)?>/': 0.0}}}}}}\n"
+      "{'parameter': {'parameter': {'my_regex_set': {'value': None, 'details': {'success_ratio': 0.0, 'evaluated_regexes': {'/https?:\\\\/\\\\/(www\\\\.)?[-a-zA-Z0-9@:%._\\\\+~#=]{2,256}\\\\.[a-z]{2,6}\\\\b([-a-zA-Z0-9@:%_\\\\+.~#()?&//=]*)/': 0.0, '\\\\b[0-9a-fA-F]{8}\\\\b-[0-9a-fA-F]{4}-[0-5][0-9a-fA-F]{3}-[089ab][0-9a-fA-F]{3}-\\\\b[0-9a-fA-F]{12}\\\\b ': 0.0, '/(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}/': 0.0, '/-?\\\\d+/': 0.0, '/-?\\\\d+(\\\\.\\\\d*)?/': 0.0, '/<\\\\/?(?:p|a|b|img)(?: \\\\/)?>/': 0.0, '/\\\\d+/': 0.0, '/[A-Za-z0-9\\\\.,;:!?()\\\\\"\\'%\\\\-]+/': 0.0, '\\\\s+/$': 0.0, '^\\\\s+/': 0.0, '/(?:25[0-5]|2[0-4]\\\\d|[01]\\\\d{2}|\\\\d{1,2})(?:.(?:25[0-5]|2[0-4]\\\\d|[01]\\\\d{2}|\\\\d{1,2})){3}/': 0.0}}}}}}\n"
      ]
     }
    ],
@@ -2320,7 +2426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2337,38 +2443,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 87,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "07b44d53e5874a299fd749ad202abb79",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculating Metrics:   0%|          | 0/6 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "83b2783892d0419e9a0c025c330875fd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculating Metrics:   0%|          | 0/5 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "regex_parameter_builder.build_parameters(\n",
     "    domain=domain,\n",
@@ -2378,14 +2455,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'parameter': {'parameter': {'my_regex_set': {'value': '^\\\\d{1}$', 'details': {'success_ratio': 1.0, 'evaluated_regexes': {'^\\\\d{1}$': 1.0}}}}}}\n"
+      "{'parameter': {'parameter': {'my_regex_set': {'value': None, 'details': {'success_ratio': 0.0, 'evaluated_regexes': {'/https?:\\\\/\\\\/(www\\\\.)?[-a-zA-Z0-9@:%._\\\\+~#=]{2,256}\\\\.[a-z]{2,6}\\\\b([-a-zA-Z0-9@:%_\\\\+.~#()?&//=]*)/': 0.0, '\\\\b[0-9a-fA-F]{8}\\\\b-[0-9a-fA-F]{4}-[0-5][0-9a-fA-F]{3}-[089ab][0-9a-fA-F]{3}-\\\\b[0-9a-fA-F]{12}\\\\b ': 0.0, '/(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}/': 0.0, '/-?\\\\d+/': 0.0, '/-?\\\\d+(\\\\.\\\\d*)?/': 0.0, '/<\\\\/?(?:p|a|b|img)(?: \\\\/)?>/': 0.0, '/\\\\d+/': 0.0, '/[A-Za-z0-9\\\\.,;:!?()\\\\\"\\'%\\\\-]+/': 0.0, '\\\\s+/$': 0.0, '^\\\\s+/': 0.0, '/(?:25[0-5]|2[0-4]\\\\d|[01]\\\\d{2}|\\\\d{1,2})(?:.(?:25[0-5]|2[0-4]\\\\d|[01]\\\\d{2}|\\\\d{1,2})){3}/': 0.0}}}}}}\n"
      ]
     }
    ],
@@ -2416,7 +2493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2425,7 +2502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2434,7 +2511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2443,7 +2520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2452,7 +2529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2468,13 +2545,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8aaf155eb1ba42ebb7253e38bde1f0ef",
+       "model_id": "b3eb7dd6794546ab84c2d397b33a2c44",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2488,7 +2565,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6fbadce0529d45b3b51a3bdcf13c0372",
+       "model_id": "7314932108d446c3b5f27388844ffca4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2509,14 +2586,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'parameter': {'parameter': {'my_value_set': {'value': '%Y-%m-%d %H:%M:%S', 'details': {'success_ratio': 1.0, 'candidate_strings': {'%Y-%m-%d %H:%M:%S': 1.0, '%y/%m/%d': 0.0, '%d-%b-%Y %H:%M:%S': 0.0, '%b %d %H:%M:%S %z': 0.0, '%m/%d/%y %H:%M:%S %z': 0.0, \"%Y-%m-%d'T'%H:%M:%S'%z'\": 0.0, '%d-%b-%Y %H:%M:%S.%f': 0.0, '%Y-%m-%d %H:%M:%S,%f%z': 0.0, '%m/%d/%y*%H:%M:%S': 0.0, '%m/%d/%Y %H:%M:%S %p': 0.0, '%d/%b %H:%M:%S,%f': 0.0, '%H:%M:%S.%f': 0.0, '%m/%d/%Y %H:%M:%S %p:%f': 0.0, '%d/%b/%Y:%H:%M:%S': 0.0, '%Y-%m-%d %H:%M:%S,%f': 0.0, '%m/%d/%Y': 0.0, '%m%d_%H:%M:%S': 0.0, '%Y %b %d %H:%M:%S.%f %Z': 0.0, '%m/%d/%Y %H:%M:%S %z': 0.0, \"%Y-%m-%d'T'%H:%M:%S%z\": 0.0, '%d/%m/%Y': 0.0, '%y-%m-%d %H:%M:%S,%f %z': 0.0, '%H:%M:%S': 0.0, '%d/%b/%Y %H:%M:%S': 0.0, '%Y/%m/%d*%H:%M:%S': 0.0, '%Y-%m-%d %H:%M:%S.%f': 0.0, '%Y %b %d %H:%M:%S.%f': 0.0, '%y-%m-%d %H:%M:%S': 0.0, '%Y-%m-%d %H:%M:%S %z': 0.0, '%m%d_%H:%M:%S.%f': 0.0, '%b %d %H:%M:%S': 0.0, '%m/%d/%Y*%H:%M:%S': 0.0, '%y%m%d %H:%M:%S': 0.0, '%Y-%m-%d*%H:%M:%S:%f': 0.0, '%Y-%m-%d %H:%M:%S%z': 0.0, '%y-%m-%d': 0.0, '%b %d %H:%M:%S %z %Y': 0.0, '%Y-%m-%d %H:%M:%S.%f%z': 0.0, '%y-%m-%d %H:%M:%S,%f': 0.0, '%Y-%m-%d': 0.0, '%d %b %Y %H:%M:%S': 0.0, '%m-%d-%Y': 0.0, '%Y/%m/%d': 0.0, '%Y %b %d %H:%M:%S.%f*%Z': 0.0, '%d %b %Y %H:%M:%S*%f': 0.0, \"%Y-%m-%d'T'%H:%M:%S\": 0.0, '%Y-%m-%dT%z': 0.0, '%b %d %Y %H:%M:%S': 0.0, \"%Y-%m-%d'T'%H:%M:%S.%f'%z'\": 0.0, \"%Y-%m-%d'T'%H:%M:%S.%f\": 0.0, '%d/%b/%Y:%H:%M:%S %z': 0.0, '%b %d, %Y %H:%M:%S %p': 0.0, '%Y-%m-%d*%H:%M:%S': 0.0, '%Y%m%d %H:%M:%S.%f': 0.0, '%m/%d/%Y*%H:%M:%S*%f': 0.0, '%H:%M:%S,%f': 0.0, '%d-%m-%Y': 0.0, '%b %d %H:%M:%S %Y': 0.0, '%y/%m/%d %H:%M:%S': 0.0}}}}}}\n"
+      "{'parameter': {'parameter': {'my_value_set': {'value': '%Y-%m-%d %H:%M:%S', 'details': {'success_ratio': 1.0, 'candidate_strings': {'%Y-%m-%d %H:%M:%S': 1.0, '%Y/%m/%d*%H:%M:%S': 0.0, '%m-%d-%Y': 0.0, '%m/%d/%y*%H:%M:%S': 0.0, '%d-%b-%Y %H:%M:%S.%f': 0.0, '%m/%d/%Y %H:%M:%S %z': 0.0, '%Y%m%d %H:%M:%S.%f': 0.0, '%b %d %H:%M:%S %z %Y': 0.0, '%y/%m/%d %H:%M:%S': 0.0, '%y-%m-%d %H:%M:%S,%f %z': 0.0, '%m%d_%H:%M:%S.%f': 0.0, '%Y-%m-%d': 0.0, '%m/%d/%Y %H:%M:%S %p:%f': 0.0, '%b %d %Y %H:%M:%S': 0.0, '%Y %b %d %H:%M:%S.%f*%Z': 0.0, '%Y-%m-%d %H:%M:%S %z': 0.0, '%H:%M:%S.%f': 0.0, '%b %d %H:%M:%S %Y': 0.0, '%m/%d/%Y': 0.0, '%y%m%d %H:%M:%S': 0.0, '%H:%M:%S,%f': 0.0, '%Y-%m-%d %H:%M:%S,%f': 0.0, '%m%d_%H:%M:%S': 0.0, '%Y-%m-%d %H:%M:%S%z': 0.0, '%y-%m-%d %H:%M:%S,%f': 0.0, '%d/%b/%Y:%H:%M:%S': 0.0, '%Y-%m-%d*%H:%M:%S:%f': 0.0, '%d %b %Y %H:%M:%S*%f': 0.0, '%b %d %H:%M:%S': 0.0, \"%Y-%m-%d'T'%H:%M:%S%z\": 0.0, '%d/%b/%Y:%H:%M:%S %z': 0.0, '%y-%m-%d': 0.0, '%m/%d/%Y %H:%M:%S %p': 0.0, '%m/%d/%Y*%H:%M:%S': 0.0, '%d %b %Y %H:%M:%S': 0.0, '%y-%m-%d %H:%M:%S': 0.0, '%Y-%m-%d %H:%M:%S.%f%z': 0.0, '%Y/%m/%d': 0.0, '%Y-%m-%d %H:%M:%S.%f': 0.0, '%Y-%m-%d %H:%M:%S,%f%z': 0.0, '%d/%b/%Y %H:%M:%S': 0.0, \"%Y-%m-%d'T'%H:%M:%S.%f'%z'\": 0.0, '%Y %b %d %H:%M:%S.%f': 0.0, '%d/%b %H:%M:%S,%f': 0.0, '%H:%M:%S': 0.0, \"%Y-%m-%d'T'%H:%M:%S'%z'\": 0.0, \"%Y-%m-%d'T'%H:%M:%S\": 0.0, '%Y %b %d %H:%M:%S.%f %Z': 0.0, '%m/%d/%y %H:%M:%S %z': 0.0, '%Y-%m-%d*%H:%M:%S': 0.0, '%y/%m/%d': 0.0, '%b %d, %Y %H:%M:%S %p': 0.0, \"%Y-%m-%d'T'%H:%M:%S.%f\": 0.0, '%d-%m-%Y': 0.0, '%d/%m/%Y': 0.0, '%Y-%m-%dT%z': 0.0, '%b %d %H:%M:%S %z': 0.0, '%m/%d/%Y*%H:%M:%S*%f': 0.0, '%d-%b-%Y %H:%M:%S': 0.0}}}}}}\n"
      ]
     }
    ],
@@ -2526,7 +2603,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -2535,7 +2612,7 @@
        "'%Y-%m-%d %H:%M:%S'"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2571,7 +2648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2580,7 +2657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2589,7 +2666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2598,7 +2675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2607,7 +2684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2625,13 +2702,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cb681f765d98430f863ee5adb3a51490",
+       "model_id": "20cdcf5da1d54d92bc11e0de28274635",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2652,14 +2729,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'parameter': {'parameter': {'column_mean_range': {'value': [16.0, 43.0], 'details': {'metric_configuration': {'metric_name': 'column.mean', 'domain_kwargs': {'column': 'total_amount'}, 'metric_value_kwargs': None, 'metric_dependencies': None}, 'num_batches': 12}}}}}\n"
+      "{'parameter': {'parameter': {'column_mean_range': {'value': [16.0, 44.0], 'details': {'metric_configuration': {'metric_name': 'column.mean', 'domain_kwargs': {'column': 'total_amount'}, 'metric_value_kwargs': None, 'metric_dependencies': None}, 'num_batches': 12}}}}}\n"
      ]
     }
    ],
@@ -2690,7 +2767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
### Scope
Up till now, Rule-Based Profiler (RBP) has been tasked with only computing and returning an `ExpectationSuite`.  In order to accomplish that, each Rule was tasked with only producing the list of `ExpectationConfiguration` objects, computed in the final stage of the rule by an `ExpectationConfigurationBuilder` for every `Domain` object, whereby the `kwargs` for `ExpectationConfiguration` are computed by `ParameterBuilder` objects.  These `ExpectationConfiguration` objects would then be added to an `ExpectationSuite` by the `RuleBasedProfiler` and returned to the caller.  In summary, every `Rule` and the entire `RuleBasedProfiler` had one purpose: compute `ExpectationConfiguration` objects and return an `ExpectationSuite` as a "one-time" `run()` operation, whereby a list of `Batch` objects, combined with RBP configuration, yield an `ExpectationSuite` on every execution of the `RuleBasedProfiler.run()` method.

As the requirements for applications built on top of the RBP technology are getting richer, a different model is required in order to support the different use cases.  In stead of producing one particular kind of an output (an `ExpectationSuite`), the operation will be more akin to a sequencer (or a "Finite-State Machine").  First, `RuleBasedProfiler.run()` executes every rule, given a list of `Batch` objects, combined with RBP configuration, and obtains the state of all rules (new `RuleState` objects).  Second, using `RuleState` and appropriate flags, corresponding outputs for a `Rule` are produced via the corresponding methods on the new `RuleOutput` object (e.g., `ExpectationConfiguration` objects, metric values for every batch, parameters computed for a `Domain` by the different `ParameterBuilder` objects, and so on).  Finally, `RuleBasedProfiler` combines `RuleOutput` objects to produce higher level return entities, such as all available `ExpectationConfiguration` objects, an `ExpectationSuite`, containing them, or the `meta` property of that `ExpectationSuite` object.

The present pull request starts with making the first few of these enhancements available: `ExpectationConfiguration`, `ExpectationSuite`, and `meta`.

The new usage pattern is:
```
            profiler.run(
                variables=None,  # override
                rules=None,  # override
                batch_list=list(self.batches.values()),   # either `Batch` objects or `BatchRequest`
                batch_request=None,   # either `Batch` objects or `BatchRequest`
                force_batch_data=False,   # whether or not to overwrite configured `batch_request`
                reconciliation_directives=BaseRuleBasedProfiler.DEFAULT_RECONCILATION_DIRECTIVES, # for handling overrides
            )

            expectation_configurations: List[
                ExpectationConfiguration
            ] = profiler.expectation_suite( # if both `expectation_suite` and `expectation_suite_name` absent, creates temp one
                expectation_suite=None,
                expectation_suite_name=None,
                include_citation=True,
            ).expectations
```

### Next Work
As part of the scope of the next several pull requests to follow (and built on top of these enhancements), `RuleOutput` will return metrics and computed parameters; we will introduce a `Result` object for packaging the outputs of the low-level style methods of `RuleOutput` for use by `DataAssistant` classes; and introduce the `DataAssistant` classes themselves.


Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- JIRA: GREAT-735/GREAT-781
- JIRA: GREAT-735/GREAT-782
- Existing tests are updated.


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
