### PR TITLE
[MAINTENANCE] Add AbstractConfig

### DIFF
--- a/great_expectations/core/configuration.py
+++ b/great_expectations/core/configuration.py
@@ -1,5 +1,6 @@
 """Contains general abstract or base classes used across configuration objects."""
 from abc import ABC
+from typing import Optional
 
 from great_expectations.types import SerializableDictDot
 
@@ -7,7 +8,7 @@ from great_expectations.types import SerializableDictDot
 class AbstractConfig(ABC, SerializableDictDot):
     """Abstract base class for Config objects. Sets the fields that must be included on a Config."""
 
-    def __init__(self, id_: str = None, name: str = None) -> None:
+    def __init__(self, id_: Optional[str] = None, name: Optional[str] = None) -> None:
         # Note: name and id are optional currently to avoid updating all documentation within
         # the scope of this work.
         if id_ is not None:

--- a/great_expectations/core/configuration.py
+++ b/great_expectations/core/configuration.py
@@ -1,0 +1,17 @@
+"""Contains general abstract or base classes used across configuration objects."""
+from abc import ABC
+
+from great_expectations.types import SerializableDictDot
+
+
+class AbstractConfig(ABC, SerializableDictDot):
+    """Abstract base class for Config objects. Sets the fields that must be included on a Config."""
+
+    def __init__(self, id_: str = None, name: str = None) -> None:
+        # Note: name and id are optional currently to avoid updating all documentation within
+        # the scope of this work.
+        if id_ is not None:
+            self.id = id_
+        if name is not None:
+            self.name = name
+        super().__init__()


### PR DESCRIPTION
Changes proposed in this pull request:
- We will be standardizing some of our config objects with specific fields. AbstractConfig will be inherited in place of SerializableDictDot to add the `id` and `name` fields.
- This is planned to be used for DatasourceConfig, see also https://github.com/great-expectations/great_expectations/pull/5560/files for usage.
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
