### PR TITLE
[BUGFIX] Remove datasource from config on delete

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -642,6 +642,7 @@ class AbstractDataContext(ABC):
         if save_changes:
             self._datasource_store.delete_by_name(datasource_name)
         self._cached_datasources.pop(datasource_name, None)
+        self.config.datasources.pop(datasource_name, None)
 
     def store_evaluation_parameters(
         self, validation_results, target_store_name=None

--- a/tests/data_context/abstract_data_context/test_datasource_delete.py
+++ b/tests/data_context/abstract_data_context/test_datasource_delete.py
@@ -1,0 +1,60 @@
+import pytest
+
+from great_expectations import DataContext
+from great_expectations.data_context import CloudDataContext
+from great_expectations.data_context.types.base import DatasourceConfig
+
+
+def test_datasource_delete_removes_from_cache_and_config_data_context(
+    empty_data_context: DataContext, datasource_config: DatasourceConfig
+):
+    """context.datasource_delete should remove from the datasource cache and also config independent of the save_changes setting."""
+
+    context: DataContext = empty_data_context
+    datasource_name: str = "my_datasource"
+
+    assert len(context.datasources) == 0
+    datasource_config["name"] = datasource_name
+    context.add_datasource(**datasource_config.to_dict())
+
+    # ensure datasource is accessible
+    assert len(context.datasources) == 1
+    assert datasource_name in context.datasources
+    assert datasource_name in context.config.datasources
+    assert context._datasource_store.retrieve_by_name(datasource_name=datasource_name)
+
+    context.delete_datasource(datasource_name)
+
+    # ensure deleted
+    assert len(context.datasources) == 0
+    assert datasource_name not in context.datasources
+    assert datasource_name not in context.config.datasources
+    with pytest.raises(ValueError):
+        assert not context._datasource_store.retrieve_by_name(
+            datasource_name=datasource_name
+        )
+
+
+def test_datasource_delete_removes_from_cache_and_config_cloud_data_context(
+    empty_cloud_data_context: CloudDataContext, datasource_config: DatasourceConfig
+):
+    """context.datasource_delete should remove from the datasource cache and also config independent of the save_changes setting."""
+
+    context: DataContext = empty_cloud_data_context
+    datasource_name: str = "my_datasource"
+
+    assert len(context.datasources) == 0
+    datasource_config["name"] = datasource_name
+    context.add_datasource(**datasource_config.to_dict())
+
+    # ensure datasource is accessible
+    assert len(context.datasources) == 1
+    assert datasource_name in context.datasources
+    assert datasource_name in context.config.datasources
+
+    context.delete_datasource(datasource_name)
+
+    # ensure deleted
+    assert len(context.datasources) == 0
+    assert datasource_name not in context.datasources
+    assert datasource_name not in context.config.datasources


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- Remove datasource from config for File, Ephemeral & Cloud data contexts
- Test for DataContext + CloudDataContext
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
