### PR TITLE
[MAINTENANCE] Store Refactor - cloud store return types & http-errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+src/dgtest/
 
 # Translations
 *.mo

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -87,6 +87,8 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     DEFAULT_BASE_URL: str = "https://app.greatexpectations.io/"
 
+    TIMEOUT: int = 20
+
     def __init__(
         self,
         ge_cloud_credentials: Dict,
@@ -171,7 +173,10 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 ge_cloud_url = ge_cloud_url.rstrip("/")
 
             response = requests.get(
-                ge_cloud_url, headers=self.auth_headers, params=params
+                ge_cloud_url,
+                headers=self.auth_headers,
+                params=params,
+                timeout=self.TIMEOUT,
             )
             return response.json()
         except JSONDecodeError as jsonError:
@@ -214,7 +219,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             url = urljoin(f"{url}/", ge_cloud_id)
 
         try:
-            response = requests.put(url, json=data, headers=self.auth_headers)
+            response = requests.put(
+                url, json=data, headers=self.auth_headers, timeout=self.TIMEOUT
+            )
             response_status_code = response.status_code
 
             # 2022-07-28 - Chetan - GX Cloud does not currently support PUT requests
@@ -224,7 +231,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 response_status_code == 405
                 and resource_type is GeCloudRESTResource.EXPECTATION_SUITE
             ):
-                response = requests.patch(url, json=data, headers=self.auth_headers)
+                response = requests.patch(
+                    url, json=data, headers=self.auth_headers, timeout=self.TIMEOUT
+                )
                 response_status_code = response.status_code
 
             if response_status_code < 300:
@@ -294,7 +303,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             f"organizations/" f"{organization_id}/" f"{hyphen(resource_name)}",
         )
         try:
-            response = requests.post(url, json=data, headers=self.auth_headers)
+            response = requests.post(
+                url, json=data, headers=self.auth_headers, timeout=self.TIMEOUT
+            )
             response_json = response.json()
 
             object_id = response_json["data"]["id"]
@@ -335,7 +346,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             f"{hyphen(self.ge_cloud_resource_name)}",
         )
         try:
-            response = requests.get(url, headers=self.auth_headers)
+            response = requests.get(
+                url, headers=self.auth_headers, timeout=self.TIMEOUT
+            )
             response_json = response.json()
             keys = [
                 (
@@ -385,7 +398,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             f"{ge_cloud_id}",
         )
         try:
-            response = requests.delete(url, json=data, headers=self.auth_headers)
+            response = requests.delete(
+                url, json=data, headers=self.auth_headers, timeout=self.TIMEOUT
+            )
             response_status_code = response.status_code
 
             if response_status_code < 300:

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -29,8 +29,6 @@ class PayloadDataField(TypedDict):
 
 class ResponsePayload(TypedDict):
     data: PayloadDataField
-    jsonapi: dict
-    links: dict
 
 
 class GeCloudRESTResource(str, Enum):

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -214,7 +214,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     def _move(self) -> None:  # type: ignore[override]
         pass
 
-    def _update(self, ge_cloud_id: str, value: Any, **kwargs: dict) -> bool:
+    def _update(self, key: str, value: Any) -> bool:
         resource_type = self.ge_cloud_resource_type
         organization_id = self.ge_cloud_credentials["organization_id"]
         attributes_key = self.PAYLOAD_ATTRIBUTES_KEYS[resource_type]
@@ -236,9 +236,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             f"{hyphen(self.ge_cloud_resource_name)}",
         )
 
-        if ge_cloud_id:
-            data["data"]["id"] = ge_cloud_id
-            url = urljoin(f"{url}/", ge_cloud_id)
+        if key:
+            data["data"]["id"] = key
+            url = urljoin(f"{url}/", key)
 
         try:
             response = requests.put(
@@ -301,7 +301,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ge_cloud_id
             or ge_cloud_resource is GeCloudRESTResource.DATA_CONTEXT_VARIABLES
         ):
-            return self._update(ge_cloud_id=ge_cloud_id, value=value, **kwargs)
+            return self._update(key=ge_cloud_id, value=value, **kwargs)
 
         resource_type = self.ge_cloud_resource_type
         resource_name = self.ge_cloud_resource_name

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -65,8 +65,8 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         },
     }
 
