### PR TITLE
[MAINTENANCE] Add id to `RuleBasedProfiler` config

### DIFF
--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -496,8 +496,6 @@ class RuleBasedProfilerConfig(AbstractConfig, BaseYamlConfig):
         self.module_name = "great_expectations.rule_based_profiler"
         self.class_name = "RuleBasedProfiler"
 
-        self.name = name
-
         self.config_version = config_version
 
         self.variables = variables
@@ -677,6 +675,7 @@ class RuleBasedProfilerConfigSchema(Schema):
         unknown = INCLUDE
         fields = (
             "name",
+            "id",
             "config_version",
             "module_name",
             "class_name",

--- a/great_expectations/rule_based_profiler/config/base.py
+++ b/great_expectations/rule_based_profiler/config/base.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 from ruamel.yaml.comments import CommentedMap
 
+from great_expectations.core.configuration import AbstractConfig
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.data_context.types.base import BaseYamlConfig
 from great_expectations.marshmallow__shade import (
@@ -482,12 +483,13 @@ class RuleConfigSchema(NotNullSchema):
     )
 
 
-class RuleBasedProfilerConfig(BaseYamlConfig):
+class RuleBasedProfilerConfig(AbstractConfig, BaseYamlConfig):
     def __init__(
         self,
         name: str,
         config_version: float,
         rules: Dict[str, dict],  # see RuleConfig
+        id_: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
         commented_map: Optional[CommentedMap] = None,
     ) -> None:
@@ -501,7 +503,8 @@ class RuleBasedProfilerConfig(BaseYamlConfig):
         self.variables = variables
         self.rules = rules
 
-        super().__init__(commented_map=commented_map)
+        AbstractConfig.__init__(self, id_=id_, name=name)
+        BaseYamlConfig.__init__(self, commented_map=commented_map)
 
     @classmethod
     def from_commented_map(cls, commented_map: CommentedMap):  # type: ignore[no-untyped-def]
@@ -684,6 +687,10 @@ class RuleBasedProfilerConfigSchema(Schema):
 
     name = fields.String(
         required=True,
+        allow_none=False,
+    )
+    id = fields.String(
+        required=False,
         allow_none=False,
     )
     config_version = fields.Float(

--- a/tests/rule_based_profiler/test_rule_based_profiler_serialization.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler_serialization.py
@@ -1,0 +1,55 @@
+"""Test v3 API RuleBasedProfiler serialization."""
+import pytest
+
+from great_expectations.rule_based_profiler.config.base import (
+    RuleBasedProfilerConfig,
+    ruleBasedProfilerConfigSchema,
+)
+
+
+@pytest.mark.parametrize(
+    "rbp_config,expected_serialized_rbp_config",
+    [
+        pytest.param(
+            RuleBasedProfilerConfig(
+                name="my_rbp",
+                config_version=1.0,
+                rules={},
+            ),
+            {
+                "class_name": "RuleBasedProfiler",
+                "config_version": 1.0,
+                "module_name": "great_expectations.rule_based_profiler",
+                "name": "my_rbp",
+                "rules": {},
+                "variables": None,
+            },
+            id="minimal_with_name",
+        ),
+        pytest.param(
+            RuleBasedProfilerConfig(
+                name="my_rbp",
+                id_="dd223ad9-as12-d823-239a-382sadaf8112",
+                config_version=1.0,
+                rules={},
+            ),
+            {
+                "class_name": "RuleBasedProfiler",
+                "config_version": 1.0,
+                "id": "dd223ad9-as12-d823-239a-382sadaf8112",
+                "module_name": "great_expectations.rule_based_profiler",
+                "name": "my_rbp",
+                "rules": {},
+                "variables": None,
+            },
+            id="minimal_with_name_and_id",
+        ),
+    ],
+)
+def test_rule_based_profiler_config_is_serialized(
+    rbp_config: RuleBasedProfilerConfig, expected_serialized_rbp_config: dict
+):
+    """RBP Config should be serialized appropriately with/without optional params."""
+    observed = ruleBasedProfilerConfigSchema.dump(rbp_config)
+
+    assert dict(observed) == expected_serialized_rbp_config


### PR DESCRIPTION
Changes proposed in this pull request:
- To enable GE Cloud, we want to add an id to the `RuleBasedProfiler` config to be able to associate objects to UUID/GUIDs.
- Please see [the equivalent PR for `Datasources`](https://github.com/great-expectations/great_expectations/pull/5560)

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
