### PR TITLE
[FEATURE] add support for Azure authentication methods

### DIFF
--- a/docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.md
+++ b/docs/guides/setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.md
@@ -56,7 +56,7 @@ data_docs_sites:
     store_backend:
        class_name: TupleAzureBlobStoreBackend
        container: \$web
-       connection_string: ${AZURE_STORAGE_WEB_CONNECTION_STRING}
+       connection_string: ${AZURE_STORAGE_CONNECTION_STRING}
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
 ```
@@ -64,12 +64,30 @@ data_docs_sites:
 You may also replace the default ``local_site`` if you would only like to maintain a single Azure Data Docs site.
 
 :::note
- Since the container is called ``$web``, if we simply set ``container: $web`` in ``great_expectations.yml`` then Great Expectations would unsuccefully try to find the variable called ``web`` in ``config_variables.yml``. 
+ Since the container is called ``$web``, if we simply set ``container: $web`` in ``great_expectations.yml`` then Great Expectations would unsuccessfully try to find the variable called ``web`` in ``config_variables.yml``. 
  We use an escape char ``\`` before the ``$`` so the [substitute_config_variable](https://legacy.docs.greatexpectations.io/en/latest/autoapi/great_expectations/data_context/util/index.html?highlight=substitute_config_variable#great_expectations.data_context.util.substitute_config_variable) method will allow us to reach the ``$web`` container.
 :::
 
 You also may configure Great Expectations to store your <TechnicalTag relative="../../../" tag="expectation" text="Expectations" /> and <TechnicalTag relative="../../../" tag="validation_result" text="Validation Results" /> in this Azure Storage account.
 You can follow the documentation from the guides for [Expectations](../../setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_azure_blob_storage.md) and [Validation Results](../../setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_azure_blob_storage.md) but be sure you set ``container: \$web`` in place of the other container name.
+
+The following options are available for this backend:
+
+  * ``container``: The name of the Azure Blob container to store your data in.
+  * ``connection_string``: The Azure Storage connection string.
+  This can also be supplied by setting the ``AZURE_STORAGE_CONNECTION_STRING`` environment variable.
+  * ``prefix``: All paths on blob storage will be prefixed with this string.
+  * ``account_url``: The URL to the blob storage account. Any other entities included in the URL path (e.g. container or blob) will be discarded.
+  This URL can be optionally authenticated with a SAS token.
+  This can only be used if you don't configure the ``connection_string``. 
+  You can also configure this by setting the ``AZURE_STORAGE_ACCOUNT_URL`` environment variable.
+
+The most common authentication methods are supported:
+
+* SAS token authentication: append the SAS token to ``account_url`` or make sure it is set in the ``connection_string``.
+* Account key authentication: include the account key in the ``connection_string``.
+* When none of the above authentication methods are specified, the [DefaultAzureCredential](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) will be used which supports most common authentication methods.
+  You still need to provide the account url either through the config file or environment variable.
 
 
 ### 4. Build the Azure Blob Data Docs site

--- a/docs/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_azure_blob_storage.md
+++ b/docs/guides/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_azure_blob_storage.md
@@ -65,6 +65,12 @@ stores:
 If the container is called ``$web`` (for [hosting and sharing Data Docs on Azure Blob Storage](../../setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.md)) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
 :::
 
+:::note
+Various authentication and configuration options are available as documented in [hosting and sharing Data Docs on Azure Blob Storage](../../setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.md).
+:::
+
+
+
 ### 4. Copy existing Validation Results JSON files to the Azure blob (This step is optional)
 
 One way to copy Validation Results into Azure Blob Storage is by using the ``az storage blob upload`` command, which is part of the Azure SDK. The following example will copy one Validation Result from a local folder to the Azure blob.   Information on other ways to copy Validation Result JSON files, like the Azure Storage browser in the Azure Portal, can be found in the [Documentation for Azure](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).

--- a/docs/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_azure_blob_storage.md
+++ b/docs/guides/setup/configuring_metadata_stores/how_to_configure_an_expectation_store_in_azure_blob_storage.md
@@ -65,6 +65,10 @@ stores:
 If the container is called ``$web`` (for [hosting and sharing Data Docs on Azure Blob Storage](../configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.md)) then set ``container: \$web`` so the escape char will allow us to reach the ``$web``container.
 :::
 
+:::note
+Various authentication and configuration options are available as documented in [hosting and sharing Data Docs on Azure Blob Storage](../../setup/configuring_data_docs/how_to_host_and_share_data_docs_on_azure_blob_storage.md).
+:::
+
 
 ### 4. Copy existing Expectation JSON files to the Azure blob (This step is optional)
 

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -1003,7 +1003,7 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
         self.account_url = account_url or os.environ.get("AZURE_STORAGE_ACCOUNT_URL")
 
     @property
-    @functools.lru_cache
+    @functools.lru_cache()
     def _container_client(self):
 
         from azure.identity import DefaultAzureCredential

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -1,11 +1,11 @@
 # PYTHON 2 - py2 - update to ABC direct use rather than __metaclass__ once we drop py2 support
+import functools
 import logging
 import os
 import random
 import re
 import shutil
 from abc import ABCMeta
-from functools import cached_property
 from typing import List, Tuple
 
 from great_expectations.data_context.store.store_backend import StoreBackend
@@ -1002,7 +1002,8 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
         self.container = container
         self.account_url = account_url or os.environ.get("AZURE_STORAGE_ACCOUNT_URL")
 
-    @cached_property
+    @property
+    @functools.lru_cache
     def _container_client(self):
 
         from azure.identity import DefaultAzureCredential

--- a/requirements-dev-azure.txt
+++ b/requirements-dev-azure.txt
@@ -1,3 +1,3 @@
-azure-identity>=1.0.0
+azure-identity>=1.10.0
 azure-keyvault-secrets>=4.0.0
 azure-storage-blob>=12.5.0

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -2,12 +2,13 @@ import datetime
 import json
 import os
 from collections import OrderedDict
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
 
 import boto3
 import pyparsing as pp
 import pytest
 from moto import mock_s3
+from pytest_mock import MockerFixture
 
 import tests.test_utils as test_utils
 from great_expectations.core.data_context_key import DataContextVariableKey
@@ -1191,14 +1192,14 @@ def test_TupleGCSStoreBackend():
     )
 
 
