### PR TITLE
[BUGFIX] In aggregate metrics, Spark Implementation already gets Column type as argument -- no need for F.col() as the operand is not a string.

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_max.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_max.py
@@ -27,5 +27,5 @@ class ColumnValuesLengthMax(ColumnAggregateMetricProvider):
         return sa.func.max(sa.func.length(column))
 
     @column_aggregate_partial(engine=SparkDFExecutionEngine, filter_column_isnull=True)
-    def _spark(cls, column: str, **kwargs: dict):  # type: ignore[no-untyped-def]
-        return F.max(F.length(F.col(column)))
+    def _spark(cls, column, **kwargs: dict):  # type: ignore[no-untyped-def]
+        return F.max(F.length(column))

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_min.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_values_length_min.py
@@ -27,5 +27,5 @@ class ColumnValuesLengthMin(ColumnAggregateMetricProvider):
         return sa.func.min(sa.func.length(column))
 
     @column_aggregate_partial(engine=SparkDFExecutionEngine, filter_column_isnull=True)
-    def _spark(cls, column: str, **kwargs: dict):  # type: ignore[no-untyped-def]
-        return F.min(F.length(F.col(column)))
+    def _spark(cls, column, **kwargs: dict):  # type: ignore[no-untyped-def]
+        return F.min(F.length(column))


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
