### PR TITLE
[MAINTENANCE] Remove checkpoint from top level of schema since it is captured in `meta`

### DIFF
--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -352,7 +352,6 @@ class ExpectationSuiteValidationResult(SerializableDictDot):
         statistics=None,
         meta=None,
         ge_cloud_id: Optional[UUID] = None,
-        checkpoint_name: Optional[str] = None,
     ) -> None:
         self.success = success
         if results is None:
@@ -482,7 +481,6 @@ class ExpectationSuiteValidationResultSchema(Schema):
     statistics = fields.Dict()
     meta = fields.Dict(allow_none=True)
     ge_cloud_id = fields.UUID(required=False, allow_none=True)
-    checkpoint_name = fields.String(required=False, allow_none=True)
     rendered_content = fields.List(fields.Nested(RenderedAtomicContentSchema))
 
     # noinspection PyUnusedLocal


### PR DESCRIPTION
Changes proposed in this pull request:
- Since `checkpoint_name` is contained within `meta` it is not needed as a top level key of `ExpectationSuiteValidationResultSchema`


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
