### PR TITLE
[FEATURE] DataAssistant: Enable passing directives to run() method using runtime_environment argument

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -441,7 +441,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         self,
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
-        runtime_environment: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> DataAssistantResult:
         """
         Run the DataAssistant as it is currently configured.
@@ -449,7 +449,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         Args:
             variables: attribute name/value pairs (overrides), commonly-used in Builder objects
             rules: name/(configuration-dictionary) (overrides)
-            runtime_environment: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
+            kwargs: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
 
         Returns:
             DataAssistantResult: The result object for the DataAssistant
@@ -464,9 +464,9 @@ class DataAssistant(metaclass=MetaDataAssistant):
             profiler=self.profiler,
             variables=variables,
             rules=rules,
-            runtime_environment=runtime_environment,
             batch_list=list(self._batches.values()),
             batch_request=None,
+            **kwargs,
         )
         return self._build_data_assistant_result(
             data_assistant_result=data_assistant_result
@@ -616,9 +616,9 @@ def run_profiler_on_data(
     profiler: BaseRuleBasedProfiler,
     variables: Optional[Dict[str, Any]] = None,
     rules: Optional[Dict[str, Dict[str, Any]]] = None,
-    runtime_environment: Optional[Dict[str, Any]] = None,
     batch_list: Optional[List[Batch]] = None,
     batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+    **kwargs,
 ) -> None:
     """
     This method executes "run()" of effective "RuleBasedProfiler" and fills "DataAssistantResult" object with outputs.
@@ -629,9 +629,9 @@ def run_profiler_on_data(
         profiler: Effective "BaseRuleBasedProfiler", representing containing "DataAssistant" object
         variables: attribute name/value pairs (overrides), commonly-used in Builder objects
         rules: name/(configuration-dictionary) (overrides)
-        runtime_environment: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
         batch_list: Explicit list of Batch objects to supply data at runtime
         batch_request: Explicit batch_request used to supply data at runtime
+        kwargs: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
     """
     if rules is None:
         rules = []
@@ -643,11 +643,11 @@ def run_profiler_on_data(
     rule_based_profiler_result: RuleBasedProfilerResult = profiler.run(
         variables=variables,
         rules=rules_configs,
-        runtime_environment=runtime_environment,
         batch_list=batch_list,
         batch_request=batch_request,
         recompute_existing_parameter_values=False,
         reconciliation_directives=DEFAULT_RECONCILATION_DIRECTIVES,
+        **kwargs,
     )
     result: DataAssistantResult = data_assistant_result
     result.profiler_config = profiler.config

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -441,6 +441,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         self,
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
+        runtime_environment: Optional[Dict[str, Any]] = None,
     ) -> DataAssistantResult:
         """
         Run the DataAssistant as it is currently configured.
@@ -448,6 +449,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         Args:
             variables: attribute name/value pairs (overrides), commonly-used in Builder objects
             rules: name/(configuration-dictionary) (overrides)
+            runtime_environment: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
 
         Returns:
             DataAssistantResult: The result object for the DataAssistant
@@ -462,6 +464,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
             profiler=self.profiler,
             variables=variables,
             rules=rules,
+            runtime_environment=runtime_environment,
             batch_list=list(self._batches.values()),
             batch_request=None,
         )
@@ -613,6 +616,7 @@ def run_profiler_on_data(
     profiler: BaseRuleBasedProfiler,
     variables: Optional[Dict[str, Any]] = None,
     rules: Optional[Dict[str, Dict[str, Any]]] = None,
+    runtime_environment: Optional[Dict[str, Any]] = None,
     batch_list: Optional[List[Batch]] = None,
     batch_request: Optional[Union[BatchRequestBase, dict]] = None,
 ) -> None:
@@ -625,6 +629,7 @@ def run_profiler_on_data(
         profiler: Effective "BaseRuleBasedProfiler", representing containing "DataAssistant" object
         variables: attribute name/value pairs (overrides), commonly-used in Builder objects
         rules: name/(configuration-dictionary) (overrides)
+        runtime_environment: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
         batch_list: Explicit list of Batch objects to supply data at runtime
         batch_request: Explicit batch_request used to supply data at runtime
     """
@@ -638,6 +643,7 @@ def run_profiler_on_data(
     rule_based_profiler_result: RuleBasedProfilerResult = profiler.run(
         variables=variables,
         rules=rules_configs,
+        runtime_environment=runtime_environment,
         batch_list=batch_list,
         batch_request=batch_request,
         recompute_existing_parameter_values=False,

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -15,6 +15,9 @@ from great_expectations.rule_based_profiler.expectation_configuration_builder im
 from great_expectations.rule_based_profiler.helpers.configuration_reconciliation import (
     DEFAULT_RECONCILATION_DIRECTIVES,
 )
+from great_expectations.rule_based_profiler.helpers.runtime_environment import (
+    RuntimeEnvironmentDomainTypeDirectives,
+)
 from great_expectations.rule_based_profiler.helpers.util import sanitize_parameter_name
 from great_expectations.rule_based_profiler.parameter_builder import (
     MeanUnexpectedMapMetricMultiBatchParameterBuilder,
@@ -441,7 +444,9 @@ class DataAssistant(metaclass=MetaDataAssistant):
         self,
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
-        **kwargs: dict,
+        domain_type_directives_list: Optional[
+            List[RuntimeEnvironmentDomainTypeDirectives]
+        ] = None,
     ) -> DataAssistantResult:
         """
         Run the DataAssistant as it is currently configured.
@@ -449,7 +454,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         Args:
             variables: attribute name/value pairs (overrides), commonly-used in Builder objects
             rules: name/(configuration-dictionary) (overrides)
-            kwargs: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
+            domain_type_directives_list: additional/override runtime directives (can modify "BaseRuleBasedProfiler")
 
         Returns:
             DataAssistantResult: The result object for the DataAssistant
@@ -466,7 +471,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
             rules=rules,
             batch_list=list(self._batches.values()),
             batch_request=None,
-            **kwargs,
+            domain_type_directives_list=domain_type_directives_list,
         )
         return self._build_data_assistant_result(
             data_assistant_result=data_assistant_result
@@ -618,7 +623,9 @@ def run_profiler_on_data(
     rules: Optional[Dict[str, Dict[str, Any]]] = None,
     batch_list: Optional[List[Batch]] = None,
     batch_request: Optional[Union[BatchRequestBase, dict]] = None,
-    **kwargs: dict,
+    domain_type_directives_list: Optional[
+        List[RuntimeEnvironmentDomainTypeDirectives]
+    ] = None,
 ) -> None:
     """
     This method executes "run()" of effective "RuleBasedProfiler" and fills "DataAssistantResult" object with outputs.
@@ -631,7 +638,7 @@ def run_profiler_on_data(
         rules: name/(configuration-dictionary) (overrides)
         batch_list: Explicit list of Batch objects to supply data at runtime
         batch_request: Explicit batch_request used to supply data at runtime
-        kwargs: additional/override directives supplied at runtime (can modify "BaseRuleBasedProfiler")
+        domain_type_directives_list: additional/override runtime directives (can modify "BaseRuleBasedProfiler")
     """
     if rules is None:
         rules = []
@@ -647,7 +654,7 @@ def run_profiler_on_data(
         batch_request=batch_request,
         recompute_existing_parameter_values=False,
         reconciliation_directives=DEFAULT_RECONCILATION_DIRECTIVES,
-        **kwargs,
+        domain_type_directives_list=domain_type_directives_list,
     )
     result: DataAssistantResult = data_assistant_result
     result.profiler_config = profiler.config

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -441,7 +441,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         self,
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
-        **kwargs,
+        **kwargs: dict,
     ) -> DataAssistantResult:
         """
         Run the DataAssistant as it is currently configured.
@@ -618,7 +618,7 @@ def run_profiler_on_data(
     rules: Optional[Dict[str, Dict[str, Any]]] = None,
     batch_list: Optional[List[Batch]] = None,
     batch_request: Optional[Union[BatchRequestBase, dict]] = None,
-    **kwargs,
+    **kwargs: dict,
 ) -> None:
     """
     This method executes "run()" of effective "RuleBasedProfiler" and fills "DataAssistantResult" object with outputs.

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -23,7 +23,7 @@ def augment_arguments(**extra_kwargs) -> Callable:
     Decorator factory that defines additional arguments that are passed to every function invocation.
     """
 
-    def signature_modification_decorator(func: Callable):
+    def signature_modification_decorator(func: Callable) -> Callable:
         @wraps(func)
         def modify_signature(*args, **kwargs):
             kwargs = kwargs or {}

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -24,8 +24,15 @@ def augment_arguments(**extra_kwargs) -> Callable:
     """
 
     def signature_modification_decorator(func: Callable) -> Callable:
