### PR TITLE
[BUGFIX] Update renderer snapshots with `None` values removed

### DIFF
--- a/tests/expectations/snapshots/snap_test_expectation_atomic_renderers.py
+++ b/tests/expectations/snapshots/snap_test_expectation_atomic_renderers.py
@@ -1162,7 +1162,6 @@ snapshots["test_atomic_prescriptive_summary_expect_table_row_count_to_be_between
     "value": {
         "header": None,
         "params": {
-            "condition_parser": {"schema": {"type": "string"}, "value": None},
             "max_value": {"schema": {"type": "number"}, "value": None},
             "min_value": {"schema": {"type": "number"}, "value": 1},
             "strict_max": {"schema": {"type": "boolean"}, "value": None},
@@ -1178,11 +1177,7 @@ snapshots["test_atomic_prescriptive_summary_expect_table_row_count_to_equal 1"] 
     "name": "atomic.prescriptive.summary",
     "value": {
         "header": None,
-        "params": {
-            "condition_parser": {"schema": {"type": "string"}, "value": None},
-            "row_condition": {"schema": {"type": "string"}, "value": None},
-            "value": {"schema": {"type": "number"}, "value": 10},
-        },
+        "params": {"value": {"schema": {"type": "number"}, "value": 10}},
         "schema": {"type": "com.superconductive.rendered.string"},
         "template": "Must have exactly $value rows.",
     },

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -32,14 +32,6 @@ from great_expectations.validator.validator import Validator
                         "schema": {"type": "com.superconductive.rendered.string"},
                         "params": {
                             "value": {"schema": {"type": "number"}, "value": 3},
-                            "row_condition": {
-                                "schema": {"type": "string"},
-                                "value": None,
-                            },
-                            "condition_parser": {
-                                "schema": {"type": "string"},
-                                "value": None,
-                            },
                         },
                     },
                 }


### PR DESCRIPTION
### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
