### PR TITLE
[MAINTENANCE] Ensure that Cloud-backed `DataContext` can send and retrieve `DataContextVariables` payload to/from Cloud API

### DIFF
--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -302,7 +302,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         # necessary properties / overrides
         self._synchronize_self_with_underlying_data_context()
 
-        self._variables = self._init_variables()
+        self._variables = self._data_context.variables
 
         # Init validation operators
         # NOTE - 20200522 - JPC - A consistent approach to lazy loading for plugins will be useful here, harmonizing

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -169,16 +169,17 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             }
         }
 
-        if ge_cloud_id:
-            data["data"]["id"] = ge_cloud_id
-
         url = urljoin(
             self.ge_cloud_base_url,
             f"organizations/"
             f"{organization_id}/"
-            f"{hyphen(self.ge_cloud_resource_name)}/"
-            f"{ge_cloud_id}",
+            f"{hyphen(self.ge_cloud_resource_name)}",
         )
+
+        if ge_cloud_id:
+            data["data"]["id"] = ge_cloud_id
+            url = urljoin(f"{url}/", ge_cloud_id)
+
         try:
             response = requests.put(url, json=data, headers=self.auth_headers)
             response_status_code = response.status_code

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -422,7 +422,7 @@ def test_data_context_variables_save_config(
 
         assert mock_put.call_count == 1
         mock_put.assert_called_with(
-            f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/data-context-variables/",
+            f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/data-context-variables",
             json={
                 "data": {
                     "type": "data_context_variables",


### PR DESCRIPTION
Changes proposed in this pull request:
- The following changes introduce minor tweaks to ensure we're able to GET and PUT variables in a Cloud-specific context.
- The `self.variables` attr on the context has been adjusted to work with `self._data_context`
- The URL creation within the `GeCloudStoreBackend` has been updated to ensure we actually hit existing endpoints.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
