### PR TITLE
[MAINTENANCE] Write E2E Cloud test for `RuleBasedProfiler` creation and retrieval

### DIFF
--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -556,7 +556,6 @@ class DataContext(BaseDataContext):
             rules=rules,
             variables=variables,
         )
-        self.save_profiler(profiler=profiler)
         return profiler
 
     @classmethod

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -27,6 +27,7 @@ from great_expectations.core.util import (
 from great_expectations.data_context.store.ge_cloud_store_backend import (
     GeCloudRESTResource,
 )
+from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
     GeCloudIdentifier,
@@ -142,6 +143,10 @@ class BaseRuleBasedProfiler(ConfigPeer):
     @property
     def ge_cloud_id(self) -> Optional[str]:
         return self._id
+
+    @ge_cloud_id.setter
+    def ge_cloud_id(self, id: str) -> None:
+        self._id = id
 
     def _init_profiler_rules(
         self,
@@ -1135,7 +1140,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
                 configuration_key=config.name,
             )
 
-        profiler_store.set(key=key, value=config)
+        response = profiler_store.set(key=key, value=config)
+        if isinstance(response, GeCloudResourceRef):
+            new_profiler.ge_cloud_id = response.ge_cloud_id
 
         return new_profiler
 

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -6,6 +6,7 @@ import pytest
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
+from great_expectations.data_context.data_context.data_context import DataContext
 from great_expectations.rule_based_profiler.config.base import (
     ruleBasedProfilerConfigSchema,
 )
@@ -195,3 +196,28 @@ def test_profiler_save_with_new_profiler_retrieves_obj_with_id_from_store(
     )
 
     assert return_profiler.ge_cloud_id == profiler_id
+
+
+@pytest.mark.e2e
+@pytest.mark.cloud
+@mock.patch("great_expectations.data_context.DataContext._save_project_config")
+def test_cloud_backed_data_context_add_profiler_e2e(
+    mock_save_project_config: mock.MagicMock,
+    profiler_rules: dict,
+) -> None:
+    context = DataContext(ge_cloud_mode=True)
+
+    name = "oss_test_profiler"
+    config_version = 1.0
+    rules = profiler_rules
+
+    profiler = context.add_profiler(
+        name=name, config_version=config_version, rules=rules
+    )
+
+    ge_cloud_id = profiler.ge_cloud_id
+
+    profiler_stored_in_cloud = context.get_profiler(ge_cloud_id=ge_cloud_id)
+
+    assert profiler.ge_cloud_id == profiler_stored_in_cloud.ge_cloud_id
+    assert profiler.to_json_dict() == profiler_stored_in_cloud.to_json_dict()


### PR DESCRIPTION
Changes proposed in this pull request:
- E2E test using `DataContext.add_profiler()` and `DataContext.get_profiler()`


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
