### PR TITLE
[MAINTENANCE] Remove condition from `autoupdate` GitHub action

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   autoupdate:
     name: autoupdate
-    if: contains(github.event.pull_request.labels.*.name, 'core-team') || contains(github.event.pull_request.labels.*.name, 'devrel')
     runs-on: ubuntu-20.04
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1


### PR DESCRIPTION
Changes proposed in this pull request:
- This action never actually runs because the condition is never true - since it should only run once `auto-merge` is enabled, I've just deleted the condition and am hoping it now works 😄 


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code