### PR TITLE
[MAINTENANCE] Delete usage_statistics_handler from the set of RuleBasedProfilerResult and DataAssistantResult object serialization keys

### DIFF
--- a/great_expectations/rule_based_profiler/rule_based_profiler_result.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler_result.py
@@ -71,7 +71,6 @@ class RuleBasedProfilerResult(SerializableDictDot):
             ],
             "citation": self.citation,
             "execution_time": self.execution_time,
-            "_usage_statistics_handler": self._usage_statistics_handler.__class__.__name__,
         }
 
     def to_json_dict(self) -> dict:

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -130,6 +130,7 @@ class DataAssistantResult(SerializableDictDot):
     }
 
     ALLOWED_KEYS = {
+        "_batch_id_to_batch_identifier_display_name_map",
         "profiler_config",
         "profiler_execution_time",
         "rule_execution_time",

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -130,7 +130,6 @@ class DataAssistantResult(SerializableDictDot):
     }
 
     ALLOWED_KEYS = {
-        "_batch_id_to_batch_identifier_display_name_map",
         "profiler_config",
         "profiler_execution_time",
         "rule_execution_time",
@@ -138,7 +137,6 @@ class DataAssistantResult(SerializableDictDot):
         "expectation_configurations",
         "citation",
         "execution_time",
-        "_usage_statistics_handler",
     }
 
     IN_JUPYTER_NOTEBOOK_KEYS = {
@@ -198,7 +196,6 @@ class DataAssistantResult(SerializableDictDot):
             ],
             "citation": convert_to_json_serializable(data=self.citation),
             "execution_time": convert_to_json_serializable(data=self.execution_time),
-            "_usage_statistics_handler": self._usage_statistics_handler.__class__.__name__,
         }
 
     def to_json_dict(self) -> dict:

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -1647,6 +1647,7 @@ def test_volume_data_assistant_result_serialization(
         bobby_volume_data_assistant_result.to_json_dict()
         == volume_data_assistant_result_as_dict
     )
+    assert len(bobby_volume_data_assistant_result.profiler_config.rules) == 2
 
 
 @mock.patch(


### PR DESCRIPTION
### Scope
* Delete `DataAssistantResult._usage_statistics_handler` and `RuleBasedProfilerResult._usage_statistics_handler` `to_dict()` serialization keys (it is deemed not useful in these objects).
* Ensure that existing tests pass.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1101
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!