### PR TITLE
[MAINTENANCE] Clean up payload for `/data-context-variables` endpoint to adhere to desired chema

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -33,6 +33,9 @@ from great_expectations.core.usage_statistics.usage_statistics import (
 )
 from great_expectations.core.util import get_datetime_string_from_strftime_format
 from great_expectations.data_asset import DataAsset
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 from great_expectations.data_context.util import (
@@ -351,7 +354,8 @@ class BaseCheckpoint(ConfigPeer):
             checkpoint_identifier = None
             if self.data_context.ge_cloud_mode:
                 checkpoint_identifier = GeCloudIdentifier(
-                    resource_type="contract", ge_cloud_id=str(self.ge_cloud_id)
+                    resource_type=GeCloudRESTResource.CONTRACT,
+                    ge_cloud_id=str(self.ge_cloud_id),
                 )
 
             operator_run_kwargs = {}

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -14,6 +14,9 @@ from ruamel.yaml.comments import CommentedMap
 
 from great_expectations.core.config_peer import ConfigPeer
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.rule_based_profiler.config.base import (
     ruleBasedProfilerConfigSchema,
@@ -1525,9 +1528,12 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         expectation_suite: ExpectationSuite = ExpectationSuite(
             expectation_suite_name=expectation_suite_name, data_context=self
         )
+
+        key: Union[GeCloudIdentifier, ExpectationSuiteIdentifier]
         if self.ge_cloud_mode:
-            key: GeCloudIdentifier = GeCloudIdentifier(
-                resource_type="expectation_suite", ge_cloud_id=ge_cloud_id
+            key = GeCloudIdentifier(
+                resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+                ge_cloud_id=ge_cloud_id,
             )
             if self.expectations_store.has_key(key) and not overwrite_existing:
                 raise ge_exceptions.DataContextError(
@@ -1537,7 +1543,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
                     )
                 )
         else:
-            key: ExpectationSuiteIdentifier = ExpectationSuiteIdentifier(
+            key = ExpectationSuiteIdentifier(
                 expectation_suite_name=expectation_suite_name
             )
             if self.expectations_store.has_key(key) and not overwrite_existing:
@@ -1564,14 +1570,14 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         Returns:
             True for Success and False for Failure.
         """
+        key: Union[GeCloudIdentifier, ExpectationSuiteIdentifier]
         if self.ge_cloud_mode:
-            key: GeCloudIdentifier = GeCloudIdentifier(
-                resource_type="expectation_suite", ge_cloud_id=ge_cloud_id
+            key = GeCloudIdentifier(
+                resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+                ge_cloud_id=ge_cloud_id,
             )
         else:
-            key: ExpectationSuiteIdentifier = ExpectationSuiteIdentifier(
-                expectation_suite_name
-            )
+            key = ExpectationSuiteIdentifier(expectation_suite_name)
         if not self.expectations_store.has_key(key):
             raise ge_exceptions.DataContextError(
                 "expectation_suite with name {} does not exist."
@@ -1593,12 +1599,14 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         Returns:
             expectation_suite
         """
+        key: Union[GeCloudIdentifier, ExpectationSuiteIdentifier]
         if self.ge_cloud_mode:
-            key: GeCloudIdentifier = GeCloudIdentifier(
-                resource_type="expectation_suite", ge_cloud_id=ge_cloud_id
+            key = GeCloudIdentifier(
+                resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+                ge_cloud_id=ge_cloud_id,
             )
         else:
-            key: Optional[ExpectationSuiteIdentifier] = ExpectationSuiteIdentifier(
+            key = ExpectationSuiteIdentifier(
                 expectation_suite_name=expectation_suite_name
             )
 
@@ -2443,7 +2451,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         rules: Dict[str, dict],
         variables: Optional[dict] = None,
         ge_cloud_id: Optional[str] = None,
-    ):
+    ) -> RuleBasedProfiler:
         config_data = {
             "name": name,
             "config_version": config_version,

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -9,6 +9,9 @@ from great_expectations.data_context.data_context.abstract_data_context import (
 from great_expectations.data_context.data_context_variables import (
     CloudDataContextVariables,
 )
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.types.base import (
     DEFAULT_USAGE_STATISTICS_URL,
     DataContextConfig,
@@ -155,7 +158,7 @@ class CloudDataContext(AbstractDataContext):
             None
         """
         key: GeCloudIdentifier = GeCloudIdentifier(
-            resource_type="expectation_suite",
+            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=ge_cloud_id
             if ge_cloud_id is not None
             else str(expectation_suite.ge_cloud_id),

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -341,11 +341,14 @@ class CloudDataContextVariables(DataContextVariables):
         from great_expectations.data_context.store.data_context_store import (
             DataContextStore,
         )
+        from great_expectations.data_context.store.ge_cloud_store_backend import (
+            GeCloudRESTResource,
+        )
 
         store_backend: dict = {
             "class_name": "GeCloudStoreBackend",
             "ge_cloud_base_url": self.ge_cloud_base_url,
-            "ge_cloud_resource_type": "data_context_variables",
+            "ge_cloud_resource_type": GeCloudRESTResource.DATA_CONTEXT_VARIABLES,
             "ge_cloud_credentials": {
                 "access_token": self.ge_cloud_access_token,
                 "organization_id": self.ge_cloud_organization_id,
@@ -363,7 +366,11 @@ class CloudDataContextVariables(DataContextVariables):
         """
         Generates a GE Cloud-specific key for use with Stores. See parent "DataContextVariables.get_key" for more details.
         """
+        from great_expectations.data_context.store.ge_cloud_store_backend import (
+            GeCloudRESTResource,
+        )
+
         key: GeCloudIdentifier = GeCloudIdentifier(
-            resource_type=DataContextVariableSchema.ALL_VARIABLES
+            resource_type=GeCloudRESTResource.DATA_CONTEXT_VARIABLES
         )
         return key

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -7,6 +7,9 @@ from typing import Dict, List, Optional, Union
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.data_context.store import ConfigurationStore
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
     DataContextConfigDefaults,
@@ -50,7 +53,8 @@ class CheckpointStore(ConfigurationStore):
         )
         if self.ge_cloud_mode:
             test_key: GeCloudIdentifier = self.key_class(
-                resource_type="contract", ge_cloud_id=str(uuid.uuid4())
+                resource_type=GeCloudRESTResource.CONTRACT,
+                ge_cloud_id=str(uuid.uuid4()),
             )
         else:
             test_key: ConfigurationIdentifier = self.key_class(

--- a/great_expectations/data_context/store/configuration_store.py
+++ b/great_expectations/data_context/store/configuration_store.py
@@ -5,6 +5,9 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
 import great_expectations.exceptions as ge_exceptions
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.base import BaseYamlConfig
@@ -161,7 +164,9 @@ class ConfigurationStore(Store):
 
         key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if ge_cloud_id:
-            key = GeCloudIdentifier(resource_type="contract", ge_cloud_id=ge_cloud_id)
+            key = GeCloudIdentifier(
+                resource_type=GeCloudRESTResource.CONTRACT, ge_cloud_id=ge_cloud_id
+            )
         else:
             key = ConfigurationIdentifier(configuration_key=name)
 

--- a/great_expectations/data_context/store/data_context_store.py
+++ b/great_expectations/data_context/store/data_context_store.py
@@ -1,13 +1,10 @@
-from typing import Tuple, Union
+from typing import Set, Tuple, Union
 
 from great_expectations.data_context.data_context_variables import (
     DataContextVariableSchema,
 )
 from great_expectations.data_context.store.configuration_store import ConfigurationStore
-from great_expectations.data_context.types.base import (
-    DataContextConfig,
-    DataContextConfigSchema,
-)
+from great_expectations.data_context.types.base import DataContextConfig
 
 
 class DataContextStore(ConfigurationStore):
@@ -17,23 +14,20 @@ class DataContextStore(ConfigurationStore):
 
     _configuration_class = DataContextConfig
 
+    ge_cloud_exclude_field_names: Set[str] = {
+        DataContextVariableSchema.DATASOURCES,
+        DataContextVariableSchema.ANONYMOUS_USAGE_STATISTICS,
+    }
+
     def serialize(
         self, key: Tuple[str, ...], value: DataContextConfig
     ) -> Union[dict, str]:
+        payload: Union[str, dict] = super().serialize(key=key, value=value)
+
+        # Cloud requires a subset of the DataContextConfig
         if self.ge_cloud_mode:
-            return self._serialize_variables(key=key, value=value)
-        return value.to_yaml_str()
-
-    def _serialize_variables(
-        self, key: Tuple[str, ...], value: DataContextConfig
-    ) -> dict:
-        config_schema: DataContextConfigSchema = value.get_schema_class()()
-        payload: dict = config_schema.dump(value)
-
-        for attr in (
-            DataContextVariableSchema.DATASOURCES,
-            DataContextVariableSchema.ANONYMOUS_USAGE_STATISTICS,
-        ):
-            payload.pop(attr)
+            assert isinstance(payload, dict)
+            for attr in self.ge_cloud_exclude_field_names:
+                payload.pop(attr)
 
         return payload

--- a/great_expectations/data_context/store/data_context_store.py
+++ b/great_expectations/data_context/store/data_context_store.py
@@ -1,5 +1,13 @@
+from typing import Tuple, Union
+
+from great_expectations.data_context.data_context_variables import (
+    DataContextVariableSchema,
+)
 from great_expectations.data_context.store.configuration_store import ConfigurationStore
-from great_expectations.data_context.types.base import DataContextConfig
+from great_expectations.data_context.types.base import (
+    DataContextConfig,
+    DataContextConfigSchema,
+)
 
 
 class DataContextStore(ConfigurationStore):
@@ -8,3 +16,24 @@ class DataContextStore(ConfigurationStore):
     """
 
     _configuration_class = DataContextConfig
+
+    def serialize(
+        self, key: Tuple[str, ...], value: DataContextConfig
+    ) -> Union[dict, str]:
+        if self.ge_cloud_mode:
+            return self._serialize_variables(key=key, value=value)
+        return value.to_yaml_str()
+
+    def _serialize_variables(
+        self, key: Tuple[str, ...], value: DataContextConfig
+    ) -> dict:
+        config_schema: DataContextConfigSchema = value.get_schema_class()()
+        payload: dict = config_schema.dump(value)
+
+        for attr in (
+            DataContextVariableSchema.DATASOURCES,
+            DataContextVariableSchema.ANONYMOUS_USAGE_STATISTICS,
+        ):
+            payload.pop(attr)
+
+        return payload

--- a/great_expectations/data_context/store/data_context_store.py
+++ b/great_expectations/data_context/store/data_context_store.py
@@ -22,6 +22,19 @@ class DataContextStore(ConfigurationStore):
     def serialize(
         self, key: Tuple[str, ...], value: DataContextConfig
     ) -> Union[dict, str]:
+        """
+        Please see `ConfigurationStore.serialize` for more information.
+
+        Note that GE Cloud utilizes a subset of the config; as such, an explicit
+        step to remove unnecessary keys is a required part of the serialization process.
+
+        Args:
+            key:
+            value: DataContextConfig to serialize utilizing the configured StoreBackend.
+
+        Returns:
+            Either a string or dictionary representation of the serialized config.
+        """
         payload: Union[str, dict] = super().serialize(key=key, value=value)
 
         # Cloud requires a subset of the DataContextConfig

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -7,6 +7,9 @@ from great_expectations.core.expectation_suite import ExpectationSuiteSchema
 from great_expectations.data_context.store.database_store_backend import (
     DatabaseStoreBackend,
 )
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.resource_identifiers import (
@@ -215,7 +218,8 @@ class ExpectationsStore(Store):
         )
         if self.ge_cloud_mode:
             test_key: GeCloudIdentifier = self.key_class(
-                resource_type="contract", ge_cloud_id=str(uuid.uuid4())
+                resource_type=GeCloudRESTResource.CONTRACT,
+                ge_cloud_id=str(uuid.uuid4()),
             )
         else:
             test_key: ExpectationSuiteIdentifier = self.key_class(test_key_name)

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -73,7 +73,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         self,
         ge_cloud_credentials: Dict,
         ge_cloud_base_url: str = "https://app.greatexpectations.io/",
-        ge_cloud_resource_type: Optional[str] = None,
+        ge_cloud_resource_type: Optional[GeCloudRESTResource] = None,
         ge_cloud_resource_name: Optional[str] = None,
         suppress_store_backend_id: bool = True,
         manually_initialize_store_backend_id: str = "",
@@ -159,14 +159,16 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
         data = {
             "data": {
-                "type": resource_type,
-                "id": ge_cloud_id,
+                "type": resource_type.value,
                 "attributes": {
                     attributes_key: value,
                     "organization_id": organization_id,
                 },
             }
         }
+
+        if ge_cloud_id:
+            data["data"]["id"] = ge_cloud_id
 
         url = urljoin(
             self.ge_cloud_base_url,
@@ -268,7 +270,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         return self._ge_cloud_resource_name
 
     @property
-    def ge_cloud_resource_type(self) -> str:
+    def ge_cloud_resource_type(self) -> GeCloudRESTResource:
         return self._ge_cloud_resource_type
 
     @property

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -9,6 +9,9 @@ from great_expectations.core.expectation_validation_result import (
 from great_expectations.data_context.store.database_store_backend import (
     DatabaseStoreBackend,
 )
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.resource_identifiers import (
@@ -203,7 +206,8 @@ class ValidationsStore(Store):
 
         if self.ge_cloud_mode:
             test_key: GeCloudIdentifier = self.key_class(
-                resource_type="contract", ge_cloud_id=str(uuid.uuid4())
+                resource_type=GeCloudRESTResource.CONTRACT,
+                ge_cloud_id=str(uuid.uuid4()),
             )
 
         else:

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 from uuid import UUID
 
 from dateutil.parser import parse
@@ -10,6 +10,11 @@ from great_expectations.core.id_dict import BatchKwargs, IDDict
 from great_expectations.core.run_identifier import RunIdentifier, RunIdentifierSchema
 from great_expectations.exceptions import DataContextError, InvalidDataContextKeyError
 from great_expectations.marshmallow__shade import Schema, fields, post_load
+
+if TYPE_CHECKING:
+    from great_expectations.data_context.store.ge_cloud_store_backend import (
+        GeCloudRESTResource,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +201,9 @@ class ValidationResultIdentifier(DataContextKey):
 
 
 class GeCloudIdentifier(DataContextKey):
-    def __init__(self, resource_type: str, ge_cloud_id: Optional[str] = None) -> None:
+    def __init__(
+        self, resource_type: "GeCloudRESTResource", ge_cloud_id: Optional[str] = None
+    ) -> None:
         super().__init__()
 
         self._resource_type = resource_type

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -7,6 +7,9 @@ from typing import Any, List, Optional, Tuple
 import great_expectations.exceptions as exceptions
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.util import nested_update
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.store.html_site_store import (
     HtmlSiteStore,
     SiteSectionIdentifier,
@@ -463,7 +466,7 @@ class DefaultSiteSectionBuilder:
                 if self.ge_cloud_mode:
                     self.target_store.set(
                         GeCloudIdentifier(
-                            resource_type="rendered_data_doc",
+                            resource_type=GeCloudRESTResource.RENDERED_DATA_DOC
                         ),
                         rendered_content,
                         source_type=resource_key.resource_type,

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -12,6 +12,9 @@ from great_expectations.core.batch import Batch
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import parse_result_format
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     GeCloudIdentifier,
@@ -370,11 +373,11 @@ class ActionListValidationOperator(ValidationOperator):
             for batch, async_batch_validation_result in batch_and_async_result_tuples:
                 if self.data_context.ge_cloud_mode:
                     expectation_suite_identifier = GeCloudIdentifier(
-                        resource_type="expectation_suite",
+                        resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
                         ge_cloud_id=batch._expectation_suite.ge_cloud_id,
                     )
                     validation_result_id = GeCloudIdentifier(
-                        resource_type="suite_validation_result"
+                        resource_type=GeCloudRESTResource.SUITE_VALIDATION_RESULT
                     )
                 else:
                     expectation_suite_identifier = ExpectationSuiteIdentifier(

--- a/scripts/check_type_hint_coverage.py
+++ b/scripts/check_type_hint_coverage.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 TYPE_HINT_ERROR_THRESHOLD: int = (
-    2490  # This number is to be reduced as we annotate more functions!
+    2488  # This number is to be reduced as we annotate more functions!
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -7,6 +7,9 @@ from moto import mock_sns
 
 from great_expectations.core import ExpectationSuiteValidationResult, RunIdentifier
 from great_expectations.data_context import BaseDataContext
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.types.resource_identifiers import (
     BatchIdentifier,
@@ -114,7 +117,8 @@ def validation_result_suite():
 @pytest.fixture(scope="module")
 def validation_result_suite_ge_cloud_identifier(validation_result_suite_ge_cloud_id):
     return GeCloudIdentifier(
-        resource_type="contract", ge_cloud_id=validation_result_suite_ge_cloud_id
+        resource_type=GeCloudRESTResource.CONTRACT,
+        ge_cloud_id=validation_result_suite_ge_cloud_id,
     )
 
 

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -10,6 +10,9 @@ from great_expectations.data_context.data_context_variables import (
     DataContextVariableSchema,
 )
 from great_expectations.data_context.store.datasource_store import DatasourceStore
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.types.base import DatasourceConfig
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 
@@ -110,7 +113,7 @@ def test_datasource_store_retrieval_cloud_mode(
     ge_cloud_store_backend_config: dict = {
         "class_name": "GeCloudStoreBackend",
         "ge_cloud_base_url": ge_cloud_base_url,
-        "ge_cloud_resource_type": "datasource",
+        "ge_cloud_resource_type": GeCloudRESTResource.DATASOURCE,
         "ge_cloud_credentials": {
             "access_token": ge_cloud_access_token,
             "organization_id": ge_cloud_organization_id,
@@ -124,7 +127,7 @@ def test_datasource_store_retrieval_cloud_mode(
     )
 
     key: GeCloudIdentifier = GeCloudIdentifier(
-        resource_type="datasource", ge_cloud_id="foobarbaz"
+        resource_type=GeCloudRESTResource.DATASOURCE, ge_cloud_id="foobarbaz"
     )
 
     with patch("requests.patch", autospec=True) as mock_patch:

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -28,6 +28,9 @@ from great_expectations.data_context.store import (
     TupleGCSStoreBackend,
     TupleS3StoreBackend,
 )
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.store.inline_store_backend import (
     InlineStoreBackend,
 )
@@ -1333,7 +1336,7 @@ def test_GeCloudStoreBackend():
         "access_token": "1234",
         "organization_id": "51379b8b-86d3-4fe7-84e9-e1a52f4a414c",
     }
-    ge_cloud_resource_type = "contract"
+    ge_cloud_resource_type = GeCloudRESTResource.CONTRACT
     my_simple_checkpoint_config: CheckpointConfig = CheckpointConfig(
         name="my_minimal_simple_checkpoint",
         class_name="SimpleCheckpoint",
@@ -1464,7 +1467,7 @@ def test_GeCloudStoreBackend():
         my_store_backend = GeCloudStoreBackend(
             ge_cloud_base_url=ge_cloud_base_url,
             ge_cloud_credentials=ge_cloud_credentials,
-            ge_cloud_resource_type="rendered_data_doc",
+            ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
         )
         my_store_backend.set(("rendered_data_doc", ""), OrderedDict())
         mock_post.assert_called_with(
@@ -1489,7 +1492,7 @@ def test_GeCloudStoreBackend():
             my_store_backend = GeCloudStoreBackend(
                 ge_cloud_base_url=ge_cloud_base_url,
                 ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type="rendered_data_doc",
+                ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
             )
             my_store_backend.get(
                 (
@@ -1511,7 +1514,7 @@ def test_GeCloudStoreBackend():
             my_store_backend = GeCloudStoreBackend(
                 ge_cloud_base_url=ge_cloud_base_url,
                 ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type="rendered_data_doc",
+                ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
             )
             my_store_backend.list_keys()
             mock_get.assert_called_with(
@@ -1530,7 +1533,7 @@ def test_GeCloudStoreBackend():
             my_store_backend = GeCloudStoreBackend(
                 ge_cloud_base_url=ge_cloud_base_url,
                 ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type="rendered_data_doc",
+                ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
             )
             my_store_backend.remove_key(
                 (

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -352,6 +352,7 @@ def test_data_context_variables_set(
 
 
 def test_data_context_variables_save_config(
+    data_context_config_dict: dict,
     ephemeral_data_context_variables: EphemeralDataContextVariables,
     file_data_context_variables: FileDataContextVariables,
     cloud_data_context_variables: CloudDataContextVariables,
@@ -387,13 +388,25 @@ def test_data_context_variables_save_config(
 
         cloud_data_context_variables.save_config()
 
-        expected_config_dict: dict = cast(
-            dict, dataContextConfigSchema.dump(cloud_data_context_variables.config)
-        )
+        expected_config_dict: dict = {}
+        for attr in (
+            "checkpoint_store_name",
+            "config_variables_file_path",
+            "config_version",
+            "data_docs_sites",
+            "evaluation_parameter_store_name",
+            "expectations_store_name",
+            "notebooks",
+            "plugins_directory",
+            "profiler_store_name",
+            "stores",
+            "validations_store_name",
+        ):
+            expected_config_dict[attr] = data_context_config_dict[attr]
 
         assert mock_patch.call_count == 1
         mock_patch.assert_called_with(
-            f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/data-context-variables",
+            f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/data-context-variables/",
             json={
                 "data": {
                     "type": "data_context_variables",

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -382,15 +382,17 @@ def test_data_context_variables_save_config(
         assert mock_save.call_count == 1
 
     # CloudDataContextVariables
-    with mock.patch("requests.post", autospec=True) as mock_post:
+    with mock.patch("requests.patch", autospec=True) as mock_patch:
+        type(mock_patch.return_value).status_code = mock.PropertyMock(return_value=200)
+
         cloud_data_context_variables.save_config()
 
         expected_config_dict: dict = cast(
             dict, dataContextConfigSchema.dump(cloud_data_context_variables.config)
         )
 
-        assert mock_post.call_count == 1
-        mock_post.assert_called_with(
+        assert mock_patch.call_count == 1
+        mock_patch.assert_called_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/data-context-variables",
             json={
                 "data": {


### PR DESCRIPTION
Changes proposed in this pull request:
- Payload is now a subset of the entire `DataContextConfig` (important since we want to omit datasources and usage stats).
- Refactored magic strings to utilize new enum.

Sample payload:
```python
# Endpoint
"https://app.test.greatexpectations.io/organizations/bd20fead-2c31-4392-bcd1-f1e87ad5a79c/data-context-variables/"

# Payload
{
    "data": {
        "type": "data_context_variables",
        "attributes": {
            "data_context_variables": {
                "config_version": 3.0,
                "stores": {
                    "expectations_store": {
                        "class_name": "ExpectationsStore",
                        "store_backend": {
                            "class_name": "TupleFilesystemStoreBackend",
                            "base_directory": "expectations/",
                        },
                    },
                    "evaluation_parameter_store": {
                        "module_name": "great_expectations.data_context.store",
                        "class_name": "EvaluationParameterStore",
                    },
                },
                "expectations_store_name": "expectations_store",
                "checkpoint_store_name": "checkpoint_store",
                "plugins_directory": "plugins/",
                "data_docs_sites": {},
                "notebooks": None,
                "evaluation_parameter_store_name": "evaluation_parameter_store",
                "config_variables_file_path": "uncommitted/config_variables.yml",
                "profiler_store_name": "profiler_store",
                "validations_store_name": "validations_store",
            },
            "organization_id": "bd20fead-2c31-4392-bcd1-f1e87ad5a79c",
        },
    }
}

# Headers
{
    "Content-Type": "application/vnd.api+json",
    "Authorization": "Bearer 6bb5b6f5c7794892a4ca168c65c2603e",
}
```

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
