### PR TITLE
[FEATURE] Notebook for `VolumeDataAssistant` Example

### DIFF
--- a/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
+++ b/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
@@ -50,3 +50,49 @@ def test_run_rbp_notebook(tmp_path):
     os.remove(
         os.path.join(base_dir, "great_expectations/expectations/.ge_store_backend_id")
     )
+
+
+def test_run_data_assistants_notebook(tmp_path):
+    """
+    What does this test and why?
+
+    One of the resources we have for DataAssistants is a Jupyter notebook that explains/shows the components in code.
+
+    This test ensures the codepaths and examples described in the Notebook actually run and pass, nbconvert's
+    `preprocess` function.
+    """
+    base_dir: str = file_relative_path(
+        __file__, "../../../test_fixtures/rule_based_profiler/example_notebooks"
+    )
+    notebook_path: str = os.path.join(
+        base_dir, "DataAssistants_Instantiation_And_Running.ipynb"
+    )
+    # temporary output notebook for traceback and debugging
+    output_notebook_path: str = os.path.join(
+        tmp_path, "DataAssistants_Instantiation_and_running_executed.ipynb"
+    )
+
+    with open(notebook_path) as f:
+        nb = nbformat.read(f, as_version=4)
+
+    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+
+    try:
+        ep.preprocess(nb, {"metadata": {"path": base_dir}})
+    except CellExecutionError:
+        msg = 'Error executing the notebook "%s".\n\n' % notebook_path
+        msg += 'See notebook "%s" for the traceback.' % output_notebook_path
+        print(msg)
+        raise
+    finally:
+        with open(output_notebook_path, mode="w", encoding="utf-8") as f:
+            nbformat.write(nb, f)
+
+    # clean up Expectations directory after running test
+    shutil.rmtree(os.path.join(base_dir, "great_expectations/expectations/tmp"))
+    os.remove(
+        os.path.join(base_dir, "great_expectations/expectations/.ge_store_backend_id")
+    )
+    os.remove(
+        os.path.join(base_dir, "great_expectations/expectations/taxi_data_suite.json")
+    )

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running.ipynb
@@ -1,0 +1,1881 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "834eb3b0",
+   "metadata": {},
+   "source": [
+    "# How to use `DataAssistants`\n",
+    "\n",
+    "* A `DataAssistant` enables you to quickly profile your data by providing a thin API over a pre-constructed `RuleBasedProfiler` configuration.\n",
+    "* As a result of the profiling, you get back a result object consisting of \n",
+    "    * `Metrics` that describe the current state of the data\n",
+    "    * `Expectations` that are able to alert you if the data deviates from the expected state in the future. \n",
+    "    \n",
+    "* `DataAssistant` results can also be plotted to help you understand their data visually.\n",
+    "* There are multiple `DataAssistants` centered around a theme (volume, nullity etc), and this notebook walks you through an example `VolumeDataAssistant` to show the capabilities and potential of this new interface."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "887b9281",
+   "metadata": {},
+   "source": [
+    "### What is a `VolumeDataAssistant`?\n",
+    "* The `VolumeDataAssistant` allows you to automatically build a set of Expectations that alerts you if the volume of records significantly deviates from the norm. \n",
+    "\n",
+    "More specfically, the `VolumeDataAssistant` profiles the data and outputs an `ExpectationSuite` containing 2 `Expecation` types \n",
+    "\n",
+    "* `expect_table_row_count_to_be_between`\n",
+    "* `expect_column_unique_value_count_to_be_between`\n",
+    "\n",
+    "with automatically selected values for upper and lower bound. The ranges are selected using a bootstrapping step on the sample `Batches`. This allows the `DataAssistant` to account for outliers, allowing it to obtain a more accurate estimate of the true ranges by taking into account the underlying distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8362d4be",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/snowflake/connector/options.py:94: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<3.1.0,>=3.0.0; extra == \"pandas\"'\n",
+      "  warn_incompatible_dep(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import great_expectations as ge\n",
+    "from great_expectations.core.yaml_handler import YAMLHandler\n",
+    "from great_expectations.core.batch import BatchRequest\n",
+    "from great_expectations.core import ExpectationSuite\n",
+    "from great_expectations.validator.validator import Validator\n",
+    "from great_expectations.rule_based_profiler.data_assistant import (\n",
+    "    DataAssistant,\n",
+    "    VolumeDataAssistant,\n",
+    ")\n",
+    "from great_expectations.rule_based_profiler.types.data_assistant_result import (\n",
+    "    DataAssistantResult,\n",
+    ")\n",
+    "yaml = YAMLHandler()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247a6073",
+   "metadata": {},
+   "source": [
+    "## Set-up: Adding `taxi_data` `Datasource`\n",
+    "* Add `taxi_data` as a new `Datasource`\n",
+    "* We are using an `InferredAssetFilesystemDataConnector` to connect to data in the `test_sets/taxi_yellow_tripdata_samples` folder and get one `DataAsset` (`yellow_tripdata_sample`) that has 36 Batches, corresponding to one batch per month from 2018-2020."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "76dcee57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context: ge.DataContext = ge.get_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a29fd9a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: PandasExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tinferred_data_connector_all_years : InferredAssetFilesystemDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (1 of 1):\n",
+      "\t\tyellow_tripdata_sample (3 of 36): ['yellow_tripdata_sample_2018-01.csv', 'yellow_tripdata_sample_2018-02.csv', 'yellow_tripdata_sample_2018-03.csv']\n",
+      "\n",
+      "\tUnmatched data_references (3 of 6):['.DS_Store', 'first_3_files', 'random_subsamples']\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7fe7ab3a5a00>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_path: str = \"../../../../test_sets/taxi_yellow_tripdata_samples\"\n",
+    "\n",
+    "datasource_config: dict = {\n",
+    "    \"name\": \"taxi_data_all_years\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"PandasExecutionEngine\",\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"inferred_data_connector_all_years\": {\n",
+    "            \"class_name\": \"InferredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"default_regex\": {\n",
+    "                \"group_names\": [\"data_asset_name\", \"year\", \"month\"],\n",
+    "                \"pattern\": \"(yellow_tripdata_sample)_(2018|2019|2020)-(\\\\d.*)\\\\.csv\",\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ee0be5a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_datasource only if it doesn't already exist in our configuration\n",
+    "try:\n",
+    "    data_context.get_datasource(datasource_config[\"name\"])\n",
+    "except ValueError:\n",
+    "    data_context.add_datasource(**datasource_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d86080dc",
+   "metadata": {},
+   "source": [
+    "#  Configure `BatchRequest`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f78301ee",
+   "metadata": {},
+   "source": [
+    "In this example, we will be using a `BatchRequest` that will return all 36 batches of data from the `taxi_data` dataset.  We will refer to the `Datasource` and `DataConnector` configured in the previous step. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b790e8b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_all_years_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_data_all_years\",\n",
+    "    data_connector_name=\"inferred_data_connector_all_years\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dbbad0b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_request: BatchRequest = multi_batch_all_years_batch_request"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46a680cd",
+   "metadata": {},
+   "source": [
+    "# Run the `VolumeDataAssistant`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "202ff1e0",
+   "metadata": {},
+   "source": [
+    "* The `VolumeDataAssistant` can be run directly from the `DataContext` by specifying `assistants` and `volume`, and passing in the `BatchRequest` from the previous step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d4e27237",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created ExpectationSuite \"tmp.volume_data_assistant.suite.2f416de9\".\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3458b7d8db1b43358cd536bc35593c18",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f9d733e97e9549caa77cbb563c334d27",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/36 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5cb950f781d2448b839baa348b4f9e81",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/36 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1d3f6864c01a4fc79d3a3f81b8369262",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0ec4262c1a0841c6a1d537abc809e74e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d9a368f753ee43e4aa85f93a83dfdb74",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f412463be3074e94a7a52a8dd126e998",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:554: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  sample_lower_quantile: np.ndarray = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:559: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  sample_upper_quantile: np.ndarray = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:578: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  bootstrap_lower_quantiles: Union[np.ndarray, Number] = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:595: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "  if bootstrap_lower_quantile_bias / bootstrap_lower_quantile_standard_error <= 0.25:\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:604: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  bootstrap_upper_quantiles: Union[np.ndarray, Number] = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:625: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "  if bootstrap_upper_quantile_bias / bootstrap_upper_quantile_standard_error <= 0.25:\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "375441a78a644f9782247a40e9d682d0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2c25c4f5f532476799f785178f0e080b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "08002363918e4f65957afc4f21c2aa56",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "510440bf478c47ceb71722e7276d6cb8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c9141fc7065340eeb49f0f04eabc0b2c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "309d88afedcc45ad8cfb6986842f322d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "84c172b58777457daac859fc806c2e25",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2483485391924d5d8f5d7a29d2e7c29c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dc3e78a96ebd4b9597650babb80e3573",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ef5b03e87af74ed18dbbec83232dbdfc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "238a8f679b8b417f98d0967c163577fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c3a1322e451c49818d939fb97f158398",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "359881bd4ff0460a8d963580951ec507",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "23e8408f23ca45deb74c0c490242f625",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5512ce10507d4d16a00b10bfbd1db714",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2ca21e58bee940429c63255cc62e7ff9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "54759eb6b71c4c00a07902943ca5ade8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f7e0355518d2449d9ea188e38bb8645f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "97d3d217997b45f6982b44b9ea9e0789",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eb6e204c850e4a19bdd52318cc7543c4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0fe3836ffe294f988fdb4876b2607152",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9eb55e5c06074b119ec63efd692ec9f4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b53e3e7052ff4123bb37eb4b63ec253a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ce8832bf5b794cca86181d8f1f0a7ac7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9242004e5d374072925d7641a33d6657",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "971b599058cd4ceebf63b28b170d81fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4dc2cc860824157b7525e3ecb4fbff2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a06d06bbfce4680a23f58ab9c6d019d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f19e97e583e648f6a35f2499094c354f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9fcf75ac55ed4875bd56ea3ecdc57c0b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1f851cd20ab0414a9abc89bf4692dcea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fbaf94729f594bac9d0bc261820fdf94",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3d1625b85b734ed8890b0b6a1268bcf7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1267841265264a9d93e16341c33de55b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created ExpectationSuite \"tmp.test.suite.9353a6f0\".\n"
+     ]
+    }
+   ],
+   "source": [
+    "result: DataAssistantResult = data_context.assistants.volume.run(batch_request=batch_request)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62b790ad",
+   "metadata": {},
+   "source": [
+    "You will see that the `DataAssistant` created a temporary `ExpectationSuite`, which is part of the `DataAssistantResult`. The `run()` method is also able to take in the following optional parameters:\n",
+    "\n",
+    "* `expectation_suite`: An existing \"ExpectationSuite\" to update.\n",
+    "* `expectation_suite_name`: A name for returned \"ExpectationSuite\". \n",
+    "* `include_citation`: Flag that controls whether or not to effective `RuleBasedProfiler` configuration should be included as a citation in metadata of the `ExpectationSuite` that is part of the `DataAssistantResult`. \n",
+    "* `save_updated_expectation_suite`: Flag that controlls whether or not the updated `ExpectationSuite` will be saved"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "972022c5",
+   "metadata": {},
+   "source": [
+    "Although the `DataAssistant` will automatically create a temporary `ExpectationSuite` when running the profiling, we do recommend that you recommend an `expectation_suite_name` (which is `taxi_data_suite` in our case) so that the results can be more easily saved later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "99616f6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "625bd4c9815e48d9bd7ff47c596f8b6c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "09576321387e44268760e3aee1b671a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/36 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04d66219cd254e72aaf3838ef4b6eea7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/36 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "367456ba07d84ed1a4526e45a3c22cbf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f3d5f45ed5eb4ddfb7d06cf79ca91193",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c97f7d4f3b8c4730aa3a34049a1777f5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e6b17420cfe424481b98a0cf05e93d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:554: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  sample_lower_quantile: np.ndarray = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:559: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  sample_upper_quantile: np.ndarray = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:578: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  bootstrap_lower_quantiles: Union[np.ndarray, Number] = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:595: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "  if bootstrap_lower_quantile_bias / bootstrap_lower_quantile_standard_error <= 0.25:\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:604: DeprecationWarning: the `interpolation=` argument to quantile was renamed to `method=`, which has additional options.\n",
+      "Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)\n",
+      "  bootstrap_upper_quantiles: Union[np.ndarray, Number] = np.quantile(\n",
+      "/Users/work/Development/great_expectations/great_expectations/rule_based_profiler/helpers/util.py:625: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "  if bootstrap_upper_quantile_bias / bootstrap_upper_quantile_standard_error <= 0.25:\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "53cf77cb9d084599aab333fcc9b657e1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "247f8c7f93ed44eba5ed220003824e2f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e020e2f28bbf45d09d6f4950b52a916e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e57a5858488b4615b2ed6056bc3a2103",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fba19ad86da84509bf80ba389c0fad0e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4fa10844fbb424eb8ffa402b7dbd619",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6a052b9f479445bfa864d838af8c7265",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "999ca78b337248d783d8cb2f74107bd0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd0af11d04c74419819bda8fd744d2ef",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f56e259d8d9542c985323fe58271e720",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "43e8696df24d466eb68953c382299fff",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e27413d63c94c18ac8651d47b78ae03",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9bb1d970ee08415bb813e3eded88e54b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c8b523133d31405e96ea752446b42347",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cd93467269b2473399d529605511788e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2553331fbd3e4b1fb09c1173159f4fc7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0749a1524b904bc4bb7a9aa963e827c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6105fa02851f4226a1510b1b60f175b7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d4ead101e95452bb64916461676b549",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7d1e97d1f9a5457b8f5447edf589d309",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "188dc338a3444b06b18c9ead57509cec",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b1edd13638e743fd90dbbd143d78b798",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "773b001150b44c4b9ea00e0ac1742d75",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "957f884d95bf4c5c882470f4e10e8561",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2dd41e0f25cc4cb997bc6b10575a7b5f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5a4fc437400648ccba42a2dc4290f42d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "64c0d91a369f43e3a4873be18085e215",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7824580ac8f34e6dab5061c70e0e30f4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a65c43c8d7f847d7b90261bbbc368e90",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "966f61e847c9405796da34d241105c5b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4d9a16c7cffc44098da37cb21d796738",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3755e7d3174d4cb9a5c36bdd5eb02782",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e89b4addf6a342c78df40dd29fffe1f3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7b975373dfc74bf5ad364f42c44e68cb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/144 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "result: DataAssistantResult = data_context.assistants.volume.run(batch_request=batch_request, expectation_suite_name=\"taxi_data_suite\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ee95efb",
+   "metadata": {},
+   "source": [
+    "# Explore `DataAssistantResult` by plotting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01a20546",
+   "metadata": {},
+   "source": [
+    "The resulting `DataAssistantResult` can be best explored by plotting. For each `Domain` considered (`Table` and `Column` in our case), the plots will display the value for each `Batch` (36 in total). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "822d8fe4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-6c251356572b4953874776cdbfc90fb3\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
+       "  (function(spec, embedOpt){\n",
+       "    let outputDiv = document.currentScript.previousElementSibling;\n",
+       "    if (outputDiv.id !== \"altair-viz-6c251356572b4953874776cdbfc90fb3\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-6c251356572b4953874776cdbfc90fb3\");\n",
+       "    }\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.17.0?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function maybeLoadScript(lib, version) {\n",
+       "      var key = `${lib.replace(\"-\", \"\")}_version`;\n",
+       "      return (VEGA_DEBUG[key] == version) ?\n",
+       "        Promise.resolve(paths[lib]) :\n",
+       "        new Promise(function(resolve, reject) {\n",
+       "          var s = document.createElement('script');\n",
+       "          document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "          s.async = true;\n",
+       "          s.onload = () => {\n",
+       "            VEGA_DEBUG[key] = version;\n",
+       "            return resolve(paths[lib]);\n",
+       "          };\n",
+       "          s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "          s.src = paths[lib];\n",
+       "        });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else {\n",
+       "      maybeLoadScript(\"vega\", \"5\")\n",
+       "        .then(() => maybeLoadScript(\"vega-lite\", \"4.17.0\"))\n",
+       "        .then(() => maybeLoadScript(\"vega-embed\", \"6\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300, \"width\": 800, \"height\": 250}, \"area\": {\"color\": \"#D6E2FF\", \"fillOpacity\": 0.5}, \"axis\": {\"titleFontSize\": 14, \"titleColor\": \"#8784FF\", \"titlePadding\": 10, \"labelFontSize\": 12, \"labelColor\": \"#1B2A4D\"}, \"axisX\": {\"labelAngle\": 0, \"labelFlush\": true, \"grid\": true}, \"font\": \"Verdana\", \"line\": {\"color\": \"#1B2A4D\", \"strokeWidth\": 3, \"tooltip\": {\"content\": \"data\"}}, \"point\": {\"size\": 70, \"color\": \"#00C2A4\", \"filled\": true, \"opacity\": 1.0, \"tooltip\": {\"content\": \"data\"}}, \"range\": {\"category\": [\"#1B2A4D\", \"#00C2A4\", \"#8784FF\", \"#FD5383\", \"#8699B7\"], \"diverging\": [\"#00C2A4\", \"#7AD3BD\", \"#B8E2D6\", \"#F1F1F1\", \"#FCC1CB\", \"#FF8FA6\", \"#FD5383\"], \"heatmap\": [\"#384B74\", \"#56678E\", \"#7584A9\", \"#94A2C5\", \"#B5C2E2\", \"#D6E2FF\"], \"ordinal\": [\"#1B2A4D\", \"#273969\", \"#354886\", \"#4657A3\", \"#5966C2\", \"#6f75E0\", \"#8784FF\"]}, \"title\": {\"align\": \"center\", \"color\": \"#00C2A4\", \"fontSize\": 15, \"dy\": -15}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"table_row_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"table_row_count\", \"title\": \"Table Row Count\", \"type\": \"quantitative\"}}, \"title\": \"Table Row Count per Batch\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"table_row_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"table_row_count\", \"title\": \"Table Row Count\", \"type\": \"quantitative\"}}, \"title\": \"Table Row Count per Batch\"}], \"data\": {\"name\": \"data-196a2dbeb8f4bcdd2bc8da8372d5ffeb\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-196a2dbeb8f4bcdd2bc8da8372d5ffeb\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"table_row_count\": 10000}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"table_row_count\": 10000}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"table_row_count\": 10000}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"table_row_count\": 10000}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"table_row_count\": 10000}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"table_row_count\": 10000}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"table_row_count\": 10000}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"table_row_count\": 10000}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"table_row_count\": 10000}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"table_row_count\": 10000}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"table_row_count\": 10000}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"table_row_count\": 10000}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"table_row_count\": 10000}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"table_row_count\": 10000}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"table_row_count\": 10000}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"table_row_count\": 10000}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"table_row_count\": 10000}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"table_row_count\": 10000}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"table_row_count\": 10000}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"table_row_count\": 10000}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"table_row_count\": 10000}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"table_row_count\": 10000}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"table_row_count\": 10000}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"table_row_count\": 10000}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"table_row_count\": 10000}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"table_row_count\": 10000}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"table_row_count\": 10000}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"table_row_count\": 10000}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"table_row_count\": 10000}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"table_row_count\": 10000}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"table_row_count\": 10000}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"table_row_count\": 10000}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"table_row_count\": 10000}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"table_row_count\": 10000}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"table_row_count\": 10000}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"table_row_count\": 10000}]}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.LayerChart(...)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-c12aaaa056d0480f9f78e4682c8f352f\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
+       "  (function(spec, embedOpt){\n",
+       "    let outputDiv = document.currentScript.previousElementSibling;\n",
+       "    if (outputDiv.id !== \"altair-viz-c12aaaa056d0480f9f78e4682c8f352f\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-c12aaaa056d0480f9f78e4682c8f352f\");\n",
+       "    }\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.17.0?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function maybeLoadScript(lib, version) {\n",
+       "      var key = `${lib.replace(\"-\", \"\")}_version`;\n",
+       "      return (VEGA_DEBUG[key] == version) ?\n",
+       "        Promise.resolve(paths[lib]) :\n",
+       "        new Promise(function(resolve, reject) {\n",
+       "          var s = document.createElement('script');\n",
+       "          document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "          s.async = true;\n",
+       "          s.onload = () => {\n",
+       "            VEGA_DEBUG[key] = version;\n",
+       "            return resolve(paths[lib]);\n",
+       "          };\n",
+       "          s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "          s.src = paths[lib];\n",
+       "        });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else {\n",
+       "      maybeLoadScript(\"vega\", \"5\")\n",
+       "        .then(() => maybeLoadScript(\"vega-lite\", \"4.17.0\"))\n",
+       "        .then(() => maybeLoadScript(\"vega-embed\", \"6\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300, \"width\": 800, \"height\": 250}, \"area\": {\"color\": \"#D6E2FF\", \"fillOpacity\": 0.5}, \"axis\": {\"titleFontSize\": 14, \"titleColor\": \"#8784FF\", \"titlePadding\": 10, \"labelFontSize\": 12, \"labelColor\": \"#1B2A4D\"}, \"axisX\": {\"labelAngle\": 0, \"labelFlush\": true, \"grid\": true}, \"font\": \"Verdana\", \"line\": {\"color\": \"#1B2A4D\", \"strokeWidth\": 3, \"tooltip\": {\"content\": \"data\"}}, \"point\": {\"size\": 70, \"color\": \"#00C2A4\", \"filled\": true, \"opacity\": 1.0, \"tooltip\": {\"content\": \"data\"}}, \"range\": {\"category\": [\"#1B2A4D\", \"#00C2A4\", \"#8784FF\", \"#FD5383\", \"#8699B7\"], \"diverging\": [\"#00C2A4\", \"#7AD3BD\", \"#B8E2D6\", \"#F1F1F1\", \"#FCC1CB\", \"#FF8FA6\", \"#FD5383\"], \"heatmap\": [\"#384B74\", \"#56678E\", \"#7584A9\", \"#94A2C5\", \"#B5C2E2\", \"#D6E2FF\"], \"ordinal\": [\"#1B2A4D\", \"#273969\", \"#354886\", \"#4657A3\", \"#5966C2\", \"#6f75E0\", \"#8784FF\"]}, \"title\": {\"align\": \"center\", \"color\": \"#00C2A4\", \"fontSize\": 15, \"dy\": -15}}, \"vconcat\": [{\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"vendor_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"Column Distinct Values Count per Batch\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"vendor_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"Column Distinct Values Count per Batch\"}], \"data\": {\"name\": \"data-847d6233599929293b23908a5519b1ee\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-59500568508ff02ee474afbdb5b6ef91\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-cc4f3d894cbd25758c5cf876e2fdcb3d\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"passenger_count\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"passenger_count\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-a6d9a53e804e1f3d654daed23b7e9067\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"trip_distance\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"trip_distance\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-c1369f35dbd9fed60db759820dd968f0\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"rate_code_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"rate_code_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-ae9ff4f84713c2e5122dc1f6f914f94d\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"store_and_fwd_flag\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"store_and_fwd_flag\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-c972ebcd49fb1d63ce6eb761eb7279e9\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-b174d35b9643ecbfb55c7f05b982ecb0\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-87e4cc8890e8651a41ba58c60d73d1f4\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"payment_type\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"payment_type\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-1cb2b02d9bd0cf78fef71a2a9372f77d\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"fare_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"fare_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-862b8223c64d4b7846d5b72d124c7b9f\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"extra\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"extra\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-9617d8d88738618a546f988ab990c6db\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"mta_tax\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"mta_tax\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-335d4d6c2cf31091b17c7b9bcfaae51d\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tip_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tip_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-072cc05661bd68250232d60364b0158c\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tolls_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tolls_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-dbf86a9edaaf5f4cbd762cf76be3b01e\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"improvement_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"improvement_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-26baba38724a828f192a2838286f4463\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"total_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"total_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-df4b86aa03d7e2450e410fa653370b99\"}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"congestion_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"congestion_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}], \"data\": {\"name\": \"data-6122ad082b2e1778ea89cc614f0c122d\"}}], \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-847d6233599929293b23908a5519b1ee\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 2}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 2}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 3}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 3}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 2}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 3}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 3}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 3}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 2}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 2}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 2}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 3}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 2}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 2}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 2}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 2}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 2}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 2}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 2}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 2}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 2}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 2}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 3}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 3}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 2}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 2}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 2}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 2}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 2}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 3}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 2}], \"data-59500568508ff02ee474afbdb5b6ef91\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 9974}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 9955}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 9970}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 9977}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 9945}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 9972}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 9983}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 9984}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 9977}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 9962}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 9941}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 9977}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 9973}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 9974}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 9976}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 9980}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 9976}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 9976}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 9976}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 9953}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 9979}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 9979}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 9982}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 9975}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 9970}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 9981}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 9974}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 9977}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 9973}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 9977}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 9955}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 9969}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 9965}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 9981}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 9968}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 9973}], \"data-cc4f3d894cbd25758c5cf876e2fdcb3d\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 9972}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 9978}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 9982}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 9972}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 9968}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 9975}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 9985}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 9976}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 9982}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 9970}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 9939}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 9967}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 9977}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 9971}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 9973}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 9977}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 9975}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 9974}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 9984}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 9965}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 9979}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 9979}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 9975}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 9978}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 9967}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 9984}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 9977}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 9986}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 9972}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 9976}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 9964}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 9971}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 9977}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 9973}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 9976}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 9966}], \"data-a6d9a53e804e1f3d654daed23b7e9067\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 7}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 7}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 8}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 8}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 7}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 7}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 8}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 7}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 7}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 7}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 7}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 7}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 7}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 7}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 7}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 7}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 8}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 7}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 7}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 7}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 7}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 7}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 7}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 7}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 7}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 7}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 7}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 7}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 6}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 7}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 7}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 7}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 7}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 7}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 7}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 7}], \"data-c1369f35dbd9fed60db759820dd968f0\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 1165}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 1319}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 1266}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 1206}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 1253}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 1212}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 1227}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 1240}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 1299}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 1207}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 1560}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 1200}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 1230}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 1236}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 1225}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 1202}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 1249}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 1310}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 1202}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 1430}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 1176}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 1157}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 1228}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 1293}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 1188}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 1279}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 1252}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 1222}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 1184}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 1204}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 1273}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 1196}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 1141}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 1190}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 1192}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 1371}], \"data-ae9ff4f84713c2e5122dc1f6f914f94d\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 5}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 5}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 6}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 6}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 5}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 6}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 5}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 5}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 5}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 5}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 6}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 5}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 5}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 6}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 5}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 6}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 5}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 5}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 5}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 6}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 6}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 5}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 5}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 6}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 6}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 5}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 6}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 5}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 7}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 5}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 6}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 5}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 5}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 6}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 6}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 6}], \"data-c972ebcd49fb1d63ce6eb761eb7279e9\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 2}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 2}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 2}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 2}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 2}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 2}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 2}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 2}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 2}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 2}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 2}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 2}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 2}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 2}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 2}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 2}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 2}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 2}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 2}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 2}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 2}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 2}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 2}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 2}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 2}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 2}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 2}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 2}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 2}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 2}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 2}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 2}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 2}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 2}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 2}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 2}], \"data-b174d35b9643ecbfb55c7f05b982ecb0\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 124}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 209}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 143}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 141}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 157}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 151}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 133}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 137}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 155}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 193}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 214}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 155}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 144}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 134}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 145}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 133}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 150}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 154}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 119}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 211}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 132}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 118}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 142}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 154}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 195}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 144}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 136}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 138}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 151}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 187}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 208}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 199}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 118}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 146}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 146}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 212}], \"data-87e4cc8890e8651a41ba58c60d73d1f4\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 196}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 232}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 206}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 205}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 207}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 197}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 202}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 202}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 213}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 224}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 237}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 205}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 198}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 203}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 205}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 204}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 204}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 205}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 200}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 238}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 190}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 184}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 206}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 217}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 222}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 203}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 203}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 196}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 199}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 230}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 234}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 224}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 197}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 204}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 192}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 233}], \"data-1cb2b02d9bd0cf78fef71a2a9372f77d\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 4}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 4}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 4}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 4}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 4}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 4}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 4}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 4}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 4}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 4}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 4}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 4}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 4}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 4}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 4}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 4}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 4}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 4}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 4}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 4}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 4}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 4}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 4}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 4}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 4}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 4}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 4}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 4}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 4}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 4}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 4}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 4}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 4}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 4}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 4}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 4}], \"data-862b8223c64d4b7846d5b72d124c7b9f\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 161}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 575}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 184}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 184}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 296}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 199}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 168}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 178}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 238}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 571}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 1500}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 201}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 246}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 169}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 202}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 161}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 252}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 248}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 153}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 813}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 156}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 153}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 259}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 253}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 568}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 246}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 176}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 170}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 187}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 552}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 797}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 588}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 148}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 267}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 170}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 575}], \"data-9617d8d88738618a546f988ab990c6db\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 6}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 12}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 11}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 6}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 14}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 6}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 5}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 12}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 12}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 11}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 11}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 10}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 12}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 6}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 12}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 4}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 13}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 13}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 6}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 10}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 5}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 6}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 12}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 14}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 10}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 16}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 7}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 10}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 8}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 11}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 10}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 10}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 6}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 15}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 7}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 13}], \"data-335d4d6c2cf31091b17c7b9bcfaae51d\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 3}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 3}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 4}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 3}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 3}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 3}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 3}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 3}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 3}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 3}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 4}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 3}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 3}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 4}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 3}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 3}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 3}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 3}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 3}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 3}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 4}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 3}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 3}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 4}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 4}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 3}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 3}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 3}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 3}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 3}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 3}], \"data-072cc05661bd68250232d60364b0158c\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 539}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 530}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 606}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 601}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 560}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 600}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 557}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 596}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 579}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 503}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 466}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 597}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 599}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 576}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 601}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 559}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 606}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 608}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 574}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 558}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 573}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 532}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 572}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 595}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 505}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 591}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 567}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 612}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 535}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 515}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 469}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 522}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 530}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 576}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 555}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 539}], \"data-dbf86a9edaaf5f4cbd762cf76be3b01e\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 28}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 22}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 23}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 26}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 20}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 24}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 23}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 27}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 31}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 21}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 22}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 26}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 23}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 24}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 20}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 25}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 26}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 28}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 21}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 30}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 24}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 20}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 27}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 27}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 22}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 32}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 26}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 27}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 22}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 16}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 19}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 20}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 24}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 29}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 19}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 27}], \"data-26baba38724a828f192a2838286f4463\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 3}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 3}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 3}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 3}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 3}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 3}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 3}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 3}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 3}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 3}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 3}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 3}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 3}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 3}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 3}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 3}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 3}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 3}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 3}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 3}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 3}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 3}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 3}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 3}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 3}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 3}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 3}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 3}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 3}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 3}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 3}], \"data-df4b86aa03d7e2450e410fa653370b99\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 905}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 1153}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 1044}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 1000}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 1060}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 1043}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 969}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 1012}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 1047}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 1154}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 2018}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 1016}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 1068}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 973}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 1016}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 945}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 1060}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 1073}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 953}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 1440}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 942}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 898}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 1037}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 1077}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 1161}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 1070}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 966}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 1026}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 942}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 1154}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 1387}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 1164}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 884}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 1036}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 972}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 1154}], \"data-6122ad082b2e1778ea89cc614f0c122d\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 0}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 3}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 3}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 0}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 3}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 0}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 0}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 4}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 3}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 3}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 3}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 0}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 0}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 3}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 3}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 0}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 3}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 0}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 0}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 4}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 3}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 3}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 0}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 1}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 3}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 3}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 3}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 0}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 3}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 0}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 3}]}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.VConcatChart(...)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "result.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d8f3d93",
+   "metadata": {},
+   "source": [
+    "An additional layer of information that can be retrieved from the `DataAssistantResult` is the `prescriptive` information, which corresponds to the range values of the `Expectations` that result from the `DataAssistant` run. \n",
+    "\n",
+    "For example the `vendor_id` plot will show that the range of distinct `vendor_id` values ranged from 2-3 across all of our `Batches`, as indicated by the blue band around the plotted values. These values correspond to the `max_value` and `min_value` for the resulting `Expectation`, `expect_column_unique_value_count_to_be_between`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f00fa397",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-1e61c536077a4692a6272729a3f8a7ae\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
+       "  (function(spec, embedOpt){\n",
+       "    let outputDiv = document.currentScript.previousElementSibling;\n",
+       "    if (outputDiv.id !== \"altair-viz-1e61c536077a4692a6272729a3f8a7ae\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-1e61c536077a4692a6272729a3f8a7ae\");\n",
+       "    }\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.17.0?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function maybeLoadScript(lib, version) {\n",
+       "      var key = `${lib.replace(\"-\", \"\")}_version`;\n",
+       "      return (VEGA_DEBUG[key] == version) ?\n",
+       "        Promise.resolve(paths[lib]) :\n",
+       "        new Promise(function(resolve, reject) {\n",
+       "          var s = document.createElement('script');\n",
+       "          document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "          s.async = true;\n",
+       "          s.onload = () => {\n",
+       "            VEGA_DEBUG[key] = version;\n",
+       "            return resolve(paths[lib]);\n",
+       "          };\n",
+       "          s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "          s.src = paths[lib];\n",
+       "        });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else {\n",
+       "      maybeLoadScript(\"vega\", \"5\")\n",
+       "        .then(() => maybeLoadScript(\"vega-lite\", \"4.17.0\"))\n",
+       "        .then(() => maybeLoadScript(\"vega-embed\", \"6\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300, \"width\": 800, \"height\": 250}, \"area\": {\"color\": \"#D6E2FF\", \"fillOpacity\": 0.5}, \"axis\": {\"titleFontSize\": 14, \"titleColor\": \"#8784FF\", \"titlePadding\": 10, \"labelFontSize\": 12, \"labelColor\": \"#1B2A4D\"}, \"axisX\": {\"labelAngle\": 0, \"labelFlush\": true, \"grid\": true}, \"font\": \"Verdana\", \"line\": {\"color\": \"#1B2A4D\", \"strokeWidth\": 3, \"tooltip\": {\"content\": \"data\"}}, \"point\": {\"size\": 70, \"color\": \"#00C2A4\", \"filled\": true, \"opacity\": 1.0, \"tooltip\": {\"content\": \"data\"}}, \"range\": {\"category\": [\"#1B2A4D\", \"#00C2A4\", \"#8784FF\", \"#FD5383\", \"#8699B7\"], \"diverging\": [\"#00C2A4\", \"#7AD3BD\", \"#B8E2D6\", \"#F1F1F1\", \"#FCC1CB\", \"#FF8FA6\", \"#FD5383\"], \"heatmap\": [\"#384B74\", \"#56678E\", \"#7584A9\", \"#94A2C5\", \"#B5C2E2\", \"#D6E2FF\"], \"ordinal\": [\"#1B2A4D\", \"#273969\", \"#354886\", \"#4657A3\", \"#5966C2\", \"#6f75E0\", \"#8784FF\"]}, \"title\": {\"align\": \"center\", \"color\": \"#00C2A4\", \"fontSize\": 15, \"dy\": -15}}, \"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"Table Row Count\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"Table Row Count\"}}}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"table_row_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"Table Row Count\", \"type\": \"quantitative\"}}}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"table_row_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"Table Row Count\", \"type\": \"quantitative\"}}}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"table_row_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"table_row_count\", \"title\": \"Table Row Count\", \"type\": \"quantitative\"}}, \"title\": \"Table Row Count per Batch\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['table_row_count']) && (datum.max_value > datum['table_row_count'])) || ((datum.min_value < datum['table_row_count']) && (datum.max_value < datum['table_row_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"table_row_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"table_row_count\", \"title\": \"Table Row Count\", \"type\": \"quantitative\"}}, \"title\": \"Table Row Count per Batch\"}]}], \"data\": {\"name\": \"data-0a45a8c4f2670fca26609857cbb4aaa8\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-0a45a8c4f2670fca26609857cbb4aaa8\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"table_row_count\": 10000, \"min_value\": 10000, \"max_value\": 10000}]}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.LayerChart(...)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-f8010b82f8e1436d8cb5d7aa4702ea2f\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  var VEGA_DEBUG = (typeof VEGA_DEBUG == \"undefined\") ? {} : VEGA_DEBUG;\n",
+       "  (function(spec, embedOpt){\n",
+       "    let outputDiv = document.currentScript.previousElementSibling;\n",
+       "    if (outputDiv.id !== \"altair-viz-f8010b82f8e1436d8cb5d7aa4702ea2f\") {\n",
+       "      outputDiv = document.getElementById(\"altair-viz-f8010b82f8e1436d8cb5d7aa4702ea2f\");\n",
+       "    }\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.17.0?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function maybeLoadScript(lib, version) {\n",
+       "      var key = `${lib.replace(\"-\", \"\")}_version`;\n",
+       "      return (VEGA_DEBUG[key] == version) ?\n",
+       "        Promise.resolve(paths[lib]) :\n",
+       "        new Promise(function(resolve, reject) {\n",
+       "          var s = document.createElement('script');\n",
+       "          document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "          s.async = true;\n",
+       "          s.onload = () => {\n",
+       "            VEGA_DEBUG[key] = version;\n",
+       "            return resolve(paths[lib]);\n",
+       "          };\n",
+       "          s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "          s.src = paths[lib];\n",
+       "        });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else {\n",
+       "      maybeLoadScript(\"vega\", \"5\")\n",
+       "        .then(() => maybeLoadScript(\"vega-lite\", \"4.17.0\"))\n",
+       "        .then(() => maybeLoadScript(\"vega-embed\", \"6\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300, \"width\": 800, \"height\": 250}, \"area\": {\"color\": \"#D6E2FF\", \"fillOpacity\": 0.5}, \"axis\": {\"titleFontSize\": 14, \"titleColor\": \"#8784FF\", \"titlePadding\": 10, \"labelFontSize\": 12, \"labelColor\": \"#1B2A4D\"}, \"axisX\": {\"labelAngle\": 0, \"labelFlush\": true, \"grid\": true}, \"font\": \"Verdana\", \"line\": {\"color\": \"#1B2A4D\", \"strokeWidth\": 3, \"tooltip\": {\"content\": \"data\"}}, \"point\": {\"size\": 70, \"color\": \"#00C2A4\", \"filled\": true, \"opacity\": 1.0, \"tooltip\": {\"content\": \"data\"}}, \"range\": {\"category\": [\"#1B2A4D\", \"#00C2A4\", \"#8784FF\", \"#FD5383\", \"#8699B7\"], \"diverging\": [\"#00C2A4\", \"#7AD3BD\", \"#B8E2D6\", \"#F1F1F1\", \"#FCC1CB\", \"#FF8FA6\", \"#FD5383\"], \"heatmap\": [\"#384B74\", \"#56678E\", \"#7584A9\", \"#94A2C5\", \"#B5C2E2\", \"#D6E2FF\"], \"ordinal\": [\"#1B2A4D\", \"#273969\", \"#354886\", \"#4657A3\", \"#5966C2\", \"#6f75E0\", \"#8784FF\"]}, \"title\": {\"align\": \"center\", \"color\": \"#00C2A4\", \"fontSize\": 15, \"dy\": -15}}, \"vconcat\": [{\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"vendor_id\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"vendor_id\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"vendor_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"vendor_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"vendor_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"Column Distinct Values Count per Batch\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"vendor_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"Column Distinct Values Count per Batch\"}]}], \"data\": {\"name\": \"data-b7f1c748e285add44aff0403648866cd\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"pickup_datetime\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"pickup_datetime\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"pickup_datetime\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"pickup_datetime\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-e381e46902142056373ded1abf4c52cb\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"dropoff_datetime\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"dropoff_datetime\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"dropoff_datetime\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"dropoff_datetime\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_datetime\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-8495203519b937aa7c869079b182ac33\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"passenger_count\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"passenger_count\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"passenger_count\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"passenger_count\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"passenger_count\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"passenger_count\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-d59c1a3aa9d907f9dd493c242e6c12c0\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"trip_distance\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"trip_distance\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"trip_distance\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"trip_distance\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"trip_distance\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"trip_distance\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-7ed5b49cc2703382e9fc0b4579041614\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"rate_code_id\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"rate_code_id\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"rate_code_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"rate_code_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"rate_code_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"rate_code_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-783331453a1f9ee16fadd39d60f52ccc\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"store_and_fwd_flag\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"store_and_fwd_flag\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"store_and_fwd_flag\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"store_and_fwd_flag\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"store_and_fwd_flag\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"store_and_fwd_flag\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-fbad477021c63006937e3688419e04ac\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"pickup_location_id\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"pickup_location_id\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"pickup_location_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"pickup_location_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"pickup_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-7728a1e660b299f490580233ce349a14\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"dropoff_location_id\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"dropoff_location_id\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"dropoff_location_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"dropoff_location_id\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"dropoff_location_id\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-91bd45eb9dc2d1b09d05f41c2a51888f\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"payment_type\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"payment_type\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"payment_type\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"payment_type\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"payment_type\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"payment_type\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-d098a63577f8e40118551a5ab5ff7599\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"fare_amount\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"fare_amount\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"fare_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"fare_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"fare_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"fare_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-9812a85f5d6b645220c7c9409d9b4011\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"extra\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"extra\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"extra\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"extra\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"extra\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"extra\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-76db58d00063860cf48d97742cabc474\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"mta_tax\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"mta_tax\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"mta_tax\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"mta_tax\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"mta_tax\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"mta_tax\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-71410ce18813bcc21eb5456458143179\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"tip_amount\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"tip_amount\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"tip_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"tip_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tip_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tip_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-519d0ad155bc1feb4824ff62c009907b\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"tolls_amount\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"tolls_amount\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"tolls_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"tolls_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tolls_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"tolls_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-4640f63fdcaaa16074e22b8fb1297ff2\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"improvement_surcharge\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"improvement_surcharge\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"improvement_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"improvement_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"improvement_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"improvement_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-48ea4c5240e6a6074eabc359e822951e\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"total_amount\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"total_amount\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"total_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"total_amount\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"total_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"total_amount\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-f50d5c17de879ff37379b9958536eed6\"}}, {\"layer\": [{\"mark\": \"area\", \"encoding\": {\"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"congestion_surcharge\", \"type\": \"quantitative\"}, \"y2\": {\"field\": \"max_value\", \"title\": \"congestion_surcharge\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"min_value\", \"title\": \"congestion_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"mark\": {\"type\": \"line\", \"color\": \"#B5C2E2\"}, \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"max_value\", \"title\": \"congestion_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150}, {\"layer\": [{\"mark\": \"line\", \"encoding\": {\"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"congestion_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}, {\"mark\": \"point\", \"encoding\": {\"color\": {\"condition\": {\"value\": \"#FD5383\", \"test\": \"(((datum.min_value > datum['column_distinct_values_count']) && (datum.max_value > datum['column_distinct_values_count'])) || ((datum.min_value < datum['column_distinct_values_count']) && (datum.max_value < datum['column_distinct_values_count'])))\"}, \"value\": \"#00C2A4\"}, \"tooltip\": [{\"field\": \"batch_id\", \"type\": \"nominal\"}, {\"field\": \"column_distinct_values_count\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"min_value\", \"format\": \",\", \"type\": \"quantitative\"}, {\"field\": \"max_value\", \"format\": \",\", \"type\": \"quantitative\"}], \"x\": {\"field\": \"batch\", \"title\": \"Batch\", \"type\": \"ordinal\"}, \"y\": {\"field\": \"column_distinct_values_count\", \"title\": \"congestion_surcharge\", \"type\": \"quantitative\"}}, \"height\": 150, \"title\": \"\"}]}], \"data\": {\"name\": \"data-de4ccd7e0fbe6919d56017ffb319735e\"}}], \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.17.0.json\", \"datasets\": {\"data-b7f1c748e285add44aff0403648866cd\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 3, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"vendor_id\"}], \"data-e381e46902142056373ded1abf4c52cb\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 9974, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 9955, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 9970, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 9977, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 9945, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 9972, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 9983, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 9984, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 9977, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 9962, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 9941, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 9977, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 9973, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 9974, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 9976, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 9980, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 9976, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 9976, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 9976, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 9953, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 9979, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 9979, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 9982, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 9975, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 9970, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 9981, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 9974, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 9977, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 9973, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 9977, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 9955, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 9969, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 9965, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 9981, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 9968, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 9973, \"min_value\": 9945, \"strict_min\": false, \"max_value\": 9983, \"strict_max\": false, \"column\": \"pickup_datetime\"}], \"data-8495203519b937aa7c869079b182ac33\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 9972, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 9978, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 9982, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 9972, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 9968, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 9975, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 9985, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 9976, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 9982, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 9970, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 9939, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 9967, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 9977, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 9971, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 9973, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 9977, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 9975, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 9974, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 9984, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 9965, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 9979, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 9979, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 9975, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 9978, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 9967, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 9984, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 9977, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 9986, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 9972, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 9976, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 9964, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 9971, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 9977, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 9973, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 9976, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 9966, \"min_value\": 9958, \"strict_min\": false, \"max_value\": 9985, \"strict_max\": false, \"column\": \"dropoff_datetime\"}], \"data-d59c1a3aa9d907f9dd493c242e6c12c0\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 8, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 8, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 8, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 8, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 6, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 7, \"min_value\": 7, \"strict_min\": false, \"max_value\": 8, \"strict_max\": false, \"column\": \"passenger_count\"}], \"data-7ed5b49cc2703382e9fc0b4579041614\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 1165, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 1319, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 1266, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 1206, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 1253, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 1212, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 1227, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 1240, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 1299, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 1207, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 1560, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 1200, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 1230, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 1236, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 1225, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 1202, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 1249, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 1310, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 1202, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 1430, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 1176, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 1157, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 1228, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 1293, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 1188, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 1279, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 1252, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 1222, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 1184, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 1204, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 1273, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 1196, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 1141, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 1190, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 1192, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 1371, \"min_value\": 1159, \"strict_min\": false, \"max_value\": 1430, \"strict_max\": false, \"column\": \"trip_distance\"}], \"data-783331453a1f9ee16fadd39d60f52ccc\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 7, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 6, \"strict_max\": false, \"column\": \"rate_code_id\"}], \"data-fbad477021c63006937e3688419e04ac\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 2, \"min_value\": 2, \"strict_min\": false, \"max_value\": 2, \"strict_max\": false, \"column\": \"store_and_fwd_flag\"}], \"data-7728a1e660b299f490580233ce349a14\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 124, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 209, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 143, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 141, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 157, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 151, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 133, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 137, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 155, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 193, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 214, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 155, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 144, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 134, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 145, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 133, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 150, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 154, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 119, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 211, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 132, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 118, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 142, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 154, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 195, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 144, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 136, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 138, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 151, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 187, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 208, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 199, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 118, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 146, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 146, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 212, \"min_value\": 118, \"strict_min\": false, \"max_value\": 211, \"strict_max\": false, \"column\": \"pickup_location_id\"}], \"data-91bd45eb9dc2d1b09d05f41c2a51888f\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 196, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 232, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 206, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 205, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 207, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 197, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 202, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 202, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 213, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 224, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 237, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 205, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 198, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 203, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 205, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 204, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 204, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 205, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 200, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 238, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 190, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 184, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 206, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 217, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 222, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 203, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 203, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 196, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 199, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 230, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 234, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 224, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 197, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 204, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 192, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 233, \"min_value\": 190, \"strict_min\": false, \"max_value\": 236, \"strict_max\": false, \"column\": \"dropoff_location_id\"}], \"data-d098a63577f8e40118551a5ab5ff7599\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 4, \"min_value\": 4, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"payment_type\"}], \"data-9812a85f5d6b645220c7c9409d9b4011\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 161, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 575, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 184, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 184, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 296, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 199, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 168, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 178, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 238, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 571, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 1500, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 201, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 246, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 169, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 202, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 161, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 252, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 248, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 153, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 813, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 156, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 153, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 259, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 253, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 568, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 246, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 176, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 170, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 187, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 552, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 797, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 588, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 148, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 267, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 170, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 575, \"min_value\": 153, \"strict_min\": false, \"max_value\": 813, \"strict_max\": false, \"column\": \"fare_amount\"}], \"data-76db58d00063860cf48d97742cabc474\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 12, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 11, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 14, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 12, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 12, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 11, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 11, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 10, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 12, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 12, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 4, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 13, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 13, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 10, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 5, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 12, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 14, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 10, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 16, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 7, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 10, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 8, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 11, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 10, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 10, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 6, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 15, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 7, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 13, \"min_value\": 5, \"strict_min\": false, \"max_value\": 15, \"strict_max\": false, \"column\": \"extra\"}], \"data-71410ce18813bcc21eb5456458143179\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 4, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 4, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 4, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 4, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 4, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 4, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"mta_tax\"}], \"data-519d0ad155bc1feb4824ff62c009907b\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 539, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 530, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 606, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 601, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 560, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 600, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 557, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 596, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 579, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 503, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 466, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 597, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 599, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 576, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 601, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 559, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 606, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 608, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 574, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 558, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 573, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 532, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 572, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 595, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 505, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 591, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 567, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 612, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 535, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 515, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 469, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 522, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 530, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 576, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 555, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 539, \"min_value\": 469, \"strict_min\": false, \"max_value\": 608, \"strict_max\": false, \"column\": \"tip_amount\"}], \"data-4640f63fdcaaa16074e22b8fb1297ff2\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 28, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 22, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 23, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 26, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 20, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 24, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 23, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 27, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 31, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 21, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 22, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 26, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 23, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 24, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 20, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 25, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 26, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 28, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 21, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 30, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 24, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 20, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 27, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 27, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 22, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 32, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 26, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 27, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 22, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 16, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 19, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 20, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 24, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 29, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 19, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 27, \"min_value\": 18, \"strict_min\": false, \"max_value\": 31, \"strict_max\": false, \"column\": \"tolls_amount\"}], \"data-48ea4c5240e6a6074eabc359e822951e\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 3, \"min_value\": 3, \"strict_min\": false, \"max_value\": 3, \"strict_max\": false, \"column\": \"improvement_surcharge\"}], \"data-f50d5c17de879ff37379b9958536eed6\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 905, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 1153, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 1044, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 1000, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 1060, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 1043, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 969, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 1012, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 1047, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 1154, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 2018, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 1016, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 1068, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 973, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 1016, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 945, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 1060, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 1073, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 953, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 1440, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 942, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 898, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 1037, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 1077, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 1161, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 1070, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 966, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 1026, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 942, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 1154, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 1387, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 1164, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 884, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 1036, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 972, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 1154, \"min_value\": 898, \"strict_min\": false, \"max_value\": 1440, \"strict_max\": false, \"column\": \"total_amount\"}], \"data-de4ccd7e0fbe6919d56017ffb319735e\": [{\"batch\": 1, \"batch_id\": \"0be8d1bcf0982016811de2c651fee45e\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 2, \"batch_id\": \"11598b81fba0f70549bef2284c869d28\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 3, \"batch_id\": \"15f1beefb43cb27e2387b724b9813c64\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 4, \"batch_id\": \"1b1d851510735994a8a1da49b0aed3ed\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 5, \"batch_id\": \"2ad4f5c2d8167dbfefe19326cbff86c9\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 6, \"batch_id\": \"2d75e0cb6dc184d032cba77f5ea54915\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 7, \"batch_id\": \"33761e8fe192ef5c607a2dbe9308487d\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 8, \"batch_id\": \"3ad8cc66678216b7c6bbc494ffd378f7\", \"column_distinct_values_count\": 4, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 9, \"batch_id\": \"3b7a9486ec8e0fec5d603f68ad397bb4\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 10, \"batch_id\": \"3d2b2c6c2b137f9f04b5c1e879039911\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 11, \"batch_id\": \"3f729299348ae59b2f400b1482765b76\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 12, \"batch_id\": \"4530c17c88abfa50e08ae54ef4727901\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 13, \"batch_id\": \"47aa191d3466452d565b356805185970\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 14, \"batch_id\": \"48be78af3557dbb4cb6dae0f1e96d1ed\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 15, \"batch_id\": \"51729508a2ee5d4c7724c46569d6d64d\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 16, \"batch_id\": \"55db1700f56722db4c894939bc586e81\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 17, \"batch_id\": \"570ca32f345f9a2068e0fe0bccb73d68\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 18, \"batch_id\": \"666a27dc63af830aa4c5e8d2ece875f8\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 19, \"batch_id\": \"721bf9f1fe4d9b2b3ea1fd62705d2b73\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 20, \"batch_id\": \"8d127365b1bfcd65cb84685a628a7f9e\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 21, \"batch_id\": \"90bf1c1562b48566376a39758b3d904a\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 22, \"batch_id\": \"9418c035f6799345703ff86f3b0101fc\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 23, \"batch_id\": \"9cf45375282d7e70585512aff0e0ce16\", \"column_distinct_values_count\": 4, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 24, \"batch_id\": \"9eaaddd565ef3d54e265db0bf0692ed7\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 25, \"batch_id\": \"a208a744b57b3655fc519fcb7c28a133\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 26, \"batch_id\": \"ab94ea3d079f3a7505d0b8a369ed795c\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 27, \"batch_id\": \"ac372cc6da52239444d7a2e5d88dd23e\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 28, \"batch_id\": \"ace508393eac9655e097b3426acb1cf7\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 29, \"batch_id\": \"b1195ebb1a6b0f56966c48b0a3c39062\", \"column_distinct_values_count\": 1, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 30, \"batch_id\": \"b1692c7ff2e2d81d6d9794806be6cb27\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 31, \"batch_id\": \"b5b0fee3d9c10af25e1169692373e2b9\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 32, \"batch_id\": \"bb91bb1d635629b45789a3e0f09782c9\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 33, \"batch_id\": \"bd0f7908174f15100c23aa36d8388336\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 34, \"batch_id\": \"c18ffebc7a6d6a064b64967325112c3c\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 35, \"batch_id\": \"d89e2839347683edd21e9472f1393b3f\", \"column_distinct_values_count\": 0, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}, {\"batch\": 36, \"batch_id\": \"edce46b020521677a662a1f259d88e58\", \"column_distinct_values_count\": 3, \"min_value\": 0, \"strict_min\": false, \"max_value\": 4, \"strict_max\": false, \"column\": \"congestion_surcharge\"}]}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.VConcatChart(...)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "result.plot(prescriptive=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "440ba528",
+   "metadata": {},
+   "source": [
+    "# Save `ExpectationSuite`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5261b90",
+   "metadata": {},
+   "source": [
+    "Finally, we can save the `ExpectationSuite` resulting from the `DataAssistant`. We can use the `DataContext`'s `save_expectation_suite()` method pass in our result. The `ExpectationSuite` will be saved with the name we specified in our `expectation_suite_name` when we ran the `DataAssistant`, which was `taxi_data_suite`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2ae1228c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/work/Development/great_expectations/tests/test_fixtures/rule_based_profiler/example_notebooks/great_expectations/expectations/taxi_data_suite.json'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_context.save_expectation_suite(expectation_suite=result.expectation_suite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e368bd44",
+   "metadata": {},
+   "source": [
+    "## Optional: Clean-up Directory\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f83b3fa",
+   "metadata": {},
+   "source": [
+    "As part of running this notebook, the `DataAssistant` will create a number of ExpectationSuite configurations in the `great_expectations/expectations/tmp` directory. Optionally run the following cell to clean up the directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "44ff59ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import shutil, os\n",
+    "# shutil.rmtree(\"great_expectations/expectations/tmp\")\n",
+    "# os.remove(\"great_expectations/expectations/.ge_store_backend_id\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "887b9281",
+   "id": "26b3aab6",
    "metadata": {},
    "source": [
     "### What is a `VolumeDataAssistant`?\n",
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d86080dc",
+   "id": "a4aa73e4",
    "metadata": {},
    "source": [
     "#  Configure `BatchRequest`"
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f78301ee",
+   "id": "61e86821",
    "metadata": {},
    "source": [
     "In this example, we will be using a `BatchRequest` that will return all 36 batches of data from the `taxi_data` dataset.  We will refer to the `Datasource` and `DataConnector` configured in the previous step. "
@@ -193,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "dbbad0b8",
+   "id": "da5b6cf0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46a680cd",
+   "id": "f9a38c3a",
    "metadata": {},
    "source": [
     "# Run the `VolumeDataAssistant`"
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "202ff1e0",
+   "id": "4c1b2796",
    "metadata": {},
    "source": [
     "* The `VolumeDataAssistant` can be run directly from the `DataContext` by specifying `assistants` and `volume`, and passing in the `BatchRequest` from the previous step."
@@ -219,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "d4e27237",
+   "id": "cd2ea1be",
    "metadata": {},
    "outputs": [
     {
@@ -846,7 +846,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62b790ad",
+   "id": "7e0291e0",
    "metadata": {},
    "source": [
     "You will see that the `DataAssistant` created a temporary `ExpectationSuite`, which is part of the `DataAssistantResult`. The `run()` method is also able to take in the following optional parameters:\n",
@@ -859,7 +859,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "972022c5",
+   "id": "33512454",
    "metadata": {},
    "source": [
     "Although the `DataAssistant` will automatically create a temporary `ExpectationSuite` when running the profiling, we do recommend that you recommend an `expectation_suite_name` (which is `taxi_data_suite` in our case) so that the results can be more easily saved later on."
@@ -868,7 +868,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "99616f6a",
+   "id": "bcf75460",
    "metadata": {},
    "outputs": [
     {
@@ -1481,7 +1481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ee95efb",
+   "id": "6646fd0b",
    "metadata": {},
    "source": [
     "# Explore `DataAssistantResult` by plotting"
@@ -1489,7 +1489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01a20546",
+   "id": "bc3d2948",
    "metadata": {},
    "source": [
     "The resulting `DataAssistantResult` can be best explored by plotting. For each `Domain` considered (`Table` and `Column` in our case), the plots will display the value for each `Batch` (36 in total). "
@@ -1498,7 +1498,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "822d8fe4",
+   "id": "dd4c66e9",
    "metadata": {},
    "outputs": [
     {
@@ -1640,7 +1640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d8f3d93",
+   "id": "e28f7a78",
    "metadata": {},
    "source": [
     "An additional layer of information that can be retrieved from the `DataAssistantResult` is the `prescriptive` information, which corresponds to the range values of the `Expectations` that result from the `DataAssistant` run. \n",
@@ -1651,7 +1651,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "f00fa397",
+   "id": "03353ac8",
    "metadata": {},
    "outputs": [
     {
@@ -1793,7 +1793,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "440ba528",
+   "id": "0437017f",
    "metadata": {},
    "source": [
     "# Save `ExpectationSuite`"
@@ -1801,7 +1801,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5261b90",
+   "id": "090b0dbc",
    "metadata": {},
    "source": [
     "Finally, we can save the `ExpectationSuite` resulting from the `DataAssistant`. We can use the `DataContext`'s `save_expectation_suite()` method pass in our result. The `ExpectationSuite` will be saved with the name we specified in our `expectation_suite_name` when we ran the `DataAssistant`, which was `taxi_data_suite`. "
@@ -1810,7 +1810,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "2ae1228c",
+   "id": "9426227a",
    "metadata": {},
    "outputs": [
     {
@@ -1830,7 +1830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e368bd44",
+   "id": "0d02f5e8",
    "metadata": {},
    "source": [
     "## Optional: Clean-up Directory\n"
@@ -1838,7 +1838,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f83b3fa",
+   "id": "f973a7ef",
    "metadata": {},
    "source": [
     "As part of running this notebook, the `DataAssistant` will create a number of ExpectationSuite configurations in the `great_expectations/expectations/tmp` directory. Optionally run the following cell to clean up the directory."
@@ -1847,13 +1847,14 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "44ff59ff",
+   "id": "4857e285",
    "metadata": {},
    "outputs": [],
    "source": [
     "# import shutil, os\n",
     "# shutil.rmtree(\"great_expectations/expectations/tmp\")\n",
-    "# os.remove(\"great_expectations/expectations/.ge_store_backend_id\")"
+    "# os.remove(\"great_expectations/expectations/.ge_store_backend_id\")\n",
+    "# os.remove(\"great_expectations/expectations/taxi_data_suite.json\")"
    ]
   }
  ],


### PR DESCRIPTION
Changes proposed in this pull request:
- This PR contains a notebook that exercises some of the major use-cases and codepaths for the `VolumeDataAssistant`.
- The notebook, `DataAssistants_Instantiation_And_Running`,  shows how to use the `VolumeDataAssistant` against a datasource containing 36 batches (corresponding to 3 years) of `taxi_data`.

The notebook describes the following major steps:
1. Setting up Datasource to connect to `taxi_data`. 
2. Configuring `BatchRequest` to retrieve 36 Batches of `taxi_data, which will be profiled using the `VolumeDataAssistant`. 
3. Running the `VolumeDataAssistant` and retrieving the `DataAssistantResult`
4. Exploring the `DataAssistantResult` by plotting, with and without `prescriptive` information. 
5. Saving resulting `ExpectationSuite`. 

Previous Design Review notes:
- GREAT-820

### Definition of Done
Please delete options that are not relevant.
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
