### PR TITLE
[BUGFIX] many small bugfixes

### DIFF
--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -142,9 +142,13 @@ def get_expectation_file_info_dict(
             if match:
                 if not line.strip().startswith("#"):
                     exp_type_set.add(match.group(1))
-        result[name]["exp_type"] = sorted(exp_type_set)[0]
+        if file_path.startswith("great_expectations"):
+            _prefix = "Core "
+        else:
+            _prefix = "Contrib "
+        result[name]["exp_type"] = _prefix + sorted(exp_type_set)[0]
         logger.debug(
-            f"Expectation type {sorted(exp_type_set)[0]} for {name} in {file_path}"
+            f"Expectation type {_prefix}{sorted(exp_type_set)[0]} for {name} in {file_path}"
         )
 
     os.chdir(oldpwd)

--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -284,7 +284,10 @@ def build_gallery(
 
     for expectation in sorted(requirements_dict):
         # Temp
-        if expectation == "expect_column_kl_divergence_to_be_less_than":
+        if expectation in [
+            "expect_column_kl_divergence_to_be_less_than",  # Infinity values break JSON
+            "expect_column_values_to_be_valid_arn",  # Contrib Expectation where pretty much no test passes on any backend
+        ]:
             continue
         group = requirements_dict[expectation]["group"]
         print(f"\n\n\n=== {expectation} ({group}) ===")

--- a/assets/scripts/build_package_gallery.py
+++ b/assets/scripts/build_package_gallery.py
@@ -104,6 +104,6 @@ if __name__ == "__main__":
         assert (
             len(payload) > 0
         ), "Something went wrong; there should packages in the payload!"
-        write_results_to_disk(os.path.join(pwd, "./package_manifests.json"), payload)
+        write_results_to_disk(os.path.join(pwd, "./package_manifests2.json"), payload)
     finally:
         os.chdir(pwd)

--- a/assets/scripts/build_package_gallery.py
+++ b/assets/scripts/build_package_gallery.py
@@ -104,6 +104,6 @@ if __name__ == "__main__":
         assert (
             len(payload) > 0
         ), "Something went wrong; there should packages in the payload!"
-        write_results_to_disk(os.path.join(pwd, "./package_manifests2.json"), payload)
+        write_results_to_disk(os.path.join(pwd, "./package_manifests.json"), payload)
     finally:
         os.chdir(pwd)

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -145,7 +145,7 @@ stages:
               secureFile: 'aws_config_sandbox'
               retryCount: '2'
 
-          - bash: python ./build_gallery.py --backends "pandas, postgresql" --outfile-name "expectation_library_v4.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
+          - bash: python ./build_gallery.py --outfile-name "expectation_library_v2.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Build Gallery'
             env:

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -145,7 +145,7 @@ stages:
               secureFile: 'aws_config_sandbox'
               retryCount: '2'
 
-          - bash: python ./build_gallery.py --outfile-name "expectation_library_v4.json" | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
+          - bash: python ./build_gallery.py --outfile-name "expectation_library_v4.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Build Gallery'
             env:

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -145,7 +145,7 @@ stages:
               secureFile: 'aws_config_sandbox'
               retryCount: '2'
 
-          - bash: python ./build_gallery.py --outfile-name "expectation_library_v4.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
+          - bash: python ./build_gallery.py --backends "pandas, postgresql" --outfile-name "expectation_library_v4.json" 2>&1 | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Build Gallery'
             env:

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -83,7 +83,7 @@ stages:
       - job: build_gallery
         timeoutInMinutes: 300
         variables:
-          python.version: '3.7'
+          python.version: '3.8'
           GE_pytest_opts: ''
 
         services:

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -186,6 +186,10 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Show Expectation types and counts'
 
+          - bash: grep -o "Implemented engines.*" output--build_gallery.txt
+            workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
+            displayName: 'Show implemented engines''
+
           - bash: cat checklists.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Show full checklist summary'

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -188,7 +188,7 @@ stages:
 
           - bash: grep -o "Implemented engines.*" output--build_gallery.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
-            displayName: 'Show implemented engines''
+            displayName: 'Show implemented engines'
 
           - bash: cat checklists.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -145,7 +145,7 @@ stages:
               secureFile: 'aws_config_sandbox'
               retryCount: '2'
 
-          - bash: python ./build_gallery.py --outfile-name "expectation_library_v2.json" | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
+          - bash: python ./build_gallery.py --outfile-name "expectation_library_v4.json" | tee output--build_gallery.txt ; grep -o "Took .* seconds to .*" output--build_gallery.txt | sort -k2,2nr > testing-times.txt ; grep -o "ERROR - (.*" output--build_gallery.txt | sort > testing-error-messages.txt; touch gallery-tracebacks.txt; grep -o "Expectation type.*" output--build_gallery.txt | sort > gallery-exp-types.txt
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Build Gallery'
             env:

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -182,7 +182,7 @@ stages:
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Show coverage scores'
 
-          - bash: cut -d " " -f 3 gallery-exp-types.txt | uniq -c | sort -nr; echo; cut -d " " -f 3,5 gallery-exp-types.txt | sort
+          - bash: cut -d " " -f 3,4 gallery-exp-types.txt | uniq -c | sort -nr; echo; cut -d " " -f 3,4,6 gallery-exp-types.txt | sort
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Show Expectation types and counts'
 

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_polygon_area_between.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_polygon_area_between.py
@@ -163,7 +163,7 @@ class ExpectColumnValuesToBePolygonAreaBetween(ColumnMapExpectation):
         "contributors": [  # Github handles for all contributors to this Expectation.
             "@mmi333",
         ],
-        "requirements": ["geopandas", "shapely"],
+        "requirements": ["geopandas", "pyogrio", "shapely"],
     }
 
     # This is the id string of the Metric used by this Expectation.

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_valid_scientific_notation.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_valid_scientific_notation.py
@@ -28,6 +28,7 @@ class ExpectColumnValuesToBeValidScientificNotation(RegexBasedColumnMapExpectati
                 "invalid": ["11.e-12", "0E+5", "007"],
                 "empty": ["", None, False],
             },
+            "suppress_test_for": ["mssql", "bigquery"],
             "tests": [
                 {
                     "title": "basic_positive_test",

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_contain_special_characters.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_not_contain_special_characters.py
@@ -79,7 +79,7 @@ class ExpectColumnValuesToNotContainSpecialCharacters(ColumnMapExpectation):
             },
             "tests": [
                 {
-                    "title": "positive_test_with_no_special_character",
+                    "title": "negative_test_with_no_special_character",
                     "exact_match_out": False,
                     "include_in_gallery": True,
                     "in": {"column": "mostly_no_special_character", "mostly": 1},

--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -184,6 +184,7 @@ class GEDependencies:
         "py-moneyed",
         "pydnsbl",
         "pygeos",
+        "pyogrio",
         "python-geohash",
         "python-stdnum",
         "pyvat",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -979,8 +979,10 @@ class Expectation(metaclass=MetaExpectation):
         """
 
         _debug = lambda x: x
+        _error = lambda x: x
         if debug_logger:
             _debug = lambda x: debug_logger.debug(f"(run_diagnostics) {x}")
+            _error = lambda x: debug_logger.error(f"(run_diagnostics) {x}")
 
         errors: List[ExpectationErrorDiagnostics] = []
 
@@ -1007,6 +1009,11 @@ class Expectation(metaclass=MetaExpectation):
         _expectation_config: ExpectationConfiguration = (
             self._get_expectation_configuration_from_examples(examples)
         )
+        if not _expectation_config:
+            _error(
+                f"Was NOT able to get Expectation configuration for {self.expectation_type}. "
+                "Is there at least one sample test where 'success' is True?"
+            )
         metric_diagnostics_list: List[
             ExpectationMetricDiagnostics
         ] = self._get_metric_diagnostics_list(

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1268,6 +1268,17 @@ class Expectation(metaclass=MetaExpectation):
                                 kwargs=test.input,
                             )
 
+            # There is no sample test where `success` is True, or there are no tests
+            for example in examples:
+                tests = example.tests
+                if tests:
+                    for test in tests:
+                        if test.input:
+                            return ExpectationConfiguration(
+                                expectation_type=self.expectation_type,
+                                kwargs=test.input,
+                            )
+
     @staticmethod
     def is_expectation_self_initializing(name: str) -> bool:
         """

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1072,7 +1072,9 @@ class Expectation(metaclass=MetaExpectation):
             _num_backends += 1
             _total_passed += result.num_passed
             _total_failed += result.num_failed
-        coverage_score = _num_backends + _num_engines + _total_passed - (1.5 * _total_failed)
+        coverage_score = (
+            _num_backends + _num_engines + _total_passed - (1.5 * _total_failed)
+        )
         _debug(
             f"coverage_score: {coverage_score} for {self.expectation_type} ... "
             f"engines: {_num_engines}, backends: {_num_backends}, "

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1598,6 +1598,8 @@ class Expectation(metaclass=MetaExpectation):
         execution_engines = {}
         for provider in execution_engine_names:
             all_true = True
+            if not metric_diagnostics_list:
+                all_true = False
             for metric_diagnostics in metric_diagnostics_list:
                 try:
                     has_provider = (
@@ -1606,6 +1608,7 @@ class Expectation(metaclass=MetaExpectation):
                     )
                     if not has_provider:
                         all_true = False
+                        break
                 except KeyError:
                     # https://github.com/great-expectations/great_expectations/blob/abd8f68a162eaf9c33839d2c412d8ba84f5d725b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py#L174-L181
                     # expect_table_row_count_to_equal_other_table does tricky things and replaces

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1066,18 +1066,16 @@ class Expectation(metaclass=MetaExpectation):
         # Set a coverage_score
         _total_passed = 0
         _total_failed = 0
-        _num_backends = 0.0001
+        _num_backends = 0
         _num_engines = sum([x for x in introspected_execution_engines.values() if x])
         for result in backend_test_result_counts:
             _num_backends += 1
             _total_passed += result.num_passed
             _total_failed += result.num_failed
-        coverage_score = _num_engines * (
-            (_total_passed / _num_backends) - (1.5 * _total_failed)
-        )
+        coverage_score = _num_backends + _num_engines + _total_passed - (1.5 * _total_failed)
         _debug(
             f"coverage_score: {coverage_score} for {self.expectation_type} ... "
-            f"engines: {_num_engines}, backends: {round(_num_backends)}, "
+            f"engines: {_num_engines}, backends: {_num_backends}, "
             f"passing tests: {_total_passed}, failing tests:{_total_failed}"
         )
 

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -131,7 +131,9 @@ def get_dialect_regex_expression(column, regex, dialect, positive=True):
     try:
         # redshift
         # noinspection PyUnresolvedReferences
-        if issubclass(dialect.dialect, sqlalchemy_redshift.dialect.RedshiftDialect):
+        if hasattr(dialect, "RedshiftDialect") or issubclass(
+            dialect.dialect, sqlalchemy_redshift.dialect.RedshiftDialect
+        ):
             if positive:
                 return BinaryExpression(column, literal(regex), custom_op("~"))
             else:
@@ -627,7 +629,6 @@ def get_dialect_like_pattern_expression(column, dialect, like_pattern, positive=
             dialect_supported = True
     except (AttributeError, TypeError):
         pass
-
 
     try:
         if hasattr(dialect, "SnowflakeDialect"):

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -609,6 +609,12 @@ def get_dialect_like_pattern_expression(column, dialect, like_pattern, positive=
             dialect_supported = True
 
     try:
+        if hasattr(dialect, "RedshiftDialect"):
+            dialect_supported = True
+    except (AttributeError, TypeError):
+        pass
+
+    try:
         # noinspection PyUnresolvedReferences
         if isinstance(dialect, sqlalchemy_redshift.dialect.RedshiftDialect):
             dialect_supported = True
@@ -618,6 +624,13 @@ def get_dialect_like_pattern_expression(column, dialect, like_pattern, positive=
     try:
         # noinspection PyUnresolvedReferences
         if isinstance(dialect, trino.sqlalchemy.dialect.TrinoDialect):
+            dialect_supported = True
+    except (AttributeError, TypeError):
+        pass
+
+
+    try:
+        if hasattr(dialect, "SnowflakeDialect"):
             dialect_supported = True
     except (AttributeError, TypeError):
         pass

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -2917,13 +2917,16 @@ def check_json_test_result(test, result, data_asset=None) -> None:
                         + str(result["result"]["unexpected_list"])
                     )
                 except AssertionError as e:
-                    if type(result["result"]["unexpected_list"][0]) == list:
-                        unexpected_list_tup = [
-                            tuple(x) for x in result["result"]["unexpected_list"]
-                        ]
-                        assert (
-                            unexpected_list_tup == value
-                        ), f"{unexpected_list_tup} != {value}"
+                    if result["result"]["unexpected_list"]:
+                        if type(result["result"]["unexpected_list"][0]) == list:
+                            unexpected_list_tup = [
+                                tuple(x) for x in result["result"]["unexpected_list"]
+                            ]
+                            assert (
+                                unexpected_list_tup == value
+                            ), f"{unexpected_list_tup} != {value}"
+                        else:
+                            raise
                     else:
                         raise
 

--- a/requirements-dev-all-contrib-expectations.txt
+++ b/requirements-dev-all-contrib-expectations.txt
@@ -27,6 +27,7 @@ pwnedpasswords
 py-moneyed
 pydnsbl
 pygeos
+pyogrio
 python-geohash
 python-stdnum
 pyvat

--- a/tests/expectations/test_run_diagnostics.py
+++ b/tests/expectations/test_run_diagnostics.py
@@ -44,9 +44,9 @@ def test_expectation_self_check():
             "docstring": "",
         },
         "execution_engines": {
-            "PandasExecutionEngine": True,
-            "SqlAlchemyExecutionEngine": True,
-            "SparkDFExecutionEngine": True,
+            "PandasExecutionEngine": False,
+            "SqlAlchemyExecutionEngine": False,
+            "SparkDFExecutionEngine": False,
         },
         "gallery_examples": [],
         "renderers": [

--- a/tests/test_definitions/column_aggregate_expectations/expect_column_mean_to_be_between.json
+++ b/tests/test_definitions/column_aggregate_expectations/expect_column_mean_to_be_between.json
@@ -167,7 +167,7 @@
             "success": true,
             "observed_value": 0.5
           },
-          "suppress_test_for": ["postgresql", "mssql", "spark", "bigquery", "trino"],
+          "suppress_test_for": ["postgresql", "mssql", "spark", "bigquery", "trino", "redshift", "snowflake"],
           "_comment": "postgresql, mssql, bigquery, and spark will not allow coercing the boolean type to an average"
         },
         {
@@ -182,7 +182,7 @@
             "success": true,
             "observed_value": 0.5
           },
-          "suppress_test_for": ["postgresql", "mssql", "bigquery", "spark", "trino"],
+          "suppress_test_for": ["postgresql", "mssql", "bigquery", "spark", "trino", "redshift", "snowflake"],
           "_comment": "postgresql, mssql, bigquery and spark will not allow coercing the boolean type to an average"
         },
         {

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_set.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_set.json
@@ -182,6 +182,9 @@
         "bigquery": {
           "empty_column": "STRING"
         },
+        "redshift": {
+          "empty_column": "VARCHAR"
+        },
         "trino": {
           "empty_column": "VARCHAR"
         }
@@ -218,6 +221,9 @@
       },
       "mssql": {
         "dates": "DATETIME"
+      },
+      "redshift": {
+        "dates": "TIMESTAMP"
       },
       "trino": {
         "dates": "TIMESTAMP"

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern.json
@@ -185,7 +185,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_exact_mostly_w_one_non_matching_value",
@@ -201,7 +201,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_column_name_has_space",
@@ -216,7 +216,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_sufficient_mostly_w_one_non_matching_value",
@@ -231,7 +231,7 @@
         "unexpected_index_list": [4],
         "unexpected_list": ["bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "negative_test_one_missing_value_and_insufficent_mostly",
@@ -246,7 +246,7 @@
         "unexpected_index_list": [3],
         "unexpected_list": ["bdd"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_one_missing_value_and_exact_mostly",
@@ -261,7 +261,7 @@
         "unexpected_index_list": [3],
         "unexpected_list": ["bdd"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_one_missing_value_and_sufficent_mostly",
@@ -276,7 +276,7 @@
         "unexpected_index_list": [3],
         "unexpected_list": ["bdd"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_all_missing_values",
@@ -290,7 +290,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_all_missing_values_mostly",
@@ -305,7 +305,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_match_characters_not_at_the_beginning_of_string",
@@ -320,7 +320,7 @@
         "unexpected_index_list": [0, 2, 3],
         "unexpected_list": ["aaa", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     }
    ]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern_list.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_match_like_pattern_list.json
@@ -121,7 +121,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title" : "positive_test_with_multiple_like_patternes",
@@ -136,7 +136,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title" : "positive_test_with_match_on__any",
@@ -151,7 +151,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title" : "positive_test_column_name_has_space_and_match_on__any",
@@ -166,7 +166,7 @@
         "unexpected_index_list": [],
         "success": true
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "snowflake", "redshift"]
     }
    ]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern.json
@@ -151,7 +151,7 @@
         "unexpected_index_list": [0, 1, 2, 3],
         "unexpected_list": ["aaa", "abb", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_exact_mostly_w_one_non_matching_value",
@@ -167,7 +167,7 @@
         "unexpected_index_list": [0, 1, 2, 3],
         "unexpected_list": ["aaa", "abb", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_sufficient_mostly_w_one_non_matching_value",
@@ -182,7 +182,7 @@
         "unexpected_index_list": [0, 1, 2, 3],
         "unexpected_list": ["aaa", "abb", "acc", "add"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "negative_test_one_missing_value_and_insufficent_mostly",
@@ -197,7 +197,7 @@
         "unexpected_index_list": [0, 1, 2],
         "unexpected_list": ["aaa", "abb", "acc"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_one_missing_value_no_exceptions",
@@ -211,7 +211,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_all_missing_values",
@@ -225,7 +225,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "positive_test_all_missing_values_mostly",
@@ -240,7 +240,7 @@
         "unexpected_index_list": [],
         "unexpected_list": []
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     },
     {
       "title": "negative_test_match_characters_not_at_the_beginning_of_string_exact_mostly",
@@ -255,7 +255,7 @@
         "unexpected_index_list": [1, 4],
         "unexpected_list": ["abb", "bee"]
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     }
    ]
   }]

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern_list.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_not_match_like_pattern_list.json
@@ -86,7 +86,7 @@
         "unexpected_index_list": [0,1,3,4,5,6,7,8],
         "success": false
       },
-      "only_for": ["sqlite", "postgresql", "mysql", "trino"]
+      "only_for": ["sqlite", "postgresql", "mysql", "trino", "bigquery", "snowflake", "redshift"]
     }
    ]
   }]

