### PR TITLE
[HACKATHON] Resubmission of 4 geospatial expectations - PR4625 Duplicate - ExpectColumnValuesGeometryToBe(Within/Near/Intersect/CentroidsWithin)Shape

### DIFF
--- a/expect_column_values_geometry_centroids_to_be_within_shape.py
+++ b/expect_column_values_geometry_centroids_to_be_within_shape.py
@@ -1,0 +1,224 @@
+from typing import Optional
+
+import pandas as pd
+import pygeos as geos
+
+from great_expectations.core.expectation_configuration import \
+    ExpectationConfiguration
+from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.execution_engine import (PandasExecutionEngine,
+                                                 SparkDFExecutionEngine,
+                                                 SqlAlchemyExecutionEngine)
+from great_expectations.expectations.expectation import ColumnMapExpectation
+from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
+                                                     column_condition_partial)
+
+
+# This class defines a Metric to support your Expectation.
+# For most ColumnMapExpectations, the main business logic for calculation will live in this class.
+class ColumnValuesGeometryCentroidsWithinShape(ColumnMapMetricProvider):
+
+    # This is the id string that will be used to reference your metric.
+    condition_metric_name = "column_values.geometry.centroids_within_shape"
+    condition_value_keys = ("shape", "shape_format", "column_shape_format")
+
+    # This method implements the core logic for the PandasExecutionEngine
+    @column_condition_partial(engine=PandasExecutionEngine)
+    def _pandas(cls, column, **kwargs):
+
+        shape = kwargs.get("shape")
+        shape_format = kwargs.get("shape_format")
+        column_shape_format = kwargs.get("column_shape_format")
+
+        # Check that shape is given and given in the correct format
+        if shape is not None:
+            try:
+                if shape_format == "wkt":
+                    shape_ref = geos.from_wkt(shape)
+                elif shape_format == "wkb":
+                    shape_ref = geos.from_wkb(shape)
+                elif shape_format == "geojson":
+                    shape_ref = geos.from_geojson(shape)
+                else:
+                    raise NotImplementedError(
+                        "Shape constructor method not implemented. Must be in WKT, WKB, or GeoJSON format."
+                    )
+            except:
+                raise Exception("A valid reference shape was not given.")
+        else:
+            raise Exception("A shape must be provided for this method.")
+
+        # Load the column into a pygeos Geometry vector from numpy array (Series not supported).
+        if column_shape_format == "wkt":
+            shape_test = geos.from_wkt(column.to_numpy(), on_invalid="ignore")
+        elif column_shape_format == "wkb":
+            shape_test = geos.from_wkb(column.to_numpy(), on_invalid="ignore")
+        else:
+            raise NotImplementedError("Column values shape format not implemented.")
+
+        # Allow for an array of reference shapes to be provided. Return a union of all the shapes in the array (Polygon or Multipolygon)
+        shape_ref = geos.union_all(shape_ref)
+
+        # Prepare the geometries
+        geos.prepare(shape_ref)
+        geos.prepare(shape_test)
+        column_centroids = geos.centroid(shape_test)
+
+        print(column_centroids)
+
+        return pd.Series(geos.within(column_centroids, shape_ref))
+
+    # This method defines the business logic for evaluating your metric when using a SqlAlchemyExecutionEngine
+    # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+    # def _sqlalchemy(cls, column, _dialect, **kwargs):
+    #     raise NotImplementedError
+
+    # This method defines the business logic for evaluating your metric when using a SparkDFExecutionEngine
+    # @column_condition_partial(engine=SparkDFExecutionEngine)
+    # def _spark(cls, column, **kwargs):
+    #     raise NotImplementedError
+
+
+# This class defines the Expectation itself
+class ExpectColumnValuesGeometryCentroidsToBeWithinShape(ColumnMapExpectation):
+    """
+    Expect that column values as geometries each have a centroid that are within a given reference shape.
+
+    expect_column_values_geometry_centroids_to_be_within_shape is a :func:`column_map_expectation <great_expectations.dataset.dataset.MetaDataset.column_map_expectation>`.
+
+    Args:
+        column (str): \
+            The column name.
+            Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+    Keyword Args:
+        shape: str or list(str)
+            The reference geometry
+
+        shape_format: str
+            Geometry format for 'shape' string(s). Can be provided as 'Well Known Text' (WKT), 'Well Known Binary' (WKB), or as GeoJSON.
+            Must be one of: [wkt, wkb, geojson]
+            Default: wkt
+
+        column_shape_format: str
+            Geometry format for 'column'. Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+    Returns:
+        An ExpectationSuiteValidationResult
+
+    Notes:
+        Convention is (X Y Z) for points, which would map to (Longitude Latitude Elevation) for geospatial cases.
+        Any convention can be followed as long as the test and reference shapes are consistent.
+        The reference shape allows for an array, but will union (merge) all the shapes into 1 and check the contains condition.
+        MultiLinestrings and Multipolygons area weighted by their length and areas, respectively. See the pygeos docs for reference.
+    """
+
+    # These examples will be shown in the public gallery.
+    # They will also be executed as unit tests for your Expectation.
+    examples = [
+        {
+            "data": {
+                "lines": [
+                    "LINESTRING(0 0, 10 10)",
+                    "LINESTRING(5 5, 8 10)",
+                    "LINESTRING(0 0, 18 2)",
+                    "LINESTRING(3 4, 0 7, 10 0, 15 10)",
+                ],
+                "polygons": [
+                    "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+                    "POLYGON ((0 0, 0 5, 5 5, 5 0, 0 0))",
+                    "POLYGON ((10 10, 10 15, 15 15, 15 10, 10 10))",
+                    None,
+                ],
+            },
+            "tests": [
+                {
+                    "title": "positive_test_with_lines",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "lines",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "negative_test_with_polygons",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "polygons",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                    },
+                    "out": {
+                        "success": False,
+                    },
+                },
+            ],
+        }
+    ]
+
+    # This is the id string of the Metric used by this Expectation.
+    # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
+    map_metric = "column_values.geometry.centroids_within_shape"
+
+    # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
+    success_keys = ("mostly", "shape", "shape_format", "column_shape_format")
+
+    # This dictionary contains default values for any parameters that should have default values
+    default_kwarg_values = {
+        "mostly": 1,
+        "shape_format": "wkt",
+        "column_shape_format": "wkt",
+    }
+
+    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+        """
+        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+        necessary configuration arguments have been provided for the validation of the expectation.
+
+        Args:
+            configuration (OPTIONAL[ExpectationConfiguration]): \
+                An optional Expectation Configuration entry that will be used to configure the expectation
+        Returns:
+            True if the configuration has been validated successfully. Otherwise, raises an exception
+        """
+
+        super().validate_configuration(configuration)
+        if configuration is None:
+            configuration = self.configuration
+
+        # # Check other things in configuration.kwargs and raise Exceptions if needed
+        # try:
+        #     assert (
+        #         ...
+        #     ), "message"
+        #     assert (
+        #         ...
+        #     ), "message"
+        # except AssertionError as e:
+        #     raise InvalidExpectationConfigurationError(str(e))
+
+        return True
+
+    # This object contains metadata for display in the public Gallery
+    library_metadata = {
+        "tags": [
+            "geospatial",
+            "hackathon-2022",
+        ],  # Tags for this Expectation in the Gallery
+        "contributors": [  # Github handles for all contributors to this Expectation.
+            "@pjdobson",  # Don't forget to add your github handle here!
+        ],
+        "requirements": ["pygeos"],
+    }
+
+
+if __name__ == "__main__":
+    ExpectColumnValuesGeometryCentroidsToBeWithinShape().print_diagnostic_checklist()

