### PR TITLE
[FEATURE] Implementation of auto-complete for DataAssistant class names in Jupyter notebooks

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
@@ -61,7 +61,7 @@ class DataAssistantDispatcher:
         data_assistant: Type[DataAssistant],  # noqa: F821
     ) -> None:
         """
-        This method executes "run()" of effective "RuleBasedProfiler" and fills "DataAssistantResult" object with outputs.
+        This method registers "DataAssistant" subclass for future instantiation and execution of its "run()" method.
 
         Args:
             data_assistant: "DataAssistant" class to be registered

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
@@ -106,7 +106,7 @@ class DataAssistantDispatcher:
 
     def __dir__(self):
         """
-        This custom magic method is used to enable expectation tab completion on "DataAssistantDispatcher" objects.
+        This custom magic method is used to enable data assistant tab completion on "DataAssistantDispatcher" objects.
         """
         data_assistant_dispatcher_attrs: Set[str] = set(super().__dir__())
         data_assistant_registered_names: Set[str] = set(

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Type
+from typing import Dict, Optional, Set, Type
 
 from great_expectations.rule_based_profiler.data_assistant import DataAssistant
 from great_expectations.rule_based_profiler.data_assistant.data_assistant_runner import (
@@ -89,14 +89,14 @@ class DataAssistantDispatcher:
     def get_data_assistant_impl(
         cls,
         name: Optional[str],
-    ) -> Optional[Type[DataAssistant]]:  # noqa: F821
+    ) -> Optional[Type[DataAssistant]]:
         """
         This method obtains (previously registered) "DataAssistant" class from DataAssistant Registry.
 
         Note that it will clean the input string before checking against registered assistants.
 
         Args:
-            data_assistant_type: String representing "snake case" version of "DataAssistant" class type
+            name: String representing "snake case" version of "DataAssistant" class type
 
         Returns:
             Class inheriting "DataAssistant" if found; otherwise, None
@@ -105,3 +105,16 @@ class DataAssistantDispatcher:
             return None
         name = name.lower()
         return cls._registered_data_assistants.get(name)
+
+    def __dir__(self):
+        """
+        This custom magic method is used to enable expectation tab completion on "DataAssistantDispatcher" objects.
+        """
+        data_assistant_dispatcher_attrs: Set[str] = set(super().__dir__())
+        data_assistant_registered_names: Set[str] = set(
+            DataAssistantDispatcher._registered_data_assistants.keys()
+        )
+        combined_dir_attrs: Set[str] = (
+            data_assistant_dispatcher_attrs | data_assistant_registered_names
+        )
+        return list(combined_dir_attrs)

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_dispatcher.py
@@ -121,4 +121,7 @@ class DataAssistantDispatcher:
 
 
 def get_registered_data_assistant_names() -> Set[str]:
+    """
+    This method returns names (registered data_assistant_type and alias name) of registered "DataAssistant" classes.
+    """
     return set(DataAssistantDispatcher._registered_data_assistants.keys())


### PR DESCRIPTION
### Scope
* Taking the cue from `Validator.__dir()__` override (hat tip to @roblim -- thanks, Rob!), we implement `DataAssistantDispatcher.__dir__(self)`, such that the "total" dir is the `set` union of the existing `dir` with the names of all registered `DataAssistant` classes by their name (as well as any defined aliases -- both `DataAssistant` class names and aliases work using the "snake-case" style naming; e.g., both "volume" and "volume_data_assistant").
* Tested in a sample `Jupyter` notebook and should go user-acceptance testing by an independent party, too.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-464/GREAT-598/GREAT-822/GREAT-844
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