-    RESOURCE_PLURALITY_LOOKUP_DICT: bidict = bidict(
-        **{
+    RESOURCE_PLURALITY_LOOKUP_DICT: bidict = bidict(  # type: ignore[misc]
+        **{  # type: ignore[arg-type]
             GeCloudRESTResource.BATCH: "batches",
             GeCloudRESTResource.CHECKPOINT: "checkpoints",
             # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
@@ -161,7 +161,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             "Authorization": f'Bearer {self.ge_cloud_credentials.get("access_token")}',
         }
 
-    def _get(self, key: Tuple[str, ...]) -> dict:
+    def _get(self, key: Tuple[str, ...]) -> dict:  # type: ignore[override]
         ge_cloud_url = self.get_url_for_key(key=key)
         params: Optional[dict] = None
         try:
@@ -184,7 +184,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 f"Unable to get object in GE Cloud Store Backend: {jsonError}"
             )
 
-    def _move(self) -> None:
+    def _move(self) -> None:  # type: ignore[override]
         pass
 
     def _update(self, ge_cloud_id: str, value: Any, **kwargs: dict) -> bool:
@@ -242,7 +242,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             self.ge_cloud_resource_type, set()
         )
 
-    def validate_set_kwargs(self, kwargs: dict) -> Optional[bool]:
+    def validate_set_kwargs(self, kwargs: dict) -> Union[bool, None]:
         kwarg_names = set(kwargs.keys())
         if len(kwarg_names) == 0:
             return True
@@ -251,12 +251,16 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         if not (kwarg_names <= self.allowed_set_kwargs):
             extra_kwargs = kwarg_names - self.allowed_set_kwargs
             raise ValueError(f'Invalid kwargs: {(", ").join(extra_kwargs)}')
+        return None
 
-    def _set(
-        self, key: Tuple[str, ...], value: Any, **kwargs: dict
+    def _set(  # type: ignore[override]
+        self,
+        key: Tuple[GeCloudRESTResource, ...],
+        value: Any,
+        **kwargs: dict,
     ) -> Union[bool, GeCloudResourceRef]:
         # Each resource type has corresponding attribute key to include in POST body
-        ge_cloud_resource: GeCloudRESTResource = key[0]
+        ge_cloud_resource = key[0]
         ge_cloud_id: str = key[1]
 
         # if key has ge_cloud_id, perform _update instead
@@ -317,13 +321,13 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     @property
     def ge_cloud_resource_type(self) -> GeCloudRESTResource:
-        return self._ge_cloud_resource_type
+        return self._ge_cloud_resource_type  # type: ignore[return-value]
 
     @property
     def ge_cloud_credentials(self) -> dict:
         return self._ge_cloud_credentials
 
-    def list_keys(self, prefix: Tuple = ()) -> List[Tuple[str, Any]]:
+    def list_keys(self, prefix: Tuple = ()) -> List[Tuple[GeCloudRESTResource, Any]]:  # type: ignore[override]
         url = urljoin(
             self.ge_cloud_base_url,
             f"organizations/"
@@ -347,7 +351,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 f"Unable to list keys in GE Cloud Store Backend: {e}"
             )
 
-    def get_url_for_key(
+    def get_url_for_key(  # type: ignore[override]
         self, key: Tuple[str, ...], protocol: Optional[Any] = None
     ) -> str:
         ge_cloud_id = key[1]
@@ -393,7 +397,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 f"Unable to delete object in GE Cloud Store Backend: {e}"
             )
 
-    def _has_key(self, key: Tuple[str, ...]) -> bool:
+    def _has_key(self, key: Tuple[str, ...]) -> bool:  # type: ignore[override]
         # self.list_keys() generates a list of length 2 tuples
         if len(key) == 3:
             key = key[:2]

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -15,7 +15,7 @@ from great_expectations.util import bidict, filter_properties_dict, hyphen
 
 try:
     from typing import TypedDict  # type: ignore[attr-defined]
-except ModuleNotFoundError:
+except ImportError:
     from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -293,7 +293,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         key: Tuple[GeCloudRESTResource, ...],
         value: Any,
         **kwargs: dict,
-    ) -> Union[bool, GeCloudResourceRef]:
+    ) -> Union[ResponsePayload, GeCloudResourceRef]:
         # Each resource type has corresponding attribute key to include in POST body
         ge_cloud_resource = key[0]
         ge_cloud_id: str = key[1]
@@ -305,7 +305,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ge_cloud_id
             or ge_cloud_resource is GeCloudRESTResource.DATA_CONTEXT_VARIABLES
         ):
-            return self._update(key=ge_cloud_id, value=value, **kwargs)
+            return self._update(key=ge_cloud_id, value=value)
 
         resource_type = self.ge_cloud_resource_type
         resource_name = self.ge_cloud_resource_name

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -294,7 +294,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         key: Tuple[GeCloudRESTResource, ...],
         value: Any,
         **kwargs: dict,
