### PR TITLE
[MAINTENANCE] `AbstractConfig.parse_obj()`

### DIFF
--- a/great_expectations/core/configuration.py
+++ b/great_expectations/core/configuration.py
@@ -1,19 +1,50 @@
 """Contains general abstract or base classes used across configuration objects."""
+import uuid
 from abc import ABC
-from typing import Optional
+from typing import Mapping, Optional, Type, Union
 
 from great_expectations.marshmallow__shade.decorators import post_dump
 from great_expectations.marshmallow__shade.schema import Schema
 from great_expectations.types import SerializableDictDot
 
+_NOT_PROVIDED = uuid.uuid4()
+
 
 class AbstractConfig(ABC, SerializableDictDot):
     """Abstract base class for Config objects. Sets the fields that must be included on a Config."""
+
+    _INIT_KEY_MAPPINGS = {"id": "id_"}
 
     def __init__(self, id_: Optional[str] = None, name: Optional[str] = None) -> None:
         self.id_ = id_
         self.name = name
         super().__init__()
+
+    @classmethod
+    def parse_obj(
+        cls: Type["AbstractConfig"], obj: Union[dict, Mapping]
+    ) -> "AbstractConfig":
+        """
+        Instantiate the class from a dictionary-like object.
+        Translates the keys as needed into `__init__` compatible keyword arguments.
+
+        No additonal logic is applied.
+        """
+        if not isinstance(obj, dict):
+            try:
+                obj = dict(obj)
+            except (TypeError, ValueError):
+                raise TypeError(
+                    f"{cls.__name__} expected dict not {obj.__class__.__name__}"
+                )
+
+        for target_key, replacement_key in cls._INIT_KEY_MAPPINGS.items():
+            # using magic string to ensure that we preserve the original value even if it was None or fasly.
+            value = obj.pop(target_key, _NOT_PROVIDED)
+            if value == _NOT_PROVIDED:
+                continue
+            obj[replacement_key] = value
+        return cls(**obj)
 
     @classmethod
     def _dict_round_trip(cls, schema: Schema, target: dict) -> dict:


### PR DESCRIPTION
See #5775 

## Changes proposed in this pull request:
- class method on `AbstractConfig` as an alternative way to call `__init__`.
- method translates keys like `id` into keyword argument safe variants (`id_`)


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
