### PR TITLE
[MAINTENANCE] DEVREL-2617/black_declarations

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -100,7 +100,7 @@ stages:
               pip install isort[requirements]==5.4.2 flake8==3.8.3 black==22.3.0 pyupgrade==2.7.2
               EXIT_STATUS=0
               isort . --check-only --skip docs/ || EXIT_STATUS=$?
-              black --check --exclude docs/ . || EXIT_STATUS=$?
+              black --check --exclude  '(docs/.*|tests/.*.fixture|.*.ge_store_backend_id)' . || EXIT_STATUS=$?
               flake8 great_expectations/core || EXIT_STATUS=$?
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS


### PR DESCRIPTION
Changes proposed in this pull request:
- Keep things in line with each-other.

```> git diff origin/develop
-              black --check --exclude docs/ . || EXIT_STATUS=$?
+              black --check --exclude  '(docs/.*|tests/.*.fixture|.*.ge_store_backend_id)' . || EXIT_STATUS=$?
```

```
> grep 'id: black' -A1 .pre-commit-config.yaml
      - id: black
        exclude: docs/.*|tests/.*.fixture|.*.ge_store_backend_id
```


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code in that it runs in bash correctly and as expected.