-    ) -> Union[ResponsePayload, GeCloudResourceRef]:
+    ) -> Union[bool, GeCloudResourceRef]:
         # Each resource type has corresponding attribute key to include in POST body
         ge_cloud_resource = key[0]
         ge_cloud_id: str = key[1]

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -13,7 +13,24 @@ from great_expectations.data_context.types.resource_identifiers import GeCloudId
 from great_expectations.exceptions import StoreBackendError
 from great_expectations.util import bidict, filter_properties_dict, hyphen
 
+try:
+    from typing import TypedDict  # type: ignore[attr-defined]
+except ModuleNotFoundError:
+    from typing_extensions import TypedDict
+
 logger = logging.getLogger(__name__)
+
+
+class PayloadDataField(TypedDict):
+    attributes: dict
+    id: str
+    type: str
+
+
+class ResponsePayload(TypedDict):
+    data: PayloadDataField
+    jsonapi: dict
+    links: dict
 
 
 class GeCloudRESTResource(str, Enum):

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -214,7 +214,8 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     def _move(self) -> None:  # type: ignore[override]
         pass
 
-    def _update(self, key: str, value: Any) -> ResponsePayload:
+    # TODO: GG 20220810 return the `ResponsePayload`
+    def _update(self, ge_cloud_id: str, value: Any) -> bool:
         resource_type = self.ge_cloud_resource_type
         organization_id = self.ge_cloud_credentials["organization_id"]
         attributes_key = self.PAYLOAD_ATTRIBUTES_KEYS[resource_type]
@@ -236,9 +237,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             f"{hyphen(self.ge_cloud_resource_name)}",
         )
 
-        if key:
-            data["data"]["id"] = key
-            url = urljoin(f"{url}/", key)
+        if ge_cloud_id:
+            data["data"]["id"] = ge_cloud_id
+            url = urljoin(f"{url}/", ge_cloud_id)
 
         try:
             response = requests.put(
@@ -259,7 +260,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 response_status_code = response.status_code
 
             response.raise_for_status()
-            return self.get(key=key)
+            return True
 
         except (requests.HTTPError, requests.Timeout) as http_exc:
             raise StoreBackendError(
@@ -305,7 +306,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             ge_cloud_id
             or ge_cloud_resource is GeCloudRESTResource.DATA_CONTEXT_VARIABLES
         ):
-            return self._update(key=ge_cloud_id, value=value)
+            return self._update(ge_cloud_id=ge_cloud_id, value=value)
 
         resource_type = self.ge_cloud_resource_type
         resource_name = self.ge_cloud_resource_name

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -82,7 +82,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         },
     }
 
