### PR TITLE
[FEATURE] Usage Statistics Events for Profiler and DataAssistant "get_expectation_suite()" methods.

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -21,9 +21,3 @@ pypandoc==1.7.5
 botocore==1.20.106  # From aiobotocore v1.4.0 dependencies https://pypi.org/project/aiobotocore/
 boto3==1.17.106  # from botocore==1.20.106 dependency
 # END NOTE
-
-# NOTE - 20220606
-# jupyter-client is used in nbconvert
-# temporarily excluding the latest version due to failing tests
-jupyter-client<7.3.2,>7.3.2
-# END NOTE

--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -62,6 +62,7 @@ class Anonymizer(BaseAnonymizer):
             StoreBackendAnonymizer,
         ]
 
+        # noinspection PyArgumentList
         self._anonymizers: Dict[Type[BaseAnonymizer], BaseAnonymizer] = {
             strategy: strategy(salt=self._salt, aggregate_anonymizer=self)
             for strategy in self._strategies
@@ -82,7 +83,7 @@ class Anonymizer(BaseAnonymizer):
         )
 
     def can_handle(self, obj: object, **kwargs) -> bool:
-        return Anonymizer._get_anonymizer(obj=obj, **kwargs) is not None
+        return self._get_anonymizer(obj=obj, **kwargs) is not None
 
     def _get_anonymizer(self, obj: object, **kwargs) -> Optional[BaseAnonymizer]:
         for anonymizer in self._anonymizers.values():

--- a/great_expectations/core/usage_statistics/anonymizers/batch_request_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/batch_request_anonymizer.py
@@ -175,4 +175,5 @@ class BatchRequestAnonymizer(BaseAnonymizer):
         for kwarg in kwargs:
             if kwarg in attrs or kwarg == "batch_request":
                 return True
+
         return False

--- a/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
@@ -33,6 +33,7 @@ class CheckpointAnonymizer(BaseAnonymizer):
     def anonymize(self, obj: Optional[object] = None, **kwargs) -> Any:
         if "config" in kwargs:
             return self._anonymize_checkpoint_config(**kwargs)
+
         return self._anonymize_checkpoint_run(obj=obj, **kwargs)
 
     def _anonymize_checkpoint_config(self, name: str, config: dict) -> dict:
@@ -61,6 +62,7 @@ class CheckpointAnonymizer(BaseAnonymizer):
         )
         return anonymized_info_dict
 
