### PR TITLE
[MAINTENANCE] Handle Pandas warnings in Data Assistant plots

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -2336,17 +2336,7 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = (
-            DataAssistantResult._determine_input_dropdown_initial_state(
-                df=df, batch_plot_component=batch_plot_component
-            )
-        )
-        input_dropdown_initial_state[
-            batch_plot_component.batch_identifiers + [domain_plot_component.name]
-        ] = " "
-        df = pd.concat([input_dropdown_initial_state, df], axis=0)
-
-        columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
+        columns: List[str] = [""] + pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
             options=columns, name="Select Column: "
         )
@@ -2427,17 +2417,7 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = (
-            DataAssistantResult._determine_input_dropdown_initial_state(
-                df=df, batch_plot_component=batch_plot_component
-            )
-        )
-        input_dropdown_initial_state[
-            batch_plot_component.batch_identifiers + [domain_plot_component.name]
-        ] = " "
-        df = pd.concat([input_dropdown_initial_state, df], axis=0)
-
-        columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
+        columns: List[str] = [""] + pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
             options=columns, name="Select Column: "
         )
@@ -2495,17 +2475,7 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = (
-            DataAssistantResult._determine_input_dropdown_initial_state(
-                df=df, batch_plot_component=batch_plot_component
-            )
-        )
-        input_dropdown_initial_state[
-            batch_plot_component.batch_identifiers + [domain_plot_component.name]
-        ] = " "
-        df = pd.concat([input_dropdown_initial_state, df], axis=0)
-
-        columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
+        columns: List[str] = [""] + pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
             options=columns, name="Select Column: "
         )
@@ -2602,21 +2572,7 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = (
-            DataAssistantResult._determine_input_dropdown_initial_state(
-                df=df, batch_plot_component=batch_plot_component
-            )
-        )
-        input_dropdown_initial_state[
-            batch_plot_component.batch_identifiers
-            + [
-                domain_plot_component.name,
-            ]
-            + expectation_kwargs_initial_dropdown_state
-        ] = " "
-        df = pd.concat([input_dropdown_initial_state, df], axis=0)
-
-        columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
+        columns: List[str] = [""] + pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
             options=columns, name="Select Column: "
         )
@@ -2767,21 +2723,7 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = (
-            DataAssistantResult._determine_input_dropdown_initial_state(
-                df=df, batch_plot_component=batch_plot_component
-            )
-        )
-        input_dropdown_initial_state[
-            batch_plot_component.batch_identifiers
-            + [
-                domain_plot_component.name,
-            ]
-            + expectation_kwargs_initial_dropdown_state
-        ] = " "
-        df = pd.concat([input_dropdown_initial_state, df], axis=0)
-
-        columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
+        columns: List[str] = [""] + pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
             options=columns, name="Select Column: "
         )
@@ -2919,21 +2861,7 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = (
-            DataAssistantResult._determine_input_dropdown_initial_state(
-                df=df, batch_plot_component=batch_plot_component
-            )
-        )
-        input_dropdown_initial_state[
-            batch_plot_component.batch_identifiers
-            + [
-                domain_plot_component.name,
-            ]
-            + expectation_kwargs_initial_dropdown_state
-        ] = " "
-        df = pd.concat([input_dropdown_initial_state, df], axis=0)
-
-        columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
+        columns: List[str] = [""] + pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
             options=columns, name="Select Column: "
         )
@@ -3980,13 +3908,6 @@ class DataAssistantResult(SerializableDictDot):
         metric_names: Set[str], iterable: Iterable[str]
     ) -> bool:
         return all([metric_name in iterable for metric_name in metric_names])
