### PR TITLE
[BUGFIX] OnboardingDataAssistant and Underlying Metrics: Add Defensive Programming Into Metric Implementations So As To Avoid Warnings About Incompatible Data

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_median.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_median.py
@@ -27,6 +27,11 @@ class ColumnMedian(ColumnAggregateMetricProvider):
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
         """Pandas Median Implementation"""
+        metrics: Dict[str, Any] = kwargs.get("metrics") or {}
+        nonnull_count = metrics.get("column_values.nonnull.count")
+        if not nonnull_count:
+            return 0.0
+
         return column.median()
 
     @metric_value(engine=SqlAlchemyExecutionEngine, metric_fn_type="value")
@@ -48,10 +53,12 @@ class ColumnMedian(ColumnAggregateMetricProvider):
         column_name = accessor_domain_kwargs["column"]
         column = sa.column(column_name)
         sqlalchemy_engine = execution_engine.engine
+
         """SqlAlchemy Median Implementation"""
         nonnull_count = metrics.get("column_values.nonnull.count")
         if not nonnull_count:
             return None
+
         element_values = sqlalchemy_engine.execute(
             sa.select([column])
             .order_by(column)
@@ -106,6 +113,10 @@ class ColumnMedian(ColumnAggregateMetricProvider):
         # in the degenerate case when n_values = 0
 
         """Spark Median Implementation"""
+        nonnull_count = metrics.get("column_values.nonnull.count")
+        if not nonnull_count:
+            return None
+
         table_row_count = metrics.get("table.row_count")
         result = df.approxQuantile(
             column, [0.5, 0.5 + (1 / (2 + (2 * table_row_count)))], 0
@@ -133,10 +144,9 @@ class ColumnMedian(ColumnAggregateMetricProvider):
             runtime_configuration=runtime_configuration,
         )
 
-        if isinstance(execution_engine, SqlAlchemyExecutionEngine):
-            dependencies["column_values.nonnull.count"] = MetricConfiguration(
-                metric_name="column_values.nonnull.count",
-                metric_domain_kwargs=metric.metric_domain_kwargs,
-            )
+        dependencies["column_values.nonnull.count"] = MetricConfiguration(
+            metric_name="column_values.nonnull.count",
+            metric_domain_kwargs=metric.metric_domain_kwargs,
+        )
 
         return dependencies

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_max.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_max.py
@@ -23,7 +23,7 @@ class ColumnValuesLengthMax(ColumnAggregateMetricProvider):
     @column_aggregate_partial(
         engine=SqlAlchemyExecutionEngine, filter_column_isnull=True
     )
-    def _sqlalchemy(cls, column: sa.Column, **kwargs: dict):  # type: ignore[no-untyped-def]
+    def _sqlalchemy(cls, column, **kwargs: dict):  # type: ignore[no-untyped-def]
         return sa.func.max(sa.func.length(column))
 
     @column_aggregate_partial(engine=SparkDFExecutionEngine, filter_column_isnull=True)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_max.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_max.py
@@ -16,14 +16,16 @@ from great_expectations.expectations.metrics.import_manager import F, sa
 class ColumnValuesLengthMax(ColumnAggregateMetricProvider):
     metric_name = "column_values.length.max"
 
-    @column_aggregate_value(engine=PandasExecutionEngine)
+    @column_aggregate_value(engine=PandasExecutionEngine, filter_column_isnull=True)
     def _pandas(cls, column: pd.Series, **kwargs: dict) -> int:
         return column.map(len).max()
 
-    @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)
-    def _sqlalchemy(cls, column: "ColumnClause", **kwargs: dict) -> int:  # noqa: F821
+    @column_aggregate_partial(
+        engine=SqlAlchemyExecutionEngine, filter_column_isnull=True
+    )
+    def _sqlalchemy(cls, column: sa.Column, **kwargs: dict):  # type: ignore[no-untyped-def]
         return sa.func.max(sa.func.length(column))
 
-    @column_aggregate_partial(engine=SparkDFExecutionEngine)
-    def _spark(cls, column, **kwargs: dict) -> int:
-        return F.max(F.length(column))
+    @column_aggregate_partial(engine=SparkDFExecutionEngine, filter_column_isnull=True)
+    def _spark(cls, column: str, **kwargs: dict):  # type: ignore[no-untyped-def]
+        return F.max(F.length(F.col(column)))

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_min.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_min.py
@@ -23,7 +23,7 @@ class ColumnValuesLengthMin(ColumnAggregateMetricProvider):
     @column_aggregate_partial(
         engine=SqlAlchemyExecutionEngine, filter_column_isnull=True
     )
-    def _sqlalchemy(cls, column: sa.Column, **kwargs: dict):  # type: ignore[no-untyped-def]
+    def _sqlalchemy(cls, column, **kwargs: dict):  # type: ignore[no-untyped-def]
         return sa.func.min(sa.func.length(column))
 
     @column_aggregate_partial(engine=SparkDFExecutionEngine, filter_column_isnull=True)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_min.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_min.py
@@ -16,14 +16,16 @@ from great_expectations.expectations.metrics.import_manager import F, sa
 class ColumnValuesLengthMin(ColumnAggregateMetricProvider):
     metric_name = "column_values.length.min"
 
-    @column_aggregate_value(engine=PandasExecutionEngine)
+    @column_aggregate_value(engine=PandasExecutionEngine, filter_column_isnull=True)
     def _pandas(cls, column: pd.Series, **kwargs: dict) -> int:
         return column.map(len).min()
 
