### PR TITLE
[FEATURE] Add batch_id for every resolved metric_value to ParameterBuilder.get_metrics() result object

### DIFF
--- a/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
@@ -140,7 +140,6 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
             variables=variables,
             parameters=parameters,
         )
-        metric_values: MetricValues = metric_computation_result.metric_values
         details: MetricComputationDetails = metric_computation_result.details
 
         # Obtain reduce_scalar_metric from "rule state" (i.e., variables and parameters); from instance variable otherwise.
@@ -155,14 +154,21 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         # As a simplification, apply reduction to scalar in case of one-dimensional metric (for convenience).
         if (
             reduce_scalar_metric
-            and isinstance(metric_values, list)
-            and len(metric_values) == 1
-            and isinstance(metric_values[0], AttributedResolvedMetrics)
-            and metric_values[0].metric_values.shape[1] == 1
+            and len(metric_computation_result.attributed_resolved_metrics) == 1
+            and metric_computation_result.attributed_resolved_metrics[
+                0
+            ].metric_values.shape[1]
+            == 1
         ):
-            metric_values = metric_values[0].metric_values[:, 0]
+            metric_values = metric_computation_result.attributed_resolved_metrics[
+                0
+            ].metric_values[:, 0]
+            return (
+                metric_values,
+                details,
+            )
 
         return (
-            metric_values,
+            metric_computation_result.attributed_resolved_metrics,
             details,
         )

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -253,7 +253,7 @@ detected.
                 )
 
             attributed_resolved_metrics: AttributedResolvedMetrics = (
-                parameter_node.value[0]
+                AttributedResolvedMetrics(**parameter_node.value[0])
             )
             metric_values = attributed_resolved_metrics.metric_values
         else:

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -1,8 +1,9 @@
 import copy
 import itertools
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from dataclasses import asdict, dataclass, make_dataclass
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
 
