### PR TITLE
Make comparisons of aggregate values date aware

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1736,6 +1736,12 @@ please see: https://greatexpectations.io/blog/why_we_dont_do_transformations_for
                 except TypeError:
                     pass
 
+        elif isinstance(metric_value, datetime.datetime):
+            if isinstance(min_value, str):
+                min_value = parse(min_value)
+            if isinstance(max_value, str):
+                max_value = parse(max_value)
+
         if not isinstance(metric_value, datetime.datetime) and pd.isnull(metric_value):
             return {"success": False, "result": {"observed_value": None}}
 

--- a/tests/test_definitions/column_aggregate_expectations/expect_column_max_to_be_between.json
+++ b/tests/test_definitions/column_aggregate_expectations/expect_column_max_to_be_between.json
@@ -6,22 +6,52 @@
       "x" : [2, 3, 4, 5, 6, 7, 8, 9, null, null],
       "y" : [1, 1, 1, 2, 2, 2, 3, 3, 3, 4],
       "a" : [null, 0, null, null, 1, null, null, 2, null, null],
-      "b" : [null, 0, null, null, 2, null, null, 1, null, null]
+      "b" : [null, 0, null, null, 2, null, null, 1, null, null],
+      "ts": [
+          "1970-01-01T12:00:01",
+          "1999-12-31T12:00:01",
+          "2000-01-01T12:00:01",
+          "2000-02-01T12:00:01",
+          "2000-03-01T12:00:01",
+          "2000-04-01T12:00:01",
+          "2000-05-01T12:00:01",
+          "2000-06-01T12:00:01",
+          null,
+          "2001-01-01T12:00:01"
+        ]
     },
     "schemas": {
+      "pandas": {
+        "w" : "int",
+        "x" : "float",
+        "y" : "float",
+        "a" : "float",
+        "b" : "float",
+        "ts": "datetime64"
+      },
+      "spark": {
+        "w" : "IntegerType",
+        "x" : "IntegerType",
+        "y" : "IntegerType",
+        "a" : "IntegerType",
+        "b" : "IntegerType",
+        "ts": "TimestampType"
+      },
       "sqlite": {
         "w" : "INTEGER",
         "x" : "INTEGER",
         "y" : "INTEGER",
         "a" : "INTEGER",
-        "b" : "INTEGER"
+        "b" : "INTEGER",
+        "ts": "DATETIME"
       },
       "postgresql": {
         "w" : "INTEGER",
         "x" : "INTEGER",
         "y" : "INTEGER",
         "a" : "INTEGER",
-        "b" : "INTEGER"
+        "b" : "INTEGER",
+        "ts": "TIMESTAMP"
       }
     },
     "tests" : [{
@@ -87,7 +117,34 @@
         "success": false,
         "observed_value": 5
       }
-    }]},
+    },{
+      "title": "datetime",
+      "exact_match_out": false,
+      "in": {
+        "column": "ts",
+        "min_value": "2001-01-01T12:00:01",
+        "max_value": "2001-01-01T12:00:01"
+      },
+      "out": {
+        "success": true,
+        "observed_value": "2001-01-01 12:00:01"
+      }
+
+    },{
+      "title": "datetime_with_evaluation_parameter",
+      "exact_match_out": false,
+      "in": {
+        "column": "ts",
+        "min_value": {
+          "$PARAMETER": "now() - timedelta(weeks=52)"
+        }
+      },
+      "out": {
+        "success": false,
+        "observed_value": "2001-01-01 12:00:01"
+      }
+    }
+    ]},
     {
       "data": {
         "empty_column": []


### PR DESCRIPTION
Fix an issue were aggregate metrics that returned datetimes did not attempt to parse the parameters as datetimes.