### PR TITLE
[DOCS] Add missing templates on `How to contribute a new Expectation to Great Expectations` page

### DIFF
--- a/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_contribute_a_new_expectation_to_great_expectations.rst
+++ b/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_contribute_a_new_expectation_to_great_expectations.rst
@@ -29,8 +29,8 @@ Steps
 
     * ``ColumnMapExpectation``: ``examples/expectations/column_map_expectation_template.py``
     * ``ColumnExpectation``: ``examples/expectations/column_aggregate_expectation_template.py``
-    * ``ColumnPairMapExpectation``: coming soon...
-    * ``TableExpectation``: coming soon...
+    * ``ColumnPairMapExpectation``: ``examples/expectations/column_pair_map_expectation_template.py``
+    * ``TableExpectation``: ``examples/expectations/table_expectation_template.py``
 
 
 #. **Copy the template file**


### PR DESCRIPTION
Changes proposed in this pull request:
- Add missing templates for `ColumnPairMapExpectation` and `TableExpectation`

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.

