### PR TITLE
[MAINTENANCE] Refactor docker test CI steps into jobs.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,56 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
     jobs:
-      - job: build_push_test_
+      - job: make_suffix
+        steps:
+          - bash: |
+              EPOCH=`date +%s`
+              SUFFIX="develop_${EPOCH}_${RANDOM}"
+              echo "Generated image suffix: ${SUFFIX}"
+              echo "##vso[task.setvariable variable=IMAGE_SUFFIX;isOutput=true]${SUFFIX}"
+            name: suffix
+
+      - job: build_push_
+        dependsOn: make_suffix
+        condition: succeeded()
+        strategy:
+          matrix:
+            Python37:
+              python.version: '3.7'
+            Python38:
+              python.version: '3.8'
+            Python39:
+              python.version: '3.9'
+        variables:
+          IMAGE_SUFFIX: $[ dependencies.make_suffix.outputs['suffix.IMAGE_SUFFIX'] ]
+        steps:
+          - bash: |
+              DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
+              # We repull the develop branch. We could build the local branch that is already present but we should
+              # prune it's depth since we don't need the git history.
+              CMD="docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:${DOCKER_TAG} "
+              CMD+="--target azure --build-arg PYTHON_VERSION=$(python.version) --build-arg SOURCE=github "
+              CMD+="--build-arg BRANCH=develop ."
+              echo ${CMD}
+              eval ${CMD}
+            displayName: 'Build python $(python.version) image'
+
+          - bash: |
+              docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}
+              DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
+              PUSH="docker push greatexpectations/test:${DOCKER_TAG}"
+              echo ${PUSH}
+              eval ${PUSH}
+              echo "Docker image can be found at https://hub.docker.com/r/greatexpectations/test/tags"
+              echo "Pull it locally using: docker pull greatexpectations/test:${DOCKER_TAG}"
+            displayName: 'Push python $(python.version) image'
+            env:
+              DOCKER_USER: $(DOCKER_USER)
+              DOCKER_TOKEN: $(DOCKER_TOKEN)
+
+      - job: comprehensive_test_
+        dependsOn: [make_suffix, build_push_]
+        condition: succeeded()
         timeoutInMinutes: 120
         strategy:
           matrix:
@@ -135,40 +184,17 @@ stages:
         services:
           postgres: postgres
         variables:
-          DOCKER_TAG: none
+          IMAGE_SUFFIX: $[ dependencies.make_suffix.outputs['suffix.IMAGE_SUFFIX'] ]
         steps:
           - bash: |
-              EPOCH=`date +%s`
-              TAG="$(python.version)_develop_${EPOCH}_${RANDOM}"
-              # We repull the develop branch. We could build the local branch that is already present but we should
-              # prune it's depth since we don't need the git history.
-              CMD="docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:${TAG} --target azure --build-arg PYTHON_VERSION=$(python.version) --build-arg SOURCE=github --build-arg BRANCH=develop ."
-              echo ${CMD}
-              eval ${CMD}
-              # Set this variable so other steps can read it.
-              echo "##vso[task.setvariable variable=DOCKER_TAG]${TAG}"
-            displayName: 'Build $(python.version)'
-
-          - bash: |
-              docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}
-              PUSH="docker push greatexpectations/test:${DOCKER_TAG}"
-              echo ${PUSH}
-              eval ${PUSH}
-              echo "Docker image can be found at https://hub.docker.com/r/greatexpectations/test/tags"
-              echo "Pull it locally using: docker pull greatexpectations/test:${DOCKER_TAG}"
-            displayName: 'Push $(python.version)'
-            env:
-              DOCKER_USER: $(DOCKER_USER)
-              DOCKER_TOKEN: $(DOCKER_TOKEN)
-
-          - bash: |
-              PULL="docker pull greatexpectations/test:$(DOCKER_TAG)"
+              DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
+              PULL="docker pull greatexpectations/test:${DOCKER_TAG}"
               echo ${PULL}
               eval ${PULL}
               mkdir coverage
               PYTEST="docker run --network=host --mount type=bind,source=${PWD}/coverage,target=/coverage "
               PYTEST+="-e GE_CLOUD_BASE_URL=$(GE_CLOUD_BASE_URL) -e GE_CLOUD_ACCESS_TOKEN=$(GE_CLOUD_ACCESS_TOKEN) "
-              PYTEST+="-e GE_CLOUD_ORGANIZATION_ID=$(GE_CLOUD_ORGANIZATION_ID) greatexpectations/test:$(DOCKER_TAG) "
+              PYTEST+="-e GE_CLOUD_ORGANIZATION_ID=$(GE_CLOUD_ORGANIZATION_ID) greatexpectations/test:${DOCKER_TAG} "
               PYTEST+="/bin/bash -c \"pytest --postgresql --spark --cloud --napoleon-docstrings --no-docker-discovery "
               # We should be able to specify --cov-report=xml:path but this doesn't work so we write to the default
               # path and then mv it.


### PR DESCRIPTION
This PR reorganizes the docker tests from using steps to jobs. This establishing a pattern I can use to integrate the other currently non-docker tests as jobs so they can run simultaneously instead of in series.

In addition, this adds a new step to create the image suffix. This is so our docker images (there is 1 per python version) for a particular pipeline run all have the same suffix so we can more easily group them together.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