+    # noinspection PyUnusedLocal
     def _anonymize_checkpoint_run(self, obj: object, **kwargs) -> dict:
         """
         Traverse the entire Checkpoint configuration structure (as per its formal, validated Marshmallow schema) and

--- a/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/profiler_anonymizer.py
@@ -22,6 +22,7 @@ class ProfilerAnonymizer(BaseAnonymizer):
     def anonymize(self, obj: Optional[object] = None, **kwargs) -> Any:
         if obj and isinstance(obj, RuleBasedProfiler):
             return self._anonymize_profiler_info(**kwargs)
+
         return self._anonymize_profiler_run(obj=obj, **kwargs)
 
     def _anonymize_profiler_info(self, name: str, config: dict) -> dict:

--- a/great_expectations/core/usage_statistics/events.py
+++ b/great_expectations/core/usage_statistics/events.py
@@ -118,10 +118,16 @@ class UsageStatsEvents(enum.Enum):
     CHECKPOINT_RUN = "checkpoint.run"
     EXPECTATION_SUITE_ADD_EXPECTATION = "expectation_suite.add_expectation"
     LEGACY_PROFILER_BUILD_SUITE = "legacy_profiler.build_suite"
-    PROFILER_RUN = "profiler.run"
-    DATA_CONTEXT_RUN_PROFILER_ON_DATA = "data_context.run_profiler_on_data"
-    DATA_CONTEXT_RUN_PROFILER_WITH_DYNAMIC_ARGUMENTS = (
+    RULE_BASED_PROFILER_RUN = "profiler.run"
+    RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE = (
+        "profiler.result.get_expectation_suite"
+    )
+    DATA_CONTEXT_RUN_RULE_BASED_PROFILER_ON_DATA = "data_context.run_profiler_on_data"
+    DATA_CONTEXT_RUN_RULE_BASED_PROFILER_WITH_DYNAMIC_ARGUMENTS = (
         "data_context.run_profiler_with_dynamic_arguments"
+    )
+    DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE = (
+        "data_assistant.result.get_expectation_suite"
     )
 
     @classmethod

--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -516,7 +516,7 @@ anonymized_validations_list_schema = {
     "items": {"$ref": "#/definitions/anonymized_validation"},
 }
 
-anonymized_save_or_edit_expectation_suite_payload_schema = {
+anonymized_get_or_edit_or_save_expectation_suite_payload_schema = {
     "$schema": SCHEMA,
     "title": "anonymized-save-or-edit-expectation-suite-payload",
     "definitions": {"anonymized_string": anonymized_string_schema},
@@ -925,7 +925,7 @@ anonymized_usage_statistics_record_schema = {
         "anonymized_batch_request": anonymized_batch_request_schema,
         "anonymized_batch": anonymized_batch_schema,
         "anonymized_expectation_suite": anonymized_expectation_suite_schema,
-        "anonymized_save_or_edit_expectation_suite_payload": anonymized_save_or_edit_expectation_suite_payload_schema,
+        "anonymized_get_or_edit_or_save_expectation_suite_payload": anonymized_get_or_edit_or_save_expectation_suite_payload_schema,
         "anonymized_cli_suite_expectation_suite_payload": anonymized_cli_suite_expectation_suite_payload_schema,
         "anonymized_cli_suite_new_expectation_suite_payload": anonymized_cli_suite_new_expectation_suite_payload_schema,
         "anonymized_cli_suite_edit_expectation_suite_payload": anonymized_cli_suite_edit_expectation_suite_payload_schema,
@@ -961,15 +961,6 @@ anonymized_usage_statistics_record_schema = {
             "properties": {
                 "event": {"enum": ["data_context.__init__"]},
                 "event_payload": {"$ref": "#/definitions/anonymized_init_payload"},
-            },
-        },
-        {
-            "type": "object",
-            "properties": {
-                "event": {"enum": ["data_context.save_expectation_suite"]},
-                "event_payload": {
-                    "$ref": "#/definitions/anonymized_save_or_edit_expectation_suite_payload"
-                },
             },
         },
         {
@@ -1039,6 +1030,21 @@ anonymized_usage_statistics_record_schema = {
                     ],
                 },
                 "event_payload": {"$ref": "#/definitions/empty_payload"},
+            },
+        },
+        {
+            "type": "object",
+            "properties": {
+                "event": {
+                    "enum": [
+                        "data_context.save_expectation_suite",
+                        "profiler.result.get_expectation_suite",
+                        "data_assistant.result.get_expectation_suite",
+                    ],
+                },
+                "event_payload": {
+                    "$ref": "#/definitions/anonymized_get_or_edit_or_save_expectation_suite_payload"
+                },
             },
         },
         {

--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -518,7 +518,7 @@ anonymized_validations_list_schema = {
 
 anonymized_get_or_edit_or_save_expectation_suite_payload_schema = {
     "$schema": SCHEMA,
-    "title": "anonymized-save-or-edit-expectation-suite-payload",
+    "title": "anonymized-get-or-edit-or-save-expectation-suite-payload",
     "definitions": {"anonymized_string": anonymized_string_schema},
     "type": "object",
     "properties": {

--- a/great_expectations/core/usage_statistics/usage_statistics.py
+++ b/great_expectations/core/usage_statistics/usage_statistics.py
@@ -614,6 +614,9 @@ def _handle_expectation_suite_usage_statistics(
     expectation_suite_name: Optional[str] = None,
     **kwargs,
 ) -> dict:
+    """
+    This method anonymizes "expectation_suite_name" for events that utilize this property.
+    """
     data_context_id: Optional[str]
     try:
         data_context_id = data_context.data_context_id

--- a/great_expectations/core/usage_statistics/usage_statistics_record_schema.json
+++ b/great_expectations/core/usage_statistics/usage_statistics_record_schema.json
@@ -1483,7 +1483,7 @@
     },
     "anonymized_get_or_edit_or_save_expectation_suite_payload": {
       "$schema": "http://json-schema.org/draft-04/schema#",
-      "title": "anonymized-save-or-edit-expectation-suite-payload",
+      "title": "anonymized-get-or-edit-or-save-expectation-suite-payload",
       "definitions": {
         "anonymized_string": {
           "$schema": "http://json-schema.org/draft-04/schema#",

--- a/great_expectations/core/usage_statistics/usage_statistics_record_schema.json
+++ b/great_expectations/core/usage_statistics/usage_statistics_record_schema.json
@@ -1481,7 +1481,7 @@
         }
       ]
     },
-    "anonymized_save_or_edit_expectation_suite_payload": {
+    "anonymized_get_or_edit_or_save_expectation_suite_payload": {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "title": "anonymized-save-or-edit-expectation-suite-payload",
       "definitions": {
@@ -5229,19 +5229,6 @@
       "properties": {
         "event": {
           "enum": [
-            "data_context.save_expectation_suite"
-          ]
-        },
-        "event_payload": {
-          "$ref": "#/definitions/anonymized_save_or_edit_expectation_suite_payload"
-        }
-      }
-    },
-    {
-      "type": "object",
-      "properties": {
-        "event": {
-          "enum": [
             "data_context.run_validation_operator"
           ]
         },
@@ -5331,6 +5318,21 @@
         },
         "event_payload": {
           "$ref": "#/definitions/empty_payload"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "event": {
+          "enum": [
+            "data_context.save_expectation_suite",
+            "profiler.result.get_expectation_suite",
+            "data_assistant.result.get_expectation_suite"
+          ]
+        },
+        "event_payload": {
+          "$ref": "#/definitions/anonymized_get_or_edit_or_save_expectation_suite_payload"
         }
       }
     },

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -3387,7 +3387,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         )
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_PROFILER_WITH_DYNAMIC_ARGUMENTS.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_RULE_BASED_PROFILER_WITH_DYNAMIC_ARGUMENTS.value,
     )
     def run_profiler_with_dynamic_arguments(
         self,
@@ -3427,7 +3427,7 @@ Generated, evaluated, and stored %d Expectations during profiling. Please review
         )
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_PROFILER_ON_DATA.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_RULE_BASED_PROFILER_ON_DATA.value,
     )
     def run_profiler_on_data(
         self,

--- a/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
+++ b/great_expectations/render/renderer/v3/suite_profile_notebook_renderer.py
@@ -254,8 +254,8 @@ result = context.run_profiler_with_dynamic_arguments(
     name="{self._profiler_name}",
     batch_request=batch_request,
 )
-_ = validator.expectation_suite.add_expectation_configurations(
-    expectation_configurations=result.expectation_configurations
+validator.expectation_suite = result.get_expectation_suite(
+    expectation_suite_name=expectation_suite_name
 )
 """,
             lint=True,

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -418,20 +418,21 @@ class DataAssistant(metaclass=MetaDataAssistant):
 
         self._batches = self._validator.batches
 
