### PR TITLE
[MAINTENANCE] Better error message for RuntimeDataConnector for BatchIdentifiers

### DIFF
--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -421,7 +421,11 @@ class RuntimeDataConnector(DataConnector):
         if not set(batch_identifiers_keys) == set(asset.batch_identifiers):
             raise ge_exceptions.DataConnectorError(
                 f"""
-                Data Asset {data_asset_name} was invoked with one or more batch_identifiers that were not configured for the asset.
+                Data Asset {data_asset_name} was invoked with one or more batch_identifiers
+                that were not configured for the asset.
+
+                The Data Asset was configured with : {asset.batch_identifiers}
+                It was invoked with : {batch_identifiers_keys}
                 """
             )
 
@@ -434,8 +438,11 @@ class RuntimeDataConnector(DataConnector):
         batch_identifiers_keys: List[str] = list(batch_identifiers.keys())
         if not set(batch_identifiers_keys) <= set(self._batch_identifiers[self.name]):
             raise ge_exceptions.DataConnectorError(
-                f"""RuntimeDataConnector "{self.name}" was invoked with one or more batch identifiers that do not
+                f"""RuntimeDataConnector {self.name} was invoked with one or more batch identifiers that do not
         appear among the configured batch identifiers.
+
+                The RuntimeDataConnector was configured with : {self._batch_identifiers[self.name]}
+                It was invoked with : {batch_identifiers_keys}
                 """
             )
 

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -326,7 +326,7 @@ def test_asset_is_named_but_batch_identifier_in_other_asset(
     runtime_data_connector: RuntimeDataConnector = (
         basic_datasource_with_assets.data_connectors["runtime"]
     )
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as error:
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource_with_assets.name,
@@ -340,6 +340,7 @@ def test_asset_is_named_but_batch_identifier_in_other_asset(
                 runtime_parameters={"batch_data": test_df_pandas},
             )
         )
+        print(error.value.message)
 
 
 def test_asset_is_named_but_batch_identifier_not_defined_anywhere(

--- a/tests/datasource/data_connector/test_runtime_data_connector.py
+++ b/tests/datasource/data_connector/test_runtime_data_connector.py
@@ -177,7 +177,7 @@ def test_add_batch_identifiers_correct(basic_datasource_with_assets):
 
 def test_batch_identifiers_missing_completely():
     # missing from base DataConnector
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         instantiate_class_from_config(
             config=yaml.load(
                 """
@@ -196,10 +196,14 @@ execution_engine:
                 "module_name": "great_expectations.datasource",
             },
         )
