### PR TITLE
[MAINTENANCE] Rule-Based Profiler -- In ParameterBuilder insure that metrics are validated for conversion to numpy array (to avoid deprecation warnings)

### DIFF
--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -488,7 +488,7 @@ def compute_quantiles(
     )
     return NumericRangeEstimationResult(
         estimation_histogram=np.histogram(a=metric_values, bins=NUM_HISTOGRAM_BINS)[0],
-        value_range=np.array([lower_quantile, upper_quantile]),
+        value_range=np.asarray([lower_quantile, upper_quantile]),
     )
 
 

--- a/great_expectations/rule_based_profiler/parameter_builder/mean_table_columns_set_match_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/mean_table_columns_set_match_multi_batch_parameter_builder.py
@@ -126,7 +126,7 @@ class MeanTableColumnsSetMatchMultiBatchParameterBuilder(
 
         one_batch_table_columns_names_set: Set[str]
         mean_table_columns_set_match: np.float64 = np.mean(
-            np.array(
+            np.asarray(
                 [
                     1
                     if one_batch_table_columns_names_set

--- a/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/numeric_metric_range_multi_batch_parameter_builder.py
@@ -515,7 +515,7 @@ be only one of {NumericMetricRangeMultiBatchParameterBuilder.RECOGNIZED_QUANTILE
                     estimation_histogram=np.histogram(
                         a=metric_value_vector, bins=NUM_HISTOGRAM_BINS
                     )[0],
-                    value_range=np.array(
+                    value_range=np.asarray(
                         [metric_value_vector[0], metric_value_vector[0]]
                     ),
                 )

--- a/great_expectations/rule_based_profiler/parameter_builder/partition_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/partition_parameter_builder.py
@@ -195,7 +195,7 @@ class PartitionParameterBuilder(MetricSingleBatchParameterBuilder):
                 ].index
             )
             weights = list(
-                np.array(
+                np.asarray(
                     column_value_counts_parameter_node[
                         FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY
                     ]
@@ -242,7 +242,7 @@ class PartitionParameterBuilder(MetricSingleBatchParameterBuilder):
             # in this case, we have requested a partition, histogram using said partition, and nonnull count
             bins = list(bins)
             weights = list(
-                np.array(parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY])
+                np.asarray(parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY])
                 / column_values_nonnull_count_parameter_node[
                     FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY
                 ]

--- a/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py
@@ -150,7 +150,12 @@ def _get_unique_values_from_nested_collection_of_sets(
         Single flattened set containing unique values.
     """
 
-    flattened: List[Set[Any]] = list(itertools.chain.from_iterable(collection))
+    flattened: Union[List[Set[Any]], Set[Any]] = list(
+        itertools.chain.from_iterable(collection)
+    )
+    element: Any
+    if all(isinstance(element, set) for element in flattened):
+        flattened = set().union(*flattened)
 
     """
     In multi-batch data analysis, values can be empty and missin, resulting in "None" added to set.  However, due to
@@ -161,7 +166,7 @@ def _get_unique_values_from_nested_collection_of_sets(
         sorted(
             filter(
                 lambda element: element is not None,
-                set().union(*flattened),
+                set(flattened),
             )
         )
     )

--- a/great_expectations/rule_based_profiler/types/attributed_resolved_metrics.py
+++ b/great_expectations/rule_based_profiler/types/attributed_resolved_metrics.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass
-from typing import Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -8,6 +8,50 @@ from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.rule_based_profiler.types import MetricValue, MetricValues
 from great_expectations.types import SerializableDictDot
 from great_expectations.types.attributes import Attributes
+
+
+def _condition_metric_values(metric_values: MetricValues) -> MetricValues:
+    def _detect_illegal_array_type_or_shape(values: MetricValues) -> bool:
+        # Python "None" is illegal as candidate for conversion into "numpy.ndarray" type.
+        if values is None:
+            return True
+
+        # Pandas "DataFrame" and "Series" are illegal as candidates for conversion into "numpy.ndarray" type.
+        if isinstance(values, (pd.DataFrame, pd.Series, set)):
+            return True
+
+        if isinstance(values, (list, tuple)):
+            value: MetricValue = values[0]
+            # Python "None" is illegal as candidate for conversion into "numpy.ndarray" type.
+            if value is None:
+                return True
+
+            # Pandas "DataFrame" and "Series" are illegal as candidates for conversion into "numpy.ndarray" type.
+            if isinstance(value, (pd.DataFrame, pd.Series, set)):
+                return True
+
+            if all(isinstance(value, list) for value in values):
+                # Components of different lengths cannot be packaged into "numpy.ndarray" type (due to undefined shape).
+                values_iterator: Iterator = iter(values)
+                first_value_length: int = len(next(values_iterator))
+                current_value: List[Any]
+                if not all(
+                    len(current_value) == first_value_length
+                    for current_value in values_iterator
+                ):
+                    return True
+
+            # Recursively evaluate each element of properly shaped iterable (list or tuple).
+            for value in values:
+                if _detect_illegal_array_type_or_shape(values=value):
+                    return True
+
+        return False
+
+    if _detect_illegal_array_type_or_shape(values=metric_values):
+        return metric_values
+    else:
+        return np.asarray(metric_values)
 
 
 @dataclass
@@ -30,11 +74,10 @@ class AttributedResolvedMetrics(SerializableDictDot):
         if attributed_metric_values is None:
             return None
 
-        values: MetricValues = list(attributed_metric_values.values())[0]
-        if values is not None and isinstance(values, (pd.DataFrame, pd.Series)):
-            return list(attributed_metric_values.values())
-
-        return np.array(list(attributed_metric_values.values()))
+        metric_values_all_batches: MetricValues = list(
+            attributed_metric_values.values()
+        )
+        return _condition_metric_values(metric_values=metric_values_all_batches)
 
     def add_resolved_metric(self, batch_id: str, value: MetricValue) -> None:
         if self.metric_values_by_batch_id is None:

--- a/great_expectations/rule_based_profiler/types/metric_computation_result.py
+++ b/great_expectations/rule_based_profiler/types/metric_computation_result.py
@@ -1,11 +1,15 @@
 from dataclasses import make_dataclass
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
-MetricValue = Union[Any, List[Any], pd.DataFrame, pd.Series, np.ndarray]
-MetricValues = Union[MetricValue, pd.DataFrame, pd.Series, np.ndarray]
+MetricValue = Union[
+    Any, List[Any], Set[Any], Tuple[Any, ...], pd.DataFrame, pd.Series, np.ndarray
+]
+MetricValues = Union[
+    MetricValue, List[MetricValue], Set[MetricValue], Tuple[MetricValue, ...]
+]
 MetricComputationDetails = Dict[str, Any]
 MetricComputationResult = make_dataclass(
     "MetricComputationResult", ["attributed_resolved_metrics", "details"]


### PR DESCRIPTION
### Scope
* We now check metrics outputs thoroughly for conditions that would preclude the output from being converted into `numpy.ndarray` in a way that does not result in deprecation warnings being printed.
* Fix to value set `ParameterBuilder` to receive sanitized array values.
* This was thoroughly tested in a Jupyter notebook.
* Existing tests pass.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-927
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
