### PR TITLE
[BUGFIX] Resolve checkpoint_identifier to ID when sending results to cloud

### DIFF
--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -392,7 +392,9 @@ class ActionListValidationOperator(ValidationOperator):
 
                 validation_result = async_batch_validation_result.result()
                 validation_result.meta["validation_id"] = validation_id
-                validation_result.meta["checkpoint_id"] = checkpoint_identifier
+                validation_result.meta[
+                    "checkpoint_id"
+                ] = checkpoint_identifier.ge_cloud_id
 
                 batch_actions_results = self._run_actions(
                     batch=batch,


### PR DESCRIPTION
Changes proposed in this pull request:
- Cloud expects a checkpoint ID not a GeCloudIdentifier. Resolve `checkpoint_identifier` properly


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