-        variables: Optional[Dict[str, Any]] = self.get_variables() or {}
-        rules: Optional[List[Rule]] = self.get_rules() or []
+        self._data_context = self._validator.data_context
 
+        variables: Optional[Dict[str, Any]] = self.get_variables() or {}
         self._profiler = RuleBasedProfiler(
             name=self.name,
             config_version=1.0,
             variables=variables,
-            data_context=self._validator.data_context,
+            data_context=self._data_context,
         )
 
         self._metrics_parameter_builders_by_domain = {}
 
-        rule: Rule
+        rules: Optional[List[Rule]] = self.get_rules() or []
 
+        rule: Rule
         for rule in rules:
             self.profiler.add_rule(rule=rule)
             self._metrics_parameter_builders_by_domain[
@@ -467,6 +468,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         data_assistant_result: DataAssistantResult = DataAssistantResult(
             batch_id_to_batch_identifier_display_name_map=self.batch_id_to_batch_identifier_display_name_map(),
             execution_time=0.0,
+            usage_statistics_handler=self._data_context._usage_statistics_handler,
         )
         run_profiler_on_data(
             data_assistant=self,

--- a/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
@@ -144,6 +144,7 @@ class OnboardingDataAssistant(DataAssistant):
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
             execution_time=data_assistant_result.execution_time,
+            usage_statistics_handler=data_assistant_result.usage_statistics_handler,
         )
 
     @staticmethod

--- a/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
@@ -76,6 +76,7 @@ class VolumeDataAssistant(DataAssistant):
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
             execution_time=data_assistant_result.execution_time,
+            usage_statistics_handler=data_assistant_result.usage_statistics_handler,
         )
 
     @staticmethod

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -212,7 +212,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         return domain_builder
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.PROFILER_RUN.value,
+        event_name=UsageStatsEvents.RULE_BASED_PROFILER_RUN.value,
         args_payload_fn=get_profiler_run_usage_statistics,
     )
     def run(
@@ -327,6 +327,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
                     "rules": effective_rules_configs,
                 },
             },
