### PR TITLE
[BUGFIX] Cleanup contrib

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_geometry_to_be_within_shape.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_geometry_to_be_within_shape.py
@@ -1,32 +1,29 @@
-import json
 from typing import Optional
 
 import pandas as pd
 import pygeos as geos
 
-from great_expectations.core.expectation_configuration import \
-    ExpectationConfiguration
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.exceptions import InvalidExpectationConfigurationError
-from great_expectations.execution_engine import (PandasExecutionEngine,
-                                                 SparkDFExecutionEngine,
-                                                 SqlAlchemyExecutionEngine)
+from great_expectations.execution_engine import (
+    PandasExecutionEngine,
+    SparkDFExecutionEngine,
+    SqlAlchemyExecutionEngine,
+)
 from great_expectations.expectations.expectation import ColumnMapExpectation
-from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
-                                                     column_condition_partial)
+from great_expectations.expectations.metrics import (
+    ColumnMapMetricProvider,
+    column_condition_partial,
+)
 
 
 # This class defines a Metric to support your Expectation.
 # For most ColumnMapExpectations, the main business logic for calculation will live in this class.
-class ColumnValuesGeometryNearShape(ColumnMapMetricProvider):
+class ColumnValuesGeometryWithinShape(ColumnMapMetricProvider):
 
     # This is the id string that will be used to reference your metric.
-    condition_metric_name = "column_values.geometry.near_shape"
-    condition_value_keys = (
-        "shape",
-        "shape_format",
-        "column_shape_format",
-        "distance_tol",
-    )
+    condition_metric_name = "column_values.geometry.within_shape"
+    condition_value_keys = ("shape", "shape_format", "column_shape_format", "properly")
 
     # This method implements the core logic for the PandasExecutionEngine
     @column_condition_partial(engine=PandasExecutionEngine)
@@ -35,7 +32,7 @@ class ColumnValuesGeometryNearShape(ColumnMapMetricProvider):
         shape = kwargs.get("shape")
         shape_format = kwargs.get("shape_format")
         column_shape_format = kwargs.get("column_shape_format")
-        distance_tol = kwargs.get("distance_tol")
+        properly = kwargs.get("properly")
 
         # Check that shape is given and given in the correct format
         if shape is not None:
@@ -70,8 +67,10 @@ class ColumnValuesGeometryNearShape(ColumnMapMetricProvider):
         geos.prepare(shape_ref)
         geos.prepare(shape_test)
 
-        # Return whether the distance is below the tolerance.
-        return pd.Series(geos.dwithin(shape_test, shape_ref, distance_tol))
+        if properly:
+            return pd.Series(geos.contains_properly(shape_ref, shape_test))
+        else:
+            return pd.Series(geos.contains(shape_ref, shape_test))
 
     # This method defines the business logic for evaluating your metric when using a SqlAlchemyExecutionEngine
     # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
@@ -85,11 +84,11 @@ class ColumnValuesGeometryNearShape(ColumnMapMetricProvider):
 
 
 # This class defines the Expectation itself