-
-    @staticmethod
-    def _determine_input_dropdown_initial_state(
-        df: pd.DataFrame, batch_plot_component: BatchPlotComponent
-    ) -> pd.DataFrame:
-        test = df.groupby([batch_plot_component.name], as_index=False).max()
-        return test
 
     @staticmethod
     def _get_expect_domain_values_ordinal_chart(

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -23,6 +23,7 @@ import ipywidgets as widgets
 import numpy as np
 import pandas as pd
 from IPython.display import HTML, display
+from packaging import version
 
 from great_expectations import __version__ as ge_version
 from great_expectations import exceptions as ge_exceptions
@@ -2335,14 +2336,15 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        if expectation_type is None:
-            input_dropdown_initial_state: pd.DataFrame = df.groupby(
-                [batch_plot_component.name], as_index=False
-            ).max()
-            input_dropdown_initial_state[
-                batch_plot_component.batch_identifiers + [domain_plot_component.name]
-            ] = " "
-            df = pd.concat([input_dropdown_initial_state, df], axis=0)
+        input_dropdown_initial_state: pd.DataFrame = (
+            DataAssistantResult._determine_input_dropdown_initial_state(
+                df=df, batch_plot_component=batch_plot_component
+            )
+        )
+        input_dropdown_initial_state[
+            batch_plot_component.batch_identifiers + [domain_plot_component.name]
+        ] = " "
+        df = pd.concat([input_dropdown_initial_state, df], axis=0)
 
         columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
@@ -2425,14 +2427,15 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        if expectation_type is None:
-            input_dropdown_initial_state: pd.DataFrame = df.groupby(
-                [batch_plot_component.name], as_index=False
-            ).max()
-            input_dropdown_initial_state[
-                batch_plot_component.batch_identifiers + [domain_plot_component.name]
-            ] = " "
-            df = pd.concat([input_dropdown_initial_state, df], axis=0)
+        input_dropdown_initial_state: pd.DataFrame = (
+            DataAssistantResult._determine_input_dropdown_initial_state(
+                df=df, batch_plot_component=batch_plot_component
+            )
+        )
+        input_dropdown_initial_state[
+            batch_plot_component.batch_identifiers + [domain_plot_component.name]
+        ] = " "
+        df = pd.concat([input_dropdown_initial_state, df], axis=0)
 
         columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
@@ -2492,14 +2495,15 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        if expectation_type is None:
-            input_dropdown_initial_state: pd.DataFrame = df.groupby(
-                [batch_plot_component.name], as_index=False
-            ).max()
-            input_dropdown_initial_state[
-                batch_plot_component.batch_identifiers + [domain_plot_component.name]
-            ] = " "
-            df = pd.concat([input_dropdown_initial_state, df], axis=0)
+        input_dropdown_initial_state: pd.DataFrame = (
+            DataAssistantResult._determine_input_dropdown_initial_state(
+                df=df, batch_plot_component=batch_plot_component
+            )
+        )
+        input_dropdown_initial_state[
+            batch_plot_component.batch_identifiers + [domain_plot_component.name]
+        ] = " "
+        df = pd.concat([input_dropdown_initial_state, df], axis=0)
 
         columns: List[str] = pd.unique(df[domain_plot_component.name]).tolist()
         input_dropdown: alt.binding_select = alt.binding_select(
@@ -2598,9 +2602,11 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = df.groupby(
-            [batch_plot_component.name], as_index=False
-        ).max()
+        input_dropdown_initial_state: pd.DataFrame = (
+            DataAssistantResult._determine_input_dropdown_initial_state(
+                df=df, batch_plot_component=batch_plot_component
+            )
+        )
         input_dropdown_initial_state[
             batch_plot_component.batch_identifiers
             + [
@@ -2761,9 +2767,11 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = df.groupby(
-            [batch_plot_component.name], as_index=False
-        ).max()
+        input_dropdown_initial_state: pd.DataFrame = (
+            DataAssistantResult._determine_input_dropdown_initial_state(
+                df=df, batch_plot_component=batch_plot_component
+            )
+        )
         input_dropdown_initial_state[
             batch_plot_component.batch_identifiers
             + [
@@ -2911,9 +2919,11 @@ class DataAssistantResult(SerializableDictDot):
             ]
         )
 
-        input_dropdown_initial_state: pd.DataFrame = df.groupby(
-            [batch_plot_component.name], as_index=False
-        ).max()
+        input_dropdown_initial_state: pd.DataFrame = (
+            DataAssistantResult._determine_input_dropdown_initial_state(
+                df=df, batch_plot_component=batch_plot_component
+            )
+        )
         input_dropdown_initial_state[
             batch_plot_component.batch_identifiers
             + [
@@ -3970,6 +3980,13 @@ class DataAssistantResult(SerializableDictDot):
         metric_names: Set[str], iterable: Iterable[str]
     ) -> bool:
         return all([metric_name in iterable for metric_name in metric_names])
+
+    @staticmethod
+    def _determine_input_dropdown_initial_state(
+        df: pd.DataFrame, batch_plot_component: BatchPlotComponent
+    ) -> pd.DataFrame:
+        test = df.groupby([batch_plot_component.name], as_index=False).max()
+        return test
 
     @staticmethod
     def _get_expect_domain_values_ordinal_chart(

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -23,7 +23,6 @@ import ipywidgets as widgets
 import numpy as np
 import pandas as pd
 from IPython.display import HTML, display
-from packaging import version
 
 from great_expectations import __version__ as ge_version
 from great_expectations import exceptions as ge_exceptions

--- a/great_expectations/rule_based_profiler/data_assistant_result/plot_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/plot_result.py
@@ -24,3 +24,6 @@ class PlotResult:
     """
 
     charts: List[alt.Chart]
+
+    def __repr__(self):
+        return ""


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1175
- Handle Pandas warnings in Data Assistant plots
- Get rid of text representation of PlotResult


### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
