### PR TITLE
[MAINTENANCE] Re-enable bigquery tests

### DIFF
--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -16,6 +16,7 @@ from great_expectations.execution_engine.sqlalchemy_batch_data import (
 )
 from great_expectations.execution_engine.sqlalchemy_data_splitter import DatePart
 from tests.test_utils import (
+    clean_up_tables_with_prefix,
     get_bigquery_connection_url,
     get_snowflake_connection_url,
     load_data_into_test_database,
@@ -31,13 +32,13 @@ def _get_connection_string_and_dialect() -> Tuple[str, str]:
 
     dialect: str = db_config["dialect"]
     if dialect == "snowflake":
-        CONNECTION_STRING: str = get_snowflake_connection_url()
+        connection_string: str = get_snowflake_connection_url()
     elif dialect == "bigquery":
-        CONNECTION_STRING: str = get_bigquery_connection_url()
+        connection_string: str = get_bigquery_connection_url()
     else:
-        CONNECTION_STRING: str = db_config["connection_string"]
+        connection_string: str = db_config["connection_string"]
 
-    return dialect, CONNECTION_STRING
+    return dialect, connection_string
 
 
 TAXI_DATA_TABLE_NAME: str = "taxi_data_all_samples"
@@ -57,15 +58,21 @@ def _load_data(
         ],
         connection_string=connection_string,
         convert_colnames_to_datetime=["pickup_datetime", "dropoff_datetime"],
+        random_table_suffix=True,
     )
 
 
 if __name__ == "test_script_module":
 
-    dialect, CONNECTION_STRING = _get_connection_string_and_dialect()
+    dialect, connection_string = _get_connection_string_and_dialect()
     print(f"Testing dialect: {dialect}")
 
-    test_df = _load_data(connection_string=CONNECTION_STRING)
+    print("Preemptively cleaning old tables")
+    clean_up_tables_with_prefix(
+        connection_string=connection_string, table_prefix=f"{TAXI_DATA_TABLE_NAME}_"
+    )
+
+    test_df = _load_data(connection_string=connection_string)
 
     YEARS_IN_TAXI_DATA = (
         pd.date_range(start="2018-01-01", end="2020-12-31", freq="AS")
@@ -190,7 +197,7 @@ if __name__ == "test_script_module":
             class_name="Datasource",
             execution_engine={
                 "class_name": "SqlAlchemyExecutionEngine",
-                "connection_string": CONNECTION_STRING,
+                "connection_string": connection_string,
             },
         )
 
@@ -255,3 +262,8 @@ if __name__ == "test_script_module":
             sa.select([sa.func.count()]).select_from(batch_data.selectable)
         ).scalar()
         assert num_rows == test_case.num_expected_rows_in_first_batch_definition
+
+    print("Clean up tables used in this test")
+    clean_up_tables_with_prefix(
+        connection_string=connection_string, table_prefix=f"{TAXI_DATA_TABLE_NAME}_"
+    )

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -707,8 +707,7 @@ docs_test_matrix += local_tests
 docs_test_matrix += dockerized_db_tests
 docs_test_matrix += cloud_snowflake_tests
 docs_test_matrix += cloud_gcp_tests
-# TODO: AJB 20220418 Temporarily disable bigquery tests since we hit our daily quota.
-# docs_test_matrix += cloud_bigquery_tests
+docs_test_matrix += cloud_bigquery_tests
 docs_test_matrix += cloud_azure_tests
 docs_test_matrix += cloud_s3_tests
 docs_test_matrix += cloud_redshift_tests

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -590,7 +590,6 @@ def clean_up_tables_with_prefix(connection_string: str, table_prefix: str) -> Li
         config_defaults={"module_name": "great_expectations.datasource.data_connector"},
     )
     introspection_output = data_connector._introspect_db()
-    print(introspection_output)
 
     tables_to_drop: List[str] = []
     tables_dropped: List[str] = []


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a `random_table_suffix` option to `test_utils.load_data_into_test_database`.
- Add a `clean_up_tables_with_prefix` method to `test_utils` to clean up these tables with random suffixes.
- Use these methods in the recently created `test_sql_data_splitting.py`.
- Re-enable bigquery tests.
- A small amount of additional cleanup.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.
