### PR TITLE
[MAINTENANCE] Add condition for custom checks in `great_expectations` pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,7 @@ stages:
 
     jobs:
     - job: type_hint_checker
+      condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
       steps:
       - script: |
           pip install mypy # Prereq for type hint script
@@ -94,6 +95,7 @@ stages:
         name: TypeHintChecker
 
     - job: docstring_checker
+      condition: or(eq(variables.isScheduled, true), eq(variables.isMain, true), eq(variables.isManual, true))
       steps:
       - bash: python scripts/check_docstring_coverage.py
         name: DocstringChecker


### PR DESCRIPTION
Changes proposed in this pull request:
- Before this PR, these checks would get run in both the `dependency_graph` and `great_expectations` pipelines.
- We should have parity between the two pipelines but only `dependency_graph` should run on each commit. `great_expectations` is reserved for scheduled runs and release cutting (and therefore is more extensive).

Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
