### PR TITLE
[BUGFIX] Update name for stdev expectation in `OnboardingDataAssistant` backend

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
@@ -462,8 +462,8 @@ class OnboardingDataAssistant(DataAssistant):
                 **column_standard_deviation_values_range_parameter_builder_for_validations.to_json_dict(),
             ),
         ]
-        expect_column_standard_deviation_to_be_between_expectation_configuration_builder: DefaultExpectationConfigurationBuilder = DefaultExpectationConfigurationBuilder(
-            expectation_type="expect_column_standard_deviation_to_be_between",
+        expect_column_stdev_to_be_between_expectation_configuration_builder: DefaultExpectationConfigurationBuilder = DefaultExpectationConfigurationBuilder(
+            expectation_type="expect_column_stdev_to_be_between",
             validation_parameter_builder_configs=validation_parameter_builder_configs,
             column=f"{DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}column",
             min_value=f"{column_standard_deviation_values_range_parameter_builder_for_validations.fully_qualified_parameter_name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[0]",
@@ -516,7 +516,7 @@ class OnboardingDataAssistant(DataAssistant):
             expect_expect_column_quantile_values_to_be_between_expectation_configuration_builder,
             expect_column_median_to_be_between_expectation_configuration_builder,
             expect_column_mean_to_be_between_expectation_configuration_builder,
-            expect_column_standard_deviation_to_be_between_expectation_configuration_builder,
+            expect_column_stdev_to_be_between_expectation_configuration_builder,
         ]
         rule: Rule = Rule(
             name="numeric_columns_rule",


### PR DESCRIPTION
Changes proposed in this pull request:
- The name of the expectation is `stdev` instead of `standard_deviation` - this changes allows our plotting to actually pick up the value.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