--- a/expect_column_values_geometry_to_be_near_shape.py
+++ b/expect_column_values_geometry_to_be_near_shape.py
@@ -1,0 +1,290 @@
+import json
+from typing import Optional
+
+import pandas as pd
+import pygeos as geos
+
+from great_expectations.core.expectation_configuration import \
+    ExpectationConfiguration
+from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.execution_engine import (PandasExecutionEngine,
+                                                 SparkDFExecutionEngine,
+                                                 SqlAlchemyExecutionEngine)
+from great_expectations.expectations.expectation import ColumnMapExpectation
+from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
+                                                     column_condition_partial)
+
+
+# This class defines a Metric to support your Expectation.
+# For most ColumnMapExpectations, the main business logic for calculation will live in this class.
+class ColumnValuesGeometryNearShape(ColumnMapMetricProvider):
+
+    # This is the id string that will be used to reference your metric.
+    condition_metric_name = "column_values.geometry.near_shape"
+    condition_value_keys = (
+        "shape",
+        "shape_format",
+        "column_shape_format",
+        "distance_tol",
+    )
+
+    # This method implements the core logic for the PandasExecutionEngine
+    @column_condition_partial(engine=PandasExecutionEngine)
+    def _pandas(cls, column, **kwargs):
+
+        shape = kwargs.get("shape")
+        shape_format = kwargs.get("shape_format")
+        column_shape_format = kwargs.get("column_shape_format")
+        distance_tol = kwargs.get("distance_tol")
+
+        # Check that shape is given and given in the correct format
+        if shape is not None:
+            try:
+                if shape_format == "wkt":
+                    shape_ref = geos.from_wkt(shape)
+                elif shape_format == "wkb":
+                    shape_ref = geos.from_wkb(shape)
+                elif shape_format == "geojson":
+                    shape_ref = geos.from_geojson(shape)
+                else:
+                    raise NotImplementedError(
+                        "Shape constructor method not implemented. Must be in WKT, WKB, or GeoJSON format."
+                    )
+            except:
+                raise Exception("A valid reference shape was not given.")
+        else:
+            raise Exception("A shape must be provided for this method.")
+
+        # Load the column into a pygeos Geometry vector from numpy array (Series not supported).
+        if column_shape_format == "wkt":
+            shape_test = geos.from_wkt(column.to_numpy(), on_invalid="ignore")
+        elif column_shape_format == "wkb":
+            shape_test = geos.from_wkb(column.to_numpy(), on_invalid="ignore")
+        else:
+            raise NotImplementedError("Column values shape format not implemented.")
+
+        # Allow for an array of reference shapes to be provided. Return a union of all the shapes in the array (Polygon or Multipolygon)
+        shape_ref = geos.union_all(shape_ref)
+
+        # Prepare the geometries
+        geos.prepare(shape_ref)
+        geos.prepare(shape_test)
+
+        # Return whether the distance is below the tolerance.
+        return pd.Series(geos.dwithin(shape_test, shape_ref, distance_tol))
+
+    # This method defines the business logic for evaluating your metric when using a SqlAlchemyExecutionEngine
+    # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+    # def _sqlalchemy(cls, column, _dialect, **kwargs):
+    #     raise NotImplementedError
+
+    # This method defines the business logic for evaluating your metric when using a SparkDFExecutionEngine
+    # @column_condition_partial(engine=SparkDFExecutionEngine)
+    # def _spark(cls, column, **kwargs):
+    #     raise NotImplementedError
+
+
+# This class defines the Expectation itself
+class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
+    """
+    Expect that column values as geometries are near (within a given distance) of a given reference shape in the units of the provided geometries.
+
+    expect_column_values_geometry_to_be_near_shape is a :func:`column_map_expectation <great_expectations.dataset.dataset.MetaDataset.column_map_expectation>`.
+
+    Args:
+        column (str): \
+            The column name.
+            Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+    Keyword Args:
+        shape: str or list(str)
+            The reference geometry
+
+        shape_format: str
+            Geometry format for 'shape' string(s). Can be provided as 'Well Known Text' (WKT), 'Well Known Binary' (WKB), or as GeoJSON.
+            Must be one of: [wkt, wkb, geojson]
+            Default: wkt
+
+        column_shape_format: str
+            Geometry format for 'column'. Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+        distance_tol: float
+            Distance tolerance for the column value geometries to the reference shape. Note that 0 evaluates to expect_column_values_to_be_within_shape.
+            Distance values are always positive. Negative tolerances will always evaluate to False.
+            Default: 0
+
+    Returns:
+        An ExpectationSuiteValidationResult
+
+    Notes:
+        The distance returned and specified is based on the coordinate system of the points, not Latitude and Longitude.
+        The user is responsible for the projection method and units (e.g. UTM in m).
+        The distance calculation is based on a cartesian coordinate system.
+        Convention is (X Y Z) for points, which would map to (Longitude Latitude Elevation) for geospatial cases.
+        Any convention can be followed as long as the test and reference shapes are consistent.
+        The reference shape allows for an array, but will union (merge) all the shapes into 1 and check the contains condition.
+    """
+
+    # These examples will be shown in the public gallery.
+    # They will also be executed as unit tests for your Expectation.
+    examples = [
+        {
+            "data": {
+                "points_only": [
+                    "POINT(1 1)",
+                    "POINT(2 2)",
+                    "POINT(6 4)",
+                    "POINT(3 9)",
+                    "POINT(8 9.999)",
+                ],
+                "points_and_lines": [
+                    "POINT(1 1)",
+                    "POINT(2 2)",
+                    "POINT(6 4)",
+                    "POINT(3 9)",
+                    "LINESTRING(5 5, 8 10)",
+                ],
+            },
+            "tests": [
+                {
+                    "title": "positive_test_with_points",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "POINT(0 0)",
+                        "shape_format": "wkt",
+                        "column_shape_format": "wkt",
+                        "distance_tol": 15.0,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_and_lines",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_and_lines",
+                        "shape": "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+                        "shape_format": "wkt",
+                        "column_shape_format": "wkt",
+                        "distance_tol": 10.0,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_and_lines_geojson_reference_shape",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_and_lines",
+                        "shape": '{"type":"Polygon","coordinates":[[[0.0,0.0],[0.0,10.0],[10.0,10.0],[10.0,0.0],[0.0,0.0]]]}',
+                        "shape_format": "geojson",
+                        "column_shape_format": "wkt",
+                        "distance_tol": 10.0,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "negative_test_with_points",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "POINT(0 0)",
+                        "shape_format": "wkt",
+                        "column_shape_format": "wkt",
+                        "distance_tol": 6.0,
+                    },
+                    "out": {"success": False, "unexpected_index_list": [2, 3, 4]},
+                },
+                {
+                    "title": "negative_test_with_points_and_lines_and_array_reference_shape",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_and_lines",
+                        "shape": ["POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", "POINT(0 10)"],
+                        "shape_format": "wkt",
+                        "column_shape_format": "wkt",
+                        "distance_tol": 5.0,
+                    },
+                    "out": {"success": False, "unexpected_index_list": [2, 4]},
+                },
+            ],
+        }
+    ]
+
+    # This is the id string of the Metric used by this Expectation.
+    # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
+    map_metric = "column_values.geometry.near_shape"
+
+    # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
+    success_keys = (
+        "mostly",
+        "shape",
+        "shape_format",
+        "column_shape_format",
+        "distance_tol",
+    )
+
+    # This dictionary contains default values for any parameters that should have default values
+    default_kwarg_values = {
+        "mostly": 1,
+        "shape_format": "wkt",
+        "column_shape_format": "wkt",
+        "distance_tol": 0.0,
+    }
+
+    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+        """
+        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+        necessary configuration arguments have been provided for the validation of the expectation.
+
+        Args:
+            configuration (OPTIONAL[ExpectationConfiguration]): \
+                An optional Expectation Configuration entry that will be used to configure the expectation
+        Returns:
+            True if the configuration has been validated successfully. Otherwise, raises an exception
+        """
+
+        super().validate_configuration(configuration)
+        if configuration is None:
+            configuration = self.configuration
+
+        # # Check other things in configuration.kwargs and raise Exceptions if needed
+        # try:
+        #     assert (
+        #         ...
+        #     ), "message"
+        #     assert (
+        #         ...
+        #     ), "message"
+        # except AssertionError as e:
+        #     raise InvalidExpectationConfigurationError(str(e))
+
+        return True
+
+    # This object contains metadata for display in the public Gallery
+    library_metadata = {
+        "tags": [
+            "geospatial",
+            "hackathon-2022",
+        ],  # Tags for this Expectation in the Gallery
+        "contributors": [  # Github handles for all contributors to this Expectation.
+            "@pjdobson",  # Don't forget to add your github handle here!
+        ],
+        "requirements": ["pygeos"],
+    }
+
+
+if __name__ == "__main__":
+    ExpectColumnValuesGeometryToBeNearShape().print_diagnostic_checklist()

