### PR TITLE
[BUGFIX] Patch flaky E2E GX Cloud tests

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -360,7 +360,7 @@ stages:
           - script: |
               # These are tests that are specific to Great Expectations Cloud.
               # In order to ensure coverage, we run them during each CI/CD cycle.
-              pytest -m cloud
+              pytest --cloud
 
             env:
               GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -360,7 +360,7 @@ stages:
           - script: |
               # These are tests that are specific to Great Expectations Cloud.
               # In order to ensure coverage, we run them during each CI/CD cycle.
-              pytest --cloud
+              pytest -m cloud
 
             env:
               GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,7 +253,7 @@ stages:
           postgres: postgres
 
         variables:
-          GE_pytest_opts: '--postgresql --spark'
+          GE_pytest_opts: '--postgresql --spark --cloud'
 
         strategy:
           matrix:

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -980,6 +980,7 @@ class AbstractDataContext(ABC):
     def delete_expectation_suite(
         self,
         expectation_suite_name: Optional[str] = None,
+        ge_cloud_id: Optional[str] = None,
     ) -> bool:
         """Delete specified expectation suite from data_context expectation store.
 

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1356,12 +1356,13 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
     def delete_expectation_suite(
         self,
         expectation_suite_name: Optional[str] = None,
+        ge_cloud_id: Optional[str] = None,
     ) -> ExpectationSuite:
         """
         See `AbstractDataContext.delete_expectation_suite` for more information.
         """
         res = self._data_context.delete_expectation_suite(
-            expectation_suite_name=expectation_suite_name
+            expectation_suite_name=expectation_suite_name, ge_cloud_id=ge_cloud_id
         )
         self._synchronize_self_with_underlying_data_context()
         return res

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,10 @@ def pytest_configure(config):
         "markers",
         "aws_integration: runs aws integration test that may be very slow and requires credentials",
     )
+    config.addinivalue_line(
+        "markers",
+        "cloud: runs GX Cloud tests that may be slow and requires credentials",
+    )
 
 
 def pytest_addoption(parser):
@@ -174,6 +178,9 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--azure", action="store_true", help="If set, execute tests again Azure"
+    )
+    parser.addoption(
+        "--cloud", action="store_true", help="If set, execute tests again GX Cloud"
     )
     parser.addoption(
         "--performance-tests",
@@ -251,15 +258,23 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption("--docs-tests"):
         # --docs-tests given in cli: do not skip documentation integration tests
         return
+    if config.getoption("--cloud"):
+        # --cloud given in cli: do not skip GX Cloud integration tests
+        return
+
     skip_aws_integration = pytest.mark.skip(
         reason="need --aws-integration option to run"
     )
     skip_docs_integration = pytest.mark.skip(reason="need --docs-tests option to run")
+    skip_cloud = pytest.mark.skip(reason="need --cloud option to run")
+
     for item in items:
         if "aws_integration" in item.keywords:
             item.add_marker(skip_aws_integration)
         if "docs" in item.keywords:
             item.add_marker(skip_docs_integration)
+        if "cloud" in item.keywords:
+            item.add_marker(skip_cloud)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -250,7 +250,6 @@ def prepare_validator_for_cloud_e2e() -> Callable[[DataContext], Tuple[Validator
 def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_cloud_backend(
     mock_save_project_config: mock.MagicMock,
     prepare_validator_for_cloud_e2e: Callable[[DataContext], Tuple[Validator, str]],
-    monkeypatch,
 ) -> None:
     """
     What does this test do and why?
@@ -260,8 +259,6 @@ def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_clo
     Saving of ExpectationSuites using such a Validator should send payloads to the Cloud
     backend.
     """
-    # Context is shared between other tests so we need to set a required env var
-    monkeypatch.setenv("MY_PLUGINS_DIRECTORY", "plugins/")
     context = DataContext(ge_cloud_mode=True)
 
     (
@@ -282,7 +279,6 @@ def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_clo
 def test_validator_e2e_workflow_with_cloud_enabled_context(
     mock_save_project_config: mock.MagicMock,
     prepare_validator_for_cloud_e2e: Callable[[DataContext], Tuple[Validator, str]],
-    monkeypatch,
 ) -> None:
     """
     What does this test do and why?
