### PR TITLE
[MAINTENANCE] Providing more robust error handling for determining `domain_type` of an `ExpectationConfiguration` object

### DIFF
--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1403,7 +1403,7 @@ class ExpectationConfiguration(SerializableDictDot):
             execution_engine=execution_engine,
         )
 
-    def get_domain_type(self) -> Optional[MetricDomainTypes]:
+    def get_domain_type(self) -> MetricDomainTypes:
         """Return "domain_type" of this expectation."""
         if self.expectation_type.startswith("expect_table_"):
             return MetricDomainTypes.TABLE
@@ -1417,7 +1417,9 @@ class ExpectationConfiguration(SerializableDictDot):
         if "column_list" in self.kwargs:
             return MetricDomainTypes.MULTICOLUMN
 
-        return None
+        raise ValueError(
+            'Unable to determine "domain_type" of this "ExpectationConfiguration" object from "kwargs" and heuristics.'
+        )
 
 
 class ExpectationConfigurationSchema(Schema):

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1346,6 +1346,7 @@ class AbstractDataContext(ABC):
                     "manually_initialize_store_backend_id": self.variables.anonymous_usage_statistics.data_context_id
                 }
             )
+
         # Set suppress_store_backend_id = True if store is inactive and has a store_backend.
         if (
             store_name not in [store["name"] for store in self.list_active_stores()]


### PR DESCRIPTION
### Scope
* Provide a more robust error handling for determining `domain_type` of an `ExpectationConfiguration` object.
* Minor cleanup.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1080
- JIRA GREAT-761/GREAT-1081
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
