### PR TITLE
[FEATURE] Enable retrieve by name for datasource with cloud store backend

### DIFF
--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -120,7 +120,9 @@ class DatasourceStore(Store):
         """
         datasource_key: Union[
             DataContextVariableKey, GeCloudIdentifier
-        ] = self.store_backend.build_key(name=datasource_name)
+        ] = self.store_backend.build_key(
+            resource_type=DataContextVariableSchema.DATASOURCES, name=datasource_name
+        )
         if not self.has_key(datasource_key):
             raise ValueError(
                 f"Unable to load datasource `{datasource_name}` -- no configuration found or invalid configuration."
@@ -160,7 +162,11 @@ class DatasourceStore(Store):
             name = datasource_config.name
         else:
             name = None
-        return self.store_backend.build_key(name=name, id_=id_)
+        return self.store_backend.build_key(
+            resource_type=DataContextVariableSchema.DATASOURCES,
+            name=name,
+            id_=id_,
+        )
 
     def set_by_name(
         self, datasource_name: str, datasource_config: DatasourceConfig

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from typing import List, Optional, Tuple, Union
 
@@ -90,6 +92,19 @@ class DatasourceStore(Store):
         else:
             return self._schema.loads(value)
 
+    def ge_cloud_response_json_to_object_dict(self, response_json: dict) -> dict:
+        """
+        This method takes full json response from GE cloud and outputs a dict appropriate for
+        deserialization into a GE object
+        """
+        datasource_ge_cloud_id: str = response_json["data"]["id_"]
+        datasource_config_dict: dict = response_json["data"]["attributes"][
+            "datasource_config"
+        ]
+        datasource_config_dict["ge_cloud_id"] = datasource_ge_cloud_id
+
+        return datasource_config_dict
+
     def retrieve_by_name(self, datasource_name: str) -> DatasourceConfig:
         """Retrieves a DatasourceConfig persisted in the store by it's given name.
 
