### PR TITLE
[BUGFIX] extras_require

### DIFF
--- a/requirements-dev-sqlalchemy.txt
+++ b/requirements-dev-sqlalchemy.txt
@@ -1,7 +1,6 @@
 --requirement requirements-dev-lite.txt
 
 --requirement requirements-dev-athena.txt
---requirement requirements-dev-azure.txt
 --requirement requirements-dev-bigquery.txt
 --requirement requirements-dev-dremio.txt
 --requirement requirements-dev-mssql.txt

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import re
 from glob import glob
 
+import pkg_resources
 from setuptools import find_packages, setup
 
 import versioneer
@@ -27,21 +28,13 @@ def get_extras_require():
     )
     ignore_keys = ("contrib", "sqlalchemy", "test")
     rx_fname_part = re.compile(r"requirements-dev-(.*).txt")
-    rx_all_but_comment = re.compile(r"^([^#]*).*")
     for fname in sorted(glob("requirements-dev-*.txt")):
         key = rx_fname_part.match(fname).group(1)
         if key in ignore_keys:
             continue
         with open(fname) as f:
-            lines = f.read().splitlines()
-            lines_stripped = []
-            for line in lines:
-                match = rx_all_but_comment.match(line)
-                if match:
-                    text = match.group(1).strip()
-                    if text:
-                        lines_stripped.append(text)
-            results[key] = lines_stripped
+            parsed = [str(req) for req in pkg_resources.parse_requirements(f)]
+            results[key] = parsed
 
     lite = results.pop("lite")
     results["boto"] = [req for req in lite if req.startswith("boto")]

--- a/setup.py
+++ b/setup.py
@@ -8,27 +8,49 @@ import versioneer
 
 def get_extras_require():
     results = {}
-    extra_keys = {
+    extra_key_mapping = {
         "aws_secrets": "boto",
         "azure_secrets": "azure",
         "gcp": "bigquery",
         "s3": "boto",
     }
+    sqla_keys = (
+        "athena",
+        "bigquery",
+        "dremio",
+        "mssql",
+        "mysql",
+        "postgresql",
+        "redshift",
+        "snowflake",
+        "teradata",
+    )
     ignore_keys = ("contrib", "sqlalchemy", "test")
-    rx = re.compile(r"requirements-dev-(.*).txt")
+    rx_fname_part = re.compile(r"requirements-dev-(.*).txt")
+    rx_all_but_comment = re.compile(r"^([^#]*).*")
     for fname in sorted(glob("requirements-dev-*.txt")):
-        key = rx.match(fname).group(1)
+        key = rx_fname_part.match(fname).group(1)
         if key in ignore_keys:
             continue
         with open(fname) as f:
-            results[key] = f.read().splitlines()
+            lines = f.read().splitlines()
+            lines_stripped = []
+            for line in lines:
+                match = rx_all_but_comment.match(line)
+                if match:
+                    text = match.group(1).strip()
+                    if text:
+                        lines_stripped.append(text)
+            results[key] = lines_stripped
 
     lite = results.pop("lite")
     results["boto"] = [req for req in lite if req.startswith("boto")]
     results["sqlalchemy"] = [req for req in lite if req.startswith("sqlalchemy")]
 
-    for new_key, existing_key in extra_keys.items():
+    for new_key, existing_key in extra_key_mapping.items():
         results[new_key] = results[existing_key]
+    for key in sqla_keys:
+        results[key] += results["sqlalchemy"]
 
     results.pop("boto")
     return results


### PR DESCRIPTION
The keys in extras_require that relate to sqlalchemy, don't include sqlalchemy in their lists

Changes proposed in this pull request:
- Remove azure from requirements-dev-sqlalchemy.txt
- Update get_extras_require func to strip comments and include sqlalchemy for some keys

```
{'arrow': ['feather-format>=0.4.1', 'pyarrow>=0.12.0'],
 'athena': ['pyathena>=1.11', 'sqlalchemy>=1.3.18,<1.4.10'],
 'aws_secrets': ['boto3==1.17.106'],
 'azure': ['azure-identity>=1.0.0',
           'azure-keyvault-secrets>=4.0.0',
           'azure-storage-blob>=12.5.0'],
 'azure_secrets': ['azure-identity>=1.0.0',
                   'azure-keyvault-secrets>=4.0.0',
                   'azure-storage-blob>=12.5.0'],
 'bigquery': ['gcsfs>=0.5.1',
              'google-cloud-secret-manager>=1.0.0',
              'google-cloud-storage>=1.28.0',
              'sqlalchemy-bigquery>=1.3.0',
              'sqlalchemy>=1.3.18,<1.4.10'],
 'dremio': ['pyarrow>=0.12.0',
            'pyodbc>=4.0.30',
            'sqlalchemy-dremio>=1.2.1',
            'sqlalchemy>=1.3.18,<1.4.10'],
 'excel': ['openpyxl>=3.0.7', 'xlrd>=1.1.0,<2.0.0'],
 'gcp': ['gcsfs>=0.5.1',
         'google-cloud-secret-manager>=1.0.0',
         'google-cloud-storage>=1.28.0',
         'sqlalchemy-bigquery>=1.3.0',
         'sqlalchemy>=1.3.18,<1.4.10'],
 'mssql': ['pyodbc>=4.0.30', 'sqlalchemy>=1.3.18,<1.4.10'],
 'mysql': ['PyMySQL>=0.9.3,<0.10', 'sqlalchemy>=1.3.18,<1.4.10'],
 'pagerduty': ['pypd==1.1.0'],
 'postgresql': ['psycopg2-binary>=2.7.6', 'sqlalchemy>=1.3.18,<1.4.10'],
 'redshift': ['psycopg2-binary>=2.7.6',
              'sqlalchemy-redshift>=0.7.7',
              'sqlalchemy>=1.3.18,<1.4.10'],
 's3': ['boto3==1.17.106'],
 'snowflake': ['snowflake-connector-python==2.5.0',
               'snowflake-sqlalchemy>=1.2.3',
               'sqlalchemy>=1.3.18,<1.4.10'],
 'spark': ['pyspark>=2.3.2'],
 'sqlalchemy': ['sqlalchemy>=1.3.18,<1.4.10'],
 'teradata': ['teradatasqlalchemy==17.0.0.1', 'sqlalchemy>=1.3.18,<1.4.10']}
 ```