### PR TITLE
[MAINTENANCE] Clean up xfails in preparation for 0.15.20 release

### DIFF
--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -203,11 +203,6 @@ def test_profiler_save_with_new_profiler_retrieves_obj_with_id_from_store(
     assert return_profiler.ge_cloud_id == profiler_id
 
 
-@pytest.mark.xfail(
-    reason="GX Cloud E2E tests are currently failing due to a schema issue with DataContextVariables; xfailing for purposes of the 0.15.20 release",
-    run=True,
-    strict=True,
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")

--- a/tests/data_context/test_base_data_context.py
+++ b/tests/data_context/test_base_data_context.py
@@ -1,6 +1,5 @@
 import os
 import random
-import string
 from typing import Callable, List, Tuple
 from unittest import mock
 
@@ -252,7 +251,7 @@ def prepare_validator_for_cloud_e2e() -> Callable[[DataContext], Tuple[Validator
 
 
 @pytest.mark.xfail(
-    reason="GX Cloud E2E tests are currently failing due to a schema issue with DataContextVariables; xfailing for purposes of the 0.15.20 release",
+    reason="GX Cloud E2E tests are currently failing due to an id issue with ExpectationSuites; xfailing for purposes of the 0.15.20 release",
     run=True,
     strict=True,
 )
@@ -286,7 +285,7 @@ def test_get_validator_with_cloud_enabled_context_saves_expectation_suite_to_clo
 
 
 @pytest.mark.xfail(
-    reason="GX Cloud E2E tests are currently failing due to a schema issue with DataContextVariables; xfailing for purposes of the 0.15.20 release",
+    reason="GX Cloud E2E tests are currently failing due to an id issue with ExpectationSuites; xfailing for purposes of the 0.15.20 release",
     run=True,
     strict=True,
 )

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -570,11 +570,6 @@ def test_file_data_context_variables_e2e(
     assert config_saved_to_disk.plugins_directory == f"${env_var_name}"
 
 
-@pytest.mark.xfail(
-    reason="GX Cloud E2E tests are currently failing due to a schema issue with DataContextVariables; xfailing for purposes of the 0.15.20 release",
-    run=True,
-    strict=True,
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
@@ -593,11 +588,6 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     assert success is True
 
 
-@pytest.mark.xfail(
-    reason="GX Cloud E2E tests are currently failing due to a schema issue with DataContextVariables; xfailing for purposes of the 0.15.20 release",
-    run=True,
-    strict=True,
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")


### PR DESCRIPTION
Changes proposed in this pull request:
- Certain tests started passing this morning due to a change made in the Cloud backend; since we set `strict`, we need to modify these tests before the release.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