-class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
+class ExpectColumnValuesGeometryToBeWithinShape(ColumnMapExpectation):
     """
-    Expect that column values as geometries are near (within a given distance) of a given reference shape in the units of the provided geometries.
+    Expect that column values as geometries are within a given reference shape.
 
-    expect_column_values_geometry_to_be_near_shape is a :func:`column_map_expectation <great_expectations.dataset.dataset.MetaDataset.column_map_expectation>`.
+    expect_column_values_geometry_to_be_within_shape is a :func:`column_map_expectation <great_expectations.dataset.dataset.MetaDataset.column_map_expectation>`.
 
     Args:
         column (str): \
@@ -110,18 +109,16 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
             Geometry format for 'column'. Column values must be provided in WKT or WKB format, which are commom formats for GIS Database formats.
             WKT can be accessed thhrough the ST_AsText() or ST_AsBinary() functions in queries for PostGIS and MSSQL.
 
-        distance_tol: float
-            Distance tolerance for the column value geometries to the reference shape. Note that 0 evaluates to expect_column_values_to_be_within_shape.
-            Distance values are always positive. Negative tolerances will always evaluate to False.
-            Default: 0
+        properly: boolean
+            Whether the 'column' values should be properly within in the reference 'shape'.
+            The method allows for shapes to be 'properly contained' within the reference, meaning no points of a given geometry can touch the boundary of the reference.
+            See the pygeos docs for reference.
+            Default: False
 
     Returns:
         An ExpectationSuiteValidationResult
 
     Notes:
-        The distance returned and specified is based on the coordinate system of the points, not Latitude and Longitude.
-        The user is responsible for the projection method and units (e.g. UTM in m).
-        The distance calculation is based on a cartesian coordinate system.
         Convention is (X Y Z) for points, which would map to (Longitude Latitude Elevation) for geospatial cases.
         Any convention can be followed as long as the test and reference shapes are consistent.
         The reference shape allows for an array, but will union (merge) all the shapes into 1 and check the contains condition.
@@ -154,10 +151,9 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
                     "include_in_gallery": True,
                     "in": {
                         "column": "points_only",
-                        "shape": "POINT(0 0)",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
                         "shape_format": "wkt",
-                        "column_shape_format": "wkt",
-                        "distance_tol": 15.0,
+                        "properly": False,
                     },
                     "out": {
                         "success": True,
@@ -169,25 +165,37 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
                     "include_in_gallery": True,
                     "in": {
                         "column": "points_and_lines",
-                        "shape": "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
                         "shape_format": "wkt",
-                        "column_shape_format": "wkt",
-                        "distance_tol": 10.0,
+                        "properly": False,
                     },
                     "out": {
                         "success": True,
                     },
                 },
                 {
-                    "title": "positive_test_with_points_and_lines_geojson_reference_shape",
+                    "title": "positive_test_with_points_wkb_reference_shape",
                     "exact_match_out": False,
                     "include_in_gallery": True,
                     "in": {
-                        "column": "points_and_lines",
+                        "column": "points_only",
+                        "shape": "010300000001000000050000000000000000000000000000000000000000000000000000000000000000002440000000000000244000000000000024400000000000002440000000000000000000000000000000000000000000000000",
+                        "shape_format": "wkb",
+                        "properly": False,
+                    },
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "positive_test_with_points_geojson_reference_shape",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {
+                        "column": "points_only",
                         "shape": '{"type":"Polygon","coordinates":[[[0.0,0.0],[0.0,10.0],[10.0,10.0],[10.0,0.0],[0.0,0.0]]]}',
                         "shape_format": "geojson",
-                        "column_shape_format": "wkt",
-                        "distance_tol": 10.0,
+                        "properly": False,
                     },
                     "out": {
                         "success": True,
@@ -199,25 +207,28 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
                     "include_in_gallery": True,
                     "in": {
                         "column": "points_only",
-                        "shape": "POINT(0 0)",
+                        "shape": "POLYGON ((0 0, 0 7.5, 7.5 7.5, 7.5 0, 0 0))",
                         "shape_format": "wkt",
-                        "column_shape_format": "wkt",
-                        "distance_tol": 6.0,
+                        "properly": True,
                     },
-                    "out": {"success": False, "unexpected_index_list": [2, 3, 4]},
+                    "out": {
+                        "success": False,
+                    },
                 },
                 {
-                    "title": "negative_test_with_points_and_lines_and_array_reference_shape",
+                    "title": "negative_test_with_points_and_lines_not_properly_contained",
                     "exact_match_out": False,
                     "include_in_gallery": True,
                     "in": {
                         "column": "points_and_lines",
-                        "shape": ["POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))", "POINT(0 10)"],
+                        "shape": "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))",
                         "shape_format": "wkt",
-                        "column_shape_format": "wkt",
-                        "distance_tol": 5.0,
+                        "properly": True,
+                        "mostly": 1,
                     },
-                    "out": {"success": False, "unexpected_index_list": [2, 4]},
+                    "out": {
+                        "success": False,
+                    },
                 },
             ],
         }
@@ -225,7 +236,7 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
 
     # This is the id string of the Metric used by this Expectation.
     # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
-    map_metric = "column_values.geometry.near_shape"
+    map_metric = "column_values.geometry.within_shape"
 
     # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
     success_keys = (
@@ -233,7 +244,7 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
         "shape",
         "shape_format",
         "column_shape_format",
-        "distance_tol",
+        "properly",
     )
 
     # This dictionary contains default values for any parameters that should have default values
@@ -241,7 +252,7 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
         "mostly": 1,
         "shape_format": "wkt",
         "column_shape_format": "wkt",
-        "distance_tol": 0.0,
+        "properly": False,
     }
 
     def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
@@ -287,4 +298,4 @@ class ExpectColumnValuesGeometryToBeNearShape(ColumnMapExpectation):
 
 
 if __name__ == "__main__":
-    ExpectColumnValuesGeometryToBeNearShape().print_diagnostic_checklist()
+    ExpectColumnValuesGeometryToBeWithinShape().print_diagnostic_checklist()

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_geometry_to_intersect_shape.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_geometry_to_intersect_shape.py
@@ -3,15 +3,18 @@ from typing import Optional
 import pandas as pd
 import pygeos as geos
 
-from great_expectations.core.expectation_configuration import \
-    ExpectationConfiguration
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.exceptions import InvalidExpectationConfigurationError
-from great_expectations.execution_engine import (PandasExecutionEngine,
-                                                 SparkDFExecutionEngine,
-                                                 SqlAlchemyExecutionEngine)
+from great_expectations.execution_engine import (
+    PandasExecutionEngine,
+    SparkDFExecutionEngine,
+    SqlAlchemyExecutionEngine,
+)
 from great_expectations.expectations.expectation import ColumnMapExpectation
-from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
-                                                     column_condition_partial)
+from great_expectations.expectations.metrics import (
+    ColumnMapMetricProvider,
+    column_condition_partial,
+)
 
 
 # This class defines a Metric to support your Expectation.


### PR DESCRIPTION
Changes proposed in this pull request:
- Lint using OSS `black` version
- Move top-level expectations into contrib module

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.