### PR TITLE
[MAINTENANCE] Improvements to Trino support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ ENV/
 
 # Vim swap files
 *.swp
+tags
 
 # Special "scratchpad" directory for notes, code samples, experiments, etc.
 DO_NOT_COMMIT

--- a/assets/docker/trino/docker-compose.yml
+++ b/assets/docker/trino/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  trino_db:
+    image: trinodb/trino:379
+    ports:
+      - "8088:8080"

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
@@ -46,7 +46,14 @@ class ColumnValuesUnique(ColumnMapMetricProvider):
         # the column we will be performing the expectation on, and the query is performed against it.
         dialect = kwargs.get("_dialect", None)
         sql_engine = kwargs.get("_sqlalchemy_engine", None)
-        if sql_engine and dialect and dialect.dialect.name == "mysql":
+        try:
+            dialect_name = dialect.dialect.name
+        except AttributeError:
+            try:
+                dialect_name = dialect.name
+            except AttributeError:
+                dialect_name = ""
+        if sql_engine and dialect and dialect_name == "mysql":
             temp_table_name = generate_temporary_table_name()
             temp_table_stmt = "CREATE TEMPORARY TABLE {new_temp_table} AS SELECT tmp.{column_name} FROM {source_table} tmp".format(
                 new_temp_table=temp_table_name,

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -397,6 +397,10 @@ def column_condition_partial(
                 sqlalchemy_engine: Engine = execution_engine.engine
 
                 dialect = execution_engine.dialect_module
+                if dialect is None:
+                    # Trino
+                    if hasattr(sqlalchemy_engine, "dialect"):
+                        dialect = sqlalchemy_engine.dialect
                 expected_condition = metric_fn(
                     cls,
                     sa.column(column_name),

--- a/scripts/check_type_hint_coverage.py
+++ b/scripts/check_type_hint_coverage.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 TYPE_HINT_ERROR_THRESHOLD: int = (
-    2568  # This number is to be reduced as we annotate more functions!
+    2570  # This number is to be reduced as we annotate more functions!
 )
 
 

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern.json
@@ -185,7 +185,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_exact_mostly_w_one_non_matching_value",
@@ -201,7 +201,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_column_name_has_space",
@@ -216,7 +216,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_sufficient_mostly_w_one_non_matching_value",
@@ -231,7 +231,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "negative_test_one_missing_value_and_insufficent_mostly",
@@ -246,7 +246,7 @@
         "unexpected_index_list": [3],
         "unexpected_list": ["bdd"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_one_missing_value_and_exact_mostly",
@@ -261,7 +261,7 @@
         "unexpected_index_list": [3],
         "unexpected_list": ["bdd"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_one_missing_value_and_sufficent_mostly",
@@ -276,7 +276,7 @@
         "unexpected_index_list": [3],
         "unexpected_list": ["bdd"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_all_missing_values",
@@ -290,7 +290,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_all_missing_values_mostly",
@@ -305,7 +305,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_match_characters_not_at_the_beginning_of_string",
@@ -320,7 +320,7 @@
         "unexpected_index_list": [0, 2, 3],
         "unexpected_list": ["aaa", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     }
    ]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern_list.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern_list.json
@@ -121,7 +121,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title" : "positive_test_with_multiple_like_patternes",
@@ -136,7 +136,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title" : "positive_test_with_match_on__any",
@@ -151,7 +151,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title" : "positive_test_column_name_has_space_and_match_on__any",
@@ -166,7 +166,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     }
    ]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern.json
@@ -151,7 +151,7 @@
         "unexpected_index_list": [0, 1, 2, 3],
         "unexpected_list": ["aaa", "abb", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_exact_mostly_w_one_non_matching_value",
@@ -167,7 +167,7 @@
         "unexpected_index_list": [0, 1, 2, 3],
         "unexpected_list": ["aaa", "abb", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_sufficient_mostly_w_one_non_matching_value",
@@ -182,7 +182,7 @@
         "unexpected_index_list": [0, 1, 2, 3],
         "unexpected_list": ["aaa", "abb", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "negative_test_one_missing_value_and_insufficent_mostly",
@@ -197,7 +197,7 @@
         "unexpected_index_list": [0, 1, 2],
         "unexpected_list": ["aaa", "abb", "acc"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_one_missing_value_no_exceptions",
@@ -211,7 +211,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_all_missing_values",
@@ -225,7 +225,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "positive_test_all_missing_values_mostly",
@@ -240,7 +240,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     },
     {
       "title": "negative_test_match_characters_not_at_the_beginning_of_string_exact_mostly",
@@ -255,7 +255,7 @@
         "unexpected_index_list": [1, 4],
         "unexpected_list": ["abb", "bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     }
    ]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern_list.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern_list.json
@@ -86,7 +86,7 @@
         "unexpected_index_list": [0,1,3,4,5,6,7,8],
         "success": false
       },
-      "only_for": ["sqlite", "postgresql", "mysql"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
     }
    ]
   }]


### PR DESCRIPTION
Full-compatibility with all core Expectations, except for 2 (both of which have partial support)

Changes proposed in this pull request:
- Add support for quantiles, regex, and like
- Add trino to more Expectation tests

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.