### PR TITLE
[BUGFIX] Patch automated release test date comparisons

### DIFF
--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -6,6 +6,7 @@ import dateutil.parser
 import pytest
 import pytz
 from packaging import version
+from pytz.tzinfo import DstTzInfo
 
 from great_expectations.data_context.util import file_relative_path
 
@@ -17,15 +18,15 @@ def release_file() -> str:
 
 
 @pytest.fixture
-def timezone() -> Any:
+def timezone() -> DstTzInfo:
     # Since releases are cut based on an EST schedule, let's ensure our validation matches that
-    tz = pytz.timezone("US/Eastern")
+    tz: DstTzInfo = cast(DstTzInfo, pytz.timezone("US/Eastern"))
     return tz
 
 
 @pytest.fixture
 def release_schedule(
-    release_file: str, timezone: Any
+    release_file: str, timezone: DstTzInfo
 ) -> Dict[dt.datetime, version.Version]:
     with open(release_file) as f:
         release_schedule: Dict[str, str] = json.loads(f.read())
@@ -42,13 +43,12 @@ def release_schedule(
 
 def test_release_schedule_adheres_to_schema(
     release_schedule: Dict[dt.datetime, version.Version],
-    timezone: Any,
+    timezone: DstTzInfo,
 ) -> None:
     today: dt.datetime = dt.datetime.now(timezone)
     prev_date: Optional[dt.datetime] = None
     prev_version: Optional[version.Version] = None
 
-    print(release_schedule)
     for timestamp, release_version in release_schedule.items():
 
         # No old releases should exist within the release schedule (deleted during release process)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,9 +1,10 @@
 import datetime as dt
 import json
-from typing import Dict, Optional, cast
+from typing import Any, Dict, Optional, cast
 
 import dateutil.parser
 import pytest
+import pytz
 from packaging import version
 
 from great_expectations.data_context.util import file_relative_path
@@ -16,13 +17,23 @@ def release_file() -> str:
 
 
 @pytest.fixture
-def release_schedule(release_file: str) -> Dict[dt.datetime, version.Version]:
+def timezone() -> Any:
+    # Since releases are cut based on an EST schedule, let's ensure our validation matches that
+    tz = pytz.timezone("US/Eastern")
+    return tz
+
+
+@pytest.fixture
+def release_schedule(
+    release_file: str, timezone: Any
+) -> Dict[dt.datetime, version.Version]:
     with open(release_file) as f:
         release_schedule: Dict[str, str] = json.loads(f.read())
 
     parsed_schedule: Dict[dt.datetime, version.Version] = {}
     for date, release_version in release_schedule.items():
         parsed_date = dateutil.parser.parse(date)
+        parsed_date = parsed_date.astimezone(timezone)
         parsed_version = cast(version.Version, version.parse(release_version))
         parsed_schedule[parsed_date] = parsed_version
 
@@ -30,24 +41,25 @@ def release_schedule(release_file: str) -> Dict[dt.datetime, version.Version]:
 
 
 def test_release_schedule_adheres_to_schema(
-    release_schedule: Dict[dt.datetime, version.Version]
+    release_schedule: Dict[dt.datetime, version.Version],
+    timezone: Any,
 ) -> None:
-    today: dt.datetime = dt.datetime.today()
+    today: dt.datetime = dt.datetime.now(timezone)
     prev_date: Optional[dt.datetime] = None
     prev_version: Optional[version.Version] = None
 
-    for date, release_version in release_schedule.items():
+    for timestamp, release_version in release_schedule.items():
 
         # No old releases should exist within the release schedule (deleted during release process)
-        assert date >= today
+        assert timestamp.date() >= today.date()
 
         if prev_date and prev_version:
 
             # Each date should be greater than the prior one
-            assert date > prev_date
+            assert timestamp > prev_date
 
             # Each release occurs on a Thursday
-            assert date.weekday() == 3
+            assert timestamp.weekday() == 3
 
             curr_minor: int = release_version.minor
             curr_patch: int = release_version.micro
@@ -61,7 +73,7 @@ def test_release_schedule_adheres_to_schema(
             else:
                 assert curr_minor - prev_minor == 0 and curr_patch - prev_patch == 1
 
-        prev_date = date
+        prev_date = timestamp
         prev_version = release_version
 
     # For release safety, there must always be items in the scheduler

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -33,7 +33,7 @@ def release_schedule(
     parsed_schedule: Dict[dt.datetime, version.Version] = {}
     for date, release_version in release_schedule.items():
         parsed_date = dateutil.parser.parse(date)
-        parsed_date = parsed_date.astimezone(timezone)
+        parsed_date = timezone.localize(parsed_date)
         parsed_version = cast(version.Version, version.parse(release_version))
         parsed_schedule[parsed_date] = parsed_version
 
@@ -48,6 +48,7 @@ def test_release_schedule_adheres_to_schema(
     prev_date: Optional[dt.datetime] = None
     prev_version: Optional[version.Version] = None
 
+    print(release_schedule)
     for timestamp, release_version in release_schedule.items():
 
         # No old releases should exist within the release schedule (deleted during release process)


### PR DESCRIPTION
Changes proposed in this pull request:
- We need to compare datetimes in EST since that's how the release schedule works (was comparing EST to UTC and that caused issues before)



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