-    RESOURCE_PLURALITY_LOOKUP_DICT: bidict = bidict(  # type: ignore[misc]
+    RESOURCE_PLURALITY_LOOKUP_DICT: bidict = bidict(  # type: ignore[misc] # Keywords must be str
         **{  # type: ignore[arg-type]
             GeCloudRESTResource.BATCH: "batches",
             GeCloudRESTResource.CHECKPOINT: "checkpoints",

--- a/tasks.py
+++ b/tasks.py
@@ -128,7 +128,7 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
     "data_asset",  # 0
     # "data_context",  # 242
     # "data_context/data_context",  # 195
-    # "data_context/store", # 83
+    # "data_context/store", # 70
     "data_context/store/ge_cloud_store_backend.py",  # 0
     "data_context/types",  # 0
     # "datasource",  # 98

--- a/tasks.py
+++ b/tasks.py
@@ -129,6 +129,7 @@ DEFAULT_PACKAGES_TO_TYPE_CHECK = [
     # "data_context",  # 242
     # "data_context/data_context",  # 195
     # "data_context/store", # 83
+    "data_context/store/ge_cloud_store_backend.py",  # 0
     "data_context/types",  # 0
     # "datasource",  # 98
     "exceptions",  # 0

--- a/tests/data_context/cloud_data_context/conftest.py
+++ b/tests/data_context/cloud_data_context/conftest.py
@@ -12,7 +12,8 @@ class MockResponse:
         exc_to_raise: Union[HTTPError, Timeout, None] = None,
     ) -> None:
         self._json_data = json_data
-        self._status_code = status_code
+        # status code should be publicly accesable
+        self.status_code = status_code
         self._exc_to_raise = exc_to_raise
 
     def json(self):
@@ -21,7 +22,7 @@ class MockResponse:
     def raise_for_status(self):
         if self._exc_to_raise:
             raise self._exc_to_raise
-        if self._status_code >= 400:
+        if self.status_code >= 400:
             raise HTTPError(response=self)
         return None
 

--- a/tests/data_context/cloud_data_context/conftest.py
+++ b/tests/data_context/cloud_data_context/conftest.py
@@ -1,7 +1,9 @@
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 
 import pytest
 from requests.exceptions import HTTPError, Timeout
+
+RequestError = Union[HTTPError, Timeout]
 
 
 class MockResponse:
@@ -9,7 +11,7 @@ class MockResponse:
         self,
         json_data: dict,
         status_code: int,
-        exc_to_raise: Union[HTTPError, Timeout, None] = None,
+        exc_to_raise: Optional[RequestError] = None,
     ) -> None:
         self._json_data = json_data
         # status code should be publicly accesable
@@ -28,8 +30,16 @@ class MockResponse:
 
 
 @pytest.fixture
-def mock_response_factory() -> Callable[[dict, int], MockResponse]:
-    def _make_mock_response(json_data: dict, status_code: int) -> MockResponse:
-        return MockResponse(json_data=json_data, status_code=status_code)
+def mock_response_factory() -> Callable[
+    [dict, int, Optional[RequestError]], MockResponse
+]:
+    def _make_mock_response(
+        json_data: dict,
+        status_code: int,
+        exc_to_raise: Optional[RequestError] = None,
+    ) -> MockResponse:
+        return MockResponse(
+            json_data=json_data, status_code=status_code, exc_to_raise=exc_to_raise
+        )
 
     return _make_mock_response

--- a/tests/data_context/cloud_data_context/conftest.py
+++ b/tests/data_context/cloud_data_context/conftest.py
@@ -1,7 +1,7 @@
-from typing import Callable, Optional
+from typing import Callable, Union
 
 import pytest
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, Timeout
 
 
 class MockResponse:
@@ -9,11 +9,11 @@ class MockResponse:
         self,
         json_data: dict,
         status_code: int,
-        _exc_to_raise: Optional[HTTPError] = None,
+        exc_to_raise: Union[HTTPError, Timeout, None] = None,
     ) -> None:
         self._json_data = json_data
         self._status_code = status_code
-        self._exc_to_raise: Optional[HTTPError] = _exc_to_raise
+        self._exc_to_raise = exc_to_raise
 
     def json(self):
         return self._json_data
@@ -21,6 +21,8 @@ class MockResponse:
     def raise_for_status(self):
         if self._exc_to_raise:
             raise self._exc_to_raise
+        if self._status_code >= 400:
+            raise HTTPError(response=self)
         return None
 
 

--- a/tests/data_context/cloud_data_context/conftest.py
+++ b/tests/data_context/cloud_data_context/conftest.py
@@ -1,15 +1,27 @@
-from typing import Callable
+from typing import Callable, Optional
 
 import pytest
+from requests.exceptions import HTTPError
 
 
 class MockResponse:
-    def __init__(self, json_data: dict, status_code: int) -> None:
+    def __init__(
+        self,
+        json_data: dict,
+        status_code: int,
+        _exc_to_raise: Optional[HTTPError] = None,
+    ) -> None:
         self._json_data = json_data
         self._status_code = status_code
+        self._exc_to_raise: Optional[HTTPError] = _exc_to_raise
 
     def json(self):
         return self._json_data
+
+    def raise_for_status(self):
+        if self._exc_to_raise:
+            raise self._exc_to_raise
+        return None
 
 
 @pytest.fixture

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -158,7 +158,7 @@ def test_cloud_backed_data_context_add_checkpoint(
     checkpoint_config: dict,
     mocked_post_response: Callable[[], MockResponse],
     mocked_get_response: Callable[[], MockResponse],
-    request_headers: Dict[str, str],
+    shared_called_with_request_kwargs: dict,
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
     request,
@@ -198,13 +198,13 @@ def test_cloud_backed_data_context_add_checkpoint(
                     },
                 },
             },
-            headers=request_headers,
+            **shared_called_with_request_kwargs,
         )
 
         mock_get.assert_called_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/checkpoints/{checkpoint_id}",
             params={"name": checkpoint_config["name"]},
-            headers=request_headers,
+            **shared_called_with_request_kwargs,
         )
 
     assert checkpoint.ge_cloud_id == checkpoint_id

