### PR TITLE
[BUGFIX] Support `ExpectationSuite` CRUD at `BaseDataContext` level

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -76,6 +76,7 @@ from great_expectations.validator.validator import Validator
 
 from great_expectations.core.usage_statistics.usage_statistics import (  # isort: skip
     UsageStatisticsHandler,
+    send_usage_message,
 )
 
 logger = logging.getLogger(__name__)
@@ -1690,3 +1691,18 @@ class AbstractDataContext(ABC):
                             "metric {} was requested by another expectation suite but is not available in "
                             "this validation result.".format(metric_name)
                         )
+
+    def send_usage_message(
+        self, event: str, event_payload: Optional[dict], success: Optional[bool] = None
+    ) -> None:
+        """helper method to send a usage method using DataContext. Used when sending usage events from
+            classes like ExpectationSuite.
+            event
+        Args:
+            event (str): str representation of event
+            event_payload (dict): optional event payload
+            success (bool): optional success param
+        Returns:
+            None
+        """
+        send_usage_message(self, event, event_payload, success)

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1326,15 +1326,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         **kwargs: Optional[dict],
     ) -> ExpectationSuite:
         """
-
-        Args:
-            expectation_suite_name (str):
-             (Optional[dict]):
-            overwrite_existing (bool):
-            ge_cloud_id (Optional[str]):
-
-        Returns:
-
+        See `AbstractDataContext.create_expectation_suite` for more information.
         """
         return self._data_context.create_expectation_suite(
             expectation_suite_name,
@@ -1349,13 +1341,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         ge_cloud_id: Optional[str] = None,
     ) -> ExpectationSuite:
         """
-
-        Args:
-            expectation_suite_name (Optional[str]):
-            ge_cloud_id (Optional[str]):
-
-        Returns:
-
+        See `AbstractDataContext.get_expectation_suite` for more information.
         """
         return self._data_context.get_expectation_suite(
             expectation_suite_name=expectation_suite_name, ge_cloud_id=ge_cloud_id
@@ -1365,12 +1351,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         self, expectation_suite_name: Optional[str] = None
     ) -> bool:
         """
-
-        Args:
-            expectation_suite_name (Optional[str]):
-
-        Returns:
-
+        See `AbstractDataContext.delete_expectation_suite` for more information.
         """
         return self._data_context.delete_expectation_suite(
             expectation_suite_name=expectation_suite_name

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1325,6 +1325,17 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         ge_cloud_id: Optional[str] = None,
         **kwargs: Optional[dict],
     ) -> ExpectationSuite:
+        """
+
+        Args:
+            expectation_suite_name (str):
+             (Optional[dict]):
+            overwrite_existing (bool):
+            ge_cloud_id (Optional[str]):
+
+        Returns:
+
+        """
         return self._data_context.create_expectation_suite(
             expectation_suite_name,
             overwrite_existing=overwrite_existing,
@@ -1337,6 +1348,15 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         expectation_suite_name: Optional[str] = None,
         ge_cloud_id: Optional[str] = None,
     ) -> ExpectationSuite:
+        """
+
+        Args:
+            expectation_suite_name (Optional[str]):
+            ge_cloud_id (Optional[str]):
+
+        Returns:
+
+        """
         return self._data_context.get_expectation_suite(
             expectation_suite_name=expectation_suite_name, ge_cloud_id=ge_cloud_id
         )
@@ -1344,6 +1364,14 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
     def delete_expectation_suite(
         self, expectation_suite_name: Optional[str] = None
     ) -> bool:
+        """
+
+        Args:
+            expectation_suite_name (Optional[str]):
+
+        Returns:
+
+        """
         return self._data_context.delete_expectation_suite(
             expectation_suite_name=expectation_suite_name
         )

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1318,20 +1318,35 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             validation_operators.append(value)
         return validation_operators
 
