### PR TITLE
[MAINTENANCE] Increase lower bound on numpy requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jsonschema>=2.5.1
 mistune>=0.8.4
 nbformat>=5.0
 notebook>=6.4.10
-numpy>=1.14.1
+numpy>=1.19.5
 packaging
 pandas>=0.23.0
 pyparsing>=2.4,<3


### PR DESCRIPTION
Changes proposed in this pull request:
- The vast majority of users have upgraded numpy to at least version 1.19.5. By removing support for older versions we reduce our maintenance burden and can build more cool new features :)

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
