### PR TITLE
[MAINTENANCE] Adds additional file extensions for Parquet assets

### DIFF
--- a/great_expectations/datasource/batch_kwargs_generator/s3_subdir_reader_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/s3_subdir_reader_batch_kwargs_generator.py
@@ -21,6 +21,8 @@ KNOWN_EXTENSIONS = [
     ".csv",
     ".tsv",
     ".parquet",
+    ".pqt",
+    ".parq",
     ".xls",
     ".xlsx",
     ".json",

--- a/great_expectations/datasource/batch_kwargs_generator/subdir_reader_batch_kwargs_generator.py
+++ b/great_expectations/datasource/batch_kwargs_generator/subdir_reader_batch_kwargs_generator.py
@@ -14,6 +14,8 @@ KNOWN_EXTENSIONS = [
     ".csv",
     ".tsv",
     ".parquet",
+    ".parq",
+    ".pqt",
     ".xls",
     ".xlsx",
     ".json",

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -270,7 +270,7 @@ class PandasDatasource(LegacyDatasource):
     def guess_reader_method_from_path(path):
         if path.endswith(".csv") or path.endswith(".tsv"):
             return {"reader_method": "read_csv"}
-        elif path.endswith(".parquet"):
+        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
             return {"reader_method": "read_parquet"}
         elif path.endswith(".xlsx") or path.endswith(".xls"):
             return {"reader_method": "read_excel"}

--- a/great_expectations/datasource/pandas_datasource.py
+++ b/great_expectations/datasource/pandas_datasource.py
@@ -270,7 +270,9 @@ class PandasDatasource(LegacyDatasource):
     def guess_reader_method_from_path(path):
         if path.endswith(".csv") or path.endswith(".tsv"):
             return {"reader_method": "read_csv"}
-        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
+        elif (
+            path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt")
+        ):
             return {"reader_method": "read_parquet"}
         elif path.endswith(".xlsx") or path.endswith(".xls"):
             return {"reader_method": "read_excel"}

--- a/great_expectations/datasource/sparkdf_datasource.py
+++ b/great_expectations/datasource/sparkdf_datasource.py
@@ -251,7 +251,9 @@ class SparkDFDatasource(LegacyDatasource):
     def guess_reader_method_from_path(path):
         if path.endswith(".csv") or path.endswith(".tsv"):
             return {"reader_method": "csv"}
-        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
+        elif (
+            path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt")
+        ):
             return {"reader_method": "parquet"}
 
         raise BatchKwargsError(

--- a/great_expectations/datasource/sparkdf_datasource.py
+++ b/great_expectations/datasource/sparkdf_datasource.py
@@ -251,7 +251,7 @@ class SparkDFDatasource(LegacyDatasource):
     def guess_reader_method_from_path(path):
         if path.endswith(".csv") or path.endswith(".tsv"):
             return {"reader_method": "csv"}
-        elif path.endswith(".parquet"):
+        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
             return {"reader_method": "parquet"}
 
         raise BatchKwargsError(

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -377,7 +377,7 @@ Please check your config."""
         """
         if path.endswith(".csv") or path.endswith(".tsv"):
             return {"reader_method": "read_csv"}
-        elif path.endswith(".parquet"):
+        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
             return {"reader_method": "read_parquet"}
         elif path.endswith(".xlsx") or path.endswith(".xls"):
             return {"reader_method": "read_excel"}

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -377,7 +377,9 @@ Please check your config."""
         """
         if path.endswith(".csv") or path.endswith(".tsv"):
             return {"reader_method": "read_csv"}
-        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
+        elif (
+            path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt")
+        ):
             return {"reader_method": "read_parquet"}
         elif path.endswith(".xlsx") or path.endswith(".xls"):
             return {"reader_method": "read_excel"}

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -351,7 +351,7 @@ Please check your config."""
         """
         if path.endswith(".csv") or path.endswith(".tsv"):
             return "csv"
-        elif path.endswith(".parquet"):
+        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
             return "parquet"
 
         raise ExecutionEngineError(

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -351,7 +351,9 @@ Please check your config."""
         """
         if path.endswith(".csv") or path.endswith(".tsv"):
             return "csv"
-        elif path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt"):
+        elif (
+            path.endswith(".parquet") or path.endswith(".parq") or path.endswith(".pqt")
+        ):
             return "parquet"
 
         raise ExecutionEngineError(


### PR DESCRIPTION
S3 stipulates that Parquet files can have `.parquet`, `.prq` or `.parq` file extensions. We have customers unable to load their data assets because we only support `.parquet` extensions. This PR remedies that. 

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