-    def send_usage_message(
-        self, event: str, event_payload: Optional[dict], success: Optional[bool] = None
-    ) -> None:
-        """helper method to send a usage method using DataContext. Used when sending usage events from
-            classes like ExpectationSuite.
-            event
-        Args:
-            event (str): str representation of event
-            event_payload (dict): optional event payload
-            success (bool): optional success param
-        Returns:
-            None
-        """
-        send_usage_message(self, event, event_payload, success)
+    def create_expectation_suite(
+        self,
+        expectation_suite_name: str,
+        overwrite_existing: bool = False,
+        ge_cloud_id: Optional[str] = None,
+        **kwargs: Optional[dict],
+    ) -> ExpectationSuite:
+        return self._data_context.create_expectation_suite(
+            expectation_suite_name,
+            overwrite_existing=overwrite_existing,
+            ge_cloud_id=ge_cloud_id,
+            **kwargs,
+        )
+
+    def get_expectation_suite(
+        self,
+        expectation_suite_name: Optional[str] = None,
+        ge_cloud_id: Optional[str] = None,
+    ) -> ExpectationSuite:
+        return self._data_context.get_expectation_suite(
+            expectation_suite_name=expectation_suite_name, ge_cloud_id=ge_cloud_id
+        )
+
+    def delete_expectation_suite(
+        self, expectation_suite_name: Optional[str] = None
+    ) -> bool:
+        return self._data_context.delete_expectation_suite(
+            expectation_suite_name=expectation_suite_name
+        )
 
     @usage_statistics_enabled_method(
         event_name=UsageStatsEvents.DATA_CONTEXT_SAVE_EXPECTATION_SUITE.value,

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -1,5 +1,6 @@
 import os
 from typing import List
+from unittest import mock
 
 import pytest
 
@@ -158,3 +159,57 @@ def test_get_config_with_variables_substituted(
         )
     finally:
         del os.environ["replace_me"]
+
+
+@pytest.mark.cloud
+@mock.patch("great_expectations.data_context.CloudDataContext.create_expectation_suite")
+def test_create_expectation_suite_with_cloud_enabled_context_uses_cloud_impl(
+    mock_cloud_create_expectation_suite: mock.MagicMock,
+    empty_cloud_data_context: BaseDataContext,
+) -> None:
+    """
+    What does this test do and why?
+
+    Ensures that when a BaseDataContext is instantiated with cloud_mode=True, the call to
+    ExpectationSuite CRUD leverages the implementation defined and managed by CloudDataContext.
+    """
+    context = empty_cloud_data_context
+
+    context.create_expectation_suite("my_expectation_suite")
+    assert mock_cloud_create_expectation_suite.call_count == 1
+
+
+@pytest.mark.cloud
+@mock.patch("great_expectations.data_context.CloudDataContext.get_expectation_suite")
+def test_get_expectation_suite_with_cloud_enabled_context_uses_cloud_impl(
+    mock_cloud_get_expectation_suite: mock.MagicMock,
+    empty_cloud_data_context: BaseDataContext,
+) -> None:
+    """
+    What does this test do and why?
+
+    Ensures that when a BaseDataContext is instantiated with cloud_mode=True, the call to
+    ExpectationSuite CRUD leverages the implementation defined and managed by CloudDataContext.
+    """
+    context = empty_cloud_data_context
+
+    context.get_expectation_suite("my_expectation_suite")
+    assert mock_cloud_get_expectation_suite.call_count == 1
+
+
+@pytest.mark.cloud
+@mock.patch("great_expectations.data_context.CloudDataContext.delete_expectation_suite")
+def test_delete_expectation_suite_with_cloud_enabled_context_uses_cloud_impl(
+    mock_cloud_delete_expectation_suite: mock.MagicMock,
+    empty_cloud_data_context: BaseDataContext,
+) -> None:
+    """
+    What does this test do and why?
+
+    Ensures that when a BaseDataContext is instantiated with cloud_mode=True, the call to
+    ExpectationSuite CRUD leverages the implementation defined and managed by CloudDataContext.
+    """
+    context = empty_cloud_data_context
+
+    context.delete_expectation_suite("my_expectation_suite")
+    assert mock_cloud_delete_expectation_suite.call_count == 1

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1924,6 +1924,7 @@ def test_add_expectation_to_expectation_suite(
 ):
     context: DataContext = empty_data_context_stats_enabled
 
+    # breakpoint()
     expectation_suite: ExpectationSuite = context.create_expectation_suite(
         expectation_suite_name="my_new_expectation_suite"
     )

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1924,7 +1924,6 @@ def test_add_expectation_to_expectation_suite(
 ):
     context: DataContext = empty_data_context_stats_enabled
 
-    # breakpoint()
     expectation_suite: ExpectationSuite = context.create_expectation_suite(
         expectation_suite_name="my_new_expectation_suite"
     )

--- a/tests/expectations/test_expectation_arguments.py
+++ b/tests/expectations/test_expectation_arguments.py
@@ -875,7 +875,6 @@ def test_in_memory_runtime_context_configured_with_usage_stats_handler(
         kwargs=expectation_arguments_without_meta,
         meta=expectation_meta,
     )
-    breakpoint()
     suite.add_expectation(expectation_configuration=expectation_configuration)
 
     # emit 1 from add_expectation

--- a/tests/expectations/test_expectation_arguments.py
+++ b/tests/expectations/test_expectation_arguments.py
@@ -836,11 +836,13 @@ def test_in_memory_runtime_context_configured_with_usage_stats_handler(
     context: DataContext = in_memory_runtime_context
 
     # manually set usage statistics handler
-    context._usage_statistics_handler = UsageStatisticsHandler(
+    handler = UsageStatisticsHandler(
         data_context=context,
         data_context_id=context._data_context_id,
         usage_statistics_url="http://fakeendpoint.com",
     )
+    context._usage_statistics_handler = handler
+    context._data_context._usage_statistics_handler = handler
 
     catch_exceptions: bool = False  # expect exceptions to be raised
     result_format: dict = {
@@ -873,6 +875,7 @@ def test_in_memory_runtime_context_configured_with_usage_stats_handler(
         kwargs=expectation_arguments_without_meta,
         meta=expectation_meta,
     )
+    breakpoint()
     suite.add_expectation(expectation_configuration=expectation_configuration)
 
     # emit 1 from add_expectation


### PR DESCRIPTION
Changes proposed in this pull request:
- To ensure we're able to support both file and Cloud environments with the `BaseDataContext`, we need to leverage the `self._data_context` pointer we use in the object.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
