### PR TITLE
[MAINTENANCE] Ensure that `parter-integration` pipeline only runs on cronjob

### DIFF
--- a/azure-pipelines-partner-integration.yml
+++ b/azure-pipelines-partner-integration.yml
@@ -8,12 +8,16 @@ schedules:
     include:
     - develop
 
+variables:
+  isScheduled: $[and(eq(variables['Build.SourceBranch'], 'refs/heads/develop'), eq(variables['Build.Reason'], 'Schedule'))]
+
 stages:
   - stage: scope_check
     pool:
       vmImage: 'ubuntu-20.04'
     jobs:
       - job: partner_integration_anthony_db
+        condition: eq(variables.isScheduled, true)
         steps:
           - bash: cd assets/partners/anthonydb; ../common/run-2.sh;
             name: RunDockerComposeUp
@@ -21,8 +25,9 @@ stages:
               DB_URL: $(ANTHONY_DB_URL)
               DB_PASS: $(ANTHONY_DB_PASS)
       - job: partner_integration_rubenshift
+        condition: eq(variables.isScheduled, true)
         steps:
-          - bash: cd assets/partners/rubenshift; ../common/run-1.sh 
+          - bash: cd assets/partners/rubenshift; ../common/run-1.sh
             name: RunDockerComposeUp
             env:
               DB_URL: $(REDSHIFT_URL)


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that pipeline only runs on cronjob and not on each commit.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
