### PR TITLE
[MAINTENANCE] type-checking round 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+.dmypy.json
 
 # vim backup files
 *~

--- a/docs/contributing/style_guides/code_style.md
+++ b/docs/contributing/style_guides/code_style.md
@@ -72,7 +72,12 @@ Our CI system will perform static type-checking using [mypy](https://mypy.readth
 Type-checked modules.
 
 ```
+data_asset
+exceptions
+jupyter_ux
 profile
+self_check
+types
 ```
 
 To verify your code will pass the CI type-checker, run `invoke type-check --install-types`.

--- a/great_expectations/core/expectation_diagnostics/expectation_test_data_cases.py
+++ b/great_expectations/core/expectation_diagnostics/expectation_test_data_cases.py
@@ -22,7 +22,7 @@ class Backend(Enum):
 @dataclass
 class TestBackend:
     backend: str
-    dialects: Optional[List[str]]
+    dialects: List[str]
 
     __test__ = False  # Tell pytest not to try to collect this class as a test
 

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -10,7 +10,7 @@ import warnings
 from collections import Counter, defaultdict, namedtuple
 from collections.abc import Hashable
 from functools import wraps
-from typing import List
+from typing import Dict, List, Optional, Union
 
 from dateutil.parser import parse
 
@@ -343,7 +343,9 @@ class DataAsset:
         return outer_wrapper
 
     def _initialize_expectations(
-        self, expectation_suite=None, expectation_suite_name=None
+        self,
+        expectation_suite: Union[Dict, ExpectationSuite, None] = None,
+        expectation_suite_name: Optional[str] = None,
     ) -> None:
         """Instantiates `_expectation_suite` as empty by default or with a specified expectation `config`.
         In addition, this always sets the `default_expectation_args` to:
@@ -372,7 +374,7 @@ class DataAsset:
                 expectation_suite_dict: dict = expectationSuiteSchema.load(
                     expectation_suite
                 )
-                expectation_suite: ExpectationSuite = ExpectationSuite(
+                expectation_suite = ExpectationSuite(
                     **expectation_suite_dict, data_context=self._data_context
                 )
             else:

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -304,7 +304,7 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
-        module_spec = importlib.util.find_spec(module_name, package=package_name)
+        module_spec = importlib.util.find_spec(module_name, package=package_name)  # type: ignore[attr-defined]
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -2,6 +2,7 @@ import importlib
 import itertools
 import json
 from collections.abc import Iterable
+from typing import Any, Dict, List, Union
 
 from great_expectations.marshmallow__shade import ValidationError
 
@@ -15,13 +16,13 @@ class GreatExpectationsError(Exception):
 class GreatExpectationsValidationError(ValidationError, GreatExpectationsError):
     def __init__(self, message, validation_error=None) -> None:
         self.message = message
-        self.messages = None
+        self.messages: Union[List[str], List[Any], Dict] = []
         if validation_error is not None:
             self.messages = validation_error.messages
 
     def __str__(self) -> str:
         if self.message is None:
-            return self.messages
+            return str(self.messages)
         return self.message
 
 

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -304,7 +304,7 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
-        module_spec = importlib.util.find_spec(module_name, package=package_name)  # type: ignore
+        module_spec = importlib.util.find_spec(module_name, package=package_name)
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -304,7 +304,7 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
-        module_spec = importlib.util.find_spec(module_name, package=package_name)
+        module_spec = importlib.util.find_spec(module_name, package=package_name)  # type: ignore
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/jupyter_ux/__init__.py
+++ b/great_expectations/jupyter_ux/__init__.py
@@ -60,13 +60,12 @@ If you did not create the data source during init, here is how to add it now: <a
                     """
 <p>
 Found more than one data source in the great_expectations.yml of your project:
-<b>{1:s}</b>
+<b>{:s}</b>
 </p>
 <p>
 Uncomment the next cell and set data_source_name to one of these names.
 </p>
 """.format(
-                        data_source_type,
                         ",".join(
                             [
                                 datasource["name"]

--- a/great_expectations/jupyter_ux/expectation_explorer.py
+++ b/great_expectations/jupyter_ux/expectation_explorer.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from itertools import chain
+from typing import Dict
 
 import ipywidgets as widgets
 
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class ExpectationExplorer:
     def __init__(self) -> None:
-        self.state = {"data_assets": {}}
+        self.state: Dict[str, Dict] = {"data_assets": {}}
         self.expectation_kwarg_field_names = {
             "expect_column_values_to_be_unique": ["mostly"],
             "expect_column_unique_value_count_to_be_between": [
@@ -243,9 +244,9 @@ class ExpectationExplorer:
     def set_expectation_state(self, data_asset, expectation_state, column=None) -> None:
         data_asset_name = data_asset.data_asset_name
         expectation_type = expectation_state.get("expectation_type")
-        data_asset_state = self.state["data_assets"].get(data_asset_name)
+        data_asset_state: Dict = self.state["data_assets"][data_asset_name]
 
-        data_asset_expectations = data_asset_state.get("expectations")
+        data_asset_expectations = data_asset_state.get("expectations", {})
 
         if column:
             column_expectations = data_asset_expectations.get(column, {})
@@ -1003,7 +1004,7 @@ class ExpectationExplorer:
         **expectation_kwargs,
     ):
         data_asset_name = expectation_state["data_asset_name"]
-        data_asset = self.state["data_assets"].get(data_asset_name)["data_asset"]
+        data_asset = self.state["data_assets"][data_asset_name]["data_asset"]
         expectation_feedback_widget = expectation_state["expectation_feedback_widget"]
         expectation_type = expectation_state["expectation_type"]
         min_max_type_widget_dict = expectation_state["kwargs"].get("min_max_type", {})

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -11,7 +11,17 @@ import traceback
 import warnings
 from functools import wraps
 from types import ModuleType
-from typing import Dict, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 import numpy as np
 import pandas as pd
@@ -54,6 +64,9 @@ from great_expectations.execution_engine.sqlalchemy_batch_data import (
 from great_expectations.profile import ColumnsExistProfiler
 from great_expectations.util import import_library_module
 from great_expectations.validator.validator import Validator
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
 
 expectationValidationResultSchema = ExpectationValidationResultSchema()
 expectationSuiteValidationResultSchema = ExpectationSuiteValidationResultSchema()
@@ -159,7 +172,7 @@ except ImportError:
         )
         try:
             getattr(sqla_bigquery, "INTEGER")
-            bigquery_types_tuple = {}
+            bigquery_types_tuple = {}  # type: ignore[var-annotated]
             BIGQUERY_TYPES = {
                 "INTEGER": sqla_bigquery.INTEGER,
                 "NUMERIC": sqla_bigquery.NUMERIC,
@@ -181,13 +194,13 @@ except ImportError:
             )
             from collections import namedtuple
 
-            BigQueryTypes = namedtuple("BigQueryTypes", sorted(sqla_bigquery._type_map))
-            bigquery_types_tuple = BigQueryTypes(**sqla_bigquery._type_map)
+            BigQueryTypes = namedtuple("BigQueryTypes", sorted(sqla_bigquery._type_map))  # type: ignore[misc]
+            bigquery_types_tuple = BigQueryTypes(**sqla_bigquery._type_map)  # type: ignore[assignment]
             BIGQUERY_TYPES = {}
 
     except (ImportError, AttributeError):
         sqla_bigquery = None
-        bigquery_types_tuple = None
+        bigquery_types_tuple = None  # type: ignore[assignment]
         BigQueryDialect = None
         pybigquery = None
         BIGQUERY_TYPES = {}
@@ -331,7 +344,7 @@ SQL_DIALECT_NAMES = (
 class SqlAlchemyConnectionManager:
     def __init__(self) -> None:
         self.lock = threading.Lock()
-        self._connections = {}
+        self._connections: Dict[str, "Connection"] = {}
 
     def get_engine(self, connection_string):
         if sqlalchemy is not None:
@@ -1069,7 +1082,7 @@ def build_sa_validator_with_data(
     sqlite_db_path=None,
     batch_definition: Optional[BatchDefinition] = None,
 ):
-    dialect_classes = {}
+    dialect_classes: Dict[str, Type] = {}
     dialect_types = {}
     try:
         dialect_classes["sqlite"] = sqlitetypes.dialect
@@ -1137,13 +1150,12 @@ def build_sa_validator_with_data(
     if (
         schemas
         and sa_engine_name in schemas
-        and isinstance(engine.dialect, dialect_classes.get(sa_engine_name))
+        and isinstance(engine.dialect, dialect_classes[sa_engine_name])
     ):
         schema = schemas[sa_engine_name]
 
         sql_dtypes = {
-            col: dialect_types.get(sa_engine_name)[dtype]
-            for (col, dtype) in schema.items()
+            col: dialect_types[sa_engine_name][dtype] for (col, dtype) in schema.items()
         }
         for col in schema:
             type_ = schema[col]
@@ -1323,7 +1335,7 @@ def build_spark_engine(
         )
 
     if batch_id is None:
-        batch_id = batch_definition.id
+        batch_id = cast(BatchDefinition, batch_definition).id
 
     if isinstance(df, pd.DataFrame):
         df = spark.createDataFrame(
@@ -1336,7 +1348,7 @@ def build_spark_engine(
             ],
             df.columns.tolist(),
         )
-    conf: List[tuple] = spark.sparkContext.getConf().getAll()
+    conf: Iterable[Tuple[str, str]] = spark.sparkContext.getConf().getAll()
     spark_config: Dict[str, str] = dict(conf)
     execution_engine: SparkDFExecutionEngine = SparkDFExecutionEngine(
         spark_config=spark_config

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -202,7 +202,7 @@ except ImportError:
         sqla_bigquery = None
         bigquery_types_tuple = None  # type: ignore[assignment]
         BigQueryDialect = None
-        pybigquery = None
+        pybigquery = None  # type: ignore[var-annotated]
         BIGQUERY_TYPES = {}
 
 

--- a/great_expectations/types/base.py
+++ b/great_expectations/types/base.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from typing import List
 
 from ruamel.yaml import YAML, yaml_object
 
@@ -34,7 +35,7 @@ class DotDict(dict):
     # The following are required to support yaml serialization, since we do not raise
     # AttributeError from __getattr__ in DotDict. We *do* raise that AttributeError when it is possible to know
     # a given attribute is not allowed (because it's not in _allowed_keys)
-    _yaml_merge = []
+    _yaml_merge: List = []
 
     @classmethod
     def yaml_anchor(cls):

--- a/great_expectations/types/base.py
+++ b/great_expectations/types/base.py
@@ -19,8 +19,8 @@ class DotDict(dict):
     def __getattr__(self, item):
         return self.get(item)
 
-    __setattr__ = dict.__setitem__  # type: ignore
-    __delattr__ = dict.__delitem__  # type: ignore
+    __setattr__ = dict.__setitem__  # type: ignore[assignment]
+    __delattr__ = dict.__delitem__  # type: ignore[assignment]
 
     def __dir__(self):
         return self.keys()

--- a/great_expectations/types/base.py
+++ b/great_expectations/types/base.py
@@ -19,8 +19,8 @@ class DotDict(dict):
     def __getattr__(self, item):
         return self.get(item)
 
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+    __setattr__ = dict.__setitem__  # type: ignore
+    __delattr__ = dict.__delitem__  # type: ignore
 
     def __dir__(self):
         return self.keys()

--- a/tasks.py
+++ b/tasks.py
@@ -142,7 +142,9 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
         "install-types": "Automatically install any needed types from `typeshed`.",
     },
 )
-def type_check(ctx, packages, install_types=False, show_default_packages=False):
+def type_check(
+    ctx, packages, install_types=False, show_default_packages=False, daemon=False
+):
     """Run mypy static type-checking on select packages."""
     if show_default_packages:
         # Use this to keep the Type-checking section of the docs up to date.
@@ -150,13 +152,18 @@ def type_check(ctx, packages, install_types=False, show_default_packages=False):
         print("\n".join(DEFAULT_PACKAGES_TO_TYPE_CHECK))
         raise invoke.Exit(code=0)
 
+    if daemon:
+        bin = "dmypy run --"
+    else:
+        bin = "mypy"
+
     packages = packages or DEFAULT_PACKAGES_TO_TYPE_CHECK
     # once we have sunsetted `type-coverage` and our typing has matured we should define
     # our packages to exclude (if any) in the mypy config file.
     # https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude
     ge_pkgs = [f"great_expectations/{p}" for p in packages]
     cmds = [
-        "mypy",
+        bin,
         *ge_pkgs,
     ]
     if install_types:

--- a/tasks.py
+++ b/tasks.py
@@ -140,6 +140,9 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
         "packages": f"One or more packages to type-check with mypy. (Default: {DEFAULT_PACKAGES_TO_TYPE_CHECK})",
         "show-default-packages": "Print the default packages to type-check and then exit.",
         "install-types": "Automatically install any needed types from `typeshed`.",
+        "daemon": "Run mypy in daemon mode with faster analysis."
+        " The daemon will be started and re-used for subsequent calls."
+        " For detailed usage see `dmypy --help`.",
     },
 )
 def type_check(

--- a/tasks.py
+++ b/tasks.py
@@ -171,4 +171,5 @@ def type_check(
     ]
     if install_types:
         cmds.extend(["--install-types", "--non-interactive"])
-    ctx.run(" ".join(cmds), echo=True)
+    # use pseudo-terminal for colorized output
+    ctx.run(" ".join(cmds), echo=True, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -171,5 +171,8 @@ def type_check(
     ]
     if install_types:
         cmds.extend(["--install-types", "--non-interactive"])
+    if daemon:
+        # see related issue https://github.com/python/mypy/issues/9475
+        cmds.extend(["--follow-imports=normal"])
     # use pseudo-terminal for colorized output
     ctx.run(" ".join(cmds), echo=True, pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -114,19 +114,19 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
     # "checkpoint",  # 78
     # "cli",  # 237
     # "core",  # 242
-    # "data_asset",  # 1
+    "data_asset",  # 0
     # "data_context",  # 272
     # "datasource",  # 98
-    # "exceptions",  # 2
+    "exceptions",  # 0
     # "execution_engine",  # 109
     # "expectations",  # 462
-    # "jupyter_ux",  # 4
+    "jupyter_ux",  # 0
     # "marshmallow__shade",  # 14
     "profile",  # 0
     # "render",  # 87
     # "rule_based_profiler",  # 469
-    # "self_check",  # 10
-    # "types",  # 3
+    "self_check",  # 0
+    "types",  # 0
     # "validation_operators", # 47
     # "validator",  # 46
     # util.py # 28


### PR DESCRIPTION
Changes proposed in this pull request:

Followup to #5540 

1. Enable type checking on the following packages.
```
data_asset
exceptions
jupyter_ux
self_check
types
```
2. Add `invoke type-check --daemon` flag to easily run `mypy` in daemon mode for faster typing feedback.
- [ ] add `--clear-cache` flag for removing the existing `mypy` cache.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing~
- ~I have run any local integration tests and made sure that nothing is broken.~


Thank you for submitting!
