### PR TITLE
[MAINTENANCE] Add `cloud` mark to `pytest.ini`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,4 +13,5 @@ markers =
     docs: mark a test as a docs test.
     integration: mark test as an integration test.
     external_sqldialect: mark test as requiring install of an external sql dialect.
+    cloud: mark test as being relevant to Great Expectations Cloud.
 testpaths = tests


### PR DESCRIPTION
Changes proposed in this pull request:
- `cloud` mark was creating a number of warnings in our Azure builds. Adding it to the `pytest.ini` removes this.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
