### PR TITLE
[BUGFIX] Add `notebook` to `GE_REQUIRED_DEPENDENCIES`

### DIFF
--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -43,6 +43,7 @@ class GEDependencies:
             "jsonschema",
             "mistune",
             "nbformat",
+            "notebook",
             "numpy",
             "packaging",
             "pandas",


### PR DESCRIPTION
Changes proposed in this pull request:
- Add new dependency `notebook` to `GE_REQUIRED_DEPENDENCIES` for testing purposes

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.