### PR TITLE
[MAINTENANCE] `DataContextVariableKey` for use in Stores

### DIFF
--- a/great_expectations/core/data_context_key.py
+++ b/great_expectations/core/data_context_key.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import Optional, Tuple
 
 
 class DataContextKey(metaclass=ABCMeta):
@@ -73,4 +74,22 @@ class StringKey(DataContextKey):
 
     @classmethod
     def from_fixed_length_tuple(cls, tuple_):
+        return cls.from_tuple(tuple_)
+
+
+class DataContextVariableKey(DataContextKey):
+    def __init__(self, resource_type: str, resource_name: Optional[str] = None) -> None:
+        self._resource_type = resource_type
+        self._resource_name = resource_name
+
+    def to_tuple(self) -> Tuple[str, Optional[str]]:
+        return (self._resource_type, self._resource_name)
+
+    def to_fixed_length_tuple(self) -> Tuple[str, Optional[str]]:
+        return self.to_tuple()
+
+    @classmethod
+    def from_fixed_length_tuple(
+        cls, tuple_: tuple
+    ) -> "DataContextVariableKey":  # noqa: F821
         return cls.from_tuple(tuple_)

--- a/great_expectations/core/data_context_key.py
+++ b/great_expectations/core/data_context_key.py
@@ -1,6 +1,10 @@
 from abc import ABCMeta, abstractmethod
 from typing import Optional, Tuple
 
+from great_expectations.data_context.types.data_context_variables import (
+    DataContextVariableSchema,
+)
+
 
 class DataContextKey(metaclass=ABCMeta):
     """DataContextKey objects are used to uniquely identify resources used by the DataContext.
@@ -78,7 +82,11 @@ class StringKey(DataContextKey):
 
 
 class DataContextVariableKey(DataContextKey):
-    def __init__(self, resource_type: str, resource_name: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        resource_type: DataContextVariableSchema,
+        resource_name: Optional[str] = None,
+    ) -> None:
         self._resource_type = resource_type
         self._resource_name = resource_name
 

--- a/great_expectations/core/data_context_key.py
+++ b/great_expectations/core/data_context_key.py
@@ -91,13 +91,22 @@ class DataContextVariableKey(DataContextKey):
         self._resource_name = resource_name
 
     def to_tuple(self) -> Tuple[str, Optional[str]]:
+        """
+        See parent `DataContextKey.to_tuple` for more information.
+        """
         return (self._resource_type, self._resource_name)
 
     def to_fixed_length_tuple(self) -> Tuple[str, Optional[str]]:
+        """
+        See parent `DataContextKey.to_fixed_length_tuple` for more information.
+        """
         return self.to_tuple()
 
     @classmethod
     def from_fixed_length_tuple(
         cls, tuple_: tuple
     ) -> "DataContextVariableKey":  # noqa: F821
+        """
+        See parent `DataContextKey.from_fixed_length_tuple` for more information.
+        """
         return cls.from_tuple(tuple_)

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1030,7 +1030,9 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         else:
             return {}
 
-    def get_config_with_variables_substituted(self, config=None) -> DataContextConfig:
+    def get_config_with_variables_substituted(
+        self, config: Optional[DataContextConfig] = None
+    ) -> DataContextConfig:
         """
         Substitute vars in config of form ${var} or $(var) with values found in the following places,
         in order of precedence: ge_cloud_config (for Data Contexts in GE Cloud mode), runtime_environment,

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Union
 
