### PR TITLE
[MAINTENANCE] Ensure that `BaseDataContext` does not persist `Datasource` changes by default

### DIFF
--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1073,6 +1073,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         """Delete a data source
         Args:
             datasource_name: The name of the datasource to delete.
+            persist_changes: Whether or not to save changes to disk.
 
         Raises:
             ValueError: If the datasource name isn't provided or cannot be found.
@@ -1833,6 +1834,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             name: the name for the new datasource to add
             initialize: if False, add the datasource to the config, but do not
                 initialize it, for example if a user needs to debug database connectivity.
+            persist_changes: Whether or not to save changes to disk.
             kwargs (keyword arguments): the configuration for the new datasource
 
         Returns:

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1068,12 +1068,12 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             yaml.dump(config_variables, config_variables_file)
 
     def delete_datasource(
-        self, datasource_name: str, persist_changes: bool = False
+        self, datasource_name: str, save_changes: bool = False
     ) -> None:
         """Delete a data source
         Args:
             datasource_name: The name of the datasource to delete.
-            persist_changes: Whether or not to save changes to disk.
+            save_changes: Whether or not to save changes to disk.
 
         Raises:
             ValueError: If the datasource name isn't provided or cannot be found.
@@ -1083,7 +1083,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         else:
             datasource = self.get_datasource(datasource_name=datasource_name)
             if datasource:
-                if persist_changes:
+                if save_changes:
                     self._datasource_store.delete_by_name(datasource_name)
                 else:
                     del self.config.datasources[datasource_name]
@@ -1826,7 +1826,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         self,
         name: str,
         initialize: bool = True,
-        persist_changes: bool = False,
+        save_changes: bool = False,
         **kwargs: dict,
     ) -> Optional[Union[LegacyDatasource, BaseDatasource]]:
         """Add a new datasource to the data context, with configuration provided as kwargs.
@@ -1834,7 +1834,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             name: the name for the new datasource to add
             initialize: if False, add the datasource to the config, but do not
                 initialize it, for example if a user needs to debug database connectivity.
-            persist_changes: Whether or not to save changes to disk.
+            save_changes: Whether or not to save changes to disk.
             kwargs (keyword arguments): the configuration for the new datasource
 
         Returns:
@@ -1861,7 +1861,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             name=name,
             config=config,
             initialize=initialize,
-            persist_changes=persist_changes,
+            save_changes=save_changes,
         )
         return datasource
 
@@ -1870,7 +1870,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         name: str,
         config: dict,
         initialize: bool = True,
-        persist_changes: bool = False,
+        save_changes: bool = False,
     ) -> Optional[Union[LegacyDatasource, BaseDatasource]]:
         datasource_config: DatasourceConfig = datasourceConfigSchema.load(
             CommentedMap(**config)
@@ -1879,7 +1879,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         self._data_context._update_config_variables()
         self._apply_temporary_overrides()
 
-        if persist_changes:
+        if save_changes:
             self._datasource_store.set_by_name(
                 datasource_name=name, datasource_config=datasource_config
             )
@@ -1902,7 +1902,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
                 self._cached_datasources[name] = datasource
             except ge_exceptions.DatasourceInitializationError as e:
                 # Do not keep configuration that could not be instantiated.
-                if persist_changes:
+                if save_changes:
                     self._datasource_store.delete_by_name(datasource_name=name)
                 else:
                     del self.config.datasources[name]

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -467,14 +467,14 @@ class DataContext(BaseDataContext):
 
         new_datasource: Optional[
             Union[LegacyDatasource, BaseDatasource]
-        ] = super().add_datasource(name=name, persist_changes=True, **kwargs)
+        ] = super().add_datasource(name=name, save_changes=True, **kwargs)
 
         return new_datasource
 
     def delete_datasource(self, name: str) -> None:
         logger.debug(f"Starting DataContext.delete_datasource for datasource {name}")
 
-        super().delete_datasource(datasource_name=name, persist_changes=True)
+        super().delete_datasource(datasource_name=name, save_changes=True)
 
     @classmethod
     def find_context_root_dir(cls):

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -467,14 +467,14 @@ class DataContext(BaseDataContext):
 
         new_datasource: Optional[
             Union[LegacyDatasource, BaseDatasource]
-        ] = super().add_datasource(name=name, **kwargs)
+        ] = super().add_datasource(name=name, persist_changes=True, **kwargs)
 
         return new_datasource
 
     def delete_datasource(self, name: str) -> None:
         logger.debug(f"Starting DataContext.delete_datasource for datasource {name}")
 
-        super().delete_datasource(datasource_name=name)
+        super().delete_datasource(datasource_name=name, persist_changes=True)
 
     @classmethod
     def find_context_root_dir(cls):

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -61,11 +61,15 @@ class DatasourceStore(Store):
         ]
         return [key for key in keys_without_store_backend_id]
 
-    def remove_key(self, key: DataContextVariableKey) -> None:
+    def remove_key(
+        self, key: DataContextVariableKey, persist_changes: bool = True
+    ) -> None:
         """
         See parent `Store.remove_key()` for more information
         """
-        return self._store_backend.remove_key(key.to_tuple())
+        return self._store_backend.remove_key(
+            key.to_tuple(), persist_changes=persist_changes
+        )
 
     def serialize(
         self, key: Optional[Any], value: DatasourceConfig
@@ -119,7 +123,9 @@ class DatasourceStore(Store):
         datasource_config: DatasourceConfig = copy.deepcopy(self.get(datasource_key))
         return datasource_config
 
-    def delete_by_name(self, datasource_name: str) -> None:
+    def delete_by_name(
+        self, datasource_name: str, persist_changes: bool = True
+    ) -> None:
         """Deletes a DatasourceConfig persisted in the store by it's given name.
 
         Args:
