### PR TITLE
[MAINTENANCE] Add end-to-end tests for multicolumn map expectations

### DIFF
--- a/tests/test_definitions/multicolumn_map_expectations/expect_multicolumn_sum_to_equal.json
+++ b/tests/test_definitions/multicolumn_map_expectations/expect_multicolumn_sum_to_equal.json
@@ -1,6 +1,78 @@
 {
   "expectation_type" : "expect_multicolumn_sum_to_equal",
   "datasets" : [{
+    "data": {
+        "a": [1,2,3,4],
+        "b": [3,2,1,0],
+        "c": [3,2,1,1]
+      },
+      "tests": [{
+          "title": "mostly_default_successful_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "b"],
+            "sum_total": 4
+          },
+          "out": {
+              "unexpected_list": [],
+              "unexpected_index_list": [],
+              "success": true
+          }
+        }, {
+          "title": "mostly_default_fails_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"],
+            "sum_total": 4
+          },
+          "out": {
+            "unexpected_list": [ {"a": 4.0, "c": 1.0 } ],
+            "success": false
+          }
+        }, {
+          "title": "mostly_set_successful_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"],
+            "sum_total": 4,
+            "mostly": 0.7
+          },
+          "out": {
+            "unexpected_list": [ {"a": 4.0, "c": 1.0 } ],
+            "success": true
+          }
+        }, {
+          "title": "mostly_set_fails_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"],
+            "sum_total": 4,
+            "mostly": 0.8
+          },
+          "out": {
+            "unexpected_list": [ {"a": 4.0, "c": 1.0 } ],
+            "success": false
+          }
+        }, {
+          "title": "mostly_set_incorrectly",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"],
+            "sum_total": 4,
+            "mostly": "One",
+            "catch_exceptions": true
+          },
+          "out": {
+            "traceback_substring": "must be an integer or float"
+          }
+        }
+      ]
+    }, {
     "data" : {
       "w": [0.2, 0.4, 0.3, 0.5, 0.8, 0.7, 0.71, 0.56, 0.45, 1.0],
       "x": [0.8, 0.6, 0.7, 0.5, 0.2, 0.3, 0.29, 0.44, 0.55, 0.0],

--- a/tests/test_definitions/multicolumn_map_expectations/expect_select_column_values_to_be_unique_within_record.json
+++ b/tests/test_definitions/multicolumn_map_expectations/expect_select_column_values_to_be_unique_within_record.json
@@ -1,6 +1,80 @@
 {
   "expectation_type" : "expect_select_column_values_to_be_unique_within_record",
   "datasets" : [{
+    "data": {
+        "a": [1,2,3,4],
+        "b": [5,6,7,8],
+        "c": [1,4,2,3]
+      },
+    "schemas": {
+      "spark": {
+        "a": "IntegerType",
+        "b": "IntegerType",
+        "c": "IntegerType"
+      }
+    },
+      "tests": [{
+          "title": "mostly_default_successful_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "b"]
+          },
+          "out": {
+              "unexpected_list": [],
+              "unexpected_index_list": [],
+              "success": true
+          }
+        }, {
+          "title": "mostly_default_fails_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"]
+          },
+          "out": {
+            "unexpected_list": [ {"a": 1.0, "c": 1.0 } ],
+            "success": false
+          }
+        }, {
+          "title": "mostly_set_successful_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"],
+            "mostly": 0.7
+          },
+          "out": {
+            "unexpected_list": [ {"a": 1.0, "c": 1.0 } ],
+            "success": true
+          }
+        }, {
+          "title": "mostly_set_fails_expectation",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"],
+            "mostly": 0.8
+          },
+          "out": {
+            "unexpected_list": [ {"a": 1.0, "c": 1.0 } ],
+            "success": false
+          }
+        }, {
+          "title": "mostly_set_incorrectly",
+          "include_in_gallery": true,
+          "exact_match_out" : false,
+          "in": {
+            "column_list": ["a", "c"],
+            "mostly": -0.3,
+            "catch_exceptions": true
+          },
+          "out": {
+            "traceback_substring": "must be between 0 and 1"
+          }
+        }
+      ]
+    }, {
     "data" : {
       "w" : [2, 3, 4, 5, 6, 7, 8, 9, 10, null],
       "x" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -265,6 +265,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.order(index=1)
+@pytest.mark.integration
 def test_case_runner(test_case):
     if test_case["skip"]:
         pytest.skip()

--- a/tests/test_definitions/test_expectations_cfe.py
+++ b/tests/test_definitions/test_expectations_cfe.py
@@ -347,6 +347,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.order(index=0)
+@pytest.mark.integration
 def test_case_runner_cfe(test_case):
     if test_case["skip"]:
         pytest.skip()


### PR DESCRIPTION
For:
https://github.com/great-expectations/great_expectations/issues/5388
https://superconductive.atlassian.net/browse/DEVREL-2374

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
