### PR TITLE
[BUGFIX] Update `test_basic_spark_datasource_self_check` to work with all supported versions of PySpark

### DIFF
--- a/tests/datasource/test_new_datasource.py
+++ b/tests/datasource/test_new_datasource.py
@@ -235,13 +235,13 @@ def test_basic_pandas_datasource_v013_self_check(basic_pandas_datasource_v013):
 
 
 def test_basic_spark_datasource_self_check(basic_spark_datasource):
-    report = basic_spark_datasource.self_check()
-    report["execution_engine"]["spark_config"].pop("spark.app.id", None)
-    report["execution_engine"]["spark_config"].pop("spark.driver.host", None)
-    report["execution_engine"]["spark_config"].pop("spark.driver.port", None)
-    report["execution_engine"]["spark_config"].pop("spark.submit.pyFiles", None)
-    report["execution_engine"]["spark_config"].pop("spark.app.startTime", None)
-    report["execution_engine"]["spark_config"].pop("spark.sql.warehouse.dir", None)
+    report: dict = basic_spark_datasource.self_check()
+
+    # The structure of this config is dynamic based on PySpark version;
+    # we deem asserting it's presence sufficient for purposes of this test
+    spark_config: dict = report["execution_engine"]["spark_config"]
+    assert isinstance(spark_config, dict) and len(spark_config.keys()) > 0
+    report["execution_engine"].pop("spark_config")
 
     assert report == {
         "data_connectors": {
@@ -270,20 +270,6 @@ def test_basic_spark_datasource_self_check(basic_spark_datasource):
             "class_name": "SparkDFExecutionEngine",
             "module_name": "great_expectations.execution_engine.sparkdf_execution_engine",
             "persist": True,
-            "spark_config": {
-                "spark.app.name": "default_great_expectations_spark_application",
-                "spark.default.parallelism": "4",
-                "spark.driver.memory": "6g",
-                "spark.executor.id": "driver",
-                "spark.executor.memory": "6g",
-                "spark.master": "local[*]",
-                "spark.rdd.compress": "True",
-                "spark.serializer.objectStreamReset": "100",
-                "spark.sql.catalogImplementation": "hive",
-                "spark.sql.shuffle.partitions": "2",
-                "spark.submit.deployMode": "client",
-                "spark.ui.showConsoleProgress": "False",
-            },
         },
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- The contents of `Datasource.self_check` with a Spark configuration is variable depending on PySpark version.
  - As such, we reduce the granularity of our check in our test to account for all different versions supported by GX.
- Broken build for reference: https://dev.azure.com/great-expectations/great_expectations/_build/results?buildId=60619&view=results



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