--- a/tests/test_definitions/test_expectations.py
+++ b/tests/test_definitions/test_expectations.py
@@ -92,7 +92,13 @@ def pytest_generate_tests(metafunc):
                             data_asset = datasets[0]
                         else:
                             schemas = d["schemas"] if "schemas" in d else None
-                            data_asset = get_dataset(c, d["data"], schemas=schemas)
+                            try:
+                                data_asset = get_dataset(c, d["data"], schemas=schemas)
+                            except Exception as e:
+                                print(
+                                    f"\n\nFor {repr(filename)} there was the following Exception\n\n{repr(e)}"
+                                )
+                                continue
 
                     for test in d["tests"]:
                         generate_test = True

--- a/tests/test_definitions/test_expectations_cfe.py
+++ b/tests/test_definitions/test_expectations_cfe.py
@@ -170,7 +170,7 @@ def pytest_generate_tests(metafunc):
                                     generate_test = True
                                 elif (
                                     "trino" in test["only_for"]
-                                    and BigQueryDialect is not None
+                                    and trinoDialect is not None
                                     and hasattr(
                                         validator_with_data.execution_engine.active_batch_data.sql_engine_dialect,
                                         "name",


### PR DESCRIPTION
**DON'T forget to undo the JSON file rename before merging**

Changes proposed in this pull request:
- Add pyogrio as a requirement for expect_column_values_to_be_polygon_area_between.py
- Use correct imported dialect in pytest_generate_tests func of test_expectations_cfe.py
- Update pytest_generate_tests func in test_expectation.py to not die if get_asset call fails
- Add expect_column_values_to_be_valid_arn to skip list in build_gallery.py
- Use Python 3.8 in expectation_gallery pipeline
- Before piping to tee with build_gallery.py, redirect error to stdout too
- Add support for match_like Expectations to redshift/snowflake/bigquery
- Add redshift/snowflake to suppress list on column_mean Expectation
- Update check_json_test_result func to make sure result['result']['unexpected_list'] isn't empty
- Add redshift schemas to some values_to_be_in_set Expectation tests
- Update get_dialect_regex_expression func to check for redshift another way
- Supppress mysql/bigquery tests on contrib expect_column_values_to_be_valid_scientific_notation
- Add a step to expectation_gallery pipeline that shows implemented engines
- Update run_diagnostics to log an error message if no _expectation_config is available
- Update _get_expectation_configuration_from_examples to fallback to trying any test input if None are success:True
- Update _get_execution_engine_diagnostics to not say all engines are implemented when metric_diagnostics_list is empty
- Change test title prefix from positive to negative for contrib exp not_contain_special_characters
- Update output in test_expectation_self_check
- Change how the coverage_score is calculated
- Add a prefix of Core/Contrib to exp_type in get_expectation_file_info_dict