### PR TITLE
[MAINTENANCE] Improve handling of "expect_column_unique_values_count_to_be_between" in VolumeDataAssistant

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -19,6 +19,7 @@ from great_expectations.rule_based_profiler.helpers.configuration_reconciliation
 )
 from great_expectations.rule_based_profiler.helpers.util import (
     convert_variables_to_dict,
+    sanitize_parameter_name,
 )
 from great_expectations.rule_based_profiler.parameter_builder import (
     MeanUnexpectedMapMetricMultiBatchParameterBuilder,
@@ -294,8 +295,9 @@ class DataAssistant(metaclass=MetaDataAssistant):
             """
             This method instantiates "MetricMultiBatchParameterBuilder" class with specific arguments for given purpose.
             """
+            name: str = sanitize_parameter_name(name=f"{metric_name}.range")
             return NumericMetricRangeMultiBatchParameterBuilder(
-                name=f"{metric_name}.range",
+                name=name,
                 metric_name=metric_name,
                 metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
                 metric_value_kwargs=metric_value_kwargs,

--- a/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
@@ -152,17 +152,17 @@ class OnboardingDataAssistant(DataAssistant):
             max_unexpected_ratio=None,
             min_max_unexpected_values_proportion=9.75e-1,
         )
-        numeric_rule: Rule = self._build_numeric_rule()
-        datetime_rule: Rule = self._build_datetime_rule()
-        categorical_rule: Rule = self._build_categorical_rule()
+        numeric_columns_rule: Rule = self._build_numeric_columns_rule()
+        datetime_columns_rule: Rule = self._build_datetime_columns_rule()
+        categorical_columns_rule: Rule = self._build_categorical_columns_rule()
 
         return [
             column_value_uniqueness_rule,
             column_value_nullity_rule,
             column_value_nonnullity_rule,
-            numeric_rule,
-            datetime_rule,
-            categorical_rule,
+            numeric_columns_rule,
+            datetime_columns_rule,
+            categorical_columns_rule,
         ]
 
     def _build_data_assistant_result(
@@ -178,7 +178,7 @@ class OnboardingDataAssistant(DataAssistant):
         )
 
     @staticmethod
-    def _build_numeric_rule() -> Rule:
+    def _build_numeric_columns_rule() -> Rule:
         """
         This method builds "Rule" object focused on emitting "ExpectationConfiguration" objects for numeric columns.
         """
@@ -455,7 +455,7 @@ class OnboardingDataAssistant(DataAssistant):
         return rule
 
     @staticmethod
-    def _build_datetime_rule() -> Rule:
+    def _build_datetime_columns_rule() -> Rule:
         """
         This method builds "Rule" object focused on emitting "ExpectationConfiguration" objects for datetime columns.
         """
@@ -624,7 +624,7 @@ class OnboardingDataAssistant(DataAssistant):
         return rule
 
     @staticmethod
-    def _build_categorical_rule() -> Rule:
+    def _build_categorical_columns_rule() -> Rule:
         """
         This method builds "Rule" object focused on emitting "ExpectationConfiguration" objects for categorical columns.
         """
@@ -777,7 +777,7 @@ class OnboardingDataAssistant(DataAssistant):
             expect_column_proportion_of_unique_values_to_be_between_expectation_configuration_builder,
         ]
         rule: Rule = Rule(
-            name="categorical_rule",
+            name="categorical_columns_rule",
             variables=variables,
             domain_builder=categorical_column_type_domain_builder,
             parameter_builders=parameter_builders,

--- a/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
@@ -1,10 +1,28 @@
 from typing import Any, Dict, List, Optional
 
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
+from great_expectations.rule_based_profiler.config import ParameterBuilderConfig
 from great_expectations.rule_based_profiler.data_assistant import DataAssistant
+from great_expectations.rule_based_profiler.domain_builder import (
+    CategoricalColumnDomainBuilder,
+)
+from great_expectations.rule_based_profiler.expectation_configuration_builder import (
+    DefaultExpectationConfigurationBuilder,
+    ExpectationConfigurationBuilder,
+)
+from great_expectations.rule_based_profiler.helpers.cardinality_checker import (
+    CardinalityLimitMode,
+)
 from great_expectations.rule_based_profiler.parameter_builder import ParameterBuilder
 from great_expectations.rule_based_profiler.rule import Rule
-from great_expectations.rule_based_profiler.types import Domain
+from great_expectations.rule_based_profiler.types import (
+    DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
+    FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY,
+    FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER,
+    FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY,
+    VARIABLES_KEY,
+    Domain,
+)
 from great_expectations.rule_based_profiler.types.data_assistant_result import (
     DataAssistantResult,
     VolumeDataAssistantResult,
@@ -41,10 +59,6 @@ class VolumeDataAssistant(DataAssistant):
                 "auto": True,
                 "profiler_config": None,
             },
-            "expect_column_unique_value_count_to_be_between": {
-                "auto": True,
-                "profiler_config": None,
-            },
         }
 
     @property
@@ -57,7 +71,6 @@ class VolumeDataAssistant(DataAssistant):
         column_distinct_values_count_metric_multi_batch_parameter_builder: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.get_column_distinct_values_count_metric_multi_batch_parameter_builder(
             json_serialize=True
         )
