### PR TITLE
[MAINTENANCE] Update `release-prep` GitHub action to ensure `ge_releaser` tool is not included in output PR

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -13,10 +13,13 @@ jobs:
           fetch-depth: 0
       - name: Install ge_releaser
         run: |
-          git clone https://github.com/superconductive/ge_releaser.git
           git config user.name github-actions
           git config user.email github-actions@github.com
+          # Install release tool in a separate repo than GE
+          pushd ..
+          git clone https://github.com/superconductive/ge_releaser.git
           pip install -e ge_releaser
+          popd
       - name: Create PR
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Changes proposed in this pull request:
- By installing `ge_releaser` while in the GE repo, we accidentally add a git submodule in our prep PR.
- By using `pushd` and `popd`, we can install the tool in a separate dir to avoid the issue.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
