### PR TITLE
[MAINTENANCE]  invoke docker --detach and more typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,20 @@ exclude = [
     # number is the current number of typing errors for the excluded pattern
     'checkpoint', # 75
     'cli', # 157
-    'core', # 201
+    'core/usage_statistics', # 1
+    'core/expectation_diagnostics', # 20
+    'core/__init__\.py', # 1
+    'core/id_dict\.py', # 1
+    'core/async_executor\.py', # 2
+    'core/batch\.py', # 29
+    'core/batch_spec\.py', # 2
+    'core/config_peer\.py', # 1
+    'core/evaluation_parameters\.py', # 6
+    'core/expectation_configuration\.py', # 21
+    'core/expectation_suite\.py', # 10
+    'core/expectation_validation_result\.py', # 9
+    'core/run_identifier\.py', # 1
+    'core/yaml_handler\.py', # 1
     'datasource', # 93
     'dataset',  # 19
     'data_context/data_context/abstract_data_context.py', # 84

--- a/scripts/check_type_hint_coverage.py
+++ b/scripts/check_type_hint_coverage.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 TYPE_HINT_ERROR_THRESHOLD: int = (
-    484  # This number is to be reduced as we annotate more functions!
+    483  # This number is to be reduced as we annotate more functions!
 )
 
 logger = logging.getLogger(__name__)

--- a/scripts/check_type_hint_coverage.py
+++ b/scripts/check_type_hint_coverage.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 TYPE_HINT_ERROR_THRESHOLD: int = (
-    440  # This number is to be reduced as we annotate more functions!
+    484  # This number is to be reduced as we annotate more functions!
 )
 
 logger = logging.getLogger(__name__)

--- a/tasks.py
+++ b/tasks.py
@@ -202,16 +202,28 @@ def mv_usage_stats_json(ctx):
     print(f"'{outfile}' copied to dbfs.")
 
 
+PYTHON_VERSION_DEFAULT: float = 3.8
+
+
 @invoke.task(
     help={
         "name": "Docker image name.",
         "tag": "Docker image tag.",
         "build": "If True build the image, otherwise run it. Defaults to False.",
         "detach": "Run container in background and print container ID. Defaults to False.",
+        "py": f"version of python to use. Default is {PYTHON_VERSION_DEFAULT}",
         "cmd": "Command for docker image. Default is bash.",
     }
 )
-def docker(ctx, name="gx38local", tag="latest", build=False, detach=False, cmd="bash"):
+def docker(
+    ctx,
+    name="gx38local",
+    tag="latest",
+    build=False,
+    detach=False,
+    cmd="bash",
+    py=PYTHON_VERSION_DEFAULT,
+):
     """
     Build or run gx docker image.
     """
@@ -235,7 +247,7 @@ def docker(ctx, name="gx38local", tag="latest", build=False, detach=False, cmd="
                 f"--tag {name}:{tag}",
                 *[
                     f"--build-arg {arg}"
-                    for arg in ["SOURCE=local", "PYTHON_VERSION=3.8"]
+                    for arg in ["SOURCE=local", f"PYTHON_VERSION={py}"]
                 ],
                 ".",
             ]


### PR DESCRIPTION
Changes proposed in this pull request:
- add `--detach` flag to `invoke docker` cmd, for running the docker container detached.
- separate `great_expectations/core` excludes to cover more of `core` and make gradual typing easier

https://docs.docker.com/engine/reference/run/#detached-vs-foreground