-def test_TupleAzureBlobStoreBackend():
-    pytest.importorskip("azure-storage-blob")
+def test_TupleAzureBlobStoreBackend_connection_string():
+    pytest.importorskip("azure.storage.blob")
     """
     What does this test test and why?
     Since no package like moto exists for Azure-Blob services, we mock the Azure-blob client
     and assert that the store backend makes the right calls for set, get, and list.
     """
-    connection_string = "this_is_a_test_conn_string"
+    connection_string = "DefaultEndpointsProtocol=https;AccountName=dummy;AccountKey=secret;EndpointSuffix=core.windows.net"
     prefix = "this_is_a_test_prefix"
     container = "dummy-container"
 
@@ -1210,53 +1211,58 @@ def test_TupleAzureBlobStoreBackend():
         "azure.storage.blob.BlobServiceClient", autospec=True
     ) as mock_azure_blob_client:
 
-        mock_container_client = mock_azure_blob_client.get_container_client.return_value
+        mock_container_client = my_store._container_client
+        mock_azure_blob_client.from_connection_string.assert_called_once()
 
         my_store.set(("AAA",), "aaa")
-
-        mock_azure_blob_client.from_connection_string.assert_called_once()
-        mock_container_client.assert_called_once()
         mock_container_client.upload_blob.assert_called_once_with(
-            name="AAA", data=b"aaa", encoding="utf-8"
+            name="this_is_a_test_prefix/AAA",
+            data="aaa",
+            encoding="utf-8",
+            overwrite=True,
         )
