### PR TITLE
[BUGFIX] Read deployment_version instead of using versioneer in deprecation tests

### DIFF
--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,12 +1,10 @@
 import glob
-import os
 import re
 from typing import List, Pattern, Tuple, cast
 
 import pytest
 from packaging import version
 
-import versioneer
 from great_expectations.data_context.util import file_relative_path
 
 
@@ -48,7 +46,6 @@ def test_deprecation_warnings_are_accompanied_by_appropriate_comment(
         ), f"Either a 'deprecated-v...' comment or 'DeprecationWarning' call is missing from {file}"
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning:versioneer")
 def test_deprecation_warnings_have_been_removed_after_two_minor_versions(
     regex_for_deprecation_comments: Pattern,
     files_with_deprecation_warnings: List[str],

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,4 +1,5 @@
 import glob
+import os
 import re
 from typing import List, Pattern, Tuple, cast
 
@@ -6,6 +7,7 @@ import pytest
 from packaging import version
 
 import versioneer
+from great_expectations.data_context.util import file_relative_path
 
 
 @pytest.fixture
@@ -57,7 +59,13 @@ def test_deprecation_warnings_have_been_removed_after_two_minor_versions(
     To ensure that we're appropriately deprecating, we want to test that we're fully
     removing warnings (and the code they correspond to) after two minor versions have passed.
     """
-    current_version: str = versioneer.get_version()
+    deployment_version_path: str = file_relative_path(
+        __file__, "../great_expectations/deployment_version"
+    )
+    current_version: str
+    with open(deployment_version_path) as f:
+        current_version = f.read().strip()
+
     current_parsed_version: version.Version = cast(
         version.Version, version.parse(current_version)
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- Use the version noted in `deployment_version` in deprecation tests for more consistent results.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.