### PR TITLE
[BUGFIX] Fix Splitter Integration Test for BigQuery

### DIFF
--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -70,13 +70,11 @@ if __name__ == "test_script_module":
 
     dialect, connection_string = _get_connection_string_and_dialect()
     print(f"Testing dialect: {dialect}")
+
     print("Preemptively cleaning old tables")
-    # see if expiration can be set with BigQuery backend?
-    # or if this is being cleaned up too often
-    # if
-    # clean_up_tables_with_prefix(
-    #     connection_string=connection_string, table_prefix=f"{TAXI_DATA_TABLE_NAME}_"
-    # )
+    clean_up_tables_with_prefix(
+        connection_string=connection_string, table_prefix=f"{TAXI_DATA_TABLE_NAME}_"
+    )
 
     loaded_table: LoadedTable = _load_data(connection_string=connection_string)
     test_df: pd.DataFrame = loaded_table.inserted_dataframe

--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -67,14 +67,13 @@ if __name__ == "test_script_module":
 
     dialect, connection_string = _get_connection_string_and_dialect()
     print(f"Testing dialect: {dialect}")
-
     print("Preemptively cleaning old tables")
     # see if expiration can be set with BigQuery backend?
     # or if this is being cleaned up too often
-
-    clean_up_tables_with_prefix(
-        connection_string=connection_string, table_prefix=f"{TAXI_DATA_TABLE_NAME}_"
-    )
+    # if
+    # clean_up_tables_with_prefix(
+    #     connection_string=connection_string, table_prefix=f"{TAXI_DATA_TABLE_NAME}_"
+    # )
 
     loaded_table: LoadedTable = _load_data(connection_string=connection_string)
     test_df: pd.DataFrame = loaded_table.inserted_dataframe

--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -38,7 +38,6 @@ def _get_connection_string_and_dialect() -> Tuple[str, str]:
     if dialect == "snowflake":
         connection_string: str = get_snowflake_connection_url()
     elif dialect == "bigquery":
-        # still needed for loading the data we keep this
         connection_string: str = get_bigquery_connection_url()
     else:
         connection_string: str = db_config["connection_string"]

--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -69,6 +69,9 @@ if __name__ == "test_script_module":
     print(f"Testing dialect: {dialect}")
 
     print("Preemptively cleaning old tables")
+    # see if expiration can be set with BigQuery backend?
+    # or if this is being cleaned up too often
+
     clean_up_tables_with_prefix(
         connection_string=connection_string, table_prefix=f"{TAXI_DATA_TABLE_NAME}_"
     )

--- a/tests/integration/db/test_sql_data_splitting.py
+++ b/tests/integration/db/test_sql_data_splitting.py
@@ -38,6 +38,7 @@ def _get_connection_string_and_dialect() -> Tuple[str, str]:
     if dialect == "snowflake":
         connection_string: str = get_snowflake_connection_url()
     elif dialect == "bigquery":
