### PR TITLE
[BUGFIX] Insure TABLE Domain Metrics Do Not Get Column Key From Column Type Rule Domain Builder

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -109,6 +109,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
             """
             return self.build_numeric_metric_multi_batch_parameter_builder(
                 metric_name="table.row_count",
+                metric_domain_kwargs=None,
                 metric_value_kwargs=None,
                 json_serialize=json_serialize,
             )
@@ -312,6 +313,9 @@ class DataAssistant(metaclass=MetaDataAssistant):
         @staticmethod
         def build_numeric_metric_multi_batch_parameter_builder(
             metric_name: str,
+            metric_domain_kwargs: Optional[
+                Union[str, dict]
+            ] = DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
             metric_value_kwargs: Optional[Union[str, dict]] = None,
             json_serialize: Union[str, bool] = True,
         ) -> MetricMultiBatchParameterBuilder:
@@ -322,7 +326,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
             return MetricMultiBatchParameterBuilder(
                 name=name,
                 metric_name=metric_name,
-                metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
+                metric_domain_kwargs=metric_domain_kwargs,
                 metric_value_kwargs=metric_value_kwargs,
                 enforce_numeric_metric=True,
                 replace_nan_with_zero=True,

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -1562,7 +1562,6 @@ def quentin_expected_rule_based_profiler_configuration() -> Callable:
                     },
                     "parameter_builders": [
                         {
-                            "metric_domain_kwargs": "$domain.domain_kwargs",
                             "replace_nan_with_zero": True,
                             "name": "table_row_count",
                             "module_name": "great_expectations.rule_based_profiler.parameter_builder.metric_multi_batch_parameter_builder",


### PR DESCRIPTION
### Scope
Certain `Rule` definitions use both, Column style `DomainBuilder` and also `ParameterBuilder` definitions that execute `TABLE` `Domain` type metrics.  That means the reserved keyword `DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME` must not be passed from `Rule` definition to the metric `ParameterBuilder` for the `TABLE` `Domain`, because it will contain the "column" key.  Simply pass `None` for `metric_domain_kwargs` in this case.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-924
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
