### PR TITLE
revert to not raising datasource errors on data context init

### DIFF
--- a/great_expectations/data_context/data_context.py
+++ b/great_expectations/data_context/data_context.py
@@ -474,12 +474,7 @@ class BaseDataContext(ConfigPeer):
                 # this error will happen if our configuration contains datasources that GE can no longer connect to.
                 # this is ok, as long as we don't use it to retrieve a batch. If we try to do that, the error will be
                 # caught at the context.get_batch() step. So we just pass here.
-                if self._ge_cloud_mode:
-                    # when running in cloud mode, we want to know if a datasource has been improperly configured at
-                    # init time.
-                    raise
-                else:
-                    pass
+                pass
 
     def _apply_global_config_overrides(self):
         # check for global usage statistics opt out

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -177,35 +177,3 @@ def test_data_context_ge_cloud_mode_with_bad_request_to_cloud_api_should_throw_e
             ge_cloud_organization_id=ge_cloud_runtime_organization_id,
             ge_cloud_access_token=ge_cloud_runtime_access_token,
         )
-
-
-def test_datasource_initialization_error_thrown_in_cloud_mode(
-    ge_cloud_data_context_config: DataContextConfig,
-    ge_cloud_runtime_base_url,
-    ge_cloud_runtime_organization_id,
-    ge_cloud_runtime_access_token,
-):
-    # normally the DataContext swallows exceptions when there is an error raised from get_datasource
-    # (which is used during initialization). In cloud mode, we want a DatasourceInitializationError to
-    # propogate.
-
-    # normally in cloud mode configuration is retrieved from an endpoint; we're providing it here in-line
-    with mock.patch(
-        "great_expectations.data_context.DataContext._retrieve_data_context_config_from_ge_cloud",
-        return_value=ge_cloud_data_context_config,
-    ):
-        # DataContext._init_datasources calls get_datasource, which may generate a DatasourceInitializationError
-        # that normally gets swallowed.
-        with mock.patch(
-            "great_expectations.data_context.DataContext.get_datasource"
-        ) as get_datasource:
-            get_datasource.side_effect = DatasourceInitializationError(
-                "mock_datasource", "mock_message"
-            )
-            with pytest.raises(DatasourceInitializationError):
-                DataContext(
-                    ge_cloud_mode=True,
-                    ge_cloud_base_url=ge_cloud_runtime_base_url,
-                    ge_cloud_organization_id=ge_cloud_runtime_organization_id,
-                    ge_cloud_access_token=ge_cloud_runtime_access_token,
-                )


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Handle errors on datasource init (within data context init) equally regardless of cloud mode.



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
