### PR TITLE
[BUGFIX] Make self-initialization in expect_column_values_to_be_between truly multi batch

### DIFF
--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -156,7 +156,7 @@ class ExpectColumnMaxToBeBetween(ColumnExpectation):
                         "lower_bound": None,
                         "upper_bound": None,
                     },
-                    "round_decimals": 0,
+                    "round_decimals": 1,
                 },
                 "domain_builder": {
                     "class_name": "ColumnDomainBuilder",

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -149,7 +149,7 @@ class ExpectColumnMinToBeBetween(ColumnExpectation):
                         "lower_bound": None,
                         "upper_bound": None,
                     },
-                    "round_decimals": 0,
+                    "round_decimals": 1,
                 },
                 "domain_builder": {
                     "class_name": "ColumnDomainBuilder",

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -108,39 +108,49 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
         "profiler_config",
     )
 
-    min_estimator_parameter_builder_config: ParameterBuilderConfig = (
-        ParameterBuilderConfig(
-            module_name="great_expectations.rule_based_profiler.parameter_builder",
-            class_name="MetricMultiBatchParameterBuilder",
-            name="min_estimator",
-            metric_name="column.min",
-            metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
-            metric_value_kwargs=None,
-            enforce_numeric_metric=True,
-            replace_nan_with_zero=True,
-            reduce_scalar_metric=True,
-            evaluation_parameter_builder_configs=None,
-            json_serialize=True,
-        )
+    column_min_range_estimator_parameter_builder_config: ParameterBuilderConfig = ParameterBuilderConfig(
+        module_name="great_expectations.rule_based_profiler.parameter_builder",
+        class_name="NumericMetricRangeMultiBatchParameterBuilder",
+        name="column_min_range_estimator",
+        metric_name="column.min",
+        metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
+        metric_value_kwargs=None,
+        enforce_numeric_metric=True,
+        replace_nan_with_zero=True,
+        reduce_scalar_metric=True,
+        false_positive_rate=f"{VARIABLES_KEY}false_positive_rate",
+        quantile_statistic_interpolation_method=f"{VARIABLES_KEY}quantile_statistic_interpolation_method",
+        estimator=f"{VARIABLES_KEY}estimator",
+        num_bootstrap_samples=f"{VARIABLES_KEY}num_bootstrap_samples",
+        bootstrap_random_seed=f"{VARIABLES_KEY}bootstrap_random_seed",
+        truncate_values=f"{VARIABLES_KEY}truncate_values",
+        round_decimals=f"{VARIABLES_KEY}round_decimals",
+        evaluation_parameter_builder_configs=None,
+        json_serialize=True,
     )
-    max_estimator_parameter_builder_config: ParameterBuilderConfig = (
-        ParameterBuilderConfig(
-            module_name="great_expectations.rule_based_profiler.parameter_builder",
-            class_name="MetricMultiBatchParameterBuilder",
-            name="max_estimator",
-            metric_name="column.max",
-            metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
-            metric_value_kwargs=None,
-            enforce_numeric_metric=True,
-            replace_nan_with_zero=True,
-            reduce_scalar_metric=True,
-            evaluation_parameter_builder_configs=None,
-            json_serialize=True,
-        )
+    column_max_range_estimator_parameter_builder_config: ParameterBuilderConfig = ParameterBuilderConfig(
+        module_name="great_expectations.rule_based_profiler.parameter_builder",
+        class_name="NumericMetricRangeMultiBatchParameterBuilder",
+        name="column_max_range_estimator",
+        metric_name="column.max",
+        metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
+        metric_value_kwargs=None,
+        enforce_numeric_metric=True,
+        replace_nan_with_zero=True,
+        reduce_scalar_metric=True,
+        false_positive_rate=f"{VARIABLES_KEY}false_positive_rate",
+        quantile_statistic_interpolation_method=f"{VARIABLES_KEY}quantile_statistic_interpolation_method",
+        estimator=f"{VARIABLES_KEY}estimator",
+        num_bootstrap_samples=f"{VARIABLES_KEY}num_bootstrap_samples",
+        bootstrap_random_seed=f"{VARIABLES_KEY}bootstrap_random_seed",
+        truncate_values=f"{VARIABLES_KEY}truncate_values",
+        round_decimals=f"{VARIABLES_KEY}round_decimals",
+        evaluation_parameter_builder_configs=None,
+        json_serialize=True,
     )
     validation_parameter_builder_configs: List[ParameterBuilderConfig] = [
-        min_estimator_parameter_builder_config,
-        max_estimator_parameter_builder_config,
+        column_min_range_estimator_parameter_builder_config,
+        column_max_range_estimator_parameter_builder_config,
     ]
     default_profiler_config: RuleBasedProfilerConfig = RuleBasedProfilerConfig(
         name="expect_column_values_to_be_between",  # Convention: use "expectation_type" as profiler name.
@@ -152,6 +162,16 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
                     "mostly": 1.0,
                     "strict_min": False,
                     "strict_max": False,
+                    "false_positive_rate": 0.05,
+                    "quantile_statistic_interpolation_method": "auto",
+                    "estimator": "bootstrap",
+                    "num_bootstrap_samples": 9999,
+                    "bootstrap_random_seed": None,
+                    "truncate_values": {
+                        "lower_bound": None,
+                        "upper_bound": None,
+                    },
+                    "round_decimals": 1,
                 },
                 "domain_builder": {
                     "class_name": "ColumnDomainBuilder",
@@ -164,15 +184,15 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
                         "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder",
                         "validation_parameter_builder_configs": validation_parameter_builder_configs,
                         "column": f"{DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}column",
-                        "min_value": f"{PARAMETER_KEY}{min_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[-1]",
-                        "max_value": f"{PARAMETER_KEY}{max_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[-1]",
+                        "min_value": f"{PARAMETER_KEY}{column_min_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[0]",
+                        "max_value": f"{PARAMETER_KEY}{column_max_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[1]",
                         "mostly": f"{VARIABLES_KEY}mostly",
                         "strict_min": f"{VARIABLES_KEY}strict_min",
                         "strict_max": f"{VARIABLES_KEY}strict_max",
                         "meta": {
                             "profiler_details": {
-                                "min_estimator": f"{PARAMETER_KEY}{min_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY}",
-                                "max_estimator": f"{PARAMETER_KEY}{max_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY}",
+                                "column_min_range_estimator": f"{PARAMETER_KEY}{column_min_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY}",
+                                "column_max_range_estimator": f"{PARAMETER_KEY}{column_max_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY}",
                             },
                         },
                     },

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -87,10 +87,10 @@ class ExpectTableRowCountToBeBetween(TableExpectation):
         "profiler_config",
     )
 
-    row_count_range_estimator_parameter_builder_config: ParameterBuilderConfig = ParameterBuilderConfig(
+    table_row_count_range_estimator_parameter_builder_config: ParameterBuilderConfig = ParameterBuilderConfig(
         module_name="great_expectations.rule_based_profiler.parameter_builder",
         class_name="NumericMetricRangeMultiBatchParameterBuilder",
-        name="row_count_range_estimator",
+        name="table_row_count_range_estimator",
         metric_name="table.row_count",
         metric_domain_kwargs=None,
         metric_value_kwargs=None,
@@ -108,7 +108,7 @@ class ExpectTableRowCountToBeBetween(TableExpectation):
         json_serialize=True,
     )
     validation_parameter_builder_configs: List[ParameterBuilderConfig] = [
-        row_count_range_estimator_parameter_builder_config,
+        table_row_count_range_estimator_parameter_builder_config,
     ]
     default_profiler_config: RuleBasedProfilerConfig = RuleBasedProfilerConfig(
         name="expect_table_row_count_to_be_between",  # Convention: use "expectation_type" as profiler name.
@@ -138,10 +138,10 @@ class ExpectTableRowCountToBeBetween(TableExpectation):
                         "class_name": "DefaultExpectationConfigurationBuilder",
                         "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder",
                         "validation_parameter_builder_configs": validation_parameter_builder_configs,
-                        "min_value": f"{PARAMETER_KEY}{row_count_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[0]",
-                        "max_value": f"{PARAMETER_KEY}{row_count_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[1]",
+                        "min_value": f"{PARAMETER_KEY}{table_row_count_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[0]",
+                        "max_value": f"{PARAMETER_KEY}{table_row_count_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[1]",
                         "meta": {
-                            "profiler_details": f"{PARAMETER_KEY}{row_count_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY}",
+                            "profiler_details": f"{PARAMETER_KEY}{table_row_count_range_estimator_parameter_builder_config.name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY}",
                         },
                     }
                 ],

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
@@ -829,6 +829,7 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
 @freeze_time(TIMESTAMP)
 def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     bobby_validator: Validator,
+    set_consistent_seed_within_numeric_metric_range_multi_batch_parameter_builder,
 ):
     validator: Validator = bobby_validator
 
