### PR TITLE
[MAINTENANCE] new invoke test flags

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -263,13 +263,14 @@ def tests(
     ]
     if not ignore_markers:
         cmds += ["-m", f"'{marker_text}'"]
-    if unit:
+    if unit and not ignore_markers:
         try:
             import pytest_timeout  # noqa: F401
 
             cmds += [f"--timeout={timeout}"]
         except ImportError:
             print("`pytest-timeout` is not installed, cannot use --timeout")
+
     if cloud:
         cmds += ["--cloud"]
     if ci:

--- a/tasks.py
+++ b/tasks.py
@@ -225,12 +225,14 @@ def tests(
     ctx,
     unit=True,
     integration=False,
+    ignore_markers=False,
     ci=False,
     html=False,
     cloud=True,
     slowest=5,
     timeout=UNIT_TEST_DEFAULT_TIMEOUT,
     package=None,
+    full_cov=False,
 ):
     """
     Run tests. Runs unit tests by default.
@@ -245,15 +247,19 @@ def tests(
 
     marker_text = " and ".join(markers)
 
+    cov_param = "--cov=great_expectations"
+    if package and not full_cov:
+        cov_param += f"/{package.replace('.', '/')}"
+
     cmds = [
         "pytest",
         f"--durations={slowest}",
-        "--cov=great_expectations",
+        cov_param,
         "--cov-report term",
         "-vv",
-        "-m",
-        f"'{marker_text}'",
     ]
+    if not ignore_markers:
+        cmds += ["-m", marker_text]
     if unit:
         try:
             import pytest_timeout  # noqa: F401

--- a/tasks.py
+++ b/tasks.py
@@ -213,12 +213,15 @@ UNIT_TEST_DEFAULT_TIMEOUT: float = 2.0
 @invoke.task(
     aliases=["test"],
     help={
+        "unit": "Runs tests marked with the 'unit' marker. Default behavior.",
         "integration": "Runs integration tests and exclude unit-tests. By default only unit tests are run.",
+        "ignore-markers": "Don't exclude any test by not passing any markers to pytest.",
         "slowest": "Report on the slowest n number of tests",
         "ci": "execute tests assuming a CI environment. Publish XML reports for coverage reporting etc.",
         "timeout": f"Fails unit-tests if calls take longer than this value. Default {UNIT_TEST_DEFAULT_TIMEOUT} seconds",
         "html": "Create html coverage report",
         "package": "Run tests on a specific package. Assumes there is a `tests/<PACKAGE>` directory of the same name.",
+        "full-cov": "Show coverage report on the entire `great_expectations` package regardless of `--package` param.",
     },
 )
 def tests(

--- a/tasks.py
+++ b/tasks.py
@@ -262,7 +262,7 @@ def tests(
         "-vv",
     ]
     if not ignore_markers:
-        cmds += ["-m", marker_text]
+        cmds += ["-m", f"'{marker_text}'"]
     if unit:
         try:
             import pytest_timeout  # noqa: F401


### PR DESCRIPTION
Changes proposed in this pull request:
- update the coverage terminal report to only show the `--package` under test
- add `--full-cov ` flag to always show the full coverage report (see ☝️ )
- add `--ignore-markers` flag to run all tests regardless of test markers

![image](https://user-images.githubusercontent.com/13108583/187493679-e17f147a-777f-47cb-9bc6-e766794fc448.png)


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