-from great_expectations.core.data_context_key import StringKey
+from great_expectations.core.data_context_key import DataContextVariableKey
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.types.base import (
     DatasourceConfig,
@@ -14,7 +14,7 @@ class DatasourceStore(Store):
     A DatasourceStore manages Datasources for the DataContext.
     """
 
-    _key_class = StringKey
+    _key_class = DataContextVariableKey
 
     def __init__(
         self,

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -46,11 +46,7 @@ class InlineStoreBackend(StoreBackend):
         config_var_type: str = key[0]
         config_var_name: Optional[str] = key[1]
 
-        variable_config: Any = (
-            self._data_context.project_config_with_variables_substituted[
-                config_var_type
-            ]
-        )
+        variable_config: Any = self._data_context.config[config_var_type]
 
         if config_var_name:
             return variable_config[config_var_name]

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -10,6 +10,13 @@ from great_expectations.util import filter_properties_dict
 
 
 class InlineStoreBackend(StoreBackend):
+    """
+    The InlineStoreBackend enables CRUD behavior with the fields noted in a user's project config (`great_expectations.yml`).
+
+    It performs these actions through a reference to a DataContext instance.
+    Please note that is it only to be used with file-backed DataContexts (DataContext and FileDataContext).
+    """
+
     def __init__(
         self,
         data_context: "DataContext",  # noqa: F821

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -2,6 +2,9 @@ from typing import Any, List, Optional, Tuple
 
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.base import DataContextConfig
+from great_expectations.data_context.types.data_context_variables import (
+    DataContextVariableSchema,
+)
 from great_expectations.exceptions.exceptions import StoreBackendError
 from great_expectations.util import filter_properties_dict
 
@@ -42,8 +45,8 @@ class InlineStoreBackend(StoreBackend):
     def config(self) -> dict:
         return self._config
 
-    def _get(self, key: Tuple[str, ...]) -> Any:
-        config_var_type: str = key[0]
+    def _get(self, key: Tuple[DataContextVariableSchema, str]) -> Any:
+        config_var_type: DataContextVariableSchema = key[0]
         config_var_name: Optional[str] = key[1]
 
         variable_config: Any = self._data_context.config[config_var_type]
@@ -52,8 +55,10 @@ class InlineStoreBackend(StoreBackend):
             return variable_config[config_var_name]
         return variable_config
 
-    def _set(self, key: Tuple[str, ...], value: Any, **kwargs: dict) -> None:
-        config_var_type: str = key[0]
+    def _set(
+        self, key: Tuple[DataContextVariableSchema, str], value: Any, **kwargs: dict
+    ) -> None:
+        config_var_type: DataContextVariableSchema = key[0]
         config_var_name: Optional[str] = key[1]
 
         project_config: DataContextConfig = self._data_context.config
@@ -92,8 +97,6 @@ class InlineStoreBackend(StoreBackend):
         return key in self._data_context.config
 
     def _validate_key(self, key: Tuple[str, ...]) -> None:
-        from great_expectations.data_context.types.base import DataContextConfig
-
         if len(key) != 2:
             raise TypeError(
                 f"Keys used in {self.__class__.__name__} must be composed of two parts: a variable type and an optional name"
@@ -101,12 +104,9 @@ class InlineStoreBackend(StoreBackend):
 
         type_, _ = key
 
-        if not isinstance(type_, str):
+        if not isinstance(
+            type_, DataContextVariableSchema
+        ) or not DataContextVariableSchema.has_value(type_):
             raise TypeError(
-                f"The resource type used in {self.__class__.__name__} keys must be of type {str} and not type {type(type_)}"
-            )
-
-        if type_ not in self._data_context.config:
-            raise TypeError(
-                f"Keys in {self.__class__.__name__} must adhere to the schema defined by {DataContextConfig.__name__}"
+                f"Keys in {self.__class__.__name__} must adhere to the schema defined by {DataContextVariableSchema.__name__}; invalid type {type(type_)} found"
             )

--- a/great_expectations/data_context/types/data_context_variables.py
+++ b/great_expectations/data_context/types/data_context_variables.py
@@ -10,13 +10,11 @@ class DataContextVariableSchema(str, enum.Enum):
     CHECKPOINT_STORE_NAME = "checkpoint_store_name"
     PROFILER_STORE_NAME = "profiler_store_name"
     PLUGINS_DIRECTORY = "plugins_directory"
-    VALIDATION_OPERATORS = "validation_operators"
     STORES = "stores"
     DATA_DOCS_SITES = "data_docs_sites"
     NOTEBOOKS = "notebooks"
     CONFIG_VARIABLES_FILE_PATH = "config_variables_file_path"
     ANONYMIZED_USAGE_STATISTICS = "anonymous_usage_statistics"
-    STORE_BACKEND_DEFAULTS = "store_backend_defaults"
     CONCURRENCY = "concurrency"
     PROGRESS_BARS = "progress_bars"
 

--- a/great_expectations/data_context/types/data_context_variables.py
+++ b/great_expectations/data_context/types/data_context_variables.py
@@ -1,0 +1,28 @@
+import enum
+
+
+class DataContextVariableSchema(str, enum.Enum):
+    CONFIG_VERSION = "config_version"
+    DATASOURCES = "datasources"
+    EXPECTATIONS_STORE_NAME = "expectations_store_name"
+    VALIDATIONS_STORE_NAME = "validations_store_name"
+    EVALUATION_PARAMETER_STORE_NAME = "evaluation_parameter_store_name"
+    CHECKPOINT_STORE_NAME = "checkpoint_store_name"
+    PROFILER_STORE_NAME = "profiler_store_name"
+    PLUGINS_DIRECTORY = "plugins_directory"
+    VALIDATION_OPERATORS = "validation_operators"
+    STORES = "stores"
+    DATA_DOCS_SITES = "data_docs_sites"
+    NOTEBOOKS = "notebooks"
+    CONFIG_VARIABLES_FILE_PATH = "config_variables_file_path"
+    ANONYMIZED_USAGE_STATISTICS = "anonymous_usage_statistics"
+    STORE_BACKEND_DEFAULTS = "store_backend_defaults"
+    CONCURRENCY = "concurrency"
+    PROGRESS_BARS = "progress_bars"
+
+    @classmethod
+    def has_value(cls, value: str) -> bool:
+        """
+        Checks whether or not a string is a value from the possible enum pairs.
+        """
+        return value in cls._value2member_map_

--- a/scripts/check_docstring_coverage.py
+++ b/scripts/check_docstring_coverage.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Tuple, cast
 Diagnostics = Dict[str, List[Tuple[ast.FunctionDef, bool]]]
 
 DOCSTRING_ERROR_THRESHOLD: int = (
-    1100  # This number is to be reduced as we document more public functions!
+    1098  # This number is to be reduced as we document more public functions!
 )
 
 

--- a/scripts/check_type_hint_coverage.py
+++ b/scripts/check_type_hint_coverage.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 TYPE_HINT_ERROR_THRESHOLD: int = (
-    2544  # This number is to be reduced as we annotate more functions!
+    2542  # This number is to be reduced as we annotate more functions!
 )
 
 

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -77,7 +77,7 @@ def test_datasource_store_retrieval(
     store: DatasourceStore = empty_datasource_store
 
     key: DataContextVariableKey = DataContextVariableKey(
-        type_="datasource", resource_name="my_datasource"
+        resource_type="datasource", resource_name="my_datasource"
     )
     store.set(key=key, value=datasource_config)
     res: DatasourceConfig = store.get(key=key)

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -6,6 +6,9 @@ from great_expectations.core.data_context_key import DataContextVariableKey, Str
 from great_expectations.data_context.data_context.data_context import DataContext
 from great_expectations.data_context.store.datasource_store import DatasourceStore
 from great_expectations.data_context.types.base import DatasourceConfig
+from great_expectations.data_context.types.data_context_variables import (
+    DataContextVariableSchema,
+)
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 
 
@@ -77,7 +80,8 @@ def test_datasource_store_retrieval(
     store: DatasourceStore = empty_datasource_store
 
     key: DataContextVariableKey = DataContextVariableKey(
-        resource_type="datasource", resource_name="my_datasource"
+        resource_type=DataContextVariableSchema.DATASOURCES,
+        resource_name="my_datasource",
     )
     store.set(key=key, value=datasource_config)
     res: DatasourceConfig = store.get(key=key)
@@ -151,7 +155,8 @@ def test_datasource_store_with_inline_store_backend(
     )
 
     key: DataContextVariableKey = DataContextVariableKey(
-        resource_type="datasources", resource_name="my_datasource"
+        resource_type=DataContextVariableSchema.DATASOURCES,
+        resource_name="my_datasource",
     )
 
     store.set(key=key, value=datasource_config)

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import os
 from collections import OrderedDict
-from typing import Optional, Tuple
 from unittest.mock import patch
 
 import boto3
@@ -31,6 +30,9 @@ from great_expectations.data_context.store.inline_store_backend import (
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
     DataContextConfig,
+)
+from great_expectations.data_context.types.data_context_variables import (
+    DataContextVariableSchema,
 )
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
@@ -1564,12 +1566,12 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
         inline_store_backend.set(tuple_, "a_random_string_value")
 
     assert (
-        "Keys in InlineStoreBackend must adhere to the schema defined by DataContextConfig"
+        "Keys in InlineStoreBackend must adhere to the schema defined by DataContextVariableSchema"
         in str(e.value)
     )
 
     # test valid .set
-    key = DataContextVariableKey(resource_type="config_version")
+    key = DataContextVariableKey(resource_type=DataContextVariableSchema.CONFIG_VERSION)
     tuple_ = key.to_tuple()
     with patch(
         "great_expectations.data_context.DataContext._save_project_config"
@@ -1580,7 +1582,7 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
     assert mock_save.call_count == 1
 
     # test .get
-    key = DataContextVariableKey(resource_type="config_version")
+    key = DataContextVariableKey(resource_type=DataContextVariableSchema.CONFIG_VERSION)
     tuple_ = key.to_tuple()
     ret = inline_store_backend.get(tuple_)
     assert ret == new_config_version
@@ -1604,10 +1606,12 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
     ]
 
     # test .move
-    key1 = DataContextVariableKey(resource_type="config_version")
+    key1 = DataContextVariableKey(
+        resource_type=DataContextVariableSchema.CONFIG_VERSION
+    )
     tuple1 = key1.to_tuple()
 
-    key2 = DataContextVariableKey(resource_type="stores")
+    key2 = DataContextVariableKey(resource_type=DataContextVariableSchema.STORES)
     tuple2 = key2.to_tuple()
 
     with pytest.raises(StoreBackendError) as e:
@@ -1616,7 +1620,7 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
     assert "InlineStoreBackend does not support moving of keys" in str(e.value)
 
     # test .remove_key
-    key = DataContextVariableKey(resource_type="progress_bars")
+    key = DataContextVariableKey(resource_type=DataContextVariableSchema.PROGRESS_BARS)
     tuple_ = key.to_tuple()
     with pytest.raises(StoreBackendError) as e:
         inline_store_backend.remove_key(tuple_)

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -13,6 +13,7 @@ import tests.test_utils as test_utils
 from great_expectations.core.data_context_key import DataContextVariableKey
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.run_identifier import RunIdentifier
+from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import DataContext
 from great_expectations.data_context.data_context import BaseDataContext
 from great_expectations.data_context.store import (
@@ -42,6 +43,8 @@ from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 from great_expectations.self_check.util import expectationSuiteSchema
 from great_expectations.util import gen_directory_tree_str, is_library_loadable
+
+yaml = YAMLHandler()
 
 
 @pytest.fixture()
@@ -1626,3 +1629,73 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
         inline_store_backend.remove_key(tuple_)
 
     assert "InlineStoreBackend does not support the deletion of keys" in str(e.value)
+
+
+@pytest.mark.integration
+def test_InlineStoreBackend_with_mocked_fs(empty_data_context: DataContext) -> None:
+    path_to_great_expectations_yml: str = os.path.join(
+        empty_data_context.root_directory, empty_data_context.GE_YML
+    )
+
+    inline_store_backend: InlineStoreBackend = InlineStoreBackend(
+        data_context=empty_data_context,
+    )
+
+    # 1. Set simple string config value and confirm it persists in the GE.yml
+
+    with open(path_to_great_expectations_yml) as data:
+        config_commented_map_from_yaml = yaml.load(data)
+
+    assert config_commented_map_from_yaml["config_version"] == 3.0
+
+    new_config_version: float = 5.0
+    key = DataContextVariableKey(resource_type=DataContextVariableSchema.CONFIG_VERSION)
+    tuple_ = key.to_tuple()
+
+    inline_store_backend.set(tuple_, new_config_version)
+
+    with open(path_to_great_expectations_yml) as data:
+        config_commented_map_from_yaml = yaml.load(data)
+
+    assert config_commented_map_from_yaml["config_version"] == new_config_version
+
+    # 2. Set nested dictionary config value and confirm it persists in the GE.yml
+
+    with open(path_to_great_expectations_yml) as data:
+        config_commented_map_from_yaml = yaml.load(data)
+
+    assert config_commented_map_from_yaml["datasources"] == {}
+
+    datasource_config_string: str = """
+        class_name: Datasource
+
+        execution_engine:
+            class_name: PandasExecutionEngine
+
+        data_connectors:
+            my_other_data_connector:
+                class_name: ConfiguredAssetFilesystemDataConnector
+                base_directory: my/base/dir/
+                glob_directive: "*.csv"
+
+                default_regex:
+                    pattern: (.+)\\.csv
+                    group_names:
+                        - name
+        """
+    datasource_config: dict = yaml.load(datasource_config_string)
+
+    key = DataContextVariableKey(
+        resource_type=DataContextVariableSchema.DATASOURCES,
+        resource_name="my_datasource",
+    )
+    tuple_ = key.to_tuple()
+
+    inline_store_backend.set(tuple_, datasource_config)
+
+    with open(path_to_great_expectations_yml) as data:
+        config_commented_map_from_yaml = yaml.load(data)
+
+    datasources: dict = config_commented_map_from_yaml["datasources"]
+    assert len(datasources) == 1
+    assert datasources["my_datasource"] == datasource_config


### PR DESCRIPTION
Changes proposed in this pull request:
- Update to `DatasourceStore` to utilize a new key called `DataContextVariableKey`
- This key adheres to a particular schema and allows devs to specify both the resource type and the name of that resource (as applicable). It provides more flexibility than the existing `StringKey` that was previously used.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
