### PR TITLE
[MAINTENANCE] Provide better error messaging if batch_request is not supplied to DataAssistant.run()

### DIFF
--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -120,18 +120,28 @@ class ProfilerError(GreatExpectationsError):
 
 
 class ProfilerConfigurationError(ProfilerError):
-    """A configuration error for a profiler."""
+    """A configuration error for a "RuleBasedProfiler" class."""
 
     pass
 
 
 class ProfilerExecutionError(ProfilerError):
-    """A runtime error for a profiler."""
+    """A runtime error for a "RuleBasedProfiler" class."""
 
     pass
 
 
 class ProfilerNotFoundError(ProfilerError):
+    pass
+
+
+class DataAssistantError(ProfilerError):
+    pass
+
+
+class DataAssistantExecutionError(DataAssistantError):
+    """A runtime error for a "DataAssistant" class."""
+
     pass
 
 

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -3,6 +3,7 @@ from functools import wraps
 from inspect import Signature, signature
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
+import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import BatchRequestBase
 from great_expectations.core.config_peer import ConfigOutputModes, ConfigOutputModeType
 from great_expectations.data_context.types.base import BaseYamlConfig
@@ -191,6 +192,13 @@ class DataAssistantRunner:
         Returns:
             DataAssistantResult: The result object for the DataAssistant
         """
+        if batch_request is None:
+            data_assistant_name: str = self._data_assistant_cls.data_assistant_type
+            raise ge_exceptions.DataAssistantExecutionError(
+                message=f"""Utilizing "{data_assistant_name}.run()" requires valid "batch_request" to be \
+specified (empty or missing "batch_request" detected)."""
+            )
+
         data_assistant: DataAssistant = self._build_data_assistant(
             batch_request=batch_request
         )


### PR DESCRIPTION
### Scope
Previously, missing `batch_request` would cause `DataAssistant.run()` to simply fail with an `AttributeError`.  Now, a formal error message is provided.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1038
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