+        """
+        Specific decorator definition for including additional arguments that are passed to every function invocation.
+        """
+
         @wraps(func)
-        def modify_signature(*args, **kwargs):
+        def modify_signature(*args, **kwargs) -> Any:
+            """
+            Actual implementation logic for including additional arguments that are passed to every function invocation.
+            """
             kwargs = kwargs or {}
             augmented_kwargs: dict = copy.deepcopy(extra_kwargs)
             augmented_kwargs.update(kwargs)

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -1,7 +1,14 @@
-from typing import Any, Dict, Optional, Type, Union
+import copy
+from functools import wraps
+from inspect import Signature, signature
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from great_expectations.core.batch import BatchRequestBase
 from great_expectations.rule_based_profiler.data_assistant import DataAssistant
+from great_expectations.rule_based_profiler.helpers.runtime_environment import (
+    RuntimeEnvironmentColumnDomainTypeDirectivesKeys,
+    RuntimeEnvironmentDomainTypeDirectivesKeys,
+)
 from great_expectations.rule_based_profiler.helpers.util import (
     get_validator_with_expectation_suite,
 )
@@ -11,6 +18,36 @@ from great_expectations.rule_based_profiler.types.data_assistant_result import (
 from great_expectations.validator.validator import Validator
 
 
+def augment_arguments(**extra_kwargs):
+    """
+    Decorator factory that defines additional arguments that are passed to every function invocation.
+    """
+
+    def signature_modification_decorator(func: Callable):
+        @wraps(func)
+        def modify_signature(*args, **kwargs):
+            kwargs = kwargs or {}
+            augmented_kwargs: dict = copy.deepcopy(extra_kwargs)
+            augmented_kwargs.update(kwargs)
+            return func(*args, **augmented_kwargs)
+
+        # Override signature.
+        sig: Signature = signature(func)
+        sig = sig.replace(parameters=tuple(sig.parameters.values())[1:])
+        modify_signature.__signature__ = sig
+
+        return modify_signature
+
+    return signature_modification_decorator
+
+
+def _enum_to_default_kwargs(
+    enum_obj: Type[RuntimeEnvironmentDomainTypeDirectivesKeys],
+) -> dict:
+    key: type(enum_obj)
+    return {key.value: None for key in enum_obj}
+
+
 class DataAssistantRunner:
     """
     DataAssistantRunner processes invocations of calls to "run()" methods of registered "DataAssistant" classes.
@@ -18,6 +55,10 @@ class DataAssistantRunner:
     The approach is to instantiate "DataAssistant" class of specified type with "Validator", containing "Batch" objects,
     specified by "batch_request", loaded into memory.  Then, "DataAssistant.run()" is issued with given directives.
     """
+
+    RUNTIME_ENVIRONMENT_KWARGS: dict = _enum_to_default_kwargs(
+        enum_obj=RuntimeEnvironmentColumnDomainTypeDirectivesKeys
+    )
 
     def __init__(
         self,
@@ -32,6 +73,7 @@ class DataAssistantRunner:
         self._data_assistant_cls = data_assistant_cls
         self._data_context = data_context
 
+    @augment_arguments(**RUNTIME_ENVIRONMENT_KWARGS)
     def run(
         self,
         variables: Optional[Dict[str, Any]] = None,

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -36,6 +36,7 @@ class DataAssistantRunner:
         self,
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
+        runtime_environment: Optional[Dict[str, Any]] = None,
         batch_request: Optional[Union[BatchRequestBase, dict]] = None,
     ) -> DataAssistantResult:
         data_assistant_name: str = self._data_assistant_cls.data_assistant_type
@@ -53,5 +54,6 @@ class DataAssistantRunner:
         data_assistant_result: DataAssistantResult = data_assistant.run(
             variables=variables,
             rules=rules,
+            runtime_environment=runtime_environment,
         )
         return data_assistant_result

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -18,7 +18,7 @@ from great_expectations.rule_based_profiler.types.data_assistant_result import (
 from great_expectations.validator.validator import Validator
 
 
-def augment_arguments(**extra_kwargs) -> Callable:
+def augment_arguments(**extra_kwargs: dict) -> Callable:
     """
     Decorator factory that defines additional arguments that are passed to every function invocation.
     """

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -18,7 +18,7 @@ from great_expectations.rule_based_profiler.types.data_assistant_result import (
 from great_expectations.validator.validator import Validator
 
 
-def augment_arguments(**extra_kwargs):
+def augment_arguments(**extra_kwargs) -> Callable:
     """
     Decorator factory that defines additional arguments that are passed to every function invocation.
     """

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -36,8 +36,8 @@ class DataAssistantRunner:
         self,
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
-        runtime_environment: Optional[Dict[str, Any]] = None,
         batch_request: Optional[Union[BatchRequestBase, dict]] = None,
+        **kwargs,
     ) -> DataAssistantResult:
         data_assistant_name: str = self._data_assistant_cls.data_assistant_type
         validator: Validator = get_validator_with_expectation_suite(
@@ -54,6 +54,6 @@ class DataAssistantRunner:
         data_assistant_result: DataAssistantResult = data_assistant.run(
             variables=variables,
             rules=rules,
-            runtime_environment=runtime_environment,
+            **kwargs,
         )
         return data_assistant_result

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -37,7 +37,7 @@ class DataAssistantRunner:
         variables: Optional[Dict[str, Any]] = None,
         rules: Optional[Dict[str, Dict[str, Any]]] = None,
         batch_request: Optional[Union[BatchRequestBase, dict]] = None,
-        **kwargs,
+        **kwargs: dict,
     ) -> DataAssistantResult:
         data_assistant_name: str = self._data_assistant_cls.data_assistant_type
         validator: Validator = get_validator_with_expectation_suite(

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -182,6 +182,9 @@ class ColumnDomainBuilder(DomainBuilder):
         validator: Optional["Validator"] = None,  # noqa: F821
         variables: Optional[ParameterContainer] = None,
     ) -> List[str]:
+        """
+        This method applies multiple directives to obtain columns to be included as part of returned "Domain" objects.
+        """
         include_column_names: Optional[List[str]] = cast(
             Optional[List[str]],
             self._resolve_list_type_property(

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -179,27 +179,53 @@ class ColumnDomainBuilder(DomainBuilder):
         validator: Optional["Validator"] = None,  # noqa: F821
         variables: Optional[ParameterContainer] = None,
     ) -> List[str]:
+        column_name: str
+
         # Obtain include_column_names from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        include_column_names: Optional[
-            List[str]
-        ] = get_parameter_value_and_validate_return_type(
-            domain=None,
-            parameter_reference=self.include_column_names,
-            expected_return_type=None,
-            variables=variables,
-            parameters=None,
-        )
+        include_column_names: Optional[List[str]] = self.include_column_names
+        if include_column_names is None:
+            include_column_names = []
+        elif isinstance(include_column_names, str):
+            include_column_names = [include_column_names]
+        else:
+            if not isinstance(include_column_names, list):
+                raise ValueError(
+                    "Unrecognized include_column_names directive -- must be list or string."
+                )
+
+        include_column_names = [
+            get_parameter_value_and_validate_return_type(
+                domain=None,
+                parameter_reference=column_name,
+                expected_return_type=None,
+                variables=variables,
+                parameters=None,
+            )
+            for column_name in include_column_names
+        ]
 
         # Obtain exclude_column_names from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        exclude_column_names: Optional[
-            List[str]
-        ] = get_parameter_value_and_validate_return_type(
-            domain=None,
-            parameter_reference=self.exclude_column_names,
-            expected_return_type=None,
-            variables=variables,
-            parameters=None,
-        )
+        exclude_column_names: Optional[List[str]] = self.exclude_column_names
+        if exclude_column_names is None:
+            exclude_column_names = []
+        elif isinstance(exclude_column_names, str):
+            exclude_column_names = [exclude_column_names]
+        else:
+            if not isinstance(exclude_column_names, list):
+                raise ValueError(
+                    "Unrecognized exclude_column_names directive -- must be list or string."
+                )
+
+        exclude_column_names = [
+            get_parameter_value_and_validate_return_type(
+                domain=None,
+                parameter_reference=column_name,
+                expected_return_type=None,
+                variables=variables,
+                parameters=None,
+            )
+            for column_name in exclude_column_names
+        ]
 
         if batch_ids is None:
             batch_ids: List[str] = self.get_batch_ids(variables=variables)
@@ -223,8 +249,6 @@ class ColumnDomainBuilder(DomainBuilder):
         if exclude_column_names is None:
             exclude_column_names = []
 
-        column_name: str
-
         effective_column_names = [
             column_name
             for column_name in effective_column_names
@@ -237,38 +261,60 @@ class ColumnDomainBuilder(DomainBuilder):
                     message=f'Error: The column "{column_name}" in BatchData does not exist.'
                 )
 
-        # include_column_name_suffixes column_name_suffixes from "rule state" (i.e., variables and parameters); from instance variable otherwise.
+        column_name_suffix: str
+
+        # Obtain include_column_name_suffixes from "rule state" (i.e., variables and parameters); from instance variable otherwise.
         include_column_name_suffixes: Optional[
             Union[str, Iterable, List[str]]
-        ] = get_parameter_value_and_validate_return_type(
-            domain=None,
-            parameter_reference=self.include_column_name_suffixes,
-            expected_return_type=None,
-            variables=variables,
-            parameters=None,
-        )
+        ] = self.include_column_name_suffixes
+        if include_column_name_suffixes is None:
+            include_column_name_suffixes = []
+        elif isinstance(include_column_name_suffixes, str):
+            include_column_name_suffixes = [include_column_name_suffixes]
+        else:
+            if not isinstance(include_column_name_suffixes, (Iterable, list)):
+                raise ValueError(
+                    "Unrecognized include_column_name_suffixes directive -- must be list or string."
+                )
 
-        # exclude_column_name_suffixes column_name_suffixes from "rule state" (i.e., variables and parameters); from instance variable otherwise.
+        include_column_name_suffixes = [
+            get_parameter_value_and_validate_return_type(
+                domain=None,
+                parameter_reference=column_name_suffix,
+                expected_return_type=None,
+                variables=variables,
+                parameters=None,
+            )
+            for column_name_suffix in include_column_name_suffixes
+        ]
+
+        # Obtain exclude_column_name_suffixes from "rule state" (i.e., variables and parameters); from instance variable otherwise.
         exclude_column_name_suffixes: Optional[
             Union[str, Iterable, List[str]]
-        ] = get_parameter_value_and_validate_return_type(
-            domain=None,
-            parameter_reference=self.exclude_column_name_suffixes,
-            expected_return_type=None,
-            variables=variables,
-            parameters=None,
-        )
+        ] = self.exclude_column_name_suffixes
+        if exclude_column_name_suffixes is None:
+            exclude_column_name_suffixes = []
+        elif isinstance(exclude_column_name_suffixes, str):
+            exclude_column_name_suffixes = [exclude_column_name_suffixes]
+        else:
+            if not isinstance(include_column_name_suffixes, (Iterable, list)):
+                raise ValueError(
+                    "Unrecognized exclude_column_name_suffixes directive -- must be list or string."
+                )
+
+        exclude_column_name_suffixes = [
+            get_parameter_value_and_validate_return_type(
+                domain=None,
+                parameter_reference=column_name_suffix,
+                expected_return_type=None,
+                variables=variables,
+                parameters=None,
+            )
+            for column_name_suffix in exclude_column_name_suffixes
+        ]
 
         if include_column_name_suffixes:
