### PR TITLE
[MAINTENANCE] Refactor `DataContext.__init__` to initialize datasources utilizing a given `DataContextConfig`

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1473,9 +1473,14 @@ class AbstractDataContext(ABC):
 
     def _init_datasources(self) -> None:
         """Initialize the datasources in store"""
-        datasource_name: str
-        datasource_config: DatasourceConfig
-        for datasource_name, datasource_config in self.config.datasources.items():
+        config: DataContextConfig = self.get_config_with_variables_substituted(
+            self.config
+        )
+        datasources: Dict[str, DatasourceConfig] = cast(
+            Dict[str, DatasourceConfig], config.datasources
+        )
+
+        for datasource_name, datasource_config in datasources.items():
             try:
                 config = copy.deepcopy(datasource_config)
                 config_dict = dict(datasourceConfigSchema.dump(config))

--- a/great_expectations/data_context/data_context/ephemeral_data_context.py
+++ b/great_expectations/data_context/data_context/ephemeral_data_context.py
@@ -66,12 +66,6 @@ class EphemeralDataContext(AbstractDataContext):
         )
         self._datasource_store = datasource_store
 
-        # Required to populate the store with values to be used downstream
-        for datasource_name, datasource_config in self.config.datasources.items():
-            self._datasource_store.set_by_name(
-                datasource_name=datasource_name, datasource_config=datasource_config
-            )
-
     def _save_project_config(self) -> None:
         """Since EphemeralDataContext does not have config as a file, display logging message instead"""
         logger.debug(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2334,12 +2334,7 @@ checkpoint_store_name: default_checkpoint_store
 
 
 @pytest.fixture
-@mock.patch(
-    "great_expectations.data_context.store.DatasourceStore.list_keys",
-    return_value=[],
-)
 def empty_cloud_data_context(
-    mock_list_keys: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GeCloudConfig,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2334,7 +2334,12 @@ checkpoint_store_name: default_checkpoint_store
 
 
 @pytest.fixture
+@mock.patch(
+    "great_expectations.data_context.store.DatasourceStore.list_keys",
+    return_value=[],
+)
 def empty_cloud_data_context(
+    mock_list_keys: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
     ge_cloud_config: GeCloudConfig,

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -16,11 +16,7 @@ from great_expectations.data_context.types.base import DataContextConfig, GeClou
 
 
 @pytest.mark.integration
-@mock.patch(
-    "great_expectations.data_context.store.DatasourceStore.list_keys", return_value=[]
-)
 def test_data_context_instantiates_ge_cloud_store_backend_with_cloud_config(
-    mock_list_keys: mock.MagicMock,
     tmp_path: pathlib,
     data_context_config_with_datasources: DataContextConfig,
     ge_cloud_config: GeCloudConfig,
@@ -39,11 +35,7 @@ def test_data_context_instantiates_ge_cloud_store_backend_with_cloud_config(
 
 
 @pytest.mark.integration
-@mock.patch(
-    "great_expectations.data_context.store.DatasourceStore.list_keys", return_value=[]
-)
 def test_data_context_instantiates_inline_store_backend_with_filesystem_config(
-    mock_list_keys: mock.MagicMock,
     tmp_path: pathlib,
     data_context_config_with_datasources: DataContextConfig,
 ) -> None:


### PR DESCRIPTION
Changes proposed in this pull request:
- Regardless of which context you are using, datasource initialization should stem from the input config object. This is how it worked in the past but was refactored as part of the `DatasourceStore` work. The current implementation leverages the `DatasourceStore` to populate the `DataContext`'s datasource cache; this came to our attention when we tried to make a series of GET requests to the Cloud backend to populate our datasource cache - why make additional requests when we already have the information we need from our first `GET` to retrieve the project config?


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
