### PR TITLE
[MAINTENANCE] Remove extra indentation from store backend test

### DIFF
--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1397,76 +1397,76 @@ def test_GeCloudStoreBackend():
             },
         )
 
-        # test .get
-        with patch("requests.get", autospec=True) as mock_get:
-            my_store_backend = GeCloudStoreBackend(
-                ge_cloud_base_url=ge_cloud_base_url,
-                ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type=ge_cloud_resource_type,
+    # test .get
+    with patch("requests.get", autospec=True) as mock_get:
+        my_store_backend = GeCloudStoreBackend(
+            ge_cloud_base_url=ge_cloud_base_url,
+            ge_cloud_credentials=ge_cloud_credentials,
+            ge_cloud_resource_type=ge_cloud_resource_type,
+        )
+        my_store_backend.get(
+            (
+                "contract",
+                "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
             )
-            my_store_backend.get(
-                (
-                    "contract",
-                    "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
-                )
-            )
-            mock_get.assert_called_with(
-                "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/contracts/0ccac18e-7631"
-                "-4bdd-8a42-3c35cce574c6",
-                headers={
-                    "Content-Type": "application/vnd.api+json",
-                    "Authorization": "Bearer 1234",
-                },
-            )
+        )
+        mock_get.assert_called_with(
+            "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/contracts/0ccac18e-7631"
+            "-4bdd-8a42-3c35cce574c6",
+            headers={
+                "Content-Type": "application/vnd.api+json",
+                "Authorization": "Bearer 1234",
+            },
+        )
 
-        # test .list_keys
-        with patch("requests.get", autospec=True) as mock_get:
-            my_store_backend = GeCloudStoreBackend(
-                ge_cloud_base_url=ge_cloud_base_url,
-                ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type=ge_cloud_resource_type,
-            )
-            my_store_backend.list_keys()
-            mock_get.assert_called_with(
-                "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/contracts",
-                headers={
-                    "Content-Type": "application/vnd.api+json",
-                    "Authorization": "Bearer 1234",
-                },
-            )
+    # test .list_keys
+    with patch("requests.get", autospec=True) as mock_get:
+        my_store_backend = GeCloudStoreBackend(
+            ge_cloud_base_url=ge_cloud_base_url,
+            ge_cloud_credentials=ge_cloud_credentials,
+            ge_cloud_resource_type=ge_cloud_resource_type,
+        )
+        my_store_backend.list_keys()
+        mock_get.assert_called_with(
+            "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/contracts",
+            headers={
+                "Content-Type": "application/vnd.api+json",
+                "Authorization": "Bearer 1234",
+            },
+        )
 
-        # test .remove_key
-        with patch("requests.delete", autospec=True) as mock_delete:
-            mock_response = mock_delete.return_value
-            mock_response.status_code = 200
+    # test .remove_key
+    with patch("requests.delete", autospec=True) as mock_delete:
+        mock_response = mock_delete.return_value
+        mock_response.status_code = 200
 
-            my_store_backend = GeCloudStoreBackend(
-                ge_cloud_base_url=ge_cloud_base_url,
-                ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type=ge_cloud_resource_type,
+        my_store_backend = GeCloudStoreBackend(
+            ge_cloud_base_url=ge_cloud_base_url,
+            ge_cloud_credentials=ge_cloud_credentials,
+            ge_cloud_resource_type=ge_cloud_resource_type,
+        )
+        my_store_backend.remove_key(
+            (
+                "contract",
+                "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
             )
-            my_store_backend.remove_key(
-                (
-                    "contract",
-                    "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
-                )
-            )
-            mock_delete.assert_called_with(
-                "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/contracts/0ccac18e-7631"
-                "-4bdd"
-                "-8a42-3c35cce574c6",
-                json={
-                    "data": {
-                        "type": "contract",
-                        "id": "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
-                        "attributes": {"deleted": True},
-                    }
-                },
-                headers={
-                    "Content-Type": "application/vnd.api+json",
-                    "Authorization": "Bearer 1234",
-                },
-            )
+        )
+        mock_delete.assert_called_with(
+            "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/contracts/0ccac18e-7631"
+            "-4bdd"
+            "-8a42-3c35cce574c6",
+            json={
+                "data": {
+                    "type": "contract",
+                    "id": "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
+                    "attributes": {"deleted": True},
+                }
+            },
+            headers={
+                "Content-Type": "application/vnd.api+json",
+                "Authorization": "Bearer 1234",
+            },
+        )
 
     # test .set
     with patch("requests.post", autospec=True) as mock_post:
@@ -1493,76 +1493,76 @@ def test_GeCloudStoreBackend():
             },
         )
 
