### PR TITLE
[MAINTENANCE] Update `DataContextVariables` `__str__` and `__repr__` to only include config

### DIFF
--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -71,6 +71,12 @@ class DataContextVariables(ABC):
         if self.substitutions is None:
             self.substitutions = {}
 
+    def __str__(self) -> str:
+        return str(self.config)
+
+    def __repr__(self) -> str:
+        return repr(self.config)
+
     @property
     def store(self) -> "DataContextStore":  # noqa: F821
         if self._store is None:
@@ -262,7 +268,7 @@ class DataContextVariables(ABC):
         )
 
 
-@dataclass
+@dataclass(repr=False)
 class EphemeralDataContextVariables(DataContextVariables):
     def _init_store(self) -> "DataContextStore":  # noqa: F821
         from great_expectations.data_context.store.data_context_store import (
@@ -277,7 +283,7 @@ class EphemeralDataContextVariables(DataContextVariables):
         return store
 
 
-@dataclass
+@dataclass(repr=False)
 class FileDataContextVariables(DataContextVariables):
     data_context: Optional["DataContext"] = None  # noqa: F821
 
@@ -311,7 +317,7 @@ class FileDataContextVariables(DataContextVariables):
         return store
 
 
-@dataclass
+@dataclass(repr=False)
 class CloudDataContextVariables(DataContextVariables):
     ge_cloud_base_url: Optional[str] = None
     ge_cloud_organization_id: Optional[str] = None

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -71,6 +71,9 @@ class DataContextVariables(ABC):
         if self.substitutions is None:
             self.substitutions = {}
 
+    def __str__(self) -> str:
+        return str(self.config)
+
     def __repr__(self) -> str:
         return repr(self.config)
 

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -71,9 +71,6 @@ class DataContextVariables(ABC):
         if self.substitutions is None:
             self.substitutions = {}
 
-    def __str__(self) -> str:
-        return str(self.config)
-
     def __repr__(self) -> str:
         return repr(self.config)
 

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -439,6 +439,29 @@ def test_data_context_variables_save_config(
         )
 
 
+@pytest.mark.unit
+def test_data_context_variables_repr_and_str_only_reveal_config(
+    data_context_config: DataContextConfig,
+) -> None:
+    config = data_context_config
+
+    substitutions_key = "my_sensitive_information"
+    substitutions = {substitutions_key: "*****"}
+    variables = EphemeralDataContextVariables(
+        config=data_context_config, substitutions=substitutions
+    )
+
+    variables_str = str(variables)
+    variables_repr = repr(variables)
+
+    assert variables_str == str(config)
+    assert variables_repr == repr(config)
+    assert (
+        substitutions_key not in variables_str
+        and substitutions_key not in variables_repr
+    )
+
+
 def test_file_data_context_variables_e2e(
     monkeypatch, file_data_context: FileDataContext, progress_bars: ProgressBarsConfig
 ) -> None:


### PR DESCRIPTION
Changes proposed in this pull request:
- As variables are a lightweight wrapper around a `DataContextConfig`, we want to make sure we're only showing that information to the user.
- Sensitive details stored in the `self.substitutions` dict should be omittted from output in Jupyter Notebooks.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
