### PR TITLE
[BUGFIX] Patch bug with `id` vs `id_` in Cloud integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,18 +209,6 @@ stages:
               GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'pytest $(python.version)'
 
-          - script: |
-              # These are integration/E2E tests that are specific to Great Expectations Cloud.
-              # In order to ensure coverage, we run them during each CI/CD cycle.
-              pytest tests --cloud -m "cloud and not unit"
-
-            env:
-              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
-              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
-              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
-            displayName: 'gx-cloud-integration'
-
-
           - task: PublishTestResults@2
             condition: succeededOrFailed()
             inputs:
@@ -419,6 +407,17 @@ stages:
               GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
               GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'pytest'
+
+          - script: |
+              # These are integration/E2E tests that are specific to Great Expectations Cloud.
+              # In order to ensure coverage, we run them during each CI/CD cycle.
+              pytest tests --cloud -m "cloud and not unit"
+
+            env:
+              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
+              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
+              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
+            displayName: 'gx-cloud-integration'
 
           - task: PublishTestResults@2
             condition: succeededOrFailed()

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -332,15 +332,26 @@ class CloudDataContext(AbstractDataContext):
         # Config must be persisted with ${VARIABLES} syntax but hydrated at time of use
         substitutions: dict = self._determine_substitutions()
         config: dict = dict(datasourceConfigSchema.dump(datasource_config))
-        substituted_config: dict = substitute_all_config_variables(
+
+        substituted_config_dict: dict = substitute_all_config_variables(
             config, substitutions, self.DOLLAR_SIGN_ESCAPE_STRING
         )
+
+        # Round trip through schema validation and config creation to ensure "id_" is present
+        #
+        # Chetan - 20220804 - This logic is utilized with other id-enabled objects and should
+        # be refactored to into the config/schema. Also, downstream methods should be refactored
+        # to accept the config object (as opposed to a dict).
+        substituted_config = DatasourceConfig(
+            **datasourceConfigSchema.load(substituted_config_dict)
+        )
+        schema_validated_substituted_config_dict = substituted_config.to_json_dict()
 
         datasource: Optional[Datasource] = None
         if initialize:
             try:
-                datasource: Datasource = self._instantiate_datasource_from_config(
-                    name=name, config=substituted_config
+                datasource = self._instantiate_datasource_from_config(
+                    name=name, config=schema_validated_substituted_config_dict
                 )
                 self._cached_datasources[name] = datasource
             except ge_exceptions.DatasourceInitializationError as e:

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -253,11 +253,11 @@ def test_cloud_backed_data_context_add_checkpoint(
     assert checkpoint.ge_cloud_id == checkpoint_id
     assert checkpoint.config.ge_cloud_id == checkpoint_id
 
-    assert checkpoint.config.validations[0]["id"] == validation_id_1
-    assert checkpoint.validations[0]["id"] == validation_id_1
+    assert checkpoint.config.validations[0]["id_"] == validation_id_1
+    assert checkpoint.validations[0]["id_"] == validation_id_1
 
-    assert checkpoint.config.validations[1]["id"] == validation_id_2
-    assert checkpoint.validations[1]["id"] == validation_id_2
+    assert checkpoint.config.validations[1]["id_"] == validation_id_2
+    assert checkpoint.validations[1]["id_"] == validation_id_2
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Changes proposed in this pull request:
- `id` is meant for serialized objects while `id_` is relevant for actual use in GX.
- Quick modification to Azure YAML to move Cloud tests to `comprehensive`.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
