### PR TITLE
[FEATURE]Enable showing expectation suite by domain and by expectation_type -- from DataAssistantResult

### DIFF
--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -391,45 +391,6 @@ class DataAssistantResult(SerializableDictDot):
 
         return auxiliary_info
 
-    def _get_expectation_suite_without_usage_statistics(
-        self,
-        expectation_suite_name: str,
-        include_profiler_config: bool = False,
-    ) -> ExpectationSuite:
-        """
-        Returns: "ExpectationSuite" object, built from properties, populated into this "DataAssistantResult" object.
-        Side Effects: None -- no usage statistics event is emitted.
-        """
-        expectation_suite: ExpectationSuite = get_or_create_expectation_suite(
-            data_context=None,
-            expectation_suite=None,
-            expectation_suite_name=expectation_suite_name,
-            component_name=self.__class__.__name__,
-            persist=False,
-        )
-        expectation_suite.add_expectation_configurations(
-            expectation_configurations=self.expectation_configurations,
-            send_usage_event=False,
-            match_type="domain",
-            overwrite_existing=True,
-        )
-
-        citation: Dict[str, Any]
-        if include_profiler_config:
-            citation = self.citation
-        else:
-            key: str
-            value: Any
-            citation = {
-                key: value
-                for key, value in self.citation.items()
-                if key != "profiler_config"
-            }
-
-        expectation_suite.add_citation(**citation)
-
-        return expectation_suite
-
     @usage_statistics_enabled_method(
         event_name=UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value,
         args_payload_fn=get_expectation_suite_usage_statistics,
@@ -442,6 +403,20 @@ class DataAssistantResult(SerializableDictDot):
         """
         Returns: "ExpectationSuite" object, built from properties, populated into this "DataAssistantResult" object.
         Side Effects: One usage statistics event (specified in "usage_statistics_enabled_method" decorator) is emitted.
+        """
+        return self._get_expectation_suite_without_usage_statistics(
+            expectation_suite_name=expectation_suite_name,
+            include_profiler_config=include_profiler_config,
+        )
+
+    def _get_expectation_suite_without_usage_statistics(
+        self,
+        expectation_suite_name: str,
+        include_profiler_config: bool = False,
+    ) -> ExpectationSuite:
+        """
+        Returns: "ExpectationSuite" object, built from properties, populated into this "DataAssistantResult" object.
+        Side Effects: None -- no usage statistics event is emitted.
         """
         expectation_suite: ExpectationSuite = get_or_create_expectation_suite(
             data_context=None,

--- a/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/types/data_assistant_result/data_assistant_result.py
@@ -163,6 +163,58 @@ class DataAssistantResult(SerializableDictDot):
     # Reference to "UsageStatisticsHandler" object for this "DataAssistantResult" object (if configured).
     _usage_statistics_handler: Optional[UsageStatisticsHandler] = field(default=None)
 
+    def show_expectations_by_domain_type(
+        self,
+        expectation_suite_name: str,
+        include_profiler_config: bool = False,
+        send_usage_event: bool = True,
+    ) -> None:
+        """
+        Populates named "ExpectationSuite" with "ExpectationConfiguration" list, stored in "DataAssistantResult" object,
+        and displays this "ExpectationConfiguration" list, grouped by "domain_type", in predetermined order.
+        """
+        self.get_expectation_suite(
+            expectation_suite_name=expectation_suite_name,
+            include_profiler_config=include_profiler_config,
+            send_usage_event=send_usage_event,
+        ).show_expectations_by_domain_type()
+
+    def show_expectations_by_expectation_type(
+        self,
+        expectation_suite_name: str,
+        include_profiler_config: bool = False,
+        send_usage_event: bool = True,
+    ) -> None:
+        """
+        Populates named "ExpectationSuite" with "ExpectationConfiguration" list, stored in "DataAssistantResult" object,
+        and displays this "ExpectationConfiguration" list, grouped by "expectation_type", in predetermined order.
+        """
+        self.get_expectation_suite(
+            expectation_suite_name=expectation_suite_name,
+            include_profiler_config=include_profiler_config,
+            send_usage_event=send_usage_event,
+        ).show_expectations_by_expectation_type()
+
+    def get_expectation_suite(
+        self,
+        expectation_suite_name: str,
+        include_profiler_config: bool = False,
+        send_usage_event: bool = True,
+    ) -> ExpectationSuite:
+        """
+        Returns: "ExpectationSuite" object, built from properties, populated into this "DataAssistantResult" object.
+        """
+        if send_usage_event:
+            return self._get_expectation_suite_with_usage_statistics(
+                expectation_suite_name=expectation_suite_name,
+                include_profiler_config=include_profiler_config,
+            )
+
+        return self._get_expectation_suite_without_usage_statistics(
+            expectation_suite_name=expectation_suite_name,
+            include_profiler_config=include_profiler_config,
+        )
+
     def to_dict(self) -> dict:
         """
         Returns: This DataAssistantResult as dictionary (JSON-serializable dictionary for DataAssistantResult objects).
@@ -339,17 +391,57 @@ class DataAssistantResult(SerializableDictDot):
 
         return auxiliary_info
 
-    @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value,
-        args_payload_fn=get_expectation_suite_usage_statistics,
-    )
-    def get_expectation_suite(
+    def _get_expectation_suite_without_usage_statistics(
         self,
         expectation_suite_name: str,
         include_profiler_config: bool = False,
     ) -> ExpectationSuite:
         """
         Returns: "ExpectationSuite" object, built from properties, populated into this "DataAssistantResult" object.
+        Side Effects: None -- no usage statistics event is emitted.
+        """
+        expectation_suite: ExpectationSuite = get_or_create_expectation_suite(
+            data_context=None,
+            expectation_suite=None,
+            expectation_suite_name=expectation_suite_name,
+            component_name=self.__class__.__name__,
+            persist=False,
+        )
+        expectation_suite.add_expectation_configurations(
+            expectation_configurations=self.expectation_configurations,
+            send_usage_event=False,
+            match_type="domain",
+            overwrite_existing=True,
+        )
+
+        citation: Dict[str, Any]
+        if include_profiler_config:
+            citation = self.citation
+        else:
+            key: str
+            value: Any
+            citation = {
+                key: value
+                for key, value in self.citation.items()
+                if key != "profiler_config"
+            }
+
+        expectation_suite.add_citation(**citation)
+
+        return expectation_suite
+
+    @usage_statistics_enabled_method(
+        event_name=UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value,
+        args_payload_fn=get_expectation_suite_usage_statistics,
+    )
+    def _get_expectation_suite_with_usage_statistics(
+        self,
+        expectation_suite_name: str,
+        include_profiler_config: bool = False,
+    ) -> ExpectationSuite:
+        """
+        Returns: "ExpectationSuite" object, built from properties, populated into this "DataAssistantResult" object.
+        Side Effects: One usage statistics event (specified in "usage_statistics_enabled_method" decorator) is emitted.
         """
         expectation_suite: ExpectationSuite = get_or_create_expectation_suite(
             data_context=None,


### PR DESCRIPTION
### Scope
* Exposing `ExpectationConfiguration` "`show_*`" methods from `ExpectationSuite` at the `DataAssistantResult` level for convenience.
* Verified in a `Jupyter` notebook.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1135
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!