### PR TITLE
[MAINTENANCE] Add module docstring and simplify access to DatePart

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_data_splitter.py
+++ b/great_expectations/execution_engine/sqlalchemy_data_splitter.py
@@ -1,3 +1,19 @@
+"""Create queries for use in sql data splitting.
+
+This module contains utilities for generating queries used by execution engines
+and data connectors to split data into batches based on the data itself. It
+is typically used from within either an execution engine or a data connector,
+not by itself.
+
+    Typical usage example:
+        __init__():
+            self._sqlalchemy_data_splitter = SqlAlchemyDataSplitter()
+
+        elsewhere():
+            splitter = self._sqlalchemy_data_splitter.get_splitter_method()
+            split_query_or_clause = splitter()
+"""
+
 import datetime
 import enum
 from typing import Callable, List, Union
@@ -39,7 +55,13 @@ class DatePart(enum.Enum):
 
 
 class SqlAlchemyDataSplitter:
-    """Methods for splitting data accessible via SqlAlchemyExecutionEngine."""
+    """Methods for splitting data accessible via SqlAlchemyExecutionEngine.
+
+    Note, for convenience, you can also access DatePart via the instance variable
+    date_part e.g. SqlAlchemyDataSplitter.date_part.MONTH
+    """
+
+    date_part: DatePart = DatePart
 
     def get_splitter_method(self, splitter_method_name: str) -> Callable:
         """Get the appropriate splitter method from the method name.

--- a/tests/execution_engine/test_sqlalchemy_execution_engine_splitting.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine_splitting.py
@@ -110,6 +110,10 @@ SINGLE_DATE_PART_DATE_PARTS: List[pytest.param] = [
         id="month_with_DatePart",
     ),
     pytest.param(
+        [SqlAlchemyDataSplitter.date_part.MONTH],
+        id="month getting date parts from SqlAlchemyDataSplitter.date_part",
+    ),
+    pytest.param(
         ["month"],
         id="month_with_string_DatePart",
     ),
@@ -220,6 +224,10 @@ MULTIPLE_DATE_PART_DATE_PARTS: List[pytest.param] = [
     pytest.param(
         [DatePart.YEAR, DatePart.MONTH],
         id="year_month_with_DatePart",
+    ),
+    pytest.param(
+        [SqlAlchemyDataSplitter.date_part.YEAR, SqlAlchemyDataSplitter.date_part.MONTH],
+        id="year_month getting date parts from SqlAlchemyDataSplitter.date_part",
     ),
     pytest.param(
         [DatePart.YEAR, "month"],


### PR DESCRIPTION
Changes proposed in this pull request:
- Small changes to add a module docstring and allow access to DatePart from SqlAlchemyDataSplitter so we can use a single import + associated tests.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
