### PR TITLE
[MAINTENANCE] Update execution time threshold in `VolumeDataAssistant` test

### DIFF
--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -365,7 +365,7 @@ def test_execution_time_within_proper_bounds(
     data_assistant_result: DataAssistantResult = data_assistant.run()
 
     assert (
-        0.0 < data_assistant_result.execution_time <= 1.0
+        0.0 < data_assistant_result.execution_time <= 2.0
     )  # Execution time (in seconds).
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Update upper bound of test to account for edge cases (1.2-1.3 seconds)

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
