### PR TITLE
[BUGFIX] Conditionally pop `spark.sql.warehouse.dir` from test Spark configs

### DIFF
--- a/tests/datasource/test_sparkdf_datasource.py
+++ b/tests/datasource/test_sparkdf_datasource.py
@@ -169,8 +169,15 @@ def test_spark_kwargs_are_passed_through(
         dataset_name
     ).config
 
+    actual_spark_config = datasource_config["spark_config"]
     expected_spark_config = dict(spark_session.sparkContext.getConf().getAll())
-    expected_spark_config.pop("spark.sql.warehouse.dir")
+
+    # 20220714 - Chetan `spark.sql.warehouse.dir` intermittently shows up in Spark config
+    # As the rest of the config adheres to expectations, we conditionally pop and assert
+    # against known values in the payload.
+    for config in (actual_spark_config, expected_spark_config):
+        config.pop("spark.sql.warehouse.dir", None)
+
     assert datasource_config["spark_config"] == expected_spark_config
     assert datasource_config["force_reuse_spark_context"] is False
 


### PR DESCRIPTION
Changes proposed in this pull request:
- `spark.sql.warehouse.dir` sometimes shows up in the `SparkDFDatasource` config and sometimes shows up in the call to `dict(spark_session.sparkContext.getConf().getAll())`
- This inconsistency results in non-deterministic tests; in order to unblock devs as we diagnose the issue, we conditionally pop the values from the objs.



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