--- a/tests/data_context/cloud_data_context/test_datasource_crud.py
+++ b/tests/data_context/cloud_data_context/test_datasource_crud.py
@@ -43,7 +43,7 @@ def test_base_data_context_in_cloud_mode_add_datasource(
     datasource_name: str,
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request_headers: dict,
+    shared_called_with_request_kwargs: dict,
     mock_response_factory: Callable,
 ):
     """A BaseDataContext in cloud mode should save to the cloud backed Datasource store when calling add_datasource
@@ -114,7 +114,7 @@ def test_base_data_context_in_cloud_mode_add_datasource(
                         },
                     }
                 },
-                headers=request_headers,
+                **shared_called_with_request_kwargs,
             )
         else:
             assert not mock_post.called
@@ -155,7 +155,7 @@ def test_data_context_in_cloud_mode_add_datasource(
     datasource_name: str,
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request_headers: dict,
+    shared_called_with_request_kwargs: dict,
     mock_response_factory: Callable,
 ):
     """A DataContext in cloud mode should save to the cloud backed Datasource store when calling add_datasource. When saving, it should use the id from the response
@@ -221,7 +221,7 @@ def test_data_context_in_cloud_mode_add_datasource(
                     },
                 }
             },
-            headers=request_headers,
+            **shared_called_with_request_kwargs,
         )
 
         # Make sure the id was populated correctly into the created datasource object and config
@@ -255,7 +255,7 @@ def test_cloud_data_context_add_datasource(
     datasource_name: str,
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request_headers: dict,
+    shared_called_with_request_kwargs: dict,
     mock_response_factory: Callable,
 ):
     """A CloudDataContext should save to the cloud backed Datasource store when calling add_datasource. When saving, it should use the id from the response
@@ -324,7 +324,7 @@ def test_cloud_data_context_add_datasource(
                     },
                 }
             },
-            headers=request_headers,
+            **shared_called_with_request_kwargs,
         )
 
         # Make sure the id was populated correctly into the created datasource object and config

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -642,27 +642,9 @@ def bearer_test_token() -> str:
 
 
 @pytest.fixture
-def shared_called_with_request_kwargs(bearer_test_token) -> dict:
+def shared_called_with_request_kwargs(request_headers) -> dict:
     """
     Standard request kwargs that all GeCloudStoreBackend http calls are made with.
     Use in combination with `assert_called_with()`
     """
-    return dict(
-        timeout=GeCloudStoreBackend.TIMEOUT,
-        headers={
-            "Content-Type": "application/vnd.api+json",
-            "Authorization": f"Bearer {bearer_test_token}",
-        },
-    )
-
-
-# @pytest.fixture
-# def gx_cloud_mock() -> responses.RequestsMock:
-#     with responses.RequestsMock() as mock_rsps:
-#         yield mock_rsps
-
-
-@pytest.fixture
-def gx_cloud_mock():
-    with requests_mock.Mocker() as mock_rsps:
-        yield mock_rsps
+    return dict(timeout=GeCloudStoreBackend.TIMEOUT, headers=request_headers)

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -637,11 +637,6 @@ def datasource_config() -> DatasourceConfig:
 
 
 @pytest.fixture
-def bearer_test_token() -> str:
-    return "6bb5b6f5c7794892a4ca168c65c2603e"
-
-
-@pytest.fixture
 def shared_called_with_request_kwargs(request_headers) -> dict:
     """
     Standard request kwargs that all GeCloudStoreBackend http calls are made with.

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -6,11 +6,11 @@ from unittest.mock import PropertyMock, patch
 import pytest
 
 import great_expectations as ge
+from great_expectations.data_context.store import GeCloudStoreBackend
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     DatasourceConfig,
 )
