### PR TITLE
[BUGFIX] Pass cloud base url to datasource store

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -68,6 +68,7 @@ class CloudDataContext(AbstractDataContext):
             "root_directory": self.root_directory,
             "ge_cloud_credentials": self.ge_cloud_config.to_dict(),
             "ge_cloud_resource_type": GeCloudRESTResource.DATASOURCE,
+            "ge_cloud_base_url": self.ge_cloud_config.base_url,
         }
 
         datasource_store: DatasourceStore = DatasourceStore(

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -69,10 +69,12 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         }
     )
 
+    DEFAULT_BASE_URL: str = "https://app.greatexpectations.io/"
+
     def __init__(
         self,
         ge_cloud_credentials: Dict,
-        ge_cloud_base_url: str = "https://app.greatexpectations.io/",
+        ge_cloud_base_url: str = DEFAULT_BASE_URL,
         ge_cloud_resource_type: Optional[GeCloudRESTResource] = None,
         ge_cloud_resource_name: Optional[str] = None,
         suppress_store_backend_id: bool = True,

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -3,7 +3,8 @@ from unittest import mock
 import pytest
 from ruamel import yaml
 
-from great_expectations.data_context import DataContext
+from great_expectations.data_context import BaseDataContext, DataContext
+from great_expectations.data_context.store import GeCloudStoreBackend
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.exceptions import DataContextError, GeCloudError
 
@@ -176,3 +177,48 @@ def test_data_context_ge_cloud_mode_with_bad_request_to_cloud_api_should_throw_e
             ge_cloud_organization_id=ge_cloud_runtime_organization_id,
             ge_cloud_access_token=ge_cloud_runtime_access_token,
         )
+
+
+@pytest.mark.cloud
+@pytest.mark.unit
+@mock.patch("requests.get")
+def test_data_context_in_cloud_mode_passes_base_url_to_store_backend(
+    mock_request,
+    ge_cloud_base_url,
+    empty_cloud_data_context_custom_base_url,
+    ge_cloud_runtime_organization_id,
+    ge_cloud_runtime_access_token,
+):
+
+    custom_base_url: str = "https://some_url.org"
+    # Ensure that the request goes through
+    mock_request.return_value.status_code = 200
+
+    context = empty_cloud_data_context_custom_base_url
+
+    # Assertions that the context fixture is set up properly
+    assert not context.ge_cloud_config.base_url == GeCloudStoreBackend.DEFAULT_BASE_URL
+    assert not context.ge_cloud_config.base_url == ge_cloud_base_url
+    assert (
+        not context.ge_cloud_config.base_url == "https://app.test.greatexpectations.io"
+    )
+
+    # The DatasourceStore should not have the default base_url or commonly used test base urls
+    assert (
+        not context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        == GeCloudStoreBackend.DEFAULT_BASE_URL
+    )
+    assert (
+        not context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        == ge_cloud_base_url
+    )
+    assert (
+        not context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        == "https://app.test.greatexpectations.io"
+    )
+
+    # The DatasourceStore should have the custom base url set
+    assert (
+        context._datasource_store.store_backend.config["ge_cloud_base_url"]
+        == custom_base_url
+    )


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- The base url was not being passed to the config for the datasource store backend. This PR also adds a test to confirm.
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