+            usage_statistics_handler=self._usage_statistics_handler,
         )
 
     def get_expectation_configurations(self) -> List[ExpectationConfiguration]:

--- a/great_expectations/rule_based_profiler/rule_based_profiler_result.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler_result.py
@@ -1,8 +1,17 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from great_expectations.core import ExpectationConfiguration
+from great_expectations.core import ExpectationConfiguration, ExpectationSuite
+from great_expectations.core.usage_statistics.events import UsageStatsEvents
+from great_expectations.core.usage_statistics.usage_statistics import (
+    UsageStatisticsHandler,
+    get_expectation_suite_usage_statistics,
+    usage_statistics_enabled_method,
+)
 from great_expectations.core.util import convert_to_json_serializable
+from great_expectations.rule_based_profiler.helpers.util import (
+    get_or_create_expectation_suite,
+)
 from great_expectations.rule_based_profiler.types import Domain, ParameterNode
 from great_expectations.types import SerializableDictDot
 
@@ -22,6 +31,7 @@ class RuleBasedProfilerResult(SerializableDictDot):
     ]
     expectation_configurations: List[ExpectationConfiguration]
     citation: dict
+    usage_statistics_handler: Optional[UsageStatisticsHandler] = None
 
     def to_dict(self) -> dict:
         """
@@ -64,3 +74,36 @@ class RuleBasedProfilerResult(SerializableDictDot):
         Returns: This RuleBasedProfilerResult as JSON-serializable dictionary.
         """
         return self.to_dict()
+
+    @property
+    def _usage_statistics_handler(self) -> Optional[UsageStatisticsHandler]:
+        """
+        Returns: "UsageStatisticsHandler" object for this RuleBasedProfilerResult object (if configured).
+        """
+        return self.usage_statistics_handler
+
+    @usage_statistics_enabled_method(
+        event_name=UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE.value,
+        args_payload_fn=get_expectation_suite_usage_statistics,
+    )
+    def get_expectation_suite(self, expectation_suite_name: str) -> ExpectationSuite:
+        """
+        Returns: "ExpectationSuite" object, built from properties, populated into this "RuleBasedProfilerResult" object.
+        """
+        expectation_suite: ExpectationSuite = get_or_create_expectation_suite(
+            data_context=None,
+            expectation_suite=None,
+            expectation_suite_name=expectation_suite_name,
+            component_name=self.__class__.__name__,
+            persist=False,
+        )
+        expectation_suite.add_expectation_configurations(
+            expectation_configurations=self.expectation_configurations,
+            send_usage_event=False,
+            match_type="domain",
+            overwrite_existing=True,
+        )
+        expectation_suite.add_citation(
+            **self.citation,
+        )
+        return expectation_suite

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -8,6 +8,12 @@ import pandas as pd
 from IPython.display import HTML, display
 
 from great_expectations.core import ExpectationConfiguration, ExpectationSuite
