### PR TITLE
[MAINTENANCE] Add condition to primary pipeline to ensure `import_ge` stage doesn't cause misleading Slack notifications

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,7 @@ stages:
       vmImage: 'ubuntu-18.04'
     jobs:
       - job: import_ge
+        condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
 
         strategy:
          matrix:

--- a/great_expectations/rule_based_profiler/types/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result.py
@@ -1,4 +1,3 @@
-# test change
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Optional
 

--- a/great_expectations/rule_based_profiler/types/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result.py
@@ -1,9 +1,10 @@
+# test change
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Optional
 
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.util import convert_to_json_serializable
-from great_expectations.rule_based_profiler.types.domain import Domain
+from great_expectations.rule_based_profiler.types import Domain
 from great_expectations.types import SerializableDictDot
 
 

--- a/great_expectations/rule_based_profiler/types/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.util import convert_to_json_serializable
-from great_expectations.rule_based_profiler.types import Domain
+from great_expectations.rule_based_profiler.types.domain import Domain
 from great_expectations.types import SerializableDictDot
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Without the condition proposed herein, any failures will trigger a Slack notification. Since this is commonplace in the development process, we should only run this stage when we're in a scheduled run or are performing a release cut (the rest of the pipeline mirrors this logic).


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)