### PR TITLE
[MAINTENANCE] Clear datasources in `test_data_context_datasources` to improve test performance and narrow test scope

### DIFF
--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -1,5 +1,4 @@
 import pathlib
-from unittest import mock
 
 import pytest
 
@@ -24,6 +23,9 @@ def test_data_context_instantiates_ge_cloud_store_backend_with_cloud_config(
     project_path = tmp_path / "my_data_context"
     project_path.mkdir()
 
+    # Clear datasources to improve test performance in DataContext._init_datasources
+    data_context_config_with_datasources.datasources = {}
+
     context = BaseDataContext(
         project_config=data_context_config_with_datasources,
         context_root_dir=str(project_path),
@@ -41,6 +43,9 @@ def test_data_context_instantiates_inline_store_backend_with_filesystem_config(
 ) -> None:
     project_path = tmp_path / "my_data_context"
     project_path.mkdir()
+
+    # Clear datasources to improve test performance in DataContext._init_datasources
+    data_context_config_with_datasources.datasources = {}
 
     context = BaseDataContext(
         project_config=data_context_config_with_datasources,


### PR DESCRIPTION
Changes proposed in this pull request:
- The tests in question are very focused around ensuring that we're instantiating the proper store - we do not care about datasource instantiation. The `_init_datasources` stage hangs and although that is a separate issue to resolve, it should not impact the test here.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