-    @column_aggregate_partial(engine=SqlAlchemyExecutionEngine)
-    def _sqlalchemy(cls, column: "ColumnClause", **kwargs: dict) -> int:  # noqa: F821
+    @column_aggregate_partial(
+        engine=SqlAlchemyExecutionEngine, filter_column_isnull=True
+    )
+    def _sqlalchemy(cls, column: sa.Column, **kwargs: dict):  # type: ignore[no-untyped-def]
         return sa.func.min(sa.func.length(column))
 
-    @column_aggregate_partial(engine=SparkDFExecutionEngine)
-    def _spark(cls, column, **kwargs: dict) -> int:
-        return F.min(F.length(column))
+    @column_aggregate_partial(engine=SparkDFExecutionEngine, filter_column_isnull=True)
+    def _spark(cls, column: str, **kwargs: dict):  # type: ignore[no-untyped-def]
+        return F.min(F.length(F.col(column)))

--- a/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
@@ -462,8 +462,8 @@ class OnboardingDataAssistant(DataAssistant):
                 **column_standard_deviation_values_range_parameter_builder_for_validations.to_json_dict(),
             ),
         ]
-        expect_column_standard_deviation_to_be_between_expectation_configuration_builder: DefaultExpectationConfigurationBuilder = DefaultExpectationConfigurationBuilder(
-            expectation_type="expect_column_standard_deviation_to_be_between",
+        expect_column_stdev_to_be_between_expectation_configuration_builder: DefaultExpectationConfigurationBuilder = DefaultExpectationConfigurationBuilder(
+            expectation_type="expect_column_stddev_to_be_between",
             validation_parameter_builder_configs=validation_parameter_builder_configs,
             column=f"{DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}column",
             min_value=f"{column_standard_deviation_values_range_parameter_builder_for_validations.fully_qualified_parameter_name}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}{FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY}[0]",
@@ -516,7 +516,7 @@ class OnboardingDataAssistant(DataAssistant):
             expect_expect_column_quantile_values_to_be_between_expectation_configuration_builder,
             expect_column_median_to_be_between_expectation_configuration_builder,
             expect_column_mean_to_be_between_expectation_configuration_builder,
-            expect_column_standard_deviation_to_be_between_expectation_configuration_builder,
+            expect_column_stdev_to_be_between_expectation_configuration_builder,
         ]
         rule: Rule = Rule(
             name="numeric_columns_rule",

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -34,11 +34,11 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
     CANDIDATE_REGEX: Set[str] = {
         r"\d+",  # whole number with 1 or more digits
         r"-?\d+",  # negative whole numbers
-        r"-?\d+(\.\d*)?",  # decimal numbers with . (period) separator
+        r"-?\d+(?:\.\d*)?",  # decimal numbers with . (period) separator
         r"[A-Za-z0-9\.,;:!?()\"'%\-]+",  # general text
         r"^\s+",  # leading space
         r"\s+$",  # trailing space
-        r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#()?&//=]*)",  #  Matching URL (including http(s) protocol)
+        r"https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#()?&//=]*)",  #  Matching URL (including http(s) protocol)
         r"<\/?(?:p|a|b|img)(?: \/)?>",  # HTML tags
         r"(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})(?:.(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})){3}",  # IPv4 IP address
         r"(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}",  # IPv6 IP address,

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -71,11 +71,11 @@ def test_regex_pattern_string_parameter_builder_instantiation_with_defaults(
     candidate_regexes: Set[str] = {
         r"\d+",  # whole number with 1 or more digits
         r"-?\d+",  # negative whole numbers
-        r"-?\d+(\.\d*)?",  # decimal numbers with . (period) separator
+        r"-?\d+(?:\.\d*)?",  # decimal numbers with . (period) separator
         r"[A-Za-z0-9\.,;:!?()\"'%\-]+",  # general text
         r"^\s+",  # leading space
         r"\s+$",  # trailing space
-        r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#()?&//=]*)",  #  Matching URL (including http(s) protocol)
+        r"https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#()?&//=]*)",  #  Matching URL (including http(s) protocol)
         r"<\/?(?:p|a|b|img)(?: \/)?>",  # HTML tags
         r"(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})(?:.(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})){3}",  # IPv4 IP address
         r"(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}",  # IPv6 IP address,
@@ -321,11 +321,11 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
             "evaluated_regexes": {
                 r"\d+": 1.0,
                 r"-?\d+": 1.0,
-                r"-?\d+(\.\d*)?": 1.0,
+                r"-?\d+(?:\.\d*)?": 1.0,
                 r"[A-Za-z0-9\.,;:!?()\"'%\-]+": 1.0,
                 r"^\s+": 0.0,
                 r"\s+$": 0.0,
-                r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#()?&//=]*)": 0.0,
+                r"https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#()?&//=]*)": 0.0,
                 r"<\/?(?:p|a|b|img)(?: \/)?>": 0.0,
                 r"(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})(?:.(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})){3}": 0.0,
                 r"(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}": 1.0,


### PR DESCRIPTION
### Scope
* Fix `ColumnValuesLengthMin` and `ColumnValuesLengthMax` metric providers to filter out `NULL` columns (cannot compute length of a string that turns into a floating point `NaN` value).
* Fix `ColumnMedian` metric provider to exit uniformly when all values in the column are `NULL` (return `0.0` in this case).
* Update `CANDIDATE_REGEX` in `RegexPatternStringParameterBuilder` to use Matching Groups instead of Capture Groups (the latter generate an "advice" warning from `Python` `RegEx` library).

### Remark
This fixes most of the warnings.  Next is to address warnings and errors, associated with `histogram` computation as well as any remaining exceptions in `Chart` graphing.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-822/GREAT-969
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
