### PR TITLE
[FEATURE] Show grouped sorted expectations by Domain and by expectation_type

### DIFF
--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -12,6 +12,7 @@ from great_expectations.core.evaluation_parameters import (
     build_evaluation_parameters,
     find_evaluation_parameter_dependencies,
 )
+from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.urn import ge_urn
 from great_expectations.core.util import (
     convert_to_json_serializable,
@@ -1401,6 +1402,22 @@ class ExpectationConfiguration(SerializableDictDot):
             runtime_configuration=runtime_configuration,
             execution_engine=execution_engine,
         )
+
+    def get_domain_type(self) -> Optional[MetricDomainTypes]:
+        """Return "domain_type" of this expectation."""
+        if self.expectation_type.startswith("expect_table_"):
+            return MetricDomainTypes.TABLE
+
+        if "column" in self.kwargs:
+            return MetricDomainTypes.COLUMN
+
+        if "column_A" in self.kwargs and "column_B" in self.kwargs:
+            return MetricDomainTypes.COLUMN_PAIR
+
+        if "column_list" in self.kwargs:
+            return MetricDomainTypes.MULTICOLUMN
+
+        return None
 
 
 class ExpectationConfigurationSchema(Schema):

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -34,10 +34,6 @@ from dateutil.parser import parse
 from packaging import version
 from pkg_resources import Distribution
 
-from great_expectations.core.expectation_suite import (
-    ExpectationSuite,
-    expectationSuiteSchema,
-)
 from great_expectations.exceptions import (
     PluginClassNotFoundError,
     PluginModuleNotFoundError,
@@ -886,6 +882,11 @@ def validate(
             expectation_suite_name=expectation_suite_name
         )
     else:
+        from great_expectations.core.expectation_suite import (
+            ExpectationSuite,
+            expectationSuiteSchema,
+        )
+
         if isinstance(expectation_suite, dict):
             expectation_suite_dict: dict = expectationSuiteSchema.load(
                 expectation_suite
@@ -1070,7 +1071,7 @@ def filter_properties_dict(
         delete_fields: list of keys that must be deleted, with the understanding that all other entries will be retained
         clean_nulls: If True, then in addition to other filtering directives, delete entries, whose values are None
         clean_falsy: If True, then in addition to other filtering directives, delete entries, whose values are Falsy
-        (If the "clean_falsy" argument is specified at "True", then "clean_nulls" is assumed to be "True" as well.)
+        (If the "clean_falsy" argument is specified as "True", then "clean_nulls" is assumed to be "True" as well.)
         inplace: If True, then modify the source properties dictionary; otherwise, make a copy for filtering purposes
         keep_falsy_numerics: If True, then in addition to other filtering directives, do not delete zero-valued numerics
 


### PR DESCRIPTION
### Scope
* Provide "pretty print" approach to displaying `ExpectationConfiguration` objects grouped either by `Domain` or by `expectation_type` for a more friendly user experience when printing `ExpectationSuite` (especially when it contains a large number of `ExpectationConfiguration` objects, such as what happens as one of the benefits when the `OnboardingDataAssistant` generates the `ExpectationSuite`).
* Use `import` statements judiciously in `great_expectations/util.py` to reduce amount of "circular imports" incidents.
* Minor cleanup.

### Remark
This was tested in the `Jupyter` notebook.  Upon further User-Acceptance Testing, additional visualization enhancements can be readily incorporated by modifying the two "ExpectationSuite.show_*()" methods.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1080
- JIRA GREAT-761/GREAT-1081
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