-
-    with patch(
-        "azure.storage.blob.BlobServiceClient", autospec=True
-    ) as mock_azure_blob_client:
-
-        mock_container_client = mock_azure_blob_client.get_container_client.return_value
-
-        my_store.set(("BBB",), b"bbb")
-
-        mock_azure_blob_client.from_connection_string.assert_called_once()
-        mock_container_client.assert_called_once()
-        mock_container_client.upload_blob.assert_called_once_with(
-            name="AAA", data=b"aaa"
-        )
-
-    with patch(
-        "azure.storage.blob.BlobServiceClient", autospec=True
-    ) as mock_azure_blob_client:
-
-        mock_container_client = mock_azure_blob_client.get_container_client.return_value
 
         my_store.get(("BBB",))
+        mock_container_client.download_blob.assert_called_once_with(
+            "this_is_a_test_prefix/BBB"
+        )
 
-        mock_azure_blob_client.from_connection_string.assert_called_once()
-        mock_container_client.assert_called_once()
-        mock_container_client.download_blob.assert_called_once_with("BBB")
+        my_store.list_keys()
+        mock_container_client.list_blobs.assert_called_once_with(
+            name_starts_with="this_is_a_test_prefix"
+        )
+
+
+def test_TupleAzureBlobStoreBackend_account_url():
+    pytest.importorskip("azure.storage.blob")
+    pytest.importorskip("azure.identity")
+    """
+    What does this test test and why?
+    Since no package like moto exists for Azure-Blob services, we mock the Azure-blob client
+    and assert that the store backend makes the right calls for set, get, and list.
+    """
+    account_url = "this_is_a_test_account_url"
+    prefix = "this_is_a_test_prefix"
+    container = "dummy-container"
+
+    my_store = TupleAzureBlobStoreBackend(
+        account_url=account_url, prefix=prefix, container=container
+    )
 
     with patch(
         "azure.storage.blob.BlobServiceClient", autospec=True
     ) as mock_azure_blob_client:
+        with patch(
+            "azure.identity.DefaultAzureCredential", autospec=True
+        ) as mock_azure_credential:
+            mock_container_client = my_store._container_client
+            mock_azure_blob_client.assert_called_once()
 
-        mock_container_client = mock_azure_blob_client.get_container_client.return_value
-
-        my_store.list_keys()
-
-        mock_azure_blob_client.from_connection_string.assert_called_once()
-        mock_container_client.assert_called_once()
-        mock_container_client.list_blobs.assert_called_once_with("this_is_a_prefix")
+            my_store.get(("BBB",))
+            mock_container_client.download_blob.assert_called_once_with(
+                "this_is_a_test_prefix/BBB"
+            )
+            mock_azure_credential.assert_called_once()
 
 
 @mock_s3

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -8,7 +8,6 @@ import boto3
 import pyparsing as pp
 import pytest
 from moto import mock_s3
-from pytest_mock import MockerFixture
 
 import tests.test_utils as test_utils
 from great_expectations.core.data_context_key import DataContextVariableKey

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1193,6 +1193,7 @@ def test_TupleGCSStoreBackend():
 
 def test_TupleAzureBlobStoreBackend_connection_string():
     pytest.importorskip("azure.storage.blob")
+    pytest.importorskip("azure.identity")
     """
     What does this test test and why?
     Since no package like moto exists for Azure-Blob services, we mock the Azure-blob client


### PR DESCRIPTION
This adds support for all common Azure authentication methods for metadata and data docs backends.

Changes proposed in this pull request:
- Fixes behaviour of `AZURE_STORAGE_CONNECTION_STRING` env var so that it matches behaviour described in the docs
- Add support for all common Azure authentication methods
- Document authentication options
- Apparently the unit tests for this backend were always skipped, so fixed them and added new ones to cover the above

Closes #3089


### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
