### PR TITLE
[MAINTENANCE] Import GE after running `ge init` in packaging CI pipeline

### DIFF
--- a/azure-pipelines-packaging.yml
+++ b/azure-pipelines-packaging.yml
@@ -34,11 +34,12 @@ trigger:
 variables:
   isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
   isScheduled: $[and(eq(variables['Build.SourceBranch'], 'refs/heads/develop'), eq(variables['Build.Reason'], 'Schedule'))]
+  isManual: $[eq(variables['Build.Reason'], 'Manual')]
 
 stages:
   - stage: user_install_linux
     dependsOn: []
-    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
+    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
     jobs:
       - template: azure/user-install-matrix.yml
         parameters:
@@ -46,7 +47,7 @@ stages:
 
   - stage: dev_install_linux
     dependsOn: user_install_linux
-    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
+    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
     jobs:
       - template: azure/dev-install-matrix.yml
         parameters:
@@ -54,7 +55,7 @@ stages:
 
   - stage: user_install_macOS
     dependsOn: []
-    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
+    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
     jobs:
       - template: azure/user-install-matrix.yml
         parameters:
@@ -62,7 +63,7 @@ stages:
 
   - stage: dev_install_macOS
     dependsOn: user_install_macOS
-    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
+    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
     jobs:
       - template: azure/dev-install-matrix.yml
         parameters:
@@ -70,7 +71,7 @@ stages:
 
   - stage: user_install_windows
     dependsOn: []
-    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
+    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
     jobs:
       - template: azure/user-install-matrix.yml
         parameters:
@@ -78,7 +79,7 @@ stages:
 
   - stage: dev_install_windows
     dependsOn: user_install_windows
-    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true))
+    condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
     jobs:
       - template: azure/dev-install-matrix.yml
         parameters:

--- a/azure/user-install-matrix.yml
+++ b/azure/user-install-matrix.yml
@@ -20,6 +20,7 @@ jobs:
         - script: |
             great_expectations --version
             great_expectations -y init --no-usage-stats
+            python -c "import great_expectations as ge; print('Successfully imported GE Version:', ge.__version__)"
           displayName: 'Confirm installation'
 
     - job:
@@ -46,4 +47,5 @@ jobs:
             source activate ge_dev
             great_expectations --version
             great_expectations -y init --no-usage-stats
+            python -c "import great_expectations as ge; print('Successfully imported GE Version:', ge.__version__)"
           displayName: 'Confirm installation'


### PR DESCRIPTION
Changes proposed in this pull request:
- Import GE after running CLI `ge init` in the packaging CI pipeline. This is a bit belt and suspenders since this is tested elsewhere but just to make sure this common initial import step works on all supported OSes.
- This also enables manual run of this pipeline. Tested here: https://dev.azure.com/great-expectations/great_expectations/_build/results?buildId=47746&view=logs&j=18e85c62-0d3d-51ce-dd5b-d3b9314d8135


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
