### PR TITLE
[DOCS] Update DataContext docstring

### DIFF
--- a/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
+++ b/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
@@ -6,38 +6,39 @@ title: class DataContext
 
 ## Synopsis
 
-A DataContext represents a Great Expectations project. It organizes storage and access for
-expectation suites, datasources, notification settings, and data fixtures.
+A DataContext represents a Great Expectations project. It is the primary entry point for a Great Expectations
+deployment, with configurations and methods for all supporting components.
 
-The DataContext is configured via a yml file stored in a directory called great_expectations; the configuration file
-as well as managed expectation suites should be stored in version control.
+The DataContext is configured via a yml file stored in a directory called great_expectations; this configuration
+file as well as managed Expectation Suites should be stored in version control. There are other ways to create a
+Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
+(coming soon). Please refer to our documentation for more details.
 
-Use the `create` classmethod to create a new empty config, or instantiate the DataContext
-by passing the path to an existing data context root directory.
+DataContexts use Data Sources and Execution Engines that you're already familiar with to interact with data. You
+can Validate data or generate Expectations using Execution Engines including:
 
-DataContexts use data sources you're already familiar with. BatchKwargGenerators help introspect data stores and data execution
-frameworks (such as airflow, Nifi, dbt, or dagster) to describe and produce batches of data ready for analysis. This
-enables fetching, validation, profiling, and documentation of your data in a way that is meaningful within your
-existing infrastructure and work environment.
+* SQL (multiple dialects supported)
+* Spark
+* Pandas
 
-DataContexts use a datasource-based namespace, where each accessible type of data has a three-part
-normalized *data_asset_name*, consisting of *datasource/generator/data_asset_name*.
+Your data can be stored in common locations including:
 
-- The datasource actually connects to a source of materialized data and returns Great Expectations DataAssets connected to a compute environment and ready for validation.
+* databases / data warehouses
+* files in s3, GCS, Azure, local storage
+* dataframes (spark and pandas) loaded into memory
 
-- The BatchKwargGenerator knows how to introspect datasources and produce identifying "batch_kwargs" that define particular slices of data.
+Please see our documentation for examples on how to set up Great Expectations, connect to your data,
+create Expectations, and Validate data.
 
-- The data_asset_name is a specific name -- often a table name or other name familiar to users -- that batch kwargs generators can slice into batches.
+Other configuration options you can apply to a DataContext besides how to access data include things like where to
+store Expectations, Profilers, Checkpoints, Metrics, Validation Results and Data Docs and how those Stores are
+configured. Take a look at our documentation for more configuration options.
 
-An expectation suite is a collection of expectations ready to be applied to a batch of data. Since
-in many projects it is useful to have different expectations evaluate in different contexts--profiling
-vs. testing; warning vs. error; high vs. low compute; ML model or dashboard--suites provide a namespace
-option for selecting which expectations a DataContext returns.
-
-In many simple projects, the datasource or batch kwargs generator name may be omitted and the DataContext will infer
-the correct name when there is no ambiguity.
-
-Similarly, if no expectation suite name is provided, the DataContext will assume the name "default".
+You can create or load a DataContext from disk via the following:
+```
+import great_expectations as ge
+ge.get_context()
+```
 
 
 ## Import statement
@@ -49,10 +50,9 @@ from great_expectations.data_context.data_context.data_context import DataContex
 
 ## Public Methods (API documentation links)
 
-*[.create(...):](../methods/great_expectations-data_context-data_context-data_context-DataContext-create)* Build a new great_expectations directory and DataContext object in the provided project_root_dir.
-*[.test_yaml_config(...):](../methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config)* Convenience method for testing yaml configs
-
+- *[.create(...):](/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-create)* Build a new great_expectations directory and DataContext object in the provided project_root_dir.
+- *[.test_yaml_config(...):](/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config)* Convenience method for testing yaml configs
 
 ## Relevant documentation (links)
 
-- [Data Context](../../terms/data_context)
+- [Data Context](/docs/terms/data_context)

--- a/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
+++ b/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
@@ -14,8 +14,7 @@ file as well as managed Expectation Suites should be stored in version control. 
 Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
 (coming soon). Please refer to our documentation for more details.
 
-You
-can Validate data or generate Expectations using Execution Engines including:
+You can Validate data or generate Expectations using Execution Engines including:
 
 * SQL (multiple dialects supported)
 * Spark

--- a/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
+++ b/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext.md
@@ -14,7 +14,7 @@ file as well as managed Expectation Suites should be stored in version control. 
 Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
 (coming soon). Please refer to our documentation for more details.
 
