### PR TITLE
[MAINTENANCE] add `--clear-cache` flag for `invoke type-check`

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -8,6 +8,9 @@ To show all available tasks `invoke --list`
 
 To show task help page `invoke <NAME> --help`
 """
+import pathlib
+import shutil
+
 import invoke
 
 from scripts import check_type_hint_coverage
@@ -162,9 +165,13 @@ def type_check(
         raise invoke.Exit(code=0)
 
     if clear_cache:
-        print("  Clearing the mypy cache ... ", end="")
-        ctx.run(" ".join(["rm", "-rf", ".mypy_cache"]))
-        print("✅"),
+        mypy_cache = pathlib.Path(".mypy_cache")
+        print(f"  Clearing {mypy_cache} ... ", end="")
+        try:
+            shutil.rmtree(mypy_cache)
+            print("✅"),
+        except FileNotFoundError as exc:
+            print(f"❌\n  {exc}")
 
     if daemon:
         bin = "dmypy run --"

--- a/tasks.py
+++ b/tasks.py
@@ -143,10 +143,16 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
         "daemon": "Run mypy in daemon mode with faster analysis."
         " The daemon will be started and re-used for subsequent calls."
         " For detailed usage see `dmypy --help`.",
+        "clear-cache": "Clear the local mypy cache directory.",
     },
 )
 def type_check(
-    ctx, packages, install_types=False, show_default_packages=False, daemon=False
+    ctx,
+    packages,
+    install_types=False,
+    show_default_packages=False,
+    daemon=False,
+    clear_cache=False,
 ):
     """Run mypy static type-checking on select packages."""
     if show_default_packages:
@@ -154,6 +160,11 @@ def type_check(
         # https://docs.greatexpectations.io/docs/contributing/style_guides/code_style#type-checking
         print("\n".join(DEFAULT_PACKAGES_TO_TYPE_CHECK))
         raise invoke.Exit(code=0)
+
+    if clear_cache:
+        print("  Clearing the mypy cache ... ", end="")
+        ctx.run(" ".join(["rm", "-rf", ".mypy_cache"]))
+        print("✅"),
 
     if daemon:
         bin = "dmypy run --"

--- a/tasks.py
+++ b/tasks.py
@@ -158,12 +158,6 @@ def type_check(
     clear_cache=False,
 ):
     """Run mypy static type-checking on select packages."""
-    if show_default_packages:
-        # Use this to keep the Type-checking section of the docs up to date.
-        # https://docs.greatexpectations.io/docs/contributing/style_guides/code_style#type-checking
-        print("\n".join(DEFAULT_PACKAGES_TO_TYPE_CHECK))
-        raise invoke.Exit(code=0)
-
     if clear_cache:
         mypy_cache = pathlib.Path(".mypy_cache")
         print(f"  Clearing {mypy_cache} ... ", end="")
@@ -172,6 +166,12 @@ def type_check(
             print("✅"),
         except FileNotFoundError as exc:
             print(f"❌\n  {exc}")
+
+    if show_default_packages:
+        # Use this to keep the Type-checking section of the docs up to date.
+        # https://docs.greatexpectations.io/docs/contributing/style_guides/code_style#type-checking
+        print("\n".join(DEFAULT_PACKAGES_TO_TYPE_CHECK))
+        raise invoke.Exit(code=0)
 
     if daemon:
         bin = "dmypy run --"

--- a/tasks.py
+++ b/tasks.py
@@ -31,7 +31,7 @@ def sort(ctx, path=".", check=False, exclude=None):
         cmds.append("--check-only")
     if exclude:
         cmds.extend(["--skip", exclude])
-    ctx.run(" ".join(cmds))
+    ctx.run(" ".join(cmds), echo=True)
 
 
 @invoke.task(
@@ -54,7 +54,7 @@ def fmt(ctx, path=".", sort_=True, check=False, exclude=None):
         cmds.append("--check")
     if exclude:
         cmds.extend(["--exclude", exclude])
-    ctx.run(" ".join(cmds))
+    ctx.run(" ".join(cmds), echo=True)
 
 
 @invoke.task


### PR DESCRIPTION
Changes proposed in this pull request:

- Minor followup to https://github.com/great-expectations/great_expectations/pull/5576#discussion_r934621741 regarding how to clear the `mypy` cache if it get's into a bad state.

- echo the `black` and `isort` calls made by `invoke fmt`