### PR TITLE
[MAINTENANCE] Type annotate relevant functions with `-> None` (per PEP 484)

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -45,7 +45,7 @@ class ValidationAction:
     The Data Context is passed to this class in its constructor.
     """
 
-    def __init__(self, data_context):
+    def __init__(self, data_context) -> None:
         self.data_context = data_context
 
     def run(
@@ -95,7 +95,7 @@ class NoOpAction(ValidationAction):
     def __init__(
         self,
         data_context,
-    ):
+    ) -> None:
         super().__init__(data_context)
 
     def _run(
@@ -107,7 +107,7 @@ class NoOpAction(ValidationAction):
         data_asset,
         expectation_suite_identifier=None,
         checkpoint_identifier=None,
-    ):
+    ) -> None:
         print("Happily doing nothing")
 
 
@@ -149,7 +149,7 @@ class SlackNotificationAction(ValidationAction):
         slack_channel=None,
         notify_on="all",
         notify_with=None,
-    ):
+    ) -> None:
         """Construct a SlackNotificationAction
 
         Args:
@@ -272,7 +272,7 @@ class PagerdutyAlertAction(ValidationAction):
         api_key,
         routing_key,
         notify_on="failure",
-    ):
+    ) -> None:
         """Construct a PagerdutyAlertAction
 
         Args:
@@ -378,7 +378,7 @@ class MicrosoftTeamsNotificationAction(ValidationAction):
         renderer,
         microsoft_teams_webhook,
         notify_on="all",
-    ):
+    ) -> None:
         """Construct a MicrosoftTeamsNotificationAction
 
         Args:
@@ -496,7 +496,7 @@ class OpsgenieAlertAction(ValidationAction):
         region=None,
         priority="P3",
         notify_on="failure",
-    ):
+    ) -> None:
         """Construct a OpsgenieAlertAction
 
         Args:
@@ -626,7 +626,7 @@ class EmailAction(ValidationAction):
         use_ssl=None,
         notify_on="all",
         notify_with=None,
-    ):
+    ) -> None:
         """Construct an EmailAction
         Args:
             data_context:
@@ -770,7 +770,7 @@ class StoreValidationResultAction(ValidationAction):
         self,
         data_context,
         target_store_name=None,
-    ):
+    ) -> None:
         """
 
         :param data_context: Data Context
@@ -856,7 +856,7 @@ class StoreEvaluationParametersAction(ValidationAction):
 
     """
 
-    def __init__(self, data_context, target_store_name=None):
+    def __init__(self, data_context, target_store_name=None) -> None:
         """
 
         Args:
@@ -923,7 +923,7 @@ class StoreMetricsAction(ValidationAction):
 
     def __init__(
         self, data_context, requested_metrics, target_store_name="metrics_store"
-    ):
+    ) -> None:
         """
 
         Args:
@@ -1013,7 +1013,7 @@ class UpdateDataDocsAction(ValidationAction):
 
     """
 
-    def __init__(self, data_context, site_names=None, target_site_names=None):
+    def __init__(self, data_context, site_names=None, target_site_names=None) -> None:
         """
         :param data_context: Data Context
         :param site_names: *optional* List of site names for building data docs
@@ -1098,7 +1098,7 @@ class CloudNotificationAction(ValidationAction):
         self,
         data_context: "DataContext",
         checkpoint_ge_cloud_id: str,
-    ):
+    ) -> None:
         super().__init__(data_context)
         self.checkpoint_ge_cloud_id = checkpoint_ge_cloud_id
 
@@ -1148,7 +1148,7 @@ class SNSNotificationAction(ValidationAction):
 
     def __init__(
         self, data_context: "DataContext", sns_topic_arn: str, sns_message_subject
-    ):
+    ) -> None:
         super().__init__(data_context)
         self.sns_topic_arn = sns_topic_arn
         self.sns_message_subject = sns_message_subject

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -62,7 +62,7 @@ class BaseCheckpoint(ConfigPeer):
         self,
         checkpoint_config: CheckpointConfig,
         data_context: "DataContext",  # noqa: F821
-    ):
+    ) -> None:
         # Note the gross typechecking to avoid a circular import
         if "DataContext" not in str(type(data_context)):
             raise TypeError("A Checkpoint requires a valid DataContext")
@@ -288,7 +288,7 @@ class BaseCheckpoint(ConfigPeer):
         run_id: Optional[Union[str, RunIdentifier]],
         idx: Optional[int] = 0,
         validation_dict: Optional[dict] = None,
-    ):
+    ) -> None:
         if validation_dict is None:
             validation_dict = {}
 
@@ -511,7 +511,7 @@ class Checkpoint(BaseCheckpoint):
         batches: Optional[List[dict]] = None,
         ge_cloud_id: Optional[UUID] = None,
         expectation_suite_ge_cloud_id: Optional[UUID] = None,
-    ):
+    ) -> None:
         # Only primitive types are allowed as constructor arguments; data frames are supplied to "run()" as arguments.
         if batch_request_contains_batch_data(batch_request=batch_request):
             raise ValueError(
@@ -861,7 +861,7 @@ class LegacyCheckpoint(Checkpoint):
         data_context,
         validation_operator_name: Optional[str] = None,
         batches: Optional[List[dict]] = None,
-    ):
+    ) -> None:
         super().__init__(
             name=name,
             data_context=data_context,
@@ -1040,7 +1040,7 @@ class SimpleCheckpoint(Checkpoint):
         notify_with: Union[str, List[str]] = "all",
         expectation_suite_ge_cloud_id: Optional[str] = None,
         **kwargs,
-    ):
+    ) -> None:
         checkpoint_config: CheckpointConfig = self._configurator_class(
             name=name,
             data_context=data_context,

--- a/great_expectations/checkpoint/configurator.py
+++ b/great_expectations/checkpoint/configurator.py
@@ -67,7 +67,7 @@ class SimpleCheckpointConfigurator:
         notify_on: str = "all",
         notify_with: Union[str, List[str]] = "all",
         **kwargs,
-    ):
+    ) -> None:
         """
         After instantiation, call the .build() method to get a new Checkpoint.
 
@@ -217,7 +217,7 @@ class SimpleCheckpointConfigurator:
         if self.site_names in ["all", None]:
             return
 
-    def _validate_notify_on(self):
+    def _validate_notify_on(self) -> None:
         if self.notify_on not in ["all", "success", "failure"]:
             raise ValueError("notify_on must be one of: 'all', 'failure', 'success'")
 
@@ -229,11 +229,11 @@ class SimpleCheckpointConfigurator:
         if not is_list_of_strings(self.notify_with):
             raise ValueError("notify_with must be a list of site names")
 
-    def _validate_slack_webhook(self):
+    def _validate_slack_webhook(self) -> None:
         if self.slack_webhook and not is_sane_slack_webhook(self.slack_webhook):
             raise ValueError("Please provide a valid slack webhook")
 
-    def _validate_slack_configuration(self):
+    def _validate_slack_configuration(self) -> None:
         """Guide the user toward correct configuration."""
         if isinstance(self.notify_with, list) and self.slack_webhook is None:
             raise ValueError(

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -457,7 +457,7 @@ def get_validations_with_batch_request_as_dict(
     return validations
 
 
-def validate_validation_dict(validation_dict: dict):
+def validate_validation_dict(validation_dict: dict) -> None:
     if validation_dict.get("batch_request") is None:
         raise ge_exceptions.CheckpointError("validation batch_request cannot be None")
     if not validation_dict.get("expectation_suite_name"):

--- a/great_expectations/cli/build_docs.py
+++ b/great_expectations/cli/build_docs.py
@@ -12,7 +12,7 @@ def build_docs(
     site_names: Optional[List[str]] = None,
     view: bool = True,
     assume_yes: bool = False,
-):
+) -> None:
     """Build documentation in a context"""
     logger.debug("Starting cli.datasource.build_docs")
 

--- a/great_expectations/cli/checkpoint.py
+++ b/great_expectations/cli/checkpoint.py
@@ -53,7 +53,7 @@ except ImportError:
 
 @click.group(short_help="Checkpoint operations")
 @click.pass_context
-def checkpoint(ctx):
+def checkpoint(ctx) -> None:
     """
     Checkpoint operations
 
@@ -93,7 +93,7 @@ def checkpoint(ctx):
     default=True,
 )
 @click.pass_context
-def checkpoint_new(ctx, name, jupyter):
+def checkpoint_new(ctx, name, jupyter) -> None:
     """Create a new Checkpoint for easy deployments.
 
     NAME is the name of the Checkpoint to create.
@@ -172,7 +172,7 @@ def _get_notebook_path(context, notebook_name):
 
 @checkpoint.command(name="list")
 @click.pass_context
-def checkpoint_list(ctx):
+def checkpoint_list(ctx) -> None:
     """List configured checkpoints."""
     context: DataContext = ctx.obj.data_context
     usage_event_end: str = ctx.obj.usage_event_end
@@ -308,7 +308,7 @@ def print_validation_operator_results_details(
 @checkpoint.command(name="script")
 @click.argument("checkpoint")
 @click.pass_context
-def checkpoint_script(ctx, checkpoint):
+def checkpoint_script(ctx, checkpoint) -> None:
     """
     Create a python script to run a Checkpoint.
 

--- a/great_expectations/cli/cli.py
+++ b/great_expectations/cli/cli.py
@@ -29,7 +29,7 @@ class CLIState:
         config_file_location: Optional[str] = None,
         data_context: Optional[DataContext] = None,
         assume_yes: bool = False,
-    ):
+    ) -> None:
         self.v3_api = v3_api
         self.config_file_location = config_file_location
         self._data_context = data_context
@@ -50,7 +50,7 @@ class CLIState:
         return self._data_context
 
     @data_context.setter
-    def data_context(self, data_context):
+    def data_context(self, data_context) -> None:
         assert isinstance(data_context, DataContext)
         self._data_context = data_context
 
@@ -92,7 +92,7 @@ class CLI(click.MultiCommand):
             return None
 
     @staticmethod
-    def print_ctx_debugging(ctx):
+    def print_ctx_debugging(ctx) -> None:
         print(f"ctx.args: {ctx.args}")
         print(f"ctx.params: {ctx.params}")
         print(f"ctx.obj: {ctx.obj}")
@@ -148,7 +148,7 @@ class CLI(click.MultiCommand):
     help='Assume "yes" for all prompts.',
 )
 @click.pass_context
-def cli(ctx, v3_api, verbose, config_file_location, assume_yes):
+def cli(ctx, v3_api, verbose, config_file_location, assume_yes) -> None:
     """
     Welcome to the great_expectations CLI!
 
@@ -180,7 +180,7 @@ def cli(ctx, v3_api, verbose, config_file_location, assume_yes):
             )
 
 
-def main():
+def main() -> None:
     cli()
 
 

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -45,7 +45,7 @@ class SupportedDatabaseBackends(enum.Enum):
 
 @click.group()
 @click.pass_context
-def datasource(ctx):
+def datasource(ctx) -> None:
     """Datasource operations"""
     ctx.obj.data_context = ctx.obj.get_data_context_from_config_file()
 
@@ -98,7 +98,7 @@ def datasource_new(ctx, name, jupyter):
 @datasource.command(name="delete")
 @click.argument("datasource")
 @click.pass_context
-def delete_datasource(ctx, datasource):
+def delete_datasource(ctx, datasource) -> None:
     """Delete the datasource specified as an argument"""
     context: DataContext = ctx.obj.data_context
     usage_event_end: str = ctx.obj.usage_event_end
@@ -244,7 +244,7 @@ class BaseDatasourceNewYamlHelper:
         datasource_type: DatasourceTypes,
         usage_stats_payload: dict,
         datasource_name: Optional[str] = None,
-    ):
+    ) -> None:
         self.datasource_type: DatasourceTypes = datasource_type
         self.datasource_name: Optional[str] = datasource_name
         self.usage_stats_payload: dict = usage_stats_payload
@@ -298,7 +298,7 @@ class FilesYamlHelper(BaseDatasourceNewYamlHelper):
         class_name: str,
         context_root_dir: str,
         datasource_name: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(datasource_type, usage_stats_payload, datasource_name)
         self.class_name: str = class_name
         self.base_path: str = ""
@@ -351,7 +351,7 @@ class PandasYamlHelper(FilesYamlHelper):
         self,
         context_root_dir: str,
         datasource_name: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(
             datasource_type=DatasourceTypes.PANDAS,
             usage_stats_payload={
@@ -372,7 +372,7 @@ class SparkYamlHelper(FilesYamlHelper):
         self,
         context_root_dir: str,
         datasource_name: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(
             datasource_type=DatasourceTypes.SPARK,
             usage_stats_payload={
@@ -404,7 +404,7 @@ class SQLCredentialYamlHelper(BaseDatasourceNewYamlHelper):
         password: str = "YOUR_PASSWORD",
         database: str = "YOUR_DATABASE",
         schema_name: str = "YOUR_SCHEMA",
-    ):
+    ) -> None:
         super().__init__(
             datasource_type=DatasourceTypes.SQL,
             usage_stats_payload=usage_stats_payload,
@@ -471,7 +471,7 @@ data_connectors:
 
 
 class MySQLCredentialYamlHelper(SQLCredentialYamlHelper):
-    def __init__(self, datasource_name: Optional[str]):
+    def __init__(self, datasource_name: Optional[str]) -> None:
         # We are insisting on pymysql driver when adding a MySQL datasource
         # through the CLI to avoid over-complication of this flow. If user wants
         # to use another driver, they must use a sqlalchemy connection string.
@@ -495,7 +495,7 @@ class MySQLCredentialYamlHelper(SQLCredentialYamlHelper):
 
 
 class PostgresCredentialYamlHelper(SQLCredentialYamlHelper):
-    def __init__(self, datasource_name: Optional[str]):
+    def __init__(self, datasource_name: Optional[str]) -> None:
         super().__init__(
             datasource_name=datasource_name,
             usage_stats_payload={
@@ -523,7 +523,7 @@ class PostgresCredentialYamlHelper(SQLCredentialYamlHelper):
 
 
 class RedshiftCredentialYamlHelper(SQLCredentialYamlHelper):
-    def __init__(self, datasource_name: Optional[str]):
+    def __init__(self, datasource_name: Optional[str]) -> None:
         # We are insisting on psycopg2 driver when adding a Redshift datasource
         # through the CLI to avoid over-complication of this flow. If user wants
         # to use another driver, they must use a sqlalchemy connection string.
@@ -575,7 +575,7 @@ class SnowflakeAuthMethod(enum.IntEnum):
 
 
 class SnowflakeCredentialYamlHelper(SQLCredentialYamlHelper):
-    def __init__(self, datasource_name: Optional[str]):
+    def __init__(self, datasource_name: Optional[str]) -> None:
         super().__init__(
             datasource_name=datasource_name,
             usage_stats_payload={
@@ -644,7 +644,7 @@ private_key_passphrase = ""   # Passphrase for the private key used for authenti
 
 
 class BigqueryCredentialYamlHelper(SQLCredentialYamlHelper):
-    def __init__(self, datasource_name: Optional[str]):
+    def __init__(self, datasource_name: Optional[str]) -> None:
         super().__init__(
             datasource_name=datasource_name,
             usage_stats_payload={
@@ -678,7 +678,7 @@ connection_string = "YOUR_BIGQUERY_CONNECTION_STRING"'''
 
 
 class ConnectionStringCredentialYamlHelper(SQLCredentialYamlHelper):
-    def __init__(self, datasource_name: Optional[str]):
+    def __init__(self, datasource_name: Optional[str]) -> None:
         super().__init__(
             datasource_name=datasource_name,
             usage_stats_payload={

--- a/great_expectations/cli/docs.py
+++ b/great_expectations/cli/docs.py
@@ -11,7 +11,7 @@ from great_expectations.exceptions import DataContextError
 
 @click.group()
 @click.pass_context
-def docs(ctx):
+def docs(ctx) -> None:
     """Data Docs operations"""
     ctx.obj.data_context = ctx.obj.get_data_context_from_config_file()
 
@@ -46,7 +46,7 @@ def docs(ctx):
     default=False,
 )
 @click.pass_context
-def docs_build(ctx, site_name=None, no_view=False):
+def docs_build(ctx, site_name=None, no_view=False) -> None:
     """Build Data Docs for a project."""
     context: DataContext = ctx.obj.data_context
     usage_event_end: str = ctx.obj.usage_event_end
@@ -128,7 +128,7 @@ def docs_list(ctx):
     help="With this, all sites will get their data docs cleaned out. See data_docs section in great_expectations.yml",
 )
 @click.pass_context
-def docs_clean(ctx, site_name=None, all_sites=False):
+def docs_clean(ctx, site_name=None, all_sites=False) -> None:
     """
     Remove all files from a Data Docs site.
 

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -41,7 +41,7 @@ except ImportError:
     default=True,
 )
 @click.pass_context
-def init(ctx, usage_stats):
+def init(ctx, usage_stats) -> None:
     """
     Initialize a new Great Expectations project.
 

--- a/great_expectations/cli/mark.py
+++ b/great_expectations/cli/mark.py
@@ -20,7 +20,7 @@ class Mark:
         """Apply as a decorator to CLI commands that are Experimental."""
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> None:
             cli_message(
                 "<yellow>Heads up! This feature is Experimental. It may change. "
                 "Please give us your feedback!</yellow>"
@@ -34,7 +34,7 @@ class Mark:
         """Apply as a decorator to CLI commands that are beta."""
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> None:
             cli_message(
                 "<yellow>Heads up! This feature is in Beta. Please give us "
                 "your feedback!</yellow>"
@@ -51,7 +51,7 @@ class Mark:
 
         def inner_decorator(func):
             @wraps(func)
-            def wrapped(*args, **kwargs):
+            def wrapped(*args, **kwargs) -> None:
                 cli_message(message)
                 func(*args, **kwargs)
 

--- a/great_expectations/cli/pretty_printing.py
+++ b/great_expectations/cli/pretty_printing.py
@@ -4,7 +4,7 @@ import sys
 from termcolor import colored
 
 
-def cli_message(string):
+def cli_message(string) -> None:
     print(cli_colorize_string(string))
 
 
@@ -30,14 +30,14 @@ def cli_colorize_string(string):
     return colored(mod_string)
 
 
-def display_not_implemented_message_and_exit():
+def display_not_implemented_message_and_exit() -> None:
     cli_message(
         "<red>This command is not yet implemented for the v3 (Batch Request) API</red>"
     )
     sys.exit(1)
 
 
-def cli_message_list(string_list, list_intro_string=None):
+def cli_message_list(string_list, list_intro_string=None) -> None:
     """Simple util function for displaying simple lists in cli"""
     if list_intro_string:
         cli_message(list_intro_string)
@@ -58,7 +58,7 @@ def action_list_to_string(action_list):
 
 def cli_message_dict(
     dict_, indent=3, bullet_char="-", message_list=None, recursion_flag=False
-):
+) -> None:
     """Util function for displaying nested dicts representing ge objects in cli"""
     if message_list is None:
         message_list = []

--- a/great_expectations/cli/project.py
+++ b/great_expectations/cli/project.py
@@ -16,14 +16,14 @@ from great_expectations.data_context.types.base import CURRENT_GE_CONFIG_VERSION
 
 
 @click.group()
-def project():
+def project() -> None:
     """Project operations"""
     pass
 
 
 @project.command(name="check-config")
 @click.pass_context
-def project_check_config(ctx):
+def project_check_config(ctx) -> None:
     """Check a config for validity and help with migrations."""
     cli_message("Checking your config files for validity...\n")
     directory = toolkit.parse_cli_config_file_location(
@@ -48,7 +48,7 @@ def project_check_config(ctx):
 
 @project.command(name="upgrade")
 @click.pass_context
-def project_upgrade(ctx):
+def project_upgrade(ctx) -> None:
     """Upgrade a project after installing the next Great Expectations major version."""
     cli_message("\nChecking project...")
     cli_message(SECTION_SEPARATOR)

--- a/great_expectations/cli/store.py
+++ b/great_expectations/cli/store.py
@@ -8,7 +8,7 @@ from great_expectations.core.usage_statistics.util import send_usage_message
 
 @click.group()
 @click.pass_context
-def store(ctx):
+def store(ctx) -> None:
     """Store operations"""
     ctx.obj.data_context = ctx.obj.get_data_context_from_config_file()
 

--- a/great_expectations/cli/suite.py
+++ b/great_expectations/cli/suite.py
@@ -39,7 +39,7 @@ except ImportError:
 
 @click.group()
 @click.pass_context
-def suite(ctx):
+def suite(ctx) -> None:
     """Expectation Suite operations"""
     ctx.obj.data_context = ctx.obj.get_data_context_from_config_file()
 

--- a/great_expectations/cli/upgrade_helpers/base_upgrade_helper.py
+++ b/great_expectations/cli/upgrade_helpers/base_upgrade_helper.py
@@ -5,21 +5,21 @@ class BaseUpgradeHelper(ABC):
     """Base UpgradeHelper abstract class"""
 
     @abstractmethod
-    def manual_steps_required(self):
+    def manual_steps_required(self) -> None:
         pass
 
     @abstractmethod
-    def get_upgrade_overview(self):
+    def get_upgrade_overview(self) -> None:
         pass
 
     @abstractmethod
-    def upgrade_project(self):
+    def upgrade_project(self) -> None:
         pass
 
     @abstractmethod
-    def _generate_upgrade_report(self):
+    def _generate_upgrade_report(self) -> None:
         pass
 
     @abstractmethod
-    def _save_upgrade_log(self):
+    def _save_upgrade_log(self) -> None:
         pass

--- a/great_expectations/cli/upgrade_helpers/upgrade_helper_v11.py
+++ b/great_expectations/cli/upgrade_helpers/upgrade_helper_v11.py
@@ -23,7 +23,7 @@ from great_expectations.data_context.types.resource_identifiers import (
 
 
 class UpgradeHelperV11(BaseUpgradeHelper):
-    def __init__(self, data_context=None, context_root_dir=None, **kwargs):
+    def __init__(self, data_context=None, context_root_dir=None, **kwargs) -> None:
         assert (
             data_context or context_root_dir
         ), "Please provide a data_context object or a context_root_dir."
@@ -91,7 +91,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
 
         self._generate_upgrade_checklist()
 
-    def _generate_upgrade_checklist(self):
+    def _generate_upgrade_checklist(self) -> None:
         for (store_name, store) in self.data_context.stores.items():
             if not isinstance(store, (ValidationsStore, MetricStore)):
                 continue
@@ -108,7 +108,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
             for site_name, site_config in sites.items():
                 self._process_docs_site_for_checklist(site_name, site_config)
 
-    def _process_docs_site_for_checklist(self, site_name, site_config):
+    def _process_docs_site_for_checklist(self, site_name, site_config) -> None:
         site_html_store = HtmlSiteStore(
             store_backend=site_config.get("store_backend"),
             runtime_environment={
@@ -138,7 +138,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
                 }
             )
 
-    def _process_validations_store_for_checklist(self, store_name, store):
+    def _process_validations_store_for_checklist(self, store_name, store) -> None:
         store_backend = store.store_backend
         if isinstance(store_backend, DatabaseStoreBackend):
             self.upgrade_log["skipped_validations_stores"][
@@ -163,7 +163,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
                 }
             )
 
-    def _process_metrics_store_for_checklist(self, store_name, store):
+    def _process_metrics_store_for_checklist(self, store_name, store) -> None:
         store_backend = store.store_backend
         if isinstance(store_backend, DatabaseStoreBackend):
             self.upgrade_log["skipped_metrics_stores"][
@@ -184,7 +184,9 @@ class UpgradeHelperV11(BaseUpgradeHelper):
                 }
             )
 
-    def _upgrade_store_backend(self, store_backend, store_name=None, site_name=None):
+    def _upgrade_store_backend(
+        self, store_backend, store_name=None, site_name=None
+    ) -> None:
         assert store_name or site_name, "Must pass either store_name or site_name."
         assert not (
             store_name and site_name
@@ -271,7 +273,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
         store_name=None,
         site_name=None,
         exception_message=None,
-    ):
+    ) -> None:
         assert store_name or site_name, "Must pass either store_name or site_name."
         assert not (
             store_name and site_name
@@ -319,7 +321,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
 
     def _update_validation_result_json(
         self, source_key, dest_key, run_name, store_backend
-    ):
+    ) -> None:
         new_run_id_dict = {
             "run_name": run_name,
             "run_time": self.validation_run_times[run_name],
@@ -329,7 +331,9 @@ class UpgradeHelperV11(BaseUpgradeHelper):
         store_backend.set(dest_key, json.dumps(validation_json_dict))
         store_backend.remove_key(source_key)
 
-    def _get_tuple_filesystem_store_backend_run_time(self, source_key, store_backend):
+    def _get_tuple_filesystem_store_backend_run_time(
+        self, source_key, store_backend
+    ) -> None:
         run_name = source_key[-2]
         try:
             self.validation_run_times[run_name] = parse(run_name).strftime(
@@ -346,7 +350,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
             ).strftime("%Y%m%dT%H%M%S.%fZ")
             self.validation_run_times[run_name] = path_mod_iso_str
 
-    def _get_tuple_s3_store_backend_run_time(self, source_key, store_backend):
+    def _get_tuple_s3_store_backend_run_time(self, source_key, store_backend) -> None:
         import boto3
 
         s3 = boto3.resource("s3")
@@ -367,7 +371,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
 
             self.validation_run_times[run_name] = source_object_last_mod
 
-    def _get_tuple_gcs_store_backend_run_time(self, source_key, store_backend):
+    def _get_tuple_gcs_store_backend_run_time(self, source_key, store_backend) -> None:
         from google.cloud import storage
 
         gcs = storage.Client(project=store_backend.project)

--- a/great_expectations/cli/upgrade_helpers/upgrade_helper_v13.py
+++ b/great_expectations/cli/upgrade_helpers/upgrade_helper_v13.py
@@ -22,7 +22,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
         data_context: Optional[DataContext] = None,
         context_root_dir: Optional[str] = None,
         update_version: bool = False,
-    ):
+    ) -> None:
         assert (
             data_context or context_root_dir
         ), "Please provide a data_context object or a context_root_dir."
@@ -56,13 +56,13 @@ class UpgradeHelperV13(BaseUpgradeHelper):
 
         self._generate_upgrade_checklist()
 
-    def _generate_upgrade_checklist(self):
+    def _generate_upgrade_checklist(self) -> None:
         self._process_checkpoint_store_for_checklist()
         self._process_checkpoint_config_for_checklist()
         self._process_datasources_for_checklist()
         self._process_validation_operators_for_checklist()
 
-    def _process_checkpoint_store_for_checklist(self):
+    def _process_checkpoint_store_for_checklist(self) -> None:
         if CheckpointStore.default_checkpoints_exist(
             directory_path=self.data_context.root_directory
         ):
@@ -98,7 +98,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
         else:
             self.upgrade_log["skipped_checkpoint_store_upgrade"] = True
 
-    def _process_checkpoint_config_for_checklist(self):
+    def _process_checkpoint_config_for_checklist(self) -> None:
         legacy_checkpoints: List[Union[Checkpoint, LegacyCheckpoint]] = []
         checkpoint: Union[Checkpoint, LegacyCheckpoint]
         checkpoint_name: str
@@ -119,7 +119,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
             self.upgrade_log["skipped_checkpoint_config_upgrade"] = True
 
     # noinspection SpellCheckingInspection
-    def _process_datasources_for_checklist(self):
+    def _process_datasources_for_checklist(self) -> None:
         config_commented_map: CommentedMap = (
             self.data_context.get_config().commented_map
         )
@@ -139,7 +139,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
         if len(self.upgrade_checklist["manual"]["datasources"]) == 0:
             self.upgrade_log["skipped_datasources_upgrade"] = True
 
-    def _process_validation_operators_for_checklist(self):
+    def _process_validation_operators_for_checklist(self) -> None:
         config_commented_map: CommentedMap = (
             self.data_context.get_config().commented_map
         )
@@ -343,7 +343,7 @@ No manual upgrade steps are required.
         ) = self._generate_upgrade_report()
         return upgrade_report, increment_version, exception_occurred
 
-    def _upgrade_configuration_automatically(self):
+    def _upgrade_configuration_automatically(self) -> None:
         if not self.upgrade_log["skipped_checkpoint_store_upgrade"]:
             config_commented_map: CommentedMap = (
                 self.data_context.get_config().commented_map

--- a/great_expectations/cli/v012/checkpoint.py
+++ b/great_expectations/cli/v012/checkpoint.py
@@ -58,7 +58,7 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 
 
 @click.group(short_help="Checkpoint operations")
-def checkpoint():
+def checkpoint() -> None:
     """
     Checkpoint operations
 
@@ -85,7 +85,7 @@ def checkpoint():
     help="The project's great_expectations directory.",
 )
 @mark.cli_as_experimental
-def checkpoint_new(checkpoint, suite, directory, datasource):
+def checkpoint_new(checkpoint, suite, directory, datasource) -> None:
     """Create a new checkpoint for easy deployments. (Experimental)"""
     suite_name = suite
     usage_event = "cli.checkpoint.new"
@@ -180,7 +180,7 @@ def _load_checkpoint_yml_template() -> dict:
     help="The project's great_expectations directory.",
 )
 @mark.cli_as_experimental
-def checkpoint_list(directory):
+def checkpoint_list(directory) -> None:
     """List configured checkpoints. (Experimental)"""
     context = toolkit.load_data_context_with_error_handling(directory)
     checkpoints = context.list_checkpoints()
@@ -219,7 +219,7 @@ def checkpoint_list(directory):
     help="The project's great_expectations directory.",
 )
 @mark.cli_as_experimental
-def checkpoint_run(checkpoint, directory):
+def checkpoint_run(checkpoint, directory) -> None:
     """Run a checkpoint. (Experimental)"""
     usage_event = "cli.checkpoint.run"
     context = toolkit.load_data_context_with_error_handling(
@@ -299,7 +299,7 @@ def print_validation_operator_results_details(
     help="The project's great_expectations directory.",
 )
 @mark.cli_as_experimental
-def checkpoint_script(checkpoint, directory):
+def checkpoint_script(checkpoint, directory) -> None:
     """
     Create a python script to run a checkpoint. (Experimental)
 

--- a/great_expectations/cli/v012/cli.py
+++ b/great_expectations/cli/v012/cli.py
@@ -33,7 +33,7 @@ except ImportError:
     default=False,
     help="Set great_expectations to use verbose output.",
 )
-def cli(verbose):
+def cli(verbose) -> None:
     """
     Welcome to the great_expectations CLI!
 
@@ -67,7 +67,7 @@ cli.add_command(store)
 cli.add_command(checkpoint)
 
 
-def main():
+def main() -> None:
     cli()
 
 

--- a/great_expectations/cli/v012/datasource.py
+++ b/great_expectations/cli/v012/datasource.py
@@ -78,7 +78,7 @@ class SupportedDatabases(enum.Enum):
 
 
 @click.group()
-def datasource():
+def datasource() -> None:
     """Datasource operations"""
     pass
 
@@ -90,7 +90,7 @@ def datasource():
     default=None,
     help="The project's great_expectations directory.",
 )
-def datasource_new(directory):
+def datasource_new(directory) -> None:
     """Add a new datasource to the data context."""
     context = toolkit.load_data_context_with_error_handling(directory)
     datasource_name, data_source_type = add_datasource(context)
