### PR TITLE
[BUGFIX] Remove `resource_type` from call to `StoreBackend.build_key`

### DIFF
--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -4,9 +4,6 @@ import copy
 from typing import List, Optional, Union
 
 from great_expectations.core.data_context_key import DataContextVariableKey
-from great_expectations.data_context.data_context_variables import (
-    DataContextVariableSchema,
-)
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.base import (
@@ -157,7 +154,6 @@ class DatasourceStore(Store):
         else:
             name = None
         return self.store_backend.build_key(
-            resource_type=DataContextVariableSchema.DATASOURCES,
             name=name,
             id_=id_,
         )


### PR DESCRIPTION
Changes proposed in this pull request:
- The signature for `build_key` was recently modified but this particular call was not updated.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
