### PR TITLE
[MAINTENANCE] enforce pre-commit in ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
+      - id: check-json
       - id: check-yaml
         exclude: docs/.*|tests/data_context/fixtures/bad_yml/great_expectations\.yml
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
+      - id: check-ast
       - id: check-json
       - id: check-yaml
         exclude: docs/.*|tests/data_context/fixtures/bad_yml/great_expectations\.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,5 +42,8 @@ ci:
     autoupdate_branch: 'develop'
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: monthly
+    # skip flake8 enforcement with pre-commit CI as it is enforced elsewhere
+    # flake8 hook also doesn't have an options to auto-fix
+    # pre-commit hooks should either have mechanisms for auto-fixing or should be simple to do manually
     skip: [flake8]
     submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,15 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
+# https://pre-commit.ci/
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: false
+    autoupdate_branch: 'develop'
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: monthly
+    skip: [flake8]
+    submodules: false

--- a/docs/contributing/style_guides/code_style.md
+++ b/docs/contributing/style_guides/code_style.md
@@ -29,7 +29,7 @@ $ invoke --list                                                                 
 Available tasks:
 
   fmt             Run code formatter.
-  hooks           Run all pre-commit hooks.
+  hooks           Run and manage pre-commit hooks.
   lint            Run code linter
   sort            Sort module imports.
   type-coverage   Check total type-hint coverage compared to `develop`.

--- a/tasks.py
+++ b/tasks.py
@@ -75,10 +75,11 @@ def upgrade(ctx, path="."):
     help={
         "all_files": "Run hooks against all files, not just the current changes.",
         "diff": "Show the diff of changes on hook failure.",
+        "sync": "Re-install the latest git hooks.",
     }
 )
-def hooks(ctx, all_files=False, diff=False):
-    """Run all pre-commit hooks."""
+def hooks(ctx, all_files=False, diff=False, sync=False):
+    """Run and manage pre-commit hooks."""
     cmds = ["pre-commit", "run"]
     if diff:
         cmds.append("--show-diff-on-failure")
@@ -89,6 +90,11 @@ def hooks(ctx, all_files=False, diff=False):
         cmds.extend(["--from-ref", "origin/HEAD", "--to-ref", "HEAD"])
 
     ctx.run(" ".join(cmds))
+
+    if sync:
+        print("  Re-installing hooks ...")
+        ctx.run(" ".join(["pre-commit", "uninstall"]), echo=True)
+        ctx.run(" ".join(["pre-commit", "install"]), echo=True)
 
 
 @invoke.task


### PR DESCRIPTION
Changes proposed in this pull request:

Enforce our pre-commit hooks with a CI check.
Either in Azure or using the [pre-commit-ci](https://pre-commit.ci/)

### Definition of Done
Please delete options that are not relevant.

- ~My code follows the Great Expectations [style guide]~(https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation - waiting on #5506 for this change
- ~I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.~
- ~I have run any local integration tests and made sure that nothing is broken.~


Thank you for submitting!