@@ -121,7 +121,7 @@ def datasource_new(directory):
     help="The project's great_expectations directory.",
 )
 @click.argument("datasource")
-def delete_datasource(directory, datasource):
+def delete_datasource(directory, datasource) -> None:
     """Delete the datasource specified as an argument"""
     context = toolkit.load_data_context_with_error_handling(directory)
     try:
@@ -146,7 +146,7 @@ def delete_datasource(directory, datasource):
     default=None,
     help="The project's great_expectations directory.",
 )
-def datasource_list(directory):
+def datasource_list(directory) -> None:
     """List known datasources."""
     context = toolkit.load_data_context_with_error_handling(directory)
     datasources = context.list_datasources()
@@ -235,7 +235,7 @@ def datasource_profile(
     view,
     additional_batch_kwargs,
     assume_yes,
-):
+) -> None:
     """
     Profile a datasource (Experimental)
 

--- a/great_expectations/cli/v012/docs.py
+++ b/great_expectations/cli/v012/docs.py
@@ -9,7 +9,7 @@ from great_expectations.core.usage_statistics.util import send_usage_message
 
 
 @click.group()
-def docs():
+def docs() -> None:
     """Data Docs operations"""
     pass
 
@@ -39,7 +39,7 @@ def docs():
     help="By default request confirmation to build docs unless you specify -y/--yes/--assume-yes flag to skip dialog",
     default=False,
 )
-def docs_build(directory, site_name, view=True, assume_yes=False):
+def docs_build(directory, site_name, view=True, assume_yes=False) -> None:
     """Build Data Docs for a project."""
     context = toolkit.load_data_context_with_error_handling(directory)
     build_docs(context, site_name=site_name, view=view, assume_yes=assume_yes)
@@ -58,7 +58,7 @@ def docs_build(directory, site_name, view=True, assume_yes=False):
     default=None,
     help="The project's great_expectations directory.",
 )
-def docs_list(directory):
+def docs_list(directory) -> None:
     """List known Data Docs Sites."""
     context = toolkit.load_data_context_with_error_handling(directory)
 
@@ -100,7 +100,7 @@ def docs_list(directory):
     is_flag=True,
     help="With this, all sites will get their data docs cleaned out. See data_docs section in great_expectations.yml",
 )
-def clean_data_docs(directory, site_name=None, all=None):
+def clean_data_docs(directory, site_name=None, all=None) -> None:
     """Delete data docs"""
     context = toolkit.load_data_context_with_error_handling(directory)
     failed = True
@@ -141,7 +141,7 @@ def _build_intro_string(docs_sites_strings):
     return list_intro_string
 
 
-def build_docs(context, site_name=None, view=True, assume_yes=False):
+def build_docs(context, site_name=None, view=True, assume_yes=False) -> None:
     """Build documentation in a context"""
     logger.debug("Starting cli.datasource.build_docs")
 

--- a/great_expectations/cli/v012/init.py
+++ b/great_expectations/cli/v012/init.py
@@ -57,7 +57,7 @@ except ImportError:
     help="By default, usage statistics are enabled unless you specify the --no-usage-stats flag.",
     default=True,
 )
-def init(target_directory, view, usage_stats):
+def init(target_directory, view, usage_stats) -> None:
     """
     Initialize a new Great Expectations project.
 

--- a/great_expectations/cli/v012/mark.py
+++ b/great_expectations/cli/v012/mark.py
@@ -20,7 +20,7 @@ class Mark:
         """Apply as a decorator to CLI commands that are Experimental."""
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> None:
             cli_message(
                 "<yellow>Heads up! This feature is Experimental. It may change. "
                 "Please give us your feedback!</yellow>"
@@ -34,7 +34,7 @@ class Mark:
         """Apply as a decorator to CLI commands that are beta."""
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> None:
             cli_message(
                 "<yellow>Heads up! This feature is in Beta. Please give us "
                 "your feedback!</yellow>"
@@ -51,7 +51,7 @@ class Mark:
 
         def inner_decorator(func):
             @wraps(func)
-            def wrapped(*args, **kwargs):
+            def wrapped(*args, **kwargs) -> None:
                 cli_message(message)
                 func(*args, **kwargs)
 

--- a/great_expectations/cli/v012/project.py
+++ b/great_expectations/cli/v012/project.py
@@ -12,7 +12,7 @@ from great_expectations.data_context.types.base import CURRENT_GE_CONFIG_VERSION
 
 
 @click.group()
-def project():
+def project() -> None:
     """Project operations"""
     pass
 
@@ -24,7 +24,7 @@ def project():
     default="./great_expectations",
     help="The project's great_expectations directory.",
 )
-def project_check_config(directory):
+def project_check_config(directory) -> None:
     """Check a config for validity and help with migrations."""
     cli_message("Checking your config files for validity...\n")
     is_config_ok, error_message, context = do_config_check(directory)
@@ -50,7 +50,7 @@ def project_check_config(directory):
     default="./great_expectations",
     help="The project's great_expectations directory.",
 )
-def project_upgrade(directory):
+def project_upgrade(directory) -> None:
     """Upgrade a project after installing the next Great Expectations major version."""
     cli_message("\nChecking project...")
     cli_message(SECTION_SEPARATOR)

--- a/great_expectations/cli/v012/store.py
+++ b/great_expectations/cli/v012/store.py
@@ -6,7 +6,7 @@ from great_expectations.core.usage_statistics.util import send_usage_message
 
 
 @click.group()
-def store():
+def store() -> None:
     """Store operations"""
     pass
 

--- a/great_expectations/cli/v012/suite.py
+++ b/great_expectations/cli/v012/suite.py
@@ -31,7 +31,7 @@ except ImportError:
 
 
 @click.group()
-def suite():
+def suite() -> None:
     """Expectation Suite operations"""
     pass
 
@@ -63,7 +63,7 @@ Make sure to escape quotes. Example: "{\"datasource\": \"my_db\", \"query\": \"s
     help="By default launch jupyter notebooks unless you specify the --no-jupyter flag",
     default=True,
 )
-def suite_edit(suite, datasource, directory, jupyter, batch_kwargs):
+def suite_edit(suite, datasource, directory, jupyter, batch_kwargs) -> None:
     """
     Generate a Jupyter notebook for editing an existing Expectation Suite.
 
@@ -95,7 +95,7 @@ def _suite_edit(
     batch_kwargs,
     usage_event,
     suppress_usage_message=False,
-):
+) -> None:
     # suppress_usage_message flag is for the situation where _suite_edit is called by _suite_new().
     # when called by _suite_new(), the flag will be set to False, otherwise it will default to True
     batch_kwargs_json = batch_kwargs
@@ -253,7 +253,7 @@ A batch of data is required to edit the suite - let's help you to specify it."""
     default=True,
 )
 @mark.cli_as_beta
-def suite_demo(suite, directory, view):
+def suite_demo(suite, directory, view) -> None:
     """
     Create a new demo Expectation Suite.
 
@@ -291,7 +291,7 @@ def suite_demo(suite, directory, view):
     default=None,
     help="Additional keyword arguments to be provided to get_batch when loading the data asset. Must be a valid JSON dictionary",
 )
-def suite_new(suite, directory, jupyter, batch_kwargs):
+def suite_new(suite, directory, jupyter, batch_kwargs) -> None:
     """
     Create a new empty Expectation Suite.
 
@@ -403,7 +403,7 @@ If you wish to avoid this you can add the `--no-jupyter` flag.</green>\n\n"""
     help="The project's great_expectations directory.",
 )
 @mark.cli_as_experimental
-def suite_delete(suite, directory):
+def suite_delete(suite, directory) -> None:
     """
     Delete an expectation suite from the expectation store.
     """
@@ -447,7 +447,7 @@ def suite_delete(suite, directory):
     default=True,
 )
 @mark.cli_as_experimental
-def suite_scaffold(suite, directory, jupyter):
+def suite_scaffold(suite, directory, jupyter) -> None:
     """Scaffold a new Expectation Suite."""
     _suite_scaffold(suite, directory, jupyter)
 

--- a/great_expectations/cli/v012/toolkit.py
+++ b/great_expectations/cli/v012/toolkit.py
@@ -216,7 +216,7 @@ Great Expectations will store these expectations in a new Expectation Suite '{:s
     return profiling_results
 
 
-def _raise_profiling_errors(profiling_results):
+def _raise_profiling_errors(profiling_results) -> None:
     if (
         profiling_results["error"]["code"]
         == DataContext.PROFILING_ERROR_CODE_SPECIFIED_DATA_ASSETS_NOT_FOUND
@@ -232,7 +232,7 @@ def _raise_profiling_errors(profiling_results):
     )
 
 
-def attempt_to_open_validation_results_in_data_docs(context, profiling_results):
+def attempt_to_open_validation_results_in_data_docs(context, profiling_results) -> None:
     try:
         # TODO this is really brittle and not covered in tests
         validation_result = profiling_results["results"][0][1]
@@ -478,7 +478,7 @@ def load_data_context_with_error_handling(
 
 def upgrade_project(
     context_root_dir, ge_config_version, from_cli_upgrade_command=False
-):
+) -> None:
     if from_cli_upgrade_command:
         message = (
             f"<red>\nYour project appears to have an out-of-date config version ({ge_config_version}) - "

--- a/great_expectations/cli/v012/upgrade_helpers/base_upgrade_helper.py
+++ b/great_expectations/cli/v012/upgrade_helpers/base_upgrade_helper.py
@@ -5,17 +5,17 @@ class BaseUpgradeHelper(ABC):
     """Base UpgradeHelper abstract class"""
 
     @abstractmethod
-    def get_upgrade_overview(self):
+    def get_upgrade_overview(self) -> None:
         pass
 
     @abstractmethod
-    def _save_upgrade_log(self):
+    def _save_upgrade_log(self) -> None:
         pass
 
     @abstractmethod
-    def _generate_upgrade_report(self):
+    def _generate_upgrade_report(self) -> None:
         pass
 
     @abstractmethod
-    def upgrade_project(self):
+    def upgrade_project(self) -> None:
         pass

--- a/great_expectations/cli/v012/upgrade_helpers/upgrade_helper_v11.py
+++ b/great_expectations/cli/v012/upgrade_helpers/upgrade_helper_v11.py
@@ -36,7 +36,7 @@ task for the full deprecation of this path has been placed in the backlog.
 
 
 class UpgradeHelperV11(BaseUpgradeHelper):
-    def __init__(self, data_context=None, context_root_dir=None):
+    def __init__(self, data_context=None, context_root_dir=None) -> None:
         assert (
             data_context or context_root_dir
         ), "Please provide a data_context object or a context_root_dir."
@@ -104,7 +104,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
 
         self._generate_upgrade_checklist()
 
-    def _generate_upgrade_checklist(self):
+    def _generate_upgrade_checklist(self) -> None:
         for (store_name, store) in self.data_context.stores.items():
             if not isinstance(store, (ValidationsStore, MetricStore)):
                 continue
@@ -121,7 +121,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
             for site_name, site_config in sites.items():
                 self._process_docs_site_for_checklist(site_name, site_config)
 
-    def _process_docs_site_for_checklist(self, site_name, site_config):
+    def _process_docs_site_for_checklist(self, site_name, site_config) -> None:
         site_html_store = HtmlSiteStore(
             store_backend=site_config.get("store_backend"),
             runtime_environment={
@@ -151,7 +151,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
                 }
             )
 
-    def _process_validations_store_for_checklist(self, store_name, store):
+    def _process_validations_store_for_checklist(self, store_name, store) -> None:
         store_backend = store.store_backend
         if isinstance(store_backend, DatabaseStoreBackend):
             self.upgrade_log["skipped_validations_stores"][
@@ -176,7 +176,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
                 }
             )
 
-    def _process_metrics_store_for_checklist(self, store_name, store):
+    def _process_metrics_store_for_checklist(self, store_name, store) -> None:
         store_backend = store.store_backend
         if isinstance(store_backend, DatabaseStoreBackend):
             self.upgrade_log["skipped_metrics_stores"][
@@ -197,7 +197,9 @@ class UpgradeHelperV11(BaseUpgradeHelper):
                 }
             )
 
-    def _upgrade_store_backend(self, store_backend, store_name=None, site_name=None):
+    def _upgrade_store_backend(
+        self, store_backend, store_name=None, site_name=None
+    ) -> None:
         assert store_name or site_name, "Must pass either store_name or site_name."
         assert not (
             store_name and site_name
@@ -284,7 +286,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
         store_name=None,
         site_name=None,
         exception_message=None,
-    ):
+    ) -> None:
         assert store_name or site_name, "Must pass either store_name or site_name."
         assert not (
             store_name and site_name
@@ -332,7 +334,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
 
     def _update_validation_result_json(
         self, source_key, dest_key, run_name, store_backend
-    ):
+    ) -> None:
         new_run_id_dict = {
             "run_name": run_name,
             "run_time": self.validation_run_times[run_name],
@@ -342,7 +344,9 @@ class UpgradeHelperV11(BaseUpgradeHelper):
         store_backend.set(dest_key, json.dumps(validation_json_dict))
         store_backend.remove_key(source_key)
 
-    def _get_tuple_filesystem_store_backend_run_time(self, source_key, store_backend):
+    def _get_tuple_filesystem_store_backend_run_time(
+        self, source_key, store_backend
+    ) -> None:
         run_name = source_key[-2]
         try:
             self.validation_run_times[run_name] = parse(run_name).strftime(
@@ -359,7 +363,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
             ).strftime("%Y%m%dT%H%M%S.%fZ")
             self.validation_run_times[run_name] = path_mod_iso_str
 
-    def _get_tuple_s3_store_backend_run_time(self, source_key, store_backend):
+    def _get_tuple_s3_store_backend_run_time(self, source_key, store_backend) -> None:
         import boto3
 
         s3 = boto3.resource("s3")
@@ -380,7 +384,7 @@ class UpgradeHelperV11(BaseUpgradeHelper):
 
             self.validation_run_times[run_name] = source_object_last_mod
 
-    def _get_tuple_gcs_store_backend_run_time(self, source_key, store_backend):
+    def _get_tuple_gcs_store_backend_run_time(self, source_key, store_backend) -> None:
         from google.cloud import storage
 
         gcs = storage.Client(project=store_backend.project)

--- a/great_expectations/cli/v012/upgrade_helpers/upgrade_helper_v13.py
+++ b/great_expectations/cli/v012/upgrade_helpers/upgrade_helper_v13.py
@@ -28,7 +28,7 @@ task for the full deprecation of this path has been placed in the backlog.
 
 
 class UpgradeHelperV13(BaseUpgradeHelper):
-    def __init__(self, data_context=None, context_root_dir=None):
+    def __init__(self, data_context=None, context_root_dir=None) -> None:
         assert (
             data_context or context_root_dir
         ), "Please provide a data_context object or a context_root_dir."
@@ -50,7 +50,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
 
         self._generate_upgrade_checklist()
 
-    def _generate_upgrade_checklist(self):
+    def _generate_upgrade_checklist(self) -> None:
         if CheckpointStore.default_checkpoints_exist(
             directory_path=self.data_context.root_directory
         ):
@@ -58,7 +58,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
         else:
             self.upgrade_log["skipped_upgrade"] = True
 
-    def _process_checkpoint_store_for_checklist(self):
+    def _process_checkpoint_store_for_checklist(self) -> None:
         config_commented_map: CommentedMap = (
             self.data_context.get_config().commented_map
         )
@@ -107,7 +107,7 @@ class UpgradeHelperV13(BaseUpgradeHelper):
         self.data_context._save_project_config()
         self._update_upgrade_log()
 
-    def _update_upgrade_log(self):
+    def _update_upgrade_log(self) -> None:
         data_context_config: DataContextConfig = self.data_context.get_config()
         self.upgrade_log["added_checkpoint_store"].update(
             {

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -19,7 +19,7 @@ except ImportError:
     colored = None
 
 
-def cli_message(string):
+def cli_message(string) -> None:
     print(cli_colorize_string(string))
 
 
@@ -45,7 +45,7 @@ def cli_colorize_string(string):
     return colored(mod_string)
 
 
-def cli_message_list(string_list, list_intro_string=None):
+def cli_message_list(string_list, list_intro_string=None) -> None:
     """Simple util function for displaying simple lists in cli"""
     if list_intro_string:
         cli_message(list_intro_string)
@@ -66,7 +66,7 @@ def action_list_to_string(action_list):
 
 def cli_message_dict(
     dict_, indent=3, bullet_char="-", message_list=None, recursion_flag=False
-):
+) -> None:
     """Util function for displaying nested dicts representing ge objects in cli"""
     if message_list is None:
         message_list = []

--- a/great_expectations/cli/v012/validation_operator.py
+++ b/great_expectations/cli/v012/validation_operator.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 @click.group()
-def validation_operator():
+def validation_operator() -> None:
     """Validation Operator operations"""
     pass
 
@@ -115,7 +115,9 @@ Please consider using either:
   - `checkpoint new` if you wish to configure a new checkpoint interactively
   - `checkpoint run` if you wish to run a saved checkpoint</yellow>"""
 )
-def validation_operator_run(name, run_name, validation_config_file, suite, directory):
+def validation_operator_run(
+    name, run_name, validation_config_file, suite, directory
+) -> None:
     # Note though the long lines here aren't pythonic, they look best if Click does the line wraps.
     """
     Run a validation operator against some data.

--- a/great_expectations/core/async_executor.py
+++ b/great_expectations/core/async_executor.py
@@ -21,7 +21,9 @@ class AsyncResult:
     WARNING: This class is experimental.
     """
 
-    def __init__(self, future: Optional[Future] = None, value: Optional[Any] = None):
+    def __init__(
+        self, future: Optional[Future] = None, value: Optional[Any] = None
+    ) -> None:
         """AsyncResult instances are created by AsyncExecutor.submit() and should not otherwise be created directly."""
         self._future = future
         self._value = value
@@ -44,7 +46,7 @@ class AsyncExecutor(AbstractContextManager):
         self,
         concurrency_config: Optional[ConcurrencyConfig],
         max_workers: int,
-    ):
+    ) -> None:
         """Initializes a new AsyncExecutor instance used to organize code for multithreaded execution.
 
         If multithreading is disabled, all execution will be done synchronously (e.g. on the main thread) during the
@@ -80,7 +82,7 @@ class AsyncExecutor(AbstractContextManager):
             else None
         )
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         self.shutdown()
         # Do NOT use the context manager exception arguments in order to get the desired default behavior (i.e. any
         # exception is NOT suppressed and the exception is propagated normally upon exit from this method). For more
@@ -99,7 +101,7 @@ class AsyncExecutor(AbstractContextManager):
         else:
             return AsyncResult(value=fn(*args, **kwargs))
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """Clean-up the resources associated with the AsyncExecutor and blocks until all running async results finish
         executing.
 
@@ -114,7 +116,7 @@ class AsyncExecutor(AbstractContextManager):
         return self._execute_concurrently
 
 
-def patch_https_connection_pool(concurrency_config: ConcurrencyConfig):
+def patch_https_connection_pool(concurrency_config: ConcurrencyConfig) -> None:
     """Patch urllib3 to enable a higher default max pool size to reduce concurrency bottlenecks.
 
     To have any effect, this method must be called before any database connections are made, e.g. by scripts leveraging
@@ -131,7 +133,7 @@ def patch_https_connection_pool(concurrency_config: ConcurrencyConfig):
     # google-cloud-python to python-bigquery-sqlalchemy and python-bigquery, this patching code can be replaced
     # following the instructions at https://github.com/googleapis/python-bigquery/issues/59#issuecomment-619047244.
     class HTTPSConnectionPoolWithHigherMaxSize(connectionpool.HTTPSConnectionPool):
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args, **kwargs) -> None:
             kwargs.update(maxsize=concurrency_config.max_database_query_concurrency)
             super().__init__(*args, **kwargs)
 

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -30,7 +30,7 @@ class BatchDefinition(SerializableDictDot):
         data_asset_name: str,
         batch_identifiers: IDDict,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         self._validate_batch_definition(
             datasource_name=datasource_name,
             data_connector_name=data_connector_name,
@@ -71,7 +71,7 @@ class BatchDefinition(SerializableDictDot):
         data_connector_name: str,
         data_asset_name: str,
         batch_identifiers: IDDict,
-    ):
+    ) -> None:
         if datasource_name is None:
             raise ValueError("A valid datasource must be specified.")
         if datasource_name and not isinstance(datasource_name, str):
@@ -124,7 +124,7 @@ class BatchDefinition(SerializableDictDot):
         return self._batch_spec_passthrough
 
     @batch_spec_passthrough.setter
-    def batch_spec_passthrough(self, batch_spec_passthrough: Optional[dict]):
+    def batch_spec_passthrough(self, batch_spec_passthrough: Optional[dict]) -> None:
         self._batch_spec_passthrough = batch_spec_passthrough
 
     @property
@@ -176,7 +176,7 @@ class BatchRequestBase(SerializableDictDot):
         runtime_parameters: Optional[dict] = None,
         batch_identifiers: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         self._datasource_name = datasource_name
         self._data_connector_name = data_connector_name
         self._data_asset_name = data_asset_name
@@ -192,7 +192,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._datasource_name
 
     @datasource_name.setter
-    def datasource_name(self, value: str):
+    def datasource_name(self, value: str) -> None:
         self._datasource_name = value
 
     @property
@@ -200,7 +200,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._data_connector_name
 
     @data_connector_name.setter
-    def data_connector_name(self, value: str):
+    def data_connector_name(self, value: str) -> None:
         self._data_connector_name = value
 
     @property
@@ -208,7 +208,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._data_asset_name
 
     @data_asset_name.setter
-    def data_asset_name(self, data_asset_name):
+    def data_asset_name(self, data_asset_name) -> None:
         self._data_asset_name = data_asset_name
 
     @property
@@ -216,7 +216,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._data_connector_query
 
     @data_connector_query.setter
-    def data_connector_query(self, value: dict):
+    def data_connector_query(self, value: dict) -> None:
         self._data_connector_query = value
 
     @property
@@ -224,7 +224,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._limit
 
     @limit.setter
-    def limit(self, value: int):
+    def limit(self, value: int) -> None:
         self._limit = value
 
     @property
@@ -232,7 +232,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._runtime_parameters
 
     @runtime_parameters.setter
-    def runtime_parameters(self, value: dict):
+    def runtime_parameters(self, value: dict) -> None:
         self._runtime_parameters = value
 
     @property
@@ -240,7 +240,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._batch_identifiers
 
     @batch_identifiers.setter
-    def batch_identifiers(self, value: dict):
+    def batch_identifiers(self, value: dict) -> None:
         self._batch_identifiers = value
 
     @property
@@ -248,7 +248,7 @@ class BatchRequestBase(SerializableDictDot):
         return self._batch_spec_passthrough
 
     @batch_spec_passthrough.setter
-    def batch_spec_passthrough(self, value: dict):
+    def batch_spec_passthrough(self, value: dict) -> None:
         self._batch_spec_passthrough = value
 
     @property
@@ -338,7 +338,7 @@ class BatchRequestBase(SerializableDictDot):
         data_asset_name: str,
         data_connector_query: Optional[dict] = None,
         limit: Optional[int] = None,
-    ):
+    ) -> None:
         # TODO test and check all logic in this validator!
         if not (datasource_name and isinstance(datasource_name, str)):
             raise TypeError(
@@ -396,7 +396,7 @@ class BatchRequest(BatchRequestBase):
         data_connector_query: Optional[dict] = None,
         limit: Optional[int] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         self._validate_init_parameters(
             datasource_name=datasource_name,
             data_connector_name=data_connector_name,
@@ -432,7 +432,7 @@ class RuntimeBatchRequest(BatchRequestBase):
         runtime_parameters: dict,
         batch_identifiers: dict,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         self._validate_init_parameters(
             datasource_name=datasource_name,
             data_connector_name=data_connector_name,
@@ -457,7 +457,7 @@ class RuntimeBatchRequest(BatchRequestBase):
         runtime_parameters: dict,
         batch_identifiers: dict,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         if not (runtime_parameters and (isinstance(runtime_parameters, dict))):
             raise TypeError(
                 f"""The runtime_parameters must be a non-empty dict object.
@@ -484,7 +484,7 @@ class BatchMarkers(BatchKwargs):
     NOT require specific keys and instead captures information about the OUTPUT of a datasource's fetch
     process, such as the timestamp at which a query was executed."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "ge_load_time" not in self:
             raise InvalidBatchIdError("BatchMarkers requires a ge_load_time")
@@ -512,7 +512,7 @@ class Batch(SerializableDictDot):
         datasource_name=None,
         batch_parameters=None,
         batch_kwargs=None,
-    ):
+    ) -> None:
         self._data = data
         if batch_request is None:
             batch_request = {}
@@ -549,7 +549,7 @@ class Batch(SerializableDictDot):
         return self._batch_request
 
     @batch_request.setter
-    def batch_request(self, batch_request):
+    def batch_request(self, batch_request) -> None:
         self._batch_request = batch_request
 
     @property
@@ -557,7 +557,7 @@ class Batch(SerializableDictDot):
         return self._batch_definition
 
     @batch_definition.setter
-    def batch_definition(self, batch_definition):
+    def batch_definition(self, batch_definition) -> None:
         self._batch_definition = batch_definition
 
     @property

--- a/great_expectations/core/batch_spec.py
+++ b/great_expectations/core/batch_spec.py
@@ -18,7 +18,7 @@ class BatchMarkers(BatchSpec):
     NOT require specific keys and instead captures information about the OUTPUT of a datasource's fetch
     process, such as the timestamp at which a query was executed."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "ge_load_time" not in self:
             raise InvalidBatchIdError("BatchMarkers requires a ge_load_time")
@@ -29,7 +29,7 @@ class BatchMarkers(BatchSpec):
 
 
 class PathBatchSpec(BatchSpec, metaclass=ABCMeta):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "path" not in self:
             raise InvalidBatchSpecError("PathBatchSpec requires a path element")
@@ -76,7 +76,7 @@ class SqlAlchemyDatasourceBatchSpec(BatchSpec, metaclass=ABCMeta):
 class RuntimeDataBatchSpec(BatchSpec):
     _id_ignore_keys = set("batch_data")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         if self.batch_data is None:
@@ -89,12 +89,12 @@ class RuntimeDataBatchSpec(BatchSpec):
         return self.get("batch_data")
 
     @batch_data.setter
-    def batch_data(self, batch_data):
+    def batch_data(self, batch_data) -> None:
         self["batch_data"] = batch_data
 
 
 class RuntimeQueryBatchSpec(BatchSpec):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         if self.query is None:
@@ -105,5 +105,5 @@ class RuntimeQueryBatchSpec(BatchSpec):
         return self.get("query")
 
     @query.setter
-    def query(self, query):
+    def query(self, query) -> None:
         self["query"] = query

--- a/great_expectations/core/data_context_key.py
+++ b/great_expectations/core/data_context_key.py
@@ -9,18 +9,18 @@ class DataContextKey(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def to_tuple(self):
+    def to_tuple(self) -> None:
         pass
 
     @classmethod
     def from_tuple(cls, tuple_):
         return cls(*tuple_)
 
-    def to_fixed_length_tuple(self):
+    def to_fixed_length_tuple(self) -> None:
         raise NotImplementedError
 
     @classmethod
-    def from_fixed_length_tuple(cls, tuple_):
+    def from_fixed_length_tuple(cls, tuple_) -> None:
         raise NotImplementedError
 
     def __eq__(self, other):
@@ -62,7 +62,7 @@ class DataContextKey(metaclass=ABCMeta):
 class StringKey(DataContextKey):
     """A simple DataContextKey with just a single string value"""
 
-    def __init__(self, key):
+    def __init__(self, key) -> None:
         self._key = key
 
     def to_tuple(self):

--- a/great_expectations/core/evaluation_parameters.py
+++ b/great_expectations/core/evaluation_parameters.py
@@ -71,21 +71,21 @@ class EvaluationParameterParser:
         "timedelta": datetime.timedelta,
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.exprStack = []
         self._parser = None
 
-    def push_first(self, toks):
+    def push_first(self, toks) -> None:
         self.exprStack.append(toks[0])
 
-    def push_unary_minus(self, toks):
+    def push_unary_minus(self, toks) -> None:
         for t in toks:
             if t == "-":
                 self.exprStack.append("unary -")
             else:
                 break
 
-    def clear_stack(self):
+    def clear_stack(self) -> None:
         del self.exprStack[:]
 
     def get_parser(self):

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -65,7 +65,7 @@ def parse_result_format(result_format: Union[str, dict]) -> dict:
 
 
 class ExpectationContext(SerializableDictDot):
-    def __init__(self, description: Optional[str] = None):
+    def __init__(self, description: Optional[str] = None) -> None:
         self._description = description
 
     @property
@@ -73,7 +73,7 @@ class ExpectationContext(SerializableDictDot):
         return self._description
 
     @description.setter
-    def description(self, value):
+    def description(self, value) -> None:
         self._description = value
 
 
@@ -950,7 +950,7 @@ class ExpectationConfiguration(SerializableDictDot):
         success_on_last_run: Optional[bool] = None,
         ge_cloud_id: Optional[str] = None,
         expectation_context: Optional[ExpectationContext] = None,
-    ):
+    ) -> None:
         if not isinstance(expectation_type, str):
             raise InvalidExpectationConfigurationError(
                 "expectation_type must be a string"

--- a/great_expectations/core/expectation_diagnostics/expectation_test_data_cases.py
+++ b/great_expectations/core/expectation_diagnostics/expectation_test_data_cases.py
@@ -26,7 +26,7 @@ class TestBackend:
 
     __test__ = False  # Tell pytest not to try to collect this class as a test
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         allowed_backend_names = ("pandas", "spark", "sqlalchemy")
         allowed_sql_dialects = ("sqlite", "postgresql", "mysql", "mssql", "bigquery")
         assert (
@@ -80,7 +80,7 @@ class ExpectationLegacyTestCaseAdapter(ExpectationTestCase):
         out,
         suppress_test_for=[],
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(
             title=title,
             input=kwargs["in"],

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -57,7 +57,7 @@ class ExpectationSuite(SerializableDictDot):
         execution_engine_type=None,
         meta=None,
         ge_cloud_id=None,
-    ):
+    ) -> None:
         self.expectation_suite_name = expectation_suite_name
         self.ge_cloud_id = ge_cloud_id
         self._data_context = data_context
@@ -99,7 +99,7 @@ class ExpectationSuite(SerializableDictDot):
         batch_parameters: Optional[dict] = None,
         profiler_config: Optional[dict] = None,
         citation_date: Optional[Union[str, datetime.datetime]] = None,
-    ):
+    ) -> None:
         if "citations" not in self.meta:
             self.meta["citations"] = []
 
@@ -271,7 +271,7 @@ class ExpectationSuite(SerializableDictDot):
 
     # CRUD methods #
 
-    def append_expectation(self, expectation_config):
+    def append_expectation(self, expectation_config) -> None:
         """Appends an expectation.
 
            Args:
@@ -440,7 +440,7 @@ class ExpectationSuite(SerializableDictDot):
         existing_expectation_configuration: Optional[ExpectationConfiguration] = None,
         match_type: str = "domain",
         ge_cloud_id: Optional[str] = None,
-    ):
+    ) -> None:
         """
         Find Expectations matching the given ExpectationConfiguration on the given match_type.
         If a ge_cloud_id is provided, match_type is ignored and only Expectations with matching
