### PR TITLE
[MAINTENANCE] expand flake8 coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/pyupgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     rev: 3.8.3
     hooks:
       - id: flake8
-        files: ^(great_expectations/core)
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:

--- a/azure-pipelines-contrib.yml
+++ b/azure-pipelines-contrib.yml
@@ -42,7 +42,7 @@ stages:
               EXIT_STATUS=0
               isort . --check-only || EXIT_STATUS=$?
               black --check . || EXIT_STATUS=$?
-              flake8 great_expectations/core || EXIT_STATUS=$?
+              flake8 . || EXIT_STATUS=$?
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 

--- a/azure-pipelines-contrib.yml
+++ b/azure-pipelines-contrib.yml
@@ -38,7 +38,7 @@ stages:
             displayName: 'Use Python $(python.version)'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2
+              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
               isort . --check-only || EXIT_STATUS=$?
               black --check . || EXIT_STATUS=$?

--- a/azure-pipelines-contrib.yml
+++ b/azure-pipelines-contrib.yml
@@ -38,7 +38,7 @@ stages:
             displayName: 'Use Python $(python.version)'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.8.3 black==22.3.0 pyupgrade==2.7.2
+              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2
               EXIT_STATUS=0
               isort . --check-only || EXIT_STATUS=$?
               black --check . || EXIT_STATUS=$?

--- a/azure-pipelines-contrib.yml
+++ b/azure-pipelines-contrib.yml
@@ -40,9 +40,8 @@ stages:
           - script: |
               pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
-              isort . --check-only || EXIT_STATUS=$?
-              black --check . || EXIT_STATUS=$?
-              flake8 . || EXIT_STATUS=$?
+              invoke fmt --check || EXIT_STATUS=$?
+              invoke lint || EXIT_STATUS=$?
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -99,9 +99,8 @@ stages:
           - script: |
               pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
-              isort . --check-only || EXIT_STATUS=$?
-              black --check . || EXIT_STATUS=$?
-              flake8 . || EXIT_STATUS=$?
+              invoke fmt --check || EXIT_STATUS=$?
+              invoke lint || EXIT_STATUS=$?
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -97,7 +97,7 @@ stages:
             displayName: 'Use Python 3.7'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.8.3 black==22.3.0 pyupgrade==2.7.2
+              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2
               EXIT_STATUS=0
               isort . --check-only || EXIT_STATUS=$?
               black --check . || EXIT_STATUS=$?

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -101,7 +101,7 @@ stages:
               EXIT_STATUS=0
               isort . --check-only || EXIT_STATUS=$?
               black --check . || EXIT_STATUS=$?
-              flake8 great_expectations/core || EXIT_STATUS=$?
+              flake8 . || EXIT_STATUS=$?
               pyupgrade --py3-plus || EXIT_STATUS=$?
               exit $EXIT_STATUS
 

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -97,7 +97,7 @@ stages:
             displayName: 'Use Python 3.7'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2
+              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
               isort . --check-only || EXIT_STATUS=$?
               black --check . || EXIT_STATUS=$?

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
             displayName: 'Use Python 3.7'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke
+              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
               invoke fmt --check || EXIT_STATUS=$?
               invoke lint || EXIT_STATUS=$?

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
             displayName: 'Use Python 3.7'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.8.3 black==22.3.0 pyupgrade==2.7.2 invoke
+              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke
               EXIT_STATUS=0
               invoke fmt --check || EXIT_STATUS=$?
               invoke lint || EXIT_STATUS=$?

--- a/docker/build.py
+++ b/docker/build.py
@@ -7,7 +7,6 @@ from typing import List
 import click
 
 import docker
-from docker import APIClient
 
 PROJECT_ROOT = str(pathlib.Path(__file__).parent.parent.absolute())
 if PROJECT_ROOT not in sys.path:

--- a/docs_rtd/conf.py
+++ b/docs_rtd/conf.py
@@ -17,10 +17,8 @@
 #
 
 import os
-import re
 import sys
 import uuid
-from collections import namedtuple
 
 from sphinx.ext.autodoc import between
 

--- a/docs_rtd/feature_annotation_parser.py
+++ b/docs_rtd/feature_annotation_parser.py
@@ -1,10 +1,7 @@
-import ast
-import json
 import logging
