### PR TITLE
[MAINTENANCE] Utilize `e2e` mark on E2E Cloud tests

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -253,10 +253,6 @@ stages:
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
                 $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
-            env:
-              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
-              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
-              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'dgtest'
 
           - task: PublishTestResults@2
@@ -330,10 +326,6 @@ stages:
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
                 $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
-            env:
-              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
-              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
-              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'dgtest'
 
           - script: |
@@ -360,10 +352,6 @@ stages:
               # In order to ensure coverage, we run them during each CI/CD cycle.
               pytest tests --cloud -m "cloud and not e2e"
 
-            env:
-              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
-              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
-              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'dgtest-cloud-overrides'
 
           - task: PublishTestResults@2
@@ -466,10 +454,6 @@ stages:
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
                 --mysql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
-            env:
-              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
-              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
-              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'dgtest'
 
       - job: mssql
@@ -509,10 +493,6 @@ stages:
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
                 --mssql --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
-            env:
-              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
-              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
-              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'dgtest'
 
       - job: trino
@@ -559,10 +539,6 @@ stages:
               dgtest run great_expectations --ignore 'tests/cli' --ignore 'tests/integration/usage_statistics' \
                 --trino --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
-            env:
-              GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)
-              GE_CLOUD_ACCESS_TOKEN: $(GE_CLOUD_ACCESS_TOKEN)
-              GE_CLOUD_ORGANIZATION_ID: $(GE_CLOUD_ORGANIZATION_ID)
             displayName: 'dgtest'
 
   - stage: cli_integration

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -358,7 +358,7 @@ stages:
           - script: |
               # These are tests that are specific to Great Expectations Cloud.
               # In order to ensure coverage, we run them during each CI/CD cycle.
-              pytest tests --cloud -m "cloud and not integration"
+              pytest tests --cloud -m "cloud and not e2e"
 
             env:
               GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -409,9 +409,9 @@ stages:
             displayName: 'pytest'
 
           - script: |
-              # These are integration/E2E tests that are specific to Great Expectations Cloud.
+              # These are E2E tests that are specific to Great Expectations Cloud.
               # In order to ensure coverage, we run them during each CI/CD cycle.
-              pytest tests --cloud -m "cloud and not unit"
+              pytest tests --cloud -m "cloud and e2e"
 
             env:
               GE_CLOUD_BASE_URL: $(GE_CLOUD_BASE_URL)

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -157,7 +157,6 @@ class DatasourceStore(Store):
         else:
             name = None
         return self.store_backend.build_key(
-            resource_type=DataContextVariableSchema.DATASOURCES,
             name=name,
             id_=id_,
         )

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -260,7 +260,7 @@ def test_cloud_backed_data_context_add_checkpoint(
     assert checkpoint.validations[1]["id_"] == validation_id_2
 
 
-@pytest.mark.integration
+@pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_cloud_backed_data_context_add_checkpoint_e2e(

--- a/tests/data_context/cloud_data_context/test_datasource_crud.py
+++ b/tests/data_context/cloud_data_context/test_datasource_crud.py
@@ -12,7 +12,7 @@ from great_expectations.datasource import BaseDatasource
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
+@pytest.mark.e2e
 @pytest.mark.parametrize(
     "save_changes",
     [
@@ -127,7 +127,7 @@ def test_base_data_context_in_cloud_mode_add_datasource(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
+@pytest.mark.e2e
 @pytest.mark.parametrize(
     "config_includes_name_setting",
     [
@@ -223,7 +223,7 @@ def test_data_context_in_cloud_mode_add_datasource(
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
+@pytest.mark.e2e
 @pytest.mark.parametrize(
     "config_includes_name_setting",
     [

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -248,7 +248,7 @@ def prepare_validator_for_cloud_e2e() -> Callable[[DataContext], Tuple[Validator
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
+@pytest.mark.e2e
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_cloud_backend(
     mock_save_project_config: mock.MagicMock,
@@ -277,7 +277,7 @@ def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_clo
 
 
 @pytest.mark.cloud
-@pytest.mark.integration
+@pytest.mark.e2e
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_validator_e2e_workflow_with_cloud_enabled_context(
     mock_save_project_config: mock.MagicMock,

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -531,7 +531,7 @@ def test_file_data_context_variables_e2e(
     assert config_saved_to_disk.plugins_directory == f"${env_var_name}"
 
 
-@pytest.mark.integration
+@pytest.mark.e2e
 @pytest.mark.cloud
 def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     cloud_data_context: CloudDataContext,
@@ -549,7 +549,7 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     assert success is True
 
 
-@pytest.mark.integration
+@pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
 def test_cloud_enabled_data_context_variables_e2e(


### PR DESCRIPTION
Changes proposed in this pull request:
- For any Cloud tests that make external requests, we want to use the new `e2e` mark.
- Updated Azure pipelines to separate out which tests get run when.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
