### PR TITLE
[MAINTENANCE] pyproject.tooml build-system typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[build-sytem]
+[build-system]
 requires = ["setuptools", "wheel"]
 # uncomment to enable pep517 after versioneer problem is fixed.
 # https://github.com/python-versioneer/python-versioneer/issues/193


### PR DESCRIPTION
typo in `pyproject.toml` `[build-system]` top level key. 🤦 

This should not cause problems for [Release `0.15.17`](https://github.com/great-expectations/great_expectations/releases/tag/0.15.17) since we weren't relying on the `build-system` - `build-backend` declaration yet.

Thanks @anthonyburdi for pointing this out!