### PR TITLE
[MAINTENANCE] Install `dgtest` test runner utilizing Git URL in CI

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -246,9 +246,8 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install pytest pytest-cov pytest-azurepipelines
-              git clone https://github.com/superconductive/dgtest.git
-              pip install -e dgtest
+              pip install git+https://github.com/superconductive/dgtest
+              pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
@@ -324,9 +323,8 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install pytest pytest-cov pytest-azurepipelines
-              git clone https://github.com/superconductive/dgtest.git
-              pip install -e dgtest
+              pip install git+https://github.com/superconductive/dgtest
+              pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
@@ -461,9 +459,8 @@ stages:
           - script: |
               # Install dependencies
               pip install --requirement requirements.txt
-              pip install pytest pytest-cov pytest-azurepipelines
-              git clone https://github.com/superconductive/dgtest.git
-              pip install -e dgtest
+              pip install git+https://github.com/superconductive/dgtest
+              pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
@@ -505,9 +502,8 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install pytest pytest-cov pytest-azurepipelines
-              git clone https://github.com/superconductive/dgtest.git
-              pip install -e dgtest
+              pip install git+https://github.com/superconductive/dgtest
+              pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
@@ -556,9 +552,8 @@ stages:
           - script: |
               # Install dependencies
               pip install --requirement requirements.txt
-              pip install pytest pytest-cov pytest-azurepipelines
-              git clone https://github.com/superconductive/dgtest.git
-              pip install -e dgtest
+              pip install git+https://github.com/superconductive/dgtest
+              pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
@@ -602,9 +597,7 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install pytest
-              git clone https://github.com/superconductive/dgtest.git
-              pip install -e dgtest
+              pip install git+https://github.com/superconductive/dgtest
 
               # Run dgtest
               dgtest run great_expectations --filter 'tests/cli' --aws-integration -v

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -246,7 +246,7 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install git+https://github.com/superconductive/dgtest
+              pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
               pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -358,7 +358,7 @@ stages:
           - script: |
               # These are tests that are specific to Great Expectations Cloud.
               # In order to ensure coverage, we run them during each CI/CD cycle.
-              pytest -m cloud --cloud
+              pytest tests -m cloud --cloud
 
             env:
               GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -323,7 +323,7 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install git+https://github.com/superconductive/dgtest
+              pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
               pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
@@ -459,7 +459,7 @@ stages:
           - script: |
               # Install dependencies
               pip install --requirement requirements.txt
-              pip install git+https://github.com/superconductive/dgtest
+              pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
               pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
@@ -502,7 +502,7 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install git+https://github.com/superconductive/dgtest
+              pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
               pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
@@ -552,7 +552,7 @@ stages:
           - script: |
               # Install dependencies
               pip install --requirement requirements.txt
-              pip install git+https://github.com/superconductive/dgtest
+              pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
               pip install pytest-cov pytest-azurepipelines
 
               # Run dgtest
@@ -597,7 +597,7 @@ stages:
 
           - script: |
               # Install dependencies
-              pip install git+https://github.com/superconductive/dgtest
+              pip install -e git+https://github.com/superconductive/dgtest/#egg=dgtest
 
               # Run dgtest
               dgtest run great_expectations --filter 'tests/cli' --aws-integration -v


### PR DESCRIPTION
Changes proposed in this pull request:
- Instead of cloning the `dgtest` repo and using `pip install -e`, we can simply just use the Git URL
- The allows us to utilize the tool without having to clone it.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
