### PR TITLE
[BUGFIX] check contrib requirements

### DIFF
--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -109,6 +109,8 @@ def get_contrib_requirements(filepath: str) -> Dict:
                 if "library_metadata" in target_ids:
                     library_metadata = ast.literal_eval(node.value)
                     requirements = library_metadata.get("requirements", [])
+                    if type(requirements) == str:
+                        requirements = [requirements]
                     requirements_info[current_class] = requirements
                     requirements_info["requirements"] += requirements
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_icd_ten_category_or_subcategory.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_icd_ten_category_or_subcategory.py
@@ -166,7 +166,7 @@ class ExpectColumnValuesToBeIcdTenCategoryOrSubcategory(ColumnMapExpectation):
         "contributors": [
             "@andyjessen",
         ],
-        "requirements": "simple_icd_10",
+        "requirements": ["simple_icd_10"],
     }
 
 

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1471,6 +1471,8 @@ class Expectation(metaclass=MetaExpectation):
                 )
             if forbidden_keys:
                 problems.append(f"Extra key(s) found: {sorted(forbidden_keys)}")
+            if type(augmented_library_metadata["requirements"]) != list:
+                problems.append("library_metadata['requirements'] is not a list ")
             if not problems:
                 augmented_library_metadata["library_metadata_passed_checks"] = True
         else:


### PR DESCRIPTION

Changes proposed in this pull request:
- Add check that requirements is a list, but don't crash if it's not
- Make requirements for icd_ten_category expectation a list