### PR TITLE
[BUGFIX] `self_check()` now also checks for `aws_config_file`

### DIFF
--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1690,10 +1690,12 @@ def build_test_backends_list(
             aws_access_key_id: Optional[str] = os.getenv("AWS_ACCESS_KEY_ID")
             aws_secret_access_key: Optional[str] = os.getenv("AWS_SECRET_ACCESS_KEY")
             aws_session_token: Optional[str] = os.getenv("AWS_SESSION_TOKEN")
+            aws_config_file: Optional[str] = os.getenv("AWS_CONFIG_FILE")
             if (
                 not aws_access_key_id
                 and not aws_secret_access_key
                 and not aws_session_token
+                and not aws_config_file
             ):
                 if raise_exceptions_for_backends is True:
                     raise ImportError(


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix of bug that was causing `docs-integration` stage to fail. 

## What was wrong?
* `build_test_backends_list()` method in `self_check` util checks whether AWS tests are requested and credentials populated. However, the `docs-integration` stage will load the file as a Secure File, meaning it is loaded into the `AWS_CONFIG_FILE` environment variable. 
* Prior to this PR, the `build_test_backends_list` method was insisting that we load the variables as key_id, access_token or _session token. 
* This PR adds the `aws_config_file` option