### PR TITLE
[MAINTENANCE] init tests for dict and json serializers

### DIFF
--- a/tests/core/test_serializers.py
+++ b/tests/core/test_serializers.py
@@ -1,7 +1,10 @@
 import pytest
 
 from great_expectations.core.configuration import AbstractConfigSchema
-from great_expectations.core.serializer import DictConfigSerializer
+from great_expectations.core.serializer import (
+    DictConfigSerializer,
+    JsonConfigSerializer,
+)
 from great_expectations.marshmallow__shade import Schema
 
 
@@ -20,15 +23,7 @@ def test_init_dict_config_serializer(empty_abstract_config_schema: Schema):
     assert serializer.schema == empty_abstract_config_schema
 
 
-@pytest.mark.xfail(
-    raises=(ImportError, NameError),
-    reason="xfail until PR 5778 merges with JsonConfigSerializer",
-    strict=True,
-)
 def test_init_json_config_serializer(empty_abstract_config_schema: Schema):
-
-    # Note: move this import statement to the top of the file once this test is meant to pass
-    from great_expectations.core.serializer import JsonConfigSerializer
 
     serializer = JsonConfigSerializer(schema=empty_abstract_config_schema)
 

--- a/tests/core/test_serializers.py
+++ b/tests/core/test_serializers.py
@@ -1,7 +1,6 @@
 import pytest
 
 from great_expectations.core.configuration import AbstractConfigSchema
-
 from great_expectations.core.serializer import DictConfigSerializer
 from great_expectations.marshmallow__shade import Schema
 

--- a/tests/core/test_serializers.py
+++ b/tests/core/test_serializers.py
@@ -1,0 +1,32 @@
+import pytest
+
+from great_expectations.core.configuration import AbstractConfigSchema
+
+from great_expectations.core.serializer import DictConfigSerializer
+from great_expectations.marshmallow__shade import Schema
+
+
+@pytest.fixture
+def empty_abstract_config_schema():
+    class EmptyAbstractConfigSchema(AbstractConfigSchema):
+        pass
+
+    schema = EmptyAbstractConfigSchema()
+    return schema
+
+
+def test_init_dict_config_serializer(empty_abstract_config_schema: Schema):
+    serializer = DictConfigSerializer(schema=empty_abstract_config_schema)
+
+    assert serializer.schema == empty_abstract_config_schema
+
+
+@pytest.mark.xfail(raises=(ImportError, NameError), reason="xfail until PR 5778 merges with JsonConfigSerializer", strict=True,)
+def test_init_json_config_serializer(empty_abstract_config_schema: Schema):
+
+    # Note: move this import statement to the top of the file once this test is meant to pass
+    from great_expectations.core.serializer import JsonConfigSerializer
+
+    serializer = JsonConfigSerializer(schema=empty_abstract_config_schema)
+
+    assert serializer.schema == empty_abstract_config_schema

--- a/tests/core/test_serializers.py
+++ b/tests/core/test_serializers.py
@@ -21,7 +21,11 @@ def test_init_dict_config_serializer(empty_abstract_config_schema: Schema):
     assert serializer.schema == empty_abstract_config_schema
 
 
-@pytest.mark.xfail(raises=(ImportError, NameError), reason="xfail until PR 5778 merges with JsonConfigSerializer", strict=True,)
+@pytest.mark.xfail(
+    raises=(ImportError, NameError),
+    reason="xfail until PR 5778 merges with JsonConfigSerializer",
+    strict=True,
+)
 def test_init_json_config_serializer(empty_abstract_config_schema: Schema):
 
     # Note: move this import statement to the top of the file once this test is meant to pass


### PR DESCRIPTION
Changes proposed in this pull request:
- Add init tests for dict and json serializers. See https://github.com/great-expectations/great_expectations/pull/5778 for JsonConfigSerializer (here marked with a strict xfail decorator until that PR is merged)
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