-        # test .get
-        with patch("requests.get", autospec=True) as mock_get:
-            my_store_backend = GeCloudStoreBackend(
-                ge_cloud_base_url=ge_cloud_base_url,
-                ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
+    # test .get
+    with patch("requests.get", autospec=True) as mock_get:
+        my_store_backend = GeCloudStoreBackend(
+            ge_cloud_base_url=ge_cloud_base_url,
+            ge_cloud_credentials=ge_cloud_credentials,
+            ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
+        )
+        my_store_backend.get(
+            (
+                "rendered_data_doc",
+                "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
             )
-            my_store_backend.get(
-                (
-                    "rendered_data_doc",
-                    "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
-                )
-            )
-            mock_get.assert_called_with(
-                "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs/1ccac18e-7631"
-                "-4bdd-8a42-3c35cce574c6",
-                headers={
-                    "Content-Type": "application/vnd.api+json",
-                    "Authorization": "Bearer 1234",
-                },
-            )
+        )
+        mock_get.assert_called_with(
+            "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs/1ccac18e-7631"
+            "-4bdd-8a42-3c35cce574c6",
+            headers={
+                "Content-Type": "application/vnd.api+json",
+                "Authorization": "Bearer 1234",
+            },
+        )
 
-        # test .list_keys
-        with patch("requests.get", autospec=True) as mock_get:
-            my_store_backend = GeCloudStoreBackend(
-                ge_cloud_base_url=ge_cloud_base_url,
-                ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
-            )
-            my_store_backend.list_keys()
-            mock_get.assert_called_with(
-                "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs",
-                headers={
-                    "Content-Type": "application/vnd.api+json",
-                    "Authorization": "Bearer 1234",
-                },
-            )
+    # test .list_keys
+    with patch("requests.get", autospec=True) as mock_get:
+        my_store_backend = GeCloudStoreBackend(
+            ge_cloud_base_url=ge_cloud_base_url,
+            ge_cloud_credentials=ge_cloud_credentials,
+            ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
+        )
+        my_store_backend.list_keys()
+        mock_get.assert_called_with(
+            "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs",
+            headers={
+                "Content-Type": "application/vnd.api+json",
+                "Authorization": "Bearer 1234",
+            },
+        )
 
-        # test .remove_key
-        with patch("requests.delete", autospec=True) as mock_delete:
-            mock_response = mock_delete.return_value
-            mock_response.status_code = 200
+    # test .remove_key
+    with patch("requests.delete", autospec=True) as mock_delete:
+        mock_response = mock_delete.return_value
+        mock_response.status_code = 200
 
-            my_store_backend = GeCloudStoreBackend(
-                ge_cloud_base_url=ge_cloud_base_url,
-                ge_cloud_credentials=ge_cloud_credentials,
-                ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
+        my_store_backend = GeCloudStoreBackend(
+            ge_cloud_base_url=ge_cloud_base_url,
+            ge_cloud_credentials=ge_cloud_credentials,
+            ge_cloud_resource_type=GeCloudRESTResource.RENDERED_DATA_DOC,
+        )
+        my_store_backend.remove_key(
+            (
+                "rendered_data_doc",
+                "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
             )
-            my_store_backend.remove_key(
-                (
-                    "rendered_data_doc",
-                    "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
-                )
-            )
-            mock_delete.assert_called_with(
-                "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs/1ccac18e-7631"
-                "-4bdd"
-                "-8a42-3c35cce574c6",
-                json={
-                    "data": {
-                        "type": "rendered_data_doc",
-                        "id": "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
-                        "attributes": {"deleted": True},
-                    }
-                },
-                headers={
-                    "Content-Type": "application/vnd.api+json",
-                    "Authorization": "Bearer 1234",
-                },
-            )
+        )
+        mock_delete.assert_called_with(
+            "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs/1ccac18e-7631"
+            "-4bdd"
+            "-8a42-3c35cce574c6",
+            json={
+                "data": {
+                    "type": "rendered_data_doc",
+                    "id": "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
+                    "attributes": {"deleted": True},
+                }
+            },
+            headers={
+                "Content-Type": "application/vnd.api+json",
+                "Authorization": "Bearer 1234",
+            },
+        )
 
 
 def test_InlineStoreBackend(empty_data_context: DataContext) -> None:


### PR DESCRIPTION
Changes proposed in this pull request:
- Noticed some extra indentation in `test_GeCloudStoreBackend()`, cleaning up
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
