### PR TITLE
[FEATURE] Multi-Batch Example Notebook - Configured and InferredAssetDataConnector examples

### DIFF
--- a/tests/integration/profiling/rule_based_profiler/test_run_profiler_notebook.py
+++ b/tests/integration/profiling/rule_based_profiler/test_run_profiler_notebook.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import shutil
-from typing import List, Optional
+from typing import List
 
 import nbformat
 from nbconvert.preprocessors import CellExecutionError, ExecutePreprocessor
+from nbformat import NotebookNode
 
 from great_expectations.data_context.util import file_relative_path
 
@@ -51,14 +52,14 @@ def test_run_rbp_notebook(tmp_path):
     )
 
     with open(notebook_path) as f:
-        nb = nbformat.read(f, as_version=4)
+        nb: NotebookNode = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+    ep: ExecutePreprocessor = ExecutePreprocessor(timeout=60, kernel_name="python3")
 
     try:
         ep.preprocess(nb, {"metadata": {"path": base_dir}})
     except CellExecutionError:
-        msg = f'Error executing the notebook "{notebook_path}".\n\n'
+        msg: str = f'Error executing the notebook "{notebook_path}".\n\n'
         msg += f'See notebook "{output_notebook_path}" for the traceback.'
         print(msg)
         raise
@@ -96,12 +97,12 @@ def test_run_data_assistants_notebook(tmp_path):
     with open(notebook_path) as f:
         nb = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+    ep: ExecutePreprocessor = ExecutePreprocessor(timeout=60, kernel_name="python3")
 
     try:
         ep.preprocess(nb, {"metadata": {"path": base_dir}})
     except CellExecutionError:
-        msg = f'Error executing the notebook "{notebook_path}".\n\n'
+        msg: str = f'Error executing the notebook "{notebook_path}".\n\n'
         msg += f'See notebook "{output_notebook_path}" for the traceback.'
         print(msg)
         raise
@@ -134,7 +135,7 @@ def test_run_self_initializing_expectations_notebook(tmp_path):
     )
 
     with open(notebook_path) as f:
-        nb = nbformat.read(f, as_version=4)
+        nb: NotebookNode = nbformat.read(f, as_version=4)
 
     ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
 
@@ -176,14 +177,14 @@ def test_run_multibatch_inferred_asset_example(tmp_path):
     )
 
     with open(notebook_path) as f:
-        nb = nbformat.read(f, as_version=4)
+        nb: NotebookNode = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+    ep: ExecutePreprocessor = ExecutePreprocessor(timeout=60, kernel_name="python3")
 
     try:
         ep.preprocess(nb, {"metadata": {"path": base_dir}})
     except CellExecutionError:
-        msg = f'Error executing the notebook "{notebook_path}".\n\n'
+        msg: str = f'Error executing the notebook "{notebook_path}".\n\n'
         msg += f'See notebook "{output_notebook_path}" for the traceback.'
         print(msg)
         raise
@@ -221,14 +222,14 @@ def test_run_multibatch_configured_asset_example(tmp_path):
     )
 
     with open(notebook_path) as f:
-        nb = nbformat.read(f, as_version=4)
+        nb: NotebookNode = nbformat.read(f, as_version=4)
 
-    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+    ep: ExecutePreprocessor = ExecutePreprocessor(timeout=60, kernel_name="python3")
 
     try:
         ep.preprocess(nb, {"metadata": {"path": base_dir}})
     except CellExecutionError:
-        msg = f'Error executing the notebook "{notebook_path}".\n\n'
+        msg: str = f'Error executing the notebook "{notebook_path}".\n\n'
         msg += f'See notebook "{output_notebook_path}" for the traceback.'
         print(msg)
         raise

