### PR TITLE
[MAINTENANCE] Move splitter related taxi integration test fixtures

### DIFF
--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import List, Tuple
 
 import pandas as pd
@@ -11,9 +10,13 @@ from great_expectations.core.batch import BatchDefinition, BatchRequest
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.datasource.data_connector import ConfiguredAssetSqlDataConnector
-from great_expectations.execution_engine.split_and_sample.data_splitter import DatePart
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
+)
+from tests.integration.fixtures.split_data.splitter_test_cases_and_fixtures import (
+    TaxiSplittingTestCase,
+    TaxiSplittingTestCases,
+    TaxiTestData,
 )
 from tests.test_utils import (
     LoadedTable,
@@ -77,114 +80,14 @@ if __name__ == "test_script_module":
     test_df: pd.DataFrame = loaded_table.inserted_dataframe
     table_name: str = loaded_table.table_name
 
-    YEARS_IN_TAXI_DATA = (
-        pd.date_range(start="2018-01-01", end="2020-12-31", freq="AS")
-        .to_pydatetime()
-        .tolist()
+    taxi_test_data: TaxiTestData = TaxiTestData(
+        test_df, test_column_name="pickup_datetime"
     )
-    YEAR_BATCH_IDENTIFIER_DATA: List[dict] = [
-        {DatePart.YEAR.value: dt.year} for dt in YEARS_IN_TAXI_DATA
-    ]
-
-    MONTHS_IN_TAXI_DATA = (
-        pd.date_range(start="2018-01-01", end="2020-12-31", freq="MS")
-        .to_pydatetime()
-        .tolist()
-    )
-    YEAR_MONTH_BATCH_IDENTIFIER_DATA: List[dict] = [
-        {DatePart.YEAR.value: dt.year, DatePart.MONTH.value: dt.month}
-        for dt in MONTHS_IN_TAXI_DATA
-    ]
-    MONTH_BATCH_IDENTIFIER_DATA: List[dict] = [
-        {DatePart.MONTH.value: dt.month} for dt in MONTHS_IN_TAXI_DATA
-    ]
-
-    TEST_COLUMN: str = "pickup_datetime"
-
-    # Since taxi data does not contain all days, we need to introspect the data to build the fixture:
-    YEAR_MONTH_DAY_BATCH_IDENTIFIER_DATA: List[dict] = list(
-        {val[0]: val[1], val[2]: val[3], val[4]: val[5]}
-        for val in {
-            (
-                DatePart.YEAR.value,
-                dt.year,
-                DatePart.MONTH.value,
-                dt.month,
-                DatePart.DAY.value,
-                dt.day,
-            )
-            for dt in test_df[TEST_COLUMN]
-        }
-    )
-    YEAR_MONTH_DAY_BATCH_IDENTIFIER_DATA: List[dict] = sorted(
-        YEAR_MONTH_DAY_BATCH_IDENTIFIER_DATA,
-        key=lambda x: (
-            x[DatePart.YEAR.value],
-            x[DatePart.MONTH.value],
-            x[DatePart.DAY.value],
-        ),
+    taxi_splitting_test_cases: TaxiSplittingTestCases = TaxiSplittingTestCases(
+        taxi_test_data
     )
 
-    @dataclass
-    class SqlSplittingTestCase:
-        splitter_method_name: str
-        splitter_kwargs: dict
-        num_expected_batch_definitions: int
-        num_expected_rows_in_first_batch_definition: int
-        expected_pickup_datetimes: List[dict]
-
-    test_cases: List[SqlSplittingTestCase] = [
-        SqlSplittingTestCase(
-            splitter_method_name="split_on_year",
-            splitter_kwargs={"column_name": TEST_COLUMN},
-            num_expected_batch_definitions=3,
-            num_expected_rows_in_first_batch_definition=120,
-            expected_pickup_datetimes=YEAR_BATCH_IDENTIFIER_DATA,
-        ),
-        SqlSplittingTestCase(
-            splitter_method_name="split_on_year_and_month",
-            splitter_kwargs={"column_name": TEST_COLUMN},
-            num_expected_batch_definitions=36,
-            num_expected_rows_in_first_batch_definition=10,
-            expected_pickup_datetimes=YEAR_MONTH_BATCH_IDENTIFIER_DATA,
-        ),
-        SqlSplittingTestCase(
-            splitter_method_name="split_on_year_and_month_and_day",
-            splitter_kwargs={"column_name": TEST_COLUMN},
-            num_expected_batch_definitions=299,
-            num_expected_rows_in_first_batch_definition=2,
-            expected_pickup_datetimes=YEAR_MONTH_DAY_BATCH_IDENTIFIER_DATA,
-        ),
-        SqlSplittingTestCase(
-            splitter_method_name="split_on_date_parts",
-            splitter_kwargs={
-                "column_name": TEST_COLUMN,
-                "date_parts": [DatePart.MONTH],
-            },
-            num_expected_batch_definitions=12,
-            num_expected_rows_in_first_batch_definition=30,
-            expected_pickup_datetimes=MONTH_BATCH_IDENTIFIER_DATA,
-        ),
-        # date_parts as a string (with mixed case):
-        SqlSplittingTestCase(
-            splitter_method_name="split_on_date_parts",
-            splitter_kwargs={"column_name": TEST_COLUMN, "date_parts": ["mOnTh"]},
-            num_expected_batch_definitions=12,
-            num_expected_rows_in_first_batch_definition=30,
-            expected_pickup_datetimes=MONTH_BATCH_IDENTIFIER_DATA,
-        ),
-        # Mix of types of date_parts:
-        SqlSplittingTestCase(
-            splitter_method_name="split_on_date_parts",
-            splitter_kwargs={
-                "column_name": TEST_COLUMN,
-                "date_parts": [DatePart.YEAR, "month"],
-            },
-            num_expected_batch_definitions=36,
-            num_expected_rows_in_first_batch_definition=10,
-            expected_pickup_datetimes=YEAR_MONTH_BATCH_IDENTIFIER_DATA,
-        ),
-    ]
+    test_cases: List[TaxiSplittingTestCase] = taxi_splitting_test_cases.test_cases()
 
     for test_case in test_cases:
 
@@ -207,7 +110,7 @@ if __name__ == "test_script_module":
         # 2. Set splitter in data connector config
         data_connector_name: str = "test_data_connector"
         data_asset_name: str = table_name  # Read from generated table name
-        column_name: str = TEST_COLUMN
+        column_name: str = taxi_splitting_test_cases.test_column_name
         data_connector: ConfiguredAssetSqlDataConnector = (
             ConfiguredAssetSqlDataConnector(
                 name=data_connector_name,

--- a/tests/integration/fixtures/split_data/splitter_test_cases_and_fixtures.py
+++ b/tests/integration/fixtures/split_data/splitter_test_cases_and_fixtures.py
@@ -1,0 +1,160 @@
+import datetime
+from dataclasses import dataclass
+from typing import List
+
+import pandas as pd
+
+from great_expectations.execution_engine.split_and_sample.data_splitter import DatePart
+
+
+class TaxiTestData:
+
+    def __init__(self, test_df: pd.DataFrame, test_column_name: str):
+        self._test_df = test_df
+        self._test_column_name = test_column_name
+
+    @property
+    def test_df(self):
+        return self._test_df
+
+    @property
+    def test_column_name(self):
+        return self._test_column_name
+
+
+    def years_in_taxi_data(self) -> List[datetime.datetime]:
+        return pd.date_range(start="2018-01-01", end="2020-12-31", freq="AS").to_pydatetime().tolist()
+
+    def year_batch_identifier_data(self) -> List[dict]:
+        return [
+            {DatePart.YEAR.value: dt.year} for dt in self.years_in_taxi_data()
+        ]
+
+    def months_in_taxi_data(self) -> List[datetime.datetime]:
+        return (
+            pd.date_range(start="2018-01-01", end="2020-12-31", freq="MS")
+                .to_pydatetime()
+                .tolist()
+        )
+
+    def year_month_batch_identifier_data(self) -> List[dict]:
+        return [
+            {DatePart.YEAR.value: dt.year, DatePart.MONTH.value: dt.month}
+            for dt in self.months_in_taxi_data()
+        ]
+
+    def month_batch_identifier_data(self) -> List[dict]:
+        return [
+            {DatePart.MONTH.value: dt.month} for dt in self.months_in_taxi_data()
+        ]
+
+
+    def year_month_day_batch_identifier_data(self) -> List[dict]:
+        # Since taxi data does not contain all days,
+        # we need to introspect the data to build the fixture:
+        year_month_day_batch_identifier_list_unsorted: List[dict] = list(
+            {val[0]: val[1], val[2]: val[3], val[4]: val[5]}
+            for val in {
+                (
+                    DatePart.YEAR.value,
+                    dt.year,
+                    DatePart.MONTH.value,
+                    dt.month,
+                    DatePart.DAY.value,
+                    dt.day,
+                )
+                for dt in self.test_df[self.test_column_name]
+            }
+        )
+
+        return sorted(
+            year_month_day_batch_identifier_list_unsorted,
+            key=lambda x: (
+                x[DatePart.YEAR.value],
+                x[DatePart.MONTH.value],
+                x[DatePart.DAY.value],
+            ),
+        )
+
+
+
+
+@dataclass
+class TaxiSplittingTestCase:
+    splitter_method_name: str
+    splitter_kwargs: dict
+    num_expected_batch_definitions: int
+    num_expected_rows_in_first_batch_definition: int
+    expected_pickup_datetimes: List[dict]
+
+
+class TaxiSplittingTestCases:
+
+    def __init__(self, taxi_test_data: TaxiTestData):
+        self._taxi_test_data = taxi_test_data
+
+    @property
+    def taxi_test_data(self) -> TaxiTestData:
+        return self._taxi_test_data
+
+    @property
+    def test_df(self) -> pd.DataFrame:
+        return self._taxi_test_data.test_df
+
+    @property
+    def test_column_name(self) -> str:
+        return self._taxi_test_data.test_column_name
+
+    def test_cases(self) -> List[TaxiSplittingTestCase]:
+        return [
+            TaxiSplittingTestCase(
+                splitter_method_name="split_on_year",
+                splitter_kwargs={"column_name": self.taxi_test_data.test_column_name},
+                num_expected_batch_definitions=3,
+                num_expected_rows_in_first_batch_definition=120,
+                expected_pickup_datetimes=self.taxi_test_data.year_batch_identifier_data(),
+            ),
+            TaxiSplittingTestCase(
+                splitter_method_name="split_on_year_and_month",
+                splitter_kwargs={"column_name": self.taxi_test_data.test_column_name},
+                num_expected_batch_definitions=36,
+                num_expected_rows_in_first_batch_definition=10,
+                expected_pickup_datetimes=self.taxi_test_data.year_month_batch_identifier_data(),
+            ),
+            TaxiSplittingTestCase(
+                splitter_method_name="split_on_year_and_month_and_day",
+                splitter_kwargs={"column_name": self.taxi_test_data.test_column_name},
+                num_expected_batch_definitions=299,
+                num_expected_rows_in_first_batch_definition=2,
+                expected_pickup_datetimes=self.taxi_test_data.year_month_day_batch_identifier_data(),
+            ),
+            TaxiSplittingTestCase(
+                splitter_method_name="split_on_date_parts",
+                splitter_kwargs={
+                    "column_name": self.taxi_test_data.test_column_name,
+                    "date_parts": [DatePart.MONTH],
+                },
+                num_expected_batch_definitions=12,
+                num_expected_rows_in_first_batch_definition=30,
+                expected_pickup_datetimes=self.taxi_test_data.month_batch_identifier_data(),
+            ),
+            # date_parts as a string (with mixed case):
+            TaxiSplittingTestCase(
+                splitter_method_name="split_on_date_parts",
+                splitter_kwargs={"column_name": self.taxi_test_data.test_column_name, "date_parts": ["mOnTh"]},
+                num_expected_batch_definitions=12,
+                num_expected_rows_in_first_batch_definition=30,
+                expected_pickup_datetimes=self.taxi_test_data.month_batch_identifier_data(),
+            ),
+            # Mix of types of date_parts:
+            TaxiSplittingTestCase(
+                splitter_method_name="split_on_date_parts",
+                splitter_kwargs={
+                    "column_name": self.taxi_test_data.test_column_name,
+                    "date_parts": [DatePart.YEAR, "month"],
+                },
+                num_expected_batch_definitions=36,
+                num_expected_rows_in_first_batch_definition=10,
+                expected_pickup_datetimes=self.taxi_test_data.year_month_batch_identifier_data(),
+            ),
+        ]

--- a/tests/integration/fixtures/split_data/splitter_test_cases_and_fixtures.py
+++ b/tests/integration/fixtures/split_data/splitter_test_cases_and_fixtures.py
@@ -8,7 +8,6 @@ from great_expectations.execution_engine.split_and_sample.data_splitter import D
 
 
 class TaxiTestData:
-
     def __init__(self, test_df: pd.DataFrame, test_column_name: str):
         self._test_df = test_df
         self._test_column_name = test_column_name
@@ -21,20 +20,21 @@ class TaxiTestData:
     def test_column_name(self):
         return self._test_column_name
 
-
     def years_in_taxi_data(self) -> List[datetime.datetime]:
-        return pd.date_range(start="2018-01-01", end="2020-12-31", freq="AS").to_pydatetime().tolist()
+        return (
+            pd.date_range(start="2018-01-01", end="2020-12-31", freq="AS")
+            .to_pydatetime()
+            .tolist()
+        )
 
     def year_batch_identifier_data(self) -> List[dict]:
-        return [
-            {DatePart.YEAR.value: dt.year} for dt in self.years_in_taxi_data()
-        ]
+        return [{DatePart.YEAR.value: dt.year} for dt in self.years_in_taxi_data()]
 
     def months_in_taxi_data(self) -> List[datetime.datetime]:
         return (
             pd.date_range(start="2018-01-01", end="2020-12-31", freq="MS")
-                .to_pydatetime()
-                .tolist()
+            .to_pydatetime()
+            .tolist()
         )
 
     def year_month_batch_identifier_data(self) -> List[dict]:
@@ -44,10 +44,7 @@ class TaxiTestData:
         ]
 
     def month_batch_identifier_data(self) -> List[dict]:
-        return [
-            {DatePart.MONTH.value: dt.month} for dt in self.months_in_taxi_data()
-        ]
-
+        return [{DatePart.MONTH.value: dt.month} for dt in self.months_in_taxi_data()]
 
     def year_month_day_batch_identifier_data(self) -> List[dict]:
         # Since taxi data does not contain all days,
@@ -77,8 +74,6 @@ class TaxiTestData:
         )
 
 
-
-
 @dataclass
 class TaxiSplittingTestCase:
     splitter_method_name: str
@@ -89,7 +84,6 @@ class TaxiSplittingTestCase:
 
 
 class TaxiSplittingTestCases:
-
     def __init__(self, taxi_test_data: TaxiTestData):
         self._taxi_test_data = taxi_test_data
 
@@ -141,7 +135,10 @@ class TaxiSplittingTestCases:
             # date_parts as a string (with mixed case):
             TaxiSplittingTestCase(
                 splitter_method_name="split_on_date_parts",
-                splitter_kwargs={"column_name": self.taxi_test_data.test_column_name, "date_parts": ["mOnTh"]},
+                splitter_kwargs={
+                    "column_name": self.taxi_test_data.test_column_name,
+                    "date_parts": ["mOnTh"],
+                },
                 num_expected_batch_definitions=12,
                 num_expected_rows_in_first_batch_definition=30,
                 expected_pickup_datetimes=self.taxi_test_data.month_batch_identifier_data(),


### PR DESCRIPTION
Changes proposed in this pull request:
- Move these text fixtures so that they can be leveraged for use in spark and pandas related integration tests as well. This is a partial refactor in preparation for GREAT-733
- Split up load_data_into_test_database so that we can use the concatenated df in tests.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
