### PR TITLE
[MAINTENANCE] revert expansive flake8 pre-commit checking - flake8 5.0.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+        files: ^(great_expectations/core)
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         files: ^(great_expectations/core)

--- a/azure-pipelines-contrib.yml
+++ b/azure-pipelines-contrib.yml
@@ -38,7 +38,7 @@ stages:
             displayName: 'Use Python $(python.version)'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
+              pip install isort[requirements]==5.10.1 flake8==5.0.4 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
               invoke fmt --check || EXIT_STATUS=$?
               invoke lint || EXIT_STATUS=$?

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -97,7 +97,7 @@ stages:
             displayName: 'Use Python 3.7'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
+              pip install isort[requirements]==5.10.1 flake8==5.0.4 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
               invoke fmt --check || EXIT_STATUS=$?
               invoke lint || EXIT_STATUS=$?

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
             displayName: 'Use Python 3.7'
 
           - script: |
-              pip install isort[requirements]==5.10.1 flake8==3.9.2 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
+              pip install isort[requirements]==5.10.1 flake8==5.0.4 black==22.3.0 pyupgrade==2.7.2 invoke==1.7.1
               EXIT_STATUS=0
               invoke fmt --check || EXIT_STATUS=$?
               invoke lint || EXIT_STATUS=$?

--- a/requirements-dev-contrib.txt
+++ b/requirements-dev-contrib.txt
@@ -1,5 +1,5 @@
 black==22.3.0
-flake8==3.9.2
+flake8==5.0.4
 invoke>=1.7.1
 isort==5.10.1
 mypy>=0.971


### PR DESCRIPTION
Changes proposed in this pull request:
- revert changes to flake8 pre-commit hook
- update flake8 from `3.9.2` to the latest `5.0.4`

The pre-commit hook does not respect the [`setup.cfg` exclude settings](https://github.com/great-expectations/great_expectations/blob/develop/setup.cfg#L15-L36) and forces developers to fix or suppress a bunch of errors if they touch files that haven't already had their linting issues addressed.

We may (or may not) want to add this back once our entire codebase has been properly linted by `flake8`.

See the related discussion 
https://github.com/great-expectations/great_expectations/pull/5676#discussion_r937819196

To be more precise, it's not that there is anything wrong with the `pre-commit` hooks, it's that flake8 overrides the `exclude` settings when files are passed to it directly. So if we `exclude` `foo/bar.py` and run `flake8` on a directory `foo/`, `foo/bar.py` gets properly skipped, but if we pass `foo/bar.py` directly as an input, the exclude setting is ignored.