### PR TITLE
[MAINTENANCE] Handle edge cases where `false_positive_rate` is not in range [0, 1] or very close to bounds

### DIFF
--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -219,25 +219,23 @@ detected.
             parameters=parameters,
         )
 
-        if false_positive_rate < 0 or false_positive_rate >= 1:
+        if false_positive_rate < 0 or false_positive_rate > 1:
             raise ge_exceptions.ProfilerExecutionError(
-                f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
+                f"""false_positive_rate must be a positive decimal number between 0 and 1 inclusive [0, 1],
 but {false_positive_rate} was provided."""
             )
-        elif false_positive_rate == 0:
-            warnings.warn(
-                f"""false_positive_rate should be a positive decimal number between 0 and 1 exclusive (0, 1),
-but {false_positive_rate} was provided. A false_positive_rate of {NP_EPSILON} has been selected instead."""
-            )
-            self._false_positive_rate = NP_EPSILON
         elif false_positive_rate <= NP_EPSILON:
             warnings.warn(
-                f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too small.
+                f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 0.
 A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
             self._false_positive_rate = NP_EPSILON
-        else:
-            self._false_positive_rate = false_positive_rate
+        elif false_positive_rate >= (1 - NP_EPSILON):
+            warnings.warn(
+                f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 1.
+A false_positive_rate of {1-NP_EPSILON} has been selected instead."""
+            )
+            self._false_positive_rate = 1 - NP_EPSILON
 
         # Compute metric value for each Batch object.
         super().build_parameters(

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -222,17 +222,23 @@ detected.
         if isinstance(false_positive_rate, str):
             false_positive_rate = float(false_positive_rate)
 
-        if false_positive_rate <= 0:
+        if false_positive_rate < 0 or false_positive_rate >= 1:
+            raise ValueError(
+                f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
+but {false_positive_rate} was provided."""
+            )
+        elif false_positive_rate == 0:
             warnings.warn(
                 f"""false_positive_rate should be a positive decimal number between 0 and 1 exclusive (0, 1),
 but {false_positive_rate} was provided. A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
             self._false_positive_rate = NP_EPSILON
-        elif false_positive_rate >= 1:
-            raise ValueError(
-                f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
-but {false_positive_rate} was provided."""
+        elif false_positive_rate <= NP_EPSILON:
+            warnings.warn(
+                f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too small.
+A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
+            self._false_positive_rate = NP_EPSILON
         else:
             self._false_positive_rate = false_positive_rate
 

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -229,13 +229,13 @@ but {false_positive_rate} was provided."""
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 0.
 A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
-            self._false_positive_rate = NP_EPSILON
+            false_positive_rate = NP_EPSILON
         elif false_positive_rate >= (1 - NP_EPSILON):
             warnings.warn(
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 1.
 A false_positive_rate of {1-NP_EPSILON} has been selected instead."""
             )
-            self._false_positive_rate = 1 - NP_EPSILON
+            false_positive_rate = 1 - NP_EPSILON
 
         # Compute metric value for each Batch object.
         super().build_parameters(
@@ -282,7 +282,7 @@ A false_positive_rate of {1-NP_EPSILON} has been selected instead."""
             )
 
         estimator_func: Callable
-        etimator_kwargs: dict
+        estimator_kwargs: dict
         if estimator == "bootstrap":
             estimator_func = self._get_bootstrap_estimate
             estimator_kwargs = {

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -219,9 +219,6 @@ detected.
             parameters=parameters,
         )
 
-        if isinstance(false_positive_rate, str):
-            false_positive_rate = float(false_positive_rate)
-
         if false_positive_rate < 0 or false_positive_rate >= 1:
             raise ValueError(
                 f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -229,14 +229,12 @@ but {false_positive_rate} was provided."""
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 0.
 A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
-            self._false_positive_rate = NP_EPSILON
             false_positive_rate = NP_EPSILON
         elif false_positive_rate >= (1 - NP_EPSILON):
             warnings.warn(
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 1.
 A false_positive_rate of {1-NP_EPSILON} has been selected instead."""
             )
-            self._false_positive_rate = 1 - NP_EPSILON
             false_positive_rate = 1 - NP_EPSILON
 
         # Compute metric value for each Batch object.

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -219,7 +219,7 @@ detected.
             parameters=parameters,
         )
 
-        if false_positive_rate < 0 or false_positive_rate > 1:
+        if not (0.0 <= false_positive_rate <= 1.0):
             raise ge_exceptions.ProfilerExecutionError(
                 f"""false_positive_rate must be a positive decimal number between 0 and 1 inclusive [0, 1],
 but {false_positive_rate} was provided."""

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -230,12 +230,12 @@ but {false_positive_rate} was provided."""
 A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
             false_positive_rate = NP_EPSILON
-        elif false_positive_rate >= (1 - NP_EPSILON):
+        elif false_positive_rate >= (1.0 - NP_EPSILON):
             warnings.warn(
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 1.
-A false_positive_rate of {1-NP_EPSILON} has been selected instead."""
+A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
             )
-            false_positive_rate = 1 - NP_EPSILON
+            false_positive_rate = 1.0 - NP_EPSILON
 
         # Compute metric value for each Batch object.
         super().build_parameters(

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -123,23 +123,7 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
             data_context=data_context,
         )
 
-        if isinstance(false_positive_rate, str):
-            false_positive_rate = float(false_positive_rate)
-
-        if false_positive_rate <= 0:
-            raise warnings.warn(
-                f"""false_positive_rate should be a positive decimal number between 0 and 1 exclusive
-(0, 1), but {false_positive_rate} was provided. A false_positive_rate of {NP_EPSILON} has been selected instead.""",
-                RuntimeWarning,
-            )
-            self._false_positive_rate = NP_EPSILON
-        elif false_positive_rate >= 1:
-            raise ValueError(
-                f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
- but {false_positive_rate} was provided."""
-            )
-        else:
-            self._false_positive_rate = false_positive_rate
+        self._false_positive_rate = false_positive_rate
 
         self._estimator = estimator
 
@@ -234,6 +218,24 @@ detected.
             variables=variables,
             parameters=parameters,
         )
+
+        if isinstance(false_positive_rate, str):
+            false_positive_rate = float(false_positive_rate)
+
+        if false_positive_rate <= 0:
+            raise warnings.warn(
+                f"""false_positive_rate should be a positive decimal number between 0 and 1 exclusive (0, 1),
+but {false_positive_rate} was provided. A false_positive_rate of {NP_EPSILON} has been selected instead."""
+            )
+            self._false_positive_rate = NP_EPSILON
+        elif false_positive_rate >= 1:
+            raise ValueError(
+                f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
+but {false_positive_rate} was provided."""
+            )
+        else:
+            self._false_positive_rate = false_positive_rate
+
         if not (0.0 <= false_positive_rate <= 1.0):
             raise ge_exceptions.ProfilerExecutionError(
                 message=f"The confidence level for {self.__class__.__name__} is outside of [0.0, 1.0] closed interval."

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -223,7 +223,7 @@ detected.
             false_positive_rate = float(false_positive_rate)
 
         if false_positive_rate <= 0:
-            raise warnings.warn(
+            warnings.warn(
                 f"""false_positive_rate should be a positive decimal number between 0 and 1 exclusive (0, 1),
 but {false_positive_rate} was provided. A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
@@ -235,11 +235,6 @@ but {false_positive_rate} was provided."""
             )
         else:
             self._false_positive_rate = false_positive_rate
-
-        if not (0.0 <= false_positive_rate <= 1.0):
-            raise ge_exceptions.ProfilerExecutionError(
-                message=f"The confidence level for {self.__class__.__name__} is outside of [0.0, 1.0] closed interval."
-            )
 
         # Compute metric value for each Batch object.
         super().build_parameters(

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 from numbers import Number
 from typing import Callable, Dict, List, Optional, Tuple, Union, cast
 
@@ -122,7 +123,23 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
             data_context=data_context,
         )
 
-        self._false_positive_rate = false_positive_rate
+        if isinstance(false_positive_rate, str):
+            false_positive_rate = float(false_positive_rate)
+
+        if false_positive_rate <= 0:
+            raise warnings.warn(
+                f"""false_positive_rate should be a positive decimal number between 0 and 1 exclusive
+(0, 1), but {false_positive_rate} was provided. A false_positive_rate of {NP_EPSILON} has been selected instead.""",
+                RuntimeWarning,
+            )
+            self._false_positive_rate = NP_EPSILON
+        elif false_positive_rate >= 1:
+            raise ValueError(
+                f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
+ but {false_positive_rate} was provided."""
+            )
+        else:
+            self._false_positive_rate = false_positive_rate
 
         self._estimator = estimator
 

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -220,7 +220,7 @@ detected.
         )
 
         if false_positive_rate < 0 or false_positive_rate >= 1:
-            raise ValueError(
+            raise ge_exceptions.ProfilerExecutionError(
                 f"""false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
 but {false_positive_rate} was provided."""
             )

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -229,12 +229,14 @@ but {false_positive_rate} was provided."""
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 0.
 A false_positive_rate of {NP_EPSILON} has been selected instead."""
             )
+            self._false_positive_rate = NP_EPSILON
             false_positive_rate = NP_EPSILON
         elif false_positive_rate >= (1 - NP_EPSILON):
             warnings.warn(
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 1.
 A false_positive_rate of {1-NP_EPSILON} has been selected instead."""
             )
+            self._false_positive_rate = 1 - NP_EPSILON
             false_positive_rate = 1 - NP_EPSILON
 
         # Compute metric value for each Batch object.

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
@@ -1652,6 +1652,13 @@ def test_quentin_expect_column_quantile_values_to_be_between_auto_yes_default_pr
     custom_profiler_config = RuleBasedProfilerConfig(
         name="expect_column_quantile_values_to_be_between",  # Convention: use "expectation_type" as profiler name.
         config_version=1.0,
+        variables={
+            "quantiles": [2.5e-1, 5.0e-1, 7.5e-1],
+            "allow_relative_error": "linear",
+            "num_bootstrap_samples": 9139,
+            "bootstrap_random_seed": 43792,
+            "false_positive_rate": 5.0e-2,
+        },
         rules={
             "column_quantiles_rule": {
                 "domain_builder": {
@@ -1742,6 +1749,13 @@ def test_quentin_expect_column_quantile_values_to_be_between_auto_yes_default_pr
     custom_profiler_config = RuleBasedProfilerConfig(
         name="expect_column_quantile_values_to_be_between",  # Convention: use "expectation_type" as profiler name.
         config_version=1.0,
+        variables={
+            "quantiles": [2.5e-1, 5.0e-1, 7.5e-1],
+            "allow_relative_error": "linear",
+            "num_bootstrap_samples": 9139,
+            "bootstrap_random_seed": 43792,
+            "false_positive_rate": 5.0e-2,
+        },
         rules={
             "column_quantiles_rule": {
                 "domain_builder": {

--- a/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 import numpy as np
 import pytest
 
+import great_expectations.exceptions as ge_exceptions
 from great_expectations.data_context import DataContext
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
 from great_expectations.rule_based_profiler.helpers.util import NP_EPSILON
@@ -288,7 +289,7 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
 but 1.0 was provided."""
     )
 
-    with pytest.raises(ValueError, match=error_message):
+    with pytest.raises(ge_exceptions.ProfilerExecutionError, match=error_message):
         numeric_metric_range_parameter_builder.build_parameters(
             domain=domain,
             variables=variables,
@@ -340,7 +341,7 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
 but -0.05 was provided."""
     )
 
-    with pytest.raises(ValueError, match=error_message):
+    with pytest.raises(ge_exceptions.ProfilerExecutionError, match=error_message):
         numeric_metric_range_parameter_builder.build_parameters(
             domain=domain,
             variables=variables,

--- a/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
@@ -285,11 +285,11 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
     assert parameter_container.parameter_nodes is None
 
     error_message: str = re.escape(
-        """false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
-but 1.0 was provided."""
+        f"""You have chosen a false_positive_rate of 1.0, which is too close to 1.
+A false_positive_rate of {1 - NP_EPSILON} has been selected instead."""
     )
 
-    with pytest.raises(ge_exceptions.ProfilerExecutionError, match=error_message):
+    with pytest.warns(UserWarning, match=error_message):
         numeric_metric_range_parameter_builder.build_parameters(
             domain=domain,
             variables=variables,
@@ -337,7 +337,7 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
     assert parameter_container.parameter_nodes is None
 
     error_message: str = re.escape(
-        """false_positive_rate must be a positive decimal number between 0 and 1 exclusive (0, 1),
+        """false_positive_rate must be a positive decimal number between 0 and 1 inclusive [0, 1],
 but -0.05 was provided."""
     )
 
@@ -389,8 +389,8 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
     assert parameter_container.parameter_nodes is None
 
     warning_message: str = re.escape(
-        """false_positive_rate should be a positive decimal number between 0 and 1 exclusive (0, 1),
-but 0.0 was provided. A false_positive_rate of 2.220446049250313e-16 has been selected instead."""
+        f"""You have chosen a false_positive_rate of 0.0, which is too close to 0.
+A false_positive_rate of {NP_EPSILON} has been selected instead."""
     )
 
     with pytest.warns(UserWarning, match=warning_message):
@@ -450,8 +450,8 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
     assert parameter_container.parameter_nodes is None
 
     warning_message: str = re.escape(
-        f"""You have chosen a false_positive_rate of {smaller_than_np_epsilon_false_positive_rate}, which is too small.
-A false_positive_rate of 2.220446049250313e-16 has been selected instead."""
+        f"""You have chosen a false_positive_rate of {smaller_than_np_epsilon_false_positive_rate}, which is too close to 0.
+A false_positive_rate of {NP_EPSILON} has been selected instead."""
     )
 
     with pytest.warns(UserWarning, match=warning_message):

--- a/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
@@ -33,16 +33,13 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby(
         "data_asset_name": "my_reports",
     }
 
-    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder
-    numeric_metric_range_parameter_builder = (
-        NumericMetricRangeMultiBatchParameterBuilder(
-            name="row_count_range",
-            metric_name="table.row_count",
-            estimator="bootstrap",
-            false_positive_rate=1.0e-2,
-            round_decimals=0,
-            data_context=data_context,
-        )
+    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder = NumericMetricRangeMultiBatchParameterBuilder(
+        name="row_count_range",
+        metric_name="table.row_count",
+        estimator="bootstrap",
+        false_positive_rate=1.0e-2,
+        round_decimals=0,
+        data_context=data_context,
     )
 
     variables: Optional[ParameterContainer] = None
@@ -126,23 +123,19 @@ def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
 
     metric_domain_kwargs: dict = {"column": "fare_amount"}
 
-    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder
-
     fully_qualified_parameter_name_for_value: str = "$parameter.column_min_range"
 
     expected_value_dict: dict
     actual_value_dict: dict
 
-    numeric_metric_range_parameter_builder = (
-        NumericMetricRangeMultiBatchParameterBuilder(
-            name="column_min_range",
-            metric_name="column.min",
-            metric_domain_kwargs=metric_domain_kwargs,
-            estimator="oneshot",
-            false_positive_rate=1.0e-2,
-            round_decimals=1,
-            data_context=data_context,
-        )
+    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder = NumericMetricRangeMultiBatchParameterBuilder(
+        name="column_min_range",
+        metric_name="column.min",
+        metric_domain_kwargs=metric_domain_kwargs,
+        estimator="oneshot",
+        false_positive_rate=1.0e-2,
+        round_decimals=1,
+        data_context=data_context,
     )
 
     variables: Optional[ParameterContainer] = None
@@ -260,16 +253,13 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
         "data_asset_name": "my_reports",
     }
 
-    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder
-    numeric_metric_range_parameter_builder = (
-        NumericMetricRangeMultiBatchParameterBuilder(
-            name="row_count_range",
-            metric_name="table.row_count",
-            estimator="bootstrap",
-            false_positive_rate=1.0,
-            round_decimals=0,
-            data_context=data_context,
-        )
+    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder = NumericMetricRangeMultiBatchParameterBuilder(
+        name="row_count_range",
+        metric_name="table.row_count",
+        estimator="bootstrap",
+        false_positive_rate=1.0,
+        round_decimals=0,
+        data_context=data_context,
     )
 
     variables: Optional[ParameterContainer] = None
@@ -312,16 +302,13 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
         "data_asset_name": "my_reports",
     }
 
-    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder
-    numeric_metric_range_parameter_builder = (
-        NumericMetricRangeMultiBatchParameterBuilder(
-            name="row_count_range",
-            metric_name="table.row_count",
-            estimator="bootstrap",
-            false_positive_rate=-0.05,
-            round_decimals=0,
-            data_context=data_context,
-        )
+    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder = NumericMetricRangeMultiBatchParameterBuilder(
+        name="row_count_range",
+        metric_name="table.row_count",
+        estimator="bootstrap",
+        false_positive_rate=-0.05,
+        round_decimals=0,
+        data_context=data_context,
     )
 
     variables: Optional[ParameterContainer] = None
@@ -364,16 +351,13 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
         "data_asset_name": "my_reports",
     }
 
-    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder
-    numeric_metric_range_parameter_builder = (
-        NumericMetricRangeMultiBatchParameterBuilder(
-            name="row_count_range",
-            metric_name="table.row_count",
-            estimator="bootstrap",
-            false_positive_rate=0.0,
-            round_decimals=0,
-            data_context=data_context,
-        )
+    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder = NumericMetricRangeMultiBatchParameterBuilder(
+        name="row_count_range",
+        metric_name="table.row_count",
+        estimator="bootstrap",
+        false_positive_rate=0.0,
+        round_decimals=0,
+        data_context=data_context,
     )
 
     variables: Optional[ParameterContainer] = None
@@ -423,16 +407,13 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
     # what if user tries a false positive rate smaller than NP_EPSILON (by an order of magnitude in this case)?
     smaller_than_np_epsilon_false_positive_rate: float = NP_EPSILON / 10
 
-    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder
-    numeric_metric_range_parameter_builder = (
-        NumericMetricRangeMultiBatchParameterBuilder(
-            name="row_count_range",
-            metric_name="table.row_count",
-            estimator="bootstrap",
-            false_positive_rate=smaller_than_np_epsilon_false_positive_rate,
-            round_decimals=0,
-            data_context=data_context,
-        )
+    numeric_metric_range_parameter_builder: NumericMetricRangeMultiBatchParameterBuilder = NumericMetricRangeMultiBatchParameterBuilder(
+        name="row_count_range",
+        metric_name="table.row_count",
+        estimator="bootstrap",
+        false_positive_rate=smaller_than_np_epsilon_false_positive_rate,
+        round_decimals=0,
+        data_context=data_context,
     )
 
     variables: Optional[ParameterContainer] = None

--- a/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
@@ -401,8 +401,6 @@ A false_positive_rate of {NP_EPSILON} has been selected instead."""
             batch_request=batch_request,
         )
 
-    assert numeric_metric_range_parameter_builder.false_positive_rate == NP_EPSILON
-
 
 def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_false_positive_rate_very_small(
     bobby_columnar_table_multi_batch_deterministic_data_context,
@@ -461,5 +459,3 @@ A false_positive_rate of {NP_EPSILON} has been selected instead."""
             parameters=parameters,
             batch_request=batch_request,
         )
-
-    assert numeric_metric_range_parameter_builder.false_positive_rate == NP_EPSILON

--- a/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
@@ -284,7 +284,7 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
 but 1.0 was provided."""
     )
 
-    with pytest.raises(ValueError, match=error_message) as e:
+    with pytest.raises(ValueError, match=error_message):
         numeric_metric_range_parameter_builder.build_parameters(
             domain=domain,
             variables=variables,
@@ -333,10 +333,10 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_fals
 
     warning_message: str = re.escape(
         """false_positive_rate should be a positive decimal number between 0 and 1 exclusive (0, 1),
-but 0 was provided. A false_positive_rate of 2.220446049250313e-16 has been selected instead."""
+but 0.0 was provided. A false_positive_rate of 2.220446049250313e-16 has been selected instead."""
     )
 
-    with pytest.warns(match=warning_message):
+    with pytest.warns(UserWarning, match=warning_message):
         numeric_metric_range_parameter_builder.build_parameters(
             domain=domain,
             variables=variables,


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-704
- Raise `ValueError` if user passes a `false_positive_rate` > 1.0 or < 0.0
- Warn and use `false_positive_rate = NP_EPSILON` if user passes `false_positive_rate` within `NP_EPSILON` range of 0.0 or 1.0


### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.