@@ -292,8 +288,6 @@ def test_validator_e2e_workflow_with_cloud_enabled_context(
     Saving of ExpectationSuites using such a Validator should send payloads to the Cloud
     backend.
     """
-    # Context is shared between other tests so we need to set a required env var
-    monkeypatch.setenv("MY_PLUGINS_DIRECTORY", "plugins/")
     context = DataContext(ge_cloud_mode=True)
 
     (

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -175,8 +175,7 @@ def prepare_validator_for_cloud_e2e() -> Callable[[DataContext], Tuple[Validator
         suites = context.list_expectation_suites()
         expectation_suite_ge_cloud_id = suites[0].ge_cloud_id
 
-        # Randomize name so subsequent tests use a clean slate
-        suite_name = f"suite_{''.join(random.choice(string.ascii_letters + string.digits) for _ in range(8))}"
+        suite_name = "oss_e2e_test_suite"
         suite = context.create_expectation_suite(
             suite_name,
             ge_cloud_id=expectation_suite_ge_cloud_id,

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -246,10 +246,9 @@ def prepare_validator_for_cloud_e2e() -> Callable[[DataContext], Tuple[Validator
 
 @pytest.mark.cloud
 @pytest.mark.integration
-@pytest.mark.xfail(
-    strict=False, reason="Flaky GX Cloud test - to be resolved post 0.15.16 release"
-)
+@mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_cloud_backend(
+    mock_save_project_config: mock.MagicMock,
     prepare_validator_for_cloud_e2e: Callable[[DataContext], Tuple[Validator, str]],
     monkeypatch,
 ) -> None:
@@ -279,12 +278,11 @@ def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_clo
 
 @pytest.mark.cloud
 @pytest.mark.integration
-@pytest.mark.xfail(
-    strict=False, reason="Flaky GX Cloud test - to be resolved post 0.15.16 release"
-)
+@mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_validator_e2e_workflow_with_cloud_enabled_context(
-    monkeypatch,
+    mock_save_project_config: mock.MagicMock,
     prepare_validator_for_cloud_e2e: Callable[[DataContext], Tuple[Validator, str]],
+    monkeypatch,
 ) -> None:
     """
     What does this test do and why?

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -174,8 +174,12 @@ def prepare_validator_for_cloud_e2e() -> Callable[[DataContext], Tuple[Validator
         # Create a suite to be used in Validator instantiation
         suites = context.list_expectation_suites()
         expectation_suite_ge_cloud_id = suites[0].ge_cloud_id
-
         suite_name = "oss_e2e_test_suite"
+
+        # Start off each test run with a clean slate
+        if expectation_suite_ge_cloud_id in context.list_expectation_suite_names():
+            context.delete_expectation_suite(ge_cloud_id=expectation_suite_ge_cloud_id)
+
         suite = context.create_expectation_suite(
             suite_name,
             ge_cloud_id=expectation_suite_ge_cloud_id,

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -568,11 +568,9 @@ def test_cloud_enabled_data_context_variables_e2e(
     It is also important to note that in the case of $VARS syntax, we NEVER want to persist the underlying
     value in order to preserve sensitive information.
     """
-    # Prepare updated plugins directory to set and save to the Cloud backend (ensuring we hide the true value behind $VARS syntax)
+    # Prepare updated plugins directory to set and save to the Cloud backend.
     # As values are persisted in the Cloud DB, we want to randomize our values each time for consistent test results
-    env_var_name = "MY_PLUGINS_DIRECTORY"
     updated_plugins_dir = f"plugins_dir_{''.join(random.choice(string.ascii_letters + string.digits) for _ in range(8))}"
-    monkeypatch.setenv(env_var_name, updated_plugins_dir)
 
     updated_data_docs_sites = data_docs_sites
     new_site_name = f"docs_site_{''.join(random.choice(string.ascii_letters + string.digits) for _ in range(8))}"
@@ -580,10 +578,10 @@ def test_cloud_enabled_data_context_variables_e2e(
 
     context = DataContext(ge_cloud_mode=True)
 
-    assert context.variables.plugins_directory != f"${env_var_name}"
+    assert context.variables.plugins_directory != updated_plugins_dir
     assert context.variables.data_docs_sites != updated_data_docs_sites
 
-    context.variables.plugins_directory = f"${env_var_name}"
+    context.variables.plugins_directory = updated_plugins_dir
     context.variables.data_docs_sites = updated_data_docs_sites
 
     assert context.variables.plugins_directory == updated_plugins_dir

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -533,9 +533,6 @@ def test_file_data_context_variables_e2e(
 
 @pytest.mark.integration
 @pytest.mark.cloud
-@pytest.mark.xfail(
-    strict=False, reason="Flaky GX Cloud test - to be resolved post 0.15.16 release"
-)
 def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     cloud_data_context: CloudDataContext,
     data_context_config: DataContextConfig,
@@ -555,9 +552,6 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
 @pytest.mark.integration
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
-@pytest.mark.xfail(
-    strict=False, reason="Flaky GX Cloud test - to be resolved post 0.15.16 release"
-)
 def test_cloud_enabled_data_context_variables_e2e(
     mock_save_project_config: mock.MagicMock, data_docs_sites: dict, monkeypatch
 ) -> None:


### PR DESCRIPTION
Changes proposed in this pull request:
- Introduce `--cloud` flag for `pytest`
- Update Azure pipelines to utilize new flag
- Remove inconsistencies from tests
  - Env var substitution - as this one fixture is shared across a few tests, let's minimize changes
  - Remove randomization of suite name - this will prevent overpopulating the dev env with test suites


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.