-from great_expectations.data_context.store import GeCloudStoreBackend
 from great_expectations.data_context.util import file_relative_path
 from tests.integration.usage_statistics.test_integration_usage_statistics import (
     USAGE_STATISTICS_QA_URL,
@@ -637,7 +637,12 @@ def datasource_config() -> DatasourceConfig:
 
 
 @pytest.fixture
-def shared_called_with_request_kwargs() -> dict:
+def bearer_test_token() -> str:
+    return "6bb5b6f5c7794892a4ca168c65c2603e"
+
+
+@pytest.fixture
+def shared_called_with_request_kwargs(bearer_test_token) -> dict:
     """
     Standard request kwargs that all GeCloudStoreBackend http calls are made with.
     Use in combination with `assert_called_with()`
@@ -646,7 +651,7 @@ def shared_called_with_request_kwargs() -> dict:
         timeout=GeCloudStoreBackend.TIMEOUT,
         headers={
             "Content-Type": "application/vnd.api+json",
-            "Authorization": "Bearer 1234",
+            "Authorization": f"Bearer {bearer_test_token}",
         },
     )
 

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -10,6 +10,7 @@ from great_expectations.data_context.types.base import (
     DataContextConfig,
     DatasourceConfig,
 )
+from great_expectations.data_context.store import GeCloudStoreBackend
 from great_expectations.data_context.util import file_relative_path
 from tests.integration.usage_statistics.test_integration_usage_statistics import (
     USAGE_STATISTICS_QA_URL,
@@ -633,3 +634,30 @@ def datasource_config() -> DatasourceConfig:
             }
         },
     )
+
+
+@pytest.fixture
+def shared_called_with_request_kwargs() -> dict:
+    """
+    Standard request kwargs that all GeCloudStoreBackend http calls are made with.
+    Use in combination with `assert_called_with()`
+    """
+    return dict(
+        timeout=GeCloudStoreBackend.TIMEOUT,
+        headers={
+            "Content-Type": "application/vnd.api+json",
+            "Authorization": "Bearer 1234",
+        },
+    )
+
+
+# @pytest.fixture
+# def gx_cloud_mock() -> responses.RequestsMock:
+#     with responses.RequestsMock() as mock_rsps:
+#         yield mock_rsps
+
+
+@pytest.fixture
+def gx_cloud_mock():
+    with requests_mock.Mocker() as mock_rsps:
+        yield mock_rsps

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -74,6 +74,7 @@ def test_datasource_store_retrieval_cloud_mode(
     ge_cloud_base_url: str,
     ge_cloud_access_token: str,
     ge_cloud_organization_id: str,
+    shared_called_with_request_kwargs: dict,
 ) -> None:
     ge_cloud_store_backend_config: dict = {
         "class_name": "GeCloudStoreBackend",
@@ -114,10 +115,7 @@ def test_datasource_store_retrieval_cloud_mode(
                     },
                 }
             },
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 6bb5b6f5c7794892a4ca168c65c2603e",
-            },
+            **shared_called_with_request_kwargs,
         )
 
 

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -11,6 +11,7 @@ from great_expectations.data_context.types.base import (
     datasourceConfigSchema,
 )
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+
 from ..cloud_data_context.conftest import MockResponse
 
 

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -11,6 +11,7 @@ from great_expectations.data_context.types.base import (
     datasourceConfigSchema,
 )
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from ..cloud_data_context.conftest import MockResponse
 
 
 @pytest.mark.cloud
@@ -75,13 +76,6 @@ def test_datasource_store_get_by_id(
     )
 
     def mocked_response(*args, **kwargs):
-        class MockResponse:
-            def __init__(self, json_data: dict, status_code: int) -> None:
-                self._json_data = json_data
-                self._status_code = status_code
-
-            def json(self):
-                return self._json_data
 
         return MockResponse(
             {
@@ -122,13 +116,6 @@ def test_datasource_store_get_by_name(
     datasource_name: str = "example_datasource_config_name"
 
     def mocked_response(*args, **kwargs):
-        class MockResponse:
-            def __init__(self, json_data: dict, status_code: int) -> None:
-                self._json_data = json_data
-                self._status_code = status_code
-
-            def json(self):
-                return self._json_data
 
         return MockResponse(
             {

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -18,7 +18,7 @@ from great_expectations.data_context.types.resource_identifiers import GeCloudId
 def test_datasource_store_create(
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request_headers: dict,
+    shared_called_with_request_kwargs: dict,
     datasource_config: DatasourceConfig,
     datasource_store_ge_cloud_backend: DatasourceStore,
 ) -> None:
@@ -50,7 +50,7 @@ def test_datasource_store_create(
                     },
                 }
             },
-            headers=request_headers,
+            **shared_called_with_request_kwargs,
         )
 
 
@@ -59,7 +59,7 @@ def test_datasource_store_create(
 def test_datasource_store_get_by_id(
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request_headers: dict,
+    shared_called_with_request_kwargs: dict,
     datasource_config: DatasourceConfig,
     datasource_store_ge_cloud_backend: DatasourceStore,
 ) -> None:
@@ -99,8 +99,8 @@ def test_datasource_store_get_by_id(
 
         mock_get.assert_called_once_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources/{id_}",
-            headers=request_headers,
             params=None,
+            **shared_called_with_request_kwargs,
         )
 
 
@@ -109,7 +109,7 @@ def test_datasource_store_get_by_id(
 def test_datasource_store_get_by_name(
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request_headers: dict,
+    shared_called_with_request_kwargs: dict,
     datasource_config: DatasourceConfig,
     datasource_store_ge_cloud_backend: DatasourceStore,
 ) -> None:
@@ -154,8 +154,8 @@ def test_datasource_store_get_by_name(
 
         mock_get.assert_called_once_with(
             f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/datasources",
-            headers=request_headers,
             params={"name": datasource_name},
+            **shared_called_with_request_kwargs,
         )
 
 
@@ -164,7 +164,7 @@ def test_datasource_store_get_by_name(
 def test_datasource_store_delete_by_id(
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request_headers: dict,
+    shared_called_with_request_kwargs: dict,
     datasource_config: DatasourceConfig,
     datasource_store_ge_cloud_backend: DatasourceStore,
 ) -> None:
@@ -192,5 +192,5 @@ def test_datasource_store_delete_by_id(
                     "attributes": {"deleted": True},
                 }
             },
-            headers=request_headers,
+            **shared_called_with_request_kwargs,
         )

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1341,7 +1341,7 @@ def test_TupleS3StoreBackend_list_over_1000_keys():
 
 
 def test_GeCloudStoreBackend(
-    shared_called_with_request_kwargs: dict, bearer_test_token: str
+    shared_called_with_request_kwargs: dict, ge_cloud_access_token: str
 ):
     """
     What does this test test and why?
@@ -1351,7 +1351,7 @@ def test_GeCloudStoreBackend(
     """
     ge_cloud_base_url = "https://app.greatexpectations.io/"
     ge_cloud_credentials = {
-        "access_token": bearer_test_token,
+        "access_token": ge_cloud_access_token,
         "organization_id": "51379b8b-86d3-4fe7-84e9-e1a52f4a414c",
     }
     ge_cloud_resource_type = GeCloudRESTResource.CHECKPOINT

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1340,7 +1340,7 @@ def test_TupleS3StoreBackend_list_over_1000_keys():
     assert len(keys) == num_keys_to_add + 1
 
 
-def test_GeCloudStoreBackend():
+def test_GeCloudStoreBackend(shared_called_with_request_kwargs: dict):
     """
     What does this test test and why?
 
@@ -1365,13 +1365,6 @@ def test_GeCloudStoreBackend():
     )
 
     # test .set
-    default_called_with = dict(
-        timeout=GeCloudStoreBackend.TIMEOUT,
-        headers={
-            "Content-Type": "application/vnd.api+json",
-            "Authorization": "Bearer 1234",
-        },
-    )
     with patch("requests.post", autospec=True) as mock_post:
         my_store_backend = GeCloudStoreBackend(
             ge_cloud_base_url=ge_cloud_base_url,
@@ -1408,7 +1401,7 @@ def test_GeCloudStoreBackend():
                     },
                 }
             },
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
     # test .get