@@ -590,7 +590,7 @@ class ExpectationSuite(SerializableDictDot):
             self.send_usage_event(success=True)
         return expectation_configuration
 
-    def send_usage_event(self, success: bool):
+    def send_usage_event(self, success: bool) -> None:
         usage_stats_event_payload: dict = {}
         if self._data_context is not None:
             self._data_context.send_usage_message(

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -45,7 +45,7 @@ class ExpectationValidationResult(SerializableDictDot):
         result=None,
         meta=None,
         exception_info=None,
-    ):
+    ) -> None:
         if result and not self.validate_result_dict(result):
             raise ge_exceptions.InvalidCacheValueError(result)
         self.success = success
@@ -280,7 +280,7 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
         statistics=None,
         meta=None,
         ge_cloud_id: Optional[UUID] = None,
-    ):
+    ) -> None:
         self.success = success
         if results is None:
             results = []

--- a/great_expectations/core/metric.py
+++ b/great_expectations/core/metric.py
@@ -17,7 +17,7 @@ class Metric:
     column name.
     """
 
-    def __init__(self, metric_name, metric_kwargs, metric_value):
+    def __init__(self, metric_name, metric_kwargs, metric_value) -> None:
         self._metric_name = metric_name
         if not isinstance(metric_kwargs, IDDict):
             metric_kwargs = IDDict(metric_kwargs)
@@ -40,7 +40,7 @@ class Metric:
 class MetricIdentifier(DataContextKey):
     """A MetricIdentifier serves as a key to store and retrieve Metrics."""
 
-    def __init__(self, metric_name, metric_kwargs_id):
+    def __init__(self, metric_name, metric_kwargs_id) -> None:
         self._metric_name = metric_name
         self._metric_kwargs_id = metric_kwargs_id
 
@@ -87,7 +87,9 @@ class MetricIdentifier(DataContextKey):
 class BatchMetric(Metric):
     """A BatchMetric is a metric associated with a particular Batch of data."""
 
-    def __init__(self, metric_name, metric_kwargs, batch_identifier, metric_value):
+    def __init__(
+        self, metric_name, metric_kwargs, batch_identifier, metric_value
+    ) -> None:
         super().__init__(metric_name, metric_kwargs, metric_value)
         self._batch_identifier = batch_identifier
 
@@ -105,7 +107,7 @@ class ValidationMetric(Metric):
         metric_name,
         metric_kwargs,
         metric_value,
-    ):
+    ) -> None:
         super().__init__(metric_name, metric_kwargs, metric_value)
         if not isinstance(expectation_suite_identifier, ExpectationSuiteIdentifier):
             expectation_suite_identifier = ExpectationSuiteIdentifier(
@@ -155,7 +157,7 @@ class ValidationMetricIdentifier(MetricIdentifier):
         expectation_suite_identifier,
         metric_name,
         metric_kwargs_id,
-    ):
+    ) -> None:
         super().__init__(metric_name, metric_kwargs_id)
         if not isinstance(expectation_suite_identifier, ExpectationSuiteIdentifier):
             expectation_suite_identifier = ExpectationSuiteIdentifier(

--- a/great_expectations/core/run_identifier.py
+++ b/great_expectations/core/run_identifier.py
@@ -11,7 +11,7 @@ from great_expectations.marshmallow__shade import Schema, fields, post_load
 class RunIdentifier(DataContextKey):
     """A RunIdentifier identifies a run (collection of validations) by run_name and run_time."""
 
-    def __init__(self, run_name=None, run_time=None):
+    def __init__(self, run_name=None, run_time=None) -> None:
         super().__init__()
         assert run_name is None or isinstance(
             run_name, str

--- a/great_expectations/core/usage_statistics/execution_environment.py
+++ b/great_expectations/core/usage_statistics/execution_environment.py
@@ -58,7 +58,7 @@ class GEExecutionEnvironment:
     Attributes: None
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._ge_dependencies: GEDependencies = GEDependencies()
         self._all_installed_packages = None
         self._get_all_installed_packages()

--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -141,7 +141,7 @@ class GEDependencies:
         GE_DEV_DEPENDENCIES_EXCLUDED_FROM_TRACKING
     )
 
-    def __init__(self, requirements_relative_base_dir: str = "../../../"):
+    def __init__(self, requirements_relative_base_dir: str = "../../../") -> None:
         self._requirements_relative_base_dir = file_relative_path(
             __file__, requirements_relative_base_dir
         )
@@ -242,7 +242,7 @@ class GEDependencies:
         return dependency_names
 
 
-def main():
+def main() -> None:
     """Run this module to generate a list of packages from requirements files to update our static lists"""
     ge_dependencies: GEDependencies = GEDependencies()
     print("\n\nRequired Dependencies:\n\n")

--- a/great_expectations/core/usage_statistics/usage_statistics.py
+++ b/great_expectations/core/usage_statistics/usage_statistics.py
@@ -53,7 +53,7 @@ class UsageStatisticsHandler:
         data_context: "DataContext",  # noqa: F821
         data_context_id: str,
         usage_statistics_url: str,
-    ):
+    ) -> None:
         self._url = usage_statistics_url
 
         self._data_context_id = data_context_id

--- a/great_expectations/core/usage_statistics/util.py
+++ b/great_expectations/core/usage_statistics/util.py
@@ -10,7 +10,7 @@ def send_usage_message(
     event_payload: Optional[dict] = None,
     api_version: str = "v3",
     success: bool = False,
-):
+) -> None:
     if not event:
         event = None
 

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -457,7 +457,7 @@ class AzureUrl:
         "wasbs://{container}@{account_name}.blob.core.windows.net/{path}"
     )
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         search = re.search(
             AzureUrl.AZURE_BLOB_STORAGE_PROTOCOL_DETECTION_REGEX_PATTERN, url
         )
@@ -511,7 +511,7 @@ class GCSUrl:
 
     OBJECT_URL_TEMPLATE: str = "gs://{bucket_or_name}/{path}"
 
-    def __init__(self, url: str):
+    def __init__(self, url: str) -> None:
         search = re.search(GCSUrl.URL_REGEX_PATTERN, url)
         assert (
             search is not None
@@ -556,7 +556,7 @@ class S3Url:
     's3://bucket/hello/world#foo?bar=2'
     """
 
-    def __init__(self, url):
+    def __init__(self, url) -> None:
         self._parsed = urlparse(url, allow_fragments=False)
 
     @property

--- a/great_expectations/core/yaml_handler.py
+++ b/great_expectations/core/yaml_handler.py
@@ -31,7 +31,7 @@ class YAMLHandler:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._handler: YAML = YAML(typ="safe")
         # TODO: ensure this does not break all usage of ruamel in GE codebase.
         self._handler.indent(mapping=2, sequence=4, offset=2)

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -45,7 +45,7 @@ class DataAsset:
     # That way, multiple backends can implement the same data_asset_type
     _data_asset_type = "DataAsset"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         """
         Initialize the DataAsset.
 
@@ -341,7 +341,7 @@ class DataAsset:
 
     def _initialize_expectations(
         self, expectation_suite=None, expectation_suite_name=None
-    ):
+    ) -> None:
         """Instantiates `_expectation_suite` as empty by default or with a specified expectation `config`.
         In addition, this always sets the `default_expectation_args` to:
             `include_config`: False,
@@ -405,7 +405,7 @@ class DataAsset:
             "result_format": "BASIC",
         }
 
-    def append_expectation(self, expectation_config):
+    def append_expectation(self, expectation_config) -> None:
         """This method is a thin wrapper for ExpectationSuite.append_expectation"""
         # deprecated-v0.12.0
         warnings.warn(
@@ -466,7 +466,7 @@ class DataAsset:
             remove_multiple_matches=remove_multiple_matches,
         )
 
-    def set_config_value(self, key, value):
+    def set_config_value(self, key, value) -> None:
         self._config[key] = value
 
     def get_config_value(self, key):
@@ -488,7 +488,7 @@ class DataAsset:
     def batch_parameters(self):
         return self._batch_parameters
 
-    def discard_failing_expectations(self):
+    def discard_failing_expectations(self) -> None:
         res = self.validate(only_return_failures=True).results
         if any(res):
             for item in res:
@@ -517,7 +517,7 @@ class DataAsset:
         """
         return self.default_expectation_args
 
-    def set_default_expectation_argument(self, argument, value):
+    def set_default_expectation_argument(self, argument, value) -> None:
         """Set a default expectation argument for this data_asset
 
         Args:
@@ -667,7 +667,7 @@ class DataAsset:
         discard_include_config_kwargs=True,
         discard_catch_exceptions_kwargs=True,
         suppress_warnings=False,
-    ):
+    ) -> None:
         """Writes ``_expectation_config`` to a JSON file.
 
            Writes the DataAsset's expectation config to the specified JSON ``filepath``. Failing expectations \
@@ -1061,7 +1061,7 @@ class DataAsset:
         else:
             return default_value
 
-    def set_evaluation_parameter(self, parameter_name, parameter_value):
+    def set_evaluation_parameter(self, parameter_name, parameter_value) -> None:
         """Provide a value to be stored in the data_asset evaluation_parameters object and used to evaluate
         parameterized expectations.
 
@@ -1080,7 +1080,7 @@ class DataAsset:
         batch_markers=None,
         batch_parameters=None,
         citation_date=None,
-    ):
+    ) -> None:
         if batch_kwargs is None:
             batch_kwargs = self.batch_kwargs
         if batch_markers is None:
@@ -1101,7 +1101,7 @@ class DataAsset:
         return self._expectation_suite.expectation_suite_name
 
     @expectation_suite_name.setter
-    def expectation_suite_name(self, expectation_suite_name):
+    def expectation_suite_name(self, expectation_suite_name) -> None:
         """Sets the expectation_suite name of this data_asset as stored in the expectations configuration."""
         self._expectation_suite.expectation_suite_name = expectation_suite_name
 

--- a/great_expectations/data_asset/file_data_asset.py
+++ b/great_expectations/data_asset/file_data_asset.py
@@ -21,7 +21,7 @@ class MetaFileDataAsset(DataAsset):
     and FileDataset implements the expectation methods themselves.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -165,7 +165,7 @@ class FileDataAsset(MetaFileDataAsset):
 
     _data_asset_type = "FileDataAsset"
 
-    def __init__(self, file_path=None, *args, **kwargs):
+    def __init__(self, file_path=None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._path = file_path
 

--- a/great_expectations/data_asset/util.py
+++ b/great_expectations/data_asset/util.py
@@ -57,7 +57,7 @@ Usage::
 
 
 class DocInherit:
-    def __init__(self, mthd):
+    def __init__(self, mthd) -> None:
         self.mthd = mthd
         self.name = mthd.__name__
         self.mthd_doc = mthd.__doc__
@@ -193,7 +193,7 @@ def recursively_convert_to_json_serializable(test_obj):
         )
 
 
-def ensure_row_condition_is_correct(row_condition_string):
+def ensure_row_condition_is_correct(row_condition_string) -> None:
     """Ensure no quote nor \\\\n are introduced in row_condition string.
 
     Otherwise it may cause an issue at the reload of the expectation.

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1114,7 +1114,7 @@ class BaseDataContext(ConfigPeer):
 
     def save_config_variable(
         self, config_variable_name, value, skip_if_substitution_variable: bool = True
-    ):
+    ) -> None:
         r"""Save config variable value
         Escapes $ unless they are used in substitution variables e.g. the $ characters in ${SOME_VAR} or $SOME_VAR are not escaped
 
@@ -1158,7 +1158,7 @@ class BaseDataContext(ConfigPeer):
         with open(config_variables_filepath, "w") as config_variables_file:
             yaml.dump(config_variables, config_variables_file)
 
-    def delete_datasource(self, datasource_name: str):
+    def delete_datasource(self, datasource_name: str) -> None:
         """Delete a data source
         Args:
             datasource_name: The name of the datasource to delete.
@@ -2012,7 +2012,7 @@ class BaseDataContext(ConfigPeer):
         )
         return generator
 
-    def set_config(self, project_config: DataContextConfig):
+    def set_config(self, project_config: DataContextConfig) -> None:
         self._project_config = project_config
 
     def _build_datasource_from_config(
@@ -2167,7 +2167,7 @@ class BaseDataContext(ConfigPeer):
 
     def send_usage_message(
         self, event: str, event_payload: Optional[dict], success: Optional[bool] = None
-    ):
+    ) -> None:
         """helper method to send a usage method using DataContext. Used when sending usage events from
             classes like ExpectationSuite.
             event
@@ -2365,7 +2365,9 @@ class BaseDataContext(ConfigPeer):
         self._evaluation_parameter_dependencies_compiled = False
         return self.expectations_store.set(key, expectation_suite, **kwargs)
 
-    def _store_metrics(self, requested_metrics, validation_results, target_store_name):
+    def _store_metrics(
+        self, requested_metrics, validation_results, target_store_name
+    ) -> None:
         """
         requested_metrics is a dictionary like this:
 
@@ -2439,10 +2441,12 @@ class BaseDataContext(ConfigPeer):
 
     def store_validation_result_metrics(
         self, requested_metrics, validation_results, target_store_name
-    ):
+    ) -> None:
         self._store_metrics(requested_metrics, validation_results, target_store_name)
 
-    def store_evaluation_parameters(self, validation_results, target_store_name=None):
+    def store_evaluation_parameters(
+        self, validation_results, target_store_name=None
+    ) -> None:
         if not self._evaluation_parameter_dependencies_compiled:
             self._compile_evaluation_parameter_dependencies()
 
@@ -2477,7 +2481,7 @@ class BaseDataContext(ConfigPeer):
     def assistants(self) -> DataAssistantDispatcher:
         return self._assistants
 
-    def _compile_evaluation_parameter_dependencies(self):
+    def _compile_evaluation_parameter_dependencies(self) -> None:
         self._evaluation_parameter_dependencies = {}
         # NOTE: Chetan - 20211118: This iteration is reverting the behavior performed here: https://github.com/great-expectations/great_expectations/pull/3377
         # This revision was necessary due to breaking changes but will need to be brought back in a future ticket.

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -318,7 +318,7 @@ class DataContext(BaseDataContext):
         ge_cloud_account_id: Optional[str] = None,
         ge_cloud_access_token: Optional[str] = None,
         ge_cloud_organization_id: Optional[str] = None,
-    ):
+    ) -> None:
         self._ge_cloud_mode = ge_cloud_mode
         self._ge_cloud_config = None
         ge_cloud_config = None
@@ -467,7 +467,7 @@ class DataContext(BaseDataContext):
 
         return new_datasource
 
-    def delete_datasource(self, name: str):
+    def delete_datasource(self, name: str) -> None:
         logger.debug(f"Starting DataContext.delete_datasource for datasource {name}")
 
         super().delete_datasource(datasource_name=name)

--- a/great_expectations/data_context/data_context/explorer_data_context.py
+++ b/great_expectations/data_context/data_context/explorer_data_context.py
@@ -12,7 +12,7 @@ yaml.default_flow_style = False
 
 
 class ExplorerDataContext(DataContext):
-    def __init__(self, context_root_dir=None, expectation_explorer=True):
+    def __init__(self, context_root_dir=None, expectation_explorer=True) -> None:
         """
             expectation_explorer: If True, load the expectation explorer manager, which will modify GE return objects \
             to include ipython notebook widgets.

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -41,7 +41,7 @@ class CheckpointStore(ConfigurationStore):
 
         return checkpoint_config_dict
 
-    def serialization_self_check(self, pretty_print: bool):
+    def serialization_self_check(self, pretty_print: bool) -> None:
         test_checkpoint_name: str = "test-name-" + "".join(
             [random.choice(list("0123456789ABCDEF")) for i in range(20)]
         )

--- a/great_expectations/data_context/store/configuration_store.py
+++ b/great_expectations/data_context/store/configuration_store.py
@@ -42,7 +42,7 @@ class ConfigurationStore(Store):
         store_backend: Optional[dict] = None,
         overwrite_existing: bool = False,
         runtime_environment: Optional[dict] = None,
-    ):
+    ) -> None:
         if not issubclass(self._configuration_class, BaseYamlConfig):
             raise ge_exceptions.DataContextError(
                 "Invalid configuration: A configuration_class needs to inherit from the BaseYamlConfig class."
@@ -112,7 +112,7 @@ class ConfigurationStore(Store):
         return self._overwrite_existing
 
     @overwrite_existing.setter
-    def overwrite_existing(self, overwrite_existing: bool):
+    def overwrite_existing(self, overwrite_existing: bool) -> None:
         self._overwrite_existing = overwrite_existing
 
     @property
@@ -148,7 +148,7 @@ class ConfigurationStore(Store):
 
         return report_object
 
-    def serialization_self_check(self, pretty_print: bool):
+    def serialization_self_check(self, pretty_print: bool) -> None:
         raise NotImplementedError
 
     @staticmethod

--- a/great_expectations/data_context/store/database_store_backend.py
+++ b/great_expectations/data_context/store/database_store_backend.py
@@ -40,7 +40,7 @@ class DatabaseStoreBackend(StoreBackend):
         suppress_store_backend_id=False,
         manually_initialize_store_backend_id: str = "",
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(
             fixed_length_key=fixed_length_key,
             suppress_store_backend_id=suppress_store_backend_id,
@@ -250,7 +250,7 @@ class DatabaseStoreBackend(StoreBackend):
             logger.debug(f"Error fetching value: {str(e)}")
             raise ge_exceptions.StoreError(f"Unable to fetch value for key: {str(key)}")
 
-    def _set(self, key, value, allow_update=True, **kwargs):
+    def _set(self, key, value, allow_update=True, **kwargs) -> None:
         cols = {k: v for (k, v) in zip(self.key_columns, key)}
         cols["value"] = value
 
@@ -276,7 +276,7 @@ class DatabaseStoreBackend(StoreBackend):
                     f"Integrity error {str(e)} while trying to store key"
                 )
 
-    def _move(self):
+    def _move(self) -> None:
         raise NotImplementedError
 
     def get_url_for_key(self, key):

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -112,7 +112,7 @@ class ExpectationsStore(Store):
         runtime_environment=None,
         store_name=None,
         data_context=None,
-    ):
+    ) -> None:
         self._expectationSuiteSchema = ExpectationSuiteSchema()
         # TODO: refactor so ExpectationStore can have access to DataContext. Currently used by usage_stats messages.
         self._data_context = data_context

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -43,7 +43,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         suppress_store_backend_id: bool = True,
         manually_initialize_store_backend_id: str = "",
         store_name: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(
             fixed_length_key=True,
             suppress_store_backend_id=suppress_store_backend_id,
@@ -112,7 +112,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 f"Unable to get object in GE Cloud Store Backend: {jsonError}"
             )
 
-    def _move(self):
+    def _move(self) -> None:
         pass
 
     def _update(self, ge_cloud_id, value, **kwargs):

--- a/great_expectations/data_context/store/html_site_store.py
+++ b/great_expectations/data_context/store/html_site_store.py
@@ -100,7 +100,7 @@ class HtmlSiteStore:
 
     _key_class = SiteSectionIdentifier
 
-    def __init__(self, store_backend=None, runtime_environment=None):
+    def __init__(self, store_backend=None, runtime_environment=None) -> None:
         store_backend_module_name = store_backend.get(
             "module_name", "great_expectations.data_context.store"
         )
@@ -366,7 +366,7 @@ class HtmlSiteStore:
             content_type="text/html; " "charset=utf-8",
         )
 
-    def clean_site(self):
+    def clean_site(self) -> None:
         for _, target_store_backend in self.store_backends.items():
             keys = target_store_backend.list_keys()
             for key in keys:

--- a/great_expectations/data_context/store/json_site_store.py
+++ b/great_expectations/data_context/store/json_site_store.py
@@ -16,7 +16,9 @@ class JsonSiteStore(Store):
 
     """
 
-    def __init__(self, store_backend=None, runtime_environment=None, store_name=None):
+    def __init__(
+        self, store_backend=None, runtime_environment=None, store_name=None
+    ) -> None:
 
         if store_backend is not None:
             store_backend_module_name = store_backend.get(
@@ -64,7 +66,7 @@ class JsonSiteStore(Store):
     def deserialize(self, key, value):
         return RenderedDocumentContent(**loads(value))
 
-    def self_check(self, pretty_print):
+    def self_check(self, pretty_print) -> None:
         NotImplementedError(
             f"The test method is not implemented for Store class {self.__class__.__name__}."
         )

--- a/great_expectations/data_context/store/metric_store.py
+++ b/great_expectations/data_context/store/metric_store.py
@@ -21,7 +21,7 @@ class MetricStore(Store):
 
     _key_class = ValidationMetricIdentifier
 
-    def __init__(self, store_backend=None, store_name=None):
+    def __init__(self, store_backend=None, store_name=None) -> None:
         if store_backend is not None:
             store_backend_module_name = store_backend.get(
                 "module_name", "great_expectations.data_context.store"
@@ -56,7 +56,7 @@ class MetricStore(Store):
         super().__init__(store_backend=store_backend, store_name=store_name)
 
     # noinspection PyMethodMayBeStatic
-    def _validate_value(self, value):
+    def _validate_value(self, value) -> None:
         # Values must be json serializable since they must be inputs to expectation configurations
         ensure_json_serializable(value)
 
@@ -69,7 +69,7 @@ class MetricStore(Store):
 
 
 class EvaluationParameterStore(MetricStore):
-    def __init__(self, store_backend=None, store_name=None):
+    def __init__(self, store_backend=None, store_name=None) -> None:
         if store_backend is not None:
             store_backend_module_name = store_backend.get(
                 "module_name", "great_expectations.data_context.store"

--- a/great_expectations/data_context/store/query_store.py
+++ b/great_expectations/data_context/store/query_store.py
@@ -42,7 +42,7 @@ class SqlAlchemyQueryStore(Store):
         store_backend=None,
         runtime_environment=None,
         store_name=None,
-    ):
+    ) -> None:
         if not sqlalchemy:
             raise ge_exceptions.DataContextError(
                 "sqlalchemy module not found, but is required for "

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -30,7 +30,7 @@ class Store:
 
     def __init__(
         self, store_backend=None, runtime_environment=None, store_name="no_store_name"
-    ):
+    ) -> None:
         """
         Runtime environment may be necessary to instantiate store backend elements.
         Args:
@@ -177,7 +177,7 @@ class Store:
                 return self._store_backend.has_key(key.to_fixed_length_tuple())
             return self._store_backend.has_key(key.to_tuple())
 
-    def self_check(self, pretty_print):
+    def self_check(self, pretty_print) -> None:
         NotImplementedError(
             f"The test method is not implemented for Store class {self.__class__.__name__}."
         )

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -33,7 +33,7 @@ class StoreBackend(metaclass=ABCMeta):
         suppress_store_backend_id=False,
         manually_initialize_store_backend_id: str = "",
         store_name="no_store_name",
-    ):
+    ) -> None:
         """
         Initialize a StoreBackend
         Args:
@@ -140,14 +140,14 @@ class StoreBackend(metaclass=ABCMeta):
         self._validate_key(key)
         return self._has_key(key)
 
-    def get_url_for_key(self, key, protocol=None):
+    def get_url_for_key(self, key, protocol=None) -> None:
         raise StoreError(
             "Store backend of type {:s} does not have an implementation of get_url_for_key".format(
                 type(self).__name__
             )
         )
 
-    def _validate_key(self, key):
+    def _validate_key(self, key) -> None:
         if isinstance(key, tuple):
             for key_element in key:
                 if not isinstance(key_element, str):
@@ -167,30 +167,30 @@ class StoreBackend(metaclass=ABCMeta):
                 )
             )
 
-    def _validate_value(self, value):
+    def _validate_value(self, value) -> None:
         pass
 
     @abstractmethod
-    def _get(self, key):
+    def _get(self, key) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def _set(self, key, value, **kwargs):
+    def _set(self, key, value, **kwargs) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def _move(self, source_key, dest_key, **kwargs):
+    def _move(self, source_key, dest_key, **kwargs) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def list_keys(self, prefix=()):
+    def list_keys(self, prefix=()) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def remove_key(self, key):
+    def remove_key(self, key) -> None:
         raise NotImplementedError
 
-    def _has_key(self, key):
+    def _has_key(self, key) -> None:
         raise NotImplementedError
 
     def is_ignored_key(self, key):
@@ -216,7 +216,7 @@ class InMemoryStoreBackend(StoreBackend):
         suppress_store_backend_id=False,
         manually_initialize_store_backend_id: str = "",
         store_name=None,
-    ):
+    ) -> None:
         super().__init__(
             fixed_length_key=fixed_length_key,
             suppress_store_backend_id=suppress_store_backend_id,
@@ -247,10 +247,10 @@ class InMemoryStoreBackend(StoreBackend):
         except KeyError as e:
             raise InvalidKeyError(f"{str(e)}")
 
-    def _set(self, key, value, **kwargs):
+    def _set(self, key, value, **kwargs) -> None:
         self._store[key] = value
 
-    def _move(self, source_key, dest_key, **kwargs):
+    def _move(self, source_key, dest_key, **kwargs) -> None:
         self._store[dest_key] = self._store[source_key]
         self._store.pop(source_key)
 
@@ -260,7 +260,7 @@ class InMemoryStoreBackend(StoreBackend):
     def _has_key(self, key):
         return key in self._store
 
-    def remove_key(self, key):
+    def remove_key(self, key) -> None:
         del self._store[key]
 
     @property

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -35,7 +35,7 @@ class TupleStoreBackend(StoreBackend, metaclass=ABCMeta):
         manually_initialize_store_backend_id: str = "",
         base_public_path=None,
         store_name=None,
-    ):
+    ) -> None:
         super().__init__(
             fixed_length_key=fixed_length_key,
             suppress_store_backend_id=suppress_store_backend_id,
@@ -72,7 +72,7 @@ class TupleStoreBackend(StoreBackend, metaclass=ABCMeta):
             self.verify_that_key_to_filepath_operation_is_reversible()
             self._fixed_length_key = True
 
-    def _validate_key(self, key):
+    def _validate_key(self, key) -> None:
         super()._validate_key(key)
 
         for key_element in key:
@@ -86,7 +86,7 @@ class TupleStoreBackend(StoreBackend, metaclass=ABCMeta):
                         )
                     )
 
-    def _validate_value(self, value):
+    def _validate_value(self, value) -> None:
         if not isinstance(value, str) and not isinstance(value, bytes):
             raise TypeError(
                 "Values in {} must be instances of {} or {}, not {}".format(
@@ -239,7 +239,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
         manually_initialize_store_backend_id: str = "",
         base_public_path=None,
         store_name=None,
-    ):
+    ) -> None:
         super().__init__(
             filepath_template=filepath_template,
             filepath_prefix=filepath_prefix,
@@ -370,7 +370,7 @@ class TupleFilesystemStoreBackend(TupleStoreBackend):
 
         return key_list
 
-    def rrmdir(self, mroot, curpath):
+    def rrmdir(self, mroot, curpath) -> None:
         """
         recursively removes empty dirs between curpath and mroot inclusive
         """
@@ -455,7 +455,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
         base_public_path=None,
         endpoint_url=None,
         store_name=None,
-    ):
+    ) -> None:
         super().__init__(
             filepath_template=filepath_template,
             filepath_prefix=filepath_prefix,
@@ -577,7 +577,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
 
         return s3_object_key
 
-    def _move(self, source_key, dest_key, **kwargs):
+    def _move(self, source_key, dest_key, **kwargs) -> None:
         s3 = self._create_resource()
 
         source_filepath = self._convert_key_to_filepath(source_key)
@@ -757,7 +757,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         public_urls=True,
         base_public_path=None,
         store_name=None,
-    ):
+    ) -> None:
         super().__init__(
             filepath_template=filepath_template,
             filepath_prefix=filepath_prefix,
@@ -857,7 +857,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
             blob.upload_from_string(value, content_type=content_type)
         return gcs_object_key
 
-    def _move(self, source_key, dest_key, **kwargs):
+    def _move(self, source_key, dest_key, **kwargs) -> None:
         from google.cloud import storage
 
         gcs = storage.Client(project=self.project)
@@ -981,7 +981,7 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
         suppress_store_backend_id=False,
         manually_initialize_store_backend_id: str = "",
         store_name=None,
-    ):
+    ) -> None:
         super().__init__(
             filepath_template=filepath_template,
             filepath_prefix=filepath_prefix,
@@ -1084,7 +1084,7 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
         all_keys = self.list_keys()
         return key in all_keys
 
-    def _move(self, source_key, dest_key, **kwargs):
+    def _move(self, source_key, dest_key, **kwargs) -> None:
         source_blob_path = self._convert_key_to_filepath(source_key)
         if not source_blob_path.startswith(self.prefix):
             source_blob_path = os.path.join(self.prefix, source_blob_path)

--- a/great_expectations/data_context/store/util.py
+++ b/great_expectations/data_context/store/util.py
@@ -77,7 +77,7 @@ def save_config_to_store_backend(
     store_backend: Union[StoreBackend, dict],
     configuration_key: str,
     configuration: BaseYamlConfig,
-):
+) -> None:
     config_store: ConfigurationStore = build_configuration_store(
         class_name=class_name,
         module_name=module_name,
@@ -117,7 +117,7 @@ def delete_config_from_store_backend(
     store_name: str,
     store_backend: Union[StoreBackend, dict],
     configuration_key: str,
-):
+) -> None:
     config_store: ConfigurationStore = build_configuration_store(
         class_name=class_name,
         module_name=module_name,
@@ -136,7 +136,7 @@ def save_checkpoint_config_to_store_backend(
     store_backend: Union[StoreBackend, dict],
     checkpoint_name: str,
     checkpoint_configuration: CheckpointConfig,
-):
+) -> None:
     config_store: CheckpointStore = build_checkpoint_store_using_store_backend(
         store_name=store_name,
         store_backend=store_backend,
@@ -173,7 +173,7 @@ def delete_checkpoint_config_from_store_backend(
     store_name: str,
     store_backend: Union[StoreBackend, dict],
     checkpoint_name: str,
-):
+) -> None:
     config_store: CheckpointStore = build_checkpoint_store_using_store_backend(
         store_name=store_name,
         store_backend=store_backend,

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -94,7 +94,9 @@ class ValidationsStore(Store):
 
     _key_class = ValidationResultIdentifier
 
-    def __init__(self, store_backend=None, runtime_environment=None, store_name=None):
+    def __init__(
+        self, store_backend=None, runtime_environment=None, store_name=None
+    ) -> None:
         self._expectationSuiteValidationResultSchema = (
             ExpectationSuiteValidationResultSchema()
         )

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -64,7 +64,7 @@ class BaseYamlConfig(SerializableDictDot):
         "commented_map",
     }
 
-    def __init__(self, commented_map: Optional[CommentedMap] = None):
+    def __init__(self, commented_map: Optional[CommentedMap] = None) -> None:
         if commented_map is None:
             commented_map = CommentedMap()
         self._commented_map = commented_map
@@ -110,7 +110,7 @@ class BaseYamlConfig(SerializableDictDot):
         commented_map.update(self._get_schema_instance().dump(self))
         return commented_map
 
-    def to_yaml(self, outfile):
+    def to_yaml(self, outfile) -> None:
         """
         :returns None (but writes a YAML file containing the project configuration)
         """
@@ -134,11 +134,11 @@ class BaseYamlConfig(SerializableDictDot):
         return self._get_schema_validated_updated_commented_map()
 
     @classmethod
-    def get_config_class(cls):
+    def get_config_class(cls) -> None:
         raise NotImplementedError
 
     @classmethod
-    def get_schema_class(cls):
+    def get_schema_class(cls) -> None:
         raise NotImplementedError
 
 
@@ -156,7 +156,7 @@ class AssetConfig(DictDot):
         batch_spec_passthrough=None,
         batch_identifiers=None,
         **kwargs,
-    ):
+    ) -> None:
         if name is not None:
             self.name = name
         self._class_name = class_name
@@ -224,7 +224,7 @@ class AssetConfigSchema(Schema):
     )
 
     @validates_schema
-    def validate_schema(self, data, **kwargs):
+    def validate_schema(self, data, **kwargs) -> None:
         pass
 
     # noinspection PyUnusedLocal
@@ -243,7 +243,7 @@ class SorterConfig(DictDot):
         reference_list=None,
         datetime_format=None,
         **kwargs,
-    ):
+    ) -> None:
         self._name = name
         self._class_name = class_name
         self._module_name = module_name
@@ -316,7 +316,7 @@ class SorterConfigSchema(Schema):
     )
 
     @validates_schema
-    def validate_schema(self, data, **kwargs):
+    def validate_schema(self, data, **kwargs) -> None:
         pass
 
     # noinspection PyUnusedLocal
@@ -354,7 +354,7 @@ class DataConnectorConfig(DictDot):
         # Both S3/Azure
         delimiter=None,
         **kwargs,
-    ):
+    ) -> None:
         self._class_name = class_name
         self._module_name = module_name
         if credentials is not None:
@@ -678,7 +678,7 @@ class ExecutionEngineConfig(DictDot):
         gcs_options=None,
         credentials_info=None,
         **kwargs,
-    ):
+    ) -> None:
         self._class_name = class_name
         self._module_name = module_name
         if caching is not None:
@@ -799,7 +799,7 @@ class DatasourceConfig(DictDot):
         reader_options=None,
         limit=None,
         **kwargs,
-    ):
+    ) -> None:
         # NOTE - JPC - 20200316: Currently, we are mostly inconsistent with respect to this type...
         self._class_name = class_name
         self._module_name = module_name
@@ -956,7 +956,9 @@ sqlalchemy data source (your data source is "{data['class_name']}").  Please upd
 
 
 class AnonymizedUsageStatisticsConfig(DictDot):
-    def __init__(self, enabled=True, data_context_id=None, usage_statistics_url=None):
+    def __init__(
+        self, enabled=True, data_context_id=None, usage_statistics_url=None
+    ) -> None:
         self._enabled = enabled
 
         if data_context_id is None:
@@ -1044,7 +1046,7 @@ class AnonymizedUsageStatisticsConfigSchema(Schema):
 
 
 class NotebookTemplateConfig(DictDot):
-    def __init__(self, file_name, template_kwargs=None):
+    def __init__(self, file_name, template_kwargs=None) -> None:
         self.file_name = file_name
         if template_kwargs:
             self.template_kwargs = template_kwargs
@@ -1082,7 +1084,7 @@ class NotebookConfig(DictDot):
         footer_code=None,
         table_expectation_code=None,
         column_expectation_code=None,
-    ):
+    ) -> None:
         self.class_name = class_name
         self.module_name = module_name
         self.custom_templates_module = custom_templates_module
@@ -1150,7 +1152,7 @@ class NotebookConfigSchema(Schema):
 
 
 class NotebooksConfig(DictDot):
-    def __init__(self, suite_edit):
+    def __init__(self, suite_edit) -> None:
         self.suite_edit = suite_edit
 
 
@@ -1171,7 +1173,7 @@ class ProgressBarsConfig(DictDot):
         globally: bool = True,
         profilers: bool = True,
         metric_calculations: bool = True,
-    ):
+    ) -> None:
         self.globally = globally
         self.profilers = profilers
         self.metric_calculations = metric_calculations
@@ -1186,7 +1188,7 @@ class ProgressBarsConfigSchema(Schema):
 class ConcurrencyConfig(DictDot):
     """WARNING: This class is experimental."""
 
-    def __init__(self, enabled: bool = False):
+    def __init__(self, enabled: bool = False) -> None:
         """Initialize a concurrency configuration to control multithreaded execution.
 
         Args:
