### PR TITLE
[MAINTENANCE] Improve code readability in the processing section of "MapMetricColumnDomainBuilder".

### DIFF
--- a/great_expectations/rule_based_profiler/domain_builder/map_metric_column_domain_builder.py
+++ b/great_expectations/rule_based_profiler/domain_builder/map_metric_column_domain_builder.py
@@ -310,15 +310,14 @@ class MapMetricColumnDomainBuilder(ColumnDomainBuilder):
             for column_name, resolved_metrics in resolved_metrics_by_column_name.items()
         }
 
+        metric_value_ratios: List[float]
         metric_value_ratio: float
         intra_batch_adherence_by_column_name: Dict[str, List[bool]] = {
             column_name: [
                 metric_value_ratio <= max_unexpected_ratio
-                for metric_value_ratio in intra_batch_unexpected_ratios_by_column_name[
-                    column_name
-                ]
+                for metric_value_ratio in metric_value_ratios
             ]
-            for column_name in intra_batch_unexpected_ratios_by_column_name.keys()
+            for column_name, metric_value_ratios in intra_batch_unexpected_ratios_by_column_name.items()
         }
 
         inter_batch_adherence_by_column_name: Dict[str, float] = {


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