-import os
 import re
 from collections import namedtuple
-from typing import Dict, Iterator, List, Mapping, Optional, Set, Tuple, Union
+from typing import List, Union
 
 logger = logging.getLogger(__name__)
 

--- a/examples/expectations/query_expectation_template.py
+++ b/examples/expectations/query_expectation_template.py
@@ -4,12 +4,9 @@ For detailed instructions on how to use it, please see:
     https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_query_expectations
 """
 
-from typing import Any, Dict, Optional, Union
+from typing import Optional, Union
 
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
-from great_expectations.exceptions.exceptions import (
-    InvalidExpectationConfigurationError,
-)
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import (
     ExpectationValidationResult,

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -678,7 +678,7 @@ def get_batch_request_as_dict(
     return batch_request
 
 
-def get_batch_request_from_acceptable_arguments(
+def get_batch_request_from_acceptable_arguments(  # noqa: C901 - complexity 21
     datasource_name: Optional[str] = None,
     data_connector_name: Optional[str] = None,
     data_asset_name: Optional[str] = None,

--- a/great_expectations/core/evaluation_parameters.py
+++ b/great_expectations/core/evaluation_parameters.py
@@ -304,7 +304,7 @@ def find_evaluation_parameter_dependencies(parameter_expression):
     return dependencies
 
 
-def parse_evaluation_parameter(
+def parse_evaluation_parameter(  # noqa: C901 - complexity 21
     parameter_expression: str,
     evaluation_parameters: Optional[Dict[str, Any]] = None,
     data_context: Optional[Any] = None,  # Cannot type 'DataContext' due to import cycle

--- a/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/checkpoint_anonymizer.py
@@ -63,7 +63,9 @@ class CheckpointAnonymizer(BaseAnonymizer):
         return anonymized_info_dict
 
     # noinspection PyUnusedLocal
-    def _anonymize_checkpoint_run(self, obj: object, **kwargs) -> dict:
+    def _anonymize_checkpoint_run(  # noqa: C901 - complexity 21
+        self, obj: object, **kwargs
+    ) -> dict:
         """
         Traverse the entire Checkpoint configuration structure (as per its formal, validated Marshmallow schema) and
         anonymize every field that can be customized by a user (public fields are recorded as their original names).

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -155,7 +155,7 @@ def determine_progress_bar_method_by_environment() -> Callable:
     return tqdm
 
 
-def convert_to_json_serializable(data):
+def convert_to_json_serializable(data):  # noqa: C901 - complexity 28
     """
     Helper function to convert an object to one that is json serializable
     Args:
@@ -283,7 +283,7 @@ def convert_to_json_serializable(data):
         )
 
 
-def ensure_json_serializable(data):
+def ensure_json_serializable(data):  # noqa: C901 - complexity 21
     """
     Helper function to convert an object to one that is json serializable
     Args:

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -144,7 +144,7 @@ class DataAsset:
         )
 
     @classmethod
-    def expectation(cls, method_arg_names):
+    def expectation(cls, method_arg_names):  # noqa: C901 - complexity 24
         """Manages configuration and running of expectation objects.
 
         Expectation builds and saves a new expectation configuration to the DataAsset object. It is the core decorator \
@@ -561,7 +561,7 @@ class DataAsset:
             suppress_warnings,
         )
 
-    def get_expectation_suite(
+    def get_expectation_suite(  # noqa: C901 - complexity 17
         self,
         discard_failed_expectations=True,
         discard_result_format_kwargs=True,
@@ -721,7 +721,7 @@ class DataAsset:
                 "Unable to save config: filepath or data_context must be available."
             )
 
-    def validate(
+    def validate(  # noqa: C901 - complexity 36
         self,
         expectation_suite=None,
         run_id=None,
@@ -905,7 +905,7 @@ class DataAsset:
 
             # Warn if our version is different from the version in the configuration
             # TODO: Deprecate "great_expectations.__version__"
-            suite_ge_version = expectation_suite.meta.get(
+            suite_ge_version = expectation_suite.meta.get(  # noqa: F841
                 "great_expectations_version"
             ) or expectation_suite.meta.get("great_expectations.__version__")
 

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -143,8 +143,8 @@ class DataAsset:
             self
         )
 
-    @classmethod
-    def expectation(cls, method_arg_names):  # noqa: C901 - complexity 24
+    @classmethod  # noqa: C901 - complexity 24
+    def expectation(cls, method_arg_names):  # noqa: C901
         """Manages configuration and running of expectation objects.
 
         Expectation builds and saves a new expectation configuration to the DataAsset object. It is the core decorator \

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -905,9 +905,6 @@ class DataAsset:
 
             # Warn if our version is different from the version in the configuration
             # TODO: Deprecate "great_expectations.__version__"
