### PR TITLE
[MAINTENANCE] Move general data splitting tasks to abstract base class

### DIFF
--- a/great_expectations/execution_engine/split_and_sample/data_splitter.py
+++ b/great_expectations/execution_engine/split_and_sample/data_splitter.py
@@ -1,0 +1,71 @@
+import abc
+import enum
+from typing import Callable, List, Union
+
+
+class DatePart(enum.Enum):
+    """SQL supported date parts for most dialects."""
+
+    YEAR = "year"
+    MONTH = "month"
+    WEEK = "week"
+    DAY = "day"
+    HOUR = "hour"
+    MINUTE = "minute"
+    SECOND = "second"
+
+    def __eq__(self, other):
+        return self.value == other.value
+
+
+class DataSplitter(abc.ABC):
+    """Abstract base class containing methods for splitting data accessible via Execution Engines.
+
+    Note, for convenience, you can also access DatePart via the instance variable
+    date_part e.g. DataSplitter.date_part.MONTH
+    """
+
+    date_part: DatePart = DatePart
+
+    def get_splitter_method(self, splitter_method_name: str) -> Callable:
+        """Get the appropriate splitter method from the method name.
+
+        Args:
+            splitter_method_name: name of the splitter to retrieve.
+
+        Returns:
+            splitter method.
+        """
+        splitter_method_name: str = self._get_splitter_method_name(splitter_method_name)
+
+        return getattr(self, splitter_method_name)
+
+    def _get_splitter_method_name(self, splitter_method_name: str) -> str:
+        """Accept splitter methods with or without starting with `_`.
+
+        Args:
+            splitter_method_name: splitter name starting with or without preceding `_`.
+
+        Returns:
+            splitter method name stripped of preceding underscore.
+        """
+        if splitter_method_name.startswith("_"):
+            return splitter_method_name[1:]
+        else:
+            return splitter_method_name
+
+    def _convert_date_parts(
+        self, date_parts: Union[List[DatePart], List[str]]
+    ) -> List[DatePart]:
+        """Convert a list of date parts to DatePart objects.
+
+        Args:
+            date_parts: List of DatePart or string representations of DatePart.
+
+        Returns:
+            List of DatePart objects
+        """
+        return [
+            DatePart(date_part.lower()) if isinstance(date_part, str) else date_part
+            for date_part in date_parts
+        ]

--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -11,10 +11,10 @@ from great_expectations.core.batch import BatchDefinition, BatchRequest
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
+from great_expectations.execution_engine.split_and_sample.data_splitter import DatePart
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
-from great_expectations.execution_engine.sqlalchemy_data_splitter import DatePart
 from tests.test_utils import (
     LoadedTable,
     clean_up_tables_with_prefix,


### PR DESCRIPTION
Changes proposed in this pull request:
- Preliminary refactor before adding splitting by datetime to spark/pandas to move some general methods to an abstract base class DataSplitter and move DatePart to the same module.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
