### PR TITLE
[MAINTENANCE] Update `autoupdate` GitHub action

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,9 +1,9 @@
 # https://github.com/marketplace/actions/auto-update
 name: autoupdate
 on:
-  pull_request:
-    types:
-      - auto_merge_enabled
+ push:
+   branches:
+     - develop # Whenever the base changes, this action should run
 
 jobs:
   autoupdate:


### PR DESCRIPTION
Changes proposed in this pull request:
- Change trigger to always run whenever the base branch changes (`develop` in this case)