-            suite_ge_version = expectation_suite.meta.get(  # noqa: F841
-                "great_expectations_version"
-            ) or expectation_suite.meta.get("great_expectations.__version__")
 
             ###
             # This is an early example of what will become part of the ValidationOperator

--- a/great_expectations/data_asset/file_data_asset.py
+++ b/great_expectations/data_asset/file_data_asset.py
@@ -101,7 +101,9 @@ class MetaFileDataAsset(DataAsset):
                     nonnull_lines = list(
                         compress(lines, np.invert(boolean_mapped_null_lines))
                     )
-                    nonnull_count = int((boolean_mapped_null_lines == False).sum())
+                    nonnull_count = int(
+                        (boolean_mapped_null_lines == False).sum()  # noqa: E712
+                    )
                     boolean_mapped_success_lines = np.array(
                         func(self, _lines=nonnull_lines, *args, **kwargs)
                     )
@@ -700,6 +702,6 @@ class FileDataAsset(MetaFileDataAsset):
                 success = False
             except jsonschema.SchemaError:
                 raise
-            except:
+            except BaseException:
                 raise
         return {"success": success}

--- a/great_expectations/data_asset/util.py
+++ b/great_expectations/data_asset/util.py
@@ -79,7 +79,7 @@ class DocInherit:
         return f
 
 
