### PR TITLE
Remove xfail markers on cloud tests

### DIFF
--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -217,9 +217,6 @@ def test_cloud_backed_data_context_add_checkpoint(
     assert checkpoint.validations[1]["id_"] == validation_id_2
 
 
-@pytest.mark.xfail(
-    reason="Environment variable issues with Azure; temporary xfail to unblock release 0.15.19"
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -251,9 +251,6 @@ def prepare_validator_for_cloud_e2e() -> Callable[[DataContext], Tuple[Validator
     return _closure
 
 
-@pytest.mark.xfail(
-    reason="Environment variable issues with Azure; temporary xfail to unblock release 0.15.19"
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")
@@ -283,9 +280,6 @@ def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_clo
     assert mock_put.call_count == 1
 
 
-@pytest.mark.xfail(
-    reason="Environment variable issues with Azure; temporary xfail to unblock release 0.15.19"
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -529,9 +529,6 @@ def test_file_data_context_variables_e2e(
     assert config_saved_to_disk.plugins_directory == f"${env_var_name}"
 
 
-@pytest.mark.xfail(
-    reason="Environment variable issues with Azure; temporary xfail to unblock release 0.15.19"
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
@@ -550,9 +547,6 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     assert success is True
 
 
-@pytest.mark.xfail(
-    reason="Environment variable issues with Azure; temporary xfail to unblock release 0.15.19"
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")


### PR DESCRIPTION
I've reset the GE cloud credentials in our azure pipeline, removed the `xfail` markers, and now I see the cloud tests passing. I'm not sure how the cloud variables could have gotten set to something invalid?

See: https://dev.azure.com/great-expectations/great_expectations/_build/results?buildId=87209&view=results