### PR TITLE
[MAINTENANCE] Remove `ge_cloud_id` from `DataContext.add_profiler()` signature

### DIFF
--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -2215,7 +2215,6 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         config_version: float,
         rules: Dict[str, dict],
         variables: Optional[dict] = None,
-        ge_cloud_id: Optional[str] = None,
     ) -> RuleBasedProfiler:
         config_data = {
             "name": name,
@@ -2236,7 +2235,6 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             config=config,
             data_context=self,
             profiler_store=self.profiler_store,
-            ge_cloud_id=ge_cloud_id,
         )
         return profiler
 

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -545,7 +545,6 @@ class DataContext(BaseDataContext):
         config_version: float,
         rules: Dict[str, dict],
         variables: Optional[dict] = None,
-        ge_cloud_id: Optional[str] = None,
     ) -> RuleBasedProfiler:
         """
         Constructs a RuleBasedProfiler instance just like the parent `BaseDataContext.add_profiler`
@@ -556,7 +555,6 @@ class DataContext(BaseDataContext):
             config_version=config_version,
             rules=rules,
             variables=variables,
-            ge_cloud_id=ge_cloud_id,
         )
         self.save_profiler(profiler=profiler)
         return profiler

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -1107,7 +1107,6 @@ class BaseRuleBasedProfiler(ConfigPeer):
         config: RuleBasedProfilerConfig,
         data_context: "BaseDataContext",  # noqa: F821
         profiler_store: "ProfilerStore",  # noqa: F821
-        ge_cloud_id: Optional[str] = None,
     ) -> "RuleBasedProfiler":  # noqa: F821
         if not RuleBasedProfiler._check_validity_of_batch_requests_in_config(
             config=config
@@ -1130,9 +1129,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if data_context.ge_cloud_mode:
-            key = GeCloudIdentifier(
-                resource_type=GeCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
-            )
+            key = GeCloudIdentifier(resource_type=GeCloudRESTResource.PROFILER)
         else:
             key = ConfigurationIdentifier(
                 configuration_key=config.name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2661,10 +2661,8 @@ def ge_cloud_profiler_id() -> str:
 
 
 @pytest.fixture
-def ge_cloud_profiler_key(ge_cloud_profiler_id: str) -> GeCloudIdentifier:
-    return GeCloudIdentifier(
-        resource_type=GeCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_profiler_id
-    )
+def ge_cloud_profiler_key() -> GeCloudIdentifier:
+    return GeCloudIdentifier(resource_type=GeCloudRESTResource.PROFILER)
 
 
 @pytest.fixture

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -1168,7 +1168,6 @@ def test_add_profiler_ge_cloud_mode(
         profiler_config_with_placeholder_args,
         data_context=mock_data_context,
         profiler_store=mock_data_context.profiler_store,
-        ge_cloud_id=ge_cloud_profiler_id,
     )
 
     assert isinstance(profiler, RuleBasedProfiler)


### PR DESCRIPTION
Changes proposed in this pull request:
- `add_profiler` is used to create new profilers; as such, we shouldn't allow ids to be passed in (they'll be provided by Cloud)


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code