### PR TITLE
[MAINTENANCE] Add CI stage importing GE with only required dependencies installed 

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -100,13 +100,12 @@ stages:
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 
-  - stage: no_sqlalchemy
-    dependsOn: [scope_check, lint]
+  - stage: import_ge
+    dependsOn: [lint]
     pool:
       vmImage: 'ubuntu-18.04'
     jobs:
-      - job: no_sqlalchemy
-        condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
+      - job: import_ge
 
         strategy:
          matrix:
@@ -129,7 +128,7 @@ stages:
 
          - script: |
              pip install  .
-           displayName: 'Install GE and dependencies'
+           displayName: 'Install GE and dependencies (not sqlalchemy)'
 
          - script: |
              python -c "import great_expectations as ge; print('GE Version:', ge.__version__)"

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -128,7 +128,7 @@ stages:
 
          - script: |
              pip install  .
-           displayName: 'Install GE and dependencies (not sqlalchemy)'
+           displayName: 'Install GE and required dependencies (i.e. not sqlalchemy)'
 
          - script: |
              python -c "import great_expectations as ge; print('GE Version:', ge.__version__)"

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -100,6 +100,41 @@ stages:
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 
+  - stage: no_sqlalchemy
+    dependsOn: [scope_check, lint]
+    pool:
+      vmImage: 'ubuntu-18.04'
+    jobs:
+      - job: no_sqlalchemy
+        condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
+
+        strategy:
+         matrix:
+           Python37:
+             python.version: '3.7'
+           Python38:
+             python.version: '3.8'
+           Python39:
+             python.version: '3.9'
+
+
+        steps:
+         - task: UsePythonVersion@0
+           inputs:
+             versionSpec: '$(python.version)'
+           displayName: 'Use Python $(python.version)'
+
+         - bash: python -m pip install --upgrade pip==21.3.1
+           displayName: 'Update pip'
+
+         - script: |
+             pip install  .
+           displayName: 'Install GE and dependencies'
+
+         - script: |
+             python -c "import great_expectations as ge; print('GE Version:', ge.__version__)"
+           displayName: 'Import Great Expectations'
+
   - stage: required
     dependsOn: [scope_check, lint]
     pool:

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -135,7 +135,7 @@ stages:
            displayName: 'Import Great Expectations'
 
   - stage: required
-    dependsOn: [scope_check, lint]
+    dependsOn: [scope_check, lint, import_ge]
     pool:
       vmImage: 'ubuntu-18.04'
 
@@ -309,7 +309,7 @@ stages:
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
   - stage: usage_stats_integration
-    dependsOn: [scope_check, lint]
+    dependsOn: [scope_check, lint, import_ge]
     pool:
       vmImage: 'ubuntu-latest'
 
@@ -345,7 +345,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
 
-    dependsOn: [scope_check, lint]
+    dependsOn: [scope_check, lint, import_ge]
 
     jobs:
       - job: mysql
@@ -438,7 +438,7 @@ stages:
             displayName: 'dgtest'
 
   - stage: cli_integration
-    dependsOn: [scope_check, lint]
+    dependsOn: [scope_check, lint, import_ge]
     pool:
       vmImage: 'ubuntu-latest'
 

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -131,7 +131,7 @@ stages:
            displayName: 'Install GE and required dependencies (i.e. not sqlalchemy)'
 
          - script: |
-             python -c "import great_expectations as ge; print('GE Version:', ge.__version__)"
+             python -c "import great_expectations as ge; print('Successfully imported GE Version:', ge.__version__)"
            displayName: 'Import Great Expectations'
 
   - stage: required

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,8 +81,42 @@ stages:
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 
-  - stage: required
+  - stage: import_ge
     dependsOn: [lint]
+    pool:
+      vmImage: 'ubuntu-18.04'
+    jobs:
+      - job: import_ge
+
+        strategy:
+         matrix:
+           Python37:
+             python.version: '3.7'
+           Python38:
+             python.version: '3.8'
+           Python39:
+             python.version: '3.9'
+
+
+        steps:
+         - task: UsePythonVersion@0
+           inputs:
+             versionSpec: '$(python.version)'
+           displayName: 'Use Python $(python.version)'
+
+         - bash: python -m pip install --upgrade pip==21.3.1
+           displayName: 'Update pip'
+
+         - script: |
+             pip install  .
+           displayName: 'Install GE and required dependencies (i.e. not sqlalchemy)'
+
+         - script: |
+             python -c "import great_expectations as ge; print('GE Version:', ge.__version__)"
+           displayName: 'Import Great Expectations'
+
+  - stage: required
+    dependsOn: [lint, import_ge]
     pool:
       vmImage: 'ubuntu-18.04'
 
@@ -152,64 +186,6 @@ stages:
               # Consider fragmenting *all* integration tests into separate folder and run
               pip install  .
             displayName: 'Install dependencies'
-
-          - script: |
-              pip install pytest pytest-cov pytest-azurepipelines
-              pytest $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
-            displayName: 'pytest'
-
-          - task: PublishTestResults@2
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFiles: '**/test-*.xml'
-              testRunTitle: 'Publish test results for Python $(python.version)'
-
-          - task: PublishCodeCoverageResults@1
-            inputs:
-              codeCoverageTool: Cobertura
-              summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-              reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
-
-      - job: no_sqlalchemy
-        condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
-
-        services:
-          postgres: postgres
-
-        variables:
-          GE_pytest_opts: '--no-sqlalchemy'
-
-        strategy:
-          matrix:
-            Python38:
-              python.version: '3.8'
-              GE_pytest_pip_opts: '--requirement requirements-dev.txt --constraint constraints-dev.txt'
-              pip_uninstall_packages: 'sqlalchemy'
-
-        steps:
-          - task: UsePythonVersion@0
-            inputs:
-              versionSpec: '$(python.version)'
-            displayName: 'Use Python $(python.version)'
-
-          - bash: python -m pip install --upgrade pip==21.3.1
-            displayName: 'Update pip'
-
-          - script: |
-              sudo apt-get install -y pandoc
-              pip install pypandoc
-            displayName: 'Install pandoc'
-
-          - script: |
-              pip install --requirement requirements.txt
-              echo "about to run pip install $(GE_pytest_pip_opts)"
-              pip install $(GE_pytest_pip_opts)
-              pip install  .
-            displayName: 'Install dependencies'
-
-          - script: |
-              pip uninstall -y $(pip_uninstall_packages)
-            displayName: 'Uninstall packages $(pip_uninstall_packages)'
 
           - script: |
               pip install pytest pytest-cov pytest-azurepipelines
