### PR TITLE
[MAINTENANCE] Increase expectation kwarg line stroke width

### DIFF
--- a/great_expectations/rule_based_profiler/types/altair/themes.py
+++ b/great_expectations/rule_based_profiler/types/altair/themes.py
@@ -72,7 +72,7 @@ fill_color: str = ColorPalettes.HEATMAP_6.value[5]
 
 # Line Chart
 line_color: str = Colors.BLUE_2.value
-line_stroke_width: int = 3
+line_stroke_width: float = 2.5
 line_opacity: float = 0.9
 
 # Point

--- a/great_expectations/rule_based_profiler/types/altair/themes.py
+++ b/great_expectations/rule_based_profiler/types/altair/themes.py
@@ -76,7 +76,7 @@ line_stroke_width: float = 2.5
 line_opacity: float = 0.9
 
 # Point
-point_size: int = 70
+point_size: int = 50
 point_color: str = Colors.GREEN.value
 point_filled: bool = True
 point_opacity: float = 1.0

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -1857,7 +1857,10 @@ class DataAssistantResult(SerializableDictDot):
         tooltip: List[alt.Tooltip],
         expectation_type: Optional[str] = None,
     ) -> alt.Chart:
-        line_color: alt.HexColor = alt.HexColor(ColorPalettes.HEATMAP_6.value[4])
+        expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
+            ColorPalettes.HEATMAP_6.value[4]
+        )
+        expectation_kwarg_line_stroke_width: int = 5
 
         title: alt.TitleParams = determine_plot_title(
             expectation_type=expectation_type,
@@ -1868,7 +1871,10 @@ class DataAssistantResult(SerializableDictDot):
 
         lower_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=batch_plot_component.plot_on_axis(),
                 y=min_value_plot_component.plot_on_axis(),
@@ -1879,7 +1885,10 @@ class DataAssistantResult(SerializableDictDot):
 
         upper_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=batch_plot_component.plot_on_axis(),
                 y=max_value_plot_component.plot_on_axis(),
@@ -1944,7 +1953,10 @@ class DataAssistantResult(SerializableDictDot):
         tooltip: List[alt.Tooltip],
         expectation_type: Optional[str] = None,
     ) -> alt.Chart:
-        line_color: alt.HexColor = alt.HexColor(ColorPalettes.HEATMAP_6.value[4])
+        expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
+            ColorPalettes.HEATMAP_6.value[4]
+        )
+        expectation_kwarg_line_stroke_width: int = 5
 
         title: alt.TitleParams = determine_plot_title(
             expectation_type=expectation_type,
@@ -1955,7 +1967,10 @@ class DataAssistantResult(SerializableDictDot):
 
         lower_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=alt.X(
                     batch_plot_component.name,
@@ -1971,7 +1986,10 @@ class DataAssistantResult(SerializableDictDot):
 
         upper_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=alt.X(
                     batch_plot_component.name,
@@ -2435,7 +2453,10 @@ class DataAssistantResult(SerializableDictDot):
         strict_max_plot_component: PlotComponent,
         predicate: Union[bool, int],
     ) -> alt.VConcatChart:
-        line_color: alt.HexColor = alt.HexColor(ColorPalettes.HEATMAP_6.value[4])
+        expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
+            ColorPalettes.HEATMAP_6.value[4]
+        )
+        expectation_kwarg_line_stroke_width: int = 5
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]
@@ -2475,7 +2496,10 @@ class DataAssistantResult(SerializableDictDot):
 
         lower_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=batch_plot_component.plot_on_axis(),
                 y=min_value_plot_component.plot_on_axis(),
@@ -2487,7 +2511,10 @@ class DataAssistantResult(SerializableDictDot):
 
         upper_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=batch_plot_component.plot_on_axis(),
                 y=max_value_plot_component.plot_on_axis(),
@@ -2555,7 +2582,10 @@ class DataAssistantResult(SerializableDictDot):
         strict_max_plot_component: PlotComponent,
         predicate: Union[bool, int],
     ) -> alt.VConcatChart:
