### PR TITLE
[BUGFIX] `great_expectations` import fails when SQL Alchemy is not installed

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -77,6 +77,7 @@ except ImportError:
     reflection = None
     DefaultDialect = None
     Selectable = None
+    BooleanClauseList = None
     TextClause = None
     quoted_name = None
     OperationalError = None


### PR DESCRIPTION
Yikes! Without this line, `import great_expectations as gx` fails unless sqlalchemy is installed.

I'm scared that this bug made it to `develop`---really glad it's not on `main` yet. Do we have any test environments that don't include SQLalchemy?

```
NameError                                 Traceback (most recent call last)
Input In [1], in <cell line: 1>()
----> 1 import great_expectations as gx

File ~/Documents/great_expectations/great_expectations/__init__.py:7, in <module>
      4 __version__ = get_versions()["version"]  # isort:skip
      5 del get_versions  # isort:skip
----> 7 from great_expectations.data_context import DataContext
      9 from .util import (
     10     from_pandas,
     11     get_context,
   (...)
     20     validate,
     21 )
     23 # from great_expectations.expectations.core import *
     24 # from great_expectations.expectations.metrics import *

File ~/Documents/great_expectations/great_expectations/data_context/__init__.py:1, in <module>
----> 1 from great_expectations.data_context.data_context import (
      2     BaseDataContext,
      3     DataContext,
      4     ExplorerDataContext,
      5     LiteDataContext,
      6 )

File ~/Documents/great_expectations/great_expectations/data_context/data_context/__init__.py:1, in <module>
----> 1 from great_expectations.data_context.data_context.base_data_context import (
      2     BaseDataContext,
      3 )
      4 from great_expectations.data_context.data_context.data_context import DataContext
      5 from great_expectations.data_context.data_context.explorer_data_context import (
      6     ExplorerDataContext,
      7 )

File ~/Documents/great_expectations/great_expectations/data_context/data_context/base_data_context.py:21, in <module>
     18 from ruamel.yaml.comments import CommentedMap
     20 from great_expectations.core.config_peer import ConfigPeer
---> 21 from great_expectations.execution_engine import ExecutionEngine
     22 from great_expectations.rule_based_profiler.config.base import (
     23     ruleBasedProfilerConfigSchema,
     24 )
     26 try:

File ~/Documents/great_expectations/great_expectations/execution_engine/__init__.py:4, in <module>
      2 from .pandas_execution_engine import PandasExecutionEngine
      3 from .sparkdf_execution_engine import SparkDFExecutionEngine
----> 4 from .sqlalchemy_execution_engine import SqlAlchemyExecutionEngine

File ~/Documents/great_expectations/great_expectations/execution_engine/sqlalchemy_execution_engine.py:216, in <module>
    212     MINUTE = "minute"
    213     SECOND = "second"
--> 216 class SqlAlchemyExecutionEngine(ExecutionEngine):
    217     def __init__(
    218         self,
    219         name: Optional[str] = None,
   (...)
    228         **kwargs,  # These will be passed as optional parameters to the SQLAlchemy engine, **not** the ExecutionEngine
    229     ):
    230         """Builds a SqlAlchemyExecutionEngine, using a provided connection string/url/engine/credentials to access the
    231         desired database. Also initializes the dialect to be used and configures usage statistics.
    232 
   (...)
    254                 concurrency (ConcurrencyConfig): Concurrency config used to configure the sqlalchemy engine.
    255         """

File ~/Documents/great_expectations/great_expectations/execution_engine/sqlalchemy_execution_engine.py:985, in SqlAlchemyExecutionEngine()
    970     """Convert the values in the named column to the given date_format, and split on that"""
    972     return (
    973         sa.func.strftime(
    974             date_format_string,
   (...)
    977         == batch_identifiers[column_name]
    978     )
    980 def split_on_year(
    981     self,
    982     table_name: str,
    983     column_name: str,
    984     batch_identifiers: dict,
--> 985 ) -> BooleanClauseList:
    986     """Split on year values in column_name.
    987 
    988     Args:
   (...)
    997             batch identifier matches the date_part value in the column_name column.
    998     """
    999     return self.split_on_date_parts(
   1000         table_name=table_name,
   1001         column_name=column_name,
   1002         batch_identifiers=batch_identifiers,
   1003         date_parts=[DatePart.YEAR],
   1004     )

NameError: name 'BooleanClauseList' is not defined
```