### PR TITLE
[FEATURE] Provide "estimation histogram" ParameterBuilder output details .

### DIFF
--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -13,8 +13,6 @@ from great_expectations.rule_based_profiler.types import (
     Domain,
     ParameterContainer,
     SemanticDomainTypes,
-)
-from great_expectations.rule_based_profiler.types.semantic_type_filter import (
     SemanticTypeFilter,
 )
 from great_expectations.validator.metric_configuration import MetricConfiguration

--- a/great_expectations/rule_based_profiler/helpers/simple_semantic_type_filter.py
+++ b/great_expectations/rule_based_profiler/helpers/simple_semantic_type_filter.py
@@ -5,8 +5,6 @@ from great_expectations.core.profiler_types_mapping import ProfilerTypeMapping
 from great_expectations.rule_based_profiler.types import (
     InferredSemanticDomainType,
     SemanticDomainTypes,
-)
-from great_expectations.rule_based_profiler.types.semantic_type_filter import (
     SemanticTypeFilter,
 )
 from great_expectations.validator.metric_configuration import MetricConfiguration

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -27,6 +27,9 @@ from great_expectations.rule_based_profiler.types import (
     get_parameter_value_by_fully_qualified_parameter_name,
     is_fully_qualified_parameter_name_literal_string_format,
 )
+from great_expectations.rule_based_profiler.types.numeric_range_estimation_result import (
+    NUM_HISTOGRAM_BINS,
+)
 from great_expectations.types import safe_deep_copy
 from great_expectations.validator.metric_configuration import MetricConfiguration
 
@@ -423,7 +426,7 @@ def compute_quantiles(
         axis=0,
     )
     return NumericRangeEstimationResult(
-        estimation_histogram=np.histogram(a=metric_values)[0],
+        estimation_histogram=np.histogram(a=metric_values, bins=NUM_HISTOGRAM_BINS)[0],
         value_range=np.array([lower_quantile, upper_quantile]),
     )
 