@@ -1242,7 +1244,7 @@ class GeCloudConfig(DictDot):
         account_id: str = None,
         access_token: str = None,
         organization_id: str = None,
-    ):
+    ) -> None:
         # access_token was given a default value to maintain arg position of account_id
         if access_token is None:
             raise ValueError("Access token cannot be None.")
@@ -1331,7 +1333,7 @@ class DataContextConfigSchema(Schema):
                 data.pop(key)
         return data
 
-    def handle_error(self, exc, data, **kwargs):
+    def handle_error(self, exc, data, **kwargs) -> None:
         """Log and raise our custom exception when (de)serialization fails."""
         if (
             exc
@@ -1351,7 +1353,7 @@ class DataContextConfigSchema(Schema):
 
     # noinspection PyUnusedLocal
     @validates_schema
-    def validate_schema(self, data, **kwargs):
+    def validate_schema(self, data, **kwargs) -> None:
         if "config_version" not in data:
             raise ge_exceptions.InvalidDataContextConfigError(
                 "The key `config_version` is missing; please check your config file.",
@@ -1551,7 +1553,7 @@ class BaseStoreBackendDefaults(DictDot):
         validation_operators: dict = None,
         stores: dict = None,
         data_docs_sites: dict = None,
-    ):
+    ) -> None:
         self.expectations_store_name = expectations_store_name
         self.validations_store_name = validations_store_name
         self.evaluation_parameter_store_name = evaluation_parameter_store_name
@@ -1611,7 +1613,7 @@ class S3StoreBackendDefaults(BaseStoreBackendDefaults):
         evaluation_parameter_store_name: str = "evaluation_parameter_store",
         checkpoint_store_name: str = "checkpoint_S3_store",
         profiler_store_name: str = "profiler_S3_store",
-    ):
+    ) -> None:
         # Initialize base defaults
         super().__init__()
 
@@ -1696,7 +1698,7 @@ class FilesystemStoreBackendDefaults(BaseStoreBackendDefaults):
         self,
         root_directory: Optional[str] = None,
         plugins_directory: Optional[str] = None,
-    ):
+    ) -> None:
         # Initialize base defaults
         super().__init__()
 
@@ -1732,7 +1734,7 @@ class InMemoryStoreBackendDefaults(BaseStoreBackendDefaults):
 
     def __init__(
         self,
-    ):
+    ) -> None:
         # Initialize base defaults
         super().__init__()
 
@@ -1820,7 +1822,7 @@ class GCSStoreBackendDefaults(BaseStoreBackendDefaults):
         evaluation_parameter_store_name: str = "evaluation_parameter_store",
         checkpoint_store_name: str = "checkpoint_GCS_store",
         profiler_store_name: str = "profiler_GCS_store",
-    ):
+    ) -> None:
         # Initialize base defaults
         super().__init__()
 
@@ -1938,7 +1940,7 @@ class DatabaseStoreBackendDefaults(BaseStoreBackendDefaults):
         evaluation_parameter_store_name: str = "evaluation_parameter_store",
         checkpoint_store_name: str = "checkpoint_database_store",
         profiler_store_name: str = "profiler_database_store",
-    ):
+    ) -> None:
         # Initialize base defaults
         super().__init__()
 
@@ -2021,7 +2023,7 @@ class DataContextConfig(BaseYamlConfig):
         commented_map: Optional[CommentedMap] = None,
         concurrency: Optional[Union[ConcurrencyConfig, Dict]] = None,
         progress_bars: Optional[ProgressBarsConfig] = None,
-    ):
+    ) -> None:
         # Set defaults
         if config_version is None:
             config_version = DataContextConfigDefaults.DEFAULT_CONFIG_VERSION.value
@@ -2239,7 +2241,7 @@ class CheckpointConfigSchema(Schema):
 
     # noinspection PyUnusedLocal
     @validates_schema
-    def validate_schema(self, data, **kwargs):
+    def validate_schema(self, data, **kwargs) -> None:
         if not (
             "name" in data or "validation_operator_name" in data or "batches" in data
         ):
@@ -2306,7 +2308,7 @@ class CheckpointConfig(BaseYamlConfig):
         notify_on: Optional[str] = None,
         notify_with: Optional[str] = None,
         expectation_suite_ge_cloud_id: Optional[Union[UUID, str]] = None,
-    ):
+    ) -> None:
         self._name = name
         self._config_version = config_version
         if self.config_version is None:
@@ -2352,7 +2354,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._validation_operator_name
 
     @validation_operator_name.setter
-    def validation_operator_name(self, value: str):
+    def validation_operator_name(self, value: str) -> None:
         self._validation_operator_name = value
 
     @property
@@ -2360,7 +2362,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._batches
 
     @batches.setter
-    def batches(self, value: List[dict]):
+    def batches(self, value: List[dict]) -> None:
         self._batches = value
 
     @property
@@ -2368,7 +2370,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._ge_cloud_id
 
     @ge_cloud_id.setter
-    def ge_cloud_id(self, value: Union[UUID, str]):
+    def ge_cloud_id(self, value: Union[UUID, str]) -> None:
         self._ge_cloud_id = value
 
     @property
@@ -2376,7 +2378,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._expectation_suite_ge_cloud_id
 
     @expectation_suite_ge_cloud_id.setter
-    def expectation_suite_ge_cloud_id(self, value: Union[UUID, str]):
+    def expectation_suite_ge_cloud_id(self, value: Union[UUID, str]) -> None:
         self._expectation_suite_ge_cloud_id = value
 
     @property
@@ -2384,7 +2386,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._name
 
     @name.setter
-    def name(self, value: str):
+    def name(self, value: str) -> None:
         self._name = value
 
     @property
@@ -2392,7 +2394,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._template_name
 
     @template_name.setter
-    def template_name(self, value: str):
+    def template_name(self, value: str) -> None:
         self._template_name = value
 
     @property
@@ -2400,7 +2402,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._config_version
 
     @config_version.setter
-    def config_version(self, value: float):
+    def config_version(self, value: float) -> None:
         self._config_version = value
 
     @property
@@ -2408,7 +2410,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._validations
 
     @validations.setter
-    def validations(self, value: List[dict]):
+    def validations(self, value: List[dict]) -> None:
         self._validations = value
 
     @property
@@ -2416,7 +2418,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._profilers
 
     @profilers.setter
-    def profilers(self, value: List[dict]):
+    def profilers(self, value: List[dict]) -> None:
         self._profilers = value
 
     @property
@@ -2424,7 +2426,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._module_name
 
     @module_name.setter
-    def module_name(self, value: str):
+    def module_name(self, value: str) -> None:
         self._module_name = value
 
     @property
@@ -2432,7 +2434,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._class_name
 
     @class_name.setter
-    def class_name(self, value: str):
+    def class_name(self, value: str) -> None:
         self._class_name = value
 
     @property
@@ -2440,7 +2442,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._run_name_template
 
     @run_name_template.setter
-    def run_name_template(self, value: str):
+    def run_name_template(self, value: str) -> None:
         self._run_name_template = value
 
     @property
@@ -2448,7 +2450,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._batch_request
 
     @batch_request.setter
-    def batch_request(self, value: dict):
+    def batch_request(self, value: dict) -> None:
         self._batch_request = value
 
     @property
@@ -2456,7 +2458,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._expectation_suite_name
 
     @expectation_suite_name.setter
-    def expectation_suite_name(self, value: str):
+    def expectation_suite_name(self, value: str) -> None:
         self._expectation_suite_name = value
 
     @property
@@ -2464,7 +2466,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._action_list
 
     @action_list.setter
-    def action_list(self, value: List[dict]):
+    def action_list(self, value: List[dict]) -> None:
         self._action_list = value
 
     @property
@@ -2472,7 +2474,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._site_names
 
     @site_names.setter
-    def site_names(self, value: List[str]):
+    def site_names(self, value: List[str]) -> None:
         self._site_names = value
 
     @property
@@ -2480,7 +2482,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._slack_webhook
 
     @slack_webhook.setter
-    def slack_webhook(self, value: str):
+    def slack_webhook(self, value: str) -> None:
         self._slack_webhook = value
 
     @property
@@ -2488,7 +2490,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._notify_on
 
     @notify_on.setter
-    def notify_on(self, value: str):
+    def notify_on(self, value: str) -> None:
         self._notify_on = value
 
     @property
@@ -2496,7 +2498,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._notify_with
 
     @notify_with.setter
-    def notify_with(self, value: str):
+    def notify_with(self, value: str) -> None:
         self._notify_with = value
 
     @property
@@ -2504,7 +2506,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._evaluation_parameters
 
     @evaluation_parameters.setter
-    def evaluation_parameters(self, value: dict):
+    def evaluation_parameters(self, value: dict) -> None:
         self._evaluation_parameters = value
 
     @property
@@ -2512,7 +2514,7 @@ class CheckpointConfig(BaseYamlConfig):
         return self._runtime_configuration
 
     @runtime_configuration.setter
-    def runtime_configuration(self, value: dict):
+    def runtime_configuration(self, value: dict) -> None:
         self._runtime_configuration = value
 
     def __deepcopy__(self, memo):

--- a/great_expectations/data_context/types/refs.py
+++ b/great_expectations/data_context/types/refs.py
@@ -3,7 +3,7 @@ class GeCloudIdAwareRef:
     This class serves as a base class for refs tied to a Great Expectations Cloud ID.
     """
 
-    def __init__(self, ge_cloud_id: str):
+    def __init__(self, ge_cloud_id: str) -> None:
         self._ge_cloud_id = ge_cloud_id
 
     @property
@@ -16,7 +16,7 @@ class GeCloudResourceRef(GeCloudIdAwareRef):
     This class represents a reference to a Great Expectations object persisted to Great Expectations Cloud.
     """
 
-    def __init__(self, resource_type: str, ge_cloud_id: str, url: str):
+    def __init__(self, resource_type: str, ge_cloud_id: str, url: str) -> None:
         self._resource_type = resource_type
         self._url = url
         super().__init__(ge_cloud_id=ge_cloud_id)

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExpectationSuiteIdentifier(DataContextKey):
-    def __init__(self, expectation_suite_name: str):
+    def __init__(self, expectation_suite_name: str) -> None:
         super().__init__()
         if not isinstance(expectation_suite_name, str):
             raise InvalidDataContextKeyError(
@@ -61,7 +61,7 @@ class BatchIdentifier(DataContextKey):
         self,
         batch_identifier: Union[BatchKwargs, dict, str],
         data_asset_name: str = None,
-    ):
+    ) -> None:
         super().__init__()
         # if isinstance(batch_identifier, (BatchKwargs, dict)):
         #     self._batch_identifier = batch_identifier.batch_fingerprint
@@ -100,7 +100,7 @@ class ValidationResultIdentifier(DataContextKey):
     and run_id.
     """
 
-    def __init__(self, expectation_suite_identifier, run_id, batch_identifier):
+    def __init__(self, expectation_suite_identifier, run_id, batch_identifier) -> None:
         """Constructs a ValidationResultIdentifier
 
         Args:
@@ -196,7 +196,7 @@ class ValidationResultIdentifier(DataContextKey):
 
 
 class GeCloudIdentifier(DataContextKey):
-    def __init__(self, resource_type: str, ge_cloud_id: Optional[str] = None):
+    def __init__(self, resource_type: str, ge_cloud_id: Optional[str] = None) -> None:
         super().__init__()
 
         self._resource_type = resource_type
@@ -207,7 +207,7 @@ class GeCloudIdentifier(DataContextKey):
         return self._resource_type
 
     @resource_type.setter
-    def resource_type(self, value):
+    def resource_type(self, value) -> None:
         self._resource_type = value
 
     @property
@@ -215,7 +215,7 @@ class GeCloudIdentifier(DataContextKey):
         return self._ge_cloud_id
 
     @ge_cloud_id.setter
-    def ge_cloud_id(self, value):
+    def ge_cloud_id(self, value) -> None:
         self._ge_cloud_id = value
 
     def to_tuple(self):
@@ -260,7 +260,7 @@ class ValidationResultIdentifierSchema(Schema):
 
 
 class SiteSectionIdentifier(DataContextKey):
-    def __init__(self, site_section_name, resource_identifier):
+    def __init__(self, site_section_name, resource_identifier) -> None:
         self._site_section_name = site_section_name
         if site_section_name in ["validations", "profiling"]:
             if isinstance(resource_identifier, ValidationResultIdentifier):
@@ -322,7 +322,7 @@ class SiteSectionIdentifier(DataContextKey):
 
 
 class ConfigurationIdentifier(DataContextKey):
-    def __init__(self, configuration_key: Union[str, UUID]):
+    def __init__(self, configuration_key: Union[str, UUID]) -> None:
         super().__init__()
         if isinstance(configuration_key, UUID):
             configuration_key = str(configuration_key)

--- a/great_expectations/dataset/dataset.py
+++ b/great_expectations/dataset/dataset.py
@@ -38,7 +38,7 @@ class MetaDataset(DataAsset):
     """
 
     @classmethod
-    def column_map_expectation(cls, func):
+    def column_map_expectation(cls, func) -> None:
         """Constructs an expectation using column-map semantics.
 
         The column_map_expectation decorator handles boilerplate issues surrounding the common pattern of evaluating
@@ -229,7 +229,7 @@ class Dataset(MetaDataset):
         "get_column_count_in_range",
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         # NOTE: using caching makes the strong assumption that the user will not modify the core data store
         # (e.g. self.spark_df) over the lifetime of the dataset instance
         self.caching = kwargs.pop("caching", True)
@@ -247,11 +247,11 @@ class Dataset(MetaDataset):
         is suitable really when a constructor knows to take its own type. In general, this should be overridden"""
         return cls(dataset)
 
-    def get_row_count(self):
+    def get_row_count(self) -> None:
         """Returns: int, table row count"""
         raise NotImplementedError
 
-    def get_column_count(self):
+    def get_column_count(self) -> None:
         """Returns: int, table column count"""
         raise NotImplementedError
 
@@ -259,15 +259,15 @@ class Dataset(MetaDataset):
         """Returns: List[str], list of column names"""
         raise NotImplementedError
 
-    def get_column_nonnull_count(self, column):
+    def get_column_nonnull_count(self, column) -> None:
         """Returns: int"""
         raise NotImplementedError
 
-    def get_column_mean(self, column):
+    def get_column_mean(self, column) -> None:
         """Returns: float"""
         raise NotImplementedError
 
-    def get_column_value_counts(self, column, sort="value", collate=None):
+    def get_column_value_counts(self, column, sort="value", collate=None) -> None:
         """Get a series containing the frequency counts of unique values from the named column.
 
         Args:
@@ -284,27 +284,27 @@ class Dataset(MetaDataset):
         """
         raise NotImplementedError
 
-    def get_column_sum(self, column):
+    def get_column_sum(self, column) -> None:
         """Returns: float"""
         raise NotImplementedError
 
-    def get_column_max(self, column, parse_strings_as_datetimes=False):
+    def get_column_max(self, column, parse_strings_as_datetimes=False) -> None:
         """Returns: Any"""
         raise NotImplementedError
 
-    def get_column_min(self, column, parse_strings_as_datetimes=False):
+    def get_column_min(self, column, parse_strings_as_datetimes=False) -> None:
         """Returns: Any"""
         raise NotImplementedError
 
-    def get_column_unique_count(self, column):
+    def get_column_unique_count(self, column) -> None:
         """Returns: int"""
         raise NotImplementedError
 
-    def get_column_modes(self, column):
+    def get_column_modes(self, column) -> None:
         """Returns: List[Any], list of modes (ties OK)"""
         raise NotImplementedError
 
-    def get_column_median(self, column):
+    def get_column_median(self, column) -> None:
         """Returns: Any"""
         raise NotImplementedError
 
@@ -322,7 +322,7 @@ class Dataset(MetaDataset):
         """
         raise NotImplementedError
 
-    def get_column_stdev(self, column):
+    def get_column_stdev(self, column) -> None:
         """Returns: float"""
         raise NotImplementedError
 
@@ -384,7 +384,7 @@ class Dataset(MetaDataset):
             raise ValueError("Invalid parameter for bins argument")
         return bins
 
-    def get_column_hist(self, column, bins):
+    def get_column_hist(self, column, bins) -> None:
         """Get a histogram of column values
         Args:
             column: the column for which to generate the histogram
@@ -395,7 +395,7 @@ class Dataset(MetaDataset):
 
     def get_column_count_in_range(
         self, column, min_val=None, max_val=None, strict_min=False, strict_max=True
-    ):
+    ) -> None:
         """Returns: int"""
         raise NotImplementedError
 
@@ -407,7 +407,7 @@ class Dataset(MetaDataset):
         bins_B=None,
         n_bins_A=None,
         n_bins_B=None,
-    ):
+    ) -> None:
         """Get crosstab of column_A and column_B, binning values if necessary"""
         raise NotImplementedError
 
@@ -974,7 +974,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect each column value to be unique.
 
         This expectation detects duplicates. All duplicated values are counted as exceptions.
@@ -1026,7 +1026,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column values to not be null.
 
         To be counted as an exception, values must be explicitly null or missing, such as a NULL in PostgreSQL or an
@@ -1081,7 +1081,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column values to be null.
 
         expect_column_values_to_be_null is a \
@@ -1134,7 +1134,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect a column to contain values of a specified data type.
 
         expect_column_values_to_be_of_type is a :func:`column_aggregate_expectation \
@@ -1201,7 +1201,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect a column to contain values from a specified type list.
 
         expect_column_values_to_be_in_type_list is a :func:`column_aggregate_expectation \
@@ -1272,7 +1272,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         # noinspection PyUnresolvedReferences
         """Expect each column value to be in a given set.
 
@@ -1351,7 +1351,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         # noinspection PyUnresolvedReferences
         """Expect column entries to not be in the set.
 
@@ -1434,7 +1434,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be between a minimum value and a maximum value (inclusive).
 
         expect_column_values_to_be_between is a \
@@ -1506,7 +1506,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column values to be increasing.
 
         By default, this expectation only works for numeric or datetime data.
@@ -1570,7 +1570,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column values to be decreasing.
 
         By default, this expectation only works for numeric or datetime data.
@@ -1640,7 +1640,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be strings with length between a minimum value and a maximum value (inclusive).
 
         This expectation only works for string-type values. Invoking it on ints or floats will raise a TypeError.
@@ -1706,7 +1706,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be strings with length equal to the provided value.
 
         This expectation only works for string-type values. Invoking it on ints or floats will raise a TypeError.
@@ -1763,7 +1763,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be strings that match a given regular expression. Valid matches can be found \
         anywhere in the string, for example "[at]+" will identify the following strings as expected: "cat", "hat", \
         "aa", "a", and "t", and the following strings as unexpected: "fish", "dog".
@@ -1823,7 +1823,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be strings that do NOT match a given regular expression. The regex must not match \
         any portion of the provided string. For example, "[at]+" would identify the following strings as expected: \
         "fish", "dog", and the following as unexpected: "cat", "hat".
@@ -1884,7 +1884,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect the column entries to be strings that can be matched to either any of or all of a list of regular
         expressions. Matches can be anywhere in the string.
 
@@ -1947,7 +1947,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect the column entries to be strings that do not match any of a list of regular expressions. Matches can
         be anywhere in the string.
 
@@ -2009,7 +2009,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be strings representing a date or time with a given format.
 
         expect_column_values_to_match_strftime_format is a \
@@ -2059,7 +2059,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be parsable using dateutil.
 
         expect_column_values_to_be_dateutil_parseable is a \
@@ -2107,7 +2107,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be data written in JavaScript Object Notation.
 
         expect_column_values_to_be_json_parseable is a \
@@ -2160,7 +2160,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column entries to be JSON objects matching a given JSON schema.
 
         expect_column_values_to_match_json_schema is a \
@@ -2222,7 +2222,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """
         Expect the column values to be distributed similarly to a scipy distribution. \
 
@@ -3841,7 +3841,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """Expect column values to be distributed similarly to the provided continuous partition. This expectation \
         compares continuous distributions using a bootstrapped Kolmogorov-Smirnov test. It returns `success=True` if \
         values in the column match the distribution of the provided partition.
@@ -4464,7 +4464,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """
         Expect the values in column A to be the same as column B.
 
@@ -4510,7 +4510,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """
         Expect values in column A to be greater than column B.
 
@@ -4559,7 +4559,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """
         Expect paired values from columns A and B to belong to a set of valid pairs.
 
@@ -4610,7 +4610,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """
         NOTE: This method is deprecated. Please use expect_select_column_values_to_be_unique_within_record instead
         Expect the values for each record to be unique across the columns listed.
@@ -4664,7 +4664,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """
         Expect the values for each record to be unique across the columns listed.
         Note that records can be duplicated.
@@ -4717,7 +4717,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """
         Expect that the columns are unique together, e.g. a multi-column primary key
         Note that all instances of any duplicates are considered failed
@@ -4767,7 +4767,7 @@ class Dataset(MetaDataset):
         include_config=True,
         catch_exceptions=None,
         meta=None,
-    ):
+    ) -> None:
         """ Multi-Column Map Expectation
 
         Expects that the sum of row values is the same for each row, summing only values in columns specified in

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -36,7 +36,7 @@ class MetaPandasDataset(Dataset):
     and PandasDataset implements the expectation methods themselves.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -409,7 +409,7 @@ Notes:
     # We may want to expand or alter support for subclassing dataframes in the future:
     # See http://pandas.pydata.org/pandas-docs/stable/extending.html#extending-subclassing-pandas
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.discard_subset_failing_expectations = kwargs.get(
             "discard_subset_failing_expectations", False

--- a/great_expectations/dataset/sparkdf_dataset.py
+++ b/great_expectations/dataset/sparkdf_dataset.py
@@ -60,7 +60,7 @@ class MetaSparkDFDataset(Dataset):
     and SparkDFDataset implements the expectation methods themselves.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -609,7 +609,7 @@ class SparkDFDataset(MetaSparkDFDataset):
         else:
             raise ValueError("from_dataset requires a SparkDFDataset dataset")
 
-    def __init__(self, spark_df, *args, **kwargs):
+    def __init__(self, spark_df, *args, **kwargs) -> None:
         # Creation of the Spark DataFrame is done outside this class
         self.spark_df = spark_df
         self._persist = kwargs.pop("persist", True)
@@ -653,7 +653,7 @@ class SparkDFDataset(MetaSparkDFDataset):
         return self.spark_df.select(column).groupBy().sum().collect()[0][0]
 
     # TODO: consider getting all basic statistics in one go:
-    def _describe_column(self, column):
+    def _describe_column(self, column) -> None:
         # temp_column = self.spark_df.select(column).where(col(column).isNotNull())
         # return self.spark_df.select(
         #     [

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -164,7 +164,7 @@ except ImportError:
 
 
 class SqlAlchemyBatchReference:
-    def __init__(self, engine, table_name=None, schema=None, query=None):
+    def __init__(self, engine, table_name=None, schema=None, query=None) -> None:
         self._engine = engine
         if table_name is None and query is None:
             raise ValueError("Table_name or query must be specified")
@@ -193,7 +193,7 @@ class SqlAlchemyBatchReference:
 
 
 class MetaSqlAlchemyDataset(Dataset):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -528,7 +528,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
         schema=None,
         *args,
         **kwargs,
-    ):
+    ) -> None:
         if custom_sql and not table_name:
             # NOTE: Eugene 2020-01-31: @James, this is a not a proper fix, but without it the "public" schema
             # was used for a temp table and raising an error
@@ -940,7 +940,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             )
 
     @classmethod
-    def _treat_quantiles_exception(cls, pe):
+    def _treat_quantiles_exception(cls, pe) -> None:
         exception_message: str = "An SQL syntax Exception occurred."
         exception_traceback: str = traceback.format_exc()
         exception_message += (
@@ -1353,7 +1353,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
 
         return convert_to_json_serializable(self.engine.execute(query).scalar())
 
-    def create_temporary_table(self, table_name, custom_sql, schema_name=None):
+    def create_temporary_table(self, table_name, custom_sql, schema_name=None) -> None:
         """
         Create Temporary table based on sql query. This will be used as a basis for executing expectations.
         WARNING: this feature is new in v0.4.

--- a/great_expectations/datasource/batch_kwargs_generator/batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/batch_kwargs_generator.py
@@ -164,7 +164,7 @@ class BatchKwargsGenerator:
     _batch_kwargs_type = BatchKwargs
     recognized_batch_parameters = set()
 
-    def __init__(self, name, datasource):
+    def __init__(self, name, datasource) -> None:
         self._name = name
         self._generator_config = {"class_name": self.__class__.__name__}
         self._data_asset_iterators = {}
@@ -176,10 +176,10 @@ class BatchKwargsGenerator:
     def name(self):
         return self._name
 
-    def _get_iterator(self, data_asset_name, **kwargs):
+    def _get_iterator(self, data_asset_name, **kwargs) -> None:
         raise NotImplementedError
 
-    def get_available_data_asset_names(self):
+    def get_available_data_asset_names(self) -> None:
         """Return the list of asset names known by this batch kwargs generator.
 
         Returns:
@@ -188,7 +188,9 @@ class BatchKwargsGenerator:
         raise NotImplementedError
 
     # TODO: deprecate generator_asset argument
-    def get_available_partition_ids(self, generator_asset=None, data_asset_name=None):
+    def get_available_partition_ids(
+        self, generator_asset=None, data_asset_name=None
+    ) -> None:
         """
         Applies the current _partitioner to the batches available on data_asset_name and returns a list of valid
         partition_id strings that can be used to identify batches of data.
@@ -205,7 +207,9 @@ class BatchKwargsGenerator:
         return self._generator_config
 
     # TODO: deprecate generator_asset argument
-    def reset_iterator(self, generator_asset=None, data_asset_name=None, **kwargs):
+    def reset_iterator(
+        self, generator_asset=None, data_asset_name=None, **kwargs
+    ) -> None:
         assert (generator_asset and not data_asset_name) or (
             not generator_asset and data_asset_name
         ), "Please provide either generator_asset or data_asset_name."
@@ -290,7 +294,7 @@ class BatchKwargsGenerator:
         batch_kwargs["datasource"] = self._datasource.name
         return batch_kwargs
 
-    def _build_batch_kwargs(self, batch_parameters):
+    def _build_batch_kwargs(self, batch_parameters) -> None:
         raise NotImplementedError
 
     # TODO: deprecate generator_asset argument

--- a/great_expectations/datasource/batch_kwargs_generator/databricks_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/databricks_batch_kwargs_generator.py
@@ -18,7 +18,7 @@ except ImportError:
 class DatabricksTableBatchKwargsGenerator(BatchKwargsGenerator):
     """Meant to be used in a Databricks notebook"""
 
-    def __init__(self, name="default", datasource=None, database="default"):
+    def __init__(self, name="default", datasource=None, database="default") -> None:
         super().__init__(name, datasource=datasource)
         self.database = database
         try:

--- a/great_expectations/datasource/batch_kwargs_generator/glob_reader_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/glob_reader_batch_kwargs_generator.py
@@ -63,7 +63,7 @@ class GlobReaderBatchKwargsGenerator(BatchKwargsGenerator):
         reader_options=None,
         asset_globs=None,
         reader_method=None,
-    ):
+    ) -> None:
         logger.debug(f"Constructing GlobReaderBatchKwargsGenerator {name!r}")
         super().__init__(name, datasource=datasource)
         if reader_options is None:
@@ -220,7 +220,7 @@ class GlobReaderBatchKwargsGenerator(BatchKwargsGenerator):
         reader_method=None,
         reader_options=None,
         limit=None,
-    ):
+    ) -> None:
         for path in path_list:
             yield self._build_batch_kwargs_from_path(
                 path,

--- a/great_expectations/datasource/batch_kwargs_generator/manual_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/manual_batch_kwargs_generator.py
@@ -38,7 +38,7 @@ class ManualBatchKwargsGenerator(BatchKwargsGenerator):
 
     recognized_batch_parameters = {"data_asset_name", "partition_id"}
 
-    def __init__(self, name="default", datasource=None, assets=None):
+    def __init__(self, name="default", datasource=None, assets=None) -> None:
         logger.debug(f"Constructing ManualBatchKwargsGenerator {name!r}")
         super().__init__(name, datasource=datasource)
 

--- a/great_expectations/datasource/batch_kwargs_generator/query_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/query_batch_kwargs_generator.py
@@ -67,7 +67,7 @@ class QueryBatchKwargsGenerator(BatchKwargsGenerator):
 
     def __init__(
         self, name="default", datasource=None, query_store_backend=None, queries=None
-    ):
+    ) -> None:
         super().__init__(name=name, datasource=datasource)
         if (
             datasource
@@ -135,7 +135,7 @@ class QueryBatchKwargsGenerator(BatchKwargsGenerator):
         return iter_
 
     # TODO: deprecate generator_asset argument, remove default on query arg
-    def add_query(self, generator_asset=None, query=None, data_asset_name=None):
+    def add_query(self, generator_asset=None, query=None, data_asset_name=None) -> None:
         assert query, "Please provide a query."
         assert (generator_asset and not data_asset_name) or (
             not generator_asset and data_asset_name
@@ -177,7 +177,9 @@ class QueryBatchKwargsGenerator(BatchKwargsGenerator):
         return SqlAlchemyDatasourceQueryBatchKwargs(batch_kwargs)
 
     # TODO: deprecate generator_asset argument
-    def get_available_partition_ids(self, generator_asset=None, data_asset_name=None):
+    def get_available_partition_ids(
+        self, generator_asset=None, data_asset_name=None
+    ) -> None:
         assert (generator_asset and not data_asset_name) or (
             not generator_asset and data_asset_name
         ), "Please provide either generator_asset or data_asset_name."

--- a/great_expectations/datasource/batch_kwargs_generator/s3_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/s3_batch_kwargs_generator.py
@@ -71,7 +71,7 @@ class S3GlobReaderBatchKwargsGenerator(BatchKwargsGenerator):
         reader_method=None,
         boto3_options=None,
         max_keys=1000,
-    ):
+    ) -> None:
         """Initialize a new S3GlobReaderBatchKwargsGenerator
 
         Args:
@@ -157,7 +157,9 @@ class S3GlobReaderBatchKwargsGenerator(BatchKwargsGenerator):
             limit=limit,
         )
 