@@ -1428,7 +1421,7 @@ def test_GeCloudStoreBackend():
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints/0ccac18e-7631"
             "-4bdd-8a42-3c35cce574c6",
             params=None,
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
     # test .list_keys
@@ -1441,7 +1434,7 @@ def test_GeCloudStoreBackend():
         my_store_backend.list_keys()
         mock_get.assert_called_with(
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints",
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
     # test .remove_key
@@ -1471,7 +1464,7 @@ def test_GeCloudStoreBackend():
                     "attributes": {"deleted": True},
                 }
             },
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
     # test .set
@@ -1493,7 +1486,7 @@ def test_GeCloudStoreBackend():
                     },
                 }
             },
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
     # test .get
@@ -1513,7 +1506,7 @@ def test_GeCloudStoreBackend():
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs/1ccac18e-7631"
             "-4bdd-8a42-3c35cce574c6",
             params=None,
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
     # test .list_keys
@@ -1526,7 +1519,7 @@ def test_GeCloudStoreBackend():
         my_store_backend.list_keys()
         mock_get.assert_called_with(
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs",
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
     # test .remove_key
@@ -1556,7 +1549,7 @@ def test_GeCloudStoreBackend():
                     "attributes": {"deleted": True},
                 }
             },
-            **default_called_with,
+            **shared_called_with_request_kwargs,
         )
 
 

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1340,7 +1340,9 @@ def test_TupleS3StoreBackend_list_over_1000_keys():
     assert len(keys) == num_keys_to_add + 1
 
 
