### PR TITLE
[MAINTENANCE] Make DataAssistantResult.usage_statistics_handler private (in order to optimize auto-complete for ease of use)

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -463,7 +463,7 @@ class DataAssistant(metaclass=MetaDataAssistant):
         data_assistant_result: DataAssistantResult = DataAssistantResult(
             _batch_id_to_batch_identifier_display_name_map=self._batch_id_to_batch_identifier_display_name_map(),
             execution_time=0.0,
-            usage_statistics_handler=usage_statistics_handler,
+            _usage_statistics_handler=usage_statistics_handler,
         )
         run_profiler_on_data(
             data_assistant=self,

--- a/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/onboarding_data_assistant.py
@@ -154,7 +154,7 @@ class OnboardingDataAssistant(DataAssistant):
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
             execution_time=data_assistant_result.execution_time,
-            usage_statistics_handler=data_assistant_result.usage_statistics_handler,
+            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,
         )
 
     @staticmethod

--- a/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/volume_data_assistant.py
@@ -78,7 +78,7 @@ class VolumeDataAssistant(DataAssistant):
             expectation_configurations=data_assistant_result.expectation_configurations,
             citation=data_assistant_result.citation,
             execution_time=data_assistant_result.execution_time,
-            usage_statistics_handler=data_assistant_result.usage_statistics_handler,
+            _usage_statistics_handler=data_assistant_result._usage_statistics_handler,
         )
 
     @staticmethod

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -340,7 +340,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
                 rule_state.rule.name: rule_state.execution_time
                 for rule_state in self.rule_states
             },
-            usage_statistics_handler=self._usage_statistics_handler,
+            _usage_statistics_handler=self._usage_statistics_handler,
         )
 
     def get_expectation_configurations(self) -> List[ExpectationConfiguration]:

--- a/great_expectations/rule_based_profiler/rule_based_profiler_result.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler_result.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from great_expectations.core import ExpectationConfiguration, ExpectationSuite
@@ -33,7 +33,8 @@ class RuleBasedProfilerResult(SerializableDictDot):
     citation: dict
     execution_time: float
     rule_execution_time: Dict[str, float]
-    usage_statistics_handler: Optional[UsageStatisticsHandler] = None
+    # Reference to  "UsageStatisticsHandler" object for this "RuleBasedProfilerResult" object (if configured).
+    _usage_statistics_handler: Optional[UsageStatisticsHandler] = field(default=None)
 
     def to_dict(self) -> dict:
         """
@@ -70,7 +71,7 @@ class RuleBasedProfilerResult(SerializableDictDot):
             ],
             "citation": self.citation,
             "execution_time": self.execution_time,
-            "usage_statistics_handler": self.usage_statistics_handler.__class__.__name__,
+            "_usage_statistics_handler": self._usage_statistics_handler.__class__.__name__,
         }
 
     def to_json_dict(self) -> dict:
@@ -78,13 +79,6 @@ class RuleBasedProfilerResult(SerializableDictDot):
         Returns: This RuleBasedProfilerResult as JSON-serializable dictionary.
         """
         return self.to_dict()
-
-    @property
-    def _usage_statistics_handler(self) -> Optional[UsageStatisticsHandler]:
-        """
-        Returns: "UsageStatisticsHandler" object for this RuleBasedProfilerResult object (if configured).
-        """
-        return self.usage_statistics_handler
 
     @usage_statistics_enabled_method(
         event_name=UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE.value,

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -138,7 +138,7 @@ class DataAssistantResult(SerializableDictDot):
         "expectation_configurations",
         "citation",
         "execution_time",
-        "usage_statistics_handler",
+        "_usage_statistics_handler",
     }
 
     IN_JUPYTER_NOTEBOOK_KEYS = {
@@ -161,7 +161,8 @@ class DataAssistantResult(SerializableDictDot):
     execution_time: Optional[
         float
     ] = None  # Overall DataAssistant execution time (in seconds).
-    usage_statistics_handler: Optional[UsageStatisticsHandler] = None
+    # Reference to "UsageStatisticsHandler" object for this "DataAssistantResult" object (if configured).
+    _usage_statistics_handler: Optional[UsageStatisticsHandler] = field(default=None)
 
     def to_dict(self) -> dict:
         """
@@ -197,7 +198,7 @@ class DataAssistantResult(SerializableDictDot):
             ],
             "citation": convert_to_json_serializable(data=self.citation),
             "execution_time": convert_to_json_serializable(data=self.execution_time),
-            "usage_statistics_handler": self.usage_statistics_handler.__class__.__name__,
+            "_usage_statistics_handler": self._usage_statistics_handler.__class__.__name__,
         }
 
     def to_json_dict(self) -> dict:
@@ -339,13 +340,6 @@ class DataAssistantResult(SerializableDictDot):
                 )
 
         return auxiliary_info
-
-    @property
-    def _usage_statistics_handler(self) -> Optional[UsageStatisticsHandler]:
-        """
-        Returns: "UsageStatisticsHandler" object for this DataAssistantResult object (if configured).
-        """
-        return self.usage_statistics_handler
 
     @usage_statistics_enabled_method(
         event_name=UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value,


### PR DESCRIPTION
### Scope
* By changing the `DataAssistantResult.usage_statistics_handler` property name to `DataAssistantResult._usage_statistics_handler` the `DataAssistantResult` will be less cluttered in `Jupyter` notebooks when using the "autocomplete" feature.
* This requires a slightly more advanced usage of the Python dataclass library.
* Ensure that existing tests pass.
* Ensure that autocomplete in a `Jupyter` notebook does not display either `usage_statistics_handler` or `_usage_statistics_handler` when hitting "Tab" on `result.` (where `result: DataAssistantResult`).

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1101
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!