@@ -299,7 +275,7 @@ stages:
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
   - stage: usage_stats_integration
-    dependsOn: [lint]
+    dependsOn: [lint, import_ge]
     pool:
       vmImage: 'ubuntu-latest'
 
@@ -333,7 +309,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
 
-    dependsOn: [lint]
+    dependsOn: [lint, import_ge]
 
     jobs:
       - job: mysql
@@ -412,7 +388,7 @@ stages:
             displayName: 'pytest'
 
   - stage: cli_integration
-    dependsOn: [lint]
+    dependsOn: [lint, import_ge]
     pool:
       vmImage: 'ubuntu-latest'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,7 +177,7 @@ stages:
           postgres: postgres
 
         variables:
-          GE_pytest_opts: ''
+          GE_pytest_opts: '--no-sqlalchemy'
 
         strategy:
           matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,6 +170,64 @@ stages:
               summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
+      - job: no_sqlalchemy
+        condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
+
+        services:
+          postgres: postgres
+
+        variables:
+          GE_pytest_opts: '--postgresql --spark'
+
+        strategy:
+          matrix:
+            Python38:
+              python.version: '3.8'
+              GE_pytest_pip_opts: '--requirement requirements-dev.txt --constraint constraints-dev.txt'
+              pip_uninstall_packages: 'sqlalchemy'
+
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '$(python.version)'
+            displayName: 'Use Python $(python.version)'
+
+          - bash: python -m pip install --upgrade pip==21.3.1
+            displayName: 'Update pip'
+
+          - script: |
+              sudo apt-get install -y pandoc
+              pip install pypandoc
+            displayName: 'Install pandoc'
+
+          - script: |
+              pip install --requirement requirements.txt
+              echo "about to run pip install $(GE_pytest_pip_opts)"
+              pip install $(GE_pytest_pip_opts)
+              pip install  .
+            displayName: 'Install dependencies'
+
+          - script: |
+              pip uninstall -y $(pip_uninstall_packages)
+            displayName: 'Uninstall packages $(pip_uninstall_packages)'
+
+          - script: |
+              pip install pytest pytest-cov pytest-azurepipelines
+              pytest $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html --ignore=tests/cli --ignore=tests/integration/usage_statistics
+            displayName: 'pytest'
+
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFiles: '**/test-*.xml'
+              testRunTitle: 'Publish test results for Python $(python.version)'
+
+          - task: PublishCodeCoverageResults@1
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+              reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+
       - job: comprehensive
         condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,7 +177,7 @@ stages:
           postgres: postgres
 
         variables:
-          GE_pytest_opts: '--postgresql --spark'
+          GE_pytest_opts: ''
 
         strategy:
           matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,7 @@ stages:
            displayName: 'Install GE and required dependencies (i.e. not sqlalchemy)'
 
          - script: |
-             python -c "import great_expectations as ge; print('GE Version:', ge.__version__)"
+             python -c "import great_expectations as ge; print('Successfully imported GE Version:', ge.__version__)"
            displayName: 'Import Great Expectations'
 
   - stage: required

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -77,6 +77,7 @@ except ImportError:
     reflection = None
     DefaultDialect = None
     Selectable = None
+    BooleanClauseList = None
     TextClause = None
     quoted_name = None
     OperationalError = None

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -77,7 +77,6 @@ except ImportError:
     reflection = None
     DefaultDialect = None
     Selectable = None
-    BooleanClauseList = None
     TextClause = None
     quoted_name = None
     OperationalError = None

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -77,7 +77,7 @@ except ImportError:
     reflection = None
     DefaultDialect = None
     Selectable = None
-    # BooleanClauseList = None
+    BooleanClauseList = None
     TextClause = None
     quoted_name = None
     OperationalError = None

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -77,7 +77,7 @@ except ImportError:
     reflection = None
     DefaultDialect = None
     Selectable = None
-    BooleanClauseList = None
+    # BooleanClauseList = None
     TextClause = None
     quoted_name = None
     OperationalError = None


### PR DESCRIPTION
Changes proposed in this pull request:
- We noticed a bug that only shows up in environments without sqlalchemy installed (fixed in: https://github.com/great-expectations/great_expectations/pull/4880), this PR adds a new CI stage that runs with only required dependencies installed (i.e. without sqlalchemy installed) so that bugs like this will be caught before they can be merged into `develop`. The test adds a new `import_ge` stage which installs GE from the branch and imports it in supported python versions. It precedes the `required` stage since it runs quickly and if there are issues in this stage they should be fixed before running the full test suite.

This branch was tested in the following CI runs:
- Failing with bug re-introduced: https://dev.azure.com/great-expectations/great_expectations/_build/results?buildId=47711&view=logs&j=2b99e989-08bc-5401-cdad-c2e6353fb293&t=af523853-95e2-5ff4-7108-1c77c9b4f35c
- Passing (in this PR)

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