-DataContexts use Data Sources and Execution Engines that you're already familiar with to interact with data. You
+You
 can Validate data or generate Expectations using Execution Engines including:
 
 * SQL (multiple dialects supported)

--- a/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-create.md
+++ b/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-create.md
@@ -1,7 +1,7 @@
 ---
 title: DataContext.create
 ---
-[Back to class documentation](../classes/great_expectations-data_context-data_context-data_context-DataContext)
+[Back to class documentation](/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext)
 
 ### Fully qualified path
 
@@ -11,7 +11,7 @@ title: DataContext.create
 
 Build a new great_expectations directory and DataContext object in the provided project_root_dir.
 
-`create` will not create a new "great_expectations" directory in the provided folder, provided one does not
+`create` will create a new "great_expectations" directory in the provided folder, provided one does not
 already exist. Then, it will initialize a new DataContext in that folder and write the resulting config.
 
 ### Parameters
@@ -28,4 +28,4 @@ DataContext
 
 ## Relevant documentation (links)
 
-- [Data Context](../../terms/data_context)
+- [Data Context](/docs/terms/data_context)

--- a/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config.md
+++ b/docs/api_docs/methods/great_expectations-data_context-data_context-data_context-DataContext-test_yaml_config.md
@@ -1,7 +1,7 @@
 ---
 title: DataContext.test_yaml_config
 ---
-[Back to class documentation](../classes/great_expectations-data_context-data_context-data_context-DataContext)
+[Back to class documentation](/docs/api_docs/classes/great_expectations-data_context-data_context-data_context-DataContext)
 
 ### Fully qualified path
 
@@ -40,5 +40,5 @@ The instantiated component (e.g. a Datasource) OR a json object containing metad
 
 ## Relevant documentation (links)
 
-- [Data Context](../../terms/data_context)
-- [How to configure a new Checkpoint using test_yaml_config](../../guides/validation/checkpoints/how_to_configure_a_new_checkpoint_using_test_yaml_config)
+- [Data Context](/docs/terms/data_context)
+- [How to configure a new Checkpoint using test_yaml_config](/docs/guides/validation/checkpoints/how_to_configure_a_new_checkpoint_using_test_yaml_config)

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -47,13 +47,17 @@ class DataContext(BaseDataContext):
 
     DataContexts use Data Sources and Execution Engines that you're already familiar with to interact with data. You
     can Validate data or generate Expectations using Execution Engines including:
+
      * SQL (multiple dialects supported)
      * Spark
      * Pandas
+
     Your data can be stored in common locations including:
+
      * databases / data warehouses
      * files in s3, GCS, Azure, local storage
      * dataframes (spark and pandas) loaded into memory
+
     Please see our documentation for examples on how to set up Great Expectations, connect to your data,
     create Expectations, and Validate data.
 

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -45,8 +45,8 @@ class DataContext(BaseDataContext):
     Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
     (coming soon). Please refer to our documentation for more details.
 
-    DataContexts use data sources and execution engines that you're already familiar with to interact with data. You
-    can validate data or generate expectations using execution engines including:
+    DataContexts use Data Sources and Execution Engines that you're already familiar with to interact with data. You
+    can Validate data or generate Expectations using Execution Engines including:
      * SQL (multiple dialects supported)
      * Spark
      * Pandas

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -57,8 +57,8 @@ class DataContext(BaseDataContext):
     Please see our documentation for examples on how to set up Great Expectations, connect to your data,
     create Expectations, and Validate data.
 
-    Other configuration options you can apply to a DataContext besides how to access data includes things like where to
-    store Expectations, Profilers, Checkpoints, Metrics, Validation Results and Data Docs and how those stores are
+    Other configuration options you can apply to a DataContext besides how to access data include things like where to
+    store Expectations, Profilers, Checkpoints, Metrics, Validation Results and Data Docs and how those Stores are
     configured. Take a look at our documentation for more configuration options.
 
     You can create or load a DataContext from disk via the following:

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -43,7 +43,7 @@ class DataContext(BaseDataContext):
     The DataContext is configured via a yml file stored in a directory called great_expectations; this configuration
     file as well as managed Expectation Suites should be stored in version control. There are other ways to create a
     Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
-    (coming soon), please refer to our documentation for more details.
+    (coming soon). Please refer to our documentation for more details.
 
     DataContexts use data sources and execution engines that you're already familiar with to interact with data. You
     can validate data or generate expectations using execution engines including:

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -41,7 +41,7 @@ class DataContext(BaseDataContext):
     deployment, with configurations and methods for all supporting components.
 
     The DataContext is configured via a yml file stored in a directory called great_expectations; this configuration
