### PR TITLE
[FEATURE] Provide display ("friendly") names for batch identifiers

### DIFF
--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -160,6 +160,7 @@ class ExpectationValidationResult(SerializableDictDot):
                 "expectation_config" in json_dict
                 and "kwargs" in json_dict["expectation_config"]
                 and "auto" in json_dict["expectation_config"]["kwargs"]
+                and json_dict["expectation_config"]["kwargs"]["auto"]
             ):
                 json_dict["expectation_config"]["meta"] = {
                     "auto_generated_at": datetime.datetime.now(

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -343,6 +343,9 @@ class DataAssistant(metaclass=MetaDataAssistant):
     def batch_id_to_batch_identifier_display_name_map(
         self,
     ) -> Dict[str, Set[Tuple[str, Any]]]:
+        """
+        This method uses loaded "Batch" objects to return the mapping between unique "batch_id" and "batch_identifiers".
+        """
         batch_id: str
         batch: Batch
         return {

--- a/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
@@ -102,6 +102,7 @@ class VolumeDataAssistant(DataAssistant):
         self, data_assistant_result: DataAssistantResult
     ) -> DataAssistantResult:
         return VolumeDataAssistantResult(
+            batch_id_to_batch_identifier_display_name_map=data_assistant_result.batch_id_to_batch_identifier_display_name_map,
             profiler_config=data_assistant_result.profiler_config,
             metrics_by_domain=data_assistant_result.metrics_by_domain,
             expectation_configurations=data_assistant_result.expectation_configurations,

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -1,7 +1,7 @@
 import copy
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import altair as alt
 import pandas as pd
@@ -39,8 +39,12 @@ class DataAssistantResult(SerializableDictDot):
     DataAssistantResult is a "dataclass" object, designed to hold results of executing "DataAssistant.run()" method.
     Available properties are: "metrics_by_domain", "expectation_configurations", and configuration object
     ("RuleBasedProfilerConfig") of effective Rule-Based Profiler, which embodies given "DataAssistant".
+    Use "batch_id_to_batch_identifier_display_name_map" to translate "batch_id" values to display ("friendly") names.
     """
 
+    batch_id_to_batch_identifier_display_name_map: Optional[
+        Dict[str, Set[Tuple[str, Any]]]
+    ] = None
     profiler_config: Optional["RuleBasedProfilerConfig"] = None  # noqa: F821
     metrics_by_domain: Optional[Dict[Domain, Dict[str, ParameterNode]]] = None
     expectation_configurations: Optional[List[ExpectationConfiguration]] = None
@@ -55,6 +59,9 @@ class DataAssistantResult(SerializableDictDot):
         parameter_values_for_fully_qualified_parameter_names: Dict[str, ParameterNode]
         expectation_configuration: ExpectationConfiguration
         return {
+            "batch_id_to_batch_identifier_display_name_map": convert_to_json_serializable(
+                data=self.batch_id_to_batch_identifier_display_name_map
+            ),
             "profiler_config": self.profiler_config.to_json_dict(),
             "metrics_by_domain": [
                 {

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -2683,7 +2683,7 @@ def test_volume_data_assistant_result_serialization(
     volume_data_assistant_result_as_dict: dict = volume_data_assistant_result.to_dict()
     assert (
         volume_data_assistant_result_as_dict is not None
-        and len(volume_data_assistant_result_as_dict) == 4
+        and len(volume_data_assistant_result_as_dict) == 5
     )
     assert (
         volume_data_assistant_result.to_json_dict()


### PR DESCRIPTION
### Scope
Adding to `DataAssistant` a utility that produces a map between unique batch IDs and batch identifiers, which are more "friendly" fore displaying purposes.  Charting and other visualization components can obtain display names by using the available `batch_id` as the key; the return value is a set of `tuples`, so potentially converting to strings may be needed.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-464/GREAT-598/GREAT-822/GREAT-825
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
