### PR TITLE
[MAINTENANCE] Add checkpoint name to validation results

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -365,6 +365,7 @@ class BaseCheckpoint(ConfigPeer):
                     ),
                     result_format=result_format,
                     checkpoint_identifier=checkpoint_identifier,
+                    checkpoint_name=self.name,
                     **operator_run_kwargs,
                 )
             )

--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -352,6 +352,7 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
         statistics=None,
         meta=None,
         ge_cloud_id: Optional[UUID] = None,
+        checkpoint_name: Optional[str] = None,
     ) -> None:
         self.success = success
         if results is None:
@@ -481,6 +482,7 @@ class ExpectationSuiteValidationResultSchema(Schema):
     statistics = fields.Dict()
     meta = fields.Dict(allow_none=True)
     ge_cloud_id = fields.UUID(required=False, allow_none=True)
+    checkpoint_name = fields.String(required=False, allow_none=True)
     rendered_content = fields.List(fields.Nested(RenderedAtomicContentSchema))
 
     # noinspection PyUnusedLocal

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from collections import OrderedDict
-from typing import Union
+from typing import Optional, Union
 
 from dateutil.parser import parse
 
@@ -286,6 +286,7 @@ class ActionListValidationOperator(ValidationOperator):
         catch_exceptions=None,
         result_format=None,
         checkpoint_identifier=None,
+        checkpoint_name: Optional[str] = None,
     ) -> ValidationOperatorResult:
         assert not (run_id and run_name) and not (
             run_id and run_time
@@ -351,6 +352,9 @@ class ActionListValidationOperator(ValidationOperator):
 
                 if catch_exceptions is not None:
                     batch_validate_arguments["catch_exceptions"] = catch_exceptions
+
+                if checkpoint_name is not None:
+                    batch_validate_arguments["checkpoint_name"] = checkpoint_name
 
                 batch_and_async_result_tuples.append(
                     (

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1766,6 +1766,7 @@ set as active.
         only_return_failures: bool = False,
         run_name: Optional[str] = None,
         run_time: Optional[str] = None,
+        checkpoint_name: Optional[str] = None,
     ) -> Union[ExpectationValidationResult, ExpectationSuiteValidationResult]:
         # noinspection SpellCheckingInspection
         """Generates a JSON-formatted report describing the outcome of all expectations.
@@ -1800,6 +1801,9 @@ set as active.
                 etc.).
             only_return_failures (boolean): \
                 If True, expectation results are only returned when ``success = False`` \
+            checkpoint_name (str): \
+                Name of the Checkpoint which invoked this Validator.validate() call against an Expectation Suite. \
+                It will be added to `meta` field of the returned ExpectationSuiteValidationResult.
 
         Returns:
             A JSON-formatted dictionary containing a list of the validation results. \
@@ -2003,6 +2007,7 @@ set as active.
                     "batch_markers": self.active_batch_markers,
                     "active_batch_definition": self.active_batch_definition,
                     "validation_time": validation_time,
+                    "checkpoint_name": checkpoint_name,
                 },
             )
 

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1801,7 +1801,7 @@ set as active.
                 etc.).
             only_return_failures (boolean): \
                 If True, expectation results are only returned when ``success = False`` \
-            checkpoint_name (str): \
+            checkpoint_name (string or None): \
                 Name of the Checkpoint which invoked this Validator.validate() call against an Expectation Suite. \
                 It will be added to `meta` field of the returned ExpectationSuiteValidationResult.
 


### PR DESCRIPTION
Changes proposed in this pull request:
- When running a validation via Checkpoint, this PR proposes adding the Checkpoint name to the validation results meta field. Satisfies internal issue GREAT-913.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
