### PR TITLE
[MAINTENANCE] Misc updates to `Datasource` CRUD on `DataContext` to ensure consistent behavior

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -619,7 +619,9 @@ class AbstractDataContext(ABC):
             datasources.append(masked_config)
         return datasources
 
-    def delete_datasource(self, datasource_name: str) -> None:
+    def delete_datasource(
+        self, datasource_name: Optional[str], save_changes: bool = False
+    ) -> None:
         """Delete a datasource
         Args:
             datasource_name: The name of the datasource to delete.
@@ -629,13 +631,15 @@ class AbstractDataContext(ABC):
         """
         if datasource_name is None:
             raise ValueError("Datasource names must be a datasource name")
-        else:
-            datasource = self.get_datasource(datasource_name=datasource_name)
-            if datasource:
-                self._datasource_store.delete_by_name(datasource_name)
-                del self._cached_datasources[datasource_name]
-            else:
-                raise ValueError(f"Datasource {datasource_name} not found")
+
+        datasource = self.get_datasource(datasource_name=datasource_name)
+
+        if datasource is None:
+            raise ValueError(f"Datasource {datasource_name} not found")
+
+        if save_changes:
+            self._datasource_store.delete_by_name(datasource_name)
+        self._cached_datasources.pop(datasource_name, None)
 
     def store_evaluation_parameters(
         self, validation_results, target_store_name=None

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -652,7 +652,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         Raises:
             ValueError: If the datasource name isn't provided or cannot be found.
         """
-        super().delete_datasource(datasource_name)
+        super().delete_datasource(datasource_name, save_changes=save_changes)
         self._synchronize_self_with_underlying_data_context()
 
     def get_available_data_asset_names(
@@ -1281,9 +1281,8 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             self._datasource_store.update_by_name(
                 datasource_name=datasource_name, datasource_config=datasource_config
             )
-        else:
-            self.config.datasources[datasource_name] = datasource_config
-            self._cached_datasources[datasource_name] = datasource_config
+        self.config.datasources[datasource_name] = datasource_config
+        self._cached_datasources[datasource_name] = datasource_config
 
     def add_batch_kwargs_generator(
         self, datasource_name, batch_kwargs_generator_name, class_name, **kwargs

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -526,7 +526,7 @@ class DataContext(BaseDataContext):
 
     def delete_datasource(self, name: str) -> None:
         logger.debug(f"Starting DataContext.delete_datasource for datasource {name}")
-        super().delete_datasource(datasource_name=name)
+        super().delete_datasource(datasource_name=name, save_changes=True)
         self._save_project_config()
 
     def add_profiler(


### PR DESCRIPTION
Changes proposed in this pull request:
- `delete_datasource` should only persist changes on the `DataContext` and must be opt-in on the `BaseDataContext`
- `update_datasource` should always update the config and cache (but only conditionally persist changes based on the save mechanism as stated above).


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code