-    file as well as managed expectation suites should be stored in version control. There are other ways to create a
+    file as well as managed Expectation Suites should be stored in version control. There are other ways to create a
     Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
     (coming soon), please refer to our documentation for more details.
 

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -45,8 +45,7 @@ class DataContext(BaseDataContext):
     Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
     (coming soon). Please refer to our documentation for more details.
 
-    DataContexts use Data Sources and Execution Engines that you're already familiar with to interact with data. You
-    can Validate data or generate Expectations using Execution Engines including:
+    You can Validate data or generate Expectations using Execution Engines including:
 
      * SQL (multiple dialects supported)
      * Spark

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -37,41 +37,35 @@ yaml.default_flow_style = False
 
 # TODO: <WILL> Most of the logic here will be migrated to FileDataContext
 class DataContext(BaseDataContext):
-    """A DataContext represents a Great Expectations project. It organizes storage and access for
-    expectation suites, datasources, notification settings, and data fixtures.
+    """A DataContext represents a Great Expectations project. It is the primary entry point for a Great Expectations
+    deployment, with configurations and methods for all supporting components.
 
-    The DataContext is configured via a yml file stored in a directory called great_expectations; the configuration file
-    as well as managed expectation suites should be stored in version control.
+    The DataContext is configured via a yml file stored in a directory called great_expectations; this configuration
+    file as well as managed expectation suites should be stored in version control. There are other ways to create a
+    Data Context that may be better suited for your particular deployment e.g. ephemerally or backed by GE Cloud
+    (coming soon), please refer to our documentation for more details.
 
-    Use the `create` classmethod to create a new empty config, or instantiate the DataContext
-    by passing the path to an existing data context root directory.
+    DataContexts use data sources and execution engines that you're already familiar with to interact with data. You
+    can validate data or generate expectations using execution engines including:
+     * SQL (multiple dialects supported)
+     * Spark
+     * Pandas
+    Your data can be stored in common locations including:
+     * databases / data warehouses
+     * files in s3, GCS, Azure, local storage
+     * dataframes (spark and pandas) loaded into memory
+    Please see our documentation for examples on how to set up Great Expectations, connect to your data,
+    create Expectations, and Validate data.
 
-    DataContexts use data sources you're already familiar with. BatchKwargGenerators help introspect data stores and data execution
-    frameworks (such as airflow, Nifi, dbt, or dagster) to describe and produce batches of data ready for analysis. This
-    enables fetching, validation, profiling, and documentation of  your data in a way that is meaningful within your
-    existing infrastructure and work environment.
+    Other configuration options you can apply to a DataContext besides how to access data includes things like where to
+    store Expectations, Profilers, Checkpoints, Metrics, Validation Results and Data Docs and how those stores are
+    configured. Take a look at our documentation for more configuration options.
 
-    DataContexts use a datasource-based namespace, where each accessible type of data has a three-part
-    normalized *data_asset_name*, consisting of *datasource/generator/data_asset_name*.
-
-    - The datasource actually connects to a source of materialized data and returns Great Expectations DataAssets \
-      connected to a compute environment and ready for validation.
-
-    - The BatchKwargGenerator knows how to introspect datasources and produce identifying "batch_kwargs" that define \
-      particular slices of data.
-
-    - The data_asset_name is a specific name -- often a table name or other name familiar to users -- that \
-      batch kwargs generators can slice into batches.
-
-    An expectation suite is a collection of expectations ready to be applied to a batch of data. Since
-    in many projects it is useful to have different expectations evaluate in different contexts--profiling
-    vs. testing; warning vs. error; high vs. low compute; ML model or dashboard--suites provide a namespace
-    option for selecting which expectations a DataContext returns.
-
-    In many simple projects, the datasource or batch kwargs generator name may be omitted and the DataContext will infer
-    the correct name when there is no ambiguity.
-
-    Similarly, if no expectation suite name is provided, the DataContext will assume the name "default".
+    You can create or load a DataContext from disk via the following:
+    ```
+    import great_expectations as ge
+    ge.get_context()
+    ```
 
     --Public API--
 
@@ -89,7 +83,7 @@ class DataContext(BaseDataContext):
         """
         Build a new great_expectations directory and DataContext object in the provided project_root_dir.
 
-        `create` will not create a new "great_expectations" directory in the provided folder, provided one does not
+        `create` will create a new "great_expectations" directory in the provided folder, provided one does not
         already exist. Then, it will initialize a new DataContext in that folder and write the resulting config.
 
         --Public API--


### PR DESCRIPTION
Changes proposed in this pull request:
- The DataContext docstring is now updated to remove references to v2 concepts (documentation on v2 concepts is still available in our legacy docs).


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation

Thank you for submitting!
