### PR TITLE
[FEATURE] Enum used by DateSplitter able to be represented as YAML

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -230,10 +230,6 @@ class AssetConfigSchema(Schema):
     )
 
     splitter_method = fields.String(required=False, allow_none=True)
-    # see if there is a way to take in string or ENUM (datetime)
-    # and if it is a ENUM, then we do the conversion.
-    # when we dump it into a YAML, then we use teh value.. or just use the string.
-    # TODO : look into
     splitter_kwargs = fields.Dict(required=False, allow_none=True)
 
     @validates_schema

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -230,6 +230,10 @@ class AssetConfigSchema(Schema):
     )
 
     splitter_method = fields.String(required=False, allow_none=True)
+    # see if there is a way to take in string or ENUM (datetime)
+    # and if it is a ENUM, then we do the conversion.
+    # when we dump it into a YAML, then we use teh value.. or just use the string.
+    # TODO : look into
     splitter_kwargs = fields.Dict(required=False, allow_none=True)
 
     @validates_schema

--- a/great_expectations/execution_engine/split_and_sample/data_splitter.py
+++ b/great_expectations/execution_engine/split_and_sample/data_splitter.py
@@ -5,11 +5,16 @@ import datetime
 import enum
 from typing import Callable, List, Union
 
+import ruamel
 from dateutil.parser import parse
+from ruamel.yaml import yaml_object
 
 import great_expectations.exceptions as ge_exceptions
 
+yaml = ruamel.yaml.YAML()
 
+
+@yaml_object(yaml)
 class DatePart(enum.Enum):
     """SQL supported date parts for most dialects."""
 
@@ -26,6 +31,13 @@ class DatePart(enum.Enum):
 
     def __hash__(self: DatePart):
         return hash(self.value)
+
+    # the to_yaml() allows for the yaml-encodable representation of ENUM, using internal methods of ruamel.
+    # pattern was found in the following stackoverflow thread.
+    # https://stackoverflow.com/questions/48017317/can-ruamel-yaml-encode-an-enum
+    @classmethod
+    def to_yaml(cls, representer, node):  # type: ignore[no-untyped-def]
+        return representer.represent_str(data=node.value)
 
 
 class DataSplitter(abc.ABC):

--- a/great_expectations/execution_engine/split_and_sample/data_splitter.py
+++ b/great_expectations/execution_engine/split_and_sample/data_splitter.py
@@ -32,11 +32,13 @@ class DatePart(enum.Enum):
     def __hash__(self: DatePart):
         return hash(self.value)
 
-    # the to_yaml() allows for the yaml-encodable representation of ENUM, using internal methods of ruamel.
-    # pattern was found in the following stackoverflow thread.
-    # https://stackoverflow.com/questions/48017317/can-ruamel-yaml-encode-an-enum
     @classmethod
     def to_yaml(cls, representer, node):  # type: ignore[no-untyped-def]
+        """
+        Method allows for yaml-encodable representation of ENUM, using internal methods of ruamel.
+        pattern was found in the following stackoverflow thread:
+        https://stackoverflow.com/questions/48017317/can-ruamel-yaml-encode-an-enum
+        """
         return representer.represent_str(data=node.value)
 
 

--- a/tests/integration/fixtures/split_and_sample_data/splitter_test_cases_and_fixtures.py
+++ b/tests/integration/fixtures/split_and_sample_data/splitter_test_cases_and_fixtures.py
@@ -126,7 +126,7 @@ class TaxiSplittingTestCases:
                 splitter_method_name="split_on_date_parts",
                 splitter_kwargs={
                     "column_name": self.taxi_test_data.test_column_name,
-                    "date_parts": [DatePart.MONTH.value],
+                    "date_parts": [DatePart.MONTH],
                 },
                 num_expected_batch_definitions=12,
                 num_expected_rows_in_first_batch_definition=30,
@@ -137,8 +137,7 @@ class TaxiSplittingTestCases:
                 splitter_method_name="split_on_date_parts",
                 splitter_kwargs={
                     "column_name": self.taxi_test_data.test_column_name,
-                    # internally we should be usign this
-                    "date_parts": [DatePart.YEAR.value, "mOnTh"],
+                    "date_parts": [DatePart.YEAR, "mOnTh"],
                 },
                 num_expected_batch_definitions=36,
                 num_expected_rows_in_first_batch_definition=10,

--- a/tests/integration/fixtures/split_and_sample_data/splitter_test_cases_and_fixtures.py
+++ b/tests/integration/fixtures/split_and_sample_data/splitter_test_cases_and_fixtures.py
@@ -126,7 +126,7 @@ class TaxiSplittingTestCases:
                 splitter_method_name="split_on_date_parts",
                 splitter_kwargs={
                     "column_name": self.taxi_test_data.test_column_name,
-                    "date_parts": [DatePart.MONTH.name],
+                    "date_parts": [DatePart.MONTH.value],
                 },
                 num_expected_batch_definitions=12,
                 num_expected_rows_in_first_batch_definition=30,
@@ -137,7 +137,8 @@ class TaxiSplittingTestCases:
                 splitter_method_name="split_on_date_parts",
                 splitter_kwargs={
                     "column_name": self.taxi_test_data.test_column_name,
-                    "date_parts": [DatePart.YEAR.name, "mOnTh"],
+                    # internally we should be usign this
+                    "date_parts": [DatePart.YEAR.value, "mOnTh"],
                 },
                 num_expected_batch_definitions=36,
                 num_expected_rows_in_first_batch_definition=10,


### PR DESCRIPTION
Changes proposed in this pull request:
- Follow-up to PR #5026
- Adds `to_yaml()` method to the `DatePart` enum that is used by the splitter, so that it can be directly used in tests + by users. 
- Modifies `splitter_test_cases_and_fixtures.py` so `date_parts` can be passed in as an ENUM directly, rather than having to go into the `.value`. 
- Adds reference to StackOverflow where the pattern was found : `https://stackoverflow.com/questions/48017317/can-ruamel-yaml-encode-an-enum`
### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.