### PR TITLE
[MAINTENANCE] Don't use jupyter-client 7.3.2

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -21,3 +21,9 @@ pypandoc==1.7.5
 botocore==1.20.106  # From aiobotocore v1.4.0 dependencies https://pypi.org/project/aiobotocore/
 boto3==1.17.106  # from botocore==1.20.106 dependency
 # END NOTE
+
+# NOTE - 20220606
+# jupyter-client is used in nbconvert
+# temporarily excluding the latest version due to failing tests
+jupyter-client<7.3.2,>7.3.2
+# END NOTE


### PR DESCRIPTION
Changes proposed in this pull request:
- There seems to be an issue with jupyter-client 7.3.2 and `tests/cli/test_checkpoint.py::test_checkpoint_new_happy_path_generates_a_notebook_and_checkpoint`, ignoring the latest version until we can triage and fix.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
