### PR TITLE
[DOCS] Add Datahub Integration Doc

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -3,4 +3,4 @@ title: "Integrations: Index"
 ---
 - [How To Write Integration (With Great Expectations) Documentation](../integrations/contributing_integration.md)
 - [Sample Integration](../integrations/integration_template.md)
-- [Datahub Integration](../integrations/integration_datahub_template.md)
+- [DataHub Integration](../integrations/integration_datahub_template.md)

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -3,3 +3,4 @@ title: "Integrations: Index"
 ---
 - [How To Write Integration (With Great Expectations) Documentation](../integrations/contributing_integration.md)
 - [Sample Integration](../integrations/integration_template.md)
+- [Datahub Integration](../integrations/integration_datahub_template.md)

--- a/docs/integrations/integration_datahub_template.md
+++ b/docs/integrations/integration_datahub_template.md
@@ -16,11 +16,11 @@ This integration allows you to push the results of running expectations into Dat
 
 
 ### Technical background
-We have implemented [Custom Action](https://docs.greatexpectations.io/docs/terms/action#how-to-create) named `DataHubValidationAction`
+There is a custom action named `DataHubValidationAction` which allows you to view expectation results inside of DataHub.
 
 :::note Prerequisites
- - Created a [Great Expectations Checkpoint](https://docs.greatexpectations.io/docs/terms/checkpoint)
- - Have Access to a [DataHub Instance](https://datahubproject.io/docs/quickstart)
+ - Create a [Great Expectations Checkpoint](https://docs.greatexpectations.io/docs/terms/checkpoint)
+ - [Deploy an instance of DataHub](https://datahubproject.io/docs/quickstart)
 :::
 
 `DataHubValidationAction` pushes expectations metadata to DataHub. This includes

--- a/docs/integrations/integration_datahub_template.md
+++ b/docs/integrations/integration_datahub_template.md
@@ -1,0 +1,96 @@
+---
+title: Integrating DataHub With Great Expectations
+authors:
+    name: AUTHOR NAME
+    url: https://datahubproject.io/
+---
+
+:::info
+* Maintained By: DataHub
+* Status: Beta
+* Support/Contact: https://slack.datahubproject.io/
+:::
+
+### Introduction
+With this integration, Great Expectations's validation results are integrated with DataHub as Data Quality metadata (Assertion) associated with Datasets. DataHub pulls metadata aspects such as Schema, Ownership, Lineage of Dataset from a variety of data platforms. With access to Validations metadata from Great Expectations, users can view Data Quality checks in DataHub UI along with other metadata from source data platforms.
+
+
+### Technical background
+We have implemented [Custom Action](https://docs.greatexpectations.io/docs/terms/action#how-to-create) named `DataHubValidationAction`
+
+:::note Prerequisites
+ - Created a [Great Expectations Checkpoint](https://docs.greatexpectations.io/docs/terms/checkpoint)
+ - Have Access to a [DataHub Instance](https://datahubproject.io/docs/quickstart)
+:::
+
+`DataHubValidationAction` pushes assertions metadata to DataHub. This includes
+
+- **Assertion Details**: Details of assertions (i.e. expectation) set on a Dataset (Table). Expectation set on a dataset in GE aligns with `AssertionInfo` aspect in DataHub. AssertionInfo captures the dataset and dataset fields on which assertion is applied, along with its scope, type and parameters. 
+- **Assertion Results**: Evaluation results for an assertion tracked over time. 
+Validation Result for an expectation in GE align with `AssertionRunEvent` aspect in DataHub. AssertionRunEvent captures the time at which validation was run, batch(subset) of dataset on which it was run, the success status along with other result fields.
+
+
+### Dev loops unlocked by integration
+* View dataset and column level expectations set on a dataset
+* View time-series history of expectation's outcome (pass/fail)
+* View current health status of dataset
+
+### Setup
+
+1. Install the required dependency in your Great Expectations environment.  
+    ```shell
+    pip install 'acryl-datahub[great-expectations]'
+    ```
+
+
+2. To add `DataHubValidationAction` in Great Expectations Checkpoint, add following configuration in action_list for your Great Expectations `Checkpoint`. For more details on setting action_list, see [Checkpoints and Actions](https://docs.greatexpectations.io/docs/reference/checkpoints_and_actions/) 
+    ```yml
+    action_list:
+      - name: datahub_action
+        action:
+          module_name: datahub.integrations.great_expectations.action
+          class_name: DataHubValidationAction
+          server_url: http://localhost:8080 #DataHub server url
+    ```
+
+## Usage
+
+:::tip
+Stand up and take a breath
+:::
+
+####  1. Ingest the metadata from source data platform into DataHub
+For example, if you have GE checkpoint that runs expectations on a BigQuery dataset,
+ingest the respective bigquery project into DataHub using [BigQuery](https://datahubproject.io/docs/generated/ingestion/sources/bigquery#module-bigquery) metadata ingestion source. You should be able to see BigQuery dataset in DataHub UI.
+
+#### 2. Update GE checkpoint Configurations
+Follow [Setup](#setup) guide to add `DataHubValidationAction` that will push validation results to DataHub. 
+
+#### 3. Run the GE checkpoint
+
+#### 4. Hurray!
+The Validation Results would show up in Validation tab on Dataset page in DataHub UI. 
+
+
+## Further discussion
+
+### Things to consider
+Currently this integration only supports v3 api datasources using SqlAlchemyExecutionEngine.
+
+This integration does not support
+
+- v2 Datasources such as SqlAlchemyDataset
+- v3 Datasources using execution engine other than SqlAlchemyExecutionEngine (Spark, Pandas)
+- Cross-dataset expectations (those involving > 1 table)
+
+### When things don't work
+
+- Follow [Debugging](https://datahubproject.io/docs/metadata-ingestion/integration_docs/great-expectations/#debugging) section to see what went wrong!
+- Feel free to ping us on [DataHub Slack](https://slack.datahubproject.io/)!
+
+
+### Other resources
+
+ - [Demo](https://www.loom.com/share/d781c9f0b270477fb5d6b0c26ef7f22d) of Great Expectations Datahub Integration in action 
+ - Configuration Options for [DataHubValidationAction](https://datahubproject.io/docs/metadata-ingestion/integration_docs/great-expectations#setting-up)
+ - DataHub [Metadata Ingestion Sources](https://datahubproject.io/docs/metadata-ingestion)

--- a/docs/integrations/integration_datahub_template.md
+++ b/docs/integrations/integration_datahub_template.md
@@ -12,7 +12,7 @@ authors:
 :::
 
 ### Introduction
-With this integration, Great Expectations's validation results are integrated with DataHub as Data Quality metadata (Assertion) associated with Datasets. DataHub pulls metadata aspects such as Schema, Ownership, Lineage of Dataset from a variety of data platforms. With access to Validations metadata from Great Expectations, users can view Data Quality checks in DataHub UI along with other metadata from source data platforms.
+This integration allows you to push the results of running expectations into DataHub (https://datahubproject.io/). DataHub is a metadata platform which enables search & discovery, federated governance, and data observability for the Modern Data Stack.
 
 
 ### Technical background
@@ -23,10 +23,10 @@ We have implemented [Custom Action](https://docs.greatexpectations.io/docs/terms
  - Have Access to a [DataHub Instance](https://datahubproject.io/docs/quickstart)
 :::
 
-`DataHubValidationAction` pushes assertions metadata to DataHub. This includes
+`DataHubValidationAction` pushes expectations metadata to DataHub. This includes
 
-- **Assertion Details**: Details of assertions (i.e. expectation) set on a Dataset (Table). Expectation set on a dataset in GE aligns with `AssertionInfo` aspect in DataHub. AssertionInfo captures the dataset and dataset fields on which assertion is applied, along with its scope, type and parameters. 
-- **Assertion Results**: Evaluation results for an assertion tracked over time. 
+- **Expectation Details**: Details of assertions (i.e. expectation) set on a Dataset (Table). Expectation set on a dataset in GE aligns with `AssertionInfo` aspect in DataHub. AssertionInfo captures the dataset and dataset fields on which assertion is applied, along with its scope, type and parameters. 
+- **Expectation Results**: Evaluation results for an assertion tracked over time. 
 Validation Result for an expectation in GE align with `AssertionRunEvent` aspect in DataHub. AssertionRunEvent captures the time at which validation was run, batch(subset) of dataset on which it was run, the success status along with other result fields.
 
 
@@ -37,21 +37,10 @@ Validation Result for an expectation in GE align with `AssertionRunEvent` aspect
 
 ### Setup
 
-1. Install the required dependency in your Great Expectations environment.  
-    ```shell
-    pip install 'acryl-datahub[great-expectations]'
-    ```
-
-
-2. To add `DataHubValidationAction` in Great Expectations Checkpoint, add following configuration in action_list for your Great Expectations `Checkpoint`. For more details on setting action_list, see [Checkpoints and Actions](https://docs.greatexpectations.io/docs/reference/checkpoints_and_actions/) 
-    ```yml
-    action_list:
-      - name: datahub_action
-        action:
-          module_name: datahub.integrations.great_expectations.action
-          class_name: DataHubValidationAction
-          server_url: http://localhost:8080 #DataHub server url
-    ```
+Install the required dependency in your Great Expectations environment.  
+```shell
+pip install 'acryl-datahub[great-expectations]'
+```
 
 ## Usage
 
@@ -60,13 +49,42 @@ Stand up and take a breath
 :::
 
 ####  1. Ingest the metadata from source data platform into DataHub
-For example, if you have GE checkpoint that runs expectations on a BigQuery dataset,
-ingest the respective bigquery project into DataHub using [BigQuery](https://datahubproject.io/docs/generated/ingestion/sources/bigquery#module-bigquery) metadata ingestion source. You should be able to see BigQuery dataset in DataHub UI.
+For example, if you have GE checkpoint that runs expectations on a BigQuery dataset, then first
+ingest the respective dataset into DataHub using [BigQuery](https://datahubproject.io/docs/generated/ingestion/sources/bigquery#module-bigquery) metadata ingestion source recipe. 
 
-#### 2. Update GE checkpoint Configurations
-Follow [Setup](#setup) guide to add `DataHubValidationAction` that will push validation results to DataHub. 
+```bash
+datahub ingest -c recipe.yaml
+```
+You should be able to see the dataset in DataHub UI.
+
+#### 2. Update GE Checkpoint Configurations
+Add `DataHubValidationAction` in action_list of your Great Expectations Checkpoint. For more details on setting action_list, see [Checkpoints and Actions](https://docs.greatexpectations.io/docs/reference/checkpoints_and_actions/) 
+```yml
+action_list:
+  - name: datahub_action
+    action:
+      module_name: datahub.integrations.great_expectations.action
+      class_name: DataHubValidationAction
+      server_url: http://localhost:8080 #DataHub server url
+```
+
+**Configuration options:**
+- `server_url` (required): URL of DataHub GMS endpoint
+- `env` (optional, defaults to "PROD"): Environment to use in namespace when constructing dataset URNs.
+- `platform_instance_map` (optional): Platform instance mapping to use when constructing dataset URNs. Maps the GE 'data source' name to a platform instance on DataHub. e.g. `platform_instance_map: { "datasource_name": "warehouse" }`
+- `graceful_exceptions` (defaults to true): If set to true, most runtime errors in the lineage backend will be suppressed and will not cause the overall checkpoint to fail. Note that configuration issues will still throw exceptions.
+- `token` (optional): Bearer token used for authentication.
+- `timeout_sec` (optional): Per-HTTP request timeout.
+- `retry_status_codes` (optional): Retry HTTP request also on these status codes.
+- `retry_max_times` (optional): Maximum times to retry if HTTP request fails. The delay between retries is increased exponentially.
+- `extra_headers` (optional): Extra headers which will be added to the datahub request.
+- `parse_table_names_from_sql` (defaults to false): The integration can use an SQL parser to try to parse the datasets being asserted. This parsing is disabled by default, but can be enabled by setting `parse_table_names_from_sql: True`.  The parser is based on the [`sqllineage`](https://pypi.org/project/sqllineage/) package.
 
 #### 3. Run the GE checkpoint
+
+```bash
+great_expectations checkpoint run my_checkpoint #replace my_checkpoint with your checkpoint name
+```
 
 #### 4. Hurray!
 The Validation Results would show up in Validation tab on Dataset page in DataHub UI. 
@@ -75,7 +93,7 @@ The Validation Results would show up in Validation tab on Dataset page in DataHu
 ## Further discussion
 
 ### Things to consider
-Currently this integration only supports v3 api datasources using SqlAlchemyExecutionEngine.
+Currently this integration only supports v3 API datasources using SqlAlchemyExecutionEngine.
 
 This integration does not support
 
@@ -91,6 +109,5 @@ This integration does not support
 
 ### Other resources
 
- - [Demo](https://www.loom.com/share/d781c9f0b270477fb5d6b0c26ef7f22d) of Great Expectations Datahub Integration in action 
- - Configuration Options for [DataHubValidationAction](https://datahubproject.io/docs/metadata-ingestion/integration_docs/great-expectations#setting-up)
+ - [Demo](https://www.loom.com/share/d781c9f0b270477fb5d6b0c26ef7f22d) of Great Expectations Datahub Integration in action
  - DataHub [Metadata Ingestion Sources](https://datahubproject.io/docs/metadata-ingestion)

--- a/sidebars.js
+++ b/sidebars.js
@@ -294,6 +294,13 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'Integrations',
+      items:[
+        { type: 'doc', id: 'integrations/index', label: 'Index' }
+      ]
+    },
+    {
+      type: 'category',
       label: 'Contributing',
       link: { type: 'doc', id: 'contributing/contributing' },
       items: [


### PR DESCRIPTION
Changes proposed in this pull request:
- Datahub Integration Document as per [this GE doc](https://docs.greatexpectations.io/docs/integrations/contributing_integration/)

### Definition of Done

- [x] I have made corresponding changes to the documentation
