### PR TITLE
[MAINTENANCE] Don't include 'test-pipeline' in extras_require dict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def get_extras_require():
         "teradata",
         "trino",
     )
-    ignore_keys = ("sqlalchemy", "test")
+    ignore_keys = ("sqlalchemy", "test", "test-pipeline")
     rx_fname_part = re.compile(r"requirements-dev-(.*).txt")
     for fname in sorted(glob("requirements-dev-*.txt")):
         key = rx_fname_part.match(fname).group(1)


### PR DESCRIPTION
A new requirements-dev-*.txt file was introduced in https://github.com/great-expectations/great_expectations/pull/5646

There's no reason to have "test-pipeline" as an extras_require key (i.e. `pip install "great_expectations[test-pipeline]"`), so it is removed

Changes proposed in this pull request:
- Don't include 'test-pipeline' in extras_require dict