--- a/expect_column_values_geometry_to_be_within_shape.py
+++ b/expect_column_values_geometry_to_be_within_shape.py
@@ -1,0 +1,298 @@
+from typing import Optional
+
+import pandas as pd
+import pygeos as geos
+
+from great_expectations.core.expectation_configuration import \
+    ExpectationConfiguration
+from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.execution_engine import (PandasExecutionEngine,
+                                                 SparkDFExecutionEngine,
+                                                 SqlAlchemyExecutionEngine)
+from great_expectations.expectations.expectation import ColumnMapExpectation
+from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
+                                                     column_condition_partial)
+
+
+# This class defines a Metric to support your Expectation.
+# For most ColumnMapExpectations, the main business logic for calculation will live in this class.
+class ColumnValuesGeometryWithinShape(ColumnMapMetricProvider):
+
+    # This is the id string that will be used to reference your metric.
+    condition_metric_name = "column_values.geometry.within_shape"
+    condition_value_keys = ("shape", "shape_format", "column_shape_format", "properly")
+
+    # This method implements the core logic for the PandasExecutionEngine
+    @column_condition_partial(engine=PandasExecutionEngine)
+    def _pandas(cls, column, **kwargs):
+
+        shape = kwargs.get("shape")
+        shape_format = kwargs.get("shape_format")
+        column_shape_format = kwargs.get("column_shape_format")
+        properly = kwargs.get("properly")
+
+        # Check that shape is given and given in the correct format
+        if shape is not None:
+            try:
+                if shape_format == "wkt":
+                    shape_ref = geos.from_wkt(shape)
+                elif shape_format == "wkb":
+                    shape_ref = geos.from_wkb(shape)
+                elif shape_format == "geojson":
+                    shape_ref = geos.from_geojson(shape)
+                else:
+                    raise NotImplementedError(
+                        "Shape constructor method not implemented. Must be in WKT, WKB, or GeoJSON format."
+                    )
+            except:
+                raise Exception("A valid reference shape was not given.")
+        else:
+            raise Exception("A shape must be provided for this method.")
+
+        # Load the column into a pygeos Geometry vector from numpy array (Series not supported).
+        if column_shape_format == "wkt":
+            shape_test = geos.from_wkt(column.to_numpy(), on_invalid="ignore")
+        elif column_shape_format == "wkb":
+            shape_test = geos.from_wkb(column.to_numpy(), on_invalid="ignore")
+        else:
+            raise NotImplementedError("Column values shape format not implemented.")
+
+        # Allow for an array of reference shapes to be provided. Return a union of all the shapes in the array (Polygon or Multipolygon)
+        shape_ref = geos.union_all(shape_ref)
+
+        # Prepare the geometries
+        geos.prepare(shape_ref)
+        geos.prepare(shape_test)
+
+        if properly:
+            return pd.Series(geos.contains_properly(shape_ref, shape_test))
+        else:
+            return pd.Series(geos.contains(shape_ref, shape_test))
+
+    # This method defines the business logic for evaluating your metric when using a SqlAlchemyExecutionEngine
+    # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+    # def _sqlalchemy(cls, column, _dialect, **kwargs):
+    #     raise NotImplementedError
+
+    # This method defines the business logic for evaluating your metric when using a SparkDFExecutionEngine
+    # @column_condition_partial(engine=SparkDFExecutionEngine)
+    # def _spark(cls, column, **kwargs):
+    #     raise NotImplementedError
+
+
+# This class defines the Expectation itself
+class ExpectColumnValuesGeometryToBeWithinShape(ColumnMapExpectation):
+    """
+    Expect that column values as geometries are within a given reference shape.
+
+    expect_column_values_geometry_to_be_within_shape is a :func:`column_map_expectation <great_expectations.dataset.dataset.MetaDataset.column_map_expectation>`.
+
+    Args:
+        column (str): \
+            The column name.
+            Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+    Keyword Args:
+        shape: str or list(str)
+            The reference geometry
+
+        shape_format: str
+            Geometry format for 'shape' string(s). Can be provided as 'Well Known Text' (WKT), 'Well Known Binary' (WKB), or as GeoJSON.
+            Must be one of: [wkt, wkb, geojson]
+            Default: wkt
+
+        column_shape_format: str
+            Geometry format for 'column'. Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+        properly: boolean
+            Whether the 'column' values should be properly within in the reference 'shape'.
+            The method allows for shapes to be 'properly contained' within the reference, meaning no points of a given geometry can touch the boundary of the reference.
+            See the pygeos docs for reference.
+            Default: False
+
+    Returns:
+        An ExpectationSuiteValidationResult
+
+    Notes:
+        Convention is (X Y Z) for points, which would map to (Longitude Latitude Elevation) for geospatial cases.
+        Any convention can be followed as long as the test and reference shapes are consistent.
+        The reference shape allows for an array, but will union (merge) all the shapes into 1 and check the contains condition.
+    """
+
+    # These examples will be shown in the public gallery.
+    # They will also be executed as unit tests for your Expectation.
+    examples = [
+        {
+            "data": {
+                "points_only": [
+                    "POINT(1 1)",
+                    "POINT(2 2)",
+                    "POINT(6 4)",
+                    "POINT(3 9)",
+                    "POINT(8 9.999)",
+                ],
+                "points_and_lines": [
+                    "POINT(1 1)",
+                    "POINT(2 2)",
+                    "POINT(6 4)",
+                    "POINT(3 9)",
+                    "LINESTRING(5 5, 8 10)",
+                ],
+            },
+            "tests": [
+                {
+                    "title": "positive_test_with_points",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                        "properly": False,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_and_lines",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_and_lines",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                        "properly": False,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_wkb_reference_shape",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "010300000001000000050000000000000000000000000000000000000000000000000000000000000000002440000000000000244000000000000024400000000000002440000000000000000000000000000000000000000000000000",
+                        "shape_format": "wkb",
+                        "properly": False,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_geojson_reference_shape",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": '{"type":"Polygon","coordinates":[[[0.0,0.0],[0.0,10.0],[10.0,10.0],[10.0,0.0],[0.0,0.0]]]}',
+                        "shape_format": "geojson",
+                        "properly": False,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "negative_test_with_points",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "POLYGON ((0 0, 0 7.5, 7.5 7.5, 7.5 0, 0 0))",
+                        "shape_format": "wkt",
+                        "properly": True,
+                    },
+                    "out": {
+                        "success": False,
+                    },
+                },
+                {
+                    "title": "negative_test_with_points_and_lines_not_properly_contained",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_and_lines",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                        "properly": True,
+                        "mostly": 1,
+                    },
+                    "out": {
+                        "success": False,
+                    },
+                },
+            ],
+        }
+    ]
+
+    # This is the id string of the Metric used by this Expectation.
+    # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
+    map_metric = "column_values.geometry.within_shape"
+
+    # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
+    success_keys = (
+        "mostly",
+        "shape",
+        "shape_format",
+        "column_shape_format",
+        "properly",
+    )
+
+    # This dictionary contains default values for any parameters that should have default values
+    default_kwarg_values = {
+        "mostly": 1,
+        "shape_format": "wkt",
+        "column_shape_format": "wkt",
+        "properly": False,
+    }
+
+    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+        """
+        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+        necessary configuration arguments have been provided for the validation of the expectation.
+
+        Args:
+            configuration (OPTIONAL[ExpectationConfiguration]): \
+                An optional Expectation Configuration entry that will be used to configure the expectation
+        Returns:
+            True if the configuration has been validated successfully. Otherwise, raises an exception
+        """
+
+        super().validate_configuration(configuration)
+        if configuration is None:
+            configuration = self.configuration
+
+        # # Check other things in configuration.kwargs and raise Exceptions if needed
+        # try:
+        #     assert (
+        #         ...
+        #     ), "message"
+        #     assert (
+        #         ...
+        #     ), "message"
+        # except AssertionError as e:
+        #     raise InvalidExpectationConfigurationError(str(e))
+
+        return True
+
+    # This object contains metadata for display in the public Gallery
+    library_metadata = {
+        "tags": [
+            "geospatial",
+            "hackathon-2022",
+        ],  # Tags for this Expectation in the Gallery
+        "contributors": [  # Github handles for all contributors to this Expectation.
+            "@pjdobson",  # Don't forget to add your github handle here!
+        ],
+        "requirements": ["pygeos"],
+    }
+
+
+if __name__ == "__main__":
+    ExpectColumnValuesGeometryToBeWithinShape().print_diagnostic_checklist()

