### PR TITLE
[MAINTENACE] Temporarily pin `cryptography` package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 altair>=4.0.0,<5
 Click>=7.1.2
 colorama>=0.4.3
-cryptography>=3.2
+cryptography>=3.2,<37.0.0
 importlib-metadata>=1.7.0 # (included in Python 3.8 by default.)
 Ipython>=7.16.3
 jinja2>=2.10,<3.1.0 # contextfilter has been renamed


### PR DESCRIPTION
# why this PR?
* `cryptography` is a dependency for the `boto` suite (`boto3`, `botocore`, `aiobotocore`) , as well as GE. Recent update to `cryptography` package is causing an `AttributeError` for GE during our `docs-integration` stage. 
* This PR proposes to temporarily pin the package < 0.37. https://pypi.org/project/cryptography/