-def recursively_convert_to_json_serializable(test_obj):
+def recursively_convert_to_json_serializable(test_obj):  # noqa: C901 - complexity 20
     """
     Helper function to convert a dict object to one that is serializable
 

--- a/great_expectations/exceptions/__init__.py
+++ b/great_expectations/exceptions/__init__.py
@@ -1,1 +1,1 @@
-from .exceptions import *
+from .exceptions import *  # noqa: F403

--- a/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py
@@ -38,7 +38,7 @@ class RegexPatternStringParameterBuilder(ParameterBuilder):
         r"[A-Za-z0-9\.,;:!?()\"'%\-]+",  # general text
         r"^\s+",  # leading space
         r"\s+$",  # trailing space
-        r"https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#()?&//=]*)",  #  Matching URL (including http(s) protocol)
+        r"https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#()?&//=]*)",  # Matching URL (including http(s) protocol)
         r"<\/?(?:p|a|b|img)(?: \/)?>",  # HTML tags
         r"(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})(?:.(?:25[0-5]|2[0-4]\d|[01]\d{2}|\d{1,2})){3}",  # IPv4 IP address
         r"(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}",  # IPv6 IP address,

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1285,8 +1285,7 @@ def is_numeric(value: Any) -> bool:
 
 def is_int(value: Any) -> bool:
     try:
-        # noinspection PyUnusedLocal
-        num: int = int(value)
+        int(value)
     except (TypeError, ValueError):
         return False
     return True
@@ -1294,8 +1293,7 @@ def is_int(value: Any) -> bool:
 
 def is_float(value: Any) -> bool:
     try:
-        # noinspection PyUnusedLocal
-        num: float = float(value)
+        float(value)
     except (TypeError, ValueError):
         return False
     return True
@@ -1408,8 +1406,7 @@ def is_candidate_subset_of_target(candidate: Any, target: Any) -> bool:
 
 def is_parseable_date(value: Any, fuzzy: bool = False) -> bool:
     try:
-        # noinspection PyUnusedLocal
-        parsed_date: datetime.datetime = parse(value, fuzzy=fuzzy)
+        parse(value, fuzzy=fuzzy)
     except (TypeError, ValueError):
         return False
     return True

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -762,7 +762,8 @@ class WarningAndFailureExpectationSuitesValidationOperator(
 
         return query
 
-    def run(
+    # complexity 18
+    def run(  # noqa: C901
         self,
         assets_to_validate,
         run_id=None,
@@ -809,8 +810,8 @@ class WarningAndFailureExpectationSuitesValidationOperator(
             batch_id = batch.batch_id
             run_id = run_id
 
-            assert not batch_id is None
-            assert not run_id is None
+            assert batch_id is not None
+            assert run_id is not None
 
             failure_expectation_suite_identifier = ExpectationSuiteIdentifier(
                 expectation_suite_name=base_expectation_suite_name

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -762,8 +762,7 @@ class WarningAndFailureExpectationSuitesValidationOperator(
 
         return query
 
-    # complexity 18
-    def run(  # noqa: C901
+    def run(  # noqa: C901 - complexity 18
         self,
         assets_to_validate,
         run_id=None,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1930,10 +1930,6 @@ set as active.
 
             # Warn if our version is different from the version in the configuration
             # TODO: Deprecate "great_expectations.__version__"
-            # noinspection PyUnusedLocal
-            suite_ge_version = expectation_suite.meta.get(  # noqa: F841
-                "great_expectations_version"
-            ) or expectation_suite.meta.get("great_expectations.__version__")
 
             # Group expectations by column
             columns = {}

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1222,7 +1222,7 @@ class Validator:
                     runtime_configuration=runtime_configuration,
                 )
 
-    def resolve_validation_graph(
+    def resolve_validation_graph(  # noqa: C901 - complexity 16
         self,
         graph: ValidationGraph,
         metrics: Dict[Tuple[str, str, str], Any],
@@ -1576,7 +1576,7 @@ set as active.
             suppress_warnings,
         )
 
-    def get_expectation_suite(
+    def get_expectation_suite(  # noqa: C901 - complexity 17
         self,
         discard_failed_expectations: bool = True,
         discard_result_format_kwargs: bool = True,
@@ -1742,7 +1742,7 @@ set as active.
             )
 
     # TODO: <Alex>Should "include_config" also be an argument of this method?</Alex>
-    def validate(
+    def validate(  # noqa: C901 - complexity 31
         self,
         expectation_suite=None,
         run_id=None,
@@ -1931,7 +1931,7 @@ set as active.
             # Warn if our version is different from the version in the configuration
             # TODO: Deprecate "great_expectations.__version__"
             # noinspection PyUnusedLocal
-            suite_ge_version = expectation_suite.meta.get(
+            suite_ge_version = expectation_suite.meta.get(  # noqa: F841
                 "great_expectations_version"
             ) or expectation_suite.meta.get("great_expectations.__version__")
 

--- a/requirements-dev-contrib.txt
+++ b/requirements-dev-contrib.txt
@@ -1,5 +1,5 @@
 black==22.3.0
-flake8==3.8.3
+flake8==3.9.2
 invoke>=1.7.1
 isort==5.10.1
 mypy>=0.971

--- a/scripts/validate_docs_snippet_line_numbers.py
+++ b/scripts/validate_docs_snippet_line_numbers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import logging
 import os

--- a/scripts/validate_docs_snippet_line_numbers.py
+++ b/scripts/validate_docs_snippet_line_numbers.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import glob
 import logging
 import os
@@ -32,7 +30,7 @@ class DocusaurusRef:
 
         start_line: int = int(start)
         end_line: int = int(end) if end else start_line
-        line_numbers: Tuple[int, int] = start_line, end_line
+        line_numbers: Tuple[int, int] = (start_line, end_line)
 
         relative_path: str = os.path.join(os.path.dirname(file), path)
         cleaned_path: str = os.path.normpath(relative_path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,6 @@ parentdir_prefix = great_expectations-
 
 [flake8]
 max-line-length = 200
-exclude = tests/*,docs/*
+exclude = tests/*,docs/*,build/*,assets/*
 per-file-ignores =
     */__init__.py: F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,5 +39,5 @@ per-file-ignores =
 # E402 - module level import not at top of file: (isort)
 extend-ignore = E501,E203,E402
 # https://github.com/pycqa/mccabe
-# TODO: reduce this 10
+# TODO: reduce this to 10
 max-complexity = 15

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,10 @@ max-line-length = 200
 exclude = tests/*,docs/*,build/*,assets/*
 per-file-ignores =
     */__init__.py: F401
+# E501 - line length (black)
 # E203 - whitespace before : (conflicts with black)
-extend-ignore = E203
+# E402 - module level import not at top of file: (isort)
+extend-ignore = E501,E203,E402
 # https://github.com/pycqa/mccabe
 # TODO: reduce this 10
 max-complexity = 15

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,19 @@ exclude = tests/*,
     contrib/*,
     versioneer*,
     examples/*,
+    # TODO: remove the items below and fix linting issues
+    great_expectations/checkpoint,
+    great_expectations/self_check,
+    great_expectations/jupyter_ux,
+    great_expectations/execution_engine,
+    great_expectations/profile,
+    great_expectations/cli,
+    great_expectations/expectations,
+    great_expectations/dataset,
+    great_expectations/datasource,
+    great_expectations/data_context,
+    great_expectations/marshmallow__shade,
+    great_expectations/render,
 per-file-ignores =
     */__init__.py: F401
 # E501 - line length (black)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,9 @@ tag_prefix =
 parentdir_prefix = great_expectations-
 
 [flake8]
-exclude = tests/*,
+exclude = .git,
+    build,
+    tests/*,
     docs/*,
     build/*,
     assets/*,

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,13 @@ tag_prefix =
 parentdir_prefix = great_expectations-
 
 [flake8]
-max-line-length = 200
-exclude = tests/*,docs/*,build/*,assets/*
+exclude = tests/*,
+    docs/*,
+    build/*,
+    assets/*,
+    contrib/*,
+    versioneer*,
+    examples/*,
 per-file-ignores =
     */__init__.py: F401
 # E501 - line length (black)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,5 @@ max-line-length = 200
 exclude = tests/*,docs/*,build/*,assets/*
 per-file-ignores =
     */__init__.py: F401
+# E203 - whitespace before : (conflicts with black)
+extend-ignore = E203

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,6 @@ per-file-ignores =
     */__init__.py: F401
 # E203 - whitespace before : (conflicts with black)
 extend-ignore = E203
+# https://github.com/pycqa/mccabe
+# TODO: reduce this 10
+max-complexity = 15

--- a/tasks.py
+++ b/tasks.py
@@ -68,11 +68,11 @@ def fmt(ctx, path=".", sort_=True, check=False, exclude=None):
     ctx.run(" ".join(cmds), echo=True)
 
 
-@invoke.task
-def lint(ctx, path="great_expectations/core"):
+@invoke.task(help={"path": _PATH_HELP_DESC})
+def lint(ctx, path="."):
     """Run code linter"""
-    cmds = ["flake8", path]
-    ctx.run(" ".join(cmds))
+    cmds = ["flake8", path, "--statistics"]
+    ctx.run(" ".join(cmds), echo=True)
 
 
 @invoke.task(help={"path": _PATH_HELP_DESC})


### PR DESCRIPTION
Formerly our `flake8` linter only checked and enforced linting issues in the package `great_expectations/core`.

This PR changes this behavior to lint everything that hasn't been explicitly excluded in the flake8 `setup.cfg` section.
To begin with, we are still excluding most of `great_expectations` from flake8 but expect followup PR's to whittle away at this.

Applied a series of low-risk fixes and/or warning suppression via `# noqa` to select modules.

Disabled some warning messages to due conflicts with our other tools (`black` & `isort`).

Added a `max-complexity` warning. The will raise warnings for classes. functions, whose [cyclomatic-complexity](https://dx42.github.io/gmetrics/metrics/CyclomaticComplexityMetric.html) reaches a certain threshold.

Updated `flake8` to the most recent version supported by `pre-commit`


## Summary of Changes
1. Change to flake8 linting to `opt-out` instead of only `great_expecations/core`
2. Initially exclude modules with high number of errors
3. Fix modules with low errors and low risk fixes
4. ignore rules that conflict with `black` or `isort`
5. add `max-complexity` rule
6. update flake8 to `3.9.2` - (latest is `5.0.4`)

## References
https://www.flake8rules.com/
https://dx42.github.io/gmetrics/metrics/CyclomaticComplexityMetric.html