-    def _build_batch_kwargs_path_iter(self, path_list, reader_options=None, limit=None):
+    def _build_batch_kwargs_path_iter(
+        self, path_list, reader_options=None, limit=None
+    ) -> None:
         for path in path_list:
             yield self._build_batch_kwargs(
                 path, reader_options=reader_options, limit=limit
@@ -245,7 +247,7 @@ class S3GlobReaderBatchKwargsGenerator(BatchKwargsGenerator):
 
         return S3BatchKwargs(batch_kwargs)
 
-    def _get_asset_options(self, asset_config, iterator_dict):
+    def _get_asset_options(self, asset_config, iterator_dict) -> None:
         query_options = {
             "Bucket": self.bucket,
             "Delimiter": asset_config.get("delimiter", self._delimiter),
@@ -318,7 +320,7 @@ class S3GlobReaderBatchKwargsGenerator(BatchKwargsGenerator):
         reader_method=None,
         reader_options=None,
         limit=None,
-    ):
+    ) -> None:
         for key in self._get_asset_options(asset_config, iterator_dict):
             yield self._build_batch_kwargs_from_key(
                 key,

--- a/great_expectations/datasource/batch_kwargs_generator/s3_subdir_reader_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/s3_subdir_reader_batch_kwargs_generator.py
@@ -58,7 +58,7 @@ class S3SubdirReaderBatchKwargsGenerator(BatchKwargsGenerator):
         reader_options=None,
         known_extensions=None,
         reader_method=None,
-    ):
+    ) -> None:
         super().__init__(name, datasource=datasource)
 
         if not s3fs:
@@ -276,7 +276,9 @@ class S3SubdirReaderBatchKwargsGenerator(BatchKwargsGenerator):
                 ),
             )
 
-    def _build_batch_kwargs_path_iter(self, path_list, reader_options=None, limit=None):
+    def _build_batch_kwargs_path_iter(
+        self, path_list, reader_options=None, limit=None
+    ) -> None:
         for path in path_list:
             yield self._build_batch_kwargs_from_path(
                 path, reader_options=reader_options, limit=limit

--- a/great_expectations/datasource/batch_kwargs_generator/subdir_reader_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/subdir_reader_batch_kwargs_generator.py
@@ -49,7 +49,7 @@ class SubdirReaderBatchKwargsGenerator(BatchKwargsGenerator):
         reader_options=None,
         known_extensions=None,
         reader_method=None,
-    ):
+    ) -> None:
         super().__init__(name, datasource=datasource)
         if reader_options is None:
             reader_options = self._default_reader_options
@@ -257,7 +257,9 @@ class SubdirReaderBatchKwargsGenerator(BatchKwargsGenerator):
                 ),
             )
 
-    def _build_batch_kwargs_path_iter(self, path_list, reader_options=None, limit=None):
+    def _build_batch_kwargs_path_iter(
+        self, path_list, reader_options=None, limit=None
+    ) -> None:
         for path in path_list:
             yield self._build_batch_kwargs_from_path(
                 path, reader_options=reader_options, limit=limit

--- a/great_expectations/datasource/batch_kwargs_generator/table_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/table_batch_kwargs_generator.py
@@ -37,7 +37,7 @@ class AssetConfigurationSchema(Schema):
 
 
 class AssetConfiguration:
-    def __init__(self, table, schema=None):
+    def __init__(self, table, schema=None) -> None:
         self.__table = table
         self.__schema = schema
 
@@ -83,7 +83,7 @@ class TableBatchKwargsGenerator(BatchKwargsGenerator):
         "query_parameters",
     }
 
-    def __init__(self, name="default", datasource=None, assets=None):
+    def __init__(self, name="default", datasource=None, assets=None) -> None:
         super().__init__(name=name, datasource=datasource)
         if not assets:
             assets = {}
@@ -288,7 +288,9 @@ class TableBatchKwargsGenerator(BatchKwargsGenerator):
         )
 
     # TODO: deprecate generator_asset argument
-    def get_available_partition_ids(self, generator_asset=None, data_asset_name=None):
+    def get_available_partition_ids(
+        self, generator_asset=None, data_asset_name=None
+    ) -> None:
         assert (generator_asset and not data_asset_name) or (
             not generator_asset and data_asset_name
         ), "Please provide either generator_asset or data_asset_name."

--- a/great_expectations/datasource/data_connector/asset/asset.py
+++ b/great_expectations/datasource/data_connector/asset/asset.py
@@ -32,7 +32,7 @@ class Asset:
         prefix: Optional[str] = None,
         # Both S3/Azure
         delimiter: Optional[str] = None,
-    ):
+    ) -> None:
         self._name = name
         self._base_directory = base_directory
         self._glob_directive = glob_directive

--- a/great_expectations/datasource/data_connector/batch_filter.py
+++ b/great_expectations/datasource/data_connector/batch_filter.py
@@ -145,7 +145,7 @@ class BatchFilter:
         batch_filter_parameters: Optional[IDDict] = None,
         index: Optional[Union[int, slice]] = None,
         limit: int = None,
-    ):
+    ) -> None:
         self._custom_filter_function = custom_filter_function
         self._batch_filter_parameters = batch_filter_parameters
         self._index = index

--- a/great_expectations/datasource/data_connector/configured_asset_azure_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_azure_data_connector.py
@@ -59,7 +59,7 @@ class ConfiguredAssetAzureDataConnector(ConfiguredAssetFilePathDataConnector):
         delimiter: str = "/",
         azure_options: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         ConfiguredAssetDataConnector for connecting to Azure.
 

--- a/great_expectations/datasource/data_connector/configured_asset_dbfs_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_dbfs_data_connector.py
@@ -37,7 +37,7 @@ class ConfiguredAssetDBFSDataConnector(ConfiguredAssetFilesystemDataConnector):
         glob_directive: str = "**/*",
         sorters: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         ConfiguredAssetDataConnector for connecting to DBFS. This class supports the configuration of default_regex
         and sorters for filtering and sorting data_references. It takes in configured `assets` as a dictionary.

--- a/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_file_path_data_connector.py
@@ -41,7 +41,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
         default_regex: Optional[dict] = None,
         sorters: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         Base class for DataConnectors that connect to filesystem-like data by taking in
         configured `assets` as a dictionary. This class supports the configuration of default_regex and
@@ -76,7 +76,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
     def assets(self) -> Dict[str, Union[dict, Asset]]:
         return self._assets
 
-    def _build_assets_from_config(self, config: Dict[str, dict]):
+    def _build_assets_from_config(self, config: Dict[str, dict]) -> None:
         for name, asset_config in config.items():
             if asset_config is None:
                 asset_config = {}
@@ -96,7 +96,7 @@ class ConfiguredAssetFilePathDataConnector(FilePathDataConnector):
         """
         return list(self.assets.keys())
 
-    def _refresh_data_references_cache(self):
+    def _refresh_data_references_cache(self) -> None:
 
         # Map data_references to batch_definitions
         self._data_references_cache = {}

--- a/great_expectations/datasource/data_connector/configured_asset_filesystem_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_filesystem_data_connector.py
@@ -38,7 +38,7 @@ class ConfiguredAssetFilesystemDataConnector(ConfiguredAssetFilePathDataConnecto
         glob_directive: str = "**/*",
         sorters: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         Base class for DataConnectors that connect to data on a filesystem. This class supports the configuration of default_regex
         and sorters for filtering and sorting data_references. It takes in configured `assets` as a dictionary.

--- a/great_expectations/datasource/data_connector/configured_asset_gcs_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_gcs_data_connector.py
@@ -64,7 +64,7 @@ class ConfiguredAssetGCSDataConnector(ConfiguredAssetFilePathDataConnector):
         max_results: Optional[int] = None,
         gcs_options: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         ConfiguredAssetDataConnector for connecting to GCS.
 

--- a/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_s3_data_connector.py
@@ -48,7 +48,7 @@ class ConfiguredAssetS3DataConnector(ConfiguredAssetFilePathDataConnector):
         max_keys: int = 1000,
         boto3_options: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         ConfiguredAssetDataConnector for connecting to S3.
 

--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -48,7 +48,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         execution_engine: Optional[ExecutionEngine] = None,
         assets: Optional[Dict[str, dict]] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         self._assets: dict = {}
         if assets:
             for asset_name, config in assets.items():
@@ -78,7 +78,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         self,
         name: str,
         config: dict,
-    ):
+    ) -> None:
         """
         Add data_asset to DataConnector using data_asset name as key, and data_asset config as value.
         """
@@ -237,7 +237,7 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
 
         return batch_identifiers_list
 
-    def _refresh_data_references_cache(self):
+    def _refresh_data_references_cache(self) -> None:
         self._data_references_cache = {}
 
         for data_asset_name in self.assets:

--- a/great_expectations/datasource/data_connector/data_connector.py
+++ b/great_expectations/datasource/data_connector/data_connector.py
@@ -45,7 +45,7 @@ class DataConnector:
         datasource_name: str,
         execution_engine: ExecutionEngine,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         Base class for DataConnectors
 
@@ -91,7 +91,7 @@ class DataConnector:
         return self._data_context_root_directory
 
     @data_context_root_directory.setter
-    def data_context_root_directory(self, data_context_root_directory: str):
+    def data_context_root_directory(self, data_context_root_directory: str) -> None:
         self._data_context_root_directory = data_context_root_directory
 
     def get_batch_data_and_metadata(
@@ -145,7 +145,7 @@ class DataConnector:
 
     def _refresh_data_references_cache(
         self,
-    ):
+    ) -> None:
         raise NotImplementedError
 
     def _get_data_reference_list(
@@ -404,7 +404,7 @@ class DataConnector:
             "n_rows": n_rows,
         }
 
-    def _validate_batch_request(self, batch_request: BatchRequestBase):
+    def _validate_batch_request(self, batch_request: BatchRequestBase) -> None:
         """
         Validate batch_request by checking:
             1. if configured datasource_name matches batch_request's datasource_name

--- a/great_expectations/datasource/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/file_path_data_connector.py
@@ -45,7 +45,7 @@ class FilePathDataConnector(DataConnector):
         default_regex: Optional[dict] = None,
         sorters: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         Base class for DataConnectors that connect to filesystem-like data. This class supports the configuration of default_regex
         and sorters for filtering and sorting data_references.
@@ -282,13 +282,15 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
         )
         return {"path": path}
 
-    def _validate_batch_request(self, batch_request: BatchRequestBase):
+    def _validate_batch_request(self, batch_request: BatchRequestBase) -> None:
         super()._validate_batch_request(batch_request=batch_request)
         self._validate_sorters_configuration(
             data_asset_name=batch_request.data_asset_name
         )
 
-    def _validate_sorters_configuration(self, data_asset_name: Optional[str] = None):
+    def _validate_sorters_configuration(
+        self, data_asset_name: Optional[str] = None
+    ) -> None:
         if self.sorters is not None and len(self.sorters) > 0:
             # data_asset_name: str = batch_request.data_asset_name
             regex_config: dict = self._get_regex_config(data_asset_name=data_asset_name)

--- a/great_expectations/datasource/data_connector/inferred_asset_azure_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_azure_data_connector.py
@@ -49,7 +49,7 @@ class InferredAssetAzureDataConnector(InferredAssetFilePathDataConnector):
         delimiter: str = "/",
         azure_options: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         InferredAssetAzureDataConnector for connecting to Azure Blob Storage.
 

--- a/great_expectations/datasource/data_connector/inferred_asset_dbfs_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_dbfs_data_connector.py
@@ -32,7 +32,7 @@ class InferredAssetDBFSDataConnector(InferredAssetFilesystemDataConnector):
         glob_directive: str = "*",
         sorters: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         Base class for DataConnectors that connect to filesystem-like data. This class supports the configuration of default_regex
         and sorters for filtering and sorting data_references.

--- a/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_file_path_data_connector.py
@@ -34,7 +34,7 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
         default_regex: Optional[dict] = None,
         sorters: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         Base class for DataConnectors that connect to filesystem-like data. This class supports the configuration of default_regex
         and sorters for filtering and sorting data_references.
@@ -58,7 +58,7 @@ class InferredAssetFilePathDataConnector(FilePathDataConnector):
             batch_spec_passthrough=batch_spec_passthrough,
         )
 
-    def _refresh_data_references_cache(self):
+    def _refresh_data_references_cache(self) -> None:
         """refreshes data_reference cache"""
         # Map data_references to batch_definitions
         self._data_references_cache = {}

--- a/great_expectations/datasource/data_connector/inferred_asset_filesystem_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_filesystem_data_connector.py
@@ -37,7 +37,7 @@ class InferredAssetFilesystemDataConnector(InferredAssetFilePathDataConnector):
         glob_directive: str = "*",
         sorters: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         Base class for DataConnectors that connect to filesystem-like data. This class supports the configuration of default_regex
         and sorters for filtering and sorting data_references.

--- a/great_expectations/datasource/data_connector/inferred_asset_gcs_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_gcs_data_connector.py
@@ -62,7 +62,7 @@ class InferredAssetGCSDataConnector(InferredAssetFilePathDataConnector):
         max_results: Optional[int] = None,
         gcs_options: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         InferredAssetDataConnector for connecting to GCS.
 

--- a/great_expectations/datasource/data_connector/inferred_asset_s3_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_s3_data_connector.py
@@ -48,7 +48,7 @@ class InferredAssetS3DataConnector(InferredAssetFilePathDataConnector):
         max_keys: int = 1000,
         boto3_options: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         InferredAssetS3DataConnector for connecting to S3.
 

--- a/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
@@ -35,7 +35,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
         skip_inapplicable_tables: bool = True,
         introspection_directives: Optional[dict] = None,
         batch_spec_passthrough: Optional[dict] = None,
-    ):
+    ) -> None:
         """
         InferredAssetDataConnector for connecting to data on a SQL database
 
@@ -100,7 +100,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
     def assets(self) -> Dict[str, Asset]:
         return self._introspected_assets_cache
 
-    def _refresh_data_references_cache(self):
+    def _refresh_data_references_cache(self) -> None:
         self._refresh_introspected_assets_cache(
             self._data_asset_name_prefix,
             self._data_asset_name_suffix,
@@ -128,7 +128,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
         excluded_tables: List = None,
         included_tables: List = None,
         skip_inapplicable_tables: bool = True,
-    ):
+    ) -> None:
         introspected_table_metadata = self._introspect_db(
             **self._introspection_directives
         )

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -44,7 +44,7 @@ class RuntimeDataConnector(DataConnector):
         batch_identifiers: Optional[list] = None,
         batch_spec_passthrough: Optional[dict] = None,
         assets: Optional[dict] = None,
-    ):
+    ) -> None:
         logger.debug(f'Constructing RuntimeDataConnector "{name}".')
 
         super().__init__(
@@ -337,7 +337,9 @@ class RuntimeDataConnector(DataConnector):
         return data_reference_name
 
     @staticmethod
-    def _validate_runtime_parameters(runtime_parameters: Union[dict, type(None)]):
+    def _validate_runtime_parameters(
+        runtime_parameters: Union[dict, type(None)]
+    ) -> None:
         if not isinstance(runtime_parameters, dict):
             raise TypeError(
                 f"""The type of runtime_parameters must be a dict object. The type given is
@@ -355,7 +357,7 @@ class RuntimeDataConnector(DataConnector):
                 "'query', 'path'."
             )
 
-    def _validate_batch_request(self, batch_request: RuntimeBatchRequest):
+    def _validate_batch_request(self, batch_request: RuntimeBatchRequest) -> None:
         super()._validate_batch_request(batch_request=batch_request)
 
         runtime_parameters = batch_request.runtime_parameters
@@ -377,7 +379,7 @@ class RuntimeDataConnector(DataConnector):
 
     def _validate_batch_identifiers(
         self, data_asset_name: str, batch_identifiers: dict
-    ):
+    ) -> None:
         """
         Called by _get_batch_definition_list_from_batch_request() ie, when a RuntimeBatchRequest is passed in.
 
@@ -408,7 +410,7 @@ class RuntimeDataConnector(DataConnector):
 
     def _validate_asset_level_batch_identifiers(
         self, data_asset_name: str, batch_identifiers: dict
-    ):
+    ) -> None:
         """
         Check that batch_identifiers passed in are an exact match to the ones configured at the Asset-level
         """
@@ -421,7 +423,9 @@ class RuntimeDataConnector(DataConnector):
                 """
             )
 
-    def _validate_data_connector_level_batch_identifiers(self, batch_identifiers: dict):
+    def _validate_data_connector_level_batch_identifiers(
+        self, batch_identifiers: dict
+    ) -> None:
         """
         Check that batch_identifiers passed in are a subset of the ones configured at the DataConnector-level
         """

--- a/great_expectations/datasource/data_connector/sorter/custom_list_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/custom_list_sorter.py
@@ -16,7 +16,7 @@ class CustomListSorter(Sorter):
 
     def __init__(
         self, name: str, orderby: str = "asc", reference_list: List[str] = None
-    ):
+    ) -> None:
         super().__init__(name=name, orderby=orderby)
 
         self._reference_list = self._validate_reference_list(

--- a/great_expectations/datasource/data_connector/sorter/date_time_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/date_time_sorter.py
@@ -11,7 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 class DateTimeSorter(Sorter):
-    def __init__(self, name: str, orderby: str = "asc", datetime_format="%Y%m%d"):
+    def __init__(
+        self, name: str, orderby: str = "asc", datetime_format="%Y%m%d"
+    ) -> None:
         super().__init__(name=name, orderby=orderby)
 
         if datetime_format and not isinstance(datetime_format, str):

--- a/great_expectations/datasource/data_connector/sorter/sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/sorter.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class Sorter:
-    def __init__(self, name: str, orderby: str = "asc"):
+    def __init__(self, name: str, orderby: str = "asc") -> None:
         self._name = name
         if orderby is None or orderby == "asc":
             reverse: bool = False

--- a/great_expectations/datasource/datasource.py
+++ b/great_expectations/datasource/datasource.py
@@ -158,7 +158,7 @@ class LegacyDatasource:
         data_asset_type=None,
         batch_kwargs_generators=None,
         **kwargs
-    ):
+    ) -> None:
         """
         Build a new datasource.
 
@@ -203,7 +203,7 @@ class LegacyDatasource:
         """
         return self._data_context
 
-    def _build_generators(self):
+    def _build_generators(self) -> None:
         """
         Build batch kwargs generator objects from the datasource configuration.
 
@@ -323,7 +323,7 @@ class LegacyDatasource:
         return batch_kwargs
 
     # TODO: move to execution engine or make a wrapper
-    def get_batch(self, batch_kwargs, batch_parameters=None):
+    def get_batch(self, batch_kwargs, batch_parameters=None) -> None:
         """Get a batch of data from the datasource.
 
         Args:

--- a/great_expectations/datasource/new_datasource.py
+++ b/great_expectations/datasource/new_datasource.py
@@ -32,7 +32,7 @@ class BaseDatasource:
         execution_engine=None,
         data_context_root_directory: Optional[str] = None,
         concurrency: Optional[ConcurrencyConfig] = None,
-    ):
+    ) -> None:
         """
         Build a new Datasource.
 
@@ -352,7 +352,7 @@ class BaseDatasource:
 
     def _validate_batch_request(
         self, batch_request: Union[BatchRequest, RuntimeBatchRequest]
-    ):
+    ) -> None:
         if not (
             batch_request.datasource_name is None
             or batch_request.datasource_name == self.name
@@ -403,7 +403,7 @@ class Datasource(BaseDatasource):
         data_connectors=None,
         data_context_root_directory: Optional[str] = None,
         concurrency: Optional[ConcurrencyConfig] = None,
-    ):
+    ) -> None:
         """
         Build a new Datasource with data connectors.
 
@@ -434,7 +434,7 @@ class Datasource(BaseDatasource):
     def _init_data_connectors(
         self,
         data_connector_configs: Dict[str, Dict[str, Any]],
-    ):
+    ) -> None:
         for name, config in data_connector_configs.items():
             self._build_data_connector_from_config(
                 name=name,

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -116,7 +116,7 @@ class PandasDatasource(LegacyDatasource):
         reader_options=None,
         limit=None,
         **kwargs,
-    ):
+    ) -> None:
         configuration_with_defaults = PandasDatasource.build_configuration(
             data_asset_type,
             batch_kwargs_generators,

--- a/great_expectations/datasource/simple_sqlalchemy_datasource.py
+++ b/great_expectations/datasource/simple_sqlalchemy_datasource.py
@@ -25,7 +25,7 @@ class SimpleSqlalchemyDatasource(BaseDatasource):
         introspection: dict = None,
         tables: dict = None,
         **kwargs
-    ):
+    ) -> None:
         introspection = introspection or {}
         tables = tables or {}
 
@@ -56,7 +56,7 @@ class SimpleSqlalchemyDatasource(BaseDatasource):
         self,
         introspection_configs: dict,
         table_configs: dict,
-    ):
+    ) -> None:
 
         # Step-1: Build DataConnectors for introspected assets
         for name, config in introspection_configs.items():

--- a/great_expectations/datasource/sparkdf_datasource.py
+++ b/great_expectations/datasource/sparkdf_datasource.py
@@ -117,7 +117,7 @@ class SparkDFDatasource(LegacyDatasource):
         spark_config=None,
         force_reuse_spark_context=False,
         **kwargs,
-    ):
+    ) -> None:
         """Build a new SparkDFDatasource instance.
 
         Args:

--- a/great_expectations/datasource/sqlalchemy_datasource.py
+++ b/great_expectations/datasource/sqlalchemy_datasource.py
@@ -213,7 +213,7 @@ class SqlAlchemyDatasource(LegacyDatasource):
         credentials=None,
         batch_kwargs_generators=None,
         **kwargs
-    ):
+    ) -> None:
         if not sqlalchemy:
             raise DatasourceInitializationError(
                 name, "ModuleNotFoundError: No module named 'sqlalchemy'"

--- a/great_expectations/datasource/types/batch_kwargs.py
+++ b/great_expectations/datasource/types/batch_kwargs.py
@@ -38,7 +38,7 @@ class SqlAlchemyDatasourceBatchKwargs(BatchKwargs, metaclass=ABCMeta):
 
 
 class PathBatchKwargs(PandasDatasourceBatchKwargs, SparkDFDatasourceBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "path" not in self:
             raise InvalidBatchKwargsError("PathBatchKwargs requires a path element")
@@ -53,7 +53,7 @@ class PathBatchKwargs(PandasDatasourceBatchKwargs, SparkDFDatasourceBatchKwargs)
 
 
 class S3BatchKwargs(PandasDatasourceBatchKwargs, SparkDFDatasourceBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "s3" not in self:
             raise InvalidBatchKwargsError("S3BatchKwargs requires a path element")
@@ -68,7 +68,7 @@ class S3BatchKwargs(PandasDatasourceBatchKwargs, SparkDFDatasourceBatchKwargs):
 
 
 class InMemoryBatchKwargs(PandasDatasourceBatchKwargs, SparkDFDatasourceBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "dataset" not in self:
             raise InvalidBatchKwargsError(
@@ -81,7 +81,7 @@ class InMemoryBatchKwargs(PandasDatasourceBatchKwargs, SparkDFDatasourceBatchKwa
 
 
 class PandasDatasourceInMemoryBatchKwargs(InMemoryBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         import pandas as pd
 
@@ -92,7 +92,7 @@ class PandasDatasourceInMemoryBatchKwargs(InMemoryBatchKwargs):
 
 
 class SparkDFDatasourceInMemoryBatchKwargs(InMemoryBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         try:
             import pyspark
@@ -107,7 +107,7 @@ class SparkDFDatasourceInMemoryBatchKwargs(InMemoryBatchKwargs):
 
 
 class SqlAlchemyDatasourceTableBatchKwargs(SqlAlchemyDatasourceBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "table" not in self:
             raise InvalidBatchKwargsError(
@@ -120,7 +120,7 @@ class SqlAlchemyDatasourceTableBatchKwargs(SqlAlchemyDatasourceBatchKwargs):
 
 
 class SqlAlchemyDatasourceQueryBatchKwargs(SqlAlchemyDatasourceBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "query" not in self:
             raise InvalidBatchKwargsError(
@@ -137,7 +137,7 @@ class SqlAlchemyDatasourceQueryBatchKwargs(SqlAlchemyDatasourceBatchKwargs):
 
 
 class SparkDFDatasourceQueryBatchKwargs(SparkDFDatasourceBatchKwargs):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if "query" not in self:
             raise InvalidBatchKwargsError(

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -7,13 +7,13 @@ from great_expectations.marshmallow__shade import ValidationError
 
 
 class GreatExpectationsError(Exception):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(message)
 
 
 class GreatExpectationsValidationError(ValidationError, GreatExpectationsError):
-    def __init__(self, message, validation_error=None):
+    def __init__(self, message, validation_error=None) -> None:
         self.message = message
         self.messages = None
         if validation_error is not None:
@@ -26,7 +26,7 @@ class GreatExpectationsValidationError(ValidationError, GreatExpectationsError):
 
 
 class SuiteEditNotebookCustomTemplateModuleNotFoundError(ModuleNotFoundError):
-    def __init__(self, custom_module):
+    def __init__(self, custom_module) -> None:
         message = f"The custom module '{custom_module}' could not be found"
         super().__init__(message)
 
@@ -64,7 +64,7 @@ class MissingTopLevelConfigKeyError(GreatExpectationsValidationError):
 
 
 class InvalidBaseYamlConfigError(GreatExpectationsValidationError):
-    def __init__(self, message, validation_error=None, field_name=None):
+    def __init__(self, message, validation_error=None, field_name=None) -> None:
         if validation_error is not None:
             if (
                 validation_error
@@ -136,13 +136,13 @@ class ProfilerNotFoundError(ProfilerError):
 
 
 class InvalidConfigError(DataContextError):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 class MissingConfigVariableError(InvalidConfigError):
-    def __init__(self, message, missing_config_variable=None):
+    def __init__(self, message, missing_config_variable=None) -> None:
         if not missing_config_variable:
             missing_config_variable = []
         self.message = message
@@ -151,7 +151,7 @@ class MissingConfigVariableError(InvalidConfigError):
 
 
 class AmbiguousDataAssetNameError(DataContextError):
-    def __init__(self, message, candidates=None):
+    def __init__(self, message, candidates=None) -> None:
         self.message = message
         self.candidates = candidates
         super().__init__(self.message)
@@ -186,7 +186,7 @@ class InvalidKeyError(StoreError):
 
 
 class InvalidCacheValueError(GreatExpectationsError):
-    def __init__(self, result_dict):
+    def __init__(self, result_dict) -> None:
         template = """\
 Invalid result values were found when trying to instantiate an ExpectationValidationResult.
 - Invalid result values are likely caused by inconsistent cache values.
@@ -201,7 +201,7 @@ Result: {}
 class ConfigNotFoundError(DataContextError):
     """The great_expectations dir could not be found."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.message = """Error: No great_expectations directory was found here!
     - Please check that you are in the correct directory or have specified the correct directory.
     - If you have never run Great Expectations in this project, please run `great_expectations init` to get started.
@@ -212,7 +212,7 @@ class ConfigNotFoundError(DataContextError):
 class PluginModuleNotFoundError(GreatExpectationsError):
     """A module import failed."""
 
