### PR TITLE
[BUGFIX] Patch issue with usage stats sync not respecting usage stats opt-out

### DIFF
--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -368,7 +368,8 @@ class DataContext(BaseDataContext):
             self._save_project_config()
 
     def _check_for_usage_stats_sync(self, project_config: DataContextConfig) -> bool:
-        """If there are differences between the DataContextConfig used to instantiate
+        """
+        If there are differences between the DataContextConfig used to instantiate
         the DataContext and the DataContextConfig assigned to `self.config`, we want
         to save those changes to disk so that subsequent instantiations will utilize
         the same values.
@@ -384,15 +385,21 @@ class DataContext(BaseDataContext):
             A boolean signifying whether or not the current DataContext's config needs
             to be persisted in order to recognize changes made to usage statistics.
         """
-        if project_config.anonymous_usage_statistics.explicit_id is False:
-            return True
-
         project_config_usage_stats: Optional[
             AnonymizedUsageStatisticsConfig
         ] = project_config.anonymous_usage_statistics
         context_config_usage_stats: Optional[
             AnonymizedUsageStatisticsConfig
         ] = self.config.anonymous_usage_statistics
+
+        if (
+            project_config_usage_stats.enabled is False
+            or context_config_usage_stats.enabled is False
+        ):
+            return False
+
+        if project_config_usage_stats.explicit_id is False:
+            return True
 
         if project_config_usage_stats == context_config_usage_stats:
             return False

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -2988,3 +2988,16 @@ def test_check_for_usage_stats_sync_does_not_find_diff(
 
     res = context._check_for_usage_stats_sync(project_config=project_config)
     assert res is False
+
+
+@pytest.mark.integration
+def test_check_for_usage_stats_sync_short_circuits_due_to_disabled_usage_stats(
+    empty_data_context: DataContext,
+    data_context_config_with_datasources: DataContextConfig,
+) -> None:
+    context = empty_data_context
+    project_config = data_context_config_with_datasources
+    project_config.anonymous_usage_statistics.enabled = False
+
+    res = context._check_for_usage_stats_sync(project_config=project_config)
+    assert res is False


### PR DESCRIPTION
Changes proposed in this pull request:
- Update logic introduced in https://github.com/great-expectations/great_expectations/pull/5555 to ensure we don't update our project config and write to disk when a user opts out of usage stats.
- Fix is in response to user issue https://github.com/great-expectations/great_expectations/issues/5637


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
