### PR TITLE
[MAINTENANCE] Remove deprecation warning from `DataConnector`-level `batch_identifiers` for `RuntimeDataConnector`

### DIFF
--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -129,11 +129,6 @@ class RuntimeDataConnector(DataConnector):
                     f"""RuntimeDataConnector "{self.name}" requires batch_identifiers to be configured, either at the DataConnector or Asset-level."""
                 )
             if batch_identifiers:
-                # deprecated-v0.15.1
-                warnings.warn(
-                    "Specifying batch_identifiers as part of the RuntimeDataConnector config is deprecated as of v0.15.1 and will be removed by v0.18. Please configure batch_identifiers as part of Assets instead.",
-                    DeprecationWarning,
-                )
                 self._batch_identifiers[self.name] = batch_identifiers
 
     def _refresh_data_references_cache(self) -> None:


### PR DESCRIPTION
Changes proposed in this pull request:
- Follow up to #4866 and #4861
- Design Doc that resulted in this PR can be found : https://superconductive.atlassian.net/wiki/spaces/SUP/pages/436502556/RuntimeDataConnectors+-+Intended+Future+State

### What does this PR enable? 
* All the code paths defined below are possible without `DeprecationWarning`. 

* Given the following Datasource
```yaml 
class_name: Datasource
    execution_engine:
        class_name: SparkDFExecutionEngine
    data_connectors:
        my_runtime_data_connector:
            class_name: RuntimeDataConnector
            batch_identifiers
              - id_a
              - id_b
            assets:
                asset_a:
                    batch_identifiers:
                        - id_c
                        - id_d

```

* We could either use a `RuntimeBatchRequest` that specifies `asset_a`, defined under `assets:` and using `asset`-level `batch_identifiers`, which are `id_c` and `id_d` in our case. 

```python

    batch_request = RuntimeBatchRequest(
        **{
            "datasource_name": "my_datasource",
            "data_connector_name": "my_runtime_data_connector",
            "data_asset_name": "asset_a",
            "batch_identifiers": {"id_c": 1, "id_d": 2},
            "runtime_parameters": {"batch_data": test_df},
        }
    )
    my_runtime_data_connector.get_batch_definition_list_from_batch_request(
        batch_request=batch_request
    )

```

* Or define `asset_b` by using the `DataConnector`-level `batch_identifiers`, which are `id_a` and `id_b` 
```python
  batch_request = RuntimeBatchRequest(
        **{
            "datasource_name": "my_datasource",
            "data_connector_name": "my_runtime_data_connector",
            "data_asset_name": "asset_b",
            "batch_identifiers": {"id_a": 3, "id_b": 4},
            "runtime_parameters": {"batch_data": test_df},
        }
    )
    my_runtime_data_connector.get_batch_definition_list_from_batch_request(
        batch_request=batch_request
    )
```

* As a third option we could also define additional assets at at the configuration-level, as in `asset_c` below. 

```yaml
class_name: Datasource
    execution_engine:
        class_name: SparkDFExecutionEngine
    data_connectors:
        my_runtime_data_connector:
            class_name: RuntimeDataConnector
            batch_identifiers
              - id_a
              - id_b
            assets:
                asset_a:
                    batch_identifiers:
                        - id_c
                        - id_d
                asset_c:
                    batch_identifiers:
                        - id_e
                        - id_f

```

* And then we could do 

```python 
  batch_request = RuntimeBatchRequest(
        **{
            "datasource_name": "my_datasource",
            "data_connector_name": "my_runtime_data_connector",
            "data_asset_name": "asset_c",
            "batch_identifiers": {"id_e": 5, "id_f": 6},
            "runtime_parameters": {"batch_data": test_df},
        }
    )
    my_runtime_data_connector.get_batch_definition_list_from_batch_request(
        batch_request=batch_request
    )

```

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