@@ -53,18 +54,25 @@ class AttributedResolvedMetrics(SerializableDictDot):
     with uniquely identifiable attribution object so that receivers can filter them from overall resolved metrics.
     """
 
-    metric_values: MetricValues
-    metric_attributes: Attributes
+    metric_attributes: Optional[Attributes] = None
+    metric_values_by_batch_id: Optional[Dict[str, MetricValue]] = None
 
-    def add_resolved_metric(self, value: Any) -> None:
-        if self.metric_values is None:
-            self.metric_values = []
+    def add_resolved_metric(self, batch_id: str, value: MetricValue) -> None:
+        if self.metric_values_by_batch_id is None:
+            self.metric_values_by_batch_id = {}
 
-        self.metric_values.append(value)
+        if not isinstance(self.metric_values_by_batch_id, OrderedDict):
+            self.metric_values_by_batch_id = OrderedDict(self.metric_values_by_batch_id)
+
+        self.metric_values_by_batch_id[batch_id] = value
 
     @property
     def id(self) -> str:
         return self.metric_attributes.to_id()
+
+    @property
+    def metric_values(self) -> MetricValues:
+        return np.array(list(self.metric_values_by_batch_id.values()))
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -358,6 +366,7 @@ class ParameterBuilder(Builder, ABC):
         )
 
         batch_id: str
+
         metric_domain_kwargs = [
             copy.deepcopy(
                 build_metric_domain_kwargs(
@@ -440,7 +449,9 @@ class ParameterBuilder(Builder, ABC):
         resolved_metrics_sorted: Dict[Tuple[str, str, str], Any] = {}
 
         metric_configuration: MetricConfiguration
+
         resolved_metric_value: Any
+
         for metric_configuration in metrics_to_resolve:
             if metric_configuration.id not in resolved_metrics:
                 raise ge_exceptions.ProfilerExecutionError(
@@ -455,60 +466,52 @@ class ParameterBuilder(Builder, ABC):
 
         attributed_resolved_metrics_map: Dict[str, AttributedResolvedMetrics] = {}
 
+        attributed_resolved_metrics: AttributedResolvedMetrics
+
         for metric_configuration in metrics_to_resolve:
-            attributed_resolved_metrics: AttributedResolvedMetrics = (
-                attributed_resolved_metrics_map.get(
-                    metric_configuration.metric_value_kwargs_id
-                )
+            attributed_resolved_metrics = attributed_resolved_metrics_map.get(
+                metric_configuration.metric_value_kwargs_id
             )
             if attributed_resolved_metrics is None:
                 attributed_resolved_metrics = AttributedResolvedMetrics(
                     metric_attributes=metric_configuration.metric_value_kwargs,
-                    metric_values=[],
+                    metric_values_by_batch_id=None,
                 )
                 attributed_resolved_metrics_map[
                     metric_configuration.metric_value_kwargs_id
                 ] = attributed_resolved_metrics
 
             resolved_metric_value = resolved_metrics_sorted[metric_configuration.id]
-            attributed_resolved_metrics.add_resolved_metric(value=resolved_metric_value)
+            attributed_resolved_metrics.add_resolved_metric(
+                batch_id=metric_configuration.metric_domain_kwargs["batch_id"],
+                value=resolved_metric_value,
+            )
+
+        # Step-8: Convert scalar metric values to vectors to enable uniformity of processing in subsequent operations.
 
         metric_attributes_id: str
-        metric_values: AttributedResolvedMetrics
-
-        # Step-8: Leverage Numpy Array capabilities for subsequent operations on results of computed/resolved metrics.
-
-        attributed_resolved_metrics_map = {
-            metric_attributes_id: AttributedResolvedMetrics(
-                metric_attributes=metric_values.metric_attributes,
-                metric_values=np.array(metric_values.metric_values),
-            )
-            for metric_attributes_id, metric_values in attributed_resolved_metrics_map.items()
-        }
-
-        # Step-9: Convert scalar metric values to vectors to enable uniformity of processing in subsequent operations.
-
-        idx: int
         for (
             metric_attributes_id,
-            metric_values,
+            attributed_resolved_metrics,
         ) in attributed_resolved_metrics_map.items():
-            if metric_values.metric_values.ndim == 1:
-                metric_values.metric_values = [
-                    [metric_values.metric_values[idx]] for idx in range(len(batch_ids))
-                ]
-                metric_values.metric_values = np.array(metric_values.metric_values)
-                attributed_resolved_metrics_map[metric_attributes_id] = metric_values
+            if attributed_resolved_metrics.metric_values.ndim == 1:
+                attributed_resolved_metrics.metric_values_by_batch_id = {
+                    batch_id: [resolved_metric_value]
+                    for batch_id, resolved_metric_value in attributed_resolved_metrics.metric_values_by_batch_id.items()
+                }
+                attributed_resolved_metrics_map[
+                    metric_attributes_id
+                ] = attributed_resolved_metrics
 
-        # Step-10: Apply numeric/hygiene flags (e.g., "enforce_numeric_metric", "replace_nan_with_zero") to results.
+        # Step-9: Apply numeric/hygiene flags (e.g., "enforce_numeric_metric", "replace_nan_with_zero") to results.
 
         for (
             metric_attributes_id,
-            metric_values,
+            attributed_resolved_metrics,
         ) in attributed_resolved_metrics_map.items():
             self._sanitize_metric_computation(
                 metric_name=metric_name,
-                metric_values=metric_values.metric_values,
+                attributed_resolved_metrics=attributed_resolved_metrics,
                 enforce_numeric_metric=enforce_numeric_metric,
                 replace_nan_with_zero=replace_nan_with_zero,
                 domain=domain,
@@ -516,7 +519,7 @@ class ParameterBuilder(Builder, ABC):
                 parameters=parameters,
             )
 
-        # Step-11: Build and return result to receiver (apply simplifications to cases of single "metric_value_kwargs").
+        # Step-10: Build and return result to receiver (apply simplifications to cases of single "metric_value_kwargs").
 
         return MetricComputationResult(
             metric_values=list(attributed_resolved_metrics_map.values()),
@@ -536,13 +539,13 @@ class ParameterBuilder(Builder, ABC):
     def _sanitize_metric_computation(
         self,
         metric_name: str,
-        metric_values: np.ndarray,
+        attributed_resolved_metrics: AttributedResolvedMetrics,
         enforce_numeric_metric: Union[str, bool] = False,
         replace_nan_with_zero: Union[str, bool] = False,
         domain: Optional[Domain] = None,
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
-    ) -> np.ndarray:
+    ) -> AttributedResolvedMetrics:
         """
         This method conditions (or "sanitizes") data samples in the format "N x R^m", where "N" (most significant
         dimension) is the number of measurements (e.g., one per Batch of data), while "R^m" is the multi-dimensional
