### PR TITLE
[BUGFIX] Ensure that `DataContext.list_datasources()` iterates through config instead of relying on `DatasourceStore` requests

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -603,11 +603,10 @@ class AbstractDataContext(ABC):
         """
         datasources: List[dict] = []
         substitutions: dict = self._determine_substitutions()
+
         datasource_name: str
-        for datasource_name in self._datasource_store.list_keys():
-            datasource_config: DatasourceConfig = (
-                self._datasource_store.retrieve_by_name(datasource_name)
-            )
+        datasource_config: DatasourceConfig
+        for datasource_name, datasource_config in self.config.datasources.items():
             datasource_dict: dict = datasource_config.to_json_dict()
             datasource_dict["name"] = datasource_name
             substituted_config: dict = cast(


### PR DESCRIPTION
Changes proposed in this pull request:
- Iterate through config for list datasources to adhere to legacy behavior


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
