### PR TITLE
[BUGFIX] RBP Profiling Dataset ProgressBar Fix

### DIFF
--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -245,16 +245,6 @@ class BaseRuleBasedProfiler(ConfigPeer):
                 if "rule_based_profiler" in progress_bars:
                     disable = not progress_bars["rule_based_profiler"]
 
-        # noinspection PyProtectedMember,SpellCheckingInspection
-        progress_bar: tqdm = tqdm(
-            desc="Profiling Dataset",
-            disable=disable,
-        )
-        progress_bar.update(0)
-        progress_bar.refresh()
-        sys.stdout.write("\n")
-        sys.stdout.flush()
-
         effective_variables: Optional[
             ParameterContainer
         ] = self.reconcile_profiler_variables(
@@ -278,9 +268,19 @@ class BaseRuleBasedProfiler(ConfigPeer):
             "rules": effective_rules_configs,
         }
 
+        # noinspection PyProtectedMember,SpellCheckingInspection
+        progress_bar: tqdm = tqdm(
+            total=len(effective_rules),
+            desc="Profiling Dataset",
+            disable=disable,
+        )
+        progress_bar.update(0)
+        progress_bar.refresh()
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
         rule_state: RuleState
         rule: Rule
-        domains_count: int = 0
         for rule in effective_rules:
             rule_state = rule.run(
                 variables=effective_variables,
@@ -290,9 +290,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
                 reconciliation_directives=reconciliation_directives,
             )
             self.rule_states.append(rule_state)
-
-            domains_count += len(rule_state.domains)
-            progress_bar.update(domains_count)
+            progress_bar.update(1)
             progress_bar.refresh()
 
         progress_bar.close()


### PR DESCRIPTION
Changes proposed in this pull request:
- ProgressBar now displays the number of Rules being profiled. This was off because we were not instantiating the progress bar with the number `n` (ie. number of items to process). 
- This PR proposes that we instantiate the ProgressBar with number of Rules and increment by 1 as each Rule is processed. 

**Before**
```
Profiling Dataset: 0it [00:00, ?it/s]
Profiling Dataset: 1it [00:00, ?it/s]
Profiling Dataset: 20it [00:00, ?it/s]
```

**After**
```
Profiling Dataset:   0%|          | 0/2 [00:00<?, ?it/s]
Profiling Dataset:  50%|█████     | 1/2 [00:00<?, ?it/s]
Profiling Dataset: 100%|██████████| 2/2 [00:00<?, ?it/s]`
```