-    def __init__(self, module_name):
+    def __init__(self, module_name) -> None:
         template = """\
 No module named `{}` could be found in your plugins directory.
     - Please verify your plugins directory is configured correctly.
@@ -231,7 +231,7 @@ No module named `{}` could be found in your plugins directory.
 class PluginClassNotFoundError(DataContextError, AttributeError):
     """A module import failed."""
 
-    def __init__(self, module_name, class_name):
+    def __init__(self, module_name, class_name) -> None:
         class_name_changes = {
             "FixedLengthTupleFilesystemStoreBackend": "TupleFilesystemStoreBackend",
             "FixedLengthTupleS3StoreBackend": "TupleS3StoreBackend",
@@ -282,7 +282,7 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 
 class ClassInstantiationError(GreatExpectationsError):
-    def __init__(self, module_name, package_name, class_name):
+    def __init__(self, module_name, package_name, class_name) -> None:
         module_spec = importlib.util.find_spec(module_name, package=package_name)
         if not module_spec:
             if not package_name:
@@ -300,7 +300,7 @@ properly defined inside its intended module and declared correctly by the callin
 
 
 class ExpectationSuiteNotFoundError(GreatExpectationsError):
-    def __init__(self, data_asset_name):
+    def __init__(self, data_asset_name) -> None:
         self.data_asset_name = data_asset_name
         self.message = (
             f"No expectation suite found for data_asset_name {data_asset_name}"
@@ -309,26 +309,26 @@ class ExpectationSuiteNotFoundError(GreatExpectationsError):
 
 
 class BatchKwargsError(DataContextError):
-    def __init__(self, message, batch_kwargs=None):
+    def __init__(self, message, batch_kwargs=None) -> None:
         self.message = message
         self.batch_kwargs = batch_kwargs
         super().__init__(self.message)
 
 
 class BatchDefinitionError(DataContextError):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 class BatchSpecError(DataContextError):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 class DatasourceError(DataContextError):
-    def __init__(self, datasource_name, message):
+    def __init__(self, datasource_name, message) -> None:
         self.message = "Cannot initialize datasource {}, error: {}".format(
             datasource_name,
             message,
@@ -353,25 +353,25 @@ class InvalidConfigValueTypeError(DataContextError):
 
 
 class DataConnectorError(DataContextError):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 class ExecutionEngineError(DataContextError):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 class BatchFilterError(DataContextError):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 class SorterError(DataContextError):
-    def __init__(self, message):
+    def __init__(self, message) -> None:
         self.message = message
         super().__init__(self.message)
 
@@ -397,7 +397,7 @@ class InvalidMetricAccessorDomainKwargsKeyError(MetricError):
 
 
 class MetricResolutionError(MetricError):
-    def __init__(self, message, failed_metrics):
+    def __init__(self, message, failed_metrics) -> None:
         super().__init__(message)
         if not isinstance(failed_metrics, Iterable):
             failed_metrics = (failed_metrics,)

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -33,7 +33,7 @@ class NoOpDict:
 
 
 class BatchData:
-    def __init__(self, execution_engine):
+    def __init__(self, execution_engine) -> None:
         self._execution_engine = execution_engine
 
     @property
@@ -161,7 +161,7 @@ class ExecutionEngine(ABC):
         batch_spec_defaults=None,
         batch_data_dict=None,
         validator=None,
-    ):
+    ) -> None:
         self.name = name
         self._validator = validator
 
@@ -208,7 +208,7 @@ class ExecutionEngine(ABC):
         }
         filter_properties_dict(properties=self._config, clean_falsy=True, inplace=True)
 
-    def configure_validator(self, validator):
+    def configure_validator(self, validator) -> None:
         """Optionally configure the validator as appropriate for the execution engine."""
         pass
 
@@ -228,7 +228,7 @@ class ExecutionEngine(ABC):
             return None
 
     @active_batch_data_id.setter
-    def active_batch_data_id(self, batch_id):
+    def active_batch_data_id(self, batch_id) -> None:
         if batch_id in self.loaded_batch_data_dict.keys():
             self._active_batch_data_id = batch_id
         else:
@@ -288,7 +288,7 @@ class ExecutionEngine(ABC):
         self._batch_data_dict[batch_id] = batch_data
         self._active_batch_data_id = batch_id
 
-    def _load_batch_data_from_dict(self, batch_data_dict):
+    def _load_batch_data_from_dict(self, batch_data_dict) -> None:
         """
         Loads all data in batch_data_dict into load_batch_data
         """
@@ -406,7 +406,7 @@ class ExecutionEngine(ABC):
 
         return resolved_metrics
 
-    def resolve_metric_bundle(self, metric_fn_bundle):
+    def resolve_metric_bundle(self, metric_fn_bundle) -> None:
         """Resolve a bundle of metrics with the same compute domain as part of a single trip to the compute engine."""
         raise NotImplementedError
 

--- a/great_expectations/execution_engine/pandas_batch_data.py
+++ b/great_expectations/execution_engine/pandas_batch_data.py
@@ -4,7 +4,7 @@ from great_expectations.execution_engine.execution_engine import BatchData
 
 
 class PandasBatchData(BatchData):
-    def __init__(self, execution_engine, dataframe: pd.DataFrame):
+    def __init__(self, execution_engine, dataframe: pd.DataFrame) -> None:
         super().__init__(execution_engine=execution_engine)
         self._dataframe = dataframe
 

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -102,7 +102,7 @@ Notes:
         "reader_options",
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.discard_subset_failing_expectations = kwargs.pop(
             "discard_subset_failing_expectations", False
         )
@@ -127,7 +127,7 @@ Notes:
             }
         )
 
-    def _instantiate_azure_client(self):
+    def _instantiate_azure_client(self) -> None:
         azure_options = self.config.get("azure_options", {})
         try:
             if "conn_str" in azure_options:
@@ -137,7 +137,7 @@ Notes:
         except (TypeError, AttributeError):
             self._azure = None
 
-    def _instantiate_s3_client(self):
+    def _instantiate_s3_client(self) -> None:
         # Try initializing cloud provider client. If unsuccessful, we'll catch it when/if a BatchSpec is passed in.
         boto3_options = self.config.get("boto3_options", {})
         try:
@@ -145,7 +145,7 @@ Notes:
         except (TypeError, AttributeError):
             self._s3 = None
 
-    def _instantiate_gcs_client(self):
+    def _instantiate_gcs_client(self) -> None:
         """
         Helper method for instantiating GCS client when GCSBatchSpec is passed in.
 
@@ -172,7 +172,7 @@ Notes:
         except (TypeError, AttributeError, DefaultCredentialsError):
             self._gcs = None
 
-    def configure_validator(self, validator):
+    def configure_validator(self, validator) -> None:
         super().configure_validator(validator)
         validator.expose_dataframe_methods = True
 

--- a/great_expectations/execution_engine/sparkdf_batch_data.py
+++ b/great_expectations/execution_engine/sparkdf_batch_data.py
@@ -2,7 +2,7 @@ from great_expectations.execution_engine.execution_engine import BatchData
 
 
 class SparkDFBatchData(BatchData):
-    def __init__(self, execution_engine, dataframe):
+    def __init__(self, execution_engine, dataframe) -> None:
         super().__init__(execution_engine)
         self._dataframe = dataframe
 

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -156,7 +156,7 @@ class SparkDFExecutionEngine(ExecutionEngine):
         spark_config=None,
         force_reuse_spark_context=False,
         **kwargs,
-    ):
+    ) -> None:
         # Creation of the Spark DataFrame is done outside this class
         self._persist = persist
 

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -37,7 +37,7 @@ class SqlAlchemyBatchData(BatchData):
         use_quoted_name: bool = False,
         source_schema_name: str = None,
         source_table_name: str = None,
-    ):
+    ) -> None:
         """A Constructor used to initialize and SqlAlchemy Batch, create an id for it, and verify that all necessary
         parameters have been provided. If a Query is given, also builds a temporary table for this query
 
@@ -185,7 +185,7 @@ class SqlAlchemyBatchData(BatchData):
 
     def _create_temporary_table(
         self, temp_table_name, query, temp_table_schema_name=None
-    ):
+    ) -> None:
         """
         Create Temporary table based on sql query. This will be used as a basis for executing expectations.
         :param query:

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -219,7 +219,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         create_temp_table: bool = True,
         concurrency: Optional[ConcurrencyConfig] = None,
         **kwargs,  # These will be passed as optional parameters to the SQLAlchemy engine, **not** the ExecutionEngine
-    ):
+    ) -> None:
         """Builds a SqlAlchemyExecutionEngine, using a provided connection string/url/engine/credentials to access the
         desired database. Also initializes the dialect to be used and configures usage statistics.
 

--- a/great_expectations/expectations/core/expect_column_bootstrapped_ks_test_p_value_to_be_greater_than.py
+++ b/great_expectations/expectations/core/expect_column_bootstrapped_ks_test_p_value_to_be_greater_than.py
@@ -39,7 +39,7 @@ class ExpectColumnBootstrappedKsTestPValueToBeGreaterThan(TableExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass
 
     @classmethod
@@ -51,5 +51,5 @@ class ExpectColumnBootstrappedKsTestPValueToBeGreaterThan(TableExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass

--- a/great_expectations/expectations/core/expect_column_chisquare_test_p_value_to_be_greater_than.py
+++ b/great_expectations/expectations/core/expect_column_chisquare_test_p_value_to_be_greater_than.py
@@ -38,7 +38,7 @@ class ExpectColumnChiSquareTestPValueToBeGreaterThan(TableExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass
 
     @classmethod
@@ -50,5 +50,5 @@ class ExpectColumnChiSquareTestPValueToBeGreaterThan(TableExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass

--- a/great_expectations/expectations/core/expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than.py
+++ b/great_expectations/expectations/core/expect_column_parameterized_distribution_ks_test_p_value_to_be_greater_than.py
@@ -35,7 +35,7 @@ class ExpectColumnParameterizedDistributionKsTestPValueToBeGreaterThan(
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass
 
     @classmethod
@@ -47,5 +47,5 @@ class ExpectColumnParameterizedDistributionKsTestPValueToBeGreaterThan(
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
@@ -73,7 +73,7 @@ class ExpectColumnValuesToMatchLikePattern(ColumnMapExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs
-    ):
+    ) -> None:
         runtime_configuration = runtime_configuration or {}
         include_column_name = runtime_configuration.get("include_column_name", True)
         include_column_name = (

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -71,7 +71,7 @@ class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs
-    ):
+    ) -> None:
         runtime_configuration = runtime_configuration or {}
         include_column_name = runtime_configuration.get("include_column_name", True)
         include_column_name = (

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -113,7 +113,7 @@ class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs
-    ):
+    ) -> None:
         runtime_configuration = runtime_configuration or {}
         include_column_name = runtime_configuration.get("include_column_name", True)
         include_column_name = (

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -119,7 +119,7 @@ class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs
-    ):
+    ) -> None:
         runtime_configuration = runtime_configuration or {}
         include_column_name = runtime_configuration.get("include_column_name", True)
         include_column_name = (

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -87,7 +87,7 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass
 
     @classmethod
@@ -99,5 +99,5 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         language=None,
         runtime_configuration=None,
         **kwargs,
-    ):
+    ) -> None:
         pass

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -167,7 +167,9 @@ class Expectation(metaclass=MetaExpectation):
     }
     args_keys = None
 
-    def __init__(self, configuration: Optional[ExpectationConfiguration] = None):
+    def __init__(
+        self, configuration: Optional[ExpectationConfiguration] = None
+    ) -> None:
         if configuration is not None:
             self.validate_configuration(configuration)
         self._configuration = configuration
@@ -177,7 +179,7 @@ class Expectation(metaclass=MetaExpectation):
         return isabstract(cls)
 
     @classmethod
-    def _register_renderer_functions(cls):
+    def _register_renderer_functions(cls) -> None:
         expectation_type = camel_to_snake(cls.__name__)
 
         for candidate_renderer_fn_name in dir(cls):
@@ -195,7 +197,7 @@ class Expectation(metaclass=MetaExpectation):
         metrics: dict,
         runtime_configuration: dict = None,
         execution_engine: ExecutionEngine = None,
-    ):
+    ) -> None:
         raise NotImplementedError
 
     @classmethod
@@ -825,7 +827,9 @@ class Expectation(metaclass=MetaExpectation):
             result_format = configuration_result_format
         return result_format
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
         if configuration is None:
             configuration = self.configuration
         try:
@@ -1684,7 +1688,9 @@ class ColumnExpectation(TableExpectation, ABC):
     domain_keys = ("batch_id", "table", "column", "row_condition", "condition_parser")
     domain_type = MetricDomainTypes.COLUMN
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
         # Ensuring basic configuration parameters are properly set
         try:
             assert (
@@ -1712,7 +1718,9 @@ class ColumnMapExpectation(TableExpectation, ABC):
     def is_abstract(cls):
         return cls.map_metric is None or super().is_abstract()
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
         super().validate_configuration(configuration)
         try:
             assert (
@@ -1924,7 +1932,9 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
     def is_abstract(cls):
         return cls.map_metric is None or super().is_abstract()
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
         super().validate_configuration(configuration)
         try:
             assert (
@@ -2121,7 +2131,9 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
     def is_abstract(cls):
         return cls.map_metric is None or super().is_abstract()
 
-    def validate_configuration(self, configuration: Optional[ExpectationConfiguration]):
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
         super().validate_configuration(configuration)
         try:
             assert (

--- a/great_expectations/expectations/metrics/metric_provider.py
+++ b/great_expectations/expectations/metrics/metric_provider.py
@@ -99,7 +99,7 @@ class MetricProvider(metaclass=MetaMetricProvider):
     default_kwarg_values = {}
 
     @classmethod
-    def _register_metric_functions(cls):
+    def _register_metric_functions(cls) -> None:
         metric_name = getattr(cls, "metric_name", None)
         metric_domain_keys = cls.domain_keys
         metric_value_keys = cls.value_keys

--- a/great_expectations/expectations/row_conditions.py
+++ b/great_expectations/expectations/row_conditions.py
@@ -26,7 +26,7 @@ except ImportError:
     sa = None
 
 
-def _set_notnull(s, l, t):
+def _set_notnull(s, l, t) -> None:
     t["notnull"] = True
 
 

--- a/great_expectations/expectations/validation_handlers.py
+++ b/great_expectations/expectations/validation_handlers.py
@@ -4,5 +4,5 @@ logger = logging.getLogger(__name__)
 
 
 class MetaPandasDataset:
-    def column_map_expectation(self):
+    def column_map_expectation(self) -> None:
         logger.debugv("MetaPandasDataset.column_map_expectation")

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -181,7 +181,7 @@ def setup_notebook_logging(logger=None, log_level=logging.INFO):
     # warnings.filterwarnings('ignore')
 
 
-def show_available_data_asset_names(context, data_source_name=None):
+def show_available_data_asset_names(context, data_source_name=None) -> None:
     """List asset names found in the current context."""
     # TODO: Needs tests.
     styles = """

--- a/great_expectations/jupyter_ux/expectation_explorer.py
+++ b/great_expectations/jupyter_ux/expectation_explorer.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExpectationExplorer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.state = {"data_assets": {}}
         self.expectation_kwarg_field_names = {
             "expect_column_values_to_be_unique": ["mostly"],
@@ -183,7 +183,7 @@ class ExpectationExplorer:
         self.debug_view = widgets.Output()
         self.styles = {"description_width": {"description_width": "150px"}}
 
-    def update_result(self, data_asset_name, new_result, column=None):
+    def update_result(self, data_asset_name, new_result, column=None) -> None:
         new_success_value = new_result.get("success")
         expectation_type = new_result.expectation_config.expectation_type
         new_result_widgets = self.generate_expectation_result_detail_widgets(
@@ -232,7 +232,7 @@ class ExpectationExplorer:
                 return None
             return non_column_expectations.get(expectation_type)
 
-    def initialize_data_asset_state(self, data_asset):
+    def initialize_data_asset_state(self, data_asset) -> None:
         data_asset_name = data_asset.data_asset_name
 
         self.state["data_assets"][data_asset_name] = {
@@ -240,7 +240,7 @@ class ExpectationExplorer:
             "expectations": {},
         }
 
-    def set_expectation_state(self, data_asset, expectation_state, column=None):
+    def set_expectation_state(self, data_asset, expectation_state, column=None) -> None:
         data_asset_name = data_asset.data_asset_name
         expectation_type = expectation_state.get("expectation_type")
         data_asset_state = self.state["data_assets"].get(data_asset_name)
@@ -284,8 +284,8 @@ class ExpectationExplorer:
 
     def update_kwarg_widget_dict(
         self, expectation_state, current_widget_dict, ge_kwarg_name, new_ge_kwarg_value
-    ):
-        def update_tag_list_widget_dict(widget_dict, new_list):
+    ) -> None:
+        def update_tag_list_widget_dict(widget_dict, new_list) -> None:
             widget_dict["ge_kwarg_value"] = new_list
             widget_display = widget_dict["widget_display"]
             widget_display.children = self.generate_tag_button_list(
@@ -294,7 +294,7 @@ class ExpectationExplorer:
                 widget_display=widget_display,
             )
 
-        def ge_number_to_widget_string(widget_dict, number_kwarg):
+        def ge_number_to_widget_string(widget_dict, number_kwarg) -> None:
             if hasattr(widget_dict["kwarg_widget"], "value"):
                 widget_dict["kwarg_widget"].value = (
                     str(number_kwarg) if number_kwarg or number_kwarg == 0 else ""
@@ -304,7 +304,7 @@ class ExpectationExplorer:
                     str(number_kwarg) if number_kwarg or number_kwarg == 0 else ""
                 )
 
-        def min_max_value_to_string(widget_dict, number_kwarg):
+        def min_max_value_to_string(widget_dict, number_kwarg) -> None:
             # expectations with min/max kwargs where widget expects a string
             number_to_string_expectations = [
                 "expect_column_values_to_be_between",
@@ -487,7 +487,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_click(button):
+        def on_click(button) -> None:
             editor_widget = expectation_state.get("editor_widget")
             expectation = data_asset.remove_expectation(
                 expectation_type=expectation_type, column=column
@@ -603,7 +603,7 @@ class ExpectationExplorer:
         widget_dict = {"kwarg_widget": output_strftime_format_widget}
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_output_strftime_format_submit(widget):
+        def on_output_strftime_format_submit(widget) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -633,7 +633,7 @@ class ExpectationExplorer:
         widget_dict = {"kwarg_widget": strftime_format_widget}
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_strftime_format_submit(widget):
+        def on_strftime_format_submit(widget) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -659,7 +659,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_value_change(change):
+        def on_value_change(change) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -689,7 +689,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_json_schema_change(change):
+        def on_json_schema_change(change) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -718,7 +718,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_ties_okay_change(change):
+        def on_ties_okay_change(change) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -748,7 +748,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_match_on_change(change):
+        def on_match_on_change(change) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -980,7 +980,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_regex_change(change):
+        def on_regex_change(change) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -1016,7 +1016,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_parse_strings_as_datetimes_change(change):
+        def on_parse_strings_as_datetimes_change(change) -> None:
             output_strftime_format_widget_dict = expectation_state["kwargs"].get(
                 "output_strftime_format", {}
             )
@@ -1055,7 +1055,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_strictly_change(change):
+        def on_strictly_change(change) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -1092,7 +1092,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_mostly_change(change):
+        def on_mostly_change(change) -> None:
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                 expectation_state["kwargs"]
             )
@@ -1131,7 +1131,7 @@ class ExpectationExplorer:
         )
 
         @expectation_feedback_widget.capture(clear_output=True)
-        def on_min_max_type_change(change):
+        def on_min_max_type_change(change) -> None:
             new_type_selection = change.get("new")
 
             ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
@@ -1305,7 +1305,7 @@ class ExpectationExplorer:
         ):
 
             @expectation_feedback_widget.capture(clear_output=True)
-            def on_min_value_change(change):
+            def on_min_value_change(change) -> None:
                 ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                     expectation_state["kwargs"]
                 )
@@ -1462,7 +1462,7 @@ class ExpectationExplorer:
         ):
 
             @expectation_feedback_widget.capture(clear_output=True)
-            def on_max_value_change(change):
+            def on_max_value_change(change) -> None:
                 ge_expectation_kwargs = self.expectation_kwarg_dict_to_ge_kwargs(
                     expectation_state["kwargs"]
                 )

--- a/great_expectations/marshmallow__shade/base.py
+++ b/great_expectations/marshmallow__shade/base.py
@@ -15,32 +15,32 @@ class FieldABC:
     parent = None
     name = None
 
-    def serialize(self, attr, obj, accessor=None):
+    def serialize(self, attr, obj, accessor=None) -> None:
         raise NotImplementedError
 
-    def deserialize(self, value):
+    def deserialize(self, value) -> None:
         raise NotImplementedError
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, attr, obj, **kwargs) -> None:
         raise NotImplementedError
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, attr, data, **kwargs) -> None:
         raise NotImplementedError
 
 
 class SchemaABC:
     """Abstract base class from which all Schemas inherit."""
 
-    def dump(self, obj, *, many: bool = None):
+    def dump(self, obj, *, many: bool = None) -> None:
         raise NotImplementedError
 
-    def dumps(self, obj, *, many: bool = None):
+    def dumps(self, obj, *, many: bool = None) -> None:
         raise NotImplementedError
 
-    def load(self, data, *, many: bool = None, partial=None, unknown=None):
+    def load(self, data, *, many: bool = None, partial=None, unknown=None) -> None:
         raise NotImplementedError
 
     def loads(
         self, json_data, *, many: bool = None, partial=None, unknown=None, **kwargs
-    ):
+    ) -> None:
         raise NotImplementedError

--- a/great_expectations/marshmallow__shade/error_store.py
+++ b/great_expectations/marshmallow__shade/error_store.py
@@ -10,11 +10,11 @@ from great_expectations.marshmallow__shade.exceptions import SCHEMA
 
 
 class ErrorStore:
-    def __init__(self):
+    def __init__(self) -> None:
         #: Dictionary of errors stored during serialization
         self.errors = {}
 
-    def store_error(self, messages, field_name=SCHEMA, index=None):
+    def store_error(self, messages, field_name=SCHEMA, index=None) -> None:
         # field error  -> store/merge error messages under field name key
         # schema error -> if string or list, store/merge under _schema key
         #              -> if dict, store/merge with other top-level keys

--- a/great_expectations/marshmallow__shade/exceptions.py
+++ b/great_expectations/marshmallow__shade/exceptions.py
@@ -34,7 +34,7 @@ class ValidationError(MarshmallowError):
             typing.List[typing.Dict[str, typing.Any]], typing.Dict[str, typing.Any]
         ] = None,
         **kwargs
-    ):
+    ) -> None:
         self.messages = [message] if isinstance(message, (str, bytes)) else message
         self.field_name = field_name
         self.data = data

--- a/great_expectations/marshmallow__shade/fields.py
+++ b/great_expectations/marshmallow__shade/fields.py
@@ -219,7 +219,7 @@ class Field(FieldABC):
         check_key = attr if attribute is None else attribute
         return accessor_func(obj, check_key, default)
 
-    def _validate(self, value):
+    def _validate(self, value) -> None:
         """Perform validation on ``value``. Raise a :exc:`ValidationError` if validation
         does not succeed.
         """
@@ -256,7 +256,7 @@ class Field(FieldABC):
             msg = msg.format(**kwargs)
         return ValidationError(msg)
 
-    def fail(self, key: str, **kwargs):
+    def fail(self, key: str, **kwargs) -> None:
         """Helper method that raises a `ValidationError` with an error message
         from ``self.error_messages``.
 
@@ -271,7 +271,7 @@ class Field(FieldABC):
         )
         raise self.make_error(key=key, **kwargs)
 
-    def _validate_missing(self, value):
+    def _validate_missing(self, value) -> None:
         """Validate missing values. Raise a :exc:`ValidationError` if
         `value` should be considered missing.
         """
@@ -338,7 +338,7 @@ class Field(FieldABC):
 
     # Methods for concrete classes to override.
 
-    def _bind_to_schema(self, field_name, schema):
+    def _bind_to_schema(self, field_name, schema) -> None:
         """Update field with values from its parent schema. Called by
         :meth:`Schema._bind_field <marshmallow.Schema._bind_field>`.
 
@@ -472,7 +472,7 @@ class Nested(Field):
         many: bool = False,
         unknown: str = None,
         **kwargs,
-    ):
+    ) -> None:
         # Raise error if only or exclude is passed as string, not list of strings
         if only is not None and not is_collection(only):
             raise StringNotCollectionError('"only" should be a collection of strings.')
@@ -563,7 +563,7 @@ class Nested(Field):
         many = schema.many or self.many
         return schema.dump(nested_obj, many=many)
 
-    def _test_collection(self, value):
+    def _test_collection(self, value) -> None:
         many = self.schema.many or self.many
         if many and not utils.is_collection(value):
             raise self.make_error("type", input=value, type=value.__class__.__name__)
@@ -620,7 +620,7 @@ class Pluck(Nested):
         nested: typing.Union[SchemaABC, type, str, typing.Callable[[], SchemaABC]],
         field_name: str,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(nested, only=(field_name,), **kwargs)
         self.field_name = field_name
 
@@ -668,7 +668,7 @@ class List(Field):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid list."}
 
-    def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
+    def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs) -> None:
         super().__init__(**kwargs)
         try:
             self.inner = resolve_field_instance(cls_or_instance)
@@ -681,7 +681,7 @@ class List(Field):
             self.only = self.inner.only
             self.exclude = self.inner.exclude
 
-    def _bind_to_schema(self, field_name, schema):
+    def _bind_to_schema(self, field_name, schema) -> None:
         super()._bind_to_schema(field_name, schema)
         self.inner = copy.deepcopy(self.inner)
         self.inner._bind_to_schema(field_name, self)
@@ -737,7 +737,7 @@ class Tuple(Field):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid tuple."}
 
-    def __init__(self, tuple_fields, *args, **kwargs):
+    def __init__(self, tuple_fields, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if not utils.is_collection(tuple_fields):
             raise ValueError(
@@ -757,7 +757,7 @@ class Tuple(Field):
 
         self.validate_length = Length(equal=len(self.tuple_fields))
 
-    def _bind_to_schema(self, field_name, schema):
+    def _bind_to_schema(self, field_name, schema) -> None:
         super()._bind_to_schema(field_name, schema)
         new_tuple_fields = []
         for field in self.tuple_fields:
@@ -863,7 +863,7 @@ class Number(Field):
         "too_large": "Number too large.",
     }
 
-    def __init__(self, *, as_string: bool = False, **kwargs):
+    def __init__(self, *, as_string: bool = False, **kwargs) -> None:
         self.as_string = as_string
         super().__init__(**kwargs)
 
@@ -914,7 +914,7 @@ class Integer(Number):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid integer."}
 
-    def __init__(self, *, strict: bool = False, **kwargs):
+    def __init__(self, *, strict: bool = False, **kwargs) -> None:
         self.strict = strict
         super().__init__(**kwargs)
 
@@ -945,7 +945,9 @@ class Float(Number):
         "special": "Special numeric values (nan or infinity) are not permitted."
     }
 
-    def __init__(self, *, allow_nan: bool = False, as_string: bool = False, **kwargs):
+    def __init__(
+        self, *, allow_nan: bool = False, as_string: bool = False, **kwargs
+    ) -> None:
         self.allow_nan = allow_nan
         super().__init__(as_string=as_string, **kwargs)
 
@@ -1009,7 +1011,7 @@ class Decimal(Number):
         allow_nan: bool = False,
         as_string: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         self.places = (
             decimal.Decimal((0, (1,), -places)) if places is not None else None
         )
@@ -1098,7 +1100,7 @@ class Boolean(Field):
 
     def __init__(
         self, *, truthy: typing.Set = None, falsy: typing.Set = None, **kwargs
-    ):
+    ) -> None:
         super().__init__(**kwargs)
 
         if truthy is not None:
@@ -1174,14 +1176,14 @@ class DateTime(Field):
         "format": '"{input}" cannot be formatted as a {obj_type}.',
     }
 
-    def __init__(self, format: str = None, **kwargs):
+    def __init__(self, format: str = None, **kwargs) -> None:
         super().__init__(**kwargs)
         # Allow this to be None. It may be set later in the ``_serialize``
         # or ``_deserialize`` methods. This allows a Schema to dynamically set the
         # format, e.g. from a Meta option
         self.format = format
 
-    def _bind_to_schema(self, field_name, schema):
+    def _bind_to_schema(self, field_name, schema) -> None:
         super()._bind_to_schema(field_name, schema)
         self.format = (
             self.format
@@ -1239,7 +1241,9 @@ class NaiveDateTime(DateTime):
 
     AWARENESS = "naive"
 
-    def __init__(self, format: str = None, *, timezone: dt.timezone = None, **kwargs):
+    def __init__(
+        self, format: str = None, *, timezone: dt.timezone = None, **kwargs
+    ) -> None:
         super().__init__(format=format, **kwargs)
         self.timezone = timezone
 
@@ -1272,7 +1276,7 @@ class AwareDateTime(DateTime):
 
     def __init__(
         self, format: str = None, *, default_timezone: dt.timezone = None, **kwargs
-    ):
+    ) -> None:
         super().__init__(format=format, **kwargs)
         self.default_timezone = default_timezone
 
@@ -1377,7 +1381,7 @@ class TimeDelta(Field):
         "format": "{input!r} cannot be formatted as a timedelta.",
     }
 
-    def __init__(self, precision: str = SECONDS, **kwargs):
+    def __init__(self, precision: str = SECONDS, **kwargs) -> None:
         precision = precision.lower()
         units = (
             self.DAYS,
@@ -1442,7 +1446,7 @@ class Mapping(Field):
         keys: typing.Union[Field, type] = None,
         values: typing.Union[Field, type] = None,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         if keys is None:
             self.key_field = None
@@ -1469,7 +1473,7 @@ class Mapping(Field):
                 self.only = self.value_field.only
                 self.exclude = self.value_field.exclude
 
-    def _bind_to_schema(self, field_name, schema):
+    def _bind_to_schema(self, field_name, schema) -> None:
         super()._bind_to_schema(field_name, schema)
         if self.value_field:
             self.value_field = copy.deepcopy(self.value_field)
@@ -1589,7 +1593,7 @@ class Url(String):
         schemes: types.StrSequenceOrSet = None,
         require_tld: bool = True,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
 
         self.relative = relative
@@ -1615,7 +1619,7 @@ class Email(String):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid email address."}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # Insert validation into self.validators so that multiple errors can be stored.
         validator = validate.Email(error=self.error_messages["invalid"])
@@ -1645,7 +1649,9 @@ class Method(Field):
 
     _CHECK_ATTRIBUTE = False
 
-    def __init__(self, serialize: str = None, deserialize: str = None, **kwargs):
+    def __init__(
+        self, serialize: str = None, deserialize: str = None, **kwargs
+    ) -> None:
         # Set dump_only and load_only based on arguments
         kwargs["dump_only"] = bool(serialize) and not bool(deserialize)
         kwargs["load_only"] = bool(deserialize) and not bool(serialize)
@@ -1707,7 +1713,7 @@ class Function(Field):
             typing.Callable[[typing.Any, typing.Dict], typing.Any],
         ] = None,
         **kwargs,
-    ):
+    ) -> None:
         # Set dump_only and load_only based on arguments
         kwargs["dump_only"] = bool(serialize) and not bool(deserialize)
         kwargs["load_only"] = bool(deserialize) and not bool(serialize)
@@ -1745,7 +1751,7 @@ class Constant(Field):
 
     _CHECK_ATTRIBUTE = False
 
-    def __init__(self, constant: typing.Any, **kwargs):
+    def __init__(self, constant: typing.Any, **kwargs) -> None:
         super().__init__(**kwargs)
         self.constant = constant
         self.missing = constant
@@ -1767,7 +1773,7 @@ class Inferred(Field):
         Users should not need to use this class directly.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # We memoize the fields to avoid creating and binding new fields
         # every time on serialization.

--- a/great_expectations/marshmallow__shade/orderedset.py
+++ b/great_expectations/marshmallow__shade/orderedset.py
@@ -24,7 +24,7 @@ from collections.abc import MutableSet
 
 
 class OrderedSet(MutableSet):
-    def __init__(self, iterable=None):
+    def __init__(self, iterable=None) -> None:
         self.end = end = []
         end += [None, end, end]  # sentinel node for doubly linked list
         self.map = {}  # key --> [key, prev, next]
@@ -37,26 +37,26 @@ class OrderedSet(MutableSet):
     def __contains__(self, key):
         return key in self.map
 