-
         return {
             Domain(domain_type=MetricDomainTypes.TABLE,): [
                 table_row_count_metric_multi_batch_parameter_builder,
@@ -73,7 +86,11 @@ class VolumeDataAssistant(DataAssistant):
 
     @property
     def rules(self) -> Optional[List[Rule]]:
-        return None
+        categorical_columns_rule: Rule = self._build_categorical_columns_rule()
+
+        return [
+            categorical_columns_rule,
+        ]
 
     def _build_data_assistant_result(
         self, data_assistant_result: DataAssistantResult
@@ -86,3 +103,98 @@ class VolumeDataAssistant(DataAssistant):
             citation=data_assistant_result.citation,
             execution_time=data_assistant_result.execution_time,
         )
+
+    @staticmethod
+    def _build_categorical_columns_rule() -> Rule:
+        """
+        This method builds "Rule" object focused on emitting "ExpectationConfiguration" objects for categorical columns.
+        """
+        # Step-1: Instantiate "CategoricalColumnDomainBuilder" for selecting columns containing "FEW" discrete values.
+
+        categorical_column_type_domain_builder: CategoricalColumnDomainBuilder = (
+            CategoricalColumnDomainBuilder(
+                include_column_names=None,
+                exclude_column_names=None,
+                include_column_name_suffixes=None,
+                exclude_column_name_suffixes=None,
+                semantic_type_filter_module_name=None,
+                semantic_type_filter_class_name=None,
+                include_semantic_types=None,
+                exclude_semantic_types=None,
+                allowed_semantic_types_passthrough=None,
+                limit_mode=CardinalityLimitMode.REL_100,
+                max_unique_values=None,
+                max_proportion_unique=None,
+                data_context=None,
+            )
+        )
+
+        # Step-2: Declare "ParameterBuilder" for every metric of interest.
+
+        column_distinct_values_count_metric_multi_batch_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.get_column_distinct_values_count_metric_multi_batch_parameter_builder(
+            json_serialize=True
+        )
+
+        # Step-3: Declare "ParameterBuilder" for every "validation" need in "ExpectationConfigurationBuilder" objects.
+
+        column_distinct_values_count_range_parameter_builder_for_validations: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.build_numeric_metric_range_multi_batch_parameter_builder(
+            metric_name="column.distinct_values.count",
+            metric_value_kwargs=None,
+            json_serialize=True,
+        )
+
+        validation_parameter_builder_configs: Optional[List[ParameterBuilderConfig]]
+
+        # Step-4: Pass "validation" "ParameterBuilderConfig" objects to every "DefaultExpectationConfigurationBuilder", responsible for emitting "ExpectationConfiguration" (with specified "expectation_type").
+
+        validation_parameter_builder_configs = [
+            ParameterBuilderConfig(
+                **column_distinct_values_count_range_parameter_builder_for_validations.to_json_dict(),
+            ),
+        ]
+        expect_column_unique_value_count_to_be_between_expectation_configuration_builder: DefaultExpectationConfigurationBuilder = DefaultExpectationConfigurationBuilder(
+            expectation_type="expect_column_unique_value_count_to_be_between",
+            validation_parameter_builder_configs=validation_parameter_builder_configs,
+            column=f"{DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}column",
+            min_value=f"{column_distinct_values_count_range_parameter_builder_for_validations.fully_qualified_parameter_name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[0]",
+            max_value=f"{column_distinct_values_count_range_parameter_builder_for_validations.fully_qualified_parameter_name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[1]",
+            strict_min=f"{VARIABLES_KEY}strict_min",
+            strict_max=f"{VARIABLES_KEY}strict_max",
+            meta={
+                "profiler_details": f"{column_distinct_values_count_range_parameter_builder_for_validations.fully_qualified_parameter_name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY}",
+            },
+        )
+
+        # Step-5: Instantiate and return "Rule" object, comprised of "variables", "domain_builder", "parameter_builders", and "expectation_configuration_builders" components.
+
+        variables: dict = {
+            "mostly": 1.0,
+            "strict_min": False,
+            "strict_max": False,
+            "false_positive_rate": 0.05,
+            "quantile_statistic_interpolation_method": "auto",
+            "estimator": "bootstrap",
+            "n_resamples": 9999,
+            "random_seed": None,
+            "include_estimator_samples_histogram_in_details": False,
+            "truncate_values": {
+                "lower_bound": 0.0,
+                "upper_bound": None,
+            },
+            "round_decimals": 1,
+        }
+        parameter_builders: List[ParameterBuilder] = [
+            column_distinct_values_count_metric_multi_batch_parameter_builder_for_metrics,
+        ]
+        expectation_configuration_builders: List[ExpectationConfigurationBuilder] = [
+            expect_column_unique_value_count_to_be_between_expectation_configuration_builder,
+        ]
+        rule: Rule = Rule(
+            name="categorical_columns_rule",
+            variables=variables,
+            domain_builder=categorical_column_type_domain_builder,
+            parameter_builders=parameter_builders,
+            expectation_configuration_builders=expectation_configuration_builders,
+        )
+
+        return rule

--- a/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/categorical_column_domain_builder.py
@@ -95,6 +95,11 @@ class CategoricalColumnDomainBuilder(ColumnDomainBuilder):
                 "id",
             ]
 
+        if exclude_column_name_suffixes is None:
+            exclude_column_name_suffixes = [
+                "_id",
+            ]
+
         if exclude_semantic_types is None:
             exclude_semantic_types = [
                 SemanticDomainTypes.BINARY,

--- a/great_expectations/rule_based_profiler/helpers/cardinality_checker.py
+++ b/great_expectations/rule_based_profiler/helpers/cardinality_checker.py
@@ -79,6 +79,7 @@ class CardinalityLimitMode(enum.Enum):
     REL_25 = RelativeCardinalityLimit("REL_25", 0.25)
     REL_50 = RelativeCardinalityLimit("REL_50", 0.50)
     REL_75 = RelativeCardinalityLimit("REL_75", 0.75)
+    REL_100 = RelativeCardinalityLimit("REL_100", 1.0)
     ONE_PCT = RelativeCardinalityLimit("ONE_PCT", 0.01)
     TEN_PCT = RelativeCardinalityLimit("TEN_PCT", 0.10)
 

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -794,4 +794,7 @@ def get_or_create_expectation_suite(
 
 
 def sanitize_parameter_name(name: str) -> str:
+    """
+    This method provides display-friendly version of "name" argument.
+    """
     return name.replace(FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER, "_")

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -20,6 +20,7 @@ from great_expectations.core.batch import (
 )
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
 from great_expectations.rule_based_profiler.types import (
+    FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER,
     INFERRED_SEMANTIC_TYPE_KEY,
     VARIABLES_PREFIX,
     Domain,
@@ -790,3 +791,7 @@ def get_or_create_expectation_suite(
             )
 
     return expectation_suite
+
+
+def sanitize_parameter_name(name: str) -> str:
+    return name.replace(FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER, "_")

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -10,6 +10,7 @@ from IPython.display import HTML, display
 from great_expectations.core import ExpectationConfiguration
 from great_expectations.core.util import convert_to_json_serializable, nested_update
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
+from great_expectations.rule_based_profiler.helpers.util import sanitize_parameter_name
 from great_expectations.rule_based_profiler.types import (
     FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY,
     FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY,
@@ -1519,8 +1520,8 @@ class DataAssistantResult(SerializableDictDot):
             ] = attributed_metrics[domain]
 
             # Altair does not accept periods.
-            metric_name = list(attributed_values_by_metric_name.keys())[0].replace(
-                ".", "_"
+            metric_name = sanitize_parameter_name(
+                name=list(attributed_values_by_metric_name.keys())[0]
             )
 
             df: pd.DataFrame = self._create_df_for_charting(

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -138,106 +138,6 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
         Domain(
             domain_type=MetricDomainTypes.COLUMN,
             domain_kwargs={
-                "column": "vendor_id",
-            },
-            details={
-                INFERRED_SEMANTIC_TYPE_KEY: {
-                    "vendor_id": SemanticDomainTypes.NUMERIC,
-                },
-            },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
-        ): {
-            "$parameter.column.distinct_values.count": {
-                "value": [
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    3,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                    2,
-                ],
-                "attributed_value": {
-                    "c92d0679f769ac83fef2bb5eaac5d12a": [2],
-                    "562969eaef9c843cb4531aecbc13bbcb": [2],
-                    "569a4a80bf434c888593c651dbf2f157": [2],
-                    "f6c389dcef63c1f214c30f66b66945c0": [2],
-                    "c4fe9afce1cf3e83eb8518a9f5abc754": [2],
-                    "e20c38f98b9830a40b851939ca7189d4": [2],
-                    "f2e4d3da6556638b55df8ce509b094c2": [3],
-                    "44c1b1947c9049e7db62c5320dde4c63": [3],
-                    "47157bdaf05a7992473cd699cabaef74": [3],
-                    "08085632aff9ce4cebbb8023049e1aec": [3],
-                    "bb54e4fa3906387218be10cff631a7c2": [3],
-                    "58ce3b40d384eacd9bad7d916eb8f705": [3],
-                    "0327cfb13205ec8512e1c28e438ab43b": [3],
-                    "0808e185a52825d22356de2fe00a8f5f": [3],
-                    "90bb41c1fbd7c71c05dbc8695320af71": [3],
-                    "6c7e43619fe5e6963e8159cc84a28321": [3],
-                    "976b121b46db6967854b9c1a6628396b": [3],
-                    "9e58d3c72c7006b6f5800b623fbc9818": [3],
-                    "ce5f02ac408b7b5c500050190f549736": [3],
-                    "bb81456ec79522bf02f34b02762f95e0": [3],
-                    "b20800a7faafd2808d6c888577a2ba1d": [2],
-                    "33d910f95326c0c7dfe7536d1cfeba51": [2],
-                    "61e4931d87cb627df2a19b8bc5819b7b": [2],
-                    "3692b23382fd4734215465251290c65b": [2],
-                    "eff8910cddcdff62e4741243099240d5": [2],
-                    "f67d274202366f6b976414c950ca14bd": [2],
-                    "7b3ce20a8e8cf3097bb9df270a7ae63a": [2],
-                    "73612fdabd337d5a8279acc30ce22d00": [2],
-                    "ad2ad2a70c3e0bf94ddef3f893e92291": [2],
-                    "8ce0d477f610ea18e2ea4fbbb46de857": [2],
-                    "ff5a6cc031dd2c98b8bccd4766af38c1": [2],
-                    "940576153c66af14a949fd19aedd5f5b": [2],
-                    "ab05b4fb82e37c8cf5b1ac40d0a37fe9": [2],
-                    "57c04d62ada3a102248b48f34c755159": [2],
-                    "816b147dcf3305839f723a131b9ad6af": [2],
-                    "84000630d1b69a0fe870c94fb26a32bc": [2],
-                },
-                "details": {
-                    "metric_configuration": {
-                        "metric_name": "column.distinct_values.count",
-                        "domain_kwargs": {"column": "vendor_id"},
-                        "metric_value_kwargs": None,
-                        "metric_dependencies": None,
-                    },
-                    "num_batches": 36,
-                },
-            }
-        },
-        Domain(
-            domain_type=MetricDomainTypes.COLUMN,
-            domain_kwargs={
                 "column": "pickup_datetime",
             },
             details={
@@ -245,7 +145,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "pickup_datetime": SemanticDomainTypes.TEXT,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -345,7 +245,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "dropoff_datetime": SemanticDomainTypes.TEXT,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -445,7 +345,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "passenger_count": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -545,7 +445,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "trip_distance": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -638,106 +538,6 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
         Domain(
             domain_type=MetricDomainTypes.COLUMN,
             domain_kwargs={
-                "column": "rate_code_id",
-            },
-            details={
-                INFERRED_SEMANTIC_TYPE_KEY: {
-                    "rate_code_id": SemanticDomainTypes.NUMERIC,
-                },
-            },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
-        ): {
-            "$parameter.column.distinct_values.count": {
-                "value": [
-                    5,
-                    5,
-                    5,
-                    6,
-                    5,
-                    6,
-                    5,
-                    6,
-                    6,
-                    6,
-                    6,
-                    6,
-                    7,
-                    5,
-                    5,
-                    5,
-                    5,
-                    6,
-                    5,
-                    6,
-                    5,
-                    5,
-                    5,
-                    5,
-                    5,
-                    6,
-                    5,
-                    6,
-                    6,
-                    6,
-                    6,
-                    5,
-                    5,
-                    6,
-                    5,
-                    5,
-                ],
-                "attributed_value": {
-                    "c92d0679f769ac83fef2bb5eaac5d12a": [5],
-                    "562969eaef9c843cb4531aecbc13bbcb": [5],
-                    "569a4a80bf434c888593c651dbf2f157": [5],
-                    "f6c389dcef63c1f214c30f66b66945c0": [6],
-                    "c4fe9afce1cf3e83eb8518a9f5abc754": [5],
-                    "e20c38f98b9830a40b851939ca7189d4": [6],
-                    "f2e4d3da6556638b55df8ce509b094c2": [5],
-                    "44c1b1947c9049e7db62c5320dde4c63": [6],
-                    "47157bdaf05a7992473cd699cabaef74": [6],
-                    "08085632aff9ce4cebbb8023049e1aec": [6],
-                    "bb54e4fa3906387218be10cff631a7c2": [6],
-                    "58ce3b40d384eacd9bad7d916eb8f705": [6],
-                    "0327cfb13205ec8512e1c28e438ab43b": [7],
-                    "0808e185a52825d22356de2fe00a8f5f": [5],
-                    "90bb41c1fbd7c71c05dbc8695320af71": [5],
-                    "6c7e43619fe5e6963e8159cc84a28321": [5],
-                    "976b121b46db6967854b9c1a6628396b": [5],
-                    "9e58d3c72c7006b6f5800b623fbc9818": [6],
-                    "ce5f02ac408b7b5c500050190f549736": [5],
-                    "bb81456ec79522bf02f34b02762f95e0": [6],
-                    "b20800a7faafd2808d6c888577a2ba1d": [5],
-                    "33d910f95326c0c7dfe7536d1cfeba51": [5],
-                    "61e4931d87cb627df2a19b8bc5819b7b": [5],
-                    "3692b23382fd4734215465251290c65b": [5],
-                    "eff8910cddcdff62e4741243099240d5": [5],
-                    "f67d274202366f6b976414c950ca14bd": [6],
-                    "7b3ce20a8e8cf3097bb9df270a7ae63a": [5],
-                    "73612fdabd337d5a8279acc30ce22d00": [6],
-                    "ad2ad2a70c3e0bf94ddef3f893e92291": [6],
-                    "8ce0d477f610ea18e2ea4fbbb46de857": [6],
-                    "ff5a6cc031dd2c98b8bccd4766af38c1": [6],
-                    "940576153c66af14a949fd19aedd5f5b": [5],
-                    "ab05b4fb82e37c8cf5b1ac40d0a37fe9": [5],
-                    "57c04d62ada3a102248b48f34c755159": [6],
-                    "816b147dcf3305839f723a131b9ad6af": [5],
-                    "84000630d1b69a0fe870c94fb26a32bc": [5],
-                },
-                "details": {
-                    "metric_configuration": {
-                        "metric_name": "column.distinct_values.count",
-                        "domain_kwargs": {"column": "rate_code_id"},
-                        "metric_value_kwargs": None,
-                        "metric_dependencies": None,
-                    },
-                    "num_batches": 36,
-                },
-            }
-        },
-        Domain(
-            domain_type=MetricDomainTypes.COLUMN,
-            domain_kwargs={
                 "column": "store_and_fwd_flag",
             },
             details={
@@ -745,7 +545,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "store_and_fwd_flag": SemanticDomainTypes.TEXT,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -838,206 +638,6 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
         Domain(
             domain_type=MetricDomainTypes.COLUMN,
             domain_kwargs={
-                "column": "pickup_location_id",
-            },
-            details={
-                INFERRED_SEMANTIC_TYPE_KEY: {
-                    "pickup_location_id": SemanticDomainTypes.NUMERIC,
-                },
-            },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
-        ): {
-            "$parameter.column.distinct_values.count": {
-                "value": [
-                    118,
-                    118,
-                    124,
-                    132,
-                    119,
-                    133,
-                    133,
-                    136,
-                    134,
-                    146,
-                    151,
-                    141,
-                    151,
-                    155,
-                    145,
-                    137,
-                    138,
-                    143,
-                    155,
-                    154,
-                    154,
-                    144,
-                    144,
-                    150,
-                    142,
-                    146,
-                    157,
-                    208,
-                    214,
-                    211,
-                    212,
-                    209,
-                    193,
-                    195,
-                    187,
-                    199,
-                ],
-                "attributed_value": {
-                    "c92d0679f769ac83fef2bb5eaac5d12a": [118],
-                    "562969eaef9c843cb4531aecbc13bbcb": [118],
-                    "569a4a80bf434c888593c651dbf2f157": [124],
-                    "f6c389dcef63c1f214c30f66b66945c0": [132],
-                    "c4fe9afce1cf3e83eb8518a9f5abc754": [119],
-                    "e20c38f98b9830a40b851939ca7189d4": [133],
-                    "f2e4d3da6556638b55df8ce509b094c2": [133],
-                    "44c1b1947c9049e7db62c5320dde4c63": [136],
-                    "47157bdaf05a7992473cd699cabaef74": [134],
-                    "08085632aff9ce4cebbb8023049e1aec": [146],
-                    "bb54e4fa3906387218be10cff631a7c2": [151],
-                    "58ce3b40d384eacd9bad7d916eb8f705": [141],
-                    "0327cfb13205ec8512e1c28e438ab43b": [151],
-                    "0808e185a52825d22356de2fe00a8f5f": [155],
-                    "90bb41c1fbd7c71c05dbc8695320af71": [145],
-                    "6c7e43619fe5e6963e8159cc84a28321": [137],
-                    "976b121b46db6967854b9c1a6628396b": [138],
-                    "9e58d3c72c7006b6f5800b623fbc9818": [143],
-                    "ce5f02ac408b7b5c500050190f549736": [155],
-                    "bb81456ec79522bf02f34b02762f95e0": [154],
-                    "b20800a7faafd2808d6c888577a2ba1d": [154],
-                    "33d910f95326c0c7dfe7536d1cfeba51": [144],
-                    "61e4931d87cb627df2a19b8bc5819b7b": [144],
-                    "3692b23382fd4734215465251290c65b": [150],
-                    "eff8910cddcdff62e4741243099240d5": [142],
-                    "f67d274202366f6b976414c950ca14bd": [146],
-                    "7b3ce20a8e8cf3097bb9df270a7ae63a": [157],
-                    "73612fdabd337d5a8279acc30ce22d00": [208],
-                    "ad2ad2a70c3e0bf94ddef3f893e92291": [214],
-                    "8ce0d477f610ea18e2ea4fbbb46de857": [211],
-                    "ff5a6cc031dd2c98b8bccd4766af38c1": [212],
-                    "940576153c66af14a949fd19aedd5f5b": [209],
-                    "ab05b4fb82e37c8cf5b1ac40d0a37fe9": [193],
-                    "57c04d62ada3a102248b48f34c755159": [195],
-                    "816b147dcf3305839f723a131b9ad6af": [187],
-                    "84000630d1b69a0fe870c94fb26a32bc": [199],
-                },
-                "details": {
-                    "metric_configuration": {
-                        "metric_name": "column.distinct_values.count",
-                        "domain_kwargs": {"column": "pickup_location_id"},
-                        "metric_value_kwargs": None,
-                        "metric_dependencies": None,
-                    },
-                    "num_batches": 36,
-                },
-            }
-        },
-        Domain(
-            domain_type=MetricDomainTypes.COLUMN,
-            domain_kwargs={
-                "column": "dropoff_location_id",
-            },
-            details={
-                INFERRED_SEMANTIC_TYPE_KEY: {
-                    "dropoff_location_id": SemanticDomainTypes.NUMERIC,
-                },
-            },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
-        ): {
-            "$parameter.column.distinct_values.count": {
-                "value": [
-                    184,
-                    197,
-                    196,
-                    190,
-                    200,
-                    204,
-                    202,
-                    203,
-                    203,
-                    192,
-                    197,
-                    205,
-                    199,
-                    205,
-                    205,
-                    202,
-                    196,
-                    206,
-                    213,
-                    217,
-                    205,
-                    203,
-                    198,
-                    204,
-                    206,
-                    204,
-                    207,
-                    234,
-                    237,
-                    238,
-                    233,
-                    232,
-                    224,
-                    222,
-                    230,
-                    224,
-                ],
-                "attributed_value": {
-                    "c92d0679f769ac83fef2bb5eaac5d12a": [184],
-                    "562969eaef9c843cb4531aecbc13bbcb": [197],
-                    "569a4a80bf434c888593c651dbf2f157": [196],
-                    "f6c389dcef63c1f214c30f66b66945c0": [190],
-                    "c4fe9afce1cf3e83eb8518a9f5abc754": [200],
-                    "e20c38f98b9830a40b851939ca7189d4": [204],
-                    "f2e4d3da6556638b55df8ce509b094c2": [202],
-                    "44c1b1947c9049e7db62c5320dde4c63": [203],
-                    "47157bdaf05a7992473cd699cabaef74": [203],
-                    "08085632aff9ce4cebbb8023049e1aec": [192],
-                    "bb54e4fa3906387218be10cff631a7c2": [197],
-                    "58ce3b40d384eacd9bad7d916eb8f705": [205],
-                    "0327cfb13205ec8512e1c28e438ab43b": [199],
-                    "0808e185a52825d22356de2fe00a8f5f": [205],
-                    "90bb41c1fbd7c71c05dbc8695320af71": [205],
-                    "6c7e43619fe5e6963e8159cc84a28321": [202],
-                    "976b121b46db6967854b9c1a6628396b": [196],
-                    "9e58d3c72c7006b6f5800b623fbc9818": [206],
-                    "ce5f02ac408b7b5c500050190f549736": [213],
-                    "bb81456ec79522bf02f34b02762f95e0": [217],
-                    "b20800a7faafd2808d6c888577a2ba1d": [205],
-                    "33d910f95326c0c7dfe7536d1cfeba51": [203],
-                    "61e4931d87cb627df2a19b8bc5819b7b": [198],
-                    "3692b23382fd4734215465251290c65b": [204],
-                    "eff8910cddcdff62e4741243099240d5": [206],
-                    "f67d274202366f6b976414c950ca14bd": [204],
-                    "7b3ce20a8e8cf3097bb9df270a7ae63a": [207],
-                    "73612fdabd337d5a8279acc30ce22d00": [234],
-                    "ad2ad2a70c3e0bf94ddef3f893e92291": [237],
-                    "8ce0d477f610ea18e2ea4fbbb46de857": [238],
-                    "ff5a6cc031dd2c98b8bccd4766af38c1": [233],
-                    "940576153c66af14a949fd19aedd5f5b": [232],
-                    "ab05b4fb82e37c8cf5b1ac40d0a37fe9": [224],
-                    "57c04d62ada3a102248b48f34c755159": [222],
-                    "816b147dcf3305839f723a131b9ad6af": [230],
-                    "84000630d1b69a0fe870c94fb26a32bc": [224],
-                },
-                "details": {
-                    "metric_configuration": {
-                        "metric_name": "column.distinct_values.count",
-                        "domain_kwargs": {"column": "dropoff_location_id"},
-                        "metric_value_kwargs": None,
-                        "metric_dependencies": None,
-                    },
-                    "num_batches": 36,
-                },
-            }
-        },
-        Domain(
-            domain_type=MetricDomainTypes.COLUMN,
-            domain_kwargs={
                 "column": "payment_type",
             },
             details={
@@ -1045,7 +645,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "payment_type": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1145,7 +745,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "fare_amount": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1245,7 +845,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "extra": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1345,7 +945,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "mta_tax": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1445,7 +1045,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "tip_amount": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1545,7 +1145,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "tolls_amount": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1645,7 +1245,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "improvement_surcharge": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1745,7 +1345,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "total_amount": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1845,7 +1445,7 @@ def quentin_expected_metrics_by_domain() -> Dict[Domain, Dict[str, Any]]:
                     "congestion_surcharge": SemanticDomainTypes.NUMERIC,
                 },
             },
-            rule_name="default_expect_column_unique_values_to_be_between_rule",
+            rule_name="categorical_columns_rule",
         ): {
             "$parameter.column.distinct_values.count": {
                 "value": [
@@ -1954,7 +1554,9 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                         "estimator": "bootstrap",
                         "n_resamples": 9999,
                         "include_estimator_samples_histogram_in_details": False,
-                        "truncate_values": {"lower_bound": 0},
+                        "truncate_values": {
+                            "lower_bound": 0,
+                        },
                         "round_decimals": 0,
                     },
                     "domain_builder": {
@@ -1972,7 +1574,7 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                             "json_serialize": True,
                             "reduce_scalar_metric": True,
                             "metric_name": "table.row_count",
-                        }
+                        },
                     ],
                     "expectation_configuration_builders": [
                         {
@@ -1995,7 +1597,7 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                                     "random_seed": "$variables.random_seed",
                                     "include_estimator_samples_histogram_in_details": "$variables.include_estimator_samples_histogram_in_details",
                                     "round_decimals": "$variables.round_decimals",
-                                }
+                                },
                             ],
                             "expectation_type": "expect_table_row_count_to_be_between",
                             "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder.default_expectation_configuration_builder",
@@ -2004,10 +1606,10 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                             },
                             "class_name": "DefaultExpectationConfigurationBuilder",
                             "min_value": "$parameter.table_row_count_range_estimator.value[0]",
-                        }
+                        },
                     ],
                 },
-                "default_expect_column_unique_values_to_be_between_rule": {
+                "categorical_columns_rule": {
                     "variables": {
                         "mostly": 1.0,
                         "strict_min": False,
@@ -2017,12 +1619,23 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                         "estimator": "bootstrap",
                         "n_resamples": 9999,
                         "include_estimator_samples_histogram_in_details": False,
-                        "truncate_values": {"lower_bound": 0},
-                        "round_decimals": 0,
+                        "truncate_values": {
+                            "lower_bound": 0.0,
+                        },
+                        "round_decimals": 1,
                     },
                     "domain_builder": {
-                        "module_name": "great_expectations.rule_based_profiler.domain_builder.column_domain_builder",
-                        "class_name": "ColumnDomainBuilder",
+                        "allowed_semantic_types_passthrough": ["logic"],
+                        "class_name": "CategoricalColumnDomainBuilder",
+                        "limit_mode": {
+                            "name": "REL_100",
+                            "max_proportion_unique": 1.0,
+                            "metric_name_defining_limit": "column.unique_proportion",
+                        },
+                        "module_name": "great_expectations.rule_based_profiler.domain_builder.categorical_column_domain_builder",
+                        "exclude_column_names": ["id"],
+                        "exclude_column_name_suffixes": ["_id"],
+                        "exclude_semantic_types": ["binary", "currency", "identifier"],
                     },
                     "parameter_builders": [
                         {
@@ -2035,43 +1648,42 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                             "json_serialize": True,
                             "reduce_scalar_metric": True,
                             "metric_name": "column.distinct_values.count",
-                        }
+                        },
                     ],
                     "expectation_configuration_builders": [
                         {
-                            "max_value": "$parameter.column_unique_values_range_estimator.value[1]",
-                            "validation_parameter_builder_configs": [
-                                {
-                                    "metric_domain_kwargs": "$domain.domain_kwargs",
-                                    "replace_nan_with_zero": True,
-                                    "name": "column_unique_values_range_estimator",
-                                    "module_name": "great_expectations.rule_based_profiler.parameter_builder",
-                                    "truncate_values": "$variables.truncate_values",
-                                    "enforce_numeric_metric": True,
-                                    "n_resamples": "$variables.n_resamples",
-                                    "class_name": "NumericMetricRangeMultiBatchParameterBuilder",
-                                    "json_serialize": True,
-                                    "estimator": "$variables.estimator",
-                                    "reduce_scalar_metric": True,
-                                    "metric_name": "column.distinct_values.count",
-                                    "false_positive_rate": "$variables.false_positive_rate",
-                                    "quantile_statistic_interpolation_method": "$variables.quantile_statistic_interpolation_method",
-                                    "random_seed": "$variables.random_seed",
-                                    "include_estimator_samples_histogram_in_details": "$variables.include_estimator_samples_histogram_in_details",
-                                    "round_decimals": "$variables.round_decimals",
-                                }
-                            ],
-                            "expectation_type": "expect_column_unique_value_count_to_be_between",
+                            "min_value": "$parameter.column_distinct_values_count_range.value[0]",
+                            "class_name": "DefaultExpectationConfigurationBuilder",
                             "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder.default_expectation_configuration_builder",
                             "meta": {
-                                "profiler_details": "$parameter.column_unique_values_range_estimator.details"
+                                "profiler_details": "$parameter.column_distinct_values_count_range.details"
                             },
-                            "class_name": "DefaultExpectationConfigurationBuilder",
-                            "strict_max": "$variables.strict_max",
-                            "min_value": "$parameter.column_unique_values_range_estimator.value[0]",
+                            "expectation_type": "expect_column_unique_value_count_to_be_between",
+                            "max_value": "$parameter.column_distinct_values_count_range.value[1]",
                             "strict_min": "$variables.strict_min",
+                            "strict_max": "$variables.strict_max",
                             "column": "$domain.domain_kwargs.column",
-                        }
+                            "validation_parameter_builder_configs": [
+                                {
+                                    "class_name": "NumericMetricRangeMultiBatchParameterBuilder",
+                                    "metric_domain_kwargs": "$domain.domain_kwargs",
+                                    "estimator": "$variables.estimator",
+                                    "json_serialize": True,
+                                    "false_positive_rate": "$variables.false_positive_rate",
+                                    "name": "column_distinct_values_count_range",
+                                    "round_decimals": "$variables.round_decimals",
+                                    "reduce_scalar_metric": True,
+                                    "metric_name": "column.distinct_values.count",
+                                    "enforce_numeric_metric": True,
+                                    "quantile_statistic_interpolation_method": "$variables.quantile_statistic_interpolation_method",
+                                    "replace_nan_with_zero": True,
+                                    "n_resamples": "$variables.n_resamples",
+                                    "module_name": "great_expectations.rule_based_profiler.parameter_builder.numeric_metric_range_multi_batch_parameter_builder",
+                                    "include_estimator_samples_histogram_in_details": "$variables.include_estimator_samples_histogram_in_details",
+                                    "truncate_values": "$variables.truncate_values",
+                                },
+                            ],
+                        },
                     ],
                 },
             },
@@ -2110,29 +1722,6 @@ def quentin_expected_expectation_suite(
         expected_expect_column_unique_value_count_to_be_between_expectation_configuration_list: List[
             ExpectationConfiguration
         ] = [
-            ExpectationConfiguration(
-                **{
-                    "meta": {
-                        "profiler_details": {
-                            "metric_configuration": {
-                                "metric_name": "column.distinct_values.count",
-                                "domain_kwargs": {"column": "vendor_id"},
-                                "metric_value_kwargs": None,
-                                "metric_dependencies": None,
-                            },
-                            "num_batches": 36,
-                        }
-                    },
-                    "expectation_type": "expect_column_unique_value_count_to_be_between",
-                    "kwargs": {
-                        "strict_max": False,
-                        "max_value": 3,
-                        "strict_min": False,
-                        "column": "vendor_id",
-                        "min_value": 2,
-                    },
-                }
-            ),
             ExpectationConfiguration(
                 **{
                     "meta": {
@@ -2231,29 +1820,6 @@ def quentin_expected_expectation_suite(
                         "profiler_details": {
                             "metric_configuration": {
                                 "metric_name": "column.distinct_values.count",
-                                "domain_kwargs": {"column": "rate_code_id"},
-                                "metric_value_kwargs": None,
-                                "metric_dependencies": None,
-                            },
-                            "num_batches": 36,
-                        }
-                    },
-                    "expectation_type": "expect_column_unique_value_count_to_be_between",
-                    "kwargs": {
-                        "strict_max": False,
-                        "max_value": 6,
-                        "strict_min": False,
-                        "column": "rate_code_id",
-                        "min_value": 5,
-                    },
-                }
-            ),
-            ExpectationConfiguration(
-                **{
-                    "meta": {
-                        "profiler_details": {
-                            "metric_configuration": {
-                                "metric_name": "column.distinct_values.count",
                                 "domain_kwargs": {"column": "store_and_fwd_flag"},
                                 "metric_value_kwargs": None,
                                 "metric_dependencies": None,
@@ -2268,52 +1834,6 @@ def quentin_expected_expectation_suite(
                         "strict_min": False,
                         "column": "store_and_fwd_flag",
                         "min_value": 2,
-                    },
-                }
-            ),
-            ExpectationConfiguration(
-                **{
-                    "meta": {
-                        "profiler_details": {
-                            "metric_configuration": {
-                                "metric_name": "column.distinct_values.count",
-                                "domain_kwargs": {"column": "pickup_location_id"},
-                                "metric_value_kwargs": None,
-                                "metric_dependencies": None,
-                            },
-                            "num_batches": 36,
-                        }
-                    },
-                    "expectation_type": "expect_column_unique_value_count_to_be_between",
-                    "kwargs": {
-                        "strict_max": False,
-                        "max_value": 211,
-                        "strict_min": False,
-                        "column": "pickup_location_id",
-                        "min_value": 118,
-                    },
-                }
-            ),
-            ExpectationConfiguration(
-                **{
-                    "meta": {
-                        "profiler_details": {
-                            "metric_configuration": {
-                                "metric_name": "column.distinct_values.count",
-                                "domain_kwargs": {"column": "dropoff_location_id"},
-                                "metric_value_kwargs": None,
-                                "metric_dependencies": None,
-                            },
-                            "num_batches": 36,
-                        }
-                    },
-                    "expectation_type": "expect_column_unique_value_count_to_be_between",
-                    "kwargs": {
-                        "strict_max": False,
-                        "max_value": 236,
-                        "strict_min": False,
-                        "column": "dropoff_location_id",
-                        "min_value": 190,
                     },
                 }
             ),

--- a/tests/rule_based_profiler/domain_builder/test_categorical_column_domain_builder.py
+++ b/tests/rule_based_profiler/domain_builder/test_categorical_column_domain_builder.py
@@ -335,7 +335,6 @@ def test_excluded_columns_empty_single_batch(alice_columnar_table_single_batch_c
     alice_all_column_names: List[str] = [
         "id",
         "event_type",
-        "user_id",
         "event_ts",
         "server_ts",
         "device_ts",
@@ -353,7 +352,7 @@ def test_excluded_columns_empty_single_batch(alice_columnar_table_single_batch_c
         )
         for column_name in alice_all_column_names
     ]
-    assert len(domains) == 7
+    assert len(domains) == 6
 
     # Unit Tests for "inferred_semantic_domain_type" are provided separately.
     domain: Domain

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb
@@ -1157,7 +1157,7 @@
    "outputs": [],
    "source": [
     "domains: list = domain_builder.get_domains(rule_name=\"my_rule\", batch_request=single_batch_batch_request)\n",
-    "assert len(domains) == 9"
+    "assert len(domains) == 7"
    ]
   },
   {


### PR DESCRIPTION
### Scope
* Instead of emitting `expect_column_unique_values_count_to_be_between` for every column `Domain`, apply `CategoricalDomainBuilder` to prevent certain high-cardinality column types from having this `ExpectationConfiguration` emitted (to avoid "noise").
* Update existing unit test.
* Clean up variable naming and add a commonly-used utility for sanitizing `ParameterBuilder` `name` property.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-822/GREAT-898
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