+        # still needed for loading the data we keep this
         connection_string: str = get_bigquery_connection_url()
     else:
         connection_string: str = db_config["connection_string"]

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -527,28 +527,28 @@ cloud_gcp_tests = [
 ]
 
 cloud_bigquery_tests = [
-    # IntegrationTestFixture(
-    #     name="bigquery_yaml_example",
-    #     user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_yaml_example.py",
-    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-    #     data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
-    #     util_script="tests/test_utils.py",
-    #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
-    # ),
-    # IntegrationTestFixture(
-    #     name="bigquery_python_example",
-    #     user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py",
-    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-    #     data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
-    #     util_script="tests/test_utils.py",
-    #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
-    # ),
-    # IntegrationTestFixture(
-    #     name="gcp_deployment_patterns_file_bigquery_yaml_configs",
-    #     user_flow_script="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery_yaml_configs.py",
-    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-    #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
-    # ),
+    IntegrationTestFixture(
+        name="bigquery_yaml_example",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_yaml_example.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
+        util_script="tests/test_utils.py",
+        extra_backend_dependencies=BackendDependencies.BIGQUERY,
+    ),
+    IntegrationTestFixture(
+        name="bigquery_python_example",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
+        util_script="tests/test_utils.py",
+        extra_backend_dependencies=BackendDependencies.BIGQUERY,
+    ),
+    IntegrationTestFixture(
+        name="gcp_deployment_patterns_file_bigquery_yaml_configs",
+        user_flow_script="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery_yaml_configs.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        extra_backend_dependencies=BackendDependencies.BIGQUERY,
+    ),
     IntegrationTestFixture(
         name="split_data_on_datetime_bigquery",
         user_flow_script="tests/integration/db/test_sql_data_splitting.py",
@@ -563,12 +563,12 @@ cloud_bigquery_tests = [
         ),
         extra_backend_dependencies=BackendDependencies.BIGQUERY,
     ),
-    # IntegrationTestFixture(
-    #     name="test_runtime_parameters_bigquery",
-    #     user_flow_script="tests/integration/db/bigquery.py",
-    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-    #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
-    # ),
+    IntegrationTestFixture(
+        name="test_runtime_parameters_bigquery",
+        user_flow_script="tests/integration/db/bigquery.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        extra_backend_dependencies=BackendDependencies.BIGQUERY,
+    ),
 ]
 
 cloud_azure_tests = [
@@ -709,14 +709,14 @@ cloud_redshift_tests = [
 ]
 
 # populate docs_test_matrix with sub-lists
-# docs_test_matrix += local_tests
-# docs_test_matrix += dockerized_db_tests
-# docs_test_matrix += cloud_snowflake_tests
-# docs_test_matrix += cloud_gcp_tests
+docs_test_matrix += local_tests
+docs_test_matrix += dockerized_db_tests
+docs_test_matrix += cloud_snowflake_tests
+docs_test_matrix += cloud_gcp_tests
 docs_test_matrix += cloud_bigquery_tests
-# docs_test_matrix += cloud_azure_tests
-# docs_test_matrix += cloud_s3_tests
-# docs_test_matrix += cloud_redshift_tests
+docs_test_matrix += cloud_azure_tests
+docs_test_matrix += cloud_s3_tests
+docs_test_matrix += cloud_redshift_tests
 
 pandas_integration_tests = [
     IntegrationTestFixture(
@@ -772,8 +772,8 @@ aws_integration_tests = [
 
 # populate integration_test_matrix with sub-lists
 integration_test_matrix: List[IntegrationTestFixture] = []
-# integration_test_matrix += aws_integration_tests
-# integration_test_matrix += pandas_integration_tests
+integration_test_matrix += aws_integration_tests
+integration_test_matrix += pandas_integration_tests
 
 
 def idfn(test_configuration):

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -527,48 +527,48 @@ cloud_gcp_tests = [
 ]
 
 cloud_bigquery_tests = [
-    IntegrationTestFixture(
-        name="bigquery_yaml_example",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_yaml_example.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
-        util_script="tests/test_utils.py",
-        extra_backend_dependencies=BackendDependencies.BIGQUERY,
-    ),
-    IntegrationTestFixture(
-        name="bigquery_python_example",
-        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
-        util_script="tests/test_utils.py",
-        extra_backend_dependencies=BackendDependencies.BIGQUERY,
-    ),
-    IntegrationTestFixture(
-        name="gcp_deployment_patterns_file_bigquery_yaml_configs",
-        user_flow_script="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery_yaml_configs.py",
-        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-        extra_backend_dependencies=BackendDependencies.BIGQUERY,
-    ),
     # IntegrationTestFixture(
-    #     name="split_data_on_datetime_bigquery",
-    #     user_flow_script="tests/integration/db/test_sql_data_splitting.py",
+    #     name="bigquery_yaml_example",
+    #     user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_yaml_example.py",
     #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
-    #     data_dir="tests/test_sets/taxi_yellow_tripdata_samples/",
+    #     data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
     #     util_script="tests/test_utils.py",
-    #     other_files=(
-    #         (
-    #             "tests/integration/fixtures/split_data/bigquery_connection_string.yml",
-    #             "connection_string.yml",
-    #         ),
-    #     ),
+    #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
+    # ),
+    # IntegrationTestFixture(
+    #     name="bigquery_python_example",
+    #     user_flow_script="tests/integration/docusaurus/connecting_to_your_data/database/bigquery_python_example.py",
+    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+    #     data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
+    #     util_script="tests/test_utils.py",
+    #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
+    # ),
+    # IntegrationTestFixture(
+    #     name="gcp_deployment_patterns_file_bigquery_yaml_configs",
+    #     user_flow_script="tests/integration/docusaurus/deployment_patterns/gcp_deployment_patterns_file_bigquery_yaml_configs.py",
+    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
     #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
     # ),
     IntegrationTestFixture(
-        name="test_runtime_parameters_bigquery",
-        user_flow_script="tests/integration/db/bigquery.py",
+        name="split_data_on_datetime_bigquery",
+        user_flow_script="tests/integration/db/test_sql_data_splitting.py",
         data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/",
+        util_script="tests/test_utils.py",
+        other_files=(
+            (
+                "tests/integration/fixtures/split_data/bigquery_connection_string.yml",
+                "connection_string.yml",
+            ),
+        ),
         extra_backend_dependencies=BackendDependencies.BIGQUERY,
     ),
+    # IntegrationTestFixture(
+    #     name="test_runtime_parameters_bigquery",
+    #     user_flow_script="tests/integration/db/bigquery.py",
+    #     data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+    #     extra_backend_dependencies=BackendDependencies.BIGQUERY,
+    # ),
 ]
 
 cloud_azure_tests = [
@@ -709,14 +709,14 @@ cloud_redshift_tests = [
 ]
 
 # populate docs_test_matrix with sub-lists
-docs_test_matrix += local_tests
-docs_test_matrix += dockerized_db_tests
-docs_test_matrix += cloud_snowflake_tests
-docs_test_matrix += cloud_gcp_tests
+# docs_test_matrix += local_tests
+# docs_test_matrix += dockerized_db_tests
+# docs_test_matrix += cloud_snowflake_tests
+# docs_test_matrix += cloud_gcp_tests
 docs_test_matrix += cloud_bigquery_tests
-docs_test_matrix += cloud_azure_tests
-docs_test_matrix += cloud_s3_tests
-docs_test_matrix += cloud_redshift_tests
+# docs_test_matrix += cloud_azure_tests
+# docs_test_matrix += cloud_s3_tests
+# docs_test_matrix += cloud_redshift_tests
 
 pandas_integration_tests = [
     IntegrationTestFixture(
@@ -772,8 +772,8 @@ aws_integration_tests = [
 
 # populate integration_test_matrix with sub-lists
 integration_test_matrix: List[IntegrationTestFixture] = []
-integration_test_matrix += aws_integration_tests
-integration_test_matrix += pandas_integration_tests
+# integration_test_matrix += aws_integration_tests
+# integration_test_matrix += pandas_integration_tests
 
 
 def idfn(test_configuration):


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes integration test for Splitters that was causing our `docs-integration` stage to fail. 

## What was the cause? 
- Using the `to_sql()` method in `Pandas` appears to have an insert query for every row [in the DataFrame](https://stackoverflow.com/questions/29706278/python-pandas-to-sql-with-sqlalchemy-how-to-speed-up-exporting-to-ms-sql), so for the ~300 line test df we were loading for the splitter tests, this was taking > 15 min and causing our tests to time out and fail.
- [The BigQuery Documentation](https://cloud.google.com/bigquery/docs/samples/bigquery-load-table-dataframe) recommends using the Google BigQuery client for these kinds of situations, which will load the Dataframe as part of 1 query. 
- Therefore, the primary change for this PR is the `load_data_into_test_bigquery_database_with_bigquery_client()` which is used by the `split_data_on_datetime_bigquery()` test.  Test now passes and runs in ~ 1 min. 



### Definition of Done
Please delete options that are not relevant.
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
