### PR TITLE
[MAINTENANCE] data_context initial type checking

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -2245,7 +2245,7 @@ class CheckpointValidationConfigSchema(Schema):
 
     id_ = fields.String(required=False, allow_none=False, data_key="id")
 
-    def dump(self, obj: dict, *, many: Optional[bool] = None) -> dict:
+    def dump(self, obj: dict, *, many: Optional[bool] = None) -> dict:  # type: ignore[override]
         """
         Chetan - 20220803 - By design, Marshmallow accepts unknown fields through the
         `unknown = INCLUDE` directive but only upon load. When dumping, it validates

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import logging
 import uuid
-from typing import Any, Dict, List, MutableMapping, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, Optional, Set, Union
 from uuid import UUID
 
 from ruamel.yaml import YAML
@@ -34,6 +34,9 @@ from great_expectations.marshmallow__shade.validate import OneOf
 from great_expectations.types import DictDot, SerializableDictDot, safe_deep_copy
 from great_expectations.types.configurations import ClassConfigSchema
 from great_expectations.util import deep_filter_properties_iterable
+
+if TYPE_CHECKING:
+    from great_expectations.checkpoint import Checkpoint
 
 yaml = YAML()
 yaml.indent(mapping=2, sequence=4, offset=2)
@@ -1410,7 +1413,7 @@ class DataContextConfigSchema(Schema):
                 data.pop(key)
         return data
 
-    def handle_error(self, exc, data, **kwargs) -> None:
+    def handle_error(self, exc, data, **kwargs) -> None:  # type: ignore[override]
         """Log and raise our custom exception when (de)serialization fails."""
         if (
             exc
@@ -1785,19 +1788,19 @@ class FilesystemStoreBackendDefaults(BaseStoreBackendDefaults):
             )
         self.plugins_directory = plugins_directory
         if root_directory is not None:
-            self.stores[self.expectations_store_name]["store_backend"][
+            self.stores[self.expectations_store_name]["store_backend"][  # type: ignore[index]
                 "root_directory"
             ] = root_directory
-            self.stores[self.validations_store_name]["store_backend"][
+            self.stores[self.validations_store_name]["store_backend"][  # type: ignore[index]
                 "root_directory"
             ] = root_directory
-            self.stores[self.checkpoint_store_name]["store_backend"][
+            self.stores[self.checkpoint_store_name]["store_backend"][  # type: ignore[index]
                 "root_directory"
             ] = root_directory
-            self.stores[self.profiler_store_name]["store_backend"][
+            self.stores[self.profiler_store_name]["store_backend"][  # type: ignore[index]
                 "root_directory"
             ] = root_directory
-            self.data_docs_sites[self.data_docs_site_name]["store_backend"][
+            self.data_docs_sites[self.data_docs_site_name]["store_backend"][  # type: ignore[index]
                 "root_directory"
             ] = root_directory
 
@@ -2127,7 +2130,7 @@ class DataContextConfig(BaseYamlConfig):
 
         self._config_version = config_version
         if datasources is None:
-            datasources = {}
+            datasources = {}  # type: ignore[assignment]
         self.datasources = datasources
         self.expectations_store_name = expectations_store_name
         self.validations_store_name = validations_store_name
@@ -2470,19 +2473,19 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def validation_operator_name(self) -> str:
-        return self._validation_operator_name
+        return self._validation_operator_name  # type: ignore[has-type]
 
     @validation_operator_name.setter
     def validation_operator_name(self, value: str) -> None:
-        self._validation_operator_name = value
+        self._validation_operator_name = value  # type: ignore[has-type]
 
     @property
     def batches(self) -> List[dict]:
-        return self._batches
+        return self._batches  # type: ignore[has-type]
 
     @batches.setter
     def batches(self, value: List[dict]) -> None:
-        self._batches = value
+        self._batches = value  # type: ignore[has-type]
 
     @property
     def ge_cloud_id(self) -> Optional[Union[UUID, str]]:
@@ -2502,7 +2505,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def name(self) -> str:
-        return self._name
+        return self._name  # type: ignore[return-value]
 
     @name.setter
     def name(self, value: str) -> None:
@@ -2510,7 +2513,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def template_name(self) -> str:
-        return self._template_name
+        return self._template_name  # type: ignore[return-value]
 
     @template_name.setter
     def template_name(self, value: str) -> None:
@@ -2518,7 +2521,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def config_version(self) -> float:
-        return self._config_version
+        return self._config_version  # type: ignore[return-value]
 
     @config_version.setter
     def config_version(self, value: float) -> None:
@@ -2558,7 +2561,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def run_name_template(self) -> str:
-        return self._run_name_template
+        return self._run_name_template  # type: ignore[return-value]
 
     @run_name_template.setter
     def run_name_template(self, value: str) -> None:
@@ -2574,7 +2577,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def expectation_suite_name(self) -> str:
-        return self._expectation_suite_name
+        return self._expectation_suite_name  # type: ignore[return-value]
 
     @expectation_suite_name.setter
     def expectation_suite_name(self, value: str) -> None:
@@ -2590,7 +2593,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def site_names(self) -> List[str]:
-        return self._site_names
+        return self._site_names  # type: ignore[return-value]
 
     @site_names.setter
     def site_names(self, value: List[str]) -> None:
@@ -2598,7 +2601,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def slack_webhook(self) -> str:
-        return self._slack_webhook
+        return self._slack_webhook  # type: ignore[return-value]
 
     @slack_webhook.setter
     def slack_webhook(self, value: str) -> None:
@@ -2606,7 +2609,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def notify_on(self) -> str:
-        return self._notify_on
+        return self._notify_on  # type: ignore[return-value]
 
     @notify_on.setter
     def notify_on(self, value: str) -> None:
@@ -2614,7 +2617,7 @@ class CheckpointConfig(BaseYamlConfig):
 
     @property
     def notify_with(self) -> str:
-        return self._notify_with
+        return self._notify_with  # type: ignore[return-value]
 
     @notify_with.setter
     def notify_with(self, value: str) -> None:
@@ -2771,36 +2774,36 @@ class CheckpointConfig(BaseYamlConfig):
 
         if run_name is None and run_name_template is not None:
             run_name = get_datetime_string_from_strftime_format(
-                format_str=run_name_template, datetime_obj=run_time
+                format_str=run_name_template, datetime_obj=run_time  # type: ignore[arg-type]
             )
 
         run_id = run_id or RunIdentifier(run_name=run_name, run_time=run_time)
 
         validation_dict: dict
 
-        for validation_dict in validations:
+        for validation_dict in validations:  # type: ignore[assignment]
             substituted_validation_dict: dict = get_substituted_validation_dict(
                 substituted_runtime_config=substituted_runtime_config,
                 validation_dict=validation_dict,
             )
-            validation_batch_request: BatchRequestBase = (
-                substituted_validation_dict.get("batch_request")
+            validation_batch_request: BatchRequestBase = substituted_validation_dict.get(
+                "batch_request"  # type: ignore[assignment]
             )
             validation_dict["batch_request"] = validation_batch_request
-            validation_expectation_suite_name: str = substituted_validation_dict.get(
+            validation_expectation_suite_name: str = substituted_validation_dict.get(  # type: ignore[assignment]
                 "expectation_suite_name"
             )
             validation_dict[
                 "expectation_suite_name"
             ] = validation_expectation_suite_name
-            validation_expectation_suite_ge_cloud_id: str = (
-                substituted_validation_dict.get("expectation_suite_ge_cloud_id")
+            validation_expectation_suite_ge_cloud_id: str = substituted_validation_dict.get(
+                "expectation_suite_ge_cloud_id"  # type: ignore[assignment]
             )
             validation_dict[
                 "expectation_suite_ge_cloud_id"
             ] = validation_expectation_suite_ge_cloud_id
             validation_action_list: list = substituted_validation_dict.get(
-                "action_list"
+                "action_list"  # type: ignore[assignment]
             )
             validation_dict["action_list"] = validation_action_list
 

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -295,13 +295,13 @@ class SiteSectionIdentifier(DataContextKey):
                 )
         elif site_section_name == "expectations":
             if isinstance(resource_identifier, ExpectationSuiteIdentifier):
-                self._resource_identifier = resource_identifier
+                self._resource_identifier = resource_identifier  # type: ignore[assignment]
             elif isinstance(resource_identifier, (tuple, list)):
-                self._resource_identifier = ExpectationSuiteIdentifier(
+                self._resource_identifier = ExpectationSuiteIdentifier(  # type: ignore[assignment]
                     *resource_identifier
                 )
             else:
-                self._resource_identifier = ExpectationSuiteIdentifier(
+                self._resource_identifier = ExpectationSuiteIdentifier(  # type: ignore[assignment]
                     **resource_identifier
                 )
         else:

--- a/tasks.py
+++ b/tasks.py
@@ -126,8 +126,10 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
     # "cli",  # 237
     # "core",  # 242
     "data_asset",  # 0
-    # "data_context",  # 272
-    "data_context/types",  # 30
+    # "data_context",  # 242
+    # "data_context/data_context",  # 195
+    # "data_context/store", # 83
+    "data_context/types",  # 0
     # "datasource",  # 98
     "exceptions",  # 0
     # "execution_engine",  # 109

--- a/tasks.py
+++ b/tasks.py
@@ -127,6 +127,7 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
     # "core",  # 242
     "data_asset",  # 0
     # "data_context",  # 272
+    "data_context/types",  # 30
     # "datasource",  # 98
     "exceptions",  # 0
     # "execution_engine",  # 109


### PR DESCRIPTION
Changes proposed in this pull request:

* begin type checking `data_context/types`
 * mostly this just means ignoring a lot of typing errors but prevents further regressions of the types.


