### PR TITLE
[MAINTENANCE] Remove references to show_cta_footer except in schemas.py

### DIFF
--- a/great_expectations/core/usage_statistics/anonymizers/data_docs_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/data_docs_anonymizer.py
@@ -37,11 +37,6 @@ class DataDocsAnonymizer(BaseAnonymizer):
         anonymized_site_index_builder = self._anonymize_site_builder_info(
             site_builder_config=site_index_builder_config
         )
-        # Note AJB-20201218 show_cta_footer was removed in v 0.9.9 via PR #1249
-        if "show_cta_footer" in site_index_builder_config:
-            anonymized_site_index_builder[
-                "show_cta_footer"
-            ] = site_index_builder_config.get("show_cta_footer")
         anonymized_info_dict[
             "anonymized_site_index_builder"
         ] = anonymized_site_index_builder

--- a/tests/core/usage_statistics/test_schema_validation.py
+++ b/tests/core/usage_statistics/test_schema_validation.py
@@ -108,7 +108,6 @@ def test_init_payload_validation():
                 },
                 "anonymized_site_index_builder": {
                     "parent_class": "DefaultSiteIndexBuilder",
-                    "show_cta_footer": True,
                 },
             }
         ],

--- a/tests/data_context/test_configuration_storage.py
+++ b/tests/data_context/test_configuration_storage.py
@@ -135,7 +135,6 @@ data_docs_sites:
       base_directory: uncommitted/data_docs/local_site/
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
-      show_cta_footer: true
 
 stores:
   expectations_store:

--- a/tests/integration/usage_statistics/test_integration_usage_statistics.py
+++ b/tests/integration/usage_statistics/test_integration_usage_statistics.py
@@ -98,7 +98,6 @@ def valid_usage_statistics_message() -> dict:
                     },
                     "anonymized_site_index_builder": {
                         "parent_class": "DefaultSiteIndexBuilder",
-                        "show_cta_footer": True,
                     },
                 }
             ],

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -214,7 +214,6 @@ valid_usage_statistics_messages = {
                         },
                         "anonymized_site_index_builder": {
                             "parent_class": "DefaultSiteIndexBuilder",
-                            "show_cta_footer": True,
                         },
                     },
                 ],
@@ -307,7 +306,6 @@ valid_usage_statistics_messages = {
                         },
                         "anonymized_site_index_builder": {
                             "parent_class": "DefaultSiteIndexBuilder",
-                            "show_cta_footer": True,
                         },
                     },
                 ],


### PR DESCRIPTION
Changes proposed in this pull request:
- This PR removes usage stats references to `show_cta_footer` which was removed in [#1249](https://github.com/great-expectations/great_expectations/pull/1249).
- It leaves the reference and notes in `schemas.py` so that we still accept events from older versions that allow it.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code

Thank you for submitting!
