### PR TITLE
[MAINTENANCE] Leverage `DataContextVariables` in `DataContext` hierarchy to automatically determine how to persist changes

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -204,7 +204,7 @@ class AbstractDataContext(ABC):
 
     def _save_project_config(self) -> None:
         """
-        Each DataContext will define how its project_config will be saved.
+        Each DataContext will define how its project_config will be saved through its internal 'variables'.
             - FileDataContext : Filesystem.
             - CloudDataContext : Cloud endpoint
             - Ephemeral : not saved, and logging message outputted

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -202,7 +202,6 @@ class AbstractDataContext(ABC):
     def _init_variables(self) -> DataContextVariables:
         raise NotImplementedError
 
-    @abstractmethod
     def _save_project_config(self) -> None:
         """
         Each DataContext will define how its project_config will be saved.
@@ -210,7 +209,7 @@ class AbstractDataContext(ABC):
             - CloudDataContext : Cloud endpoint
             - Ephemeral : not saved, and logging message outputted
         """
-        raise NotImplementedError
+        self.variables.save_config()
 
     @abstractmethod
     def save_expectation_suite(

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -14,9 +14,6 @@ from ruamel.yaml.comments import CommentedMap
 
 from great_expectations.core.config_peer import ConfigPeer
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
-from great_expectations.data_context.data_context_variables import (
-    FileDataContextVariables,
-)
 from great_expectations.data_context.store.ge_cloud_store_backend import (
     GeCloudRESTResource,
 )
@@ -363,19 +360,16 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         self._assistants = self._data_context._assistants
 
     def _save_project_config(self) -> None:
-        """
-        Although the BaseDataContext has the ability to act ephemeral or cloud-backed,
-        the `_save_project_config` method has always historically written to disk.
-
-        As such, it utilizes an instance of `FileDataContextVariables` to maintain
-        legacy behavior.
-        """
+        """Save the current project to disk."""
         logger.debug("Starting DataContext._save_project_config")
 
-        file_backed_vars = FileDataContextVariables(
-            config=self.config, data_context=self
-        )
-        file_backed_vars.save_config()
+        config_filepath = os.path.join(self.root_directory, self.GE_YML)
+
+        try:
+            with open(config_filepath, "w") as outfile:
+                self.config.to_yaml(outfile)
+        except PermissionError as e:
+            logger.warning(f"Could not save project config to disk: {e}")
 
     def add_store(self, store_name: str, store_config: dict) -> Optional[Store]:
         """Add a new Store to the DataContext and (for convenience) return the instantiated Store object.

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -361,6 +361,8 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
 
     def _save_project_config(self) -> None:
         """Save the current project to disk."""
+        logger.debug("Starting DataContext._save_project_config")
+
         config_filepath = os.path.join(self.root_directory, self.GE_YML)
 
         try:

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -361,8 +361,6 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
 
     def _save_project_config(self) -> None:
         """Save the current project to disk."""
-        logger.debug("Starting DataContext._save_project_config")
-
         config_filepath = os.path.join(self.root_directory, self.GE_YML)
 
         try:

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -121,12 +121,12 @@ class CloudDataContext(AbstractDataContext):
         # if in ge_cloud_mode, use ge_cloud_organization_id
         return self.ge_cloud_config.organization_id
 
-    def _save_project_config(self) -> None:
-        """Save the current project to disk."""
-        logger.debug(
-            "ge_cloud_mode detected - skipping DataContext._save_project_config"
-        )
-        return None
+    # def _save_project_config(self) -> None:
+    #     """Save the current project to disk."""
+    #     logger.debug(
+    #         "ge_cloud_mode detected - skipping DataContext._save_project_config"
+    #     )
+    #     return None
 
     def get_config_with_variables_substituted(
         self, config: Optional[DataContextConfig] = None

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -121,13 +121,6 @@ class CloudDataContext(AbstractDataContext):
         # if in ge_cloud_mode, use ge_cloud_organization_id
         return self.ge_cloud_config.organization_id
 
-    # def _save_project_config(self) -> None:
-    #     """Save the current project to disk."""
-    #     logger.debug(
-    #         "ge_cloud_mode detected - skipping DataContext._save_project_config"
-    #     )
-    #     return None
-
     def get_config_with_variables_substituted(
         self, config: Optional[DataContextConfig] = None
     ) -> DataContextConfig:

--- a/great_expectations/data_context/data_context/ephemeral_data_context.py
+++ b/great_expectations/data_context/data_context/ephemeral_data_context.py
@@ -66,12 +66,12 @@ class EphemeralDataContext(AbstractDataContext):
         )
         self._datasource_store = datasource_store
 
