### PR TITLE
[MAINTENANCE] Helper method for RBP Notebook tests that does clean-up

### DIFF
--- a/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
+++ b/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
@@ -11,19 +11,21 @@ from great_expectations.data_context.util import file_relative_path
 logger = logging.getLogger(__name__)
 
 
-def clean_up_test_files(paths: List[str]) -> None:
+def clean_up_test_files(base_dir: str, paths: List[str]) -> None:
     """
     Helper method to clean-up the files created by tests
     Args:
+        base_dir str: tmp path created by the test
         paths List(str): paths or directories to delete
     """
     for path in paths:
-        if not os.path.exists(path):
+        full_path: str = os.path.join(base_dir, path)
+        if not os.path.exists(full_path):
             continue
-        if os.path.isdir(path):
-            shutil.rmtree(path)
+        if os.path.isdir(full_path):
+            shutil.rmtree(full_path)
         else:
-            os.remove(path)
+            os.remove(full_path)
 
 
 def test_run_rbp_notebook(tmp_path):
@@ -65,12 +67,10 @@ def test_run_rbp_notebook(tmp_path):
             nbformat.write(nb, f)
 
         paths_to_clean_up: List[str] = [
-            os.path.join(base_dir, "great_expectations/expectations/tmp"),
-            os.path.join(
-                base_dir, "great_expectations/expectations/.ge_store_backend_id"
-            ),
+            "great_expectations/expectations/tmp",
+            "great_expectations/expectations/.ge_store_backend_id",
         ]
-        clean_up_test_files(paths=paths_to_clean_up)
+        clean_up_test_files(base_dir=base_dir, paths=paths_to_clean_up)
 
 
 def test_run_data_assistants_notebook(tmp_path):
@@ -108,16 +108,13 @@ def test_run_data_assistants_notebook(tmp_path):
     finally:
         with open(output_notebook_path, mode="w", encoding="utf-8") as f:
             nbformat.write(nb, f)
+
         paths_to_clean_up: List[str] = [
-            os.path.join(base_dir, "great_expectations/expectations/tmp"),
-            os.path.join(
-                base_dir, "great_expectations/expectations/.ge_store_backend_id"
-            ),
-            os.path.join(
-                base_dir, "great_expectations/expectations/taxi_data_suite.json"
-            ),
+            "great_expectations/expectations/tmp",
+            "great_expectations/expectations/.ge_store_backend_id",
+            "great_expectations/expectations/taxi_data_suite.json",
         ]
-        clean_up_test_files(paths=paths_to_clean_up)
+        clean_up_test_files(base_dir=base_dir, paths=paths_to_clean_up)
 
 
 def test_run_self_initializing_expectations_notebook(tmp_path):
@@ -153,12 +150,8 @@ def test_run_self_initializing_expectations_notebook(tmp_path):
             nbformat.write(nb, f)
 
         paths_to_clean_up: List[str] = [
-            os.path.join(base_dir, "great_expectations/expectations/tmp"),
-            os.path.join(
-                base_dir, "great_expectations/expectations/.ge_store_backend_id"
-            ),
-            os.path.join(
-                base_dir, "great_expectations/expectations/new_expectation_suite.json"
-            ),
+            "great_expectations/expectations/tmp",
+            "great_expectations/expectations/.ge_store_backend_id",
+            "great_expectations/expectations/new_expectation_suite.json",
         ]
-        clean_up_test_files(paths=paths_to_clean_up)
+        clean_up_test_files(base_dir=base_dir, paths=paths_to_clean_up)

--- a/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
+++ b/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-from posixpath import basename
 from typing import List, Optional
 
 import nbformat

--- a/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
+++ b/tests/integration/profiling/rule_based_profilers/test_run_profiler_notebook.py
@@ -11,28 +11,19 @@ from great_expectations.data_context.util import file_relative_path
 logger = logging.getLogger(__name__)
 
 
-def clean_up_test_files(
-    base_dir: str, additional_files_to_clean_up: Optional[List[str]] = None
-) -> None:
+def clean_up_test_files(paths: List[str]) -> None:
     """
-    Helper method to clean-up files created by tests
+    Helper method to clean-up the files created by tests
+    Args:
+        paths List(str): paths or directories to delete
     """
-    expectations_tmp_path: str = os.path.join(
-        base_dir, "great_expectations/expectations/tmp"
-    )
-
-    files_to_clean_up: List[str] = [
-        os.path.join(base_dir, "great_expectations/expectations/.ge_store_backend_id")
-    ]
-    if additional_files_to_clean_up:
-        files_to_clean_up += additional_files_to_clean_up
-
-    # clean up
-    if os.path.exists(expectations_tmp_path):
-        shutil.rmtree(expectations_tmp_path)
-    for file in files_to_clean_up:
-        if os.path.exists(file):
-            os.remove(file)
+    for path in paths:
+        if not os.path.exists(path):
+            continue
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
 
 
 def test_run_rbp_notebook(tmp_path):
@@ -73,7 +64,13 @@ def test_run_rbp_notebook(tmp_path):
         with open(output_notebook_path, mode="w", encoding="utf-8") as f:
             nbformat.write(nb, f)
 
-    clean_up_test_files(base_dir=base_dir)
+        paths_to_clean_up: List[str] = [
+            os.path.join(base_dir, "great_expectations/expectations/tmp"),
+            os.path.join(
+                base_dir, "great_expectations/expectations/.ge_store_backend_id"
+            ),
+        ]
+        clean_up_test_files(paths=paths_to_clean_up)
 
 
 def test_run_data_assistants_notebook(tmp_path):
@@ -111,16 +108,16 @@ def test_run_data_assistants_notebook(tmp_path):
     finally:
         with open(output_notebook_path, mode="w", encoding="utf-8") as f:
             nbformat.write(nb, f)
-
-    # clean up Expectations directory after running test
-    clean_up_test_files(
-        base_dir=base_dir,
-        additional_files_to_clean_up=[
+        paths_to_clean_up: List[str] = [
+            os.path.join(base_dir, "great_expectations/expectations/tmp"),
+            os.path.join(
+                base_dir, "great_expectations/expectations/.ge_store_backend_id"
+            ),
             os.path.join(
                 base_dir, "great_expectations/expectations/taxi_data_suite.json"
-            )
-        ],
-    )
+            ),
+        ]
+        clean_up_test_files(paths=paths_to_clean_up)
 
 
 def test_run_self_initializing_expectations_notebook(tmp_path):
@@ -154,13 +151,14 @@ def test_run_self_initializing_expectations_notebook(tmp_path):
     finally:
         with open(output_notebook_path, mode="w", encoding="utf-8") as f:
             nbformat.write(nb, f)
-        # clean up Expectations directory after running test
 
-    clean_up_test_files(
-        base_dir=base_dir,
-        additional_files_to_clean_up=[
+        paths_to_clean_up: List[str] = [
+            os.path.join(base_dir, "great_expectations/expectations/tmp"),
+            os.path.join(
+                base_dir, "great_expectations/expectations/.ge_store_backend_id"
+            ),
             os.path.join(
                 base_dir, "great_expectations/expectations/new_expectation_suite.json"
-            )
-        ],
-    )
+            ),
+        ]
+        clean_up_test_files(paths=paths_to_clean_up)


### PR DESCRIPTION

Changes proposed in this pull request:
- Follow up to PR #5169 
- Adds clean-up code to helper method that leverages `os.path.exists()` as per @anthonyburdi 's suggestion
-

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