@@ -128,10 +134,13 @@ class DatasourceStore(Store):
         datasource_key: DataContextVariableKey = self._determine_datasource_key(
             datasource_name=datasource_name
         )
-        self.remove_key(datasource_key)
+        self.remove_key(datasource_key, persist_changes=persist_changes)
 
     def set_by_name(
-        self, datasource_name: str, datasource_config: DatasourceConfig
+        self,
+        datasource_name: str,
+        datasource_config: DatasourceConfig,
+        persist_changes: bool = True,
     ) -> None:
         """Persists a DatasourceConfig in the store by a given name.
 
@@ -142,7 +151,7 @@ class DatasourceStore(Store):
         datasource_key: DataContextVariableKey = self._determine_datasource_key(
             datasource_name=datasource_name
         )
-        self.set(datasource_key, datasource_config)
+        self.set(datasource_key, datasource_config, persist_changes=persist_changes)
 
     def _determine_datasource_key(self, datasource_name: str) -> DataContextVariableKey:
         datasource_key: DataContextVariableKey = DataContextVariableKey(

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -61,15 +61,11 @@ class DatasourceStore(Store):
         ]
         return [key for key in keys_without_store_backend_id]
 
-    def remove_key(
-        self, key: DataContextVariableKey, persist_changes: bool = True
-    ) -> None:
+    def remove_key(self, key: DataContextVariableKey) -> None:
         """
         See parent `Store.remove_key()` for more information
         """
-        return self._store_backend.remove_key(
-            key.to_tuple(), persist_changes=persist_changes
-        )
+        return self._store_backend.remove_key(key.to_tuple())
 
     def serialize(
         self, key: Optional[Any], value: DatasourceConfig
@@ -123,9 +119,7 @@ class DatasourceStore(Store):
         datasource_config: DatasourceConfig = copy.deepcopy(self.get(datasource_key))
         return datasource_config
 
-    def delete_by_name(
-        self, datasource_name: str, persist_changes: bool = True
-    ) -> None:
+    def delete_by_name(self, datasource_name: str) -> None:
         """Deletes a DatasourceConfig persisted in the store by it's given name.
 
         Args:
@@ -134,13 +128,12 @@ class DatasourceStore(Store):
         datasource_key: DataContextVariableKey = self._determine_datasource_key(
             datasource_name=datasource_name
         )
-        self.remove_key(datasource_key, persist_changes=persist_changes)
+        self.remove_key(datasource_key)
 
     def set_by_name(
         self,
         datasource_name: str,
         datasource_config: DatasourceConfig,
-        persist_changes: bool = True,
     ) -> None:
         """Persists a DatasourceConfig in the store by a given name.
 
@@ -151,7 +144,7 @@ class DatasourceStore(Store):
         datasource_key: DataContextVariableKey = self._determine_datasource_key(
             datasource_name=datasource_name
         )
-        self.set(datasource_key, datasource_config, persist_changes=persist_changes)
+        self.set(datasource_key, datasource_config)
 
     def _determine_datasource_key(self, datasource_name: str) -> DataContextVariableKey:
         datasource_key: DataContextVariableKey = DataContextVariableKey(

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -131,9 +131,7 @@ class DatasourceStore(Store):
         self.remove_key(datasource_key)
 
     def set_by_name(
-        self,
-        datasource_name: str,
-        datasource_config: DatasourceConfig,
+        self, datasource_name: str, datasource_config: DatasourceConfig
     ) -> None:
         """Persists a DatasourceConfig in the store by a given name.
 

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -84,7 +84,13 @@ class InlineStoreBackend(StoreBackend):
 
         return variable_config
 