-    def add(self, key):
+    def add(self, key) -> None:
         if key not in self.map:
             end = self.end
             curr = end[1]
             curr[2] = end[1] = self.map[key] = [key, curr, end]
 
-    def discard(self, key):
+    def discard(self, key) -> None:
         if key in self.map:
             key, prev, next = self.map.pop(key)
             prev[2] = next
             next[1] = prev
 
-    def __iter__(self):
+    def __iter__(self) -> None:
         end = self.end
         curr = end[2]
         while curr is not end:
             yield curr[0]
             curr = curr[2]
 
-    def __reversed__(self):
+    def __reversed__(self) -> None:
         end = self.end
         curr = end[1]
         while curr is not end:

--- a/great_expectations/marshmallow__shade/schema.py
+++ b/great_expectations/marshmallow__shade/schema.py
@@ -152,7 +152,7 @@ class SchemaMeta(type):
         """
         return dict_cls(inherited_fields + cls_fields)
 
-    def __init__(cls, name, bases, attrs):
+    def __init__(cls, name, bases, attrs) -> None:
         super().__init__(name, bases, attrs)
         if name and cls.opts.register:
             class_registry.register(name, cls)
@@ -201,7 +201,7 @@ class SchemaMeta(type):
 class SchemaOpts:
     """class Meta options for the :class:`Schema`. Defines defaults."""
 
-    def __init__(self, meta, ordered: bool = False):
+    def __init__(self, meta, ordered: bool = False) -> None:
         self.fields = getattr(meta, "fields", ())
         if not isinstance(self.fields, (list, tuple)):
             raise ValueError("`fields` option must be a list or tuple.")
@@ -378,7 +378,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         dump_only: types.StrSequenceOrSet = (),
         partial: typing.Union[bool, types.StrSequenceOrSet] = False,
         unknown: str = None,
-    ):
+    ) -> None:
         # Raise error if only or exclude is passed as string, not list of strings
         if only is not None and not is_collection(only):
             raise StringNotCollectionError('"only" should be a list of strings')
@@ -455,7 +455,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
 
     def handle_error(
         self, error: ValidationError, data: typing.Any, *, many: bool, **kwargs
-    ):
+    ) -> None:
         """Custom error handler function for the schema.
 
         :param error: The `ValidationError` raised during (de)serialization.
@@ -777,7 +777,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         partial,
         pass_original,
         index=None,
-    ):
+    ) -> None:
         try:
             if pass_original:  # Pass original, raw data (before unmarshalling)
                 validator_func(output, original_data, partial=partial, many=many)
@@ -1108,7 +1108,9 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         )
         return data
 
-    def _invoke_field_validators(self, *, error_store: ErrorStore, data, many: bool):
+    def _invoke_field_validators(
+        self, *, error_store: ErrorStore, data, many: bool
+    ) -> None:
         for attr_name in self._hooks[VALIDATES]:
             validator = getattr(self, attr_name)
             validator_kwargs = validator.__marshmallow_hook__[VALIDATES]
@@ -1165,7 +1167,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         many: bool,
         partial: typing.Union[bool, types.StrSequenceOrSet],
         field_errors: bool = False,
-    ):
+    ) -> None:
         for attr_name in self._hooks[(VALIDATES_SCHEMA, pass_many)]:
             validator = getattr(self, attr_name)
             validator_kwargs = validator.__marshmallow_hook__[

--- a/great_expectations/marshmallow__shade/utils.py
+++ b/great_expectations/marshmallow__shade/utils.py
@@ -253,7 +253,7 @@ def _get_value_for_key(obj, key, default):
         return getattr(obj, key, default)
 
 
-def set_value(dct: typing.Dict[str, typing.Any], key: str, value: typing.Any):
+def set_value(dct: typing.Dict[str, typing.Any], key: str, value: typing.Any) -> None:
     """Set a value in a dict. If `key` contains a '.', it is assumed
     be a path (i.e. dot-delimited string) to the value's location.
 

--- a/great_expectations/marshmallow__shade/validate.py
+++ b/great_expectations/marshmallow__shade/validate.py
@@ -46,7 +46,7 @@ class URL(Validator):
     """
 
     class RegexMemoizer:
-        def __init__(self):
+        def __init__(self) -> None:
             self._memoized = {}
 
         def _regex_generator(self, relative: bool, require_tld: bool):
@@ -96,7 +96,7 @@ class URL(Validator):
         schemes: types.StrSequenceOrSet = None,
         require_tld: bool = True,
         error: str = None,
-    ):
+    ) -> None:
         self.relative = relative
         self.error = error or self.default_message  # type: str
         self.schemes = schemes or self.default_schemes
@@ -156,7 +156,7 @@ class Email(Validator):
 
     default_message = "Not a valid email address."
 
-    def __init__(self, *, error: str = None):
+    def __init__(self, *, error: str = None) -> None:
         self.error = error or self.default_message  # type: str
 
     def _format_error(self, value) -> typing.Any:
@@ -223,7 +223,7 @@ class Range(Validator):
         min_inclusive: bool = True,
         max_inclusive: bool = True,
         error: str = None,
-    ):
+    ) -> None:
         self.min = min
         self.max = max
         self.error = error
@@ -288,7 +288,7 @@ class Length(Validator):
 
     def __init__(
         self, min: int = None, max: int = None, *, equal: int = None, error: str = None
-    ):
+    ) -> None:
         if equal is not None and any([min, max]):
             raise ValueError(
                 "The `equal` parameter was provided, maximum or "
@@ -338,7 +338,7 @@ class Equal(Validator):
 
     default_message = "Must be equal to {other}."
 
-    def __init__(self, comparable, *, error: str = None):
+    def __init__(self, comparable, *, error: str = None) -> None:
         self.comparable = comparable
         self.error = error or self.default_message  # type: str
 
@@ -377,7 +377,7 @@ class Regexp(Validator):
         flags=0,
         *,
         error: str = None,
-    ):
+    ) -> None:
         self.regex = (
             re.compile(regex, flags) if isinstance(regex, (str, bytes)) else regex
         )
@@ -410,7 +410,7 @@ class Predicate(Validator):
 
     default_message = "Invalid input."
 
-    def __init__(self, method: str, *, error: str = None, **kwargs):
+    def __init__(self, method: str, *, error: str = None, **kwargs) -> None:
         self.method = method
         self.error = error or self.default_message  # type: str
         self.kwargs = kwargs
@@ -440,7 +440,7 @@ class NoneOf(Validator):
 
     default_message = "Invalid input."
 
-    def __init__(self, iterable: typing.Iterable, *, error: str = None):
+    def __init__(self, iterable: typing.Iterable, *, error: str = None) -> None:
         self.iterable = iterable
         self.values_text = ", ".join(str(each) for each in self.iterable)
         self.error = error or self.default_message  # type: str
@@ -478,7 +478,7 @@ class OneOf(Validator):
         labels: typing.Iterable[str] = None,
         *,
         error: str = None,
-    ):
+    ) -> None:
         self.choices = choices
         self.choices_text = ", ".join(str(choice) for choice in self.choices)
         self.labels = labels if labels is not None else []

--- a/great_expectations/profile/base.py
+++ b/great_expectations/profile/base.py
@@ -144,7 +144,7 @@ class Profiler(metaclass=abc.ABCMeta):
       kind of object. You should raise an appropriate Exception if the object is not valid.
     """
 
-    def __init__(self, configuration: dict = None):
+    def __init__(self, configuration: dict = None) -> None:
         self.configuration = configuration
 
     def validate(self, item_to_validate: Any) -> None:
@@ -259,5 +259,5 @@ class DatasetProfiler(DataAssetProfiler):
         return expectation_suite, validation_results
 
     @classmethod
-    def _profile(cls, dataset, configuration=None):
+    def _profile(cls, dataset, configuration=None) -> None:
         raise NotImplementedError

--- a/great_expectations/profile/basic_suite_builder_profiler.py
+++ b/great_expectations/profile/basic_suite_builder_profiler.py
@@ -145,7 +145,7 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
         column_cache,
         excluded_expectations=None,
         included_expectations=None,
-    ):
+    ) -> None:
         cls._create_non_nullity_expectations(
             dataset,
             column,
@@ -192,7 +192,7 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
     @classmethod
     def _create_non_nullity_expectations(
         cls, dataset, column, excluded_expectations=None, included_expectations=None
-    ):
+    ) -> None:
         if (
             not excluded_expectations
             or "expect_column_values_to_not_be_null" not in excluded_expectations
@@ -212,7 +212,7 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
     @classmethod
     def _create_expectations_for_numeric_column(
         cls, dataset, column, excluded_expectations=None, included_expectations=None
-    ):
+    ) -> None:
         cls._create_non_nullity_expectations(
             dataset,
             column,
@@ -350,7 +350,7 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
     @classmethod
     def _create_expectations_for_string_column(
         cls, dataset, column, excluded_expectations=None, included_expectations=None
-    ):
+    ) -> None:
         cls._create_non_nullity_expectations(
             dataset,
             column,
@@ -457,7 +457,7 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
     @classmethod
     def _create_expectations_for_datetime_column(
         cls, dataset, column, excluded_expectations=None, included_expectations=None
-    ):
+    ) -> None:
         cls._create_non_nullity_expectations(
             dataset,
             column,
@@ -814,14 +814,14 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
         return expectation_suite
 
 
-def _check_that_expectations_are_available(dataset, expectations):
+def _check_that_expectations_are_available(dataset, expectations) -> None:
     if expectations:
         for expectation in expectations:
             if expectation not in dataset.list_available_expectation_types():
                 raise ProfilerError(f"Expectation {expectation} is not available.")
 
 
-def _check_that_columns_exist(dataset, columns):
+def _check_that_columns_exist(dataset, columns) -> None:
     if columns:
         for column in columns:
             if column not in dataset.get_table_columns():

--- a/great_expectations/profile/json_schema_profiler.py
+++ b/great_expectations/profile/json_schema_profiler.py
@@ -46,7 +46,7 @@ class JsonSchemaProfiler(Profiler):
         JsonSchemaTypes.BOOLEAN.value: ProfilerTypeMapping.BOOLEAN_TYPE_NAMES,
     }
 
-    def __init__(self, configuration: dict = None):
+    def __init__(self, configuration: dict = None) -> None:
         super().__init__(configuration)
 
     def validate(self, schema: dict) -> bool:

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -69,7 +69,7 @@ class UserConfigurableProfiler:
         semantic_types_dict: Optional[Dict[str, List[str]]] = None,
         table_expectations_only: bool = False,
         value_set_threshold: str = "MANY",
-    ):
+    ) -> None:
         """
         The UserConfigurableProfiler is used to build an expectation suite from a dataset. The profiler may be
         instantiated with or without a config. The config may contain a semantic_types dict or not. Once a profiler is
@@ -238,7 +238,7 @@ class UserConfigurableProfiler:
 
         return expectation_suite
 
-    def _send_usage_stats_message(self):
+    def _send_usage_stats_message(self) -> None:
         profile_dataset_type: str = str(type(self.profile_dataset))
         if "Dataset" in profile_dataset_type:
             profile_dataset_type = "Dataset"
@@ -1111,7 +1111,7 @@ type detected is "{str(type(self.profile_dataset))}", which is illegal.
 
         return profile_dataset
 
-    def _build_expectations_for_all_column_types(self, profile_dataset, column):
+    def _build_expectations_for_all_column_types(self, profile_dataset, column) -> None:
         """
         Adds these expectations for all included columns irrespective of type. Includes:
             - `expect_column_values_to_not_be_null` (or `expect_column_values_to_be_null`)
@@ -1203,7 +1203,7 @@ nan: {pct_unique}
                     f"Skipping expect_column_values_to_be_in_type_list for this column."
                 )
 
-    def _build_expectations_table(self, profile_dataset):
+    def _build_expectations_table(self, profile_dataset) -> None:
         """
         Adds two table level expectations to the dataset
         Args:

--- a/great_expectations/render/renderer/checkpoint_new_notebook_renderer.py
+++ b/great_expectations/render/renderer/checkpoint_new_notebook_renderer.py
@@ -7,7 +7,7 @@ from great_expectations.render.renderer.notebook_renderer import BaseNotebookRen
 
 
 class CheckpointNewNotebookRenderer(BaseNotebookRenderer):
-    def __init__(self, context: DataContext, checkpoint_name: str):
+    def __init__(self, context: DataContext, checkpoint_name: str) -> None:
         super().__init__(context=context)
         self.context = context
         self.checkpoint_name = checkpoint_name
@@ -35,7 +35,7 @@ class CheckpointNewNotebookRenderer(BaseNotebookRenderer):
                     break
         return datasource_candidate
 
-    def _add_header(self):
+    def _add_header(self) -> None:
         self.add_markdown_cell(
             f"""# Create Your Checkpoint
 Use this notebook to configure a new Checkpoint and add it to your project:
@@ -43,7 +43,7 @@ Use this notebook to configure a new Checkpoint and add it to your project:
 **Checkpoint Name**: `{self.checkpoint_name}`"""
         )
 
-    def _add_imports(self):
+    def _add_imports(self) -> None:
         self.add_code_cell(
             """from ruamel.yaml import YAML
 import great_expectations as ge
@@ -55,7 +55,7 @@ context = ge.get_context()
             lint=True,
         )
 
-    def _add_optional_customize_your_config(self):
+    def _add_optional_customize_your_config(self) -> None:
         self.add_markdown_cell(
             """# Customize Your Configuration
 The following cells show examples for listing your current configuration. You can replace values in the sample configuration with these values to customize your Checkpoint."""
@@ -67,7 +67,7 @@ pprint(context.get_available_data_asset_names())""",
         )
         self.add_code_cell("context.list_expectation_suite_names()")
 
-    def _add_sample_checkpoint_config(self):
+    def _add_sample_checkpoint_config(self) -> None:
         self.add_markdown_cell(
             """# Create a Checkpoint Configuration
 
@@ -132,7 +132,7 @@ validations:
                 "Sorry, we were unable to create a sample configuration. Perhaps you don't have a Datasource or Expectation Suite configured."
             )
 
-    def _add_test_and_save_your_checkpoint_configuration(self):
+    def _add_test_and_save_your_checkpoint_configuration(self) -> None:
         self.add_markdown_cell(
             """# Test Your Checkpoint Configuration
 Here we will test your Checkpoint configuration to make sure it is valid.
@@ -146,7 +146,7 @@ If you instead wish to use python instead of yaml to configure your Checkpoint, 
             lint=True,
         )
 
-    def _add_review_checkpoint(self):
+    def _add_review_checkpoint(self) -> None:
         self.add_markdown_cell(
             """# Review Your Checkpoint
 
@@ -154,7 +154,7 @@ You can run the following cell to print out the full yaml configuration. For exa
         )
         self.add_code_cell('print(my_checkpoint.get_config(mode="yaml"))', lint=True)
 
-    def _add_add_checkpoint(self):
+    def _add_add_checkpoint(self) -> None:
         self.add_markdown_cell(
             """# Add Your Checkpoint
 
@@ -165,7 +165,7 @@ Run the following cell to save this Checkpoint to your Checkpoint Store."""
             lint=True,
         )
 
-    def _add_optional_run_checkpoint(self):
+    def _add_optional_run_checkpoint(self) -> None:
         self.add_markdown_cell(
             """# Run Your Checkpoint & Open Data Docs(Optional)
 

--- a/great_expectations/render/renderer/column_section_renderer.py
+++ b/great_expectations/render/renderer/column_section_renderer.py
@@ -32,7 +32,7 @@ def convert_to_string_and_escape(var):
 
 
 class ColumnSectionRenderer(Renderer):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     @classmethod
@@ -56,7 +56,9 @@ class ColumnSectionRenderer(Renderer):
 
 
 class ProfilingResultsColumnSectionRenderer(ColumnSectionRenderer):
-    def __init__(self, properties_table_renderer=None, runtime_environment=None):
+    def __init__(
+        self, properties_table_renderer=None, runtime_environment=None
+    ) -> None:
         super().__init__()
         if properties_table_renderer is None:
             properties_table_renderer = {
@@ -175,7 +177,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
         )
 
     @classmethod
-    def _render_expectation_types(cls, evrs, content_blocks):
+    def _render_expectation_types(cls, evrs, content_blocks) -> None:
         # NOTE: The evr-fetching function is an kinda similar to the code other_section_
         # renderer.ProfilingResultsOverviewSectionRenderer._render_expectation_types
 
@@ -392,7 +394,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
         return ExceptionListContentBlockRenderer.render(evrs, include_column_name=False)
 
     @classmethod
-    def _render_unrecognized(cls, evrs, content_blocks):
+    def _render_unrecognized(cls, evrs, content_blocks) -> None:
         unrendered_blocks = []
         new_block = None
         for evr in evrs:
@@ -427,7 +429,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
 
 
 class ValidationResultsColumnSectionRenderer(ColumnSectionRenderer):
-    def __init__(self, table_renderer=None):
+    def __init__(self, table_renderer=None) -> None:
         super().__init__()
         if table_renderer is None:
             table_renderer = {
@@ -490,7 +492,7 @@ class ValidationResultsColumnSectionRenderer(ColumnSectionRenderer):
 
 
 class ExpectationSuiteColumnSectionRenderer(ColumnSectionRenderer):
-    def __init__(self, bullet_list_renderer=None):
+    def __init__(self, bullet_list_renderer=None) -> None:
         super().__init__()
         if bullet_list_renderer is None:
             bullet_list_renderer = {

--- a/great_expectations/render/renderer/content_block/content_block.py
+++ b/great_expectations/render/renderer/content_block/content_block.py
@@ -389,7 +389,9 @@ diagnose and repair the underlying issue.  Detailed information follows:
             )
 
     @classmethod
-    def _process_content_block(cls, content_block, has_failed_evr, render_object=None):
+    def _process_content_block(
+        cls, content_block, has_failed_evr, render_object=None
+    ) -> None:
         header = cls._get_header()
         if header != "":
             content_block.header = header

--- a/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
+++ b/great_expectations/render/renderer/content_block/validation_results_table_content_block.py
@@ -61,7 +61,9 @@ class ValidationResultsTableContentBlockRenderer(ExpectationStringRenderer):
         return sorted(custom_columns)
 
     @classmethod
-    def _process_content_block(cls, content_block, has_failed_evr, render_object=None):
+    def _process_content_block(
+        cls, content_block, has_failed_evr, render_object=None
+    ) -> None:
         super()._process_content_block(content_block, has_failed_evr)
         content_block.header_row = ["Status", "Expectation", "Observed Value"]
         content_block.header_row_options = {"Status": {"sortable": True}}

--- a/great_expectations/render/renderer/datasource_new_notebook_renderer.py
+++ b/great_expectations/render/renderer/datasource_new_notebook_renderer.py
@@ -47,7 +47,7 @@ Give your datasource a unique name:"""
         datasource_yaml: str,
         datasource_name: str = "my_datasource",
         sql_credentials_snippet: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(context=context)
         self.datasource_type = datasource_type
         self.datasource_yaml = datasource_yaml
@@ -56,7 +56,7 @@ Give your datasource a unique name:"""
             datasource_name = "my_datasource"
         self.datasource_name = datasource_name
 
-    def _add_header(self):
+    def _add_header(self) -> None:
         self.add_markdown_cell(
             f"""# Create a new {self.datasource_type.value} Datasource
 Use this notebook to configure a new {self.datasource_type.value} Datasource and add it to your project."""
@@ -67,7 +67,7 @@ from great_expectations.cli.datasource import sanitize_yaml_and_save_datasource,
 context = ge.get_context()""",
         )
 
-    def _add_docs_cell(self):
+    def _add_docs_cell(self) -> None:
         self.add_markdown_cell(self.DOCS_INTRO)
         self.add_code_cell(f'datasource_name = "{self.datasource_name}"')
 
@@ -76,7 +76,7 @@ context = ge.get_context()""",
         elif self.datasource_type == DatasourceTypes.SQL:
             self.add_markdown_cell(self.SQL_DOCS)
 
-    def _add_sql_credentials_cell(self):
+    def _add_sql_credentials_cell(self) -> None:
         self.add_code_cell(self.sql_credentials_code_snippet)
 
     def _add_template_cell(self, lint: bool = True) -> None:

--- a/great_expectations/render/renderer/email_renderer.py
+++ b/great_expectations/render/renderer/email_renderer.py
@@ -8,7 +8,7 @@ from great_expectations.render.renderer.renderer import Renderer
 
 
 class EmailRenderer(Renderer):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def render(self, validation_result=None, data_docs_pages=None, notify_with=None):

--- a/great_expectations/render/renderer/microsoft_teams_renderer.py
+++ b/great_expectations/render/renderer/microsoft_teams_renderer.py
@@ -12,7 +12,7 @@ class MicrosoftTeamsRenderer(Renderer):
 
     MICROSOFT_TEAMS_SCHEMA_URL = "http://adaptivecards.io/schemas/adaptive-card.json"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def render(

--- a/great_expectations/render/renderer/notebook_renderer.py
+++ b/great_expectations/render/renderer/notebook_renderer.py
@@ -15,7 +15,7 @@ class BaseNotebookRenderer(Renderer):
     Abstract base class for methods that help with rendering a jupyter notebook.
     """
 
-    def __init__(self, context: Optional[DataContext] = None):
+    def __init__(self, context: Optional[DataContext] = None) -> None:
         super().__init__()
         self.context = context
         # Add cells to this notebook, then render by implementing a
@@ -68,7 +68,7 @@ class BaseNotebookRenderer(Renderer):
         with open(notebook_file_path, "w") as f:
             nbformat.write(notebook, f)
 
-    def render(self):
+    def render(self) -> None:
         """
         Render a notebook from parameters.
         """

--- a/great_expectations/render/renderer/opsgenie_renderer.py
+++ b/great_expectations/render/renderer/opsgenie_renderer.py
@@ -7,7 +7,7 @@ from great_expectations.render.renderer.renderer import Renderer
 
 
 class OpsgenieRenderer(Renderer):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def render(

--- a/great_expectations/render/renderer/page_renderer.py
+++ b/great_expectations/render/renderer/page_renderer.py
@@ -38,7 +38,7 @@ class ValidationResultsPageRenderer(Renderer):
         column_section_renderer=None,
         run_info_at_end: bool = False,
         data_context=None,
-    ):
+    ) -> None:
         """
         Args:
             column_section_renderer:
@@ -643,7 +643,7 @@ class ValidationResultsPageRenderer(Renderer):
 
 
 class ExpectationSuitePageRenderer(Renderer):
-    def __init__(self, column_section_renderer=None):
+    def __init__(self, column_section_renderer=None) -> None:
         super().__init__()
         if column_section_renderer is None:
             column_section_renderer = {
@@ -895,7 +895,9 @@ class ExpectationSuitePageRenderer(Renderer):
 
 
 class ProfilingResultsPageRenderer(Renderer):
-    def __init__(self, overview_section_renderer=None, column_section_renderer=None):
+    def __init__(
+        self, overview_section_renderer=None, column_section_renderer=None
+    ) -> None:
         super().__init__()
         if overview_section_renderer is None:
             overview_section_renderer = {

--- a/great_expectations/render/renderer/profiling_results_overview_section_renderer.py
+++ b/great_expectations/render/renderer/profiling_results_overview_section_renderer.py
@@ -33,7 +33,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         )
 
     @classmethod
-    def _render_header(cls, evrs, content_blocks):
+    def _render_header(cls, evrs, content_blocks) -> None:
         content_blocks.append(
             RenderedHeaderContent(
                 **{
@@ -57,7 +57,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         )
 
     @classmethod
-    def _render_dataset_info(cls, evrs, content_blocks):
+    def _render_dataset_info(cls, evrs, content_blocks) -> None:
         expect_table_row_count_to_be_between_evr = cls._find_evr_by_type(
             evrs["results"], "expect_table_row_count_to_be_between"
         )
@@ -121,7 +121,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         )
 
     @classmethod
-    def _render_variable_types(cls, evrs, content_blocks):
+    def _render_variable_types(cls, evrs, content_blocks) -> None:
 
         column_types = cls._get_column_types(evrs)
         # TODO: check if we have the information to make this statement. Do all columns have type expectations?
@@ -154,7 +154,7 @@ class ProfilingResultsOverviewSectionRenderer(Renderer):
         )
 
     @classmethod
-    def _render_expectation_types(cls, evrs, content_blocks):
+    def _render_expectation_types(cls, evrs, content_blocks) -> None:
 
         type_counts = defaultdict(int)
 

--- a/great_expectations/render/renderer/renderer.py
+++ b/great_expectations/render/renderer/renderer.py
@@ -20,7 +20,7 @@ def renderer(renderer_type, **kwargs):
 
 
 class Renderer:
-    def __init__(self):
+    def __init__(self) -> None:
         # This is purely a convenience to provide an explicit mechanism to instantiate any Renderer, even ones that
         # used to be composed exclusively of classmethods
         pass

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -120,7 +120,7 @@ class SiteBuilder:
         runtime_environment=None,
         ge_cloud_mode=False,
         **kwargs,
-    ):
+    ) -> None:
         self.site_name = site_name
         self.data_context = data_context
         self.store_backend = store_backend
@@ -279,7 +279,7 @@ class SiteBuilder:
                 class_name=site_index_builder["class_name"],
             )
 
-    def clean_site(self):
+    def clean_site(self) -> None:
         self.target_store.clean_site()
 
     def build(self, resource_identifiers=None, build_index: bool = True):
@@ -350,7 +350,7 @@ class DefaultSiteSectionBuilder:
         data_context_id=None,
         ge_cloud_mode=False,
         **kwargs,
-    ):
+    ) -> None:
         self.name = name
         self.data_context = data_context
         self.source_store = data_context.stores[source_store_name]
@@ -402,7 +402,7 @@ class DefaultSiteSectionBuilder:
                 class_name=view["class_name"],
             )
 
-    def build(self, resource_identifiers=None):
+    def build(self, resource_identifiers=None) -> None:
         source_store_keys = self.source_store.list_keys()
         if self.name == "validations" and self.validation_results_limit:
             source_store_keys = sorted(
@@ -514,7 +514,7 @@ class DefaultSiteIndexBuilder:
         data_context_id=None,
         source_stores=None,
         **kwargs,
-    ):
+    ) -> None:
         # NOTE: This method is almost identical to DefaultSiteSectionBuilder
         self.name = name
         self.site_name = site_name
@@ -948,6 +948,6 @@ diagnose and repair the underlying issue.  Detailed information follows:
 
 
 class CallToActionButton:
-    def __init__(self, title, link):
+    def __init__(self, title, link) -> None:
         self.title = title
         self.link = link

--- a/great_expectations/render/renderer/slack_renderer.py
+++ b/great_expectations/render/renderer/slack_renderer.py
@@ -7,7 +7,7 @@ from great_expectations.render.renderer.renderer import Renderer
 
 
 class SlackRenderer(Renderer):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def render(

--- a/great_expectations/render/renderer/suite_edit_notebook_renderer.py
+++ b/great_expectations/render/renderer/suite_edit_notebook_renderer.py
@@ -44,7 +44,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         column_expectation_code: Optional[NotebookTemplateConfig] = None,
         table_expectation_code: Optional[NotebookTemplateConfig] = None,
         context: Optional[DataContext] = None,
-    ):
+    ) -> None:
         super().__init__()
         custom_loader = []
 
@@ -193,7 +193,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         )
         self.add_code_cell(code)
 
-    def add_expectation_cells_from_suite(self, expectations):
+    def add_expectation_cells_from_suite(self, expectations) -> None:
         expectations_by_column = self._get_expectations_by_column(expectations)
         markdown = self.render_with_overwrite(
             self.table_expectations_header_markdown, "TABLE_EXPECTATIONS_HEADER.md"
@@ -306,7 +306,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         self.render(suite, batch_kwargs)
         self.write_notebook_to_disk(self._notebook, notebook_file_path)
 
-    def add_authoring_intro(self):
+    def add_authoring_intro(self) -> None:
         markdown = self.render_with_overwrite(
             self.authoring_intro_markdown, "AUTHORING_INTRO.md"
         )

--- a/great_expectations/render/renderer/suite_scaffold_notebook_renderer.py
+++ b/great_expectations/render/renderer/suite_scaffold_notebook_renderer.py
@@ -9,14 +9,16 @@ from great_expectations.render.renderer.suite_edit_notebook_renderer import (
 
 
 class SuiteScaffoldNotebookRenderer(SuiteEditNotebookRenderer):
-    def __init__(self, context: DataContext, suite: ExpectationSuite, batch_kwargs):
+    def __init__(
+        self, context: DataContext, suite: ExpectationSuite, batch_kwargs
+    ) -> None:
         super().__init__(context=context)
         self.suite = suite
         self.suite_name = suite.expectation_suite_name
         self.batch_kwargs = self.get_batch_kwargs(self.suite, batch_kwargs)
         self.batch = self.load_batch()
 
-    def add_header(self):
+    def add_header(self) -> None:
         self.add_markdown_cell(
             f"""# Scaffold a new Expectation Suite (Experimental)
 This process helps you avoid writing lots of boilerplate when authoring suites by allowing you to select columns and other factors that you care about and letting a profiler write some candidate expectations for you to adjust.
@@ -48,7 +50,7 @@ batch.head()""",
             lint=True,
         )
 
-    def _add_scaffold_column_list(self):
+    def _add_scaffold_column_list(self) -> None:
         columns = [f"    '{col}'" for col in self.batch.get_table_columns()]
         columns = ",\n".join(columns)
         code = f"""\
@@ -57,7 +59,7 @@ ignored_columns = [
 ]"""
         self.add_code_cell(code, lint=True)
 
-    def add_footer(self):
+    def add_footer(self) -> None:
         self.add_markdown_cell(
             """## Save & review the scaffolded Expectation Suite
 
@@ -160,7 +162,7 @@ You can find more information about [how to configure this profiler, including a
         self.render(self.batch_kwargs)
         self.write_notebook_to_disk(self._notebook, notebook_file_path)
 
-    def _add_scaffold_cell(self):
+    def _add_scaffold_cell(self) -> None:
         self.add_code_cell(
             """\
 profiler = UserConfigurableProfiler(profile_dataset=batch,

--- a/great_expectations/render/renderer/v3/suite_edit_notebook_renderer.py
+++ b/great_expectations/render/renderer/v3/suite_edit_notebook_renderer.py
@@ -52,7 +52,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         table_expectation_code: Optional[NotebookTemplateConfig] = None,
         column_expectation_code: Optional[NotebookTemplateConfig] = None,
         context: Optional[DataContext] = None,
-    ):
+    ) -> None:
         super().__init__(context=context)
         custom_loader: list = []
 
@@ -217,7 +217,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         batch_request: Optional[
             Union[str, Dict[str, Union[str, int, Dict[str, Any]]]]
         ] = None,
-    ):
+    ) -> None:
         expectations_by_column: Dict[
             str, List[ExpectationConfiguration]
         ] = self._get_expectations_by_column(expectations=expectations)
@@ -423,7 +423,7 @@ class SuiteEditNotebookRenderer(BaseNotebookRenderer):
         batch_request: Optional[
             Union[str, Dict[str, Union[str, int, Dict[str, Any]]]]
         ] = None,