+    expected_error_message: str = """
+        RuntimeDataConnector "runtime" requires batch_identifiers to be configured, either at the DataConnector or Asset-level.
+    """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
 
 def test_batch_identifiers_missing_from_named_asset():
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         basic_datasource: Datasource = instantiate_class_from_config(
             config=yaml.load(
                 """
@@ -223,6 +227,11 @@ execution_engine:
                 "module_name": "great_expectations.datasource",
             },
         )
+
+    expected_error_message: str = """
+        RuntimeDataConnector "runtime" requires batch_identifiers to be configured when specifying Assets.
+        """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
 
 def test_error_checking_unknown_datasource(basic_datasource):
@@ -326,7 +335,7 @@ def test_asset_is_named_but_batch_identifier_in_other_asset(
     runtime_data_connector: RuntimeDataConnector = (
         basic_datasource_with_assets.data_connectors["runtime"]
     )
-    with pytest.raises(ge_exceptions.DataConnectorError) as error:
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource_with_assets.name,
@@ -340,7 +349,14 @@ def test_asset_is_named_but_batch_identifier_in_other_asset(
                 runtime_parameters={"batch_data": test_df_pandas},
             )
         )
-        print(error.value.message)
+    expected_error_message: str = """
+                Data Asset asset_a was invoked with one or more batch_identifiers
+                that were not configured for the asset.
+
+                The Data Asset was configured with : ['day', 'month']
+                It was invoked with : ['year', 'month', 'day']
+    """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
 
 def test_asset_is_named_but_batch_identifier_not_defined_anywhere(
@@ -349,7 +365,7 @@ def test_asset_is_named_but_batch_identifier_not_defined_anywhere(
     runtime_data_connector: RuntimeDataConnector = (
         basic_datasource_with_assets.data_connectors["runtime"]
     )
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource_with_assets.name,
@@ -359,6 +375,14 @@ def test_asset_is_named_but_batch_identifier_not_defined_anywhere(
                 runtime_parameters={"batch_data": test_df_pandas},
             )
         )
+    expected_error_message: str = """
+                Data Asset asset_a was invoked with one or more batch_identifiers
+                that were not configured for the asset.
+
+                The Data Asset was configured with : ['day', 'month']
+                It was invoked with : ['blorg']
+    """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
 
 def test_named_asset_is_trying_to_use_batch_identifier_defined_in_data_connector(
@@ -367,7 +391,7 @@ def test_named_asset_is_trying_to_use_batch_identifier_defined_in_data_connector
     runtime_data_connector: RuntimeDataConnector = (
         basic_datasource_with_assets.data_connectors["runtime"]
     )
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource_with_assets.name,
@@ -381,6 +405,14 @@ def test_named_asset_is_trying_to_use_batch_identifier_defined_in_data_connector
                 runtime_parameters={"batch_data": test_df_pandas},
             )
         )
+    expected_error_message: str = """
+                Data Asset asset_a was invoked with one or more batch_identifiers
+                that were not configured for the asset.
+
+                The Data Asset was configured with : ['day', 'month']
+                It was invoked with : ['month', 'day', 'hour']
+    """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
 
 def test_runtime_batch_request_trying_to_use_batch_identifier_defined_at_asset_level(
@@ -389,7 +421,7 @@ def test_runtime_batch_request_trying_to_use_batch_identifier_defined_at_asset_l
     runtime_data_connector: RuntimeDataConnector = (
         basic_datasource_with_assets.data_connectors["runtime"]
     )
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=RuntimeBatchRequest(
                 datasource_name=basic_datasource_with_assets.name,
@@ -403,6 +435,14 @@ def test_runtime_batch_request_trying_to_use_batch_identifier_defined_at_asset_l
                 runtime_parameters={"batch_data": test_df_pandas},
             )
         )
+    expected_error_message: str = """
+                RuntimeDataConnector runtime was invoked with one or more batch identifiers that do not
+        appear among the configured batch identifiers.
+
+                The RuntimeDataConnector was configured with : ['hour', 'minute']
+                It was invoked with : ['year', 'hour', 'minute']
+    """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
 
 def test_error_checking_too_many_runtime_parameters(basic_datasource):
@@ -493,13 +533,21 @@ def test_batch_identifiers_and_batch_identifiers_error_illegal_keys(
     }
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
 
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         # noinspection PyUnusedLocal
         batch_definition_list: List[
             BatchDefinition
         ] = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
+    expected_error_message: str = """
+        RuntimeDataConnector test_runtime_data_connector was invoked with one or more batch identifiers that do not
+        appear among the configured batch identifiers.
+
+                The RuntimeDataConnector was configured with : ['pipeline_stage_name', 'airflow_run_id', 'custom_key_0']
+                It was invoked with : ['pipeline_stage_name', 'airflow_run_id', 'custom_key_0', 'custom_key_1']
+    """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
     batch_identifiers = {"batch_identifiers": {"unknown_key": "some_value"}}
 
@@ -518,13 +566,20 @@ def test_batch_identifiers_and_batch_identifiers_error_illegal_keys(
     }
     batch_request: RuntimeBatchRequest = RuntimeBatchRequest(**batch_request)
 
-    with pytest.raises(ge_exceptions.DataConnectorError):
+    with pytest.raises(ge_exceptions.DataConnectorError) as data_connector_error:
         # noinspection PyUnusedLocal
         batch_definition_list: List[
             BatchDefinition
         ] = test_runtime_data_connector.get_batch_definition_list_from_batch_request(
             batch_request=batch_request
         )
+    expected_error_message: str = """
+        RuntimeDataConnector test_runtime_data_connector was invoked with one or more batch identifiers that do not
+        appear among the configured batch identifiers.
+
+                The RuntimeDataConnector was configured with : ['pipeline_stage_name', 'airflow_run_id', 'custom_key_0']
+                It was invoked with : ['batch_identifiers']    """
+    assert str(data_connector_error.value).strip() == expected_error_message.strip()
 
 
 def test_get_available_data_asset_names(basic_datasource):


### PR DESCRIPTION
- GREAT-1072
- This PR proposes a more-informative error message for `batch_identifers` in `RuntimeDataConnectors`, both at the `DataConnector` and `Asset`-level. Previously the error message was something like : ` Data Asset {data_asset_name} was invoked with one or more batch_identifiers that were not configured for the asset.`, which didn't give (useful) detail on what went wrong. 
- Now the error messages look like: 
```
 Data Asset asset_a was invoked with one or more batch_identifiers that were not configured for the asset.
        The Data Asset was configured with : ['day', 'month']
        It was invoked with : ['year', 'month', 'day']
```
- Tests have been updated to check for error message

### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