@@ -569,6 +572,8 @@ class ParameterBuilder(Builder, ABC):
             parameters=parameters,
         )
 
+        metric_values: MetricValues = attributed_resolved_metrics.metric_values
+
         # Outer-most dimension is data samples (e.g., one per Batch); the rest are dimensions of the actual metric.
         metric_value_shape: tuple = metric_values.shape[1:]
 
@@ -590,9 +595,11 @@ class ParameterBuilder(Builder, ABC):
 
         # Traverse indices of sample vectors corresponding to every element of multi-dimensional metric.
         metric_value_vector: np.ndarray
+        batch_id: str
+        resolved_metric_value: Any
         for metric_value_idx in metric_value_vector_indices:
             # Obtain "N"-element-long vector of samples for each element of multi-dimensional metric.
-            metric_value_vector = metric_values[metric_value_idx]
+            metric_value_vector = cast(np.ndarray, metric_values)[metric_value_idx]
             if enforce_numeric_metric:
                 if not np.issubdtype(metric_value_vector.dtype, np.number):
                     raise ge_exceptions.ProfilerExecutionError(
@@ -608,9 +615,14 @@ class ParameterBuilder(Builder, ABC):
 """
                         )
 
-                    np.nan_to_num(metric_value_vector, copy=False, nan=0.0)
+                    attributed_resolved_metrics.metric_values_by_batch_id = {
+                        batch_id: np.nan_to_num(
+                            metric_value_vector, copy=False, nan=0.0
+                        )
+                        for batch_id, resolved_metric_value in attributed_resolved_metrics.metric_values_by_batch_id.items()
+                    }
 
-        return metric_values
+        return attributed_resolved_metrics
 
     @staticmethod
     def _get_best_candidate_above_threshold(

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -41,7 +41,7 @@ MetricValue = Union[Any, List[Any], np.ndarray]
 MetricValues = Union[MetricValue, np.ndarray]
 MetricComputationDetails = Dict[str, Any]
 MetricComputationResult = make_dataclass(
-    "MetricComputationResult", ["metric_values", "details"]
+    "MetricComputationResult", ["attributed_resolved_metrics", "details"]
 )
 
 
@@ -522,7 +522,7 @@ class ParameterBuilder(Builder, ABC):
         # Step-10: Build and return result to receiver (apply simplifications to cases of single "metric_value_kwargs").
 
         return MetricComputationResult(
-            metric_values=list(attributed_resolved_metrics_map.values()),
+            attributed_resolved_metrics=list(attributed_resolved_metrics_map.values()),
             details={
                 "metric_configuration": {
                     "metric_name": metric_name,

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -149,17 +149,16 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
         )
 
         # This should never happen.
-        if not (
-            isinstance(metric_computation_result.metric_values, list)
-            and len(metric_computation_result.metric_values) == 1
-        ):
+        if len(metric_computation_result.attributed_resolved_metrics) != 1:
             raise ge_exceptions.ProfilerExecutionError(
-                message=f'Result of metric computations for {self.__class__.__name__} must be a list with exactly 1 element of type "AttributedResolvedMetrics" ({metric_computation_result.metric_values} found).'
+                message=f'Result of metric computations for {self.__class__.__name__} must be a list with exactly 1 element of type "AttributedResolvedMetrics" ({metric_computation_result.attributed_resolved_metrics} found).'
             )
 
         attributed_resolved_metrics: AttributedResolvedMetrics
 
-        attributed_resolved_metrics = metric_computation_result.metric_values[0]
+        attributed_resolved_metrics = (
+            metric_computation_result.attributed_resolved_metrics[0]
+        )
 
         metric_values: MetricValues
 
@@ -215,7 +214,9 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
 
         regex_string_success_ratios: dict = {}
 
-        for attributed_resolved_metrics in metric_computation_result.metric_values:
+        for (
+            attributed_resolved_metrics
+        ) in metric_computation_result.attributed_resolved_metrics:
             # Now obtain 1-dimensional vector of values of computed metric (each element corresponds to a Batch ID).
             metric_values = attributed_resolved_metrics.metric_values[:, 0]
 

--- a/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
@@ -199,17 +199,16 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
         )
 
         # This should never happen.
-        if not (
-            isinstance(metric_computation_result.metric_values, list)
-            and len(metric_computation_result.metric_values) == 1
-        ):
+        if len(metric_computation_result.attributed_resolved_metrics) != 1:
             raise ge_exceptions.ProfilerExecutionError(
-                message=f'Result of metric computations for {self.__class__.__name__} must be a list with exactly 1 element of type "AttributedResolvedMetrics" ({metric_computation_result.metric_values} found).'
+                message=f'Result of metric computations for {self.__class__.__name__} must be a list with exactly 1 element of type "AttributedResolvedMetrics" ({metric_computation_result.attributed_resolved_metrics} found).'
             )
 
         attributed_resolved_metrics: AttributedResolvedMetrics
 
-        attributed_resolved_metrics = metric_computation_result.metric_values[0]
+        attributed_resolved_metrics = (
+            metric_computation_result.attributed_resolved_metrics[0]
+        )
 
         metric_values: MetricValues
 
@@ -263,7 +262,9 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
 
         format_string_success_ratios: dict = {}
 
-        for attributed_resolved_metrics in metric_computation_result.metric_values:
+        for (
+            attributed_resolved_metrics
+        ) in metric_computation_result.attributed_resolved_metrics:
             # Now obtain 1-dimensional vector of values of computed metric (each element corresponds to a Batch ID).
             metric_values = attributed_resolved_metrics.metric_values[:, 0]
 

--- a/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
@@ -129,7 +129,9 @@ class ValueSetMultiBatchParameterBuilder(MetricMultiBatchParameterBuilder):
                 message=f'Result of metric computations for {self.__class__.__name__} must be a list with exactly 1 element of type "AttributedResolvedMetrics" ({parameter_node.value} found).'
             )
 
-        attributed_resolved_metrics: AttributedResolvedMetrics = parameter_node.value[0]
+        attributed_resolved_metrics: AttributedResolvedMetrics = (
+            AttributedResolvedMetrics(**parameter_node.value[0])
+        )
         metric_values: MetricValues = attributed_resolved_metrics.metric_values
 
         return (


### PR DESCRIPTION
### Scope
* Insure that every resolved metric is associated with ID of `Batch`, based on which this metric was computed.
* Update existing logic to work properly with newly enriched output of resolving all `MetricConfiguration` combinations simultaneously.
* Update name of variable, which incorporates resolved metrics for their associated `metric_value_kwargs` directive.


Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/en/latest/contributing/contribution_checklist.html).

Changes proposed in this pull request:
- Prerequisite for JIRA: GREAT-735/GREAT-798
-
-


After submitting your PR, CI checks will run and @ge-cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-




### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
