### PR TITLE
[BUGFIX] Use string dialect name if not found in enum

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -109,7 +109,13 @@ class SqlAlchemyBatchData(BatchData):
                 "schema_name can only be used with table_name. Use temp_table_schema_name to provide a target schema for creating a temporary table."
             )
 
-        dialect: GESqlDialect = GESqlDialect(engine.dialect.name.lower())
+        try:
+            dialect: Union[GESqlDialect, str] = GESqlDialect(
+                engine.dialect.name.lower()
+            )
+        except ValueError:
+            dialect: Union[GESqlDialect, str] = engine.dialect.name.lower()
+
         if table_name:
             # Suggestion: pull this block out as its own _function
             if use_quoted_name:

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Union
 
 from great_expectations.execution_engine.execution_engine import BatchData
 from great_expectations.execution_engine.sqlalchemy_dialect import GESqlDialect

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -109,12 +109,12 @@ class SqlAlchemyBatchData(BatchData):
                 "schema_name can only be used with table_name. Use temp_table_schema_name to provide a target schema for creating a temporary table."
             )
 
+        dialect_name: str = engine.dialect.name.lower()
+
         try:
-            dialect: Union[GESqlDialect, str] = GESqlDialect(
-                engine.dialect.name.lower()
-            )
+            dialect: GESqlDialect = GESqlDialect(dialect_name)
         except ValueError:
-            dialect: Union[GESqlDialect, str] = engine.dialect.name.lower()
+            dialect: GESqlDialect = GESqlDialect.UNSUPPORTED
 
         if table_name:
             # Suggestion: pull this block out as its own _function
@@ -207,9 +207,9 @@ class SqlAlchemyBatchData(BatchData):
         dialect_name: str = self.sql_engine_dialect.name.lower()
 
         try:
-            dialect: Union[GESqlDialect, str] = GESqlDialect(dialect_name)
+            dialect: GESqlDialect = GESqlDialect(dialect_name)
         except ValueError:
-            dialect: Union[GESqlDialect, str] = dialect_name
+            dialect: GESqlDialect = GESqlDialect.UNSUPPORTED
 
         if dialect == GESqlDialect.BIGQUERY:
             # BigQuery Table is created using with an expiration of 24 hours using Google's Data Definition Language

--- a/great_expectations/execution_engine/sqlalchemy_dialect.py
+++ b/great_expectations/execution_engine/sqlalchemy_dialect.py
@@ -5,6 +5,10 @@ from typing import Any, List
 
 
 class GESqlDialect(enum.Enum):
+    """Contains sql dialects that have some level of support in Great Expectations.
+    Also contains an unsupported attribute if the dialect is not in the list.
+    """
+
     AWSATHENA = "awsathena"
     BIGQUERY = "bigquery"
     DREMIO = "dremio"
@@ -18,6 +22,7 @@ class GESqlDialect(enum.Enum):
     SQLITE = "sqlite"
     TERADATASQL = "teradatasql"
     TRINO = "trino"
+    UNSUPPORTED = "unsupported"
 
     @classmethod
     def _missing_(cls, value: Any) -> None:
@@ -30,9 +35,13 @@ class GESqlDialect(enum.Enum):
     @classmethod
     def get_all_dialect_names(cls) -> List[str]:
         """Get dialect names for all SQL dialects."""
-        return [dialect_name.value for dialect_name in cls]
+        return [
+            dialect_name.value
+            for dialect_name in cls
+            if dialect_name != GESqlDialect.UNSUPPORTED
+        ]
 
     @classmethod
     def get_all_dialects(cls) -> List[GESqlDialect]:
         """Get all dialects."""
-        return [dialect for dialect in cls]
+        return [dialect for dialect in cls if dialect != GESqlDialect.UNSUPPORTED]

--- a/tests/execution_engine/test_sqlalchemy_dialect.py
+++ b/tests/execution_engine/test_sqlalchemy_dialect.py
@@ -7,3 +7,11 @@ def test_dialect_instantiation_with_string():
 
 def test_dialect_instantiation_with_byte_string():
     assert GESqlDialect(b"hive") == GESqlDialect.HIVE
+
+
+def test_get_all_dialect_names_no_unsupported():
+    assert GESqlDialect.UNSUPPORTED.value not in GESqlDialect.get_all_dialect_names()
+
+
+def test_get_all_dialects_no_unsupported():
+    assert GESqlDialect.UNSUPPORTED not in GESqlDialect.get_all_dialects()


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- Dialects not found in GESqlDialect were causing errors e.g. Vertica. This PR is intended as a quick fix to ensure the string name is used if the dialect is not found in the enum.
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
