### PR TITLE
[MAINTENANCE] Remove pyparsing pin for <3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ notebook>=6.4.10
 numpy>=1.18.5
 packaging
 pandas>=1.1.0
-pyparsing>=2.4,<3
+pyparsing>=2.4
 python-dateutil>=2.8.1
 pytz>=2021.3
 requests>=2.20


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- Removes the upper bound for `pyparsing` in `requirements.txt`
- This _does not_ update the pyparsing classes used to reflect the latest version of pyparsing in our to maintain compatibility for users on older versions of pyparsing (since pyparsing maintains backward compatibility).
- Resolves #5801 

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code


Thank you for submitting!
