### PR TITLE
[MAINTENANCE] Misc cleanup post `0.15.10` release

### DIFF
--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -54,7 +54,7 @@ def titanic_data_context_v2_datasources_and_validation_operators_usage_stats_ena
     os.makedirs(os.path.join(context_path, "checkpoints"), exist_ok=True)
     data_path = os.path.join(context_path, "..", "data")
     os.makedirs(os.path.join(data_path), exist_ok=True)
-    # this is
+
     titanic_yml_path = file_relative_path(
         __file__, "../test_fixtures/great_expectations_v013_titanic.yml"
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- Delete unnecessary comment in test
- Refactor Spark test to still assert that our config is a subset of the larger payload.
  - This adds a bit more granularity while also being flexible in terms of backwards compatability (as PySpark increments SemVer).


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
