### PR TITLE
[MAINTENANCE] ignore `marshmallow_shade` in coverage reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,9 @@ testpaths = "tests"
 # use `pytest-mock` drop-in replacement for `unittest.mock`
 # https://pytest-mock.readthedocs.io/en/latest/configuration.html#use-standalone-mock-package
 mock_use_standalone_module = true
+
+[tool.coverage]
+[tool.coverage.run]
+omit = [
+    "great_expectations/marshmallow__shade",
+    ]

--- a/tasks.py
+++ b/tasks.py
@@ -221,7 +221,8 @@ def tests(ctx, unit=True, ci=False, html=False, cloud=True, slowest=5):
         "pytest",
         f"--durations={slowest}",
         "--cov=great_expectations",
-        "--cov-report term:skip-covered",  # modules with 100% will not be shown
+        "--cov-report term:skip-covered",  # modules with 100% will not be shown'
+        "--cov-config=pyproject.toml",
         "-vv",
     ]
     if unit:


### PR DESCRIPTION
Changes proposed in this pull request:
- add a coverage config section to `pyproject.toml`
- exclude the vendored package `marshmallow_shade` from coverage reporting
- update `invoke tests` to use the `pyproject.toml` configuration file

See https://github.com/great-expectations/great_expectations/pull/5866