-        line_color: alt.HexColor = alt.HexColor(ColorPalettes.HEATMAP_6.value[4])
+        expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
+            ColorPalettes.HEATMAP_6.value[4]
+        )
+        expectation_kwarg_line_stroke_width: int = 5
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]
@@ -2613,7 +2643,10 @@ class DataAssistantResult(SerializableDictDot):
 
         lower_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=alt.X(
                     batch_plot_component.name,
@@ -2631,7 +2664,10 @@ class DataAssistantResult(SerializableDictDot):
 
         upper_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=alt.X(
                     batch_plot_component.name,
@@ -2694,7 +2730,10 @@ class DataAssistantResult(SerializableDictDot):
         strict_max_plot_component: PlotComponent,
         predicate: Union[bool, int],
     ) -> alt.VConcatChart:
-        line_color: alt.HexColor = alt.HexColor(ColorPalettes.HEATMAP_6.value[4])
+        expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
+            ColorPalettes.HEATMAP_6.value[4]
+        )
+        expectation_kwarg_line_stroke_width: int = 5
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]
@@ -2746,7 +2785,10 @@ class DataAssistantResult(SerializableDictDot):
 
         lower_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=alt.X(
                     batch_plot_component.name,
@@ -2765,7 +2807,10 @@ class DataAssistantResult(SerializableDictDot):
 
         upper_limit: alt.Chart = (
             alt.Chart(data=df)
-            .mark_line(color=line_color)
+            .mark_line(
+                color=expectation_kwarg_line_color,
+                strokeWidth=expectation_kwarg_line_stroke_width,
+            )
             .encode(
                 x=alt.X(
                     batch_plot_component.name,

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -1860,7 +1860,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 5
+        expectation_kwarg_line_stroke_width: int = 6
 
         title: alt.TitleParams = determine_plot_title(
             expectation_type=expectation_type,
@@ -1956,7 +1956,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 5
+        expectation_kwarg_line_stroke_width: int = 6
 
         title: alt.TitleParams = determine_plot_title(
             expectation_type=expectation_type,
@@ -2456,7 +2456,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 5
+        expectation_kwarg_line_stroke_width: int = 6
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]
@@ -2585,7 +2585,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 5
+        expectation_kwarg_line_stroke_width: int = 6
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]
@@ -2733,7 +2733,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 5
+        expectation_kwarg_line_stroke_width: int = 6
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -1860,7 +1860,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 6
+        expectation_kwarg_line_stroke_width: int = 5
 
         title: alt.TitleParams = determine_plot_title(
             expectation_type=expectation_type,
@@ -1956,7 +1956,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 6
+        expectation_kwarg_line_stroke_width: int = 5
 
         title: alt.TitleParams = determine_plot_title(
             expectation_type=expectation_type,
@@ -2456,7 +2456,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 6
+        expectation_kwarg_line_stroke_width: int = 5
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]
@@ -2585,7 +2585,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 6
+        expectation_kwarg_line_stroke_width: int = 5
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]
@@ -2733,7 +2733,7 @@ class DataAssistantResult(SerializableDictDot):
         expectation_kwarg_line_color: alt.HexColor = alt.HexColor(
             ColorPalettes.HEATMAP_6.value[4]
         )
-        expectation_kwarg_line_stroke_width: int = 6
+        expectation_kwarg_line_stroke_width: int = 5
 
         tooltip: List[alt.Tooltip] = (
             [domain_plot_component.generate_tooltip()]


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1039
- Increase expectation kwarg line stroke width in order to make it visible when it is underneath a metric line

Comparing Metrics view to Expectations and Metrics view:

![image](https://user-images.githubusercontent.com/19361723/181104605-d4199fb3-7795-47ae-8328-2c85181c117f.png)

![image](https://user-images.githubusercontent.com/19361723/181104359-a62a9f25-c7c0-4500-99f1-e1d55ae62070.png)

Change to typical view:

![image](https://user-images.githubusercontent.com/19361723/181104738-2d5578dd-635a-4430-a44f-3ca9a3b07747.png)


### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have run any local integration tests and made sure that nothing is broken.
