### PR TITLE
[MAINTENANCE] Update `list_` methods on `DataContext` to emit names along with object ids

### DIFF
--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -2369,6 +2369,12 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             ge_cloud_id=ge_cloud_id,
         )
 
+    def list_expectation_suites(self) -> Optional[List[str]]:
+        return self._data_context.list_expectation_suites()
+
+    def list_expectation_suite_names(self) -> List[str]:
+        return self._data_context.list_expectation_suite_names()
+
     def test_yaml_config(  # noqa: C901 - complexity 17
         self,
         yaml_config: str,

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -2370,9 +2370,15 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         )
 
     def list_expectation_suites(self) -> Optional[List[str]]:
+        """
+        See parent 'AbstractDataContext.list_expectation_suites()` for more information.
+        """
         return self._data_context.list_expectation_suites()
 
     def list_expectation_suite_names(self) -> List[str]:
+        """
+        See parent 'AbstractDataContext.list_expectation_suite_names()` for more information.
+        """
         return self._data_context.list_expectation_suite_names()
 
     def test_yaml_config(  # noqa: C901 - complexity 17

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -1336,9 +1336,6 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             validation_operators.append(value)
         return validation_operators
 
-    def list_expectation_suite_names(self) -> List[str]:
-        return self._data_context.list_expectation_suite_names()
-
     def create_expectation_suite(
         self,
         expectation_suite_name: str,

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -91,7 +91,7 @@ class CloudDataContext(AbstractDataContext):
         Lists the available expectation suite names. If in ge_cloud_mode, a list of
         GE Cloud ids is returned instead.
         """
-        return [suite_key.ge_cloud_id for suite_key in self.list_expectation_suites()]
+        return [suite_key.resource_name for suite_key in self.list_expectation_suites()]
 
     @property
     def ge_cloud_config(self) -> Optional[GeCloudConfig]:

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -439,15 +439,19 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
             keys = []
             for resource in response_json["data"]:
-                id: Optional[str] = resource.get("id")
+                id: str = resource["id"]
                 resource_name: Optional[str] = None
-                attr: Optional[dict] = resource.get("attributes", {}).get(
-                    attributes_key
+                resource_dict: dict = resource.get("attributes", {}).get(
+                    attributes_key, {}
                 )
-                if attr:
-                    resource_name = attr.get("name") or attr.get(
-                        "expectation_suite_name"
-                    )
+                # Chetan - 20220824 - Explicit fork due to ExpectationSuite using a different name field.
+                # Once 'expectation_suite_name' is renamed, this can be removed.
+                attr = (
+                    "name"
+                    if resource_type is not GeCloudRESTResource.EXPECTATION_SUITE
+                    else "expectation_suite_name"
+                )
+                resource_name: Optional[str] = resource_dict.get(attr)
 
                 key = (resource_type, id, resource_name)
                 keys.append(key)

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -423,7 +423,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     def ge_cloud_credentials(self) -> dict:
         return self._ge_cloud_credentials
 
-    def list_keys(self, prefix: Tuple = ()) -> List[Tuple[GeCloudRESTResource, Any]]:  # type: ignore[override]
+    def list_keys(self, prefix: Tuple = ()) -> List[Tuple[GeCloudRESTResource, str, Optional[str]]]:  # type: ignore[override]
         url = urljoin(
             self.ge_cloud_base_url,
             f"organizations/"

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -437,21 +437,22 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             response = requests.get(url, headers=self.headers, timeout=self.TIMEOUT)
             response_json = response.json()
 
+            # Chetan - 20220824 - Explicit fork due to ExpectationSuite using a different name field.
+            # Once 'expectation_suite_name' is renamed, this can be removed.
+            name_attr: str
+            if resource_type is GeCloudRESTResource.EXPECTATION_SUITE:
+                name_attr = "expectation_suite_name"
+            else:
+                name_attr = "name"
+
             keys = []
             for resource in response_json["data"]:
                 id: str = resource["id"]
-                resource_name: Optional[str] = None
+
                 resource_dict: dict = resource.get("attributes", {}).get(
                     attributes_key, {}
                 )
-                # Chetan - 20220824 - Explicit fork due to ExpectationSuite using a different name field.
-                # Once 'expectation_suite_name' is renamed, this can be removed.
-                attr = (
-                    "name"
-                    if resource_type is not GeCloudRESTResource.EXPECTATION_SUITE
-                    else "expectation_suite_name"
-                )
-                resource_name: Optional[str] = resource_dict.get(attr)
+                resource_name: Optional[str] = resource_dict.get(name_attr)
 
                 key = (resource_type, id, resource_name)
                 keys.append(key)

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -435,6 +435,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
         try:
             response = requests.get(url, headers=self.headers, timeout=self.TIMEOUT)
+            response.raise_for_status()
             response_json = response.json()
 
             # Chetan - 20220824 - Explicit fork due to ExpectationSuite using a different name field.

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -253,7 +253,10 @@ class GeCloudIdentifier(DataContextKey):
         return cls.from_tuple(tuple_)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}::{self.resource_type}::{self.ge_cloud_id}"
+        repr = f"{self.__class__.__name__}::{self.resource_type}::{self.ge_cloud_id}"
+        if self.resource_name:
+            repr += f"::{self.resource_name}"
+        return repr
 
 
 class ValidationResultIdentifierSchema(Schema):

--- a/scripts/check_docstring_coverage.py
+++ b/scripts/check_docstring_coverage.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Tuple, cast
 Diagnostics = Dict[str, List[Tuple[ast.FunctionDef, bool]]]
 
 DOCSTRING_ERROR_THRESHOLD: int = (
-    1092  # This number is to be reduced as we document more public functions!
+    1090  # This number is to be reduced as we document more public functions!
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Callable, Dict, Tuple, Type
+from typing import Callable, Tuple, Type
 from unittest import mock
 
 import pytest
@@ -14,10 +14,16 @@ from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
 from great_expectations.data_context.data_context.data_context import DataContext
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
+    DataContextConfig,
+    GeCloudConfig,
     checkpointConfigSchema,
 )
+from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 from tests.data_context.conftest import MockResponse
 
 
@@ -237,3 +243,143 @@ def test_cloud_backed_data_context_add_checkpoint_e2e(
         checkpoint.config.to_json_dict()
         == checkpoint_stored_in_cloud.config.to_json_dict()
     )
+
+
+@pytest.fixture
+def checkpoint_names_and_ids() -> Tuple[Tuple[str, str], Tuple[str, str]]:
+    checkpoint_name_1 = "Test Checkpoint 1"
+    checkpoint_id_1 = "9db8721d-52e3-4263-90b3-ddb83a7aca04"
+    checkpoint_name_2 = "Test Checkpoint 2"
+    checkpoint_id_2 = "88972771-1774-4e7c-b76a-0c30063bea55"
+
+    checkpoint_1 = (checkpoint_name_1, checkpoint_id_1)
+    checkpoint_2 = (checkpoint_name_2, checkpoint_id_2)
+    return checkpoint_1, checkpoint_2
+
+
+@pytest.fixture
+def mock_get_all_checkpoints_json(
+    checkpoint_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]]
+) -> dict:
+    checkpoint_1, checkpoint_2 = checkpoint_names_and_ids
+    checkpoint_name_1, checkpoint_id_1 = checkpoint_1
+    checkpoint_name_2, checkpoint_id_2 = checkpoint_2
+
+    mock_json = {
+        "data": [
+            {
+                "attributes": {
+                    "checkpoint_config": {
+                        "action_list": [],
+                        "batch_request": {},
+                        "class_name": "Checkpoint",
+                        "config_version": 1.0,
+                        "evaluation_parameters": {},
+                        "module_name": "great_expectations.checkpoint",
+                        "name": checkpoint_name_1,
+                        "profilers": [],
+                        "run_name_template": None,
+                        "runtime_configuration": {},
+                        "template_name": None,
+                        "validations": [
+                            {
+                                "batch_request": {
+                                    "data_asset_name": "my_data_asset",
+                                    "data_connector_name": "my_data_connector",
+                                    "data_connector_query": {"index": 0},
+                                    "datasource_name": "data__dir",
+                                },
+                                "expectation_suite_name": "raw_health.critical",
+                            }
+                        ],
+                    },
+                    "class_name": "Checkpoint",
+                    "created_by_id": "329eb0a6-6559-4221-8b27-131a9185118d",
+                    "default_validation_id": None,
+                    "id": checkpoint_id_1,
+                    "name": checkpoint_name_1,
+                    "organization_id": "77eb8b08-f2f4-40b1-8b41-50e7fbedcda3",
+                },
+                "id": checkpoint_id_1,
+                "type": "checkpoint",
+            },
+            {
+                "attributes": {
+                    "checkpoint_config": {
+                        "action_list": [],
+                        "batch_request": {},
+                        "class_name": "Checkpoint",
+                        "config_version": 1.0,
+                        "evaluation_parameters": {},
+                        "module_name": "great_expectations.checkpoint",
+                        "name": checkpoint_name_2,
+                        "profilers": [],
+                        "run_name_template": None,
+                        "runtime_configuration": {},
+                        "template_name": None,
+                        "validations": [
+                            {
+                                "batch_request": {
+                                    "data_asset_name": "my_data_asset",
+                                    "data_connector_name": "my_data_connector",
+                                    "data_connector_query": {"index": 0},
+                                    "datasource_name": "data__dir",
+                                },
+                                "expectation_suite_name": "raw_health.critical",
+                            }
+                        ],
+                    },
+                    "class_name": "Checkpoint",
+                    "created_by_id": "329eb0a6-6559-4221-8b27-131a9185118d",
+                    "default_validation_id": None,
+                    "id": checkpoint_id_2,
+                    "name": checkpoint_name_2,
+                    "organization_id": "77eb8b08-f2f4-40b1-8b41-50e7fbedcda3",
+                },
+                "id": checkpoint_id_2,
+                "type": "checkpoint",
+            },
+        ]
+    }
+    return mock_json
+
+
+@pytest.mark.unit
+@pytest.mark.cloud
+def test_list_checkpoints(
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GeCloudConfig,
+    checkpoint_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]],
+    mock_get_all_checkpoints_json: dict,
+) -> None:
+    project_path_name = "foo/bar/baz"
+
+    context = BaseDataContext(
+        project_config=empty_ge_cloud_data_context_config,
+        context_root_dir=project_path_name,
+        ge_cloud_config=ge_cloud_config,
+        ge_cloud_mode=True,
+    )
+
+    checkpoint_1, checkpoint_2 = checkpoint_names_and_ids
+    checkpoint_name_1, checkpoint_id_1 = checkpoint_1
+    checkpoint_name_2, checkpoint_id_2 = checkpoint_2
+
+    with mock.patch("requests.get", autospec=True) as mock_get:
+        mock_get.return_value = mock.Mock(
+            status_code=200, json=lambda: mock_get_all_checkpoints_json
+        )
+        checkpoints = context.list_checkpoints()
+
+    assert checkpoints == [
+        GeCloudIdentifier(
+            resource_type=GeCloudRESTResource.CHECKPOINT,
+            ge_cloud_id=checkpoint_id_1,
+            resource_name=checkpoint_name_1,
+        ),
+        GeCloudIdentifier(
+            resource_type=GeCloudRESTResource.CHECKPOINT,
+            ge_cloud_id=checkpoint_id_2,
+            resource_name=checkpoint_name_2,
+        ),
+    ]

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -1,0 +1,136 @@
+from typing import Tuple
+from unittest import mock
+
+import pytest
+
+from great_expectations.data_context.data_context.base_data_context import (
+    BaseDataContext,
+)
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
+from great_expectations.data_context.types.base import DataContextConfig, GeCloudConfig
+from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+
+
+@pytest.fixture
+def suite_names_and_ids() -> Tuple[Tuple[str, str], Tuple[str, str]]:
+    suite_name_1 = "Test Suite 1"
+    suite_id_1 = "9db8721d-52e3-4263-90b3-ddb83a7aca04"
+    suite_name_2 = "Test Suite 2"
+    suite_id_2 = "88972771-1774-4e7c-b76a-0c30063bea55"
+
+    suite_1 = (suite_name_1, suite_id_1)
+    suite_2 = (suite_name_2, suite_id_2)
+    return suite_1, suite_2
+
+
+@pytest.fixture
+def mock_get_all_suites_json(
+    suite_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]]
+) -> dict:
+    suite_1, suite_2 = suite_names_and_ids
+    suite_name_1, suite_id_1 = suite_1
+    suite_name_2, suite_id_2 = suite_2
+    mock_json = {
+        "data": [
+            {
+                "attributes": {
+                    "clause_id": None,
+                    "created_at": "2022-03-02T19:34:00.687921",
+                    "created_by_id": "934e0898-6a5c-4ffd-9125-89381a46d191",
+                    "deleted": False,
+                    "deleted_at": None,
+                    "organization_id": "77eb8b08-f2f4-40b1-8b41-50e7fbedcda3",
+                    "rendered_data_doc_id": None,
+                    "suite": {
+                        "data_asset_type": None,
+                        "expectation_suite_name": suite_name_1,
+                        "expectations": [
+                            {
+                                "expectation_type": "expect_column_to_exist",
+                                "ge_cloud_id": "c8a239a6-fb80-4f51-a90e-40c38dffdf91",
+                                "kwargs": {"column": "infinities"},
+                                "meta": {},
+                            },
+                        ],
+                        "ge_cloud_id": suite_id_1,
+                        "meta": {"great_expectations_version": "0.15.19"},
+                    },
+                    "updated_at": "2022-08-18T18:34:17.561984",
+                },
+                "id": suite_id_1,
+                "type": "expectation_suite",
+            },
+            {
+                "attributes": {
+                    "clause_id": None,
+                    "created_at": "2022-03-02T19:34:00.687921",
+                    "created_by_id": "934e0898-6a5c-4ffd-9125-89381a46d191",
+                    "deleted": False,
+                    "deleted_at": None,
+                    "organization_id": "77eb8b08-f2f4-40b1-8b41-50e7fbedcda3",
+                    "rendered_data_doc_id": None,
+                    "suite": {
+                        "data_asset_type": None,
+                        "expectation_suite_name": suite_name_2,
+                        "expectations": [
+                            {
+                                "expectation_type": "expect_column_to_exist",
+                                "ge_cloud_id": "c8a239a6-fb80-4f51-a90e-40c38dffdf91",
+                                "kwargs": {"column": "infinities"},
+                                "meta": {},
+                            },
+                        ],
+                        "ge_cloud_id": suite_id_2,
+                        "meta": {"great_expectations_version": "0.15.19"},
+                    },
+                    "updated_at": "2022-08-18T18:34:17.561984",
+                },
+                "id": suite_id_2,
+                "type": "expectation_suite",
+            },
+        ]
+    }
+    return mock_json
+
+
+@pytest.mark.unit
+@pytest.mark.cloud
+def test_list_expectation_suites(
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GeCloudConfig,
+    suite_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]],
+    mock_get_all_suites_json: dict,
+) -> None:
+    project_path_name = "foo/bar/baz"
+
+    context = BaseDataContext(
+        project_config=empty_ge_cloud_data_context_config,
+        context_root_dir=project_path_name,
+        ge_cloud_config=ge_cloud_config,
+        ge_cloud_mode=True,
+    )
+
+    suite_1, suite_2 = suite_names_and_ids
+    suite_name_1, suite_id_1 = suite_1
+    suite_name_2, suite_id_2 = suite_2
+
+    with mock.patch("requests.get", autospec=True) as mock_get:
+        mock_get.return_value = mock.Mock(
+            status_code=200, json=lambda: mock_get_all_suites_json
+        )
+        suites = context.list_expectation_suites()
+
+    assert suites == [
+        GeCloudIdentifier(
+            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            ge_cloud_id=suite_id_1,
+            resource_name=suite_name_1,
+        ),
+        GeCloudIdentifier(
+            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            ge_cloud_id=suite_id_2,
+            resource_name=suite_name_2,
+        ),
+    ]

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Tuple
 from unittest import mock
 
 import pytest
@@ -7,6 +7,11 @@ from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
 from great_expectations.data_context.data_context.data_context import DataContext
+from great_expectations.data_context.store.ge_cloud_store_backend import (
+    GeCloudRESTResource,
+)
+from great_expectations.data_context.types.base import DataContextConfig, GeCloudConfig
+from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 from great_expectations.rule_based_profiler.config.base import (
     ruleBasedProfilerConfigSchema,
 )
@@ -221,3 +226,150 @@ def test_cloud_backed_data_context_add_profiler_e2e(
 
     assert profiler.ge_cloud_id == profiler_stored_in_cloud.ge_cloud_id
     assert profiler.to_json_dict() == profiler_stored_in_cloud.to_json_dict()
+
+
+@pytest.fixture
+def profiler_names_and_ids() -> Tuple[Tuple[str, str], Tuple[str, str]]:
+    profiler_name_1 = "Test Profiler 1"
+    profiler_id_1 = "43996c1d-ac32-493d-8e68-eb41e37ac039"
+    profiler_name_2 = "Test Profiler 2"
+    profiler_id_2 = "94604e27-22d6-4264-89fe-a52c9e4b654d"
+
+    profiler_1 = (profiler_name_1, profiler_id_1)
+    profiler_2 = (profiler_name_2, profiler_id_2)
+    return profiler_1, profiler_2
+
+
+@pytest.fixture
+def mock_get_all_profilers_json(
+    profiler_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]]
+) -> dict:
+    profiler_1, profiler_2 = profiler_names_and_ids
+    profiler_name_1, profiler_id_1 = profiler_1
+    profiler_name_2, profiler_id_2 = profiler_2
+    mock_json = {
+        "data": [
+            {
+                "attributes": {
+                    "created_by_id": "df665fc4-1891-4ef7-9a12-a0c46015c92c",
+                    "organization_id": "841d7bd5-e321-4951-9b60-deb086203c7d",
+                    "profiler": {
+                        "name": profiler_name_1,
+                        "rules": {
+                            "my_rule_for_numeric_columns": {
+                                "domain_builder": {
+                                    "batch_request": "$variables.my_last_month_sales_batch_request",
+                                    "class_name": "SemanticTypeColumnDomainBuilder",
+                                    "semantic_types": ["numeric"],
+                                },
+                                "expectation_configuration_builders": [
+                                    {
+                                        "class_name": "DefaultExpectationConfigurationBuilder",
+                                        "column": "$domain.domain_kwargs.column",
+                                        "expectation_type": "expect_column_values_to_be_between",
+                                        "max_value": "$parameter.my_column_max.value",
+                                        "min_value": "$parameter.my_column_min.value",
+                                        "mostly": "$variables.mostly_default",
+                                    }
+                                ],
+                                "parameter_builders": [
+                                    {
+                                        "batch_request": "$variables.my_last_month_sales_batch_request",
+                                        "class_name": "MetricParameterBuilder",
+                                        "metric_domain_kwargs": "$domain.domain_kwargs",
+                                        "metric_name": "column.min",
+                                        "parameter_name": "my_column_min",
+                                    },
+                                ],
+                            }
+                        },
+                        "variables": {},
+                    },
+                },
+                "id": profiler_id_1,
+                "type": "profiler",
+            },
+            {
+                "attributes": {
+                    "created_by_id": "df665fc4-1891-4ef7-9a12-a0c46015c92c",
+                    "organization_id": "841d7bd5-e321-4951-9b60-deb086203c7d",
+                    "profiler": {
+                        "name": profiler_name_2,
+                        "rules": {
+                            "my_rule_for_numeric_columns": {
+                                "domain_builder": {
+                                    "batch_request": "$variables.my_last_month_sales_batch_request",
+                                    "class_name": "SemanticTypeColumnDomainBuilder",
+                                    "semantic_types": ["numeric"],
+                                },
+                                "expectation_configuration_builders": [
+                                    {
+                                        "class_name": "DefaultExpectationConfigurationBuilder",
+                                        "column": "$domain.domain_kwargs.column",
+                                        "expectation_type": "expect_column_values_to_be_between",
+                                        "max_value": "$parameter.my_column_max.value",
+                                        "min_value": "$parameter.my_column_min.value",
+                                        "mostly": "$variables.mostly_default",
+                                    }
+                                ],
+                                "parameter_builders": [
+                                    {
+                                        "batch_request": "$variables.my_last_month_sales_batch_request",
+                                        "class_name": "MetricParameterBuilder",
+                                        "metric_domain_kwargs": "$domain.domain_kwargs",
+                                        "metric_name": "column.min",
+                                        "parameter_name": "my_column_min",
+                                    },
+                                ],
+                            }
+                        },
+                        "variables": {},
+                    },
+                },
+                "id": profiler_id_2,
+                "type": "profiler",
+            },
+        ]
+    }
+    return mock_json
+
+
+@pytest.mark.unit
+@pytest.mark.cloud
+def test_list_profilers(
+    empty_ge_cloud_data_context_config: DataContextConfig,
+    ge_cloud_config: GeCloudConfig,
+    profiler_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]],
+    mock_get_all_profilers_json: dict,
+) -> None:
+    project_path_name = "foo/bar/baz"
+
+    context = BaseDataContext(
+        project_config=empty_ge_cloud_data_context_config,
+        context_root_dir=project_path_name,
+        ge_cloud_config=ge_cloud_config,
+        ge_cloud_mode=True,
+    )
+
+    profiler_1, profiler_2 = profiler_names_and_ids
+    profiler_name_1, profiler_id_1 = profiler_1
+    profiler_name_2, profiler_id_2 = profiler_2
+
+    with mock.patch("requests.get", autospec=True) as mock_get:
+        mock_get.return_value = mock.Mock(
+            status_code=200, json=lambda: mock_get_all_profilers_json
+        )
+        profilers = context.list_profilers()
+
+    assert profilers == [
+        GeCloudIdentifier(
+            resource_type=GeCloudRESTResource.PROFILER,
+            ge_cloud_id=profiler_id_1,
+            resource_name=profiler_name_1,
+        ),
+        GeCloudIdentifier(
+            resource_type=GeCloudRESTResource.PROFILER,
+            ge_cloud_id=profiler_id_2,
+            resource_name=profiler_name_2,
+        ),
+    ]


### PR DESCRIPTION
Changes proposed in this pull request:
- Cloud-enabled contexts print out ids instead of object names; this makes it difficult to know which object to reference in config.
- The changes herein ensure that expectation suites and checkpoints are printed with their name.

Loom: https://www.loom.com/share/245cf3753e954eeaa4606f16fad2ae89

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