@@ -562,7 +565,9 @@ def compute_bootstrap_quantiles_point_estimate(
         )
 
     return NumericRangeEstimationResult(
-        estimation_histogram=np.histogram(a=bootstraps.flatten())[0],
+        estimation_histogram=np.histogram(
+            a=bootstraps.flatten(), bins=NUM_HISTOGRAM_BINS
+        )[0],
         value_range=[
             lower_quantile_bias_corrected_point_estimate,
             upper_quantile_bias_corrected_point_estimate,

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -37,7 +37,7 @@ NP_EPSILON: Union[Number, np.float64] = np.finfo(float).eps
 TEMPORARY_EXPECTATION_SUITE_NAME_PREFIX: str = "tmp"
 TEMPORARY_EXPECTATION_SUITE_NAME_STEM: str = "suite"
 TEMPORARY_EXPECTATION_SUITE_NAME_PATTERN: re.Pattern = re.compile(
-    rf"^{TEMPORARY_EXPECTATION_SUITE_NAME_PREFIX}\..+\.{TEMPORARY_EXPECTATION_SUITE_NAME_STEM}\w{8}"
+    rf"^{TEMPORARY_EXPECTATION_SUITE_NAME_PREFIX}\..+\.{TEMPORARY_EXPECTATION_SUITE_NAME_STEM}\.\w{8}"
 )
 
 
@@ -627,7 +627,7 @@ def get_or_create_expectation_suite(
         if not component_name:
             component_name = "test"
 
-        expectation_suite_name = f"{TEMPORARY_EXPECTATION_SUITE_NAME_PREFIX}.{component_name}.{TEMPORARY_EXPECTATION_SUITE_NAME_STEM}{str(uuid.uuid4())[:8]}"
+        expectation_suite_name = f"{TEMPORARY_EXPECTATION_SUITE_NAME_PREFIX}.{component_name}.{TEMPORARY_EXPECTATION_SUITE_NAME_STEM}.{str(uuid.uuid4())[:8]}"
 
     if create_expectation_suite:
         try:

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -490,15 +490,16 @@ def compute_bootstrap_quantiles_point_estimate(
     sample_lower_quantile: np.ndarray = np.quantile(metric_values, q=lower_quantile_pct)
     sample_upper_quantile: np.ndarray = np.quantile(metric_values, q=upper_quantile_pct)
 
+    bootstraps: np.ndarray
     if random_seed:
         random_state: np.random.Generator = np.random.Generator(
             np.random.PCG64(random_seed)
         )
-        bootstraps: np.ndarray = random_state.choice(
+        bootstraps = random_state.choice(
             metric_values, size=(n_resamples, metric_values.size)
         )
     else:
-        bootstraps: np.ndarray = np.random.choice(
+        bootstraps = np.random.choice(
             metric_values, size=(n_resamples, metric_values.size)
         )
 

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -413,7 +413,7 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
             )  # appends "[0]" element
             metric_value_range_max_idx = metric_value_idx + (
                 slice(1, 2, None),
-            )  # appends "[0]" element
+            )  # appends "[1]" element
 
             # Store computed min and max value estimates into allocated range estimate for multi-dimensional metric.
             metric_value_range[metric_value_range_min_idx] = round(

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -235,7 +235,7 @@ A false_positive_rate of {NP_EPSILON} has been selected instead."""
                 f"""You have chosen a false_positive_rate of {false_positive_rate}, which is too close to 1.
 A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
             )
-            false_positive_rate = 1.0 - NP_EPSILON
+            false_positive_rate = np.float64(1.0 - NP_EPSILON)
 
         # Compute metric value for each Batch object.
         super().build_parameters(

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -1,7 +1,7 @@
 import itertools
 import warnings
 from numbers import Number
-from typing import Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 
@@ -23,6 +23,7 @@ from great_expectations.rule_based_profiler.types import (
     FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY,
     FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY,
     Domain,
+    NumericRangeEstimationResult,
     ParameterContainer,
     ParameterNode,
 )
@@ -296,21 +297,29 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
                 "false_positive_rate": false_positive_rate,
             }
 
-        metric_value_range: np.ndarray = self._estimate_metric_value_range(
-            metric_values=metric_values,
-            estimator_func=estimator_func,
-            domain=domain,
-            variables=variables,
-            parameters=parameters,
-            **estimator_kwargs,
+        numeric_range_estimation_result: NumericRangeEstimationResult = (
+            self._estimate_metric_value_range(
+                metric_values=metric_values,
+                estimator_func=estimator_func,
+                domain=domain,
+                variables=variables,
+                parameters=parameters,
+                **estimator_kwargs,
+            )
+        )
+
+        value_range: np.ndarray = numeric_range_estimation_result.value_range
+        details: Dict[str, Any] = dict(
+            **parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY],
+            **{
+                "estimation_histogram": numeric_range_estimation_result.estimation_histogram,
+            },
         )
 
         return Attributes(
             {
-                FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY: metric_value_range,
-                FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY: parameter_node[
-                    FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY
-                ],
+                FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY: value_range,
+                FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY: details,
             }
         )
 
@@ -322,7 +331,7 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
         **kwargs,
-    ) -> np.ndarray:
+    ) -> NumericRangeEstimationResult:
         """
         This method accepts an estimator Callable and data samples in the format "N x R^m", where "N" (most significant
         dimension) is the number of measurements (e.g., one per Batch of data), while "R^m" is the multi-dimensional
@@ -349,9 +358,6 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
         min_value: Number
         max_value: Number
 
-        lower_quantile: Number
-        upper_quantile: Number
-
         # Outer-most dimension is data samples (e.g., one per Batch); the rest are dimensions of the actual metric.
         metric_value_shape: tuple = metric_values.shape[1:]
 
@@ -371,24 +377,34 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
             for metric_value_idx in metric_value_indices
         ]
 
+        # Initialize value range estimate for multi-dimensional metric to all trivial values (to be updated in situ).
         # Since range includes min and max values, value range estimate contains 2-element least-significant dimension.
         metric_value_range_shape: tuple = metric_value_shape + (2,)
-        # Initialize value range estimate for multi-dimensional metric to all trivial values (to be updated in situ).
         metric_value_range: np.ndarray = np.zeros(shape=metric_value_range_shape)
+        # Initialize observed_values for multi-dimensional metric to all trivial values (to be updated in situ).
+        # Since "numpy.histogram()" uses 10 bins by default, histogram contains 10-element least-significant dimension.
+        estimation_histogram_shape: tuple = metric_value_shape + (10,)
+        estimation_histogram: np.ndarray = np.zeros(shape=estimation_histogram_shape)
 
         metric_value_vector: np.ndarray
         metric_value_range_min_idx: tuple
         metric_value_range_max_idx: tuple
+        numeric_range_estimation_result: NumericRangeEstimationResult
         # Traverse indices of sample vectors corresponding to every element of multi-dimensional metric.
         for metric_value_idx in metric_value_vector_indices:
             # Obtain "N"-element-long vector of samples for each element of multi-dimensional metric.
             metric_value_vector = metric_values[metric_value_idx]
             if np.all(np.isclose(metric_value_vector, metric_value_vector[0])):
                 # Computation is unnecessary if distribution is degenerate.
-                lower_quantile = upper_quantile = metric_value_vector[0]
+                numeric_range_estimation_result = NumericRangeEstimationResult(
+                    estimation_histogram=np.histogram(a=metric_value_vector)[0],
+                    value_range=np.array(
+                        [metric_value_vector[0], metric_value_vector[0]]
+                    ),
+                )
             else:
                 # Compute low and high estimates for vector of samples for given element of multi-dimensional metric.
-                lower_quantile, upper_quantile = estimator_func(
+                numeric_range_estimation_result = estimator_func(
                     metric_values=metric_value_vector,
                     domain=domain,
                     variables=variables,
@@ -396,11 +412,11 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
                     **kwargs,
                 )
 
-            min_value = lower_quantile
+            min_value = numeric_range_estimation_result.value_range[0]
             if lower_bound is not None:
                 min_value = max(cast(float, min_value), lower_bound)
 
-            max_value = upper_quantile
+            max_value = numeric_range_estimation_result.value_range[1]
             if upper_bound is not None:
                 max_value = min(cast(float, max_value), upper_bound)
 
@@ -415,6 +431,10 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
                 slice(1, 2, None),
             )  # appends "[1]" element
 
+            # Store computed estimation_histogram into allocated range estimate for multi-dimensional metric.
+            estimation_histogram[
+                metric_value_idx
+            ] = numeric_range_estimation_result.estimation_histogram
             # Store computed min and max value estimates into allocated range estimate for multi-dimensional metric.
             metric_value_range[metric_value_range_min_idx] = round(
                 cast(float, min_value), round_decimals
@@ -425,12 +445,16 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
 
         # As a simplification, apply reduction to scalar in case of one-dimensional metric (for convenience).
         if metric_value_range.shape[0] == 1:
+            estimation_histogram = estimation_histogram[0]
             metric_value_range = metric_value_range[0]
 
         if round_decimals == 0:
             metric_value_range = metric_value_range.astype(np.int64)
 
-        return metric_value_range
+        return NumericRangeEstimationResult(
+            estimation_histogram=estimation_histogram,
+            value_range=metric_value_range,
+        )
 
     def _get_truncate_values_using_heuristics(
         self,
@@ -518,7 +542,7 @@ positive integer, or must be omitted (or set to None).
         variables: Optional[ParameterContainer] = None,
         parameters: Optional[Dict[str, ParameterContainer]] = None,
         **kwargs,
-    ) -> Tuple[Number, Number]:
+    ) -> NumericRangeEstimationResult:
         false_positive_rate: np.float64 = kwargs.get("false_positive_rate", 5.0e-2)
 
         # Obtain num_bootstrap_samples override from "rule state" (i.e., variables and parameters); from instance variable otherwise.
@@ -558,7 +582,7 @@ positive integer, or must be omitted (or set to None).
     def _get_deterministic_estimate(
         metric_values: np.ndarray,
         **kwargs,
-    ) -> Tuple[Number, Number]:
+    ) -> NumericRangeEstimationResult:
         false_positive_rate: np.float64 = kwargs.get("false_positive_rate", 5.0e-2)
 
         return compute_quantiles(

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -27,6 +27,9 @@ from great_expectations.rule_based_profiler.types import (
     ParameterContainer,
     ParameterNode,
 )
+from great_expectations.rule_based_profiler.types.numeric_range_estimation_result import (
+    NUM_HISTOGRAM_BINS,
+)
 from great_expectations.types.attributes import Attributes
 from great_expectations.util import is_numeric
 
@@ -397,7 +400,9 @@ A false_positive_rate of {1.0-NP_EPSILON} has been selected instead."""
             if np.all(np.isclose(metric_value_vector, metric_value_vector[0])):
                 # Computation is unnecessary if distribution is degenerate.
                 numeric_range_estimation_result = NumericRangeEstimationResult(
-                    estimation_histogram=np.histogram(a=metric_value_vector)[0],
+                    estimation_histogram=np.histogram(
+                        a=metric_value_vector, bins=NUM_HISTOGRAM_BINS
+                    )[0],
                     value_range=np.array(
                         [metric_value_vector[0], metric_value_vector[0]]
                     ),

--- a/great_expectations/rule_based_profiler/types/__init__.py
+++ b/great_expectations/rule_based_profiler/types/__init__.py
@@ -5,6 +5,8 @@ from .domain import (  # isort:skip
     SemanticDomainTypes,
     InferredSemanticDomainType,
 )
+from .semantic_type_filter import SemanticTypeFilter  # isort:skip
+from .numeric_range_estimation_result import NumericRangeEstimationResult  # isort:skip
 from .parameter_container import (  # isort:skip
     DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
     FULLY_QUALIFIED_PARAMETER_NAME_DELIMITER_CHARACTER,

--- a/great_expectations/rule_based_profiler/types/numeric_range_estimation_result.py
+++ b/great_expectations/rule_based_profiler/types/numeric_range_estimation_result.py
@@ -1,0 +1,22 @@
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+from great_expectations.types import DictDot
+
+NUM_HISTOGRAM_BINS: int = 10  # Equal to "numpy.histogram()" default (can be turned into configurable argument).
+
+
+@dataclass(frozen=True)
+class NumericRangeEstimationResult(DictDot):
+    """
+    NumericRangeEstimationResult is a "dataclass" object, designed to hold results of executing numeric range estimator
+    for multidimensional datasets, which consist of "estimation_histogram" and "value_range" for each numeric dimension.
+    """
+
+    estimation_histogram: np.ndarray
+    value_range: np.ndarray
+
+    def to_dict(self) -> dict:
+        """Returns: this NumericRangeEstimationResult as a dictionary"""
+        return asdict(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2400,7 +2400,7 @@ def profiler_config_with_placeholder_args(
                         "my_arg": "$parameter.my_parameter.value[0]",
                         "my_other_arg": "$parameter.my_parameter.value[1]",
                         "meta": {
-                            "details": {
+                            "profiler_details": {
                                 "my_parameter_estimator": "$parameter.my_parameter.details",
                                 "note": "Important remarks about estimation algorithm.",
                             },
@@ -2678,23 +2678,21 @@ def alice_columnar_table_single_batch(empty_data_context):
                     expectation_type="expect_column_values_to_match_strftime_format",
                     kwargs={
                         "column": column_data["column_name"],
-                        "strftime_format": {
-                            "value": event_ts_column_data[
-                                "observed_strftime_format"
-                            ],  # Pin to event_ts column
-                            "details": {
-                                "success_ratio": 1.0,
-                                "candidate_strings": expected_candidate_strings_dict,
-                            },
-                        },
+                        "strftime_format": event_ts_column_data[
+                            "observed_strftime_format"
+                        ],  # Pin to event_ts column
                     },
                     meta={
+                        "profiler_details": {
+                            "success_ratio": 1.0,
+                            "candidate_strings": expected_candidate_strings_dict,
+                        },
                         "notes": {
                             "format": "markdown",
                             "content": [
                                 "### This expectation confirms that fields ending in _ts are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                             ],
-                        }
+                        },
                     },
                 ),
             ]
@@ -3030,17 +3028,18 @@ def alice_columnar_table_single_batch(empty_data_context):
                     {
                         "column": "$domain.domain_kwargs.column",
                         "meta": {
+                            "profiler_details": "$parameter.my_date_format.details",
                             "notes": {
                                 "format": "markdown",
                                 "content": [
                                     "### This expectation confirms that fields ending in _ts are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                                 ],
-                            }
+                            },
                         },
                         "expectation_type": "expect_column_values_to_match_strftime_format",
                         "condition": None,
                         "class_name": "DefaultExpectationConfigurationBuilder",
-                        "strftime_format": "$parameter.my_date_format",
+                        "strftime_format": "$parameter.my_date_format.value",
                         "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder.default_expectation_configuration_builder",
                         "validation_parameter_builder_configs": None,
                     },
@@ -3924,7 +3923,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                 },
                 "expectation_type": "expect_column_values_to_match_strftime_format",
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "success_ratio": 1.0,
                         "candidate_strings": {
                             "%Y-%m-%d %H:%M:%S": 1.0,
@@ -3948,7 +3947,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                 },
                 "expectation_type": "expect_column_values_to_match_strftime_format",
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "success_ratio": 1.0,
                         "candidate_strings": {
                             "%Y-%m-%d %H:%M:%S": 1.0,
@@ -3977,7 +3976,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     "strftime_format": "%Y-%m-%d %H:%M:%S",
                 },
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "success_ratio": 1.0,
                         "candidate_strings": {
                             "%Y-%m-%d %H:%M:%S": 1.0,
@@ -4001,7 +4000,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     "strftime_format": "%Y-%m-%d %H:%M:%S",
                 },
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "success_ratio": 1.0,
                         "candidate_strings": {
                             "%Y-%m-%d %H:%M:%S": 1.0,
@@ -4030,7 +4029,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     "regex": r"^\d{1}$",
                 },
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "evaluated_regexes": {r"^\d{1}$": 1.0, r"^\d{2}$": 0.0},
                         "success_ratio": 1.0,
                     },
@@ -4051,7 +4050,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     "regex": r"^\d{1}$",
                 },
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "evaluated_regexes": {r"^\d{1}$": 1.0, r"^\d{2}$": 0.0},
                         "success_ratio": 1.0,
                     },
@@ -4072,7 +4071,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     "regex": r"^\d{1}$",
                 },
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "evaluated_regexes": {r"^\d{1}$": 1.0, r"^\d{2}$": 0.0},
                         "success_ratio": 1.0,
                     },
