### PR TITLE
[MAINTENANCE] Add v2_api flag for v2_api specific tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,5 +81,6 @@ markers = [
     "external_sqldialect: mark test as requiring install of an external sql dialect.",
     "cloud: mark test as being relevant to Great Expectations Cloud.",
     "base_data_context: mark test as being relevant to BaseDataContext, which will be removed during refactor",
+    "v2_api: mark test as specific to the v2 api (e.g. pre Data Connectors)",
 ]
 testpaths = "tests"

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -306,7 +306,8 @@ def test_compile_evaluation_parameter_dependencies(
     )
 
 
-def test_list_datasources(data_context_parameterized_expectation_suite):
+@pytest.mark.v2_api
+def test_list_datasources_v2_api(data_context_parameterized_expectation_suite):
     datasources = data_context_parameterized_expectation_suite.list_datasources()
 
     assert datasources == [


### PR DESCRIPTION
Changes proposed in this pull request:
- A new mark to use when tests are specific to only the v2 api
- Addition of mark to one test and rename of test to clearly identify it as a v2 api specific test

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