--- a/tests/integration/profiling/rule_based_profiler/test_run_profiler_notebook.py
+++ b/tests/integration/profiling/rule_based_profiler/test_run_profiler_notebook.py
@@ -120,9 +120,9 @@ def test_run_data_assistants_notebook(tmp_path):
 def test_run_self_initializing_expectations_notebook(tmp_path):
     """
     What does this test and why?
-    One of the resources we have for self-initializing Expectations is a Jupyter notebook that explains/shows the components in code.
-    This test ensures the codepaths and examples described in the Notebook actually run and pass, nbconvert's
-    `preprocess` function.
+    One of the resources we have for self-initializing Expectations is a Jupyter notebook that explains/shows the
+    components in code.  This test ensures the codepaths and examples described in the Notebook actually run and pass,
+    nbconvert's `preprocess` function.
     """
     base_dir: str = file_relative_path(
         __file__, "../../../test_fixtures/rule_based_profiler/example_notebooks"
@@ -153,5 +153,95 @@ def test_run_self_initializing_expectations_notebook(tmp_path):
             "great_expectations/expectations/tmp",
             "great_expectations/expectations/.ge_store_backend_id",
             "great_expectations/expectations/new_expectation_suite.json",
+        ]
+        clean_up_test_files(base_dir=base_dir, paths=paths_to_clean_up)
+
+
+def test_run_multibatch_inferred_asset_example(tmp_path):
+    """
+    What does this test and why?
+    One of the resources we have for multi-batch Expectations is a Jupyter notebook that explains/shows the components
+    in code. This test ensures the codepaths and examples described in the Notebook actually run and pass, nbconvert's
+    `preprocess` function.
+    """
+    base_dir: str = file_relative_path(
+        __file__, "../../../test_fixtures/rule_based_profiler/example_notebooks"
+    )
+    notebook_path: str = os.path.join(
+        base_dir, "MultiBatchExample_InferredAssetFileSystemExample.ipynb"
+    )
+    # temporary output notebook for traceback and debugging
+    output_notebook_path: str = os.path.join(
+        tmp_path, "MultiBatchExample_InferredAssetFileSystemExample_executed.ipynb"
+    )
+
+    with open(notebook_path) as f:
+        nb = nbformat.read(f, as_version=4)
+
+    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+
+    try:
+        ep.preprocess(nb, {"metadata": {"path": base_dir}})
+    except CellExecutionError:
+        msg = f'Error executing the notebook "{notebook_path}".\n\n'
+        msg += f'See notebook "{output_notebook_path}" for the traceback.'
+        print(msg)
+        raise
+    finally:
+        with open(output_notebook_path, mode="w", encoding="utf-8") as f:
+            nbformat.write(nb, f)
+
+        paths_to_clean_up: List[str] = [
+            "great_expectations/expectations/tmp",
+            "great_expectations/expectations/.ge_store_backend_id",
+            "great_expectations/expectations/example_inferred_suite.json",
+            "great_expectations/checkpoints/my_checkpoint.yml",
+            "great_expectations/uncommitted/data_docs",
+            "great_expectations/uncommitted/validations/example_inferred_suite",
+        ]
+        clean_up_test_files(base_dir=base_dir, paths=paths_to_clean_up)
+
+
+def test_run_multibatch_configured_asset_example(tmp_path):
+    """
+    What does this test and why?
+    One of the resources we have for multi-batch Expectations is a Jupyter notebook that explains/shows the components
+    in code. This test ensures the codepaths and examples described in the Notebook actually run and pass, nbconvert's
+    `preprocess` function.
+    """
+    base_dir: str = file_relative_path(
+        __file__, "../../../test_fixtures/rule_based_profiler/example_notebooks"
+    )
+    notebook_path: str = os.path.join(
+        base_dir, "MultiBatchExample_ConfiguredAssetFileSystemExample.ipynb"
+    )
+    # temporary output notebook for traceback and debugging
+    output_notebook_path: str = os.path.join(
+        tmp_path, "MultiBatchExample_ConfiguredAssetFileSystemExample_executed.ipynb"
+    )
+
+    with open(notebook_path) as f:
+        nb = nbformat.read(f, as_version=4)
+
+    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+
+    try:
+        ep.preprocess(nb, {"metadata": {"path": base_dir}})
+    except CellExecutionError:
+        msg = f'Error executing the notebook "{notebook_path}".\n\n'
+        msg += f'See notebook "{output_notebook_path}" for the traceback.'
+        print(msg)
+        raise
+    finally:
+        with open(output_notebook_path, mode="w", encoding="utf-8") as f:
+            nbformat.write(nb, f)
+
+        paths_to_clean_up: List[str] = [
+            "great_expectations/expectations/tmp",
+            "great_expectations/expectations/.ge_store_backend_id",
+            "great_expectations/expectations/example_configured_suite.json",
+            "great_expectations/checkpoints/my_checkpoint.yml",
+            "great_expectations/uncommitted/data_docs",
+            "great_expectations/uncommitted/validations/example_configured_suite",
         ]
         clean_up_test_files(base_dir=base_dir, paths=paths_to_clean_up)

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetFileSystemExample.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetFileSystemExample.ipynb
@@ -1,0 +1,1129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f0a5264-b003-4101-862f-45653f2aed1b",
+   "metadata": {},
+   "source": [
+    "# How to write multi-batch `BatchRequest` - `ConfiguredAsset` Example\n",
+    "* A `BatchRequest` facilitates the return of a `batch` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_a_batch_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
+    "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
+    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   2. DataAssistants to profile your data and create and Expectation suite self-intialized parameters.\n",
+    "   \n",
+    "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4462320-d76e-492c-96fb-f0ff8f788851",
+   "metadata": {},
+   "source": [
+    "## FileSystem Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6e04726",
+   "metadata": {},
+   "source": [
+    "### Example Directory\n",
+    "\n",
+    "Imagine we have a directory of 12 csv files, each corresponding to 1 month of Taxi rider data\n",
+    "\n",
+    "```\n",
+    "yellow_tripdata_sample_2020-01.csv\n",
+    "yellow_tripdata_sample_2020-02.csv\n",
+    "yellow_tripdata_sample_2020-03.csv\n",
+    "yellow_tripdata_sample_2020-04.csv\n",
+    "yellow_tripdata_sample_2020-05.csv\n",
+    "yellow_tripdata_sample_2020-06.csv\n",
+    "yellow_tripdata_sample_2020-07.csv\n",
+    "yellow_tripdata_sample_2020-08.csv\n",
+    "yellow_tripdata_sample_2020-09.csv\n",
+    "yellow_tripdata_sample_2020-10.csv\n",
+    "yellow_tripdata_sample_2020-11.csv\n",
+    "yellow_tripdata_sample_2020-12.csv\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ee54886b-4f88-46d9-9afe-dfd8bb061e19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import great_expectations as ge\n",
+    "\n",
+    "from ruamel import yaml\n",
+    "\n",
+    "from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest\n",
+    "\n",
+    "from great_expectations.rule_based_profiler.rule.rule import Rule\n",
+    "from great_expectations.rule_based_profiler.rule_based_profiler import RuleBasedProfiler, RuleBasedProfilerResult\n",
+    "\n",
+    "from great_expectations.rule_based_profiler.domain_builder import (\n",
+    "    DomainBuilder,\n",
+    "    ColumnDomainBuilder,\n",
+    ")\n",
+    "from great_expectations.rule_based_profiler.parameter_builder import (\n",
+    "    MetricMultiBatchParameterBuilder,\n",
+    ")\n",
+    "from great_expectations.rule_based_profiler.expectation_configuration_builder import (\n",
+    "    DefaultExpectationConfigurationBuilder,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96a2eb4f",
+   "metadata": {},
+   "source": [
+    "* Load `DataContext`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "45b1854b-2a75-422e-83bb-5509d868e0c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context: ge.DataContext = ge.get_context()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49515697-83a2-432d-8b74-33e2f01db72c",
+   "metadata": {},
+   "source": [
+    "### `ConfiguredDataConnector` Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df19a29c",
+   "metadata": {},
+   "source": [
+    "* Add `Datasource` named `taxi_multi_batch_configured_datasource` with two `ConfiguredAssetDataConnectors `. A key difference is in the `pattern` used to identify one Batch from another. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a7a8284",
+   "metadata": {},
+   "source": [
+    "* The first DataConnector is called `configured_data_connector_single_batch_asset`, which names two `assets`: `yellow_trip_data_jan` and `yellow_trip_data_feb`. \n",
+    "    * This can be seen in the output of `test_yaml_config()`, which shows the 2 data assets, with 1 Batch each\n",
+    "    * Here is the output: \n",
+    "    ```\t\n",
+    "    Available data_asset_names (2 of 2):\n",
+    "\t\tyellow_trip_data_feb (1 of 1): ['yellow_tripdata_sample_2020-02.csv']\n",
+    "\t\tyellow_trip_data_jan (1 of 1): ['yellow_tripdata_sample_2020-01.csv']\n",
+    "    ```\n",
+    "    * **Note**: in this case we actually don't need a `group_name` defined if we are just saying our pattern was `yellow_tripdata_sample_2020-(01)\\\\.csv`. However, GE currently doesn't allow a `pattern` to be defined without `group_name` also defined. So in our case, we set regex defined in `pattern` to capture the `month`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0852b21a",
+   "metadata": {},
+   "source": [
+    "* A second DataConnector is called `configured_data_connector_multi_batch_asset`:\n",
+    "    * It defines one asset `yellow_tripdata_all_months`, that takes all 12 `yellow_tripdata_sample_2020` files and maps it to the same asset, with each of the 12 months corresponding to Batches for the asset. \n",
+    "    * In order to do this, we define the `pattern` as `\"yellow_tripdata_sample_(.*)\\\\.csv\"` which matches all months, with one capture group `(.*)` defined as `month`. This allows the resulting Batches to be distinguishable from one another, and allows them be specified using a `batch_definition`.\n",
+    "    * The results can be seen in the output of `test_yaml_config()`, which shows 3 of the 12 Batches corresponding to `yellow_tripdata_all_months`\n",
+    "    * Here is the output:\n",
+    " ```\n",
+    " Available data_asset_names (1 of 1):\n",
+    "       yellow_tripdata_all_months (3 of 12): ['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-02.csv', 'yellow_tripdata_sample_2020-03.csv']\n",
+    " ```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "85390899-96f0-4551-bfe5-beb0ef296620",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: PandasExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetFilesystemDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (1 of 1):\n",
+      "\t\tyellow_tripdata_all_months (3 of 12): ['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-02.csv', 'yellow_tripdata_sample_2020-03.csv']\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n",
+      "\tconfigured_data_connector_single_batch_asset : ConfiguredAssetFilesystemDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_trip_data_feb (1 of 1): ['yellow_tripdata_sample_2020-02.csv']\n",
+      "\t\tyellow_trip_data_jan (1 of 1): ['yellow_tripdata_sample_2020-01.csv']\n",
+      "\n",
+      "\tUnmatched data_references (3 of 22):['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-03.csv', 'yellow_tripdata_sample_2020-04.csv']\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7fcd41bc6bb0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_path: str = \"../../../../test_sets/taxi_yellow_tripdata_samples/samples_2020\"\n",
+    "\n",
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_configured_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"PandasExecutionEngine\",\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_single_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"assets\": {\n",
+    "                \"yellow_trip_data_jan\":\n",
+    "                {\n",
+    "                    \"group_names\": [\"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_2020-(01)\\\\.csv\",\n",
+    "                },\n",
+    "                \"yellow_trip_data_feb\":\n",
+    "                {\n",
+    "                    \"group_names\": [\"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_2020-(02)\\\\.csv\",\n",
+    "                }\n",
+    "            },\n",
+    "        },\n",
+    "        \n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"assets\": {\n",
+    "                \"yellow_tripdata_all_months\":{\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_(.*)\\\\.csv\",\n",
+    "                    \"group_names\": [\"month\"],\n",
+    "\n",
+    "                }\n",
+    "            },\n",
+    "        },\n",
+    "        \n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7636ffff-0ddc-48fd-a4cf-f8e139a5e36e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_datasource only if it doesn't already exist in our configuration\n",
+    "try:\n",
+    "    data_context.get_datasource(datasource_config[\"name\"])\n",
+    "except ValueError:\n",
+    "    data_context.add_datasource(**datasource_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "438146be",
+   "metadata": {},
+   "source": [
+    "## BatchRequest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "117cdb0d",
+   "metadata": {},
+   "source": [
+    "* Depending on which `DataConnector` you send a `BatchRequest` to, you will retrieve a different number of `Batches`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87bc9c59",
+   "metadata": {},
+   "source": [
+    "* Single Batch returned by `configured_data_connector_single_batch_asset` DataConnector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1b1e142e-c076-497e-b82a-4ea950cc5e68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_configured_datasource\",\n",
+    "    data_connector_name=\"configured_data_connector_single_batch_asset\",\n",
+    "    data_asset_name=\"yellow_trip_data_jan\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "35df7084",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d8e74a05-3fd1-4e47-9105-b721dbcf3516",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7fcd41ace220>]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be7f4fa5",
+   "metadata": {},
+   "source": [
+    "* Multi Batch returned by the `configured_data_connector_multi_batch_asset` DataConnector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c32dbac9-af5d-4677-98f9-f098ef091b6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_configured_datasource\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_all_months\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3a284bfd-00aa-4068-bc09-71c6dea627e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7bf3e1ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7fcd41d07e20>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41b90520>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41b0f070>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41b872b0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41d23910>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41b6c220>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41d16b20>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41d4a190>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41d39d60>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41d34880>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41d59220>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fcd41ace670>]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_batch_batch_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "790746ee",
+   "metadata": {},
+   "source": [
+    "* You can also get a single Batch from a multi-batch DataConnector by passing in `data_connector_query`. Index `-1` will return the most recent (month = `12`) batch. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "eb4d9254-37a4-48fe-a9c6-c67f346224ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request_from_multi: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_configured_datasource\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_all_months\",\n",
+    "    data_connector_query={\n",
+    "        \"index\": -1 # month: 12\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "727ec9e4-e996-48eb-8428-57f3cb55dceb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request_from_multi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f5e1667f-70e9-49a2-9815-28732f9c1287",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7fcd41bc0ca0>]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "229815cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data': '<great_expectations.execution_engine.pandas_batch_data.PandasBatchData object at 0x7fcd41d97220>',\n",
+       " 'batch_request': {'datasource_name': 'taxi_multi_batch_configured_datasource',\n",
+       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_all_months',\n",
+       "  'data_connector_query': {'index': -1},\n",
+       "  'limit': None,\n",
+       "  'batch_spec_passthrough': None},\n",
+       " 'batch_definition': {'datasource_name': 'taxi_multi_batch_configured_datasource',\n",
+       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_all_months',\n",
+       "  'batch_identifiers': {'month': '2020-12'}},\n",
+       " 'batch_spec': {'path': '/Users/work/Development/great_expectations/tests/test_fixtures/rule_based_profiler/example_notebooks/great_expectations/../../../../test_sets/taxi_yellow_tripdata_samples/samples_2020/yellow_tripdata_sample_2020-12.csv'},\n",
+       " 'batch_markers': {'ge_load_time': '20220722T032954.534762Z',\n",
+       "  'pandas_data_fingerprint': 'b1b9772f30b6c43a0a26dafac04e26a7'}}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list[0].to_dict() # 'batch_identifiers': {'month': '12'}},"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "907a6ef5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Using auto-initializing `Expectations` to generate parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6efe9c76",
+   "metadata": {},
+   "source": [
+    "* We will generate a `Validator` using our `multi_batch_batch_list`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "847ce4a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a1eca55b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_suite = data_context.create_expectation_suite(expectation_suite_name=\"example_configured_suite\", overwrite_existing=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "852deba1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator = data_context.get_validator_using_batch_list(batch_list=multi_batch_batch_list, expectation_suite=example_suite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee01a0e9",
+   "metadata": {},
+   "source": [
+    "* When you run methods on the validator, it will typically run on the most recent batch (index `-1`), even if the Validator has access to a longer Batch list. For example, notice that the `pickup_datetime` and `dropoff_datetime` below are all associated with December, indicating that it is with the most recent Batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "65fe8b51",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "938a54ea80a743608c9ba783e3ee0bbb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>vendor_id</th>\n",
+       "      <th>pickup_datetime</th>\n",
+       "      <th>dropoff_datetime</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>trip_distance</th>\n",
+       "      <th>rate_code_id</th>\n",
+       "      <th>store_and_fwd_flag</th>\n",
+       "      <th>pickup_location_id</th>\n",
+       "      <th>dropoff_location_id</th>\n",
+       "      <th>payment_type</th>\n",
+       "      <th>fare_amount</th>\n",
+       "      <th>extra</th>\n",
+       "      <th>mta_tax</th>\n",
+       "      <th>tip_amount</th>\n",
+       "      <th>tolls_amount</th>\n",
+       "      <th>improvement_surcharge</th>\n",
+       "      <th>total_amount</th>\n",
+       "      <th>congestion_surcharge</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-15 12:20:27</td>\n",
+       "      <td>2020-12-15 12:40:49</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>5.76</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>209</td>\n",
+       "      <td>237</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.50</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>26.80</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-28 12:51:25</td>\n",
+       "      <td>2020-12-28 13:15:12</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>11.64</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>161</td>\n",
+       "      <td>220</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>33.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>5.00</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>44.60</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-27 10:43:42</td>\n",
+       "      <td>2020-12-27 10:51:05</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.22</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>163</td>\n",
+       "      <td>48</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.06</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.36</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-08 13:42:52</td>\n",
+       "      <td>2020-12-08 13:54:45</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.84</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>137</td>\n",
+       "      <td>229</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.30</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-19 11:56:43</td>\n",
+       "      <td>2020-12-19 12:08:43</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.55</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>24</td>\n",
+       "      <td>74</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>9.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.88</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   vendor_id      pickup_datetime     dropoff_datetime  passenger_count  \\\n",
+       "0        2.0  2020-12-15 12:20:27  2020-12-15 12:40:49              4.0   \n",
+       "1        2.0  2020-12-28 12:51:25  2020-12-28 13:15:12              1.0   \n",
+       "2        2.0  2020-12-27 10:43:42  2020-12-27 10:51:05              1.0   \n",
+       "3        2.0  2020-12-08 13:42:52  2020-12-08 13:54:45              1.0   \n",
+       "4        2.0  2020-12-19 11:56:43  2020-12-19 12:08:43              1.0   \n",
+       "\n",
+       "   trip_distance  rate_code_id store_and_fwd_flag  pickup_location_id  \\\n",
+       "0           5.76           1.0                  N                 209   \n",
+       "1          11.64           1.0                  N                 161   \n",
+       "2           1.22           1.0                  N                 163   \n",
+       "3           1.84           1.0                  N                 137   \n",
+       "4           1.55           1.0                  N                  24   \n",
+       "\n",
+       "   dropoff_location_id  payment_type  fare_amount  extra  mta_tax  tip_amount  \\\n",
+       "0                  237           1.0         21.0    0.0      0.5        2.50   \n",
+       "1                  220           1.0         33.5    0.0      0.5        5.00   \n",
+       "2                   48           1.0          7.0    0.0      0.5        2.06   \n",
+       "3                  229           2.0          9.0    0.0      0.5        0.00   \n",
+       "4                   74           1.0          9.5    0.0      0.5        2.58   \n",
+       "\n",
+       "   tolls_amount  improvement_surcharge  total_amount  congestion_surcharge  \n",
+       "0           0.0                    0.3         26.80                   2.5  \n",
+       "1           2.8                    0.3         44.60                   2.5  \n",
+       "2           0.0                    0.3         12.36                   2.5  \n",
+       "3           0.0                    0.3         12.30                   2.5  \n",
+       "4           0.0                    0.3         12.88                   0.0  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8be66602",
+   "metadata": {},
+   "source": [
+    "### Typical Workflow\n",
+    "* A `batch_list` becomes really useful when you are calculating parameters for auto-initializing Expectations, as they us a `RuleBasedProfiler` under-the-hood to calculate parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdef9ad7",
+   "metadata": {},
+   "source": [
+    "* Here is an example running `expect_column_median_to_be_between()` by \"guessing\" at the `min_value` and `max_value`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "b524a2df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "026b26bc61a94b1a8893fc8cfe9d58e3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"success\": false,\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.61\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.expect_column_median_to_be_between(column=\"trip_distance\", min_value=0, max_value=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f18d096f",
+   "metadata": {},
+   "source": [
+    "* The observed value for the most recent batch (December/2020) is going to be `1.61`, which means the Expectation fails"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c5016d8",
+   "metadata": {},
+   "source": [
+    "* Now we run the same expectation again, but this time with `auto=True`. This means the `median` values are going to calculated across the `batch_list` associated with the `Validator` (ie 12 Batches for 2020), which gives the min value of `1.6` and the max value of `1.92`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "cdd821c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "949b6d988230475cb06f1fc4342ff9b4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating Expectations:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7d449d7b7e59461188cbb5fe9e966826",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"expectation_config\": {\n",
+       "    \"expectation_type\": \"expect_column_median_to_be_between\",\n",
+       "    \"kwargs\": {\n",
+       "      \"column\": \"trip_distance\",\n",
+       "      \"min_value\": 1.6,\n",
+       "      \"max_value\": 1.93,\n",
+       "      \"strict_min\": false,\n",
+       "      \"strict_max\": false\n",
+       "    },\n",
+       "    \"meta\": {\n",
+       "      \"auto_generated_at\": \"20220722T032955.450265Z\",\n",
+       "      \"great_expectations_version\": \"0.15.13+79.g5c6db848e.dirty\"\n",
+       "    }\n",
+       "  },\n",
+       "  \"success\": true,\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.61\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.expect_column_median_to_be_between(column=\"trip_distance\", auto=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6a6c277",
+   "metadata": {},
+   "source": [
+    "* The `auto=True` will also automatically run the Expectation against the most recent Batch (which has an observed value of `1.61`) and the Expectation will pass. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90b8b938",
+   "metadata": {},
+   "source": [
+    "* You can now save the `ExpectationSuite`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "eba880ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator.save_expectation_suite()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b7ec631",
+   "metadata": {},
+   "source": [
+    "### Running the `ExpectationSuite` against single `Batch`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "477381f5",
+   "metadata": {},
+   "source": [
+    "Now the ExpectationSuite can be used to validate single batches using a Checkpoint. As before, we can use `data_connector_query` to specify the batch that we would like to run the `Checkpoint` on, but the recommended way would be to use the `batch_identifier` parameter, where we have set `month` to `01` to specify the January 2020 batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "747dea95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_inferred_datasource\",\n",
+    "    data_connector_name=\"inferred_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020\",\n",
+    "    #data_connector_query={\n",
+    "    #    \"index\": 0 # this one will correspond to Jan 2020\n",
+    "    #}\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "9d392e80",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"action_list\": [\n",
+       "    {\n",
+       "      \"name\": \"store_validation_result\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreValidationResultAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"store_evaluation_params\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreEvaluationParametersAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"update_data_docs\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"UpdateDataDocsAction\",\n",
+       "        \"site_names\": []\n",
+       "      }\n",
+       "    }\n",
+       "  ],\n",
+       "  \"batch_request\": {},\n",
+       "  \"class_name\": \"Checkpoint\",\n",
+       "  \"config_version\": 1.0,\n",
+       "  \"evaluation_parameters\": {},\n",
+       "  \"module_name\": \"great_expectations.checkpoint\",\n",
+       "  \"name\": \"my_checkpoint\",\n",
+       "  \"profilers\": [],\n",
+       "  \"runtime_configuration\": {},\n",
+       "  \"validations\": [\n",
+       "    {\n",
+       "      \"batch_request\": {\n",
+       "        \"datasource_name\": \"taxi_multi_batch_configured_datasource\",\n",
+       "        \"data_connector_name\": \"configured_data_connector_multi_batch_asset\",\n",
+       "        \"data_asset_name\": \"yellow_tripdata_all_months\",\n",
+       "        \"data_connector_query\": {\n",
+       "          \"index\": -1\n",
+       "        }\n",
+       "      },\n",
+       "      \"expectation_suite_name\": \"example_configured_suite\",\n",
+       "      \"batch_identifiers\": {\n",
+       "        \"month\": \"01\"\n",
+       "      }\n",
+       "    }\n",
+       "  ]\n",
+       "}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "checkpoint_config = {\n",
+    "    \"name\": \"my_checkpoint\",\n",
+    "    \"config_version\": 1,\n",
+    "    \"class_name\": \"SimpleCheckpoint\",\n",
+    "    \"validations\": [\n",
+    "        {\n",
+    "            \"batch_request\": single_batch_batch_request_from_multi,\n",
+    "            \"expectation_suite_name\": \"example_configured_suite\",\n",
+    "            \"batch_identifiers\":{\"month\": \"01\"} # batch_identifier month is set to 01\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "data_context.add_checkpoint(**checkpoint_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "3269dfba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3cb1c28cc62f403e92380b6ec00a5058",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results = data_context.run_checkpoint(\n",
+    "    checkpoint_name=\"my_checkpoint\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "c6234082",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results.success"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1626a62-6ba6-433f-982d-c5774e564d66",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetFileSystemExample.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_InferredAssetFileSystemExample.ipynb
@@ -1,0 +1,1108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f0a5264-b003-4101-862f-45653f2aed1b",
+   "metadata": {},
+   "source": [
+    "# How to write multi-batch `BatchRequest` - `InferredAsset` Example\n",
+    "* A `BatchRequest` facilitates the return of a `batch` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_a_batch_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
+    "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
+    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   2. DataAssistants to profile your data and create and Expectation suite self-intialized parameters.\n",
+    "   \n",
+    "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4462320-d76e-492c-96fb-f0ff8f788851",
+   "metadata": {},
+   "source": [
+    "## FileSystem Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6e04726",
+   "metadata": {},
+   "source": [
+    "### Example Directory\n",
+    "\n",
+    "Imagine we have a directory of 12 csv files, each corresponding to 1 month of Taxi rider data\n",
+    "\n",
+    "```\n",
+    "yellow_tripdata_sample_2020-01.csv\n",
+    "yellow_tripdata_sample_2020-02.csv\n",
+    "yellow_tripdata_sample_2020-03.csv\n",
+    "yellow_tripdata_sample_2020-04.csv\n",
+    "yellow_tripdata_sample_2020-05.csv\n",
+    "yellow_tripdata_sample_2020-06.csv\n",
+    "yellow_tripdata_sample_2020-07.csv\n",
+    "yellow_tripdata_sample_2020-08.csv\n",
+    "yellow_tripdata_sample_2020-09.csv\n",
+    "yellow_tripdata_sample_2020-10.csv\n",
+    "yellow_tripdata_sample_2020-11.csv\n",
+    "yellow_tripdata_sample_2020-12.csv\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ee54886b-4f88-46d9-9afe-dfd8bb061e19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import great_expectations as ge\n",
+    "\n",
+    "from ruamel import yaml\n",
+    "\n",
+    "from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest\n",
+    "\n",
+    "from great_expectations.rule_based_profiler.rule.rule import Rule\n",
+    "from great_expectations.rule_based_profiler.rule_based_profiler import RuleBasedProfiler, RuleBasedProfilerResult\n",
+    "\n",
+    "from great_expectations.rule_based_profiler.domain_builder import (\n",
+    "    DomainBuilder,\n",
+    "    ColumnDomainBuilder,\n",
+    ")\n",
+    "from great_expectations.rule_based_profiler.parameter_builder import (\n",
+    "    MetricMultiBatchParameterBuilder,\n",
+    ")\n",
+    "from great_expectations.rule_based_profiler.expectation_configuration_builder import (\n",
+    "    DefaultExpectationConfigurationBuilder,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96a2eb4f",
+   "metadata": {},
+   "source": [
+    "* Load `DataContext`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "45b1854b-2a75-422e-83bb-5509d868e0c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context: ge.DataContext = ge.get_context()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49515697-83a2-432d-8b74-33e2f01db72c",
+   "metadata": {},
+   "source": [
+    "### `InferredAssetDataConnector` Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df19a29c",
+   "metadata": {},
+   "source": [
+    "* Add `Datasource` named `taxi_multi_batch_inferred_datasource` with two `InferredAssetDataConnectors`. A key difference is in the `pattern` they use to build the `data_asset_name`. Depending on which `group_names` are used, we can either create a data Asset with a single batch (corresponding to 1 csv file) or a data Asset with 12 batches (corresponding to 12 csv files for 2020)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a7a8284",
+   "metadata": {},
+   "source": [
+    "* The first DataConnector is called `inferred_data_connector_single_batch_asset`, which takes the entire file name  (`(.*)`), and maps it to the `data_asset_name` group.\n",
+    "    * For the directory , we get 12 Data Assets, with 1 Batch each.\n",
+    "    * This can be seen in the output of `test_yaml_config()`, which shows the 12 data assets, with 1 Batch each. \n",
+    "    \n",
+    "    * Here is the output: \n",
+    "    \n",
+    "    ```\t\n",
+    "    Available data_asset_names (3 of 12):\n",
+    "\t\tyellow_tripdata_sample_2020-01 (1 of 1): ['yellow_tripdata_sample_2020-01.csv']\n",
+    "\t\tyellow_tripdata_sample_2020-02 (1 of 1): ['yellow_tripdata_sample_2020-02.csv']\n",
+    "\t\tyellow_tripdata_sample_2020-03 (1 of 1): ['yellow_tripdata_sample_2020-03.csv']\n",
+    "    ```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0852b21a",
+   "metadata": {},
+   "source": [
+    "* A second DataConnector is called `inferred_data_connector_multi_batch_asset`\n",
+    "    * It takes `(yellow_tripdata_sample_2020)` and maps it to the `data_asset_name` group, and matches the month (`(\\\\d.*)`) as the second group (`month`). \n",
+    "    * In the case of the files in our directory, we will return a single data asset named `yellow_tripdata_sample_2020`, with each of the 12 months corresponding to Batches for the asset. \n",
+    "    * This can be seen in the output of `test_yaml_config()`, which shows 3 of the 12 Batches corresponding to `yellow_tripdata_sample_2020`\n",
+    "    * Here is the output:\n",
+    " ```\n",
+    " Available data_asset_names (1 of 1):\n",
+    "       yellow_tripdata_sample_2020 (3 of 12): ['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-02.csv', 'yellow_tripdata_sample_2020-03.csv']\n",
+    " ```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "84150f65-bbd6-4b45-95ab-9590a29f116a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: PandasExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tinferred_data_connector_multi_batch_asset : InferredAssetFilesystemDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (1 of 1):\n",
+      "\t\tyellow_tripdata_sample_2020 (3 of 12): ['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-02.csv', 'yellow_tripdata_sample_2020-03.csv']\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n",
+      "\tinferred_data_connector_single_batch_asset : InferredAssetFilesystemDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (3 of 12):\n",
+      "\t\tyellow_tripdata_sample_2020-01 (1 of 1): ['yellow_tripdata_sample_2020-01.csv']\n",
+      "\t\tyellow_tripdata_sample_2020-02 (1 of 1): ['yellow_tripdata_sample_2020-02.csv']\n",
+      "\t\tyellow_tripdata_sample_2020-03 (1 of 1): ['yellow_tripdata_sample_2020-03.csv']\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7faaec1673d0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_path: str = \"../../../../test_sets/taxi_yellow_tripdata_samples/samples_2020\"\n",
+    "\n",
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_inferred_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"PandasExecutionEngine\",\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"inferred_data_connector_single_batch_asset\": {\n",
+    "            \"class_name\": \"InferredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"default_regex\": {\n",
+    "                \"group_names\": [\"data_asset_name\"],\n",
+    "                \"pattern\": \"(.*)\\\\.csv\",\n",
+    "            },\n",
+    "        },\n",
+    "        \"inferred_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"InferredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"default_regex\": {\n",
+    "                \"group_names\": [\"data_asset_name\", \"month\"],\n",
+    "                \"pattern\": \"(yellow_tripdata_sample_2020)-(\\\\d.*)\\\\.csv\",\n",
+    "            },\n",
+    "        },\n",
+    "        \n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7636ffff-0ddc-48fd-a4cf-f8e139a5e36e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_datasource only if it doesn't already exist in our configuration\n",
+    "try:\n",
+    "    data_context.get_datasource(datasource_config[\"name\"])\n",
+    "except ValueError:\n",
+    "    data_context.add_datasource(**datasource_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "438146be",
+   "metadata": {},
+   "source": [
+    "## BatchRequest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "117cdb0d",
+   "metadata": {},
+   "source": [
+    "* Depending on which `DataConnector` you send a `BatchRequest` to, you will retrieve a different number of `Batches`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87bc9c59",
+   "metadata": {},
+   "source": [
+    "* Single Batch returned by `inferred_data_connector_single_batch_asset` DataConnector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0453cd3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_inferred_datasource\",\n",
+    "    data_connector_name=\"inferred_data_connector_single_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020-01\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "35df7084",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d8e74a05-3fd1-4e47-9105-b721dbcf3516",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7faaec1405b0>]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be7f4fa5",
+   "metadata": {},
+   "source": [
+    "* Multi Batch returned by `inferred_data_connector_multi_batch_asset` DataConnector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c32dbac9-af5d-4677-98f9-f098ef091b6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_inferred_datasource\",\n",
+    "    data_connector_name=\"inferred_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3a284bfd-00aa-4068-bc09-71c6dea627e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7bf3e1ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7faaec16e850>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec161130>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec143970>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec1e3ac0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec1ea340>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec20cee0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec209ee0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec1f4f10>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec2141f0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec21df70>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec204190>,\n",
+       " <great_expectations.core.batch.Batch at 0x7faaec1493a0>]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_batch_batch_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "790746ee",
+   "metadata": {},
+   "source": [
+    "* You can also get a single Batch from a multi-batch DataConnector by passing in `data_connector_query`. Index `-1` will return the most recent (month = `12`) batch. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "16612bb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request_from_multi: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_inferred_datasource\",\n",
+    "    data_connector_name=\"inferred_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020\",\n",
+    "    data_connector_query={\n",
+    "        \"index\": -1 \n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6ef1b6a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request_from_multi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2c857607",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7faaec1ab100>]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "229815cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data': '<great_expectations.execution_engine.pandas_batch_data.PandasBatchData object at 0x7faaec18b370>',\n",
+       " 'batch_request': {'datasource_name': 'taxi_multi_batch_inferred_datasource',\n",
+       "  'data_connector_name': 'inferred_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_sample_2020',\n",
+       "  'limit': None,\n",
+       "  'data_connector_query': {'index': -1},\n",
+       "  'batch_spec_passthrough': None},\n",
+       " 'batch_definition': {'datasource_name': 'taxi_multi_batch_inferred_datasource',\n",
+       "  'data_connector_name': 'inferred_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_sample_2020',\n",
+       "  'batch_identifiers': {'month': '12'}},\n",
+       " 'batch_spec': {'path': '/Users/work/Development/great_expectations/tests/test_fixtures/rule_based_profiler/example_notebooks/great_expectations/../../../../test_sets/taxi_yellow_tripdata_samples/samples_2020/yellow_tripdata_sample_2020-12.csv'},\n",
+       " 'batch_markers': {'ge_load_time': '20220722T032413.060093Z',\n",
+       "  'pandas_data_fingerprint': 'b1b9772f30b6c43a0a26dafac04e26a7'}}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list[0].to_dict() # 'batch_identifiers': {'month': '12'}},"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "907a6ef5",
+   "metadata": {},
+   "source": [
+    "# Using auto-initializing `Expectations` to generate parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6efe9c76",
+   "metadata": {},
+   "source": [
+    "* We will generate a `Validator` using our `multi_batch_batch_list`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "847ce4a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a1eca55b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_suite = data_context.create_expectation_suite(expectation_suite_name=\"example_inferred_suite\", overwrite_existing=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "852deba1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator = data_context.get_validator_using_batch_list(batch_list=multi_batch_batch_list, expectation_suite=example_suite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee01a0e9",
+   "metadata": {},
+   "source": [
+    "* When you run methods on the validator, it will typically run on the most recent batch (index `-1`), even if the Validator has access to a longer Batch list. For example, notice that the `pickup_datetime` and `dropoff_datetime` below are all associated with December, indicating that it is with the most recent Batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "65fe8b51",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "74aa656940624e7b8ac4813558385f7e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>vendor_id</th>\n",
+       "      <th>pickup_datetime</th>\n",
+       "      <th>dropoff_datetime</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>trip_distance</th>\n",
+       "      <th>rate_code_id</th>\n",
+       "      <th>store_and_fwd_flag</th>\n",
+       "      <th>pickup_location_id</th>\n",
+       "      <th>dropoff_location_id</th>\n",
+       "      <th>payment_type</th>\n",
+       "      <th>fare_amount</th>\n",
+       "      <th>extra</th>\n",
+       "      <th>mta_tax</th>\n",
+       "      <th>tip_amount</th>\n",
+       "      <th>tolls_amount</th>\n",
+       "      <th>improvement_surcharge</th>\n",
+       "      <th>total_amount</th>\n",
+       "      <th>congestion_surcharge</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-15 12:20:27</td>\n",
+       "      <td>2020-12-15 12:40:49</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>5.76</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>209</td>\n",
+       "      <td>237</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.50</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>26.80</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-28 12:51:25</td>\n",
+       "      <td>2020-12-28 13:15:12</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>11.64</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>161</td>\n",
+       "      <td>220</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>33.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>5.00</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>44.60</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-27 10:43:42</td>\n",
+       "      <td>2020-12-27 10:51:05</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.22</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>163</td>\n",
+       "      <td>48</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.06</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.36</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-08 13:42:52</td>\n",
+       "      <td>2020-12-08 13:54:45</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.84</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>137</td>\n",
+       "      <td>229</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.30</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-19 11:56:43</td>\n",
+       "      <td>2020-12-19 12:08:43</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.55</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>24</td>\n",
+       "      <td>74</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>9.5</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.88</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   vendor_id      pickup_datetime     dropoff_datetime  passenger_count  \\\n",
+       "0        2.0  2020-12-15 12:20:27  2020-12-15 12:40:49              4.0   \n",
+       "1        2.0  2020-12-28 12:51:25  2020-12-28 13:15:12              1.0   \n",
+       "2        2.0  2020-12-27 10:43:42  2020-12-27 10:51:05              1.0   \n",
+       "3        2.0  2020-12-08 13:42:52  2020-12-08 13:54:45              1.0   \n",
+       "4        2.0  2020-12-19 11:56:43  2020-12-19 12:08:43              1.0   \n",
+       "\n",
+       "   trip_distance  rate_code_id store_and_fwd_flag  pickup_location_id  \\\n",
+       "0           5.76           1.0                  N                 209   \n",
+       "1          11.64           1.0                  N                 161   \n",
+       "2           1.22           1.0                  N                 163   \n",
+       "3           1.84           1.0                  N                 137   \n",
+       "4           1.55           1.0                  N                  24   \n",
+       "\n",
+       "   dropoff_location_id  payment_type  fare_amount  extra  mta_tax  tip_amount  \\\n",
+       "0                  237           1.0         21.0    0.0      0.5        2.50   \n",
+       "1                  220           1.0         33.5    0.0      0.5        5.00   \n",
+       "2                   48           1.0          7.0    0.0      0.5        2.06   \n",
+       "3                  229           2.0          9.0    0.0      0.5        0.00   \n",
+       "4                   74           1.0          9.5    0.0      0.5        2.58   \n",
+       "\n",
+       "   tolls_amount  improvement_surcharge  total_amount  congestion_surcharge  \n",
+       "0           0.0                    0.3         26.80                   2.5  \n",
+       "1           2.8                    0.3         44.60                   2.5  \n",
+       "2           0.0                    0.3         12.36                   2.5  \n",
+       "3           0.0                    0.3         12.30                   2.5  \n",
+       "4           0.0                    0.3         12.88                   0.0  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8be66602",
+   "metadata": {},
+   "source": [
+    "### Typical Workflow\n",
+    "* A `batch_list` becomes really useful when you are calculating parameters for auto-initializing Expectations, as they us a `RuleBasedProfiler` under-the-hood to calculate parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdef9ad7",
+   "metadata": {},
+   "source": [
+    "* Here is an example running `expect_column_median_to_be_between()` by \"guessing\" at the `min_value` and `max_value`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "b524a2df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4aa885dd3555460382c289c5d0dded87",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.61\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"success\": false,\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.expect_column_median_to_be_between(column=\"trip_distance\", min_value=0, max_value=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f18d096f",
+   "metadata": {},
+   "source": [
+    "* The observed value for the most recent batch (December/2020) is going to be `1.61`, which means the Expectation fails"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c5016d8",
+   "metadata": {},
+   "source": [
+    "* Now we run the same expectation again, but this time with `auto=True`. This means the `median` values are going to calculated across the `batch_list` associated with the `Validator` (ie 12 Batches for 2020), which gives the min value of `1.6` and the max value of `1.92`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "cdd821c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1ffc54906ef148ed9d0092b41725f43b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating Expectations:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "09a83b88bdb84195899d76be12c3c06c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.61\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"success\": true,\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  },\n",
+       "  \"expectation_config\": {\n",
+       "    \"kwargs\": {\n",
+       "      \"column\": \"trip_distance\",\n",
+       "      \"min_value\": 1.6,\n",
+       "      \"max_value\": 1.92,\n",
+       "      \"strict_min\": false,\n",
+       "      \"strict_max\": false\n",
+       "    },\n",
+       "    \"meta\": {\n",
+       "      \"auto_generated_at\": \"20220722T032413.926244Z\",\n",
+       "      \"great_expectations_version\": \"0.15.13+79.g5c6db848e.dirty\"\n",
+       "    },\n",
+       "    \"expectation_type\": \"expect_column_median_to_be_between\"\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.expect_column_median_to_be_between(column=\"trip_distance\", auto=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6a6c277",
+   "metadata": {},
+   "source": [
+    "* The `auto=True` will also automatically run the Expectation against the most recent Batch (which has an observed value of `1.61`) and the Expectation will pass. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90b8b938",
+   "metadata": {},
+   "source": [
+    "* You can now save the `ExpectationSuite`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "eba880ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator.save_expectation_suite()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b7ec631",
+   "metadata": {},
+   "source": [
+    "### Running the `ExpectationSuite` against single `Batch`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "477381f5",
+   "metadata": {},
+   "source": [
+    "* Now the ExpectationSuite can be used to validate single batches using a Checkpoint. As before, we can use `data_connector_query` to specify the batch that we would like to run the `Checkpoint` on, but the recommended way would be to use the `batch_identifier` parameter, where we have set `month` to `01` to specify the January 2020 batch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "747dea95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_inferred_datasource\",\n",
+    "    data_connector_name=\"inferred_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020\",\n",
+    "    #data_connector_query={\n",
+    "    #    \"index\": 0 # this one will correspond to Jan 2020\n",
+    "    #}\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "9d392e80",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"action_list\": [\n",
+       "    {\n",
+       "      \"name\": \"store_validation_result\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreValidationResultAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"store_evaluation_params\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreEvaluationParametersAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"update_data_docs\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"UpdateDataDocsAction\",\n",
+       "        \"site_names\": []\n",
+       "      }\n",
+       "    }\n",
+       "  ],\n",
+       "  \"batch_request\": {},\n",
+       "  \"class_name\": \"Checkpoint\",\n",
+       "  \"config_version\": 1.0,\n",
+       "  \"evaluation_parameters\": {},\n",
+       "  \"module_name\": \"great_expectations.checkpoint\",\n",
+       "  \"name\": \"my_checkpoint\",\n",
+       "  \"profilers\": [],\n",
+       "  \"runtime_configuration\": {},\n",
+       "  \"validations\": [\n",
+       "    {\n",
+       "      \"batch_request\": {\n",
+       "        \"datasource_name\": \"taxi_multi_batch_inferred_datasource\",\n",
+       "        \"data_connector_name\": \"inferred_data_connector_multi_batch_asset\",\n",
+       "        \"data_asset_name\": \"yellow_tripdata_sample_2020\"\n",
+       "      },\n",
+       "      \"expectation_suite_name\": \"example_inferred_suite\",\n",
+       "      \"batch_identifiers\": {\n",
+       "        \"month\": \"01\"\n",
+       "      }\n",
+       "    }\n",
+       "  ]\n",
+       "}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "checkpoint_config = {\n",
+    "    \"name\": \"my_checkpoint\",\n",
+    "    \"config_version\": 1,\n",
+    "    \"class_name\": \"SimpleCheckpoint\",\n",
+    "    \"validations\": [\n",
+    "        {\n",
+    "            \"batch_request\": multi_batch_batch_request,\n",
+    "            \"expectation_suite_name\": \"example_inferred_suite\",\n",
+    "            \"batch_identifiers\":{\"month\": \"01\"} # batch_identifier month is set to 01\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "data_context.add_checkpoint(**checkpoint_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "3269dfba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "67d60a16007b42c58009ddc5519e94d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results = data_context.run_checkpoint(\n",
+    "    checkpoint_name=\"my_checkpoint\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "c6234082",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results.success"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Multi-Batch Example Notebook for Configured and InferredAssetDataConnectors (FileSystem). Notebooks take 12 csv files corresponding to 2020 Taxi data and do the following: 
   - Adds Datasource that contains 2 DataConnectors that facilitate the loading of data as single or multiple batches
   - Provides examples of BatchRequests that can load data as single or multiple batches
   - Shows how the resulting `batch_list` can be used with `self-initializing` Expectations to estimate parameters.
   - Shows how the resulting `ExpectationSuite` can be used to run a `SimpleCheckpoint`.
- SqlDataConnector example follows a slightly different pattern and will be added in a subsequent PR
- Tests for the notebooks added to `tests/integration/profiling/rule_based_profiler/test_run_profiler_notebook.py`

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.