-            if isinstance(include_column_name_suffixes, str):
-                include_column_name_suffixes = [include_column_name_suffixes]
-            else:
-                if not isinstance(include_column_name_suffixes, (Iterable, list)):
-                    raise ValueError(
-                        "Unrecognized include_column_name_suffixes directive -- must be a list or a string."
-                    )
-
-            effective_column_names: List[str] = list(
+            effective_column_names = list(
                 filter(
                     lambda candidate_column_name: candidate_column_name.endswith(
                         tuple(include_column_name_suffixes)
@@ -278,15 +324,7 @@ class ColumnDomainBuilder(DomainBuilder):
             )
 
         if exclude_column_name_suffixes:
-            if isinstance(exclude_column_name_suffixes, str):
-                exclude_column_name_suffixes = [exclude_column_name_suffixes]
-            else:
-                if not isinstance(exclude_column_name_suffixes, (Iterable, list)):
-                    raise ValueError(
-                        "Unrecognized exclude_column_name_suffixes directive -- must be a list or a string."
-                    )
-
-            effective_column_names: List[str] = list(
+            effective_column_names = list(
                 filter(
                     lambda candidate_column_name: not candidate_column_name.endswith(
                         tuple(exclude_column_name_suffixes)
@@ -335,16 +373,33 @@ class ColumnDomainBuilder(DomainBuilder):
         )
         self._semantic_type_filter = semantic_type_filter
 
+        semantic_type: str
+
         # Obtain include_semantic_types from "rule state" (i.e., variables and parameters); from instance variable otherwise.
         include_semantic_types: Optional[
             Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
-        ] = get_parameter_value_and_validate_return_type(
-            domain=None,
-            parameter_reference=self.include_semantic_types,
-            expected_return_type=None,
-            variables=variables,
-            parameters=None,
-        )
+        ] = self.include_semantic_types
+        if include_semantic_types is None:
+            include_semantic_types = []
+        elif isinstance(include_semantic_types, str):
+            include_semantic_types = [include_semantic_types]
+        else:
+            if not isinstance(include_semantic_types, (SemanticDomainTypes, list)):
+                raise ValueError(
+                    'Unrecognized include_semantic_types directive -- must be list or "SemanticDomainTypes" or string.'
+                )
+
+        include_semantic_types = [
+            get_parameter_value_and_validate_return_type(
+                domain=None,
+                parameter_reference=semantic_type,
+                expected_return_type=None,
+                variables=variables,
+                parameters=None,
+            )
+            for semantic_type in include_semantic_types
+        ]
+
         include_semantic_types = (
             self.semantic_type_filter.parse_semantic_domain_type_argument(
                 semantic_types=include_semantic_types
@@ -354,13 +409,31 @@ class ColumnDomainBuilder(DomainBuilder):
         # Obtain exclude_semantic_types from "rule state" (i.e., variables and parameters); from instance variable otherwise.
         exclude_semantic_types: Optional[
             Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
-        ] = get_parameter_value_and_validate_return_type(
-            domain=None,
-            parameter_reference=self.exclude_semantic_types,
-            expected_return_type=None,
-            variables=variables,
-            parameters=None,
-        )
+        ] = self.exclude_semantic_types
+        exclude_semantic_types: Optional[
+            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
+        ] = self.exclude_semantic_types
+        if exclude_semantic_types is None:
+            exclude_semantic_types = []
+        elif isinstance(exclude_semantic_types, str):
+            exclude_semantic_types = [exclude_semantic_types]
+        else:
+            if not isinstance(exclude_semantic_types, (SemanticDomainTypes, list)):
+                raise ValueError(
+                    'Unrecognized exclude_semantic_types directive -- must be list or "SemanticDomainTypes" or string.'
+                )
+
+        exclude_semantic_types = [
+            get_parameter_value_and_validate_return_type(
+                domain=None,
+                parameter_reference=semantic_type,
+                expected_return_type=None,
+                variables=variables,
+                parameters=None,
+            )
+            for semantic_type in exclude_semantic_types
+        ]
+
         exclude_semantic_types = (
             self.semantic_type_filter.parse_semantic_domain_type_argument(
                 semantic_types=exclude_semantic_types

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -410,9 +410,6 @@ class ColumnDomainBuilder(DomainBuilder):
         exclude_semantic_types: Optional[
             Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
         ] = self.exclude_semantic_types
-        exclude_semantic_types: Optional[
-            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
-        ] = self.exclude_semantic_types
         if exclude_semantic_types is None:
             exclude_semantic_types = []
         elif isinstance(exclude_semantic_types, str):

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -1,4 +1,6 @@
-from typing import Iterable, List, Optional, Set, Union
+# noinspection PyUnresolvedReferences
+from types import GenericAlias
+from typing import Iterable, List, Optional, Set, Union, _UnionGenericAlias, cast
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -179,53 +181,14 @@ class ColumnDomainBuilder(DomainBuilder):
         validator: Optional["Validator"] = None,  # noqa: F821
         variables: Optional[ParameterContainer] = None,
     ) -> List[str]:
-        column_name: str
-
-        # Obtain include_column_names from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        include_column_names: Optional[List[str]] = self.include_column_names
-        if include_column_names is None:
-            include_column_names = []
-        elif isinstance(include_column_names, str):
-            include_column_names = [include_column_names]
-        else:
-            if not isinstance(include_column_names, list):
-                raise ValueError(
-                    "Unrecognized include_column_names directive -- must be list or string."
-                )
-
-        include_column_names = [
-            get_parameter_value_and_validate_return_type(
-                domain=None,
-                parameter_reference=column_name,
-                expected_return_type=None,
+        include_column_names: Optional[List[str]] = cast(
+            Optional[List[stype_tr]],
+            self._resolve_list_type_property(
+                property_name="include_column_names",
+                property_value_type=list,
                 variables=variables,
-                parameters=None,
-            )
-            for column_name in include_column_names
-        ]
-
-        # Obtain exclude_column_names from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        exclude_column_names: Optional[List[str]] = self.exclude_column_names
-        if exclude_column_names is None:
-            exclude_column_names = []
-        elif isinstance(exclude_column_names, str):
-            exclude_column_names = [exclude_column_names]
-        else:
-            if not isinstance(exclude_column_names, list):
-                raise ValueError(
-                    "Unrecognized exclude_column_names directive -- must be list or string."
-                )
-
-        exclude_column_names = [
-            get_parameter_value_and_validate_return_type(
-                domain=None,
-                parameter_reference=column_name,
-                expected_return_type=None,
-                variables=variables,
-                parameters=None,
-            )
-            for column_name in exclude_column_names
-        ]
+            ),
+        )
 
         if batch_ids is None:
             batch_ids: List[str] = self.get_batch_ids(variables=variables)
@@ -246,8 +209,16 @@ class ColumnDomainBuilder(DomainBuilder):
 
         effective_column_names: List[str] = include_column_names or table_columns
 
-        if exclude_column_names is None:
-            exclude_column_names = []
+        exclude_column_names: Optional[List[str]] = cast(
+            Optional[List[str]],
+            self._resolve_list_type_property(
+                property_name="exclude_column_names",
+                property_value_type=list,
+                variables=variables,
+            ),
+        )
+
+        column_name: str
 
         effective_column_names = [
             column_name
@@ -261,58 +232,14 @@ class ColumnDomainBuilder(DomainBuilder):
                     message=f'Error: The column "{column_name}" in BatchData does not exist.'
                 )
 
-        column_name_suffix: str
-
-        # Obtain include_column_name_suffixes from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        include_column_name_suffixes: Optional[
-            Union[str, Iterable, List[str]]
-        ] = self.include_column_name_suffixes
-        if include_column_name_suffixes is None:
-            include_column_name_suffixes = []
-        elif isinstance(include_column_name_suffixes, str):
-            include_column_name_suffixes = [include_column_name_suffixes]
-        else:
-            if not isinstance(include_column_name_suffixes, (Iterable, list)):
-                raise ValueError(
-                    "Unrecognized include_column_name_suffixes directive -- must be list or string."
-                )
-
-        include_column_name_suffixes = [
-            get_parameter_value_and_validate_return_type(
-                domain=None,
-                parameter_reference=column_name_suffix,
-                expected_return_type=None,
+        include_column_name_suffixes: Union[str, Iterable, List[str]] = cast(
+            Union[str, Iterable, List[str]],
+            self._resolve_list_type_property(
+                property_name="include_column_name_suffixes",
+                property_value_type=(str, Iterable, list),
                 variables=variables,
-                parameters=None,
-            )
-            for column_name_suffix in include_column_name_suffixes
-        ]
-
-        # Obtain exclude_column_name_suffixes from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        exclude_column_name_suffixes: Optional[
-            Union[str, Iterable, List[str]]
-        ] = self.exclude_column_name_suffixes
-        if exclude_column_name_suffixes is None:
-            exclude_column_name_suffixes = []
-        elif isinstance(exclude_column_name_suffixes, str):
-            exclude_column_name_suffixes = [exclude_column_name_suffixes]
-        else:
-            if not isinstance(include_column_name_suffixes, (Iterable, list)):
-                raise ValueError(
-                    "Unrecognized exclude_column_name_suffixes directive -- must be list or string."
-                )
-
-        exclude_column_name_suffixes = [
-            get_parameter_value_and_validate_return_type(
-                domain=None,
-                parameter_reference=column_name_suffix,
-                expected_return_type=None,
-                variables=variables,
-                parameters=None,
-            )
-            for column_name_suffix in exclude_column_name_suffixes
-        ]
-
+            ),
+        )
         if include_column_name_suffixes:
             effective_column_names = list(
                 filter(
@@ -323,6 +250,14 @@ class ColumnDomainBuilder(DomainBuilder):
                 )
             )
 
+        exclude_column_name_suffixes: Union[str, Iterable, List[str]] = cast(
+            Union[str, Iterable, List[str]],
+            self._resolve_list_type_property(
+                property_name="exclude_column_name_suffixes",
+                property_value_type=(str, Iterable, list),
+                variables=variables,
+            ),
+        )
         if exclude_column_name_suffixes:
             effective_column_names = list(
                 filter(
@@ -373,67 +308,19 @@ class ColumnDomainBuilder(DomainBuilder):
         )
         self._semantic_type_filter = semantic_type_filter
 
-        semantic_type: str
-
-        # Obtain include_semantic_types from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        include_semantic_types: Optional[
-            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
-        ] = self.include_semantic_types
-        if include_semantic_types is None:
-            include_semantic_types = []
-        elif isinstance(include_semantic_types, str):
-            include_semantic_types = [include_semantic_types]
-        else:
-            if not isinstance(include_semantic_types, (SemanticDomainTypes, list)):
-                raise ValueError(
-                    'Unrecognized include_semantic_types directive -- must be list or "SemanticDomainTypes" or string.'
-                )
-
-        include_semantic_types = [
-            get_parameter_value_and_validate_return_type(
-                domain=None,
-                parameter_reference=semantic_type,
-                expected_return_type=None,
+        include_semantic_types: Union[
+            str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]
+        ] = cast(
+            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]],
+            self._resolve_list_type_property(
+                property_name="include_semantic_types",
+                property_value_type=(str, SemanticDomainTypes, list),
                 variables=variables,
-                parameters=None,
-            )
-            for semantic_type in include_semantic_types
-        ]
-
+            ),
+        )
         include_semantic_types = (
             self.semantic_type_filter.parse_semantic_domain_type_argument(
                 semantic_types=include_semantic_types
-            )
-        )
-
-        # Obtain exclude_semantic_types from "rule state" (i.e., variables and parameters); from instance variable otherwise.
-        exclude_semantic_types: Optional[
-            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]]
-        ] = self.exclude_semantic_types
-        if exclude_semantic_types is None:
-            exclude_semantic_types = []
-        elif isinstance(exclude_semantic_types, str):
-            exclude_semantic_types = [exclude_semantic_types]
-        else:
-            if not isinstance(exclude_semantic_types, (SemanticDomainTypes, list)):
-                raise ValueError(
-                    'Unrecognized exclude_semantic_types directive -- must be list or "SemanticDomainTypes" or string.'
-                )
-
-        exclude_semantic_types = [
-            get_parameter_value_and_validate_return_type(
-                domain=None,
-                parameter_reference=semantic_type,
-                expected_return_type=None,
-                variables=variables,
-                parameters=None,
-            )
-            for semantic_type in exclude_semantic_types
-        ]
-
-        exclude_semantic_types = (
-            self.semantic_type_filter.parse_semantic_domain_type_argument(
-                semantic_types=exclude_semantic_types
             )
         )
 
