### PR TITLE
[FEATURE] Add Rule Statistics to DataAssistantResult for display in Jupyter notebook

### DIFF
--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -218,7 +218,15 @@ class DataAssistantResult(SerializableDictDot):
                 ).strftime("%Y%m%dT%H%M%S.%fZ"),
                 "great_expectations_version": ge_version,
             }
-            verbose: bool = os.getenv("GE_TROUBLESHOOTING", False)
+
+            verbose: Union[bool, str] = str(
+                os.getenv("GE_TROUBLESHOOTING", False)
+            ).lower()
+            if verbose != "true":
+                verbose = "false"
+
+            verbose = json.loads(verbose)
+
             if verbose:
                 rule_name_to_rule_stats_map: Dict[str, RuleStats] = {}
                 rule_stats: RuleStats

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -1,8 +1,9 @@
 import copy
 import datetime
 import json
+import os
 from collections import defaultdict, namedtuple
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, Dict, KeysView, List, Optional, Set, Tuple, Union
 
 import altair as alt
@@ -52,8 +53,35 @@ from great_expectations.rule_based_profiler.types.data_assistant_result.plot_res
     PlotResult,
 )
 from great_expectations.types import ColorPalettes, Colors, SerializableDictDot
+from great_expectations.types.attributes import Attributes
 
 ColumnDataFrame = namedtuple("ColumnDataFrame", ["column", "df"])
+
+
+@dataclass
+class RuleStats(SerializableDictDot):
+    """
+    This class encapsulates basic "Rule" execution statistics.
+    """
+
+    domains_count_by_domain_type: Dict[MetricDomainTypes, int] = field(
+        default_factory=dict
+    )
+    domains_by_domain_type: Dict[MetricDomainTypes, List[dict]] = field(
+        default_factory=dict
+    )
+
+    def to_dict(self) -> dict:
+        """
+        Returns dictionary equivalent of this object.
+        """
+        return asdict(self)
+
+    def to_json_dict(self) -> dict:
+        """
+        Returns JSON dictionary equivalent of this object.
+        """
+        return convert_to_json_serializable(data=self.to_dict())
 
 
 @dataclass
@@ -183,19 +211,45 @@ class DataAssistantResult(SerializableDictDot):
                 for key, value in json_dict.items()
                 if key in DataAssistantResult.IN_JUPYTER_NOTEBOOK_KEYS
             }
-            json_dict.update(
-                {
-                    "num_profiler_rules": len(self.profiler_config.rules),
-                    "num_domains": len(self.metrics_by_domain),
-                    "num_expectation_configurations": len(
-                        self.expectation_configurations
-                    ),
-                    "auto_generated_at": datetime.datetime.now(
-                        datetime.timezone.utc
-                    ).strftime("%Y%m%dT%H%M%S.%fZ"),
-                    "great_expectations_version": ge_version,
-                }
-            )
+            additional_info: dict = {
+                "num_profiler_rules": len(self.profiler_config.rules),
+                "num_expectation_configurations": len(self.expectation_configurations),
+                "auto_generated_at": datetime.datetime.now(
+                    datetime.timezone.utc
+                ).strftime("%Y%m%dT%H%M%S.%fZ"),
+                "great_expectations_version": ge_version,
+            }
+            verbose: bool = os.getenv("GE_TROUBLESHOOTING", False)
+            if verbose:
+                rule_name_to_rule_stats_map: Dict[str, RuleStats] = {}
+                rule_stats: RuleStats
+                domain: Domain
+                domain_as_json_dict: dict
+                rule_name: str
+                for domain in self.metrics_by_domain.keys():
+                    domain_as_json_dict = domain.to_json_dict()
+                    domain_as_json_dict.pop("domain_type")
+                    domain_as_json_dict.pop("rule_name")
+                    rule_name = domain.rule_name
+                    rule_stats = rule_name_to_rule_stats_map.get(rule_name)
+                    if rule_stats is None:
+                        rule_stats = RuleStats()
+                        rule_name_to_rule_stats_map[rule_name] = rule_stats
+                        rule_stats.domains_count_by_domain_type[domain.domain_type] = 1
+                        rule_stats.domains_by_domain_type[domain.domain_type] = [
+                            domain_as_json_dict
+                        ]
+                    else:
+                        rule_stats.domains_count_by_domain_type[domain.domain_type] += 1
+                        rule_stats.domains_by_domain_type[domain.domain_type].append(
+                            domain_as_json_dict
+                        )
+
+                    additional_info.update(
+                        convert_to_json_serializable(data=rule_name_to_rule_stats_map)
+                    )
+
+            json_dict.update(additional_info)
 
         return json.dumps(json_dict, indent=2)
 

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -53,7 +53,6 @@ from great_expectations.rule_based_profiler.types.data_assistant_result.plot_res
     PlotResult,
 )
 from great_expectations.types import ColorPalettes, Colors, SerializableDictDot
-from great_expectations.types.attributes import Attributes
 
 ColumnDataFrame = namedtuple("ColumnDataFrame", ["column", "df"])
 


### PR DESCRIPTION
### Scope
Example output that becomes available when stating `domain_assistant_result` in a `Jupyter` notebook cell:
```
{
  "execution_time": 29.54336964,
  "num_profiler_rules": 8,
  "num_expectation_configurations": 31,
  "auto_generated_at": "20220623T004304.712287Z",
  "great_expectations_version": "0.15.11+4.gb45d64306",
  "table_rule": {
    "domains_count_by_domain_type": {
      "MetricDomainTypes.TABLE": 1
    },
    "domains_by_domain_type": {
      "MetricDomainTypes.TABLE": [
        {}
      ]
    }
  },
  "column_value_nonnullity_rule": {
    "domains_count_by_domain_type": {
      "MetricDomainTypes.COLUMN": 6
    },
    "domains_by_domain_type": {
      "MetricDomainTypes.COLUMN": [
        {
          "domain_kwargs": {
            "column": "pickup_datetime"
          },
          "details": {
            "inferred_semantic_domain_type": {
              "pickup_datetime": "text"
            }
          }
        },
        {
          "domain_kwargs": {
            "column": "dropoff_datetime"
          },
          "details": {
            "inferred_semantic_domain_type": {
              "dropoff_datetime": "text"
            }
          }
        }
...
```

This functionality is activated via an environment variable: `%env GE_TROUBLESHOOTING=True`

### Future Work
Consider adding execution times for `DomainBuilder` and `ParameterBuilder` computations (if possible; otherwise, these quantities will continue being determined using the inline decorators, `@profile` and/or 
```
@measure_execution_time(
    pretty_print=True,
    include_arguments=False,
)
```

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1017
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
