### PR TITLE
[DOCS] updated the channel name

### DIFF
--- a/docs/contributing/contributing_overview.md
+++ b/docs/contributing/contributing_overview.md
@@ -9,7 +9,7 @@ Our goal is to make your experience as great as possible. Please follow these st
 
 #### 1. Join the community on Slack
 
-* Go to [greatexpectations.io/slack](https://greatexpectations.io/slack) and introduce yourself in the `#contributors-contributing` channel.
+* Go to [greatexpectations.io/slack](https://greatexpectations.io/slack) and introduce yourself in the `#introductions` channel.
 
 #### 2. Contribute small changes directly through GitHub 
 


### PR DESCRIPTION
`#contributors-contributing` channel does not exist on slack anymore or not public. Contributors may use `#introductions` channel for introduction. 
