### PR TITLE
[MAINTENANCE] Add proper unit tests for Column Histogram metric and use Column Value Partitioner in OnboardingDataAssistant

### DIFF
--- a/great_expectations/execution_engine/util.py
+++ b/great_expectations/execution_engine/util.py
@@ -116,19 +116,20 @@ def build_continuous_partition_object(
         bins = bins.tolist()
     else:
         bins = list(bins)
+
     hist_metric_configuration = MetricConfiguration(
         "column.histogram",
         metric_domain_kwargs=domain_kwargs,
         metric_value_kwargs={
             "bins": tuple(bins),
         },
+        metric_dependencies=None,
     )
     nonnull_configuration = MetricConfiguration(
         "column_values.nonnull.count",
         metric_domain_kwargs=domain_kwargs,
-        metric_value_kwargs={
-            "bins": tuple(bins),
-        },
+        metric_value_kwargs=None,
+        metric_dependencies=None,
     )
     metrics = execution_engine.resolve_metrics(
         (hist_metric_configuration, nonnull_configuration)
@@ -172,10 +173,13 @@ def build_categorical_partition_object(execution_engine, domain_kwargs, sort="va
         metric_value_kwargs={
             "sort": sort,
         },
+        metric_dependencies=None,
     )
     nonnull_configuration = MetricConfiguration(
         "column_values.nonnull.count",
         metric_domain_kwargs=domain_kwargs,
+        metric_value_kwargs=None,
+        metric_dependencies=None,
     )
     metrics = execution_engine.resolve_metrics(
         (counts_configuration, nonnull_configuration)

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
@@ -1,7 +1,6 @@
 import copy
 import logging
-import traceback
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
@@ -19,39 +18,10 @@ from great_expectations.execution_engine.execution_engine import MetricDomainTyp
 from great_expectations.expectations.metrics.column_aggregate_metric_provider import (
     ColumnAggregateMetricProvider,
 )
-from great_expectations.expectations.metrics.import_manager import (
-    Bucketizer,
-    F,
-    sa,
-    sparktypes,
-)
+from great_expectations.expectations.metrics.import_manager import Bucketizer, F, sa
 from great_expectations.expectations.metrics.metric_provider import metric_value
 
 logger = logging.getLogger(__name__)
-
-try:
-    from sqlalchemy.exc import ProgrammingError
-    from sqlalchemy.sql import Select
-except ImportError:
-    logger.debug(
-        "Unable to load SqlAlchemy context; install optional sqlalchemy dependency for support"
-    )
-    ProgrammingError = None
-    Select = None
-
-try:
-    from sqlalchemy.engine.row import Row
-except ImportError:
-    try:
-        from sqlalchemy.engine.row import RowProxy
-
-        Row = RowProxy
-    except ImportError:
-        logger.debug(
-            "Unable to load SqlAlchemy Row class; please upgrade you sqlalchemy installation to the latest version."
-        )
-        RowProxy = None
-        Row = None
 
 
 class ColumnHistogram(ColumnAggregateMetricProvider):
@@ -99,32 +69,10 @@ class ColumnHistogram(ColumnAggregateMetricProvider):
         column = accessor_domain_kwargs["column"]
         bins = metric_value_kwargs["bins"]
 
-        """return a list of counts corresponding to bins"""
         case_conditions = []
         idx = 0
         if isinstance(bins, np.ndarray):
             bins = bins.tolist()
-        elif isinstance(bins, int):
-            sqlalchemy_engine = execution_engine.engine
-            query: Select = (
-                sa.select(sa.column(column))
-                .distinct()
-                .where(sa.column(column) != None)
-                .order_by(sa.column(column).asc())
-                .select_from(selectable)
-            )
-            try:
-                rows: List[Row] = sqlalchemy_engine.execute(query).fetchall()
-                row: Row
-                column_values: np.ndarray = np.asarray([row[0] for row in rows])
-                bins = np.histogram_bin_edges(column_values, bins=bins)
-                bins = bins.tolist()
-            except ProgrammingError as pe:
-                exception_message: str = "An SQL syntax Exception occurred."
-                exception_traceback: str = traceback.format_exc()
-                exception_message += f'{type(pe).__name__}: "{str(pe)}".  Traceback: "{exception_traceback}".'
-                logger.error(exception_message)
-                raise pe
         else:
             bins = list(bins)
 
@@ -225,27 +173,10 @@ class ColumnHistogram(ColumnAggregateMetricProvider):
         df, _, accessor_domain_kwargs = execution_engine.get_compute_domain(
             domain_kwargs=metric_domain_kwargs, domain_type=MetricDomainTypes.COLUMN
         )
-        column = metric_domain_kwargs["column"]
         bins = metric_value_kwargs["bins"]
+        column = metric_domain_kwargs["column"]
 
         """return a list of counts corresponding to bins"""
-        if isinstance(bins, np.ndarray):
-            bins = bins.tolist()
-        elif isinstance(bins, int):
-            rows: List[sparktypes.Row] = (
-                df.select(column)
-                .distinct()
-                .where(F.col(column).isNotNull())
-                .orderBy(F.col(column).asc())
-                .collect()
-            )
-            row: sparktypes.Row
-            column_values: np.ndarray = np.asarray([row[column] for row in rows])
-            bins = np.histogram_bin_edges(column_values, bins=bins)
-            bins = bins.tolist()
-        else:
-            bins = list(bins)
-
         bins = list(
             copy.deepcopy(bins)
         )  # take a copy since we are inserting and popping

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -390,6 +390,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
             return PartitionParameterBuilder(
                 name=name,
                 bucketize_data=bucketize_data,
+                evaluation_parameter_builder_configs=None,
                 json_serialize=json_serialize,
                 data_context=None,
             )

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -25,6 +25,7 @@ from great_expectations.rule_based_profiler.parameter_builder import (
     MetricMultiBatchParameterBuilder,
     NumericMetricRangeMultiBatchParameterBuilder,
     ParameterBuilder,
+    PartitionParameterBuilder,
 )
 from great_expectations.rule_based_profiler.parameter_builder.regex_pattern_string_parameter_builder import (
     RegexPatternStringParameterBuilder,
@@ -189,21 +190,6 @@ class DataAssistant(metaclass=MetaDataAssistant):
             return self.build_numeric_metric_multi_batch_parameter_builder(
                 metric_name="column_values.null.unexpected_count",
                 metric_value_kwargs=None,
-                json_serialize=json_serialize,
-            )
-
-        def get_column_histogram_metric_multi_batch_parameter_builder(
-            self,
-            json_serialize: Union[str, bool] = True,
-        ) -> ParameterBuilder:
-            """
-            This method instantiates one commonly used "MetricMultiBatchParameterBuilder" with specified directives.
-            """
-            return self.build_numeric_metric_multi_batch_parameter_builder(
-                metric_name="column.histogram",
-                metric_value_kwargs={
-                    "bins": f"{VARIABLES_KEY}bins",
-                },
                 json_serialize=json_serialize,
             )
 
@@ -379,6 +365,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
             """
             This method instantiates "RegexPatternStringParameterBuilder" class with specific arguments for given purpose.
             """
+            name: str = sanitize_parameter_name(name=f"{name}")
             return RegexPatternStringParameterBuilder(
                 name=name,
                 metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
@@ -386,6 +373,23 @@ class DataAssistant(metaclass=MetaDataAssistant):
                 threshold=1.0,
                 candidate_regexes=None,
                 evaluation_parameter_builder_configs=None,
+                json_serialize=json_serialize,
+                data_context=None,
+            )
+
+        @staticmethod
+        def build_partition_parameter_builder(
+            name: str,
+            bucketize_data: Union[str, bool] = True,
+            json_serialize: Union[str, bool] = True,
+        ) -> PartitionParameterBuilder:
+            """
+            This method instantiates "PartitionParameterBuilder" class with specific arguments for given purpose.
+            """
+            name: str = sanitize_parameter_name(name=f"{name}")
+            return PartitionParameterBuilder(
+                name=name,
+                bucketize_data=bucketize_data,
                 json_serialize=json_serialize,
                 data_context=None,
             )

--- a/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
@@ -280,8 +280,10 @@ class OnboardingDataAssistant(DataAssistant):
 
         # Step-2: Declare "ParameterBuilder" for every metric of interest.
 
-        column_histogram_metric_multi_batch_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.get_column_histogram_metric_multi_batch_parameter_builder(
-            json_serialize=True
+        column_partition_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.build_partition_parameter_builder(
+            name="column_values.partition",
+            bucketize_data=True,
+            json_serialize=True,
         )
         column_column_quantile_values_metric_multi_batch_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.get_column_quantile_values_metric_multi_batch_parameter_builder(
             json_serialize=True
@@ -488,7 +490,6 @@ class OnboardingDataAssistant(DataAssistant):
                 0.75,
             ],
             "allow_relative_error": "linear",
-            "bins": 10,
             "false_positive_rate": 0.05,
             "quantile_statistic_interpolation_method": "auto",
             "estimator": "bootstrap",
@@ -502,7 +503,7 @@ class OnboardingDataAssistant(DataAssistant):
             "round_decimals": 1,
         }
         parameter_builders: List[ParameterBuilder] = [
-            column_histogram_metric_multi_batch_parameter_builder_for_metrics,
+            column_partition_parameter_builder_for_metrics,
             column_column_quantile_values_metric_multi_batch_parameter_builder_for_metrics,
             column_min_metric_multi_batch_parameter_builder_for_metrics,
             column_max_metric_multi_batch_parameter_builder_for_metrics,
@@ -555,8 +556,10 @@ class OnboardingDataAssistant(DataAssistant):
 
         # Step-2: Declare "ParameterBuilder" for every metric of interest.
 
-        column_histogram_metric_multi_batch_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.get_column_histogram_metric_multi_batch_parameter_builder(
-            json_serialize=True
+        column_partition_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.build_partition_parameter_builder(
+            name="column_values.partition",
+            bucketize_data=True,
+            json_serialize=True,
         )
         column_column_quantile_values_metric_multi_batch_parameter_builder_for_metrics: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.get_column_quantile_values_metric_multi_batch_parameter_builder(
             json_serialize=True
@@ -661,7 +664,7 @@ class OnboardingDataAssistant(DataAssistant):
             "mostly": 1.0,
             "strict_min": False,
             "strict_max": False,
-            "bins": 10,
+            "allow_relative_error": "linear",
             "false_positive_rate": 0.05,
             "quantile_statistic_interpolation_method": "auto",
             "estimator": "bootstrap",
@@ -675,7 +678,7 @@ class OnboardingDataAssistant(DataAssistant):
             "round_decimals": 1,
         }
         parameter_builders: List[ParameterBuilder] = [
-            column_histogram_metric_multi_batch_parameter_builder_for_metrics,
+            column_partition_parameter_builder_for_metrics,
             column_column_quantile_values_metric_multi_batch_parameter_builder_for_metrics,
             column_min_metric_multi_batch_parameter_builder_for_metrics,
             column_max_metric_multi_batch_parameter_builder_for_metrics,
@@ -742,7 +745,8 @@ class OnboardingDataAssistant(DataAssistant):
             json_serialize=True,
         )
         column_values_to_match_regex_parameter_builder_for_validations: ParameterBuilder = DataAssistant.commonly_used_parameter_builders.build_regex_pattern_string_parameter_builder(
-            name="column_values.match_regex", json_serialize=True
+            name="column_values.match_regex",
+            json_serialize=True,
         )
 
         # Step-4: Pass "validation" "ParameterBuilderConfig" objects to every "DefaultExpectationConfigurationBuilder", responsible for emitting "ExpectationConfiguration" (with specified "expectation_type").

--- a/great_expectations/rule_based_profiler/parameter_builder/metric_single_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_single_batch_parameter_builder.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional, Union
 
-import great_expectations.exceptions as ge_exceptions
 from great_expectations.rule_based_profiler.config import ParameterBuilderConfig
 from great_expectations.rule_based_profiler.helpers.util import (
     get_parameter_value_and_validate_return_type,

--- a/great_expectations/rule_based_profiler/parameter_builder/metric_single_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/metric_single_batch_parameter_builder.py
@@ -83,19 +83,6 @@ class MetricSingleBatchParameterBuilder(MetricMultiBatchParameterBuilder):
         Returns:
             Attributes object, containing computed parameter values and parameter computation details metadata.
         """
-        batch_ids: Optional[List[str]] = self.get_batch_ids(
-            domain=domain,
-            variables=variables,
-            parameters=parameters,
-        )
-        num_batch_ids: int = len(batch_ids)
-        if num_batch_ids != 1:
-            raise ge_exceptions.ProfilerExecutionError(
-                message=f"""Utilizing a {self.__class__.__name__} requires exactly one Batch of data to be available
-({num_batch_ids} Batch identifiers found).
-"""
-            )
-
         # Compute metric value for one Batch object (expressed as list of Batch objects).
         super().build_parameters(
             domain=domain,

--- a/great_expectations/rule_based_profiler/parameter_builder/partition_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/partition_parameter_builder.py
@@ -32,12 +32,21 @@ class PartitionParameterBuilder(MetricSingleBatchParameterBuilder):
         "column_partition_metric_single_batch_parameter_builder_config",
         "column_value_counts_metric_single_batch_parameter_builder_config",
         "column_values_nonnull_count_metric_single_batch_parameter_builder_config",
+        "metric_name",
+        "metric_domain_kwargs",
+        "metric_value_kwargs",
+        "enforce_numeric_metric",
+        "replace_nan_with_zero",
+        "reduce_scalar_metric",
     }
 
     def __init__(
         self,
         name: str,
         bucketize_data: Union[str, bool] = True,
+        evaluation_parameter_builder_configs: Optional[
+            List[ParameterBuilderConfig]
+        ] = None,
         json_serialize: Union[str, bool] = True,
         data_context: Optional["BaseDataContext"] = None,  # noqa: F821
     ) -> None:
@@ -47,6 +56,9 @@ class PartitionParameterBuilder(MetricSingleBatchParameterBuilder):
             it is not the fully-qualified parameter name; a fully-qualified parameter name must start with "$parameter."
             and may contain one or more subsequent parts (e.g., "$parameter.<my_param_from_config>.<metric_name>").
             bucketize_data: If True (default), then data is continuous (non-categorical); hence, must bucketize it.
+            evaluation_parameter_builder_configs: ParameterBuilder configurations, executing and making whose respective
+            ParameterBuilder objects' outputs available (as fully-qualified parameter names) is pre-requisite.
+            These "ParameterBuilder" configurations help build parameters needed for this "ParameterBuilder".
             json_serialize: If True (default), convert computed value to JSON prior to saving results.
             data_context: BaseDataContext associated with this ParameterBuilder
         """
@@ -96,11 +108,12 @@ class PartitionParameterBuilder(MetricSingleBatchParameterBuilder):
             json_serialize=False,
         )
 
-        evaluation_parameter_builder_configs: Optional[List[ParameterBuilderConfig]] = [
-            self._column_partition_metric_single_batch_parameter_builder_config,
-            self._column_value_counts_metric_single_batch_parameter_builder_config,
-            self._column_values_nonnull_count_metric_single_batch_parameter_builder_config,
-        ]
+        if evaluation_parameter_builder_configs is None:
+            evaluation_parameter_builder_configs = [
+                self._column_partition_metric_single_batch_parameter_builder_config,
+                self._column_value_counts_metric_single_batch_parameter_builder_config,
+                self._column_values_nonnull_count_metric_single_batch_parameter_builder_config,
+            ]
 
         super().__init__(
             name=name,

--- a/great_expectations/rule_based_profiler/parameter_builder/partition_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/partition_parameter_builder.py
@@ -15,6 +15,7 @@ from great_expectations.rule_based_profiler.types import (
     FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY,
     PARAMETER_KEY,
     Domain,
+    MetricValue,
     ParameterContainer,
     ParameterNode,
 )
@@ -77,7 +78,7 @@ class PartitionParameterBuilder(MetricSingleBatchParameterBuilder):
             replace_nan_with_zero=False,
             reduce_scalar_metric=False,
             evaluation_parameter_builder_configs=None,
-            json_serialize=False,
+            json_serialize=True,
         )
         self._column_value_counts_metric_single_batch_parameter_builder_config: ParameterBuilderConfig = ParameterBuilderConfig(
             module_name="great_expectations.rule_based_profiler.parameter_builder",
@@ -167,7 +168,7 @@ class PartitionParameterBuilder(MetricSingleBatchParameterBuilder):
             variables=variables,
             parameters=parameters,
         )
-        bins: list = column_partition_parameter_node[
+        bins: MetricValue = column_partition_parameter_node[
             FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY
         ]
 

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -157,15 +157,16 @@ class DataAssistantResult(SerializableDictDot):
         domain: Domain
         parameter_values_for_fully_qualified_parameter_names: Dict[str, ParameterNode]
         fully_qualified_parameter_name: str
-        parameter_value: ParameterNode
+        parameter_node: ParameterNode
         metrics_attributed_values_by_domain: Dict[Domain, Dict[str, ParameterNode]] = {
             domain: {
-                parameter_value[
+                parameter_node[
                     FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY
-                ].metric_configuration.metric_name: parameter_value[
+                ].metric_configuration.metric_name: parameter_node[
                     FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY
                 ]
-                for fully_qualified_parameter_name, parameter_value in parameter_values_for_fully_qualified_parameter_names.items()
+                for fully_qualified_parameter_name, parameter_node in parameter_values_for_fully_qualified_parameter_names.items()
+                if FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY in parameter_node
             }
             for domain, parameter_values_for_fully_qualified_parameter_names in self.metrics_by_domain.items()
         }
@@ -1975,6 +1976,7 @@ class DataAssistantResult(SerializableDictDot):
     def _determine_attributed_metrics_by_domain_type(
         self, metric_domain_type: MetricDomainTypes
     ) -> Dict[Domain, Dict[str, ParameterNode]]:
+        # noinspection PyTypeChecker
         attributed_metrics_by_domain: Dict[Domain, Dict[str, ParameterNode]] = dict(
             filter(
                 lambda element: element[0].domain_type == metric_domain_type,

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -539,7 +539,7 @@ def test_column_histogram_metric_pd():
         metric_name="column.histogram",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "bins": 10,
+            "bins": [0.0, 0.9, 1.8, 2.7, 3.6, 4.5, 5.4, 6.3, 7.2, 8.1, 9.0],
         },
         metric_dependencies={
             "table.columns": table_columns_metric,
@@ -567,7 +567,7 @@ def test_column_histogram_metric_sa(sa):
         metric_name="column.histogram",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "bins": 10,
+            "bins": [0.0, 0.9, 1.8, 2.7, 3.6, 4.5, 5.4, 6.3, 7.2, 8.1, 9.0],
         },
         metric_dependencies={
             "table.columns": table_columns_metric,
@@ -599,7 +599,7 @@ def test_column_histogram_metric_spark(spark_session):
         metric_name="column.histogram",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
-            "bins": 10,
+            "bins": [0.0, 0.9, 1.8, 2.7, 3.6, 4.5, 5.4, 6.3, 7.2, 8.1, 9.0],
         },
         metric_dependencies={
             "table.columns": table_columns_metric,

--- a/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profilers/test_profiler_user_workflows.py
@@ -259,7 +259,7 @@ def test_alice_profiler_user_workflow_single_batch(
         == alice_columnar_table_single_batch["expected_expectation_suite"].expectations
     )
 
-    assert mock_emit.call_count == 54
+    assert mock_emit.call_count == 43
 
     assert all(
         payload[0][0]["event"] == "data_context.get_batch_list"

--- a/tests/integration/profiling/rule_based_profilers/test_rule_based_profiler.py
+++ b/tests/integration/profiling/rule_based_profilers/test_rule_based_profiler.py
@@ -163,7 +163,7 @@ def test_profile_includes_citations(
 
     assert result.citation is not None and len(result.citation.keys()) > 0
 
-    assert mock_emit.call_count == 54
+    assert mock_emit.call_count == 43
     assert all(
         payload[0][0]["event"] == "data_context.get_batch_list"
         for payload in mock_emit.call_args_list[:-1]
@@ -221,7 +221,7 @@ def test_profile_get_expectation_suite(
 
     assert suite is not None and len(suite.expectations) > 0
 
-    assert mock_emit.call_count == 55
+    assert mock_emit.call_count == 44
 
     # noinspection PyUnresolvedReferences
     actual_events: List[unittest.mock._Call] = mock_emit.call_args_list

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -281,9 +281,11 @@ def test_onboarding_data_assistant_result_batch_id_to_batch_identifier_display_n
         is not None
         for parameter_values_for_fully_qualified_parameter_names in metrics_by_domain.values()
         for parameter_node in parameter_values_for_fully_qualified_parameter_names.values()
-        for batch_id in parameter_node[
-            FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY
-        ].keys()
+        for batch_id in (
+            parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY]
+            if FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY in parameter_node
+            else {}
+        ).keys()
     )
 
 

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -2384,9 +2384,11 @@ def test_volume_data_assistant_result_batch_id_to_batch_identifier_display_name_
         is not None
         for parameter_values_for_fully_qualified_parameter_names in metrics_by_domain.values()
         for parameter_node in parameter_values_for_fully_qualified_parameter_names.values()
-        for batch_id in parameter_node[
-            FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY
-        ].keys()
+        for batch_id in (
+            parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY]
+            if FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY in parameter_node
+            else {}
+        ).keys()
     )
 
 

--- a/tests/rule_based_profiler/parameter_builder/test_partition_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_partition_parameter_builder.py
@@ -57,6 +57,8 @@ def test_partition_parameter_builder_alice_continuous(
     parameter_builder: ParameterBuilder = PartitionParameterBuilder(
         name="my_name",
         bucketize_data=True,
+        evaluation_parameter_builder_configs=None,
+        json_serialize=True,
         data_context=data_context,
     )
 
@@ -124,6 +126,8 @@ def test_partition_parameter_builder_alice_categorical(
     parameter_builder: ParameterBuilder = PartitionParameterBuilder(
         name="my_name",
         bucketize_data=False,
+        evaluation_parameter_builder_configs=None,
+        json_serialize=True,
         data_context=data_context,
     )
 
@@ -190,6 +194,8 @@ def test_partition_parameter_builder_alice_continuous_changed_to_categorical(
     parameter_builder: ParameterBuilder = PartitionParameterBuilder(
         name="my_name",
         bucketize_data=True,
+        evaluation_parameter_builder_configs=None,
+        json_serialize=True,
         data_context=data_context,
     )
 
@@ -254,6 +260,8 @@ def test_partition_parameter_builder_alice_continuous_check_serialized_keys(
     parameter_builder: ParameterBuilder = PartitionParameterBuilder(
         name="my_name",
         bucketize_data=True,
+        evaluation_parameter_builder_configs=None,
+        json_serialize=True,
         data_context=data_context,
     )
 

--- a/tests/rule_based_profiler/parameter_builder/test_partition_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_partition_parameter_builder.py
@@ -271,12 +271,6 @@ def test_partition_parameter_builder_alice_continuous_check_serialized_keys(
         "module_name",
         "name",
         "bucketize_data",
-        "metric_name",
-        "metric_domain_kwargs",
-        "metric_value_kwargs",
-        "enforce_numeric_metric",
-        "replace_nan_with_zero",
-        "reduce_scalar_metric",
         "evaluation_parameter_builder_configs",
         "json_serialize",
     }


### PR DESCRIPTION
### Scope
This contribution accomplishes several related tasks:
* Add proper unit tests for the "column.histogram" metric.
* Use `PartitionParameterBuilder` in `OnboardingDataAssistant` due to its generality of handling histogram style requirements for both, categorical as well as finely-quantized (as an approximation to "continuous") column data values.
* Update `DataAssistant` unit tests to handle the available `ParameterNode` keys robustly.
* Various code styling cleanup.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-465/GREAT-982
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