+from great_expectations.core.usage_statistics.events import UsageStatsEvents
+from great_expectations.core.usage_statistics.usage_statistics import (
+    UsageStatisticsHandler,
+    get_expectation_suite_usage_statistics,
+    usage_statistics_enabled_method,
+)
 from great_expectations.core.util import convert_to_json_serializable, nested_update
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
 from great_expectations.rule_based_profiler.helpers.util import (
@@ -63,6 +69,7 @@ class DataAssistantResult(SerializableDictDot):
         "metrics_by_domain",
         "expectation_configurations",
         "execution_time",
+        "usage_statistics_handler",
     }
 
     batch_id_to_batch_identifier_display_name_map: Optional[
@@ -73,6 +80,7 @@ class DataAssistantResult(SerializableDictDot):
     expectation_configurations: Optional[List[ExpectationConfiguration]] = None
     citation: Optional[dict] = None
     execution_time: Optional[float] = None  # Execution time (in seconds).
+    usage_statistics_handler: Optional[UsageStatisticsHandler] = None
 
     def to_dict(self) -> dict:
         """
@@ -101,6 +109,7 @@ class DataAssistantResult(SerializableDictDot):
                 for expectation_configuration in self.expectation_configurations
             ],
             "execution_time": convert_to_json_serializable(data=self.execution_time),
+            "usage_statistics_handler": self.usage_statistics_handler.__class__.__name__,
         }
 
     def to_json_dict(self) -> dict:
@@ -109,6 +118,17 @@ class DataAssistantResult(SerializableDictDot):
         """
         return self.to_dict()
 
+    @property
+    def _usage_statistics_handler(self) -> Optional[UsageStatisticsHandler]:
+        """
+        Returns: "UsageStatisticsHandler" object for this DataAssistantResult object (if configured).
+        """
+        return self.usage_statistics_handler
+
+    @usage_statistics_enabled_method(
+        event_name=UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value,
+        args_payload_fn=get_expectation_suite_usage_statistics,
+    )
     def get_expectation_suite(self, expectation_suite_name: str) -> ExpectationSuite:
         """
         Returns: "ExpectationSuite" object, built from properties, populated into this "DataAssistantResult" object.

--- a/tests/cli/test_suite.py
+++ b/tests/cli/test_suite.py
@@ -3730,7 +3730,9 @@ result = context.run_profiler_with_dynamic_arguments(
     name="{profiler_name}",
     batch_request=batch_request,
 )
-_ = validator.expectation_suite.add_expectation_configurations(expectation_configurations=result.expectation_configurations)
+validator.expectation_suite = result.get_expectation_suite(
+    expectation_suite_name=expectation_suite_name
+)
 """
     profiler_code_cell = lint_code(code=profiler_code_cell).rstrip("\n")
 
@@ -3855,7 +3857,9 @@ result = context.run_profiler_with_dynamic_arguments(
     name="{profiler_name}",
     batch_request=batch_request,
 )
-_ = validator.expectation_suite.add_expectation_configurations(expectation_configurations=result.expectation_configurations)
+validator.expectation_suite = result.get_expectation_suite(
+    expectation_suite_name=expectation_suite_name
+)
 """
     profiler_code_cell = lint_code(code=profiler_code_cell).rstrip("\n")
 

--- a/tests/core/usage_statistics/test_usage_stats_schema.py
+++ b/tests/core/usage_statistics/test_usage_stats_schema.py
@@ -11,6 +11,7 @@ from great_expectations.core.usage_statistics.schemas import (
     anonymized_cli_suite_expectation_suite_payload_schema,
     anonymized_datasource_schema,
     anonymized_datasource_sqlalchemy_connect_payload_schema,
+    anonymized_get_or_edit_or_save_expectation_suite_payload_schema,
     anonymized_init_payload_schema,
     anonymized_legacy_profiler_build_suite_payload_schema,
     anonymized_rule_based_profiler_run_schema,
@@ -77,6 +78,8 @@ def test_comprehensive_list_of_messages():
         "profiler.run",
         "data_context.run_profiler_on_data",
         "data_context.run_profiler_with_dynamic_arguments",
+        "profiler.result.get_expectation_suite",
+        "data_assistant.result.get_expectation_suite",
     }
     # Note: "cli.project.upgrade" has no base event, only .begin and .end events
     assert set(valid_message_list) == set(
@@ -208,6 +211,8 @@ def test_legacy_profiler_build_suite_message():
 def test_data_context_save_expectation_suite_message():
     usage_stats_records_messages = [
         "data_context.save_expectation_suite",
+        "profiler.result.get_expectation_suite",
+        "data_assistant.result.get_expectation_suite",
     ]
     for message_type in usage_stats_records_messages:
         for message in valid_usage_statistics_messages[message_type]:
@@ -218,7 +223,7 @@ def test_data_context_save_expectation_suite_message():
             )
             jsonschema.validate(
                 message["event_payload"],
-                anonymized_cli_suite_expectation_suite_payload_schema,
+                anonymized_get_or_edit_or_save_expectation_suite_payload_schema,
             )
 
 

--- a/tests/integration/docusaurus/tutorials/getting-started/getting_started.py
+++ b/tests/integration/docusaurus/tutorials/getting-started/getting_started.py
@@ -147,8 +147,8 @@ data_assistant_result: DataAssistantResult = context.assistants.onboarding.run(
     #     "round_decimals": 3,
     # },
 )
-_ = validator.expectation_suite.add_expectation_configurations(
-    expectation_configurations=data_assistant_result.expectation_configurations
+validator.expectation_suite = data_assistant_result.get_expectation_suite(
+    expectation_suite_name=expectation_suite_name
 )
 validator.save_expectation_suite(discard_failed_expectations=False)
 

--- a/tests/integration/profiling/rule_based_profilers/test_rule_based_profiler.py
+++ b/tests/integration/profiling/rule_based_profilers/test_rule_based_profiler.py
@@ -4,7 +4,9 @@ from unittest import mock
 from ruamel.yaml import YAML
 
 from great_expectations import DataContext
+from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import BatchRequest
+from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from great_expectations.rule_based_profiler import RuleBasedProfilerResult
 from great_expectations.rule_based_profiler.rule_based_profiler import RuleBasedProfiler
 from great_expectations.validator.metric_configuration import MetricConfiguration
@@ -166,4 +168,64 @@ def test_profile_includes_citations(
         payload[0][0]["event"] == "data_context.get_batch_list"
         for payload in mock_emit.call_args_list[:-1]
     )
-    assert mock_emit.call_args_list[-1][0][0]["event"] == "profiler.run"
+
+    # noinspection PyUnresolvedReferences
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    assert (
+        actual_events[-1][0][0]["event"]
+        == UsageStatsEvents.RULE_BASED_PROFILER_RUN.value
+    )
+
+
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
+)
+def test_profile_get_expectation_suite(
+    mock_emit,
+    alice_columnar_table_single_batch_context,
+    alice_columnar_table_single_batch,
+):
+    # Load data context
+    data_context: DataContext = alice_columnar_table_single_batch_context
+
+    # Load profiler configs & loop (run tests for each one)
+    yaml_config: str = alice_columnar_table_single_batch["profiler_config"]
+
+    # Instantiate Profiler
+    profiler_config = yaml.load(yaml_config)
+    # `class_name`/`module_name` are generally consumed through `instantiate_class_from_config`
+    # so we need to manually remove those values if we wish to use the **kwargs instantiation pattern
+    profiler_config.pop("class_name")
+
+    profiler: RuleBasedProfiler = RuleBasedProfiler(
+        **profiler_config,
+        data_context=data_context,
+    )
+
+    # BatchRequest yielding exactly one batch
+    alice_single_batch_data_batch_request: dict = {
+        "datasource_name": "alice_columnar_table_single_batch_datasource",
+        "data_connector_name": "alice_columnar_table_single_batch_data_connector",
+        "data_asset_name": "alice_columnar_table_single_batch_data_asset",
+    }
+
+    result: RuleBasedProfilerResult = profiler.run(
+        batch_request=alice_single_batch_data_batch_request
+    )
+
+    expectation_suite_name: str = "my_suite"
+
+    suite: ExpectationSuite = result.get_expectation_suite(
+        expectation_suite_name=expectation_suite_name
+    )
+
+    assert suite is not None and len(suite.expectations) > 0
+
+    assert mock_emit.call_count == 55
+
+    # noinspection PyUnresolvedReferences
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    assert (
+        actual_events[-1][0][0]["event"]
+        == UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE.value
+    )

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -1299,6 +1299,36 @@ valid_usage_statistics_messages = {
             "x-forwarded-for": "00.000.00.000, 00.000.000.000",
         },
     ],
+    "profiler.result.get_expectation_suite": [
+        {
+            "event": "profiler.result.get_expectation_suite",
+            "event_payload": {
+                "anonymized_expectation_suite_name": "4b6bf73298fcc2db6da929a8f18173f7"
+            },
+            "success": True,
+            "version": "1.0.0",
+            "event_time": "2020-06-25T16:08:23.570Z",
+            "data_context_id": "00000000-0000-0000-0000-000000000002",
+            "data_context_instance_id": "10000000-0000-0000-0000-000000000002",
+            "ge_version": "0.11.9.manual_testing",
+            "x-forwarded-for": "00.000.00.000, 00.000.000.000",
+        },
+    ],
+    "data_assistant.result.get_expectation_suite": [
+        {
+            "event": "data_assistant.result.get_expectation_suite",
+            "event_payload": {
+                "anonymized_expectation_suite_name": "4b6bf73298fcc2db6da929a8f18173f7"
+            },
+            "success": True,
+            "version": "1.0.0",
+            "event_time": "2020-06-25T16:08:23.570Z",
+            "data_context_id": "00000000-0000-0000-0000-000000000002",
+            "data_context_instance_id": "10000000-0000-0000-0000-000000000002",
+            "ge_version": "0.11.9.manual_testing",
+            "x-forwarded-for": "00.000.00.000, 00.000.000.000",
+        },
+    ],
     # BaseDataContext.test_yaml_config() MESSAGES
     "data_context.test_yaml_config": generate_messages_with_defaults(
         defaults={

--- a/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
+++ b/tests/render/renderer/v3/test_suite_profile_notebook_renderer.py
@@ -389,8 +389,8 @@ result = context.run_profiler_with_dynamic_arguments(
     name="my_profiler",
     batch_request=batch_request,
 )
-_ = validator.expectation_suite.add_expectation_configurations(
-    expectation_configurations=result.expectation_configurations
+validator.expectation_suite = result.get_expectation_suite(
+    expectation_suite_name=expectation_suite_name
 )""",
     ]
 

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Dict, List, Optional, cast
+from unittest import mock
 
 import altair as alt
 import nbconvert