--- a/expect_column_values_geometry_to_intersect_shape.py
+++ b/expect_column_values_geometry_to_intersect_shape.py
@@ -1,0 +1,277 @@
+from typing import Optional
+
+import pandas as pd
+import pygeos as geos
+
+from great_expectations.core.expectation_configuration import \
+    ExpectationConfiguration
+from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.execution_engine import (PandasExecutionEngine,
+                                                 SparkDFExecutionEngine,
+                                                 SqlAlchemyExecutionEngine)
+from great_expectations.expectations.expectation import ColumnMapExpectation
+from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
+                                                     column_condition_partial)
+
+
+# This class defines a Metric to support your Expectation.
+# For most ColumnMapExpectations, the main business logic for calculation will live in this class.
+class ColumnValuesGeometryIntersectsShape(ColumnMapMetricProvider):
+
+    # This is the id string that will be used to reference your metric.
+    condition_metric_name = "column_values.geometry.intersects_shape"
+    condition_value_keys = ("shape", "shape_format", "column_shape_format")
+
+    # This method implements the core logic for the PandasExecutionEngine
+    @column_condition_partial(engine=PandasExecutionEngine)
+    def _pandas(cls, column, **kwargs):
+
+        shape = kwargs.get("shape")
+        shape_format = kwargs.get("shape_format")
+        column_shape_format = kwargs.get("column_shape_format")
+
+        # Check that shape is given and given in the correct format
+        if shape is not None:
+            try:
+                if shape_format == "wkt":
+                    shape_ref = geos.from_wkt(shape)
+                elif shape_format == "wkb":
+                    shape_ref = geos.from_wkb(shape)
+                elif shape_format == "geojson":
+                    shape_ref = geos.from_geojson(shape)
+                else:
+                    raise NotImplementedError(
+                        "Shape constructor method not implemented. Must be in WKT, WKB, or GeoJSON format."
+                    )
+            except:
+                raise Exception("A valid reference shape was not given.")
+        else:
+            raise Exception("A shape must be provided for this method.")
+
+        # Load the column into a pygeos Geometry vector from numpy array (Series not supported).
+        if column_shape_format == "wkt":
+            shape_test = geos.from_wkt(column.to_numpy(), on_invalid="ignore")
+        elif column_shape_format == "wkb":
+            shape_test = geos.from_wkb(column.to_numpy(), on_invalid="ignore")
+        else:
+            raise NotImplementedError("Column values shape format not implemented.")
+
+        # Allow for an array of reference shapes to be provided. Return a union of all the shapes in the array (Polygon or Multipolygon)
+        shape_ref = geos.union_all(shape_ref)
+
+        # Prepare the geometries
+        geos.prepare(shape_ref)
+        geos.prepare(shape_test)
+
+        return pd.Series(geos.intersects(shape_ref, shape_test))
+
+    # This method defines the business logic for evaluating your metric when using a SqlAlchemyExecutionEngine
+    # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+    # def _sqlalchemy(cls, column, _dialect, **kwargs):
+    #     raise NotImplementedError
+
+    # This method defines the business logic for evaluating your metric when using a SparkDFExecutionEngine
+    # @column_condition_partial(engine=SparkDFExecutionEngine)
+    # def _spark(cls, column, **kwargs):
+    #     raise NotImplementedError
+
+
+# This class defines the Expectation itself
+class ExpectColumnValuesGeometryToInstersectShape(ColumnMapExpectation):
+    """
+    Expect that column values as geometries intersect a given reference shape.
+
+    expect_column_values_geometry_to_intersect_shape is a :func:`column_map_expectation <great_expectations.dataset.dataset.MetaDataset.column_map_expectation>`.
+
+    Args:
+        column (str): \
+            The column name.
+            Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+    Keyword Args:
+        shape: str or list(str)
+            The reference geometry
+
+        shape_format: str
+            Geometry format for 'shape' string(s). Can be provided as 'Well Known Text' (WKT), 'Well Known Binary' (WKB), or as GeoJSON.
+            Must be one of: [wkt, wkb, geojson]
+            Default: wkt
+
+        column_shape_format: str
+            Geometry format for 'column'. Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
+            WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
+
+    Returns:
+        An ExpectationSuiteValidationResult
+
+    Notes:
+        Convention is (X Y Z) for points, which would map to (Longitude Latitude Elevation) for geospatial cases.
+        Any convention can be followed as long as the test and reference shapes are consistent.
+        The reference shape allows for an array, but will union (merge) all the shapes into 1 and check the contains condition.
+    """
+
+    # These examples will be shown in the public gallery.
+    # They will also be executed as unit tests for your Expectation.
+    examples = [
+        {
+            "data": {
+                "points_only": [
+                    "POINT(1 1)",
+                    "POINT(2 2)",
+                    "POINT(6 4)",
+                    "POINT(3 9)",
+                    "POINT(8 9.999)",
+                ],
+                "points_and_lines": [
+                    "POINT(1 1)",
+                    "POINT(2 2)",
+                    "POINT(6 4)",
+                    "POINT(3 9)",
+                    "LINESTRING(5 5, 8 10)",
+                ],
+                "points_and_lines_negative": [
+                    "POINT(1 1)",
+                    "POINT(2 2)",
+                    "POINT(6 4)",
+                    "LINESTRING(5 5, 8 10)",
+                    "LINESTRING(11 5, 10 20)",
+                ],
+            },
+            "tests": [
+                {
+                    "title": "positive_test_with_points",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_and_lines",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_and_lines",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_wkb_reference_shape",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "010300000001000000050000000000000000000000000000000000000000000000000000000000000000002440000000000000244000000000000024400000000000002440000000000000000000000000000000000000000000000000",
+                        "shape_format": "wkb",
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_geojson_reference_shape",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": '{"type":"Polygon","coordinates":[[[0.0,0.0],[0.0,10.0],[10.0,10.0],[10.0,0.0],[0.0,0.0]]]}',
+                        "shape_format": "geojson",
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "negative_test_with_points",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
+                        "shape": "POLYGON ((0 0, 0 7.5, 7.5 7.5, 7.5 0, 0 0))",
+                        "shape_format": "wkt",
+                    },
+                    "out": {"success": False, "unexpected_index_list": [3, 4]},
+                },
+                {
+                    "title": "negative_test_with_points_and_lines",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_and_lines_negative",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
+                        "shape_format": "wkt",
+                    },
+                    "out": {"success": False, "unexpected_index_list": [4]},
+                },
+            ],
+        }
+    ]
+
+    # This is the id string of the Metric used by this Expectation.
+    # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
+    map_metric = "column_values.geometry.intersects_shape"
+
+    # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
+    success_keys = ("mostly", "shape", "shape_format", "column_shape_format")
+
+    # This dictionary contains default values for any parameters that should have default values
+    default_kwarg_values = {
+        "mostly": 1,
+        "shape_format": "wkt",
+        "column_shape_format": "wkt",
+    }
+
+    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+        """
+        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+        necessary configuration arguments have been provided for the validation of the expectation.
+
+        Args:
+            configuration (OPTIONAL[ExpectationConfiguration]): \
+                An optional Expectation Configuration entry that will be used to configure the expectation
+        Returns:
+            True if the configuration has been validated successfully. Otherwise, raises an exception
+        """
+
+        super().validate_configuration(configuration)
+        if configuration is None:
+            configuration = self.configuration
+
+        # # Check other things in configuration.kwargs and raise Exceptions if needed
+        # try:
+        #     assert (
+        #         ...
+        #     ), "message"
+        #     assert (
+        #         ...
+        #     ), "message"
+        # except AssertionError as e:
+        #     raise InvalidExpectationConfigurationError(str(e))
+
+        return True
+
+    # This object contains metadata for display in the public Gallery
+    library_metadata = {
+        "tags": [
+            "geospatial",
+            "hackathon-22",
+        ],  # Tags for this Expectation in the Gallery
+        "contributors": [  # Github handles for all contributors to this Expectation.
+            "@pjdobson",  # Don't forget to add your github handle here!
+        ],
+        "requirements": ["pygeos"],
+    }
+
+
+if __name__ == "__main__":
+    ExpectColumnValuesGeometryToInstersectShape().print_diagnostic_checklist()


### PR DESCRIPTION
Hackathon 2022. Duplicate with branch feature/hackathon-geospatial-1 with PR 4625

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Addition of 4 similar column map expectations to check if column values (presented as geometries in WKT or WKB) have an interaction with a given reference shape
- geometries within (& properly within) reference 
- geometries intersecting with reference
- geometries near (within a distance of) a reference 
- geometry centroids 


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- Resubmission of PR4625 to correct contributor email and cla-bot issues
- All requested changes from 4625 applied.
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