@@ -447,6 +334,22 @@ class ColumnDomainBuilder(DomainBuilder):
                     effective_column_names,
                 )
             )
+
+        exclude_semantic_types: Union[
+            str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]
+        ] = cast(
+            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]],
+            self._resolve_list_type_property(
+                property_name="exclude_semantic_types",
+                property_value_type=(str, SemanticDomainTypes, list),
+                variables=variables,
+            ),
+        )
+        exclude_semantic_types = (
+            self.semantic_type_filter.parse_semantic_domain_type_argument(
+                semantic_types=exclude_semantic_types
+            )
+        )
 
         if exclude_semantic_types:
             effective_column_names = list(
@@ -488,3 +391,35 @@ class ColumnDomainBuilder(DomainBuilder):
         )
 
         return domains
+
+    def _resolve_list_type_property(
+        self,
+        property_name: str,
+        property_value_type: Union[GenericAlias, _UnionGenericAlias],
+        variables: Optional[ParameterContainer] = None,
+    ) -> List[Union[GenericAlias, _UnionGenericAlias]]:
+        property_value: Optional[property_value_type] = getattr(self, property_name, [])
+        if property_value is None:
+            property_value = []
+        elif isinstance(property_value, str):
+            property_value = [property_value]
+        else:
+            if not isinstance(property_value, property_value_type):
+                raise ValueError(
+                    f'Unrecognized "{property_name}" directive -- must be "{property_value_type}" (or string).'
+                )
+
+        property_cursor: Union[GenericAlias, _UnionGenericAlias]
+        property_value = [
+            # Obtain property from "rule state" (i.e., variables and parameters); from instance variable otherwise.
+            get_parameter_value_and_validate_return_type(
+                domain=None,
+                parameter_reference=property_cursor,
+                expected_return_type=None,
+                variables=variables,
+                parameters=None,
+            )
+            for property_cursor in property_value
+        ]
+
+        return property_value

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -183,7 +183,7 @@ class ColumnDomainBuilder(DomainBuilder):
         This method applies multiple directives to obtain columns to be included as part of returned "Domain" objects.
         """
         include_column_names: Optional[List[str]] = cast(
-            Optional[List[str]],
+            List[str],
             self._resolve_list_type_property(
                 property_name="include_column_names",
                 property_value_type=list,
@@ -211,7 +211,7 @@ class ColumnDomainBuilder(DomainBuilder):
         effective_column_names: List[str] = include_column_names or table_columns
 
         exclude_column_names: Optional[List[str]] = cast(
-            Optional[List[str]],
+            List[str],
             self._resolve_list_type_property(
                 property_name="exclude_column_names",
                 property_value_type=list,
@@ -234,7 +234,7 @@ class ColumnDomainBuilder(DomainBuilder):
                 )
 
         include_column_name_suffixes: Union[str, Iterable, List[str]] = cast(
-            Union[str, Iterable, List[str]],
+            List[str],
             self._resolve_list_type_property(
                 property_name="include_column_name_suffixes",
                 property_value_type=(str, Iterable, list),
@@ -252,7 +252,7 @@ class ColumnDomainBuilder(DomainBuilder):
             )
 
         exclude_column_name_suffixes: Union[str, Iterable, List[str]] = cast(
-            Union[str, Iterable, List[str]],
+            List[str],
             self._resolve_list_type_property(
                 property_name="exclude_column_name_suffixes",
                 property_value_type=(str, Iterable, list),
@@ -312,7 +312,7 @@ class ColumnDomainBuilder(DomainBuilder):
         include_semantic_types: Union[
             str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]
         ] = cast(
-            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]],
+            List[Union[str, SemanticDomainTypes]],
             self._resolve_list_type_property(
                 property_name="include_semantic_types",
                 property_value_type=(str, SemanticDomainTypes, list),
@@ -339,7 +339,7 @@ class ColumnDomainBuilder(DomainBuilder):
         exclude_semantic_types: Union[
             str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]
         ] = cast(
-            Union[str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]],
+            List[Union[str, SemanticDomainTypes]],
             self._resolve_list_type_property(
                 property_name="exclude_semantic_types",
                 property_value_type=(str, SemanticDomainTypes, list),

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -1,7 +1,4 @@
-from types import GenericAlias
-
-# noinspection PyUnresolvedReferences
-from typing import Iterable, List, Optional, Set, Union, _UnionGenericAlias, cast
+from typing import Iterable, List, Optional, Set, Tuple, Union, cast
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -399,9 +396,9 @@ class ColumnDomainBuilder(DomainBuilder):
     def _resolve_list_type_property(
         self,
         property_name: str,
-        property_value_type: Union[GenericAlias, _UnionGenericAlias],
+        property_value_type: Union[type, Tuple[type, ...]],
         variables: Optional[ParameterContainer] = None,
-    ) -> List[Union[GenericAlias, _UnionGenericAlias]]:
+    ) -> List[type]:
         property_value: Optional[property_value_type] = getattr(self, property_name, [])
         if property_value is None:
             property_value = []
@@ -413,7 +410,7 @@ class ColumnDomainBuilder(DomainBuilder):
                     f'Unrecognized "{property_name}" directive -- must be "{property_value_type}" (or string).'
                 )
 
-        property_cursor: Union[GenericAlias, _UnionGenericAlias]
+        property_cursor: type
         property_value = [
             # Obtain property from "rule state" (i.e., variables and parameters); from instance variable otherwise.
             get_parameter_value_and_validate_return_type(

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -182,7 +182,7 @@ class ColumnDomainBuilder(DomainBuilder):
         """
         This method applies multiple directives to obtain columns to be included as part of returned "Domain" objects.
         """
-        include_column_names: Optional[List[str]] = cast(
+        include_column_names: List[str] = cast(
             List[str],
             self._resolve_list_type_property(
                 property_name="include_column_names",
@@ -210,7 +210,7 @@ class ColumnDomainBuilder(DomainBuilder):
 
         effective_column_names: List[str] = include_column_names or table_columns
 
-        exclude_column_names: Optional[List[str]] = cast(
+        exclude_column_names: List[str] = cast(
             List[str],
             self._resolve_list_type_property(
                 property_name="exclude_column_names",
@@ -233,7 +233,7 @@ class ColumnDomainBuilder(DomainBuilder):
                     message=f'Error: The column "{column_name}" in BatchData does not exist.'
                 )
 
-        include_column_name_suffixes: Union[str, Iterable, List[str]] = cast(
+        include_column_name_suffixes: List[str] = cast(
             List[str],
             self._resolve_list_type_property(
                 property_name="include_column_name_suffixes",
@@ -251,7 +251,7 @@ class ColumnDomainBuilder(DomainBuilder):
                 )
             )
 
-        exclude_column_name_suffixes: Union[str, Iterable, List[str]] = cast(
+        exclude_column_name_suffixes: List[str] = cast(
             List[str],
             self._resolve_list_type_property(
                 property_name="exclude_column_name_suffixes",
@@ -309,9 +309,7 @@ class ColumnDomainBuilder(DomainBuilder):
         )
         self._semantic_type_filter = semantic_type_filter
 
-        include_semantic_types: Union[
-            str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]
-        ] = cast(
+        include_semantic_types: Union[List[Union[str, SemanticDomainTypes]]] = cast(
             List[Union[str, SemanticDomainTypes]],
             self._resolve_list_type_property(
                 property_name="include_semantic_types",
@@ -336,9 +334,7 @@ class ColumnDomainBuilder(DomainBuilder):
                 )
             )
 
-        exclude_semantic_types: Union[
-            str, SemanticDomainTypes, List[Union[str, SemanticDomainTypes]]
-        ] = cast(
+        exclude_semantic_types: Union[List[Union[str, SemanticDomainTypes]]] = cast(
             List[Union[str, SemanticDomainTypes]],
             self._resolve_list_type_property(
                 property_name="exclude_semantic_types",

--- a/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/column_domain_builder.py
@@ -1,5 +1,6 @@
-# noinspection PyUnresolvedReferences
 from types import GenericAlias
+
+# noinspection PyUnresolvedReferences
 from typing import Iterable, List, Optional, Set, Union, _UnionGenericAlias, cast
 
 import great_expectations.exceptions as ge_exceptions
@@ -182,7 +183,7 @@ class ColumnDomainBuilder(DomainBuilder):
         variables: Optional[ParameterContainer] = None,
     ) -> List[str]:
         include_column_names: Optional[List[str]] = cast(
-            Optional[List[stype_tr]],
+            Optional[List[str]],
             self._resolve_list_type_property(
                 property_name="include_column_names",
                 property_value_type=list,

--- a/great_expectations/rule_based_profiler/helpers/runtime_environment.py
+++ b/great_expectations/rule_based_profiler/helpers/runtime_environment.py
@@ -1,0 +1,102 @@
+import logging
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Dict, List, Union, cast
+
+import great_expectations.exceptions as ge_exceptions
+from great_expectations.core.util import convert_to_json_serializable
+from great_expectations.execution_engine.execution_engine import MetricDomainTypes
+from great_expectations.types import SerializableDictDot
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class RuntimeEnvironmentColumnDomainTypeDirectivesKeys(Enum):
+    INCLUDE_COLUMN_NAMES = "include_column_names"
+    EXCLUDE_COLUMN_NAMES = "exclude_column_names"
+    INCLUDE_COLUMN_NAME_SUFFIXES = "include_column_name_suffixes"
+    EXCLUDE_COLUMN_NAME_SUFFIXES = "exclude_column_name_suffixes"
+    INCLUDE_SEMANTIC_TYPES = "include_semantic_types"
+    EXCLUDE_SEMANTIC_TYPES = "exclude_semantic_types"
+
+
+class RuntimeEnvironmentColumnPairDomainTypeDirectivesKeys(Enum):
+    pass
+
+
+class RuntimeEnvironmentMulticolumnDomainTypeDirectivesKeys(Enum):
+    pass
+
+
+class RuntimeEnvironmentTableDomainTypeDirectivesKeys(Enum):
+    pass
+
+
+RuntimeEnvironmentDomainTypeDirectivesKeys = Union[
+    RuntimeEnvironmentColumnDomainTypeDirectivesKeys,
+    RuntimeEnvironmentColumnPairDomainTypeDirectivesKeys,
+    RuntimeEnvironmentMulticolumnDomainTypeDirectivesKeys,
+    RuntimeEnvironmentTableDomainTypeDirectivesKeys,
+]
+
+
+@dataclass
+class RuntimeEnvironmentDomainTypeDirectives(SerializableDictDot):
+    domain_type: MetricDomainTypes
+    directives: Dict[RuntimeEnvironmentDomainTypeDirectivesKeys, Any]
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json_dict(self) -> dict:
+        return convert_to_json_serializable(data=self.to_dict())
+
+
+def build_domain_type_directives(
+    **kwargs,
+) -> List[RuntimeEnvironmentDomainTypeDirectives]:
+    domain_type_directives_list: List[RuntimeEnvironmentDomainTypeDirectives] = []
+
+    column_domain_type_directives: RuntimeEnvironmentDomainTypeDirectives = (
+        _build_specific_domain_type_directives(
+            domain_type=MetricDomainTypes.COLUMN,
+            domain_type_directives_keys=cast(
+                RuntimeEnvironmentDomainTypeDirectivesKeys,
+                RuntimeEnvironmentColumnDomainTypeDirectivesKeys,
+            ),
+            **kwargs,
+        )
+    )
+    domain_type_directives_list.append(column_domain_type_directives)
+
+    return domain_type_directives_list
+
+
+def _build_specific_domain_type_directives(
+    domain_type: MetricDomainTypes,
+    domain_type_directives_keys: RuntimeEnvironmentDomainTypeDirectivesKeys,
+    **kwargs,
+) -> RuntimeEnvironmentDomainTypeDirectives:
+    domain_type_directives: RuntimeEnvironmentDomainTypeDirectives = (
+        RuntimeEnvironmentDomainTypeDirectives(
+            domain_type=domain_type,
+            directives={},
+        )
+    )
+
+    key: RuntimeEnvironmentDomainTypeDirectivesKeys
+    value: Any
+    for key, value in kwargs.items():
+        try:
+            # noinspection PyCallingNonCallable
+            domain_type_directives_key: RuntimeEnvironmentDomainTypeDirectivesKeys = (
+                domain_type_directives_keys(key)
+            )
+            domain_type_directives.directives[domain_type_directives_key] = value
+        except ValueError as e:
+            raise ge_exceptions.ProfilerExecutionError(
+                message=f'Unknown property "{key}" in "{domain_type_directives_keys}"; {e} was raised.'
+            )
+
+    return domain_type_directives

--- a/great_expectations/rule_based_profiler/helpers/runtime_environment.py
+++ b/great_expectations/rule_based_profiler/helpers/runtime_environment.py
@@ -47,15 +47,26 @@ class RuntimeEnvironmentDomainTypeDirectives(SerializableDictDot):
     directives: Dict[RuntimeEnvironmentDomainTypeDirectivesKeys, Any]
 
     def to_dict(self) -> dict:
+        """
+        Returns dictionary equivalent of this object.
+        """
         return asdict(self)
 
     def to_json_dict(self) -> dict:
+        """
+        Returns JSON dictionary equivalent of this object.
+        """
         return convert_to_json_serializable(data=self.to_dict())
 
 
 def build_domain_type_directives(
-    **kwargs,
+    **kwargs: dict,
 ) -> List[RuntimeEnvironmentDomainTypeDirectives]:
+    """
+    This method makes best-effort attempt to identify directives, supplied in "kwargs", as supported properties,
+    corresponnding to "DomainBuilder" classes, associated with every "MetricDomainTypes", and return each of these
+    directives as part of dedicated "RuntimeEnvironmentDomainTypeDirectives" typed object for every "MetricDomainTypes".
+    """
     domain_type_directives_list: List[RuntimeEnvironmentDomainTypeDirectives] = []
 
     column_domain_type_directives: RuntimeEnvironmentDomainTypeDirectives = (
@@ -76,7 +87,7 @@ def build_domain_type_directives(
 def _build_specific_domain_type_directives(
     domain_type: MetricDomainTypes,
     domain_type_directives_keys: RuntimeEnvironmentDomainTypeDirectivesKeys,
-    **kwargs,
+    **kwargs: dict,
 ) -> RuntimeEnvironmentDomainTypeDirectives:
     domain_type_directives: RuntimeEnvironmentDomainTypeDirectives = (
         RuntimeEnvironmentDomainTypeDirectives(

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -861,6 +861,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
         rules: name/(configuration-dictionary) to modify using "runtime_environment"
         domain_type_directives_list: additional/override runtime directives (can modify "BaseRuleBasedProfiler")
         """
