### PR TITLE
[MAINTENANCE] Refactor `datasource_name` out of `DataContext.update_datasource`

### DIFF
--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1865,7 +1865,6 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
 
     def update_datasource(
         self,
-        datasource_name: str,
         datasource: Union[LegacyDatasource, BaseDatasource],
         save_changes: bool = False,
     ) -> None:
@@ -1873,12 +1872,12 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         Updates a DatasourceConfig that already exists in the store.
 
         Args:
-            datasource_name: The name of the Datasource to update.
             datasource_config: The config object to persist using the DatasourceStore.
             save_changes: Whether or not to save changes to disk.
         """
         datasource_config_dict: dict = datasourceConfigSchema.dump(datasource.config)
         datasource_config: DatasourceConfig = DatasourceConfig(**datasource_config_dict)
+        datasource_name: str = datasource.name
 
         if save_changes:
             self._datasource_store.update_by_name(

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -473,7 +473,6 @@ class DataContext(BaseDataContext):
 
     def update_datasource(
         self,
-        datasource_name: str,
         datasource: Union[LegacyDatasource, BaseDatasource],
     ) -> None:
         """
@@ -481,11 +480,10 @@ class DataContext(BaseDataContext):
         Note that this method persists changes using an underlying Store.
         """
         logger.debug(
-            f"Starting DataContext.update_datasource for datasource {datasource_name}"
+            f"Starting DataContext.update_datasource for datasource {datasource.name}"
         )
 
         super().update_datasource(
-            datasource_name=datasource_name,
             datasource=datasource,
             save_changes=True,
         )

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -448,13 +448,9 @@ def test_update_datasource_persists_changes_with_store(
 ) -> None:
     context: DataContext = data_context_parameterized_expectation_suite
 
-    datasource_name: str
-    datasource_to_update: Datasource
-    datasource_name, datasource_to_update = tuple(context.datasources.items())[0]
+    datasource_to_update: Datasource = tuple(context.datasources.values())[0]
 
-    context.update_datasource(
-        datasource_name=datasource_name, datasource=datasource_to_update
-    )
+    context.update_datasource(datasource=datasource_to_update)
 
     assert mock_update_by_name.call_count == 1
 


### PR DESCRIPTION
Changes proposed in this pull request:
- As the `Datasource` object already contains a `name` attr, the inclusion of a `datasource_name` argument is redundant.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