@@ -8,6 +9,8 @@ import pytest
 from freezegun import freeze_time
 
 from great_expectations import DataContext
+from great_expectations.core import ExpectationSuite
+from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from great_expectations.execution_engine.execution_engine import MetricDomainTypes
 from great_expectations.rule_based_profiler.types import (
     FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY,
@@ -201,6 +204,33 @@ def test_onboarding_data_assistant_result_serialization(
         == onboarding_data_assistant_result_as_dict
     )
     assert len(bobby_onboarding_data_assistant_result.profiler_config.rules) == 8
+
+
+@mock.patch(
+    "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
+)
+def test_onboarding_data_assistant_result_get_expectation_suite(
+    mock_emit,
+    bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
+):
+    expectation_suite_name: str = "my_suite"
+
+    suite: ExpectationSuite = (
+        bobby_onboarding_data_assistant_result.get_expectation_suite(
+            expectation_suite_name=expectation_suite_name
+        )
+    )
+
+    assert suite is not None and len(suite.expectations) > 0
+
+    assert mock_emit.call_count == 1
+
+    # noinspection PyUnresolvedReferences
+    actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
+    assert (
+        actual_events[-1][0][0]["event"]
+        == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value
+    )
 
 
 def test_onboarding_data_assistant_metrics_count(


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