@@ -4093,7 +4092,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     "regex": r"^\d{1}$",
                 },
                 "meta": {
-                    "details": {
+                    "profiler_details": {
                         "evaluated_regexes": {r"^\d{1}$": 1.0, r"^\d{2}$": 0.0},
                         "success_ratio": 1.0,
                     },
@@ -4329,7 +4328,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     {
                         "column": "$domain.domain_kwargs.column",
                         "meta": {
-                            "details": "$parameter.my_date_format.details",
+                            "profiler_details": "$parameter.my_date_format.details",
                             "notes": {
                                 "format": "markdown",
                                 "content": [
@@ -4377,7 +4376,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                     {
                         "column": "$domain.domain_kwargs.column",
                         "meta": {
-                            "details": "$parameter.my_regex.details",
+                            "profiler_details": "$parameter.my_regex.details",
                             "notes": {
                                 "format": "markdown",
                                 "content": [

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
@@ -12,7 +12,11 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
 from great_expectations import DataContext
-from great_expectations.core import ExpectationSuite, ExpectationValidationResult
+from great_expectations.core import (
+    ExpectationConfiguration,
+    ExpectationSuite,
+    ExpectationValidationResult,
+)
 from great_expectations.core.batch import BatchRequest
 from great_expectations.datasource import DataConnector, Datasource
 from great_expectations.expectations.registry import get_expectation_impl
@@ -132,6 +136,13 @@ def test_alice_profiler_user_workflow_single_batch(
         ],
         include_citation=True,
     )
+
+    expectation_configuration: ExpectationConfiguration
+    for expectation_configuration in expectation_suite.expectations:
+        if "profiler_details" in expectation_configuration.meta:
+            expectation_configuration.meta["profiler_details"].pop(
+                "estimation_histogram", None
+            )
 
     assert (
         expectation_suite.expectations
@@ -421,6 +432,13 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
     fixture_expectation_suite: ExpectationSuite = bobby_columnar_table_multi_batch[
         "test_configuration_oneshot_estimator"
     ]["expected_expectation_suite"]
+
+    expectation_configuration: ExpectationConfiguration
+    for expectation_configuration in profiled_expectation_suite.expectations:
+        if "profiler_details" in expectation_configuration.meta:
+            expectation_configuration.meta["profiler_details"].pop(
+                "estimation_histogram", None
+            )
 
     assert (
         profiled_expectation_suite.expectations

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -2504,6 +2504,16 @@ def test_get_metrics_and_expectations_using_explicit_instantiation(
     )
 
     assert data_assistant_result.metrics_by_domain == quentin_expected_metrics_by_domain
+
+    expectation_configuration: ExpectationConfiguration
+    for (
+        expectation_configuration
+    ) in data_assistant_result.expectation_suite.expectations:
+        if "profiler_details" in expectation_configuration.meta:
+            expectation_configuration.meta["profiler_details"].pop(
+                "estimation_histogram", None
+            )
+
     assert (
         data_assistant_result.expectation_suite.expectations
         == expected_expectation_suite.expectations
@@ -2561,6 +2571,16 @@ def test_get_metrics_and_expectations_using_implicit_invocation(
     )
 
     assert data_assistant_result.metrics_by_domain == quentin_expected_metrics_by_domain
+
+    expectation_configuration: ExpectationConfiguration
+    for (
+        expectation_configuration
+    ) in data_assistant_result.expectation_suite.expectations:
+        if "profiler_details" in expectation_configuration.meta:
+            expectation_configuration.meta["profiler_details"].pop(
+                "estimation_histogram", None
+            )
+
     assert (
         data_assistant_result.expectation_suite.expectations
         == expected_expectation_suite.expectations

--- a/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional
 
 import numpy as np
 import pytest
+import scipy.stats as stats
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.data_context import DataContext
@@ -39,6 +40,7 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby(
         estimator="bootstrap",
         false_positive_rate=1.0e-2,
         round_decimals=0,
+        json_serialize=False,
         data_context=data_context,
     )
 
@@ -80,18 +82,24 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby(
         },
     }
 
-    actual_value_dict: dict = get_parameter_value_by_fully_qualified_parameter_name(
-        fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
-        domain=domain,
-        parameters=parameters,
+    actual_value_parameter_node: ParameterNode = (
+        get_parameter_value_by_fully_qualified_parameter_name(
+            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            domain=domain,
+            parameters=parameters,
+        )
     )
 
-    actual_value = actual_value_dict.pop("value")
-    actual_value_dict["value"] = None
+    actual_value: np.ndarray = actual_value_parameter_node.pop("value")
+    actual_value_parameter_node["value"] = None
 
-    assert actual_value_dict == expected_value_dict
+    actual_estimation_histogram: np.ndarray = actual_value_parameter_node.details.pop(
+        "estimation_histogram"
+    )
 
-    expected_value = np.array([7510, 8806])
+    assert actual_value_parameter_node == expected_value_dict
+
+    expected_value: np.ndarray = np.array([7510, 8806])
 
     # Measure of "closeness" between "actual" and "desired" is computed as: atol + rtol * abs(desired)
     # (see "https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_allclose.html" for details).
@@ -106,6 +114,28 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby(
         atol=atol,
         err_msg=f"Actual value of {actual_value} differs from expected value of {expected_value} by more than {atol + rtol * abs(expected_value)} tolerance.",
     )
+
+    expected_estimation_histogram: np.ndarray = np.array(
+        [
+            10100.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            9889.0,
+            0.0,
+            0.0,
+            10008.0,
+        ]
+    )
+
+    # Assert no significant difference between expected (null hypothesis) and actual estimation histograms.
+    ks_result: tuple = stats.ks_2samp(
+        data1=actual_estimation_histogram, data2=expected_estimation_histogram
+    )
+    p_value: float = ks_result[1]
+    assert p_value > 9.5e-1
 
 
 def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
@@ -135,6 +165,7 @@ def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
         estimator="oneshot",
         false_positive_rate=1.0e-2,
         round_decimals=1,
+        json_serialize=False,
         data_context=data_context,
     )
 
@@ -176,16 +207,22 @@ def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
         },
     }
 
-    actual_value_dict = get_parameter_value_by_fully_qualified_parameter_name(
-        fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
-        domain=domain,
-        parameters=parameters,
+    actual_value_parameter_node: ParameterNode = (
+        get_parameter_value_by_fully_qualified_parameter_name(
+            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            domain=domain,
+            parameters=parameters,
+        )
     )
 
-    actual_values_01 = actual_value_dict.pop("value")
-    actual_value_dict["value"] = None
+    actual_values_01: np.ndarray = actual_value_parameter_node.pop("value")
+    actual_value_parameter_node["value"] = None
 
-    assert actual_value_dict == expected_value_dict
+    actual_estimation_histogram: np.ndarray = actual_value_parameter_node.details.pop(
+        "estimation_histogram"
+    )
+
+    assert actual_value_parameter_node == expected_value_dict
 
     actual_value_01_lower: float = actual_values_01[0]
     actual_value_01_upper: float = actual_values_01[1]
@@ -195,6 +232,28 @@ def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
     assert actual_value_01_lower == expected_value_01_lower
     assert actual_value_01_upper == expected_value_01_upper
 
+    expected_estimation_histogram: np.ndarray = np.array(
+        [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+        ]
+    )
+
+    # Assert no significant difference between expected (null hypothesis) and actual estimation histograms.
+    ks_result: tuple = stats.ks_2samp(
+        data1=actual_estimation_histogram, data2=expected_estimation_histogram
+    )
+    p_value: float = ks_result[1]
+    assert p_value > 9.5e-1
+
     numeric_metric_range_parameter_builder = (
         NumericMetricRangeMultiBatchParameterBuilder(
             name="column_min_range",
@@ -203,6 +262,7 @@ def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
             estimator="oneshot",
             false_positive_rate=5.0e-2,
             round_decimals=1,
+            json_serialize=False,
             data_context=data_context,
         )
     )
@@ -215,16 +275,22 @@ def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
         batch_request=batch_request,
     )
 
-    actual_value_dict = get_parameter_value_by_fully_qualified_parameter_name(
-        fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
-        domain=domain,
-        parameters=parameters,
+    actual_value_parameter_node: ParameterNode = (
+        get_parameter_value_by_fully_qualified_parameter_name(
+            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            domain=domain,
+            parameters=parameters,
+        )
     )
 
-    actual_values_05 = actual_value_dict.pop("value")
-    actual_value_dict["value"] = None
+    actual_values_05 = actual_value_parameter_node.pop("value")
+    actual_value_parameter_node["value"] = None
 
-    assert actual_value_dict == expected_value_dict
+    actual_estimation_histogram: np.ndarray = actual_value_parameter_node.details.pop(
+        "estimation_histogram"
+    )
+
+    assert actual_value_parameter_node == expected_value_dict
 
     actual_value_05_lower: float = actual_values_05[0]
     actual_value_05_upper: float = actual_values_05[1]
@@ -237,6 +303,28 @@ def test_oneshot_numeric_metric_range_multi_batch_parameter_builder_bobby(
     # if false positive rate is higher, our range should be more narrow
     assert actual_value_01_lower < actual_value_05_lower
     assert actual_value_01_upper > actual_value_05_upper
+
+    expected_estimation_histogram: np.ndarray = np.array(
+        [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+        ]
+    )
+
+    # Assert no significant difference between expected (null hypothesis) and actual estimation histograms.
+    ks_result: tuple = stats.ks_2samp(
+        data1=actual_estimation_histogram, data2=expected_estimation_histogram
+    )
+    p_value: float = ks_result[1]
+    assert p_value > 9.5e-1
 
 
 def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby_false_positive_rate_one(

--- a/tests/rule_based_profiler/parameter_builder/test_parameter_computations.py
+++ b/tests/rule_based_profiler/parameter_builder/test_parameter_computations.py
@@ -1,6 +1,4 @@
-import math
-from numbers import Number
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Dict, Union
 
 import numpy as np
 import pandas as pd
@@ -13,6 +11,8 @@ from great_expectations.rule_based_profiler.parameter_builder.numeric_metric_ran
 )
 
 # Allowable tolerance for how closely a bootstrap method approximates the sample
+from great_expectations.rule_based_profiler.types import NumericRangeEstimationResult
+
 EFFICACY_TOLERANCE: float = 1.0e-2
 
 # Measure of "closeness" between "actual" and "desired" is computed as: atol + rtol * abs(desired)
@@ -40,18 +40,18 @@ def test_bootstrap_point_estimate_efficacy(
 
     distribution_types: pd.Index = distribution_samples.columns
     distribution: str
+    numeric_range_estimation_result: NumericRangeEstimationResult
     lower_quantile_point_estimate: np.float64
     upper_quantile_point_estimate: np.float64
     actual_false_positive_rates: Dict[str, Union[float, np.float64]] = {}
     for distribution in distribution_types:
-        (
-            lower_quantile_point_estimate,
-            upper_quantile_point_estimate,
-        ) = compute_bootstrap_quantiles_point_estimate(
+        numeric_range_estimation_result = compute_bootstrap_quantiles_point_estimate(
             metric_values=distribution_samples[distribution],
             false_positive_rate=false_positive_rate,
             n_resamples=DEFAULT_BOOTSTRAP_NUM_RESAMPLES,
         )
+        lower_quantile_point_estimate = numeric_range_estimation_result.value_range[0]
+        upper_quantile_point_estimate = numeric_range_estimation_result.value_range[1]
         actual_false_positive_rates[distribution] = (
             1.0
             - np.sum(

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -139,7 +139,7 @@ def test_reconcile_profiler_rules_new_rule_override(
                     "column_B": "$domain.domain_kwargs.column_B",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -152,7 +152,7 @@ def test_reconcile_profiler_rules_new_rule_override(
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -203,7 +203,7 @@ def test_reconcile_profiler_rules_new_rule_override(
                     "column_B": "$domain.domain_kwargs.column_B",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -216,7 +216,7 @@ def test_reconcile_profiler_rules_new_rule_override(
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -252,7 +252,7 @@ def test_reconcile_profiler_rules_new_rule_override(
                     "my_arg": "$parameter.my_parameter.value[0]",
                     "my_other_arg": "$parameter.my_parameter.value[1]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -323,7 +323,7 @@ def test_reconcile_profiler_rules_existing_rule_domain_builder_override(
                     "my_arg": "$parameter.my_parameter.value[0]",
                     "my_other_arg": "$parameter.my_parameter.value[1]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -419,7 +419,7 @@ def test_reconcile_profiler_rules_existing_rule_parameter_builder_overrides(
                     "my_arg": "$parameter.my_parameter.value[0]",
                     "my_other_arg": "$parameter.my_parameter.value[1]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -456,7 +456,7 @@ def test_reconcile_profiler_rules_existing_rule_expectation_configuration_builde
                     "column_B": "$domain.domain_kwargs.column_B",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -469,7 +469,7 @@ def test_reconcile_profiler_rules_existing_rule_expectation_configuration_builde
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -507,7 +507,7 @@ def test_reconcile_profiler_rules_existing_rule_expectation_configuration_builde
                     "column_B": "$domain.domain_kwargs.column_B",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -520,7 +520,7 @@ def test_reconcile_profiler_rules_existing_rule_expectation_configuration_builde
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -578,7 +578,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_nested_update
                     "column_B": "$domain.domain_kwargs.column_B",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -591,7 +591,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_nested_update
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -644,7 +644,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_nested_update
                     "my_other_arg": "$parameter.my_parameter.value[1]",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -657,7 +657,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_nested_update
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -714,7 +714,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_replace(
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -754,7 +754,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_replace(
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -819,7 +819,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_update(
                     "column_B": "$domain.domain_kwargs.column_B",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -832,7 +832,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_update(
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -883,7 +883,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_update(
                     "column_B": "$domain.domain_kwargs.column_B",
                     "my_one_arg": "$parameter.my_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_parameter_estimator": "$parameter.my_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -896,7 +896,7 @@ def test_reconcile_profiler_rules_existing_rule_full_rule_override_update(
                     "column": "$domain.domain_kwargs.column",
                     "my_another_arg": "$parameter.my_other_parameter.value[0]",
                     "meta": {
-                        "details": {
+                        "profiler_details": {
                             "my_other_parameter_estimator": "$parameter.my_other_parameter.details",
                             "note": "Important remarks about estimation algorithm.",
                         },
@@ -1117,7 +1117,7 @@ def test_serialize_profiler_config(
         "my_arg": "$parameter.my_parameter.value[0]",
         "my_other_arg": "$parameter.my_parameter.value[1]",
         "meta": {
-            "details": {
+            "profiler_details": {
                 "my_parameter_estimator": "$parameter.my_parameter.details",
                 "note": "Important remarks about estimation algorithm.",
             },

--- a/tests/test_fixtures/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
+++ b/tests/test_fixtures/rule_based_profiler/alice_user_workflow_verbose_profiler_config.yml
@@ -128,8 +128,9 @@ rules:
         class_name: DefaultExpectationConfigurationBuilder
         module_name: great_expectations.rule_based_profiler.expectation_configuration_builder
         column: $domain.domain_kwargs.column
-        strftime_format: $parameter.my_date_format
+        strftime_format: $parameter.my_date_format.value
         meta:
+          profiler_details: $parameter.my_date_format.details
           notes:
             format: markdown
             content:

--- a/tests/test_fixtures/rule_based_profiler/bobby_user_workflow_verbose_profiler_config.yml
+++ b/tests/test_fixtures/rule_based_profiler/bobby_user_workflow_verbose_profiler_config.yml
@@ -92,7 +92,7 @@ rules:
         column: $domain.domain_kwargs.column
         strftime_format: $parameter.my_date_format.value
         meta:
-          details: $parameter.my_date_format.details
+          profiler_details: $parameter.my_date_format.details
           notes:
             format: markdown
             content:
@@ -121,7 +121,7 @@ rules:
         column: $domain.domain_kwargs.column
         regex: $parameter.my_regex.value
         meta:
-          details: $parameter.my_regex.details
+          profiler_details: $parameter.my_regex.details
           notes:
             format: markdown
             content:


### PR DESCRIPTION
### Scope
* Introduce `NumericRangeEstimationResult` `dataclass` to contain the estimated value range and the histogram of the estimated statistic's samples.  In the case of the `bootstrap` estimator, all `bootstrap` samples are concatenated for computing the histogram, since this represents a correct approximation to the realization of the underlying distribution.
* The estimation histogram (broken into the default of 10 buckets) is added to the profiler details.  The goal of this new detail is to enable a qualitative confirmation that the distribution of statistics is near-normal as per the bootstrap method's inherent assumption (and increase the number of bootstrap re-samples if it falls short of the near-normality).
* Unit tests for the new histogram capability are added, where the actual and expected histograms are compared using the 2-sample Kolmogorov-Smirnoff statistic, whereby the `p-value` has to be above the commonly accepted value of `0.95` in order to confirm that the null hypothesis cannot be rejected (i.e., the distribution behind the actual histogram is statistically close to that behind the expected histogram).
* Unit tests of histogram computation are provided for both `oneshot` and `bootstrap` estimators; however, the histograms are deleted from the `profiler_details` of the `ExpectationConfiguration` `meta` fields for integration testing (since the `ExpectationConfiguration` objects in corresponding fixtures are too numerous to check individually).
* Clean up type hints, fix typos, and insure that `profiler_details` is the key (not `details`) and is used consistently.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-699/GREAT-709
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
