### PR TITLE
[MAINTENANCE] Ensure that code style scripts in CI/CD exit early on failure

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -153,7 +153,7 @@ stages:
            displayName: 'Import Great Expectations'
 
   - stage: required
-    dependsOn: [scope_check, lint, import_ge]
+    dependsOn: [scope_check, lint, import_ge, custom_checks]
     pool:
       vmImage: 'ubuntu-18.04'
 
@@ -343,7 +343,7 @@ stages:
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
   - stage: usage_stats_integration
-    dependsOn: [scope_check, lint, import_ge]
+    dependsOn: [scope_check, lint, import_ge, custom_checks]
     pool:
       vmImage: 'ubuntu-latest'
 
@@ -379,7 +379,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
 
-    dependsOn: [scope_check, lint, import_ge]
+    dependsOn: [scope_check, lint, import_ge, custom_checks]
 
     jobs:
       - job: mysql
@@ -472,7 +472,7 @@ stages:
             displayName: 'dgtest'
 
   - stage: cli_integration
-    dependsOn: [scope_check, lint, import_ge]
+    dependsOn: [scope_check, lint, import_ge, custom_checks]
     pool:
       vmImage: 'ubuntu-latest'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,6 @@ stages:
               exit $EXIT_STATUS
 
   - stage: custom_checks
-    dependsOn: scope_check
     pool:
       vmImage: 'ubuntu-latest'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,24 @@ stages:
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 
+  - stage: custom_checks
+    dependsOn: scope_check
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    jobs:
+    - job: type_hint_checker
+      steps:
+      - script: |
+          pip install mypy # Prereq for type hint script
+          python scripts/check_type_hint_coverage.py
+        name: TypeHintChecker
+
+    - job: docstring_checker
+      steps:
+      - bash: python scripts/check_docstring_coverage.py
+        name: DocstringChecker
+
   - stage: import_ge
     dependsOn: [lint]
     pool:
@@ -117,7 +135,7 @@ stages:
            displayName: 'Import Great Expectations'
 
   - stage: required
-    dependsOn: [lint, import_ge]
+    dependsOn: [lint, import_ge, custom_checks]
     pool:
       vmImage: 'ubuntu-18.04'
 
@@ -276,7 +294,7 @@ stages:
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
   - stage: usage_stats_integration
-    dependsOn: [lint, import_ge]
+    dependsOn: [lint, import_ge, custom_checks]
     pool:
       vmImage: 'ubuntu-latest'
 
@@ -310,7 +328,7 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
 
-    dependsOn: [lint, import_ge]
+    dependsOn: [lint, import_ge, custom_checks]
 
     jobs:
       - job: mysql
@@ -389,7 +407,7 @@ stages:
             displayName: 'pytest'
 
   - stage: cli_integration
-    dependsOn: [lint, import_ge]
+    dependsOn: [lint, import_ge, custom_checks]
     pool:
       vmImage: 'ubuntu-latest'
 
@@ -432,7 +450,7 @@ stages:
     condition: and(succeeded(), eq(variables.isMain, true))
     pool:
       vmImage: 'ubuntu-18.04'
-    dependsOn: [required, lint, db_integration, usage_stats_integration, cli_integration]
+    dependsOn: [import_ge, custom_checks, required, lint, db_integration, usage_stats_integration, cli_integration]
 
     jobs:
       - job: build_gallery
@@ -524,7 +542,7 @@ stages:
     condition: and(succeeded(), eq(variables.isMain, true))
     pool:
       vmImage: 'ubuntu-latest'
-    dependsOn: [required, lint, db_integration, usage_stats_integration, cli_integration]
+    dependsOn: [import_ge, custom_checks, required, lint, db_integration, usage_stats_integration, cli_integration]
 
     jobs:
       - job: deploy


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that if `custom_checks` fail, the whole pipeline fails early.
- Add checks to `great_expectations` to ensure parity between two primary pipelines.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code

Thank you for submitting!