-def test_GeCloudStoreBackend(shared_called_with_request_kwargs: dict):
+def test_GeCloudStoreBackend(
+    shared_called_with_request_kwargs: dict, bearer_test_token: str
+):
     """
     What does this test test and why?
 
@@ -1349,7 +1351,7 @@ def test_GeCloudStoreBackend(shared_called_with_request_kwargs: dict):
     """
     ge_cloud_base_url = "https://app.greatexpectations.io/"
     ge_cloud_credentials = {
-        "access_token": "1234",
+        "access_token": bearer_test_token,
         "organization_id": "51379b8b-86d3-4fe7-84e9-e1a52f4a414c",
     }
     ge_cloud_resource_type = GeCloudRESTResource.CHECKPOINT

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1365,6 +1365,13 @@ def test_GeCloudStoreBackend():
     )
 
     # test .set
+    default_called_with = dict(
+        timeout=GeCloudStoreBackend.TIMEOUT,
+        headers={
+            "Content-Type": "application/vnd.api+json",
+            "Authorization": "Bearer 1234",
+        },
+    )
     with patch("requests.post", autospec=True) as mock_post:
         my_store_backend = GeCloudStoreBackend(
             ge_cloud_base_url=ge_cloud_base_url,
@@ -1401,10 +1408,7 @@ def test_GeCloudStoreBackend():
                     },
                 }
             },
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
+            **default_called_with,
         )
 
     # test .get
@@ -1423,11 +1427,8 @@ def test_GeCloudStoreBackend():
         mock_get.assert_called_with(
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints/0ccac18e-7631"
             "-4bdd-8a42-3c35cce574c6",
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
             params=None,
+            **default_called_with,
         )
 
     # test .list_keys
@@ -1440,10 +1441,7 @@ def test_GeCloudStoreBackend():
         my_store_backend.list_keys()
         mock_get.assert_called_with(
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints",
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
+            **default_called_with,
         )
 
     # test .remove_key
@@ -1473,10 +1471,7 @@ def test_GeCloudStoreBackend():
                     "attributes": {"deleted": True},
                 }
             },
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
+            **default_called_with,
         )
 
     # test .set
@@ -1498,10 +1493,7 @@ def test_GeCloudStoreBackend():
                     },
                 }
             },
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
+            **default_called_with,
         )
 
     # test .get
@@ -1520,11 +1512,8 @@ def test_GeCloudStoreBackend():
         mock_get.assert_called_with(
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs/1ccac18e-7631"
             "-4bdd-8a42-3c35cce574c6",
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
             params=None,
+            **default_called_with,
         )
 
     # test .list_keys
@@ -1537,10 +1526,7 @@ def test_GeCloudStoreBackend():
         my_store_backend.list_keys()
         mock_get.assert_called_with(
             "https://app.greatexpectations.io/organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/rendered-data-docs",
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
+            **default_called_with,
         )
 
     # test .remove_key
@@ -1570,10 +1556,7 @@ def test_GeCloudStoreBackend():
                     "attributes": {"deleted": True},
                 }
             },
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": "Bearer 1234",
-            },
+            **default_called_with,
         )
 
 

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -400,6 +400,7 @@ def test_data_context_variables_save_config(
     ephemeral_data_context_variables: EphemeralDataContextVariables,
     file_data_context_variables: FileDataContextVariables,
     cloud_data_context_variables: CloudDataContextVariables,
+    shared_called_with_request_kwargs: dict,
     # The below GE Cloud variables were used to instantiate the above CloudDataContextVariables
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
@@ -455,10 +456,7 @@ def test_data_context_variables_save_config(
                     },
                 }
             },
-            headers={
-                "Content-Type": "application/vnd.api+json",
-                "Authorization": f"Bearer {ge_cloud_access_token}",
-            },
+            **shared_called_with_request_kwargs,
         )
 
 


### PR DESCRIPTION
Split from https://github.com/great-expectations/great_expectations/pull/5664

Changes proposed in this pull request:
- `TypedDict` return for `GeCloudStoreBackend._get()` 
   - changing return types for the other CRUD methods would require additional changes outside of `ge_cloud_store_backend.py`, this is planned but being done elsewhere.
- [adding default `timeout` values to `request` calls to prevent hanging until the connection closes](https://stackoverflow.com/a/17782541/6304433)
- always throw `StoreBackendError` on HTTP errors
- type-checking for `data_context/store/ge_cloud_store_backend.py`
- add and update Cloud related fixtures
  - new `shared_called_with_request_kwargs` fixture
  - updated `MockResponse` to support `.raise_for_status()`
  - re-use `MockResponse` instead of redefining it

## TODO
- [x] - update mocks to account for `.raise_for_status_call()`


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~I have made corresponding changes to the documentation~
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