-    ):
+    ) -> None:
         markdown: str = self.render_with_overwrite(
             notebook_config=self.authoring_intro_markdown,
             default_file_name="AUTHORING_INTRO.md",

--- a/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
+++ b/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
@@ -20,7 +20,7 @@ class SuiteProfileNotebookRenderer(SuiteEditNotebookRenderer):
         expectation_suite_name: str,
         profiler_name: str,
         batch_request: Union[str, Dict[str, Union[str, int, Dict[str, Any]]]],
-    ):
+    ) -> None:
         super().__init__(context=context)
 
         if batch_request is None:

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -56,7 +56,7 @@ class RenderedContent:
 
 
 class RenderedComponentContent(RenderedContent):
-    def __init__(self, content_block_type, styling=None):
+    def __init__(self, content_block_type, styling=None) -> None:
         self.content_block_type = content_block_type
         if styling is None:
             styling = {}
@@ -78,7 +78,7 @@ class RenderedHeaderContent(RenderedComponentContent):
         header_row=None,
         styling=None,
         content_block_type="header",
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.header = header
         self.header_row = header_row
@@ -108,7 +108,7 @@ class RenderedGraphContent(RenderedComponentContent):
         subheader=None,
         styling=None,
         content_block_type="graph",
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.graph = graph
         self.header = header
@@ -141,7 +141,7 @@ class RenderedTableContent(RenderedComponentContent):
         content_block_type="table",
         table_options=None,
         header_row_options=None,
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.header = header
         self.subheader = subheader
@@ -177,7 +177,7 @@ class RenderedTableContent(RenderedComponentContent):
 class RenderedTabsContent(RenderedComponentContent):
     def __init__(
         self, tabs, header=None, subheader=None, styling=None, content_block_type="tabs"
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.tabs = tabs
         self.header = header
@@ -212,7 +212,7 @@ class RenderedBootstrapTableContent(RenderedComponentContent):
         subheader=None,
         styling=None,
         content_block_type="bootstrap_table",
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.table_data = table_data
         self.table_columns = table_columns
@@ -252,7 +252,7 @@ class RenderedBootstrapTableContent(RenderedComponentContent):
 class RenderedContentBlockContainer(RenderedComponentContent):
     def __init__(
         self, content_blocks, styling=None, content_block_type="content_block_container"
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.content_blocks = content_blocks
 
@@ -265,7 +265,7 @@ class RenderedContentBlockContainer(RenderedComponentContent):
 
 
 class RenderedMarkdownContent(RenderedComponentContent):
-    def __init__(self, markdown, styling=None, content_block_type="markdown"):
+    def __init__(self, markdown, styling=None, content_block_type="markdown") -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.markdown = markdown
 
@@ -278,7 +278,7 @@ class RenderedMarkdownContent(RenderedComponentContent):
 class RenderedStringTemplateContent(RenderedComponentContent):
     def __init__(
         self, string_template, styling=None, content_block_type="string_template"
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.string_template = string_template
 
@@ -302,7 +302,7 @@ class RenderedBulletListContent(RenderedComponentContent):
         subheader=None,
         styling=None,
         content_block_type="bullet_list",
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.header = header
         self.subheader = subheader
@@ -334,7 +334,7 @@ class ValueListContent(RenderedComponentContent):
         subheader=None,
         styling=None,
         content_block_type="value_list",
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.header = header
         self.subheader = subheader
@@ -359,7 +359,7 @@ class ValueListContent(RenderedComponentContent):
 class TextContent(RenderedComponentContent):
     def __init__(
         self, text, header=None, subheader=None, styling=None, content_block_type="text"
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.text = text
         self.header = header
@@ -392,7 +392,7 @@ class CollapseContent(RenderedComponentContent):
         styling=None,
         content_block_type="collapse",
         inline_link=False,
-    ):
+    ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.collapse_toggle_link = collapse_toggle_link
         self.header = header
@@ -438,7 +438,7 @@ class RenderedDocumentContent(RenderedContent):
         batch_kwargs=None,
         batch_spec=None,
         ge_cloud_id=None,
-    ):
+    ) -> None:
         if not isinstance(sections, list) and all(
             [isinstance(section, RenderedSectionContent) for section in sections]
         ):
@@ -475,7 +475,7 @@ class RenderedDocumentContent(RenderedContent):
 
 
 class RenderedSectionContent(RenderedContent):
-    def __init__(self, content_blocks, section_name=None):
+    def __init__(self, content_blocks, section_name=None) -> None:
         if not isinstance(content_blocks, list) and all(
             [
                 isinstance(content_block, RenderedComponentContent)
@@ -508,7 +508,7 @@ class RenderedAtomicValue(DictDot):
         header_row: Optional[List["RenderedAtomicValue"]] = None,
         table: Optional[List[List["RenderedAtomicValue"]]] = None,
         graph: Optional[dict] = None,
-    ):
+    ) -> None:
         # StringValueType
         self.template: Optional[str] = template
         self.params: Optional[dict] = params
@@ -551,7 +551,7 @@ class RenderedAtomicContent(RenderedContent):
         name: Optional[str] = None,
         value: Optional[RenderedAtomicValue] = None,
         value_type: Optional[str] = None,
-    ):
+    ) -> None:
         self.name = name
         self.value = value
         self.value_type = value_type

--- a/great_expectations/render/view/view.py
+++ b/great_expectations/render/view/view.py
@@ -29,7 +29,7 @@ class NoOpTemplate:
 
 
 class PrettyPrintTemplate:
-    def render(self, document, indent=2):
+    def render(self, document, indent=2) -> None:
         print(json.dumps(document, indent=indent))
 
 
@@ -53,7 +53,9 @@ class DefaultJinjaView:
 
     _template = NoOpTemplate
 
-    def __init__(self, custom_styles_directory=None, custom_views_directory=None):
+    def __init__(
+        self, custom_styles_directory=None, custom_views_directory=None
+    ) -> None:
         self.custom_styles_directory = custom_styles_directory
         self.custom_views_directory = custom_views_directory
 
@@ -194,7 +196,9 @@ class DefaultJinjaView:
                 jinja_context, content_block=content_block, index=index
             )
 
-    def render_dict_values(self, context, dict_, index=None, content_block_id=None):
+    def render_dict_values(
+        self, context, dict_, index=None, content_block_id=None
+    ) -> None:
         for key, val in dict_.items():
             if key.startswith("_"):
                 continue
@@ -430,14 +434,14 @@ class DefaultJinjaView:
             )
         ).safe_substitute(template.get("params", {}))
 
-    def _validate_document(self, document):
+    def _validate_document(self, document) -> None:
         raise NotImplementedError
 
 
 class DefaultJinjaPageView(DefaultJinjaView):
     _template = "page.j2"
 
-    def _validate_document(self, document):
+    def _validate_document(self, document) -> None:
         assert isinstance(document, RenderedDocumentContent)
 
 
@@ -448,7 +452,7 @@ class DefaultJinjaIndexPageView(DefaultJinjaPageView):
 class DefaultJinjaSectionView(DefaultJinjaView):
     _template = "section.j2"
 
-    def _validate_document(self, document):
+    def _validate_document(self, document) -> None:
         assert isinstance(
             document["section"], dict
         )  # For now low-level views take dicts
@@ -457,7 +461,7 @@ class DefaultJinjaSectionView(DefaultJinjaView):
 class DefaultJinjaComponentView(DefaultJinjaView):
     _template = "component.j2"
 
-    def _validate_document(self, document):
+    def _validate_document(self, document) -> None:
         assert isinstance(
             document["content_block"], dict
         )  # For now low-level views take dicts

--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -108,7 +108,7 @@ class DomainBuilderConfig(DictDot):
         class_name: str,
         module_name: Optional[str] = None,
         **kwargs,
-    ):
+    ) -> None:
         self.module_name = module_name
         self.class_name = class_name
 
@@ -148,7 +148,7 @@ class ParameterBuilderConfig(DictDot):
         evaluation_parameter_builder_configs: Optional[list] = None,
         json_serialize: bool = True,
         **kwargs,
-    ):
+    ) -> None:
         self.module_name = module_name
         self.class_name = class_name
 
@@ -212,7 +212,7 @@ class ExpectationConfigurationBuilderConfig(DictDot):
         meta: Optional[dict] = None,
         validation_parameter_builder_configs: Optional[list] = None,
         **kwargs,
-    ):
+    ) -> None:
         self.module_name = module_name
         self.class_name = class_name
 
@@ -281,7 +281,7 @@ class RuleConfig(SerializableDictDot):
         expectation_configuration_builders: Optional[
             List[dict]
         ] = None,  # see ExpectationConfigurationBuilderConfig
-    ):
+    ) -> None:
         self.variables = variables
         self.domain_builder = domain_builder
         self.parameter_builders = parameter_builders
@@ -378,7 +378,7 @@ class RuleBasedProfilerConfig(BaseYamlConfig):
         rules: Dict[str, dict],  # see RuleConfig
         variables: Optional[Dict[str, Any]] = None,
         commented_map: Optional[CommentedMap] = None,
-    ):
+    ) -> None:
         self.module_name = "great_expectations.rule_based_profiler"
         self.class_name = "RuleBasedProfiler"
 

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -83,7 +83,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         self,
         name: str,
         validator: Validator,
-    ):
+    ) -> None:
         """
         DataAssistant subclasses guide "RuleBasedProfiler" to contain Rule configurations to embody profiling behaviors,
         corresponding to indended exploration and validation goals.  Then executing "RuleBasedProfiler.run()" yields

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -24,7 +24,7 @@ class DataAssistantRunner:
         self,
         data_assistant_cls: Type["DataAssistant"],  # noqa: F821
         data_context: "BaseDataContext",  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             data_assistant_cls: DataAssistant class associated with this DataAssistantRunner

--- a/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
@@ -31,7 +31,7 @@ class VolumeDataAssistant(DataAssistant):
         self,
         name: str,
         validator: Validator,
-    ):
+    ) -> None:
         super().__init__(
             name=name,
             validator=validator,

--- a/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
@@ -53,7 +53,7 @@ class CategoricalColumnDomainBuilder(ColumnDomainBuilder):
         max_unique_values: Optional[Union[str, int]] = None,
         max_proportion_unique: Optional[Union[str, float]] = None,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """Create column domains where cardinality is within the specified limit.
 
         Cardinality refers to the number of unique values in a given domain.
@@ -145,7 +145,7 @@ class CategoricalColumnDomainBuilder(ColumnDomainBuilder):
         value: Optional[
             Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
         ],
-    ):
+    ) -> None:
         self._allowed_semantic_types_passthrough = value
 
     @property

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -40,7 +40,7 @@ class ColumnDomainBuilder(DomainBuilder):
             Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
         ] = None,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         A semantic type is distinguished from the structured column type;
         An example structured column type would be "integer".  The inferred semantic type would be "id".
@@ -115,7 +115,7 @@ class ColumnDomainBuilder(DomainBuilder):
     @include_column_name_suffixes.setter
     def include_column_name_suffixes(
         self, value: Optional[Union[str, Iterable, List[str]]]
-    ):
+    ) -> None:
         self._include_column_name_suffixes = value
 
     @property
@@ -127,7 +127,7 @@ class ColumnDomainBuilder(DomainBuilder):
     @exclude_column_name_suffixes.setter
     def exclude_column_name_suffixes(
         self, value: Optional[Union[str, Iterable, List[str]]]
-    ):
+    ) -> None:
         self._exclude_column_name_suffixes = value
 
     @property
@@ -152,7 +152,7 @@ class ColumnDomainBuilder(DomainBuilder):
         value: Optional[
             Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
         ],
-    ):
+    ) -> None:
         self._include_semantic_types = value
 
     @property
@@ -169,7 +169,7 @@ class ColumnDomainBuilder(DomainBuilder):
         value: Optional[
             Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
         ],
-    ):
+    ) -> None:
         self._exclude_semantic_types = value
 
     @property

--- a/great_expectations/rule_based_profiler/domain_builder/column_pair_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_pair_domain_builder.py
@@ -15,7 +15,7 @@ class ColumnPairDomainBuilder(ColumnDomainBuilder):
         self,
         include_column_names: Optional[Union[str, Optional[List[str]]]] = None,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             include_column_names: Explicitly specified exactly two desired columns

--- a/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/domain_builder.py
@@ -28,7 +28,7 @@ class DomainBuilder(ABC, Builder):
     def __init__(
         self,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             data_context: BaseDataContext associated with DomainBuilder

--- a/great_expectations/rule_based_profiler/domain_builder/map_metric_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/map_metric_column_domain_builder.py
@@ -38,7 +38,7 @@ class MapMetricColumnDomainBuilder(ColumnDomainBuilder):
         max_unexpected_ratio: Optional[Union[str, float]] = None,
         min_max_unexpected_values_proportion: Union[str, float] = 9.75e-1,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Create column domains using tolerance for inter-Batch proportion of adherence to intra-Batch "unexpected_count"
         value of specified "map_metric_name" as criterion for emitting Domain for column under consideration.

--- a/great_expectations/rule_based_profiler/domain_builder/multi_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/multi_column_domain_builder.py
@@ -15,7 +15,7 @@ class MultiColumnDomainBuilder(ColumnDomainBuilder):
         self,
         include_column_names: Optional[Union[str, Optional[List[str]]]] = None,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             include_column_names: Explicitly specified desired columns

--- a/great_expectations/rule_based_profiler/domain_builder/table_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/table_domain_builder.py
@@ -9,7 +9,7 @@ class TableDomainBuilder(DomainBuilder):
     def __init__(
         self,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             data_context: BaseDataContext associated with this DomainBuilder

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/default_expectation_configuration_builder.py
@@ -72,7 +72,7 @@ class DefaultExpectationConfigurationBuilder(ExpectationConfigurationBuilder):
         ] = None,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
         **kwargs,
-    ):
+    ) -> None:
         """
         Args:
             expectation_type: the "expectation_type" argument of "ExpectationConfiguration" object to be emitted.

--- a/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
+++ b/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py
@@ -33,7 +33,7 @@ class ExpectationConfigurationBuilder(ABC, Builder):
         ] = None,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
         **kwargs
-    ):
+    ) -> None:
         """
         The ExpectationConfigurationBuilder will build ExpectationConfiguration objects for a Domain from the Rule.
 

--- a/great_expectations/rule_based_profiler/helpers/cardinality_checker.py
+++ b/great_expectations/rule_based_profiler/helpers/cardinality_checker.py
@@ -117,7 +117,7 @@ class CardinalityChecker:
         limit_mode: Optional[Union[CardinalityLimitMode, str]] = None,
         max_unique_values: Optional[int] = None,
         max_proportion_unique: Optional[float] = None,
-    ):
+    ) -> None:
         self._limit_mode = self._convert_to_cardinality_mode(
             limit_mode=limit_mode,
             max_unique_values=max_unique_values,

--- a/great_expectations/rule_based_profiler/helpers/simple_semantic_type_filter.py
+++ b/great_expectations/rule_based_profiler/helpers/simple_semantic_type_filter.py
@@ -22,7 +22,7 @@ class SimpleSemanticTypeFilter(SemanticTypeFilter):
         batch_ids: Optional[List[str]] = None,
         validator: Optional["Validator"] = None,  # noqa: F821
         column_names: Optional[List[str]] = None,
-    ):
+    ) -> None:
         self._table_column_name_to_inferred_semantic_domain_type_mapping = (
             self._get_table_column_name_to_inferred_semantic_domain_type_mapping(
                 batch_ids=batch_ids,

--- a/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/mean_unexpected_map_metric_multi_batch_parameter_builder.py
@@ -50,7 +50,7 @@ class MeanUnexpectedMapMetricMultiBatchParameterBuilder(
         ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             name: the name of this parameter -- this is user-specified parameter name (from configuration);

--- a/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_multi_batch_parameter_builder.py
@@ -40,7 +40,7 @@ class MetricMultiBatchParameterBuilder(ParameterBuilder):
         ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             name: the name of this parameter -- this is user-specified parameter name (from configuration);

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -80,7 +80,7 @@ class NumericMetricRangeMultiBatchParameterBuilder(MetricMultiBatchParameterBuil
         ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             name: the name of this parameter -- this is user-specified parameter name (from configuration);

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -121,7 +121,7 @@ class ParameterBuilder(ABC, Builder):
         ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         The ParameterBuilder will build ParameterNode objects for a Domain from the Rule.
 

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -60,7 +60,7 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
         ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Configure this RegexPatternStringParameterBuilder
         Args:

--- a/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/simple_date_format_string_parameter_builder.py
@@ -105,7 +105,7 @@ class SimpleDateFormatStringParameterBuilder(ParameterBuilder):
         ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Configure this SimpleDateFormatStringParameterBuilder
         Args:

--- a/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
@@ -59,7 +59,7 @@ class ValueSetMultiBatchParameterBuilder(MetricMultiBatchParameterBuilder):
         ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             name: the name of this parameter -- this is user-specified parameter name (from configuration);

--- a/great_expectations/rule_based_profiler/rule/rule.py
+++ b/great_expectations/rule_based_profiler/rule/rule.py
@@ -42,7 +42,7 @@ class Rule(SerializableDictDot):
         expectation_configuration_builders: Optional[
             List[ExpectationConfigurationBuilder]
         ] = None,
-    ):
+    ) -> None:
         """
         Sets Rule name, variables, domain builder, parameters builders, configuration builders, and other instance data.
 
@@ -168,7 +168,7 @@ class Rule(SerializableDictDot):
         return copy.deepcopy(self._variables)
 
     @variables.setter
-    def variables(self, value: Optional[ParameterContainer]):
+    def variables(self, value: Optional[ParameterContainer]) -> None:
         self._variables = value
 
     @property

--- a/great_expectations/rule_based_profiler/rule/rule_output.py
+++ b/great_expectations/rule_based_profiler/rule/rule_output.py
@@ -21,7 +21,7 @@ class RuleOutput:
     def __init__(
         self,
         rule_state: RuleState,
-    ):
+    ) -> None:
         """
         Args:
             rule_state: RuleState object represented by "Domain" objects and parameters,.computed for one Rule object.

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -89,7 +89,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         profiler_config: RuleBasedProfilerConfig,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
         usage_statistics_handler: Optional[UsageStatisticsHandler] = None,
-    ):
+    ) -> None:
         """
         Create a new RuleBasedProfilerBase using configured rules (as captured in the RuleBasedProfilerConfig object).
 
@@ -1150,7 +1150,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         return copy.deepcopy(self._variables)
 
     @variables.setter
-    def variables(self, value: Optional[ParameterContainer]):
+    def variables(self, value: Optional[ParameterContainer]) -> None:
         self._variables = value
         self.config.variables = convert_variables_to_dict(variables=value)
 
@@ -1159,7 +1159,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         return self._rules
 
     @rules.setter
-    def rules(self, value: List[Rule]):
+    def rules(self, value: List[Rule]) -> None:
         self._rules = value
 
     @property
@@ -1167,7 +1167,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         return self._citation
 
     @citation.setter
-    def citation(self, value: Optional[Dict[str, Any]]):
+    def citation(self, value: Optional[Dict[str, Any]]) -> None:
         self._citation = value
 
     @property
@@ -1279,7 +1279,7 @@ class RuleBasedProfiler(BaseRuleBasedProfiler):
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Create a new Profiler using configured rules.
         For a Rule or an item in a Rule configuration, instantiates the following if
@@ -1312,7 +1312,7 @@ class RuleBasedProfiler(BaseRuleBasedProfiler):
         )
 
 
-def _validate_builder_override_config(builder_config: dict):
+def _validate_builder_override_config(builder_config: dict) -> None:
     """
     In order to insure successful instantiation of custom builder classes using "instantiate_class_from_config()",
     candidate builder override configurations are required to supply both "class_name" and "module_name" attributes.

--- a/great_expectations/rule_based_profiler/types/builder.py
+++ b/great_expectations/rule_based_profiler/types/builder.py
@@ -27,7 +27,7 @@ class Builder(SerializableDictDot):
     def __init__(
         self,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
-    ):
+    ) -> None:
         """
         Args:
             data_context: BaseDataContext associated with this Builder

--- a/great_expectations/rule_based_profiler/types/domain.py
+++ b/great_expectations/rule_based_profiler/types/domain.py
@@ -54,7 +54,7 @@ class Domain(SerializableDotDict):
         domain_type: Union[str, MetricDomainTypes],
         domain_kwargs: Optional[Union[Dict[str, Any], DomainKwargs]] = None,
         details: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> None:
         if isinstance(domain_type, str):
             try:
                 domain_type = MetricDomainTypes(domain_type)

--- a/great_expectations/rule_based_profiler/types/parameter_container.py
+++ b/great_expectations/rule_based_profiler/types/parameter_container.py
@@ -100,7 +100,9 @@ def is_fully_qualified_parameter_name_literal_string_format(
     )
 
 
-def validate_fully_qualified_parameter_name(fully_qualified_parameter_name: str):
+def validate_fully_qualified_parameter_name(
+    fully_qualified_parameter_name: str,
+) -> None:
     if not is_fully_qualified_parameter_name_literal_string_format(
         fully_qualified_parameter_name=fully_qualified_parameter_name
     ):
@@ -198,7 +200,7 @@ class ParameterContainer(SerializableDictDot):
 
     def set_parameter_node(
         self, parameter_name_root: str, parameter_node: ParameterNode
-    ):
+    ) -> None:
         if self.parameter_nodes is None:
             self.parameter_nodes = {}
 
@@ -291,7 +293,7 @@ def build_parameter_container_for_variables(
 def build_parameter_container(
     parameter_container: ParameterContainer,
     parameter_values: Dict[str, Any],
-):
+) -> None:
     """
     Builds the ParameterNode trees, corresponding to the fully_qualified_parameter_name first-level keys.
 
@@ -356,7 +358,7 @@ def _build_parameter_node_tree_for_one_parameter(
     parameter_node: ParameterNode,
     parameter_name_as_list: List[str],
     parameter_value: Any,
-):
+) -> None:
     """
     Recursively builds a tree of ParameterNode objects, creating new ParameterNode objects parsimoniously (i.e., only if
     ParameterNode object, corresponding to a part of fully-qualified parameter names in a "name space" does not exist).

--- a/great_expectations/rule_based_profiler/types/rule_state.py
+++ b/great_expectations/rule_based_profiler/types/rule_state.py
@@ -18,7 +18,7 @@ class RuleState:
         variables: Optional[ParameterContainer] = None,
         domains: Optional[List[Domain]] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
-    ):
+    ) -> None:
         """
         Args:
             rule: Rule object for which present RuleState object corresponds (needed for various Rule properties).

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -285,7 +285,7 @@ SQL_DIALECT_NAMES = (
 
 
 class SqlAlchemyConnectionManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self.lock = threading.Lock()
         self._connections = {}
 
@@ -310,7 +310,7 @@ connection_manager = SqlAlchemyConnectionManager()
 
 
 class LockingConnectionCheck:
-    def __init__(self, sa, connection_string):
+    def __init__(self, sa, connection_string) -> None:
         self.lock = threading.Lock()
         self.sa = sa
         self.connection_string = connection_string
@@ -1085,7 +1085,7 @@ def build_sa_validator_with_data(
 
 def modify_locale(func):
     @wraps(func)
-    def locale_wrapper(*args, **kwargs):
+    def locale_wrapper(*args, **kwargs) -> None:
         old_locale = locale.setlocale(locale.LC_TIME, None)
         print(old_locale)
         # old_locale = locale.getlocale(locale.LC_TIME) Why not getlocale? not sure
@@ -1706,7 +1706,7 @@ def sort_unexpected_values(test_value_list, result_value_list):
     return test_value_list, result_value_list
 
 
-def evaluate_json_test(data_asset, expectation_type, test):
+def evaluate_json_test(data_asset, expectation_type, test) -> None:
     """
     This method will evaluate the result of a test build using the Great Expectations json test format.
 
@@ -1857,7 +1857,7 @@ def evaluate_json_test_cfe(validator, expectation_type, test, raise_exception=Tr
     return (result, error_message, stack_trace)
 
 
-def check_json_test_result(test, result, data_asset=None):
+def check_json_test_result(test, result, data_asset=None) -> None:
     # We do not guarantee the order in which values are returned (e.g. Spark), so we sort for testing purposes
     if "unexpected_list" in result["result"]:
         if ("result" in test["output"]) and (

--- a/great_expectations/types/__init__.py
+++ b/great_expectations/types/__init__.py
@@ -72,10 +72,10 @@ class DictDot:
             return list(self.__dict__.keys())[item]
         return getattr(self, item)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value) -> None:
         setattr(self, key, value)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key) -> None:
         delattr(self, key)
 
     def __contains__(self, key):
@@ -202,7 +202,7 @@ class DictDot:
 
         keys_for_exclusion: list = []
 
-        def assert_valid_keys(keys: Set[str], purpose: str):
+        def assert_valid_keys(keys: Set[str], purpose: str) -> None:
             name: str
             for name in keys:
                 try:

--- a/great_expectations/types/configurations.py
+++ b/great_expectations/types/configurations.py
@@ -4,7 +4,7 @@ from great_expectations.marshmallow__shade import Schema, fields
 class ClassConfig:
     """Defines information sufficient to identify a class to be (dynamically) loaded for a DataContext."""
 
-    def __init__(self, class_name, module_name=None):
+    def __init__(self, class_name, module_name=None) -> None:
         self._class_name = class_name
         self._module_name = module_name
 

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -38,7 +38,7 @@ class ValidationOperator:
         self._validation_operator_config = None
 
     @property
-    def validation_operator_config(self):
+    def validation_operator_config(self) -> None:
         """
         This method builds the config dict of a particular validation operator. The "kwargs" key is what really
         distinguishes different validation operators.
@@ -77,7 +77,7 @@ class ValidationOperator:
         evaluation_parameters=None,
         run_name=None,
         run_time=None,
-    ):
+    ) -> None:
         raise NotImplementedError
 
 
@@ -193,7 +193,7 @@ class ActionListValidationOperator(ValidationOperator):
         action_list,
         name,
         result_format={"result_format": "SUMMARY"},
-    ):
+    ) -> None:
         super().__init__()
         self.data_context = data_context
         self.name = name
@@ -618,7 +618,7 @@ class WarningAndFailureExpectationSuitesValidationOperator(
         notify_on="all",
         notify_with=None,
         result_format={"result_format": "SUMMARY"},
-    ):
+    ) -> None:
         super().__init__(data_context, action_list, name)
 
         if expectation_suite_name_suffixes is None:

--- a/great_expectations/validator/exception_info.py
+++ b/great_expectations/validator/exception_info.py
@@ -11,7 +11,7 @@ class ExceptionInfo(SerializableDotDict):
         exception_traceback: str,
         exception_message: str,
         raised_exception: bool = True,
-    ):
+    ) -> None:
         super().__init__(
             exception_traceback=exception_traceback,
             exception_message=exception_message,

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -11,7 +11,7 @@ class MetricConfiguration:
         metric_domain_kwargs: dict,
         metric_value_kwargs: dict = None,
         metric_dependencies: dict = None,
-    ):
+    ) -> None:
         self._metric_name = metric_name
         if not isinstance(metric_domain_kwargs, IDDict):
             metric_domain_kwargs = IDDict(metric_domain_kwargs)
@@ -56,7 +56,7 @@ class MetricConfiguration:
         return self._metric_dependencies
 
     @metric_dependencies.setter
-    def metric_dependencies(self, metric_dependencies):
+    def metric_dependencies(self, metric_dependencies) -> None:
         self._metric_dependencies = metric_dependencies
 
     @property

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -9,7 +9,7 @@ from great_expectations.validator.metric_configuration import MetricConfiguratio
 class MetricEdge:
     def __init__(
         self, left: MetricConfiguration, right: Optional[MetricConfiguration] = None
-    ):
+    ) -> None:
         self._left = left
         self._right = right
 
@@ -29,7 +29,7 @@ class MetricEdge:
 
 
 class ValidationGraph:
-    def __init__(self, edges: Optional[List[MetricEdge]] = None):
+    def __init__(self, edges: Optional[List[MetricEdge]] = None) -> None:
         if edges:
             self._edges = edges
         else:
@@ -37,7 +37,7 @@ class ValidationGraph:
 
         self._edge_ids = {edge.id for edge in self._edges}
 
-    def add(self, edge: MetricEdge):
+    def add(self, edge: MetricEdge) -> None:
         if edge.id not in self._edge_ids:
             self._edges.append(edge)
             self._edge_ids.add(edge.id)
@@ -52,11 +52,11 @@ class ValidationGraph:
 
 
 class ExpectationValidationGraph:
-    def __init__(self, configuration: ExpectationConfiguration):
+    def __init__(self, configuration: ExpectationConfiguration) -> None:
         self._configuration = configuration
         self._graph = ValidationGraph()
 
-    def update(self, graph: ValidationGraph):
+    def update(self, graph: ValidationGraph) -> None:
         edge: MetricEdge
         for edge in graph.edges:
             self.graph.add(edge=edge)

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -148,7 +148,7 @@ class Validator:
         ] = None,  # Cannot type DataContext due to circular import
         batches: Optional[List[Batch]] = None,
         **kwargs,
-    ):
+    ) -> None:
         """
         Validator is the key object used to create Expectations, validate Expectations,
         and get Metrics for Expectations.
@@ -736,7 +736,7 @@ class Validator:
         self,
         parameter_builder: ParameterBuilder,
         metric_value_kwargs: Optional[dict] = None,
-    ):
+    ) -> None:
         if metric_value_kwargs is None:
             metric_value_kwargs = {}
 
@@ -1146,7 +1146,7 @@ class Validator:
         metric_configuration: MetricConfiguration,
         configuration: Optional[ExpectationConfiguration] = None,
         runtime_configuration: Optional[dict] = None,
-    ):
+    ) -> None:
         """Obtain domain and value keys for metrics and proceeds to add these metrics to the validation graph
         until all metrics have been added."""
 
@@ -2012,7 +2012,7 @@ set as active.
         else:
             return default_value
 
-    def set_evaluation_parameter(self, parameter_name, parameter_value):
+    def set_evaluation_parameter(self, parameter_name, parameter_value) -> None:
         """
         Provide a value to be stored in the data_asset evaluation_parameters object and used to evaluate
         parameterized expectations.
@@ -2186,7 +2186,7 @@ set as active.
         self,
         expectation_suite: ExpectationSuite = None,
         expectation_suite_name: str = None,
-    ):
+    ) -> None:
         """Instantiates `_expectation_suite` as empty by default or with a specified expectation `config`.
         In addition, this always sets the `default_expectation_args` to:
             `include_config`: False,
@@ -2282,7 +2282,9 @@ set as active.
 class BridgeValidator:
     """This is currently helping bridge APIs"""
 
-    def __init__(self, batch, expectation_suite, expectation_engine=None, **kwargs):
+    def __init__(
+        self, batch, expectation_suite, expectation_engine=None, **kwargs
+    ) -> None:
         """Builds an expectation_engine object using an expectation suite and a batch, with the expectation engine being
         determined either by the user or by the type of batch data (pandas dataframe, SqlAlchemy table, etc.)
 

--- a/scripts/check_type_hint_coverage.py
+++ b/scripts/check_type_hint_coverage.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 TYPE_HINT_ERROR_THRESHOLD: int = (
-    2850  # This number is to be reduced as we annotate more functions!
+    2639  # This number is to be reduced as we annotate more functions!
 )
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Update type annotations for functions that should be annotated with return `None` (in accordance with https://peps.python.org/pep-0484/)

Script used: https://gist.github.com/cdkini/135ba4596ae52a96983ce61bf8e07a23

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
