### PR TITLE
Fix links to API docs

### DIFF
--- a/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
+++ b/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
@@ -49,9 +49,9 @@ from great_expectations.data_context.data_context.data_context import DataContex
 
 ## Public Methods (API documentation links)
 
-*[.create(...):](/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-create)* Build a new great_expectations directory and DataContext object in the provided project_root_dir.
-*[.test_yaml_config(...):](/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config)* Convenience method for testing yaml configs
+*[.create(...):](../methods/great_expectations-data_context-data_context-data_context-DataContext-create)* Build a new great_expectations directory and DataContext object in the provided project_root_dir.
+*[.test_yaml_config(...):](../methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config)* Convenience method for testing yaml configs
 
 ## Relevant documentation (links)
 
-- [Data Context](/docs/terms/data_context)
+- [Data Context](../../terms/data_context)

--- a/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-create.md
+++ b/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-create.md
@@ -1,7 +1,7 @@
 ---
 title: DataContext.create
 ---
-[Back to class documentation](/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext)
+[Back to class documentation](../classes/great_expectations-data_context-data_context-data_context-DataContext)
 
 ### Fully qualified path
 
@@ -28,4 +28,4 @@ DataContext
 
 ## Relevant documentation (links)
 
-- [Data Context](/docs/terms/data_context)
+- [Data Context](../../terms/data_context)

--- a/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config.md
+++ b/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config.md
@@ -1,7 +1,7 @@
 ---
 title: DataContext.test_yaml_config
 ---
-[Back to class documentation](/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext)
+[Back to class documentation](../classes/great_expectations-data_context-data_context-data_context-DataContext)
 
 ### Fully qualified path
 
@@ -40,5 +40,5 @@ The instantiated component (e.g. a Datasource) OR a json object containing metad
 
 ## Relevant documentation (links)
 
-- [Data Context](/docs/terms/data_context)
-- [How to configure a new Checkpoint using test_yaml_config](/docs/guides/validation/checkpoints/how_to_configure_a_new_checkpoint_using_test_yaml_config)
+- [Data Context](../../terms/data_context)
+- [How to configure a new Checkpoint using test_yaml_config](../../guides/validation/checkpoints/how_to_configure_a_new_checkpoint_using_test_yaml_config)


### PR DESCRIPTION
Current links are broken. Consider changing to relative links.

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
