### PR TITLE
[MAINTENANCE] Update expectation_gallery pipeline

### DIFF
--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -206,7 +206,7 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Show gallery tracebacks'
 
-          - bash: grep "to df.to_sql" testing-times.txt
+          - bash: grep "to df.to_sql" testing-times.txt || echo "No df.to_sql calls were made"
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Show DataFrame to SQL times'
 


### PR DESCRIPTION

Changes proposed in this pull request:
- Update the 'Show DataFrame to SQL times' step of expectation_gallery pipeline to not die if no SQL backend used