### PR TITLE
[FEATURE] `OnboardingDataAssistant` plots for `expect_table_row_count_to_be_between` non-sequential batches

### DIFF
--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -1303,9 +1303,9 @@ class DataAssistantResult(SerializableDictDot):
             options=columns, name="Select Column: "
         )
         selection: alt.selection_single = alt.selection_single(
+            empty="none",
             bind=input_dropdown,
             fields=[domain_component.name],
-            init={domain_component.name: " "},
         )
 
         bars: alt.Chart = (


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-847/GREAT-856
- Fix initial position for non-sequential `expect_table_row_count_to_be_between` chart on non-sequential batches

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