@@ -846,8 +847,8 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
     assert result.success
     assert result.expectation_config["kwargs"] == {
         "column": "fare_amount",
-        "min_value": -22.5,
-        "max_value": 250.0,
+        "min_value": -50.5,
+        "max_value": 2121.9,
         "strict_min": False,
         "strict_max": False,
         "mostly": 1.0,
@@ -870,7 +871,7 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
     assert result.expectation_config["kwargs"] == {
         "column": "fare_amount",
         "min_value": 0.0,
-        "max_value": 250.0,
+        "max_value": 2121.9,
         "strict_min": False,
         "strict_max": False,
         "mostly": 1.0,
@@ -894,7 +895,7 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
     assert result.expectation_config["kwargs"] == {
         "column": "fare_amount",
         "min_value": 0.0,
-        "max_value": 250.0,
+        "max_value": 2121.9,
         "strict_min": False,
         "strict_max": False,
         "mostly": 8.75e-1,
@@ -2008,8 +2009,8 @@ def test_quentin_expect_column_max_to_be_between_auto_yes_default_profiler_confi
     rtol: float = 2.0e1 * RTOL
     atol: float = 2.0e1 * ATOL
 
-    min_value_actual: int = result.expectation_config["kwargs"]["min_value"]
-    min_value_expected: int = 155
+    min_value_actual: float = result.expectation_config["kwargs"]["min_value"]
+    min_value_expected: float = 155.0
 
     np.testing.assert_allclose(
         actual=float(min_value_actual),
@@ -2019,8 +2020,8 @@ def test_quentin_expect_column_max_to_be_between_auto_yes_default_profiler_confi
         err_msg=f"Actual value of {min_value_actual} differs from expected value of {min_value_expected} by more than {atol + rtol * abs(min_value_expected)} tolerance.",
     )
 
-    max_value_actual: int = result.expectation_config["kwargs"]["max_value"]
-    max_value_expected: int = 3004
+    max_value_actual: float = result.expectation_config["kwargs"]["max_value"]
+    max_value_expected: float = 56314.8
     np.testing.assert_allclose(
         actual=float(max_value_actual),
         desired=float(max_value_expected),

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -1973,11 +1973,11 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                     ],
                     "expectation_configuration_builders": [
                         {
-                            "max_value": "$parameter.row_count_range_estimator.value[1]",
+                            "max_value": "$parameter.table_row_count_range_estimator.value[1]",
                             "validation_parameter_builder_configs": [
                                 {
                                     "replace_nan_with_zero": True,
-                                    "name": "row_count_range_estimator",
+                                    "name": "table_row_count_range_estimator",
                                     "module_name": "great_expectations.rule_based_profiler.parameter_builder",
                                     "truncate_values": "$variables.truncate_values",
                                     "enforce_numeric_metric": True,
@@ -1996,10 +1996,10 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                             "expectation_type": "expect_table_row_count_to_be_between",
                             "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder.default_expectation_configuration_builder",
                             "meta": {
-                                "profiler_details": "$parameter.row_count_range_estimator.details"
+                                "profiler_details": "$parameter.table_row_count_range_estimator.details"
                             },
                             "class_name": "DefaultExpectationConfigurationBuilder",
-                            "min_value": "$parameter.row_count_range_estimator.value[0]",
+                            "min_value": "$parameter.table_row_count_range_estimator.value[0]",
                         }
                     ],
                 },


### PR DESCRIPTION
### Scope
Previously, the `kwargs` estimator in `expect_column_values_to_be_between` did not take advantage of all `Batch` objects available (it was using only the most recent `Batch`).  This is corrected and test tolerances adjusted.  Also, some cleanup.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-464/GREAT-598/GREAT-822/GREAT-842
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