-    def _set(self, key: Tuple[str, ...], value: Any, **kwargs: dict) -> None:
+    def _set(
+        self,
+        key: Tuple[str, ...],
+        value: Any,
+        persist_changes: bool = True,
+        **kwargs: dict,
+    ) -> None:
         (
             resource_type,
             resource_name,
@@ -103,7 +109,8 @@ class InlineStoreBackend(StoreBackend):
         else:
             project_config[resource_type] = value
 
-        self._persist_changes()
+        if persist_changes:
+            self._persist_changes()
 
     def _move(
         self, source_key: Tuple[str, ...], dest_key: Tuple[str, ...], **kwargs: dict
@@ -141,7 +148,7 @@ class InlineStoreBackend(StoreBackend):
 
         return keys
 
-    def remove_key(self, key: Tuple[str, ...]) -> None:
+    def remove_key(self, key: Tuple[str, ...], persist_changes: bool = True) -> None:
         """
         See `StoreBackend.remove_key` for more information.
         """
@@ -165,7 +172,8 @@ class InlineStoreBackend(StoreBackend):
 
         del self._data_context.config[resource_type][resource_name]
 
-        self._persist_changes()
+        if persist_changes:
+            self._persist_changes()
 
     def _has_key(self, key: Tuple[str, ...]) -> bool:
         (

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -84,13 +84,7 @@ class InlineStoreBackend(StoreBackend):
 
         return variable_config
 
-    def _set(
-        self,
-        key: Tuple[str, ...],
-        value: Any,
-        persist_changes: bool = True,
-        **kwargs: dict,
-    ) -> None:
+    def _set(self, key: Tuple[str, ...], value: Any, **kwargs: dict) -> None:
         (
             resource_type,
             resource_name,
@@ -109,8 +103,7 @@ class InlineStoreBackend(StoreBackend):
         else:
             project_config[resource_type] = value
 
-        if persist_changes:
-            self._persist_changes()
+        self._persist_changes()
 
     def _move(
         self, source_key: Tuple[str, ...], dest_key: Tuple[str, ...], **kwargs: dict
@@ -148,7 +141,7 @@ class InlineStoreBackend(StoreBackend):
 
         return keys
 
-    def remove_key(self, key: Tuple[str, ...], persist_changes: bool = True) -> None:
+    def remove_key(self, key: Tuple[str, ...]) -> None:
         """
         See `StoreBackend.remove_key` for more information.
         """
@@ -172,8 +165,7 @@ class InlineStoreBackend(StoreBackend):
 
         del self._data_context.config[resource_type][resource_name]
 
-        if persist_changes:
-            self._persist_changes()
+        self._persist_changes()
 
     def _has_key(self, key: Tuple[str, ...]) -> bool:
         (

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -203,12 +203,7 @@ class InlineStoreBackend(StoreBackend):
             )
 
     def _persist_changes(self) -> None:
-        try:
-            self._data_context._save_project_config()
-        except AttributeError as e:
-            logger.warning(
-                f"DataContext of type {type(self._data_context)} used with {self.__class__.__name__} is not file-system enabled: {e}"
-            )
+        self._data_context._save_project_config()
 
     @staticmethod
     def _determine_resource_type_and_name_from_key(

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -195,12 +195,7 @@ class InlineStoreBackend(StoreBackend):
             )
 
     def _persist_changes(self) -> None:
-        try:
-            self._data_context._save_project_config()
-        except AttributeError as e:
-            logger.warning(
-                f"DataContext of type {type(self._data_context)} used with {self.__class__.__name__} is not file-system enabled: {e}"
-            )
+        self._data_context._save_project_config()
 
     @staticmethod
     def _determine_resource_type_and_name_from_key(

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -103,7 +103,7 @@ class InlineStoreBackend(StoreBackend):
         else:
             project_config[resource_type] = value
 
-        self._persist_changes()
+        self._save_changes()
 
     def _move(
         self, source_key: Tuple[str, ...], dest_key: Tuple[str, ...], **kwargs: dict
@@ -165,7 +165,7 @@ class InlineStoreBackend(StoreBackend):
 
         del self._data_context.config[resource_type][resource_name]
 
-        self._persist_changes()
+        self._save_changes()
 
     def _has_key(self, key: Tuple[str, ...]) -> bool:
         (
@@ -194,7 +194,7 @@ class InlineStoreBackend(StoreBackend):
                 f"Keys in {self.__class__.__name__} must adhere to the schema defined by {DataContextVariableSchema.__name__}; invalid value ({resource_type}) of type {type(resource_type)} found"
             )
 
-    def _persist_changes(self) -> None:
+    def _save_changes(self) -> None:
         self._data_context._save_project_config()
 
     @staticmethod


### PR DESCRIPTION
Changes proposed in this pull request:
- By design, the `BaseDataContext` does not automatically persist changes made to its internal state. Once a user is happy with the changes made, an explicit, opt-in call must be made to actually save the changes to disk. While this contract was adhered to in the past, recent changes (through the introduction of the `DatasourceStore`) have violated this implicit agreement.
- The changes herein revert the behavior users have come to expect while continuing to leverage the new `DatasourceStore`.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
