### PR TITLE
[MAINTNANCE] Return DatasourceConfig from DatasourceStore.set()

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -20,7 +20,6 @@ from great_expectations.data_context.types.base import (
     GeCloudConfig,
     datasourceConfigSchema,
 )
-from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 from great_expectations.data_context.util import substitute_all_config_variables
 from great_expectations.datasource import Datasource

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -318,14 +318,11 @@ class CloudDataContext(AbstractDataContext):
         """
 
         datasource_config: DatasourceConfig = datasourceConfigSchema.load(config)
+        datasource_config.name = name
 
         if save_changes:
 
-            datasource_config["name"] = name
-            resource_ref: GeCloudResourceRef = self._datasource_store.create(
-                datasource_config
-            )
-            datasource_config.id_ = resource_ref.ge_cloud_id
+            datasource_config = self._datasource_store.set(datasource_config)
 
         self.config.datasources[name] = datasource_config
 

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -194,25 +194,6 @@ class DatasourceStore(Store):
 
         return config
 
-    # def _create(
-    #     self, datasource_config: DatasourceConfig
-    # ) -> DatasourceConfig:
-    #     # """Create a datasource config in the store using a store_backend-specific key.
-    #     #
-    #     # Args:
-    #     #     datasource_config: Config containing the datasource name.
-    #     #
-    #     # Returns:
-    #     #     None unless using GeCloudStoreBackend and if so the GeCloudResourceRef which contains the id
-    #     #     which was used to create the config in the backend.
-    #     # """
-    #     # key: Union[
-    #     #     GeCloudIdentifier, DataContextVariableKey
-    #     # ] = self._build_key_from_config(datasource_config)
-    #     # config = self.set(key, datasource_config)
-    #     self._create(datasource_config)
-    #     return DatasourceConfig(**config)
-
     def update_by_name(
         self, datasource_name: str, datasource_config: DatasourceConfig
     ) -> None:

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -182,22 +182,36 @@ class DatasourceStore(Store):
         )
         self.set(datasource_key, datasource_config)
 
-    def create(
-        self, datasource_config: DatasourceConfig
-    ) -> Optional[GeCloudResourceRef]:
-        """Create a datasource config in the store using a store_backend-specific key.
-
-        Args:
-            datasource_config: Config containing the datasource name.
-
-        Returns:
-            None unless using GeCloudStoreBackend and if so the GeCloudResourceRef which contains the id
-            which was used to create the config in the backend.
-        """
+    def set(self, config: DatasourceConfig) -> DatasourceConfig:
+        """Create a datasource config in the store using a store_backend-specific key."""
         key: Union[
             GeCloudIdentifier, DataContextVariableKey
-        ] = self._build_key_from_config(datasource_config)
-        return self.set(key, datasource_config)
+        ] = self._build_key_from_config(config)
+
+        identifier: Optional[Union[bool, GeCloudResourceRef]] = super().set(key, config)
+        if isinstance(identifier, GeCloudResourceRef):
+            config.id_ = identifier.ge_cloud_id
+
+        return config
+
+    # def _create(
+    #     self, datasource_config: DatasourceConfig
+    # ) -> DatasourceConfig:
+    #     # """Create a datasource config in the store using a store_backend-specific key.
+    #     #
+    #     # Args:
+    #     #     datasource_config: Config containing the datasource name.
+    #     #
+    #     # Returns:
+    #     #     None unless using GeCloudStoreBackend and if so the GeCloudResourceRef which contains the id
+    #     #     which was used to create the config in the backend.
+    #     # """
+    #     # key: Union[
+    #     #     GeCloudIdentifier, DataContextVariableKey
+    #     # ] = self._build_key_from_config(datasource_config)
+    #     # config = self.set(key, datasource_config)
+    #     self._create(datasource_config)
+    #     return DatasourceConfig(**config)
 
     def update_by_name(
         self, datasource_name: str, datasource_config: DatasourceConfig

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -202,7 +202,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             url = urljoin(f"{url}/", ge_cloud_id)
 
         try:
-            response = requests.put(url, json=data, headers=self.auth_headers)
+            response = requests.put(
+                url, json=data, headers=self.auth_headers, timeout=15
+            )
             response_status_code = response.status_code
 
             # 2022-07-28 - Chetan - GX Cloud does not currently support PUT requests
@@ -213,11 +215,15 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 and resource_type is GeCloudRESTResource.EXPECTATION_SUITE
             ):
                 response = requests.patch(url, json=data, headers=self.auth_headers)
-                response_status_code = response.status_code
 
-            if response_status_code < 300:
-                return True
-            return False
+            response.raise_for_status()
+
+        except requests.HTTPError as httperror:
+            logger.warning(str(httperror))
+            raise StoreBackendError(
+                f"Unable to update object in GE Cloud Store Backend: HttpError: {response}"
+            )
+
         except Exception as e:
             logger.debug(str(e))
             raise StoreBackendError(

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -169,16 +169,6 @@ class Store:
             self.key_to_tuple(key), self.serialize(value), **kwargs
         )
 
-    # def create(self, config: AbstractConfig) -> AbstractConfig:
-    #     key: Union[
-    #         GeCloudIdentifier, DataContextVariableKey
-    #     ] = self._build_key_from_config(config)
-    #     config = self.set(key, config)
-    #     return config
-    #
-    # def _create(self):
-    #     raise NotImplementedError
-
     def list_keys(self) -> List[DataContextKey]:
         keys_without_store_backend_id = [
             key

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -169,6 +169,16 @@ class Store:
             self.key_to_tuple(key), self.serialize(value), **kwargs
         )
 
+    # def create(self, config: AbstractConfig) -> AbstractConfig:
+    #     key: Union[
+    #         GeCloudIdentifier, DataContextVariableKey
+    #     ] = self._build_key_from_config(config)
+    #     config = self.set(key, config)
+    #     return config
+    #
+    # def _create(self):
+    #     raise NotImplementedError
+
     def list_keys(self) -> List[DataContextKey]:
         keys_without_store_backend_id = [
             key


### PR DESCRIPTION
Changes proposed in this pull request:
- Return DatasourceConfig from DatasourceStore.set()
- Add id to the config when applicable.
- Rename `create` to `set` to be consistent with other stores.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