-    def _save_project_config(self) -> None:
-        """Since EphemeralDataContext does not have config as a file, display logging message instead"""
-        logger.debug(
-            "EphemeralDataContext has been detected - skipping DataContext._save_project_config"
-        )
-        return None
+    # def _save_project_config(self) -> None:
+    #     """Since EphemeralDataContext does not have config as a file, display logging message instead"""
+    #     logger.debug(
+    #         "EphemeralDataContext has been detected - skipping DataContext._save_project_config"
+    #     )
+    #     return None
 
     def save_expectation_suite(
         self,

--- a/great_expectations/data_context/data_context/ephemeral_data_context.py
+++ b/great_expectations/data_context/data_context/ephemeral_data_context.py
@@ -66,13 +66,6 @@ class EphemeralDataContext(AbstractDataContext):
         )
         self._datasource_store = datasource_store
 
-    # def _save_project_config(self) -> None:
-    #     """Since EphemeralDataContext does not have config as a file, display logging message instead"""
-    #     logger.debug(
-    #         "EphemeralDataContext has been detected - skipping DataContext._save_project_config"
-    #     )
-    #     return None
-
     def save_expectation_suite(
         self,
         expectation_suite: ExpectationSuite,

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -130,14 +130,3 @@ class FileDataContext(AbstractDataContext):
             data_context=self,
         )
         return variables
-
-    def _save_project_config(self) -> None:
-        """Save the current project to disk."""
-        logger.debug("Starting DataContext._save_project_config")
-        self._save_project_config_to_disk()
-
-    def _save_project_config_to_disk(self) -> None:
-        """Helper method to make save_project_config more explicit"""
-        config_filepath = os.path.join(self.root_directory, self.GE_YML)
-        with open(config_filepath, "w") as outfile:
-            self.config.to_yaml(outfile)

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, List, Optional, Tuple
 
 from great_expectations.core.data_context_key import DataContextVariableKey
@@ -183,8 +184,14 @@ class InlineStoreBackend(StoreBackend):
         return resource_type in self._data_context.config
 
     def _save_changes(self) -> None:
-        # NOTE: <DataContextRefactor> This responsibility will be moved into DataContext Variables object
-        self._data_context._save_project_config()
+        context = self._data_context
+        config_filepath = os.path.join(context.root_directory, context.GE_YML)
+
+        try:
+            with open(config_filepath, "w") as outfile:
+                context.config.to_yaml(outfile)
+        except PermissionError as e:
+            logger.warning(f"Could not save project config to disk: {e}")
 
     @staticmethod
     def _determine_resource_name(key: Tuple[str, ...]) -> Optional[str]:

--- a/great_expectations/data_context/store/inline_store_backend.py
+++ b/great_expectations/data_context/store/inline_store_backend.py
@@ -1,5 +1,5 @@
 import logging
-import os
+import pathlib
 from typing import Any, List, Optional, Tuple
 
 from great_expectations.core.data_context_key import DataContextVariableKey
@@ -185,11 +185,13 @@ class InlineStoreBackend(StoreBackend):
 
     def _save_changes(self) -> None:
         context = self._data_context
-        config_filepath = os.path.join(context.root_directory, context.GE_YML)
+        config_filepath = pathlib.Path(context.root_directory) / context.GE_YML
 
         try:
             with open(config_filepath, "w") as outfile:
                 context.config.to_yaml(outfile)
+        # In environments where wrting to disk is not allowed, it is impossible to
+        # save changes. As such, we log a warning but do not raise.
         except PermissionError as e:
             logger.warning(f"Could not save project config to disk: {e}")
 

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1614,7 +1614,7 @@ def test_InlineStoreBackend(empty_data_context: DataContext) -> None:
     key = DataContextVariableKey()
     tuple_ = key.to_tuple()
     with patch(
-        "great_expectations.data_context.DataContext._save_project_config"
+        "great_expectations.data_context.store.InlineStoreBackend._save_changes"
     ) as mock_save:
         inline_store_backend.set(tuple_, new_config_version)
 

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -419,7 +419,7 @@ def test_data_context_variables_save_config(
 
     # FileDataContextVariables
     with mock.patch(
-        "great_expectations.data_context.DataContext._save_project_config",
+        "great_expectations.data_context.store.InlineStoreBackend._save_changes",
         autospec=True,
     ) as mock_save:
         file_data_context_variables.save_config()


### PR DESCRIPTION
Changes proposed in this pull request:
- Instead of defining a `_save_project_config` method on each context, we can just leverage the given instance of `DataContextVariables` (which already knows how to persist values based on environment).
- `BaseDataContext` is an edge case as this method always writes to disk (even if working in a Cloud-backend env).


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
