### PR TITLE
[FEATURE] Example Notebook for self-initializing `Expectations`

### DIFF
--- a/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
+++ b/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
@@ -114,3 +114,55 @@ def test_run_data_assistants_notebook(tmp_path):
                 "Files were already deleted by running the optional last cell in the notebook. "
                 "We therefore allow the test to pass"
             )
+
+
+def test_run_self_initializing_expectations_notebook(tmp_path):
+    """
+    What does this test and why?
+    One of the resources we have for self-initializing Expectations is a Jupyter notebook that explains/shows the components in code.
+    This test ensures the codepaths and examples described in the Notebook actually run and pass, nbconvert's
+    `preprocess` function.
+    """
+    base_dir: str = file_relative_path(
+        __file__, "../../../test_fixtures/rule_based_profiler/example_notebooks"
+    )
+    notebook_path: str = os.path.join(base_dir, "SelfInitializingExpectations.ipynb")
+    # temporary output notebook for traceback and debugging
+    output_notebook_path: str = os.path.join(
+        tmp_path, "SelfInitializingExpectations_executed.ipynb"
+    )
+
+    with open(notebook_path) as f:
+        nb = nbformat.read(f, as_version=4)
+
+    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+
+    try:
+        ep.preprocess(nb, {"metadata": {"path": base_dir}})
+    except CellExecutionError:
+        msg = 'Error executing the notebook "%s".\n\n' % notebook_path
+        msg += 'See notebook "%s" for the traceback.' % output_notebook_path
+        print(msg)
+        raise
+    finally:
+        with open(output_notebook_path, mode="w", encoding="utf-8") as f:
+            nbformat.write(nb, f)
+        # clean up Expectations directory after running test
+        try:
+            shutil.rmtree(os.path.join(base_dir, "great_expectations/expectations/tmp"))
+            os.remove(
+                os.path.join(
+                    base_dir, "great_expectations/expectations/.ge_store_backend_id"
+                )
+            )
+            os.remove(
+                os.path.join(
+                    base_dir,
+                    "great_expectations/expectations/new_expectation_suite.json",
+                )
+            )
+        except FileNotFoundError:
+            logger.debug(
+                "Files were already deleted by running the optional last cell in the notebook. "
+                "We therefore allow the test to pass"
+            )

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
@@ -1,0 +1,886 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cda410dd-b44e-4456-b04b-57537b635654",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ruamel import yaml\n",
+    "import great_expectations as ge\n",
+    "from great_expectations.core.batch import BatchRequest\n",
+    "from great_expectations.expectations.expectation import Expectation\n",
+    "from great_expectations.rule_based_profiler.config import RuleBasedProfilerConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a25cb0ae-94d9-4584-ac3a-6d5685ca2201",
+   "metadata": {},
+   "source": [
+    "# Self-Initializing Expectations\n",
+    "- Self-initializing `Expectations` utilize `RuleBasedProfilers` to automate parameter estimation for Expectations using a Batch or Batches that have been loaded into a `Validator`. \n",
+    "\n",
+    "### Do they work for all `Expectations`?\n",
+    "- No, not all `Expectations` have parameters that can be estimated. As an example, `ExpectColumnToExist` only takes in a `Domain` (which is the column name)  and outputs whether the values in the column are `None`. It would be an example of an `Expectation` that would not work under the self-initializing framework. \n",
+    "- An example of an `Expectation` that would work under the self-initializing framework would be ones that have numeric ranges, like `ExpectColumnMeanToBeBetween`, `ExpectColumnMaxToBeBetween`, and `ExpectColumnSumToBeBetween`\n",
+    "- To check whether the `Expectation` you are interested in by running the `is_expectation_self_initializing()` method on `Expectations`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "1875746a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Expectation expect_column_to_exist is not able to be self-initialized.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Expectation.is_expectation_self_initializing(name=\"expect_column_to_exist\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "816691c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Expectation expect_column_mean_to_be_between is able to be self-initialized. Please run by using the auto=True parameter.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Expectation.is_expectation_self_initializing(name=\"expect_column_mean_to_be_between\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f68faa9",
+   "metadata": {},
+   "source": [
+    "# Set-up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "492f223a",
+   "metadata": {},
+   "source": [
+    "* To setup an example usecase for self-initializing `Expectations`, we will start from a new Great Expectations Data Context (ie `great_expectations` folder after running `great_expectations init`), and begin by adding the `Datasource`, and configuring a `BatchRequest`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "fc7c8362-2bb2-4c1e-83ca-23c5d253f020",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context: ge.DataContext = ge.get_context()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96d1da15-120d-49d9-ac03-ec036a8f0aad",
+   "metadata": {},
+   "source": [
+    "### Adding `taxi_data` Datasource\n",
+    "We are using an `InferredAssetFilesystemDataConnector` (named `2018_data`) to connect to data in the `test_sets/taxi_yellow_tripdata_samples` folder and get one `DataAsset` (`yellow_tripdata_sample_2018`) that has 12 Batches (1 Batch/month)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "3da1f552-a14f-4d33-a5ab-3680f9999215",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: PandasExecutionEngine\n",
+      "Data Connectors:\n",
+      "\t2018_data : InferredAssetFilesystemDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (1 of 1):\n",
+      "\t\tyellow_tripdata_sample_2018 (3 of 12): ['yellow_tripdata_sample_2018-01.csv', 'yellow_tripdata_sample_2018-02.csv', 'yellow_tripdata_sample_2018-03.csv']\n",
+      "\n",
+      "\tUnmatched data_references (3 of 30):['.DS_Store', 'first_3_files', 'random_subsamples']\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7fc8c860f4f0>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_path: str = \"../../../../test_sets/taxi_yellow_tripdata_samples\"\n",
+    "\n",
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"PandasExecutionEngine\",\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"2018_data\": {\n",
+    "            \"class_name\": \"InferredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"default_regex\": {\n",
+    "                \"group_names\": [\"data_asset_name\", \"month\"],\n",
+    "                \"pattern\": \"(yellow_tripdata_sample_2018)-(\\\\d.*)\\\\.csv\",\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "cd011ba5-9bbc-4c8c-8cb7-a886edcbb4e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_datasource only if it doesn't already exist in our configuration\n",
+    "try:\n",
+    "    data_context.get_datasource(datasource_config[\"name\"])\n",
+    "except ValueError:\n",
+    "    data_context.add_datasource(**datasource_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11c741ea",
+   "metadata": {},
+   "source": [
+    "### Configuring BatchRequest\n",
+    "In this example, we will be using a `BatchRequest` that returns 12 `Batches` of data from the 2018 `taxi_data` datataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "0f2a40e3-4f9a-488d-9a28-ccb29531ba87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_request_2018_data: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_datasource\",\n",
+    "    data_connector_name=\"2018_data\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2018\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20a6f3f1",
+   "metadata": {},
+   "source": [
+    "### Get Validator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "408a6f0c",
+   "metadata": {},
+   "source": [
+    "Load `taxi_data` into a `Validator` using the `BatchRequest` from the previous step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "d900f504-3029-463c-a017-c34a1aa2c42d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "suite = data_context.create_expectation_suite(expectation_suite_name=\"new_expectation_suite\", overwrite_existing=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "b682164f-6a5d-4794-a786-fa5c4e239ed7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator = data_context.get_validator(expectation_suite=suite, batch_request=batch_request_2018_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86cea0a1",
+   "metadata": {},
+   "source": [
+    "Check that the number of batches in our validator is 12 (1 batch / month for 2018)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "f604195e-f157-4232-83e0-10860ca49994",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert len(validator.batches) == 12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31bf7beb",
+   "metadata": {},
+   "source": [
+    "# Running Self-Initializing Expectation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f70ea62e",
+   "metadata": {},
+   "source": [
+    "Now we have all the components we need to build an ExpectationSuite by using a Validator. Let's first look at our data by running `validator.head()` which will output the first few rows of our most recent (December 2018) Batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "03f8d782",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "efb39759cd9d49da8edf8fd12edd01c1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>vendor_id</th>\n",
+       "      <th>pickup_datetime</th>\n",
+       "      <th>dropoff_datetime</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>trip_distance</th>\n",
+       "      <th>rate_code_id</th>\n",
+       "      <th>store_and_fwd_flag</th>\n",
+       "      <th>pickup_location_id</th>\n",
+       "      <th>dropoff_location_id</th>\n",
+       "      <th>payment_type</th>\n",
+       "      <th>fare_amount</th>\n",
+       "      <th>extra</th>\n",
+       "      <th>mta_tax</th>\n",
+       "      <th>tip_amount</th>\n",
+       "      <th>tolls_amount</th>\n",
+       "      <th>improvement_surcharge</th>\n",
+       "      <th>total_amount</th>\n",
+       "      <th>congestion_surcharge</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-12-22 18:30:39</td>\n",
+       "      <td>2018-12-22 18:42:37</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.39</td>\n",
+       "      <td>1</td>\n",
+       "      <td>N</td>\n",
+       "      <td>170</td>\n",
+       "      <td>229</td>\n",
+       "      <td>2</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>9.80</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-12-29 14:46:47</td>\n",
+       "      <td>2018-12-29 15:07:41</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3.77</td>\n",
+       "      <td>1</td>\n",
+       "      <td>N</td>\n",
+       "      <td>68</td>\n",
+       "      <td>140</td>\n",
+       "      <td>1</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>5.04</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>21.84</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2018-12-01 16:04:05</td>\n",
+       "      <td>2018-12-01 16:45:20</td>\n",
+       "      <td>1</td>\n",
+       "      <td>4.90</td>\n",
+       "      <td>1</td>\n",
+       "      <td>N</td>\n",
+       "      <td>263</td>\n",
+       "      <td>249</td>\n",
+       "      <td>1</td>\n",
+       "      <td>26.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>5.46</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>32.76</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2018-12-31 15:28:07</td>\n",
+       "      <td>2018-12-31 15:28:16</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>5</td>\n",
+       "      <td>N</td>\n",
+       "      <td>132</td>\n",
+       "      <td>132</td>\n",
+       "      <td>1</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>70.30</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2018-12-31 18:13:34</td>\n",
+       "      <td>2018-12-31 18:41:03</td>\n",
+       "      <td>1</td>\n",
+       "      <td>6.74</td>\n",
+       "      <td>1</td>\n",
+       "      <td>N</td>\n",
+       "      <td>162</td>\n",
+       "      <td>116</td>\n",
+       "      <td>1</td>\n",
+       "      <td>24.5</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>5.26</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>31.56</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   vendor_id      pickup_datetime  ... total_amount  congestion_surcharge\n",
+       "0          2  2018-12-22 18:30:39  ...         9.80                   NaN\n",
+       "1          2  2018-12-29 14:46:47  ...        21.84                   NaN\n",
+       "2          1  2018-12-01 16:04:05  ...        32.76                   NaN\n",
+       "3          1  2018-12-31 15:28:07  ...        70.30                   NaN\n",
+       "4          2  2018-12-31 18:13:34  ...        31.56                   NaN\n",
+       "\n",
+       "[5 rows x 18 columns]"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7739f248-a13c-47eb-8158-7f3165af3467",
+   "metadata": {},
+   "source": [
+    "#### The \"old\" way"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffa313e2",
+   "metadata": {},
+   "source": [
+    "Let's say that you were interested in constructing an `Expectation` that captured the average distance for taxi trips during a year and alerted you if the average trip distance fell out of the previous year's range. \n",
+    "\n",
+    "A good starting point would be the `expect_column_mean_to_be_between()`, and a look at the signature reveals the following parameters: \n",
+    "\n",
+    "```\n",
+    "column (str): The column name.\n",
+    "min_value (float or None): The minimum value for the column mean.\n",
+    "max_value (float or None): The maximum value for the column mean.\n",
+    "strict_min (boolean): If True, the column mean must be strictly larger than min_value, default=False\n",
+    "strict_max (boolean): If True, the column mean must be strictly smaller than max_value, default=False\n",
+    "```\n",
+    "\n",
+    "`column` and the boolean flags (`strict_min` and `strict_max`) seem straightfoward enough, but how do you set the appropriate `min_value` and `max_value`?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16cc2da8-6ecd-46bc-b1c4-672598d6bbd3",
+   "metadata": {},
+   "source": [
+    "Previously, this would involve loading each `Batch` (month's data) individually, calculating the mean value for `trip_distance` for each `Batch`, and using calculated `mean` values to determine the `min_value` and `max_value` parameters to pass to our `Expectation`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4910467-f35d-4c76-b8e4-210c5540266f",
+   "metadata": {},
+   "source": [
+    "#### The \"new\" way"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da1b2a9b-3b72-453b-9d7f-e4774e15dc73",
+   "metadata": {},
+   "source": [
+    "Self-initializing `Expectations` automate this sort of calculation across batches. To do perform the same calculation described above (the mean ranges across the 12 `Batches` in the 2018 data), the only thing you need to do is run the `Expectation` with `auto=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "d064d6ef-6ce2-4669-a8cc-cae6cfd54ae3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e7d9360c9504be7989868c6d5479d39",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04958512523342758e363282a68ebf60",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"success\": true,\n",
+       "  \"expectation_config\": {\n",
+       "    \"expectation_type\": \"expect_column_mean_to_be_between\",\n",
+       "    \"kwargs\": {\n",
+       "      \"column\": \"trip_distance\",\n",
+       "      \"min_value\": 2.83,\n",
+       "      \"max_value\": 3.06,\n",
+       "      \"strict_min\": false,\n",
+       "      \"strict_max\": false\n",
+       "    },\n",
+       "    \"meta\": {\n",
+       "      \"auto_generated_at\": \"20220519T230312.066546Z\",\n",
+       "      \"great_expectations_version\": \"0.15.6+20.gd61afe072.dirty\"\n",
+       "    }\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 2.926081\n",
+       "  },\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.expect_column_mean_to_be_between(column=\"trip_distance\", auto=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "333da5f0",
+   "metadata": {},
+   "source": [
+    "Then the Expectation will calculate the `min_value` (`2.83`) and `max_value` (`3.06`) using all the `Batches` that are loaded into the Validator, in our case the 12 batches associated with 2018 `taxi_data`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a280e69",
+   "metadata": {},
+   "source": [
+    "Now the Expectation can be saved to the ExpectaionSuite associated with the Validator, with the upper and lower bounds having come from the Batches."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "306d012a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator.save_expectation_suite(discard_failed_expectations=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d09a8920",
+   "metadata": {},
+   "source": [
+    "# How to write your own self-initializing Expectation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1edb05aa",
+   "metadata": {},
+   "source": [
+    "Inside each of the `Expectatations` is a `RuleBasedProfiler` configuration that is run by the `Validator` when building the `ExpectationConfiguration`. Writing your own self-initializing `Expectation` involved writing your own `RuleBasedProfiler` configuration (or adapting an existing configuration) to automatically estimate the parameters that the `Expectation` requires. For more information on `RuleBasedProfiler` components, and their requirements, please refer to the [RBP Jupyter Notebook](https://github.com/great-expectations/great_expectations/blob/d91fe2e801879f8c407082dd4330dbe9a11d2d78/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ba4c538-d238-43d2-be98-ce028e8e500d",
+   "metadata": {},
+   "source": [
+    "The following is the configuration that is part of `ExpectColumnMeanToBeBetween`, which can be found [here](https://github.com/great-expectations/great_expectations/blob/f53e27b068007471b819fc089f008d2a24864d20/great_expectations/expectations/core/expect_column_mean_to_be_between.py). Please also note that some `ENUM` values (like `DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME`) have been translated into string values for readability."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "256ccc2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_profiler_config: RuleBasedProfilerConfig = RuleBasedProfilerConfig(\n",
+    "    name=\"expect_column_mean_to_be_between\",\n",
+    "    config_version=1.0,\n",
+    "    variables={},\n",
+    "    rules={\n",
+    "    \"default_expect_column_mean_to_be_between_rule\": {\n",
+    "      \"variables\": {\n",
+    "        \"strict_min\": False,\n",
+    "        \"strict_max\": False,\n",
+    "        \"false_positive_rate\": 0.05,\n",
+    "        \"quantile_statistic_interpolation_method\": \"auto\",\n",
+    "        \"estimator\": \"bootstrap\",\n",
+    "        \"n_resamples\": 9999,\n",
+    "        \"include_estimator_samples_histogram_in_details\": False,\n",
+    "        \"truncate_values\": {},\n",
+    "        \"round_decimals\": 2\n",
+    "      },\n",
+    "      \"domain_builder\": {\n",
+    "        \"class_name\": \"ColumnDomainBuilder\",\n",
+    "        \"module_name\": \"great_expectations.rule_based_profiler.domain_builder\"\n",
+    "      },\n",
+    "      \"expectation_configuration_builders\": [\n",
+    "        {\n",
+    "          \"expectation_type\": \"expect_column_mean_to_be_between\",\n",
+    "          \"class_name\": \"DefaultExpectationConfigurationBuilder\",\n",
+    "          \"module_name\": \"great_expectations.rule_based_profiler.expectation_configuration_builder\",\n",
+    "          \"validation_parameter_builder_configs\": [\n",
+    "            {\n",
+    "              \"json_serialize\": True,\n",
+    "              \"module_name\": \"great_expectations.rule_based_profiler.parameter_builder\",\n",
+    "              \"estimator\": \"$variables.estimator\",\n",
+    "              \"quantile_statistic_interpolation_method\": \"$variables.quantile_statistic_interpolation_method\",\n",
+    "              \"enforce_numeric_metric\": True,\n",
+    "              \"n_resamples\": \"$variables.n_resamples\",\n",
+    "              \"name\": \"mean_range_estimator\",\n",
+    "              \"metric_name\": \"column.mean\",\n",
+    "              \"class_name\": \"NumericMetricRangeMultiBatchParameterBuilder\",\n",
+    "              \"round_decimals\": \"$variables.round_decimals\",\n",
+    "              \"metric_domain_kwargs\": \"$domain.domain_kwargs\",\n",
+    "              \"reduce_scalar_metric\": True,\n",
+    "              \"include_estimator_samples_histogram_in_details\": \"$variables.include_estimator_samples_histogram_in_details\",\n",
+    "              \"truncate_values\": \"$variables.truncate_values\",\n",
+    "              \"false_positive_rate\": \"$variables.false_positive_rate\",\n",
+    "              \"replace_nan_with_zero\": True\n",
+    "            }\n",
+    "          ],\n",
+    "          \"column\": \"$domain.domain_kwargs.column\",\n",
+    "          \"min_value\": \"$parameter.mean_range_estimator.value[0]\",\n",
+    "          \"max_value\": \"$parameter.mean_range_estimator.value[1]\",\n",
+    "          \"strict_min\": \"$variables.strict_min\",\n",
+    "          \"strict_max\": \"$variables.strict_max\",\n",
+    "          \"meta\": {\n",
+    "            \"profiler_details\": \"$parameter.mean_range_estimator.details\"\n",
+    "          }\n",
+    "        }\n",
+    "      ]\n",
+    "    }\n",
+    "  }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9e827f3",
+   "metadata": {},
+   "source": [
+    "## More Details"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "289c8243",
+   "metadata": {},
+   "source": [
+    "## `variables`\n",
+    "Key-value pairs defined in this portion of the configuration are be shared across `Rules` and `Rule` components, help you keep track of values without having to input them multiple times.\n",
+    "\n",
+    "* `strict_min`: Used by `expect_column_mean_to_be_between` Expectation. Recognized values are `True` or `False`.\n",
+    "* `strict_max`: Used by `expect_column_mean_to_be_between` Expectation. Recognized values are `True` or `False`. \n",
+    "* `false_positive_rate`: Used by `NumericMetricRangeMultiBatchParameterBuilder`. Typically a float `0 <= 1.0`.\n",
+    "* `quantile_statistic_interpolation_method`: Used by `NumericMetricRangeMultiBatchParameterBuilder`, which is used when estimating quantile values (not relevant in our case). Recognized values include `auto`, `nearest`, and `linear`.\n",
+    "* `estimator`: Used by `NumericMetricRangeMultiBatchParameterBuilder`. Recognized values include `oneshot`, `bootstrap`, and `kde`. \n",
+    "* `n_resamples`:  Used by `NumericMetricRangeMultiBatchParameterBuilder`. Integer values are expected. \n",
+    "* `include_estimator_samples_histogram_in_details`: Used by `NumericMetricRangeMultiBatchParameterBuilder`. Recognized values are `True` or `False`.\n",
+    "* `truncate_values`: A value used by the `NumericMetricRangeMultiBatchParameterBuilder` to specify the `[lower_bound, upper_bound]` interval, where either boundary is numeric or None. In our case the value is an empty dictionary, and an equivalent configuration would have been `truncate_values : { lower_bound: None, upper_bound: None }`. \n",
+    "* `round_decimals` : Used by `NumericMetricRangeMultiBatchParameterBuilder`, and determines how many digits after the decimal point to output (in our case 2). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "327fd56a",
+   "metadata": {},
+   "source": [
+    "## `domain_builder`\n",
+    "The `DomainBuilder` configuration requires a `class_name` and `module_name`:\n",
+    "- `class_name`: is `ColumnDomainBuilder` in our case. For examples of additional DomainBuilders, please refer to the Appendix of the [RBP Jupyter Notebook](https://github.com/great-expectations/great_expectations/blob/d91fe2e801879f8c407082dd4330dbe9a11d2d78/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb)\n",
+    "- `module_name`: is `great_expectations.rule_based_profiler.domain_builder`, which is common for all `DomainBuilders`. \n",
+    "- The `ColumnDomainBuilder` outputs the column of interest (in our case `trip_distance`), which is accessed by the `ExpectationConfigurationBuilder` using the variable `$domain.domain_kwargs.column`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0075689",
+   "metadata": {},
+   "source": [
+    "## `validation_parameter_builder_configs`\n",
+    "Our list contains a configuration for 1 `ParamterBuilder`, a `NumericMetricRangeMultiBatchParameterBuilder`.  For examples of additional DomainBuilders, please refer to the Appendix of the [RBP Jupyter Notebook](https://github.com/great-expectations/great_expectations/blob/d91fe2e801879f8c407082dd4330dbe9a11d2d78/tests/test_fixtures/rule_based_profiler/example_notebooks/BasicExample_RBP_Instantiation_and_running.ipynb)\n",
+    "* `name`: `mean_range_estimator`\n",
+    "* `class_name`: `NumericMetricRangeMultiBatchParameterBuilder`\n",
+    "* `module_name`: `great_expectations.rule_based_profiler.parameter_builder` which is the same for all `ParameterBuilders`.\n",
+    "* `json_serialize`: Boolean value that determines whether to convert computed value to JSON prior to saving result. \n",
+    "* `estimator`: choice of the estimation algorithm: \"oneshot\" (one observation), \"bootstrap\" (default), or \"kde\" (kernel density estimation). Value is pulled from `$variables.estimator`, which is set to \"bootstrap\" in our configuration.  \n",
+    "* `quantile_statistic_interpolation_method`:  Applicable for the \"bootstrap\" sampling method. Determines the value of interpolation \"method\" to `np.quantile()` statistic, which is used for confidence intervals. Value is pulled from `$variables.quantile_statistic_interpolation_method`, which is set to \"auto\" in our configuration.\n",
+    "* `enforce_numeric_metric`: used in `MetricConfiguration` to ensure that metric computations return numeric values. Set to `True`. \n",
+    "* `n_resamples`: Applicable for the \"bootstrap\" and \"kde\" sampling methods -- if omitted (default), then 9999 is used.  Value is pulled from `$variables.n_resamples`, which is set to `9999` in our configuration.\n",
+    "* `round_decimals`: User-configured non-negative integer indicating the number of decimals of the rounding precision of the computed parameter values (i.e., `min_value`, `max_value`) prior to packaging them on output.  If omitted, then no rounding is performed, unless the computed value is already an integer. Value is pulled from `$variables.round_decimals` which is `2` in our configuration.\n",
+    "* `reduce_scalar_metric`: If `True` (default), then reduces computation of 1-dimensional metric to scalar value. This value is set to `True`.\n",
+    "* `include_estimator_samples_histogram_in_details`: For the \"bootstrap\" sampling method -- if True, then add 10-bin histogram of bootstraps to \"details\"; otherwise, omit this information (default). Value pulled from `$variables.include_estimator_samples_histogram_in_details`, which is `False` in our configuration.\n",
+    "* `truncate_values`: User-configured directive for whether or not to allow the computed parameter values (i.e.,`lower_bound`, `upper_bound`) to take on values outside the specified bounds when packaged on output. Value pulled from `$variables.truncate_values`, which is `None` in our configuration.\n",
+    "* `false_positive_rate`: User-configured fraction between 0 and 1 expressing desired false positive rate for identifying unexpected values as judged by the upper- and lower- quantiles of the observed metric data. Value pulled from `$variables.false_positive_rate` and is `0.05` in our configuration.\n",
+    "* `replace_nan_with_zero`: If False, then if the computed metric gives `NaN`, then exception is raised; otherwise, if True (default), then if the computed metric gives NaN, then it is converted to the 0.0 (float) value. Set to `True` in our configuration.\n",
+    "* `metric_domain_kwargs`: Domain values for `ParameteBuilder`. Pulled from `$domain.domain_kwargs`, and is empty in our configuration."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "099cbad8",
+   "metadata": {},
+   "source": [
+    "## `expectation_configuration_builders`\n",
+    "Our Configuration contains 1 `ExpectationConfigurationBuilder`, for the `expect_column_mean_to_be_between` Expectation type. \n",
+    "\n",
+    "The `ExpectationConfigurationBuilder` configuration requires a `expectation_type`, `class_name` and `module_name`:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a439997-88ba-471e-8f26-3a15a4fc0b7e",
+   "metadata": {},
+   "source": [
+    "* `expectation_type`: `expect_column_mean_to_be_between`\n",
+    "* `class_name`: `DefaultExpectationConfigurationBuilder`\n",
+    "* `module_name`: `great_expectations.rule_based_profiler.expectation_configuration_builder` which is common for all `ExpectationConfigurationBuilders`\n",
+    "\n",
+    "Also included are: \n",
+    "* `validation_parameter_builder_configs`: Which are a list of `ValidationParameterBuilder` configurations, and our configuration case contains the `ParameterBuilder` described in the previous section. \n",
+    "\n",
+    "Next are the parameters that are specific to the `expect_column_mean_to_be_between` `Expectation`.\n",
+    "* `column`: Pulled from `DomainBuilder` using the parameter`$domain.domain_kwargs.column`\n",
+    "* `min_value`:  Pulled from the `ParameterBuilder` using `$parameter.mean_range_estimator.value[0]`\n",
+    "* `max_value`: Pulled from the `ParameterBuilder` using `$parameter.mean_range_estimator.value[1]`\n",
+    "* `strict_min`: Pulled from ``$variables.strict_min`, which is `False`. \n",
+    "* `strict_max`: Pulled from ``$variables.strict_max`, which is `False`. \n",
+    "\n",
+    "\n",
+    "Last is `meta` which contains `details` from our `parameter_builder`. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d02f5e8",
+   "metadata": {},
+   "source": [
+    "## Optional: Clean-up Directory\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f973a7ef",
+   "metadata": {},
+   "source": [
+    "As part of running this notebook, the `DataAssistant` will create a number of ExpectationSuite configurations in the `great_expectations/expectations/tmp` directory. Optionally run the following cell to clean up the directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c8eed9de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import shutil, os\n",
+    "# try:\n",
+    "#     shutil.rmtree(\"great_expectations/expectations/tmp\")\n",
+    "#     os.remove(\"great_expectations/expectations/.ge_store_backend_id\")\n",
+    "#     os.remove(\"great_expectations/expectations/new_expectation_suite.json\")\n",
+    "# except FileNotFoundError:\n",
+    "#     pass"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/SelfInitializingExpectations.ipynb
@@ -23,7 +23,7 @@
     "- Self-initializing `Expectations` utilize `RuleBasedProfilers` to automate parameter estimation for Expectations using a Batch or Batches that have been loaded into a `Validator`. \n",
     "\n",
     "### Do they work for all `Expectations`?\n",
-    "- No, not all `Expectations` have parameters that can be estimated. As an example, `ExpectColumnToExist` only takes in a `Domain` (which is the column name)  and outputs whether the values in the column are `None`. It would be an example of an `Expectation` that would not work under the self-initializing framework. \n",
+    "- No, not all `Expectations` have parameters that can be estimated. As an example, `ExpectColumnToExist` only takes in a `Domain` (which is the column name) and checks whether the column name is in the list of names in the table's metadata. It would be an example of an `Expectation` that would not work under the self-initializing framework. \n",
     "- An example of an `Expectation` that would work under the self-initializing framework would be ones that have numeric ranges, like `ExpectColumnMeanToBeBetween`, `ExpectColumnMaxToBeBetween`, and `ExpectColumnSumToBeBetween`\n",
     "- To check whether the `Expectation` you are interested in by running the `is_expectation_self_initializing()` method on `Expectations`. "
    ]


### PR DESCRIPTION
Changes proposed in this pull request:
This PR contains a notebook that exercises a code path for the self-initializing `Expectation`, `expect_column_mean_to_be_between()`.

The notebook, `SelfInitializingExpectations.ipynb`, shows how how to use the self-initializing `Expectations`, and against a datasource containing 12 batches (corresponding to 1 year) of taxi_data.

The notebook describes the following major steps:

- Setting up Datasource to connect to taxi_data.
- Configuring BatchRequest to retrieve 12 Batches of taxi_data
- Running `expect_column_mean_to_be_between()` with `auto=True`.
- Description of `RuleBasedProfiler` configuration used to make the `Expectation` self-initializing. 
- Adds integration test for notebook
- Closes GREAT-693


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.