+        if domain_type_directives_list is None:
+            domain_type_directives_list = []
+
         domain_type_directives: RuntimeEnvironmentDomainTypeDirectives
         domain_rules: List[Rule]
         rule: Rule

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -223,7 +223,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         batch_request: Optional[Union[BatchRequestBase, dict]] = None,
         recompute_existing_parameter_values: bool = False,
         reconciliation_directives: ReconciliationDirectives = DEFAULT_RECONCILATION_DIRECTIVES,
-        **kwargs,
+        **kwargs: dict,
     ) -> RuleBasedProfilerResult:
         """
         Executes and collects "RuleState" side-effect from all "Rule" objects of this "RuleBasedProfiler".
@@ -851,7 +851,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
     def _apply_runtime_environment(
         variables: Optional[ParameterContainer] = None,
         rules: Optional[List[Rule]] = None,
-        **kwargs,
+        **kwargs: dict,
     ) -> None:
         """
         variables: attribute name/value pairs, commonly-used in Builder objects, to modify using "runtime_environment"

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -901,8 +901,8 @@ class BaseRuleBasedProfiler(ConfigPeer):
         dest_property_value: Optional[Any] = None,
         source_property_value: Optional[Any] = None,
     ) -> Optional[Any]:
-        if dest_property_value is None and source_property_value is None:
-            return None
+        if dest_property_value is None:
+            return source_property_value
 
         if type(source_property_value) != type(dest_property_value):
             raise ge_exceptions.ProfilerExecutionError(

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -2472,12 +2472,8 @@ def test_get_metrics_and_expectations_using_implicit_invocation_with_exclude_col
     ]
     data_assistant_result: DataAssistantResult = context.assistants.volume.run(
         batch_request=batch_request,
-        runtime_environment={
-            "domain": {
-                "column": {
-                    "exclude_column_names": exclude_column_names,
-                },
-            },
+        **{
+            "exclude_column_names": exclude_column_names,
         },
     )
 

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -2472,9 +2472,7 @@ def test_get_metrics_and_expectations_using_implicit_invocation_with_exclude_col
     ]
     data_assistant_result: DataAssistantResult = context.assistants.volume.run(
         batch_request=batch_request,
-        **{
-            "exclude_column_names": exclude_column_names,
-        },
+        exclude_column_names=exclude_column_names,
     )
 
     column_name: str

--- a/tests/test_fixtures/rule_based_profiler/bobby_user_workflow_verbose_profiler_config.yml
+++ b/tests/test_fixtures/rule_based_profiler/bobby_user_workflow_verbose_profiler_config.yml
@@ -131,7 +131,15 @@ rules:
       class_name: CategoricalColumnDomainBuilder
       module_name: great_expectations.rule_based_profiler.domain_builder
       limit_mode: VERY_FEW
-      exclude_column_names: DOLocationID, RatecodeID, store_and_fwd_flag, payment_type, extra, mta_tax, improvement_surcharge, congestion_surcharge
+      exclude_column_names:
+        - DOLocationID
+        - RatecodeID
+        - store_and_fwd_flag
+        - payment_type
+        - extra
+        - mta_tax
+        - improvement_surcharge
+        - congestion_surcharge
     parameter_builders:
       - name: my_pickup_location_id_value_set
         class_name: ValueSetMultiBatchParameterBuilder


### PR DESCRIPTION
### Scope
* Added standard `**kwargs` to `DataAssistant.run()` which can be configured with multiple overrides, including column inclusions/exclusions and other properties influencing the underlying `RuleBasedProfiler` execution.
 
Syntax example:
```
    exclude_column_names: List[str] = [
        "dropoff_datetime",
        "store_and_fwd_flag",
        "extra",
        "congestion_surcharge",
    ]
    data_assistant_result: DataAssistantResult = context.assistants.volume.run(
        batch_request=batch_request,       
        exclude_column_names=exclude_column_names,
         # can add other directives here,
    )
```
The implementation attempts to associate the directives in `**kwargs` with `Domain Types`, appropriate for a uniquely identified `DomainBuilder` (e.g., `ColumnDomainBuilder`).
* Enhanced `ColumnDomain` builder to properly accept values set by setter methods and reconcile these values with those from existing configuration.
* Added a unit test for column exclusion.
* Fixed incorrectly configured existing unit test.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-822/GREAT-905
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