@@ -103,9 +118,9 @@ class DatasourceStore(Store):
         Raises:
             ValueError if a DatasourceConfig is not found.
         """
-        datasource_key: DataContextVariableKey = self._determine_datasource_key(
-            datasource_name=datasource_name
-        )
+        datasource_key: Union[
+            DataContextVariableKey, GeCloudIdentifier
+        ] = self.store_backend.build_key(name=datasource_name)
         if not self.has_key(datasource_key):
             raise ValueError(
                 f"Unable to load datasource `{datasource_name}` -- no configuration found or invalid configuration."

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -7,6 +7,9 @@ from urllib.parse import urljoin
 
 import requests
 
+from great_expectations.data_context.data_context_variables import (
+    DataContextVariableSchema,
+)
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
@@ -387,9 +390,12 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         return self._config
 
     def build_key(
-        self, id_: Optional[str] = None, name: Optional[str] = None
+        self,
+        resource_type: DataContextVariableSchema,
+        id_: Optional[str] = None,
+        name: Optional[str] = None,
     ) -> GeCloudIdentifier:
-        """Get the store backend specific implementation of the key."""
+        """Get the store backend specific implementation of the key. ignore resource_type since it is defined when initializing the cloud store backend."""
         return GeCloudIdentifier(
             resource_type=self.ge_cloud_resource_type,
             ge_cloud_id=id_,

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -148,17 +148,16 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     def _get(self, key: Tuple[str, ...]) -> dict:
         ge_cloud_url = self.get_url_for_key(key=key)
+        params: Optional[dict] = None
         try:
-            params: dict
             # if name is included in the key, add as a param
             if len(key) > 2 and key[2]:
                 params = {"name": key[2]}
                 ge_cloud_url = ge_cloud_url.rstrip("/")
-                response = requests.get(
-                    ge_cloud_url, headers=self.auth_headers, params=params
-                )
-            else:
-                response = requests.get(ge_cloud_url, headers=self.auth_headers)
+
+            response = requests.get(
+                ge_cloud_url, headers=self.auth_headers, params=params
+            )
             return response.json()
         except JSONDecodeError as jsonError:
             logger.debug(

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -7,10 +7,6 @@ from urllib.parse import urljoin
 
 import requests
 
-from great_expectations.core.data_context_key import DataContextVariableKey
-from great_expectations.data_context.data_context_variables import (
-    DataContextVariableSchema,
-)
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -386,14 +386,12 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     def config(self) -> dict:
         return self._config
 
-    def build_key(self, id_: Optional[str] = None, **kwargs) -> GeCloudIdentifier:
-        """Get the store backend specific implementation of the key, ignore irrelevant kwargs."""
-        if "name" in kwargs:
-            return GeCloudIdentifier(
-                resource_type=self.ge_cloud_resource_type,
-                ge_cloud_id=id_,
-                resource_name=kwargs["name"],
-            )
+    def build_key(
+        self, id_: Optional[str] = None, name: Optional[str] = None
+    ) -> GeCloudIdentifier:
+        """Get the store backend specific implementation of the key."""
         return GeCloudIdentifier(
-            resource_type=self.ge_cloud_resource_type, ge_cloud_id=id_
+            resource_type=self.ge_cloud_resource_type,
+            ge_cloud_id=id_,
+            resource_name=name,
         )

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -210,8 +210,10 @@ class InlineStoreBackend(StoreBackend):
 
         return resource_type, resource_name
 
-    def build_key(self, name: str, **kwargs) -> DataContextVariableKey:
-        """Get the store backend specific implementation of the key, ignore irrelevant kwargs."""
+    def build_key(
+        self, id_: Optional[str] = None, name: Optional[str] = None
+    ) -> DataContextVariableKey:
+        """Get the store backend specific implementation of the key. id_ included for super class compatibility."""
         return DataContextVariableKey(
             resource_type=DataContextVariableSchema.DATASOURCES,
             resource_name=name,

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -211,10 +211,13 @@ class InlineStoreBackend(StoreBackend):
         return resource_type, resource_name
 
     def build_key(
-        self, id_: Optional[str] = None, name: Optional[str] = None
+        self,
+        resource_type: DataContextVariableSchema,
+        id_: Optional[str] = None,
+        name: Optional[str] = None,
     ) -> DataContextVariableKey:
         """Get the store backend specific implementation of the key. id_ included for super class compatibility."""
         return DataContextVariableKey(
-            resource_type=DataContextVariableSchema.DATASOURCES,
+            resource_type=resource_type,
             resource_name=name,
         )

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -5,6 +5,10 @@ from typing import Any, Optional
 
 import pyparsing as pp
 
+from great_expectations.core.data_context_key import DataContextVariableKey
+from great_expectations.data_context.data_context_variables import (
+    DataContextVariableSchema,
+)
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 from great_expectations.util import filter_properties_dict
 
@@ -204,7 +208,12 @@ class StoreBackend(metaclass=ABCMeta):
     def config(self) -> dict:
         raise NotImplementedError
 
-    def build_key(self, id_: Optional[str] = None, name: Optional[str] = None) -> Any:
+    def build_key(
+        self,
+        resource_type: DataContextVariableSchema,
+        id_: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> Any:
         """Build a key specific to the store backend implementation."""
         raise NotImplementedError
 
@@ -270,3 +279,15 @@ class InMemoryStoreBackend(StoreBackend):
     @property
     def config(self) -> dict:
         return self._config
+
+    def build_key(
+        self,
+        resource_type: DataContextVariableSchema,
+        id_: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> DataContextVariableKey:
+        """Get the store backend specific implementation of the key. id_ included for super class compatibility."""
+        return DataContextVariableKey(
+            resource_type=resource_type,
+            resource_name=name,
+        )

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -204,7 +204,7 @@ class StoreBackend(metaclass=ABCMeta):
     def config(self) -> dict:
         raise NotImplementedError
 
-    def build_key(self, **kwargs) -> Any:
+    def build_key(self, id_: Optional[str] = None, name: Optional[str] = None) -> Any:
         """Build a key specific to the store backend implementation."""
         raise NotImplementedError
 

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from abc import ABCMeta, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 import pyparsing as pp
 
@@ -202,6 +202,9 @@ class StoreBackend(metaclass=ABCMeta):
 
     @property
     def config(self) -> dict:
+        raise NotImplementedError
+
+    def build_key(self, **kwargs) -> Any:
         raise NotImplementedError
 
 

--- a/great_expectations/data_context/store/store_backend.py
+++ b/great_expectations/data_context/store/store_backend.py
@@ -205,6 +205,7 @@ class StoreBackend(metaclass=ABCMeta):
         raise NotImplementedError
 
     def build_key(self, **kwargs) -> Any:
+        """Build a key specific to the store backend implementation."""
         raise NotImplementedError
 
 

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -202,12 +202,16 @@ class ValidationResultIdentifier(DataContextKey):
 
 class GeCloudIdentifier(DataContextKey):
     def __init__(
-        self, resource_type: "GeCloudRESTResource", ge_cloud_id: Optional[str] = None
+        self,
+        resource_type: "GeCloudRESTResource",
+        ge_cloud_id: Optional[str] = None,
+        resource_name: Optional[str] = None,
     ) -> None:
         super().__init__()
 
         self._resource_type = resource_type
         self._ge_cloud_id = ge_cloud_id if ge_cloud_id is not None else ""
+        self._resource_name = resource_name if resource_name is not None else ""
 
     @property
     def resource_type(self):
@@ -225,14 +229,23 @@ class GeCloudIdentifier(DataContextKey):
     def ge_cloud_id(self, value) -> None:
         self._ge_cloud_id = value
 
+    @property
+    def resource_name(self) -> str:
+        return self._resource_name
+
     def to_tuple(self):
-        return (self.resource_type, self.ge_cloud_id)
+        return (self.resource_type, self.ge_cloud_id, self.resource_name)
 
     def to_fixed_length_tuple(self):
         return self.to_tuple()
 
     @classmethod
     def from_tuple(cls, tuple_):
+        # Only add resource name if it exists in the tuple_
+        if len(tuple_) == 3:
+            return cls(
+                resource_type=tuple_[0], ge_cloud_id=tuple_[1], resource_name=tuple_[2]
+            )
         return cls(resource_type=tuple_[0], ge_cloud_id=tuple_[1])
 
     @classmethod

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -210,8 +210,8 @@ class GeCloudIdentifier(DataContextKey):
         super().__init__()
 
         self._resource_type = resource_type
-        self._ge_cloud_id = ge_cloud_id if ge_cloud_id is not None else ""
-        self._resource_name = resource_name if resource_name is not None else ""
+        self._ge_cloud_id = ge_cloud_id or ""
+        self._resource_name = resource_name or ""
 
     @property
     def resource_type(self):

--- a/tests/data_context/cloud_data_context/test_datasource_crud.py
+++ b/tests/data_context/cloud_data_context/test_datasource_crud.py
@@ -250,7 +250,7 @@ def test_data_context_in_cloud_mode_add_datasource(
         ),
     ],
 )
-def test_data_context_in_cloud_mode_add_datasource(
+def test_cloud_data_context_add_datasource(
     config_includes_name_setting: str,
     empty_cloud_data_context: CloudDataContext,
     datasource_config: DatasourceConfig,

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -78,7 +78,15 @@ def test_datasource_store_get_by_id(
             def json(self):
                 return self._json_data
 
-        return MockResponse({"data": {"id": id_}}, 201)
+        return MockResponse(
+            {
+                "data": {
+                    "id_": id_,
+                    "attributes": {"datasource_config": datasource_config},
+                }
+            },
+            201,
+        )
 
     with patch("requests.get", autospec=True, side_effect=mocked_response) as mock_get:
 
@@ -87,6 +95,61 @@ def test_datasource_store_get_by_id(
         mock_get.assert_called_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources/{id_}",
             headers=request_headers,
+        )
+
+
+@pytest.mark.cloud
+@pytest.mark.unit
+def test_datasource_store_get_by_name(
+    ge_cloud_base_url: str,
+    ge_cloud_organization_id: str,
+    request_headers: dict,
+    datasource_config: DatasourceConfig,
+    datasource_store_ge_cloud_backend: DatasourceStore,
+) -> None:
+    """What does this test and why?
+
+    The datasource store when used with a cloud backend should emit the correct request when getting a datasource with a name.
+    """
+
+    id_: str = "example_id_normally_uuid"
+    datasource_name: str = "example_datasource_config_name"
+
+    def mocked_response(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data: dict, status_code: int) -> None:
+                self._json_data = json_data
+                self._status_code = status_code
+
+            def json(self):
+                return self._json_data
+
+        return MockResponse(
+            {
+                "data": {
+                    "id_": id_,
+                    "attributes": {"datasource_config": datasource_config},
+                }
+            },
+            201,
+        )
+
+    with patch(
+        "requests.get", autospec=True, side_effect=mocked_response
+    ) as mock_get, patch(
+        "great_expectations.data_context.store.DatasourceStore.has_key", autospec=True
+    ) as mock_has_key:
+        # Mocking has_key so that we don't try to connect to the cloud backend to verify key existence.
+        mock_has_key.return_value = True
+
+        datasource_store_ge_cloud_backend.retrieve_by_name(
+            datasource_name=datasource_name
+        )
+
+        mock_get.assert_called_with(
+            f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources",
+            headers=request_headers,
+            params={"name": datasource_name},
         )
 
 
@@ -119,7 +182,7 @@ def test_datasource_store_delete_by_id(
             json={
                 "data": {
                     "type": "datasource",
-                    "id": id_,
+                    "id_": id_,
                     "attributes": {"deleted": True},
                 }
             },

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -85,7 +85,7 @@ def test_datasource_store_get_by_id(
                     "attributes": {"datasource_config": datasource_config},
                 }
             },
-            201,
+            200,
         )
 
     with patch("requests.get", autospec=True, side_effect=mocked_response) as mock_get:
@@ -131,7 +131,7 @@ def test_datasource_store_get_by_name(
                     "attributes": {"datasource_config": datasource_config},
                 }
             },
-            201,
+            200,
         )
 
     with patch(

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -34,7 +34,7 @@ def test_datasource_store_create(
 
         datasource_store_ge_cloud_backend.set(key=key, value=datasource_config)
 
-        mock_post.assert_called_with(
+        mock_post.assert_called_once_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources",
             json={
                 "data": {
@@ -92,7 +92,7 @@ def test_datasource_store_get_by_id(
 
         datasource_store_ge_cloud_backend.get(key=key)
 
-        mock_get.assert_called_with(
+        mock_get.assert_called_once_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources/{id_}",
             headers=request_headers,
             params=None,
@@ -147,7 +147,7 @@ def test_datasource_store_get_by_name(
             datasource_name=datasource_name
         )
 
-        mock_get.assert_called_with(
+        mock_get.assert_called_once_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources",
             headers=request_headers,
             params={"name": datasource_name},
@@ -178,7 +178,7 @@ def test_datasource_store_delete_by_id(
 
         datasource_store_ge_cloud_backend.remove_key(key=key)
 
-        mock_delete.assert_called_with(
+        mock_delete.assert_called_once_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources/{id_}",
             json={
                 "data": {

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -95,6 +95,7 @@ def test_datasource_store_get_by_id(
         mock_get.assert_called_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources/{id_}",
             headers=request_headers,
+            params=None,
         )
 
 

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1427,6 +1427,7 @@ def test_GeCloudStoreBackend():
                 "Content-Type": "application/vnd.api+json",
                 "Authorization": "Bearer 1234",
             },
+            params=None,
         )
 
     # test .list_keys
@@ -1468,7 +1469,7 @@ def test_GeCloudStoreBackend():
             json={
                 "data": {
                     "type": "contract",
-                    "id": "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
+                    "id_": "0ccac18e-7631-4bdd-8a42-3c35cce574c6",
                     "attributes": {"deleted": True},
                 }
             },
@@ -1523,6 +1524,7 @@ def test_GeCloudStoreBackend():
                 "Content-Type": "application/vnd.api+json",
                 "Authorization": "Bearer 1234",
             },
+            params=None,
         )
 
     # test .list_keys
@@ -1564,7 +1566,7 @@ def test_GeCloudStoreBackend():
             json={
                 "data": {
                     "type": "rendered_data_doc",
-                    "id": "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
+                    "id_": "1ccac18e-7631-4bdd-8a42-3c35cce574c6",
                     "attributes": {"deleted": True},
                 }
             },


### PR DESCRIPTION
Changes proposed in this pull request:
- Enable using a datasource `name` to retrieve a datasource configuration from the GeCloudStoreBackend
- Uses a query param to hit the tbd `GET /organizations/<org_id>/datasources?name=<name>` endpoint.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
