### PR TITLE
 [BUGFIX] JSON Serialize RowCondition and MetricBundle computation result to enable IDDict.to_id() for SparkDFExecutionEngine

### DIFF
--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -17,7 +17,11 @@ from great_expectations.core.batch_spec import (
 )
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.metric_domain_types import MetricDomainTypes
-from great_expectations.core.util import AzureUrl, get_or_create_spark_application
+from great_expectations.core.util import (
+    AzureUrl,
+    convert_to_json_serializable,
+    get_or_create_spark_application,
+)
 from great_expectations.exceptions import (
     BatchSpecError,
     ExecutionEngineError,
@@ -657,7 +661,9 @@ Please check your config."""
             if not isinstance(compute_domain_kwargs, IDDict):
                 compute_domain_kwargs = IDDict(compute_domain_kwargs)
 
-            domain_id = compute_domain_kwargs.to_id()
+            domain_id = IDDict.convert_dictionary_to_id_dict(
+                data=convert_to_json_serializable(data=compute_domain_kwargs)
+            ).to_id()
             if domain_id not in aggregates:
                 aggregates[domain_id] = {
                     "column_aggregates": [],
@@ -688,6 +694,10 @@ Please check your config."""
 
             res = df.agg(*aggregate_cols).collect()
 
+            logger.debug(
+                f"SparkDFExecutionEngine computed {len(res[0])} metrics on domain_id {IDDict.convert_dictionary_to_id_dict(data=convert_to_json_serializable(data=domain_kwargs)).to_id()}"
+            )
+
             assert (
                 len(res) == 1
             ), "all bundle-computed metrics must be single-value statistics"
@@ -695,14 +705,14 @@ Please check your config."""
                 res[0]
             ), "unexpected number of metrics returned"
 
-            logger.debug(
-                f"SparkDFExecutionEngine computed {len(res[0])} metrics on domain_id {IDDict(domain_kwargs).to_id()}"
-            )
-
             idx: int
             metric_id: Tuple[str, str, str]
             for idx, metric_id in enumerate(aggregate["ids"]):
-                resolved_metrics[metric_id] = res[0][idx]
+                # Converting DataFrame.collect() results into JSON-serializable format produces simple data types,
+                # amenable for subsequent post-processing by higher-level "Metric" and "Expectation" layers.
+                resolved_metrics[metric_id] = convert_to_json_serializable(
+                    data=res[0][idx]
+                )
 
         return resolved_metrics
 

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1630,6 +1630,7 @@ def build_sa_engine(
     df: pd.DataFrame,
     sa: ModuleType,
     schema: Optional[str] = None,
+    batch_id: Optional[str] = None,
     if_exists: str = "fail",
     index: bool = False,
     dtype: Optional[dict] = None,
@@ -1655,8 +1656,11 @@ def build_sa_engine(
     )
     batch = Batch(data=batch_data)
 
+    if batch_id is None:
+        batch_id = batch.id
+
     execution_engine = SqlAlchemyExecutionEngine(
-        engine=sqlalchemy_engine, batch_data_dict={batch.id: batch_data}
+        engine=sqlalchemy_engine, batch_data_dict={batch_id: batch_data}
     )
 
     return execution_engine

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -391,10 +391,10 @@ def test_column_value_lengths_max_metric_spark(spark_session):
         metric_domain_kwargs={
             "column": "names",
         },
+        metric_value_kwargs=None,
         metric_dependencies={
             "table.columns": table_columns_metric,
         },
-        metric_value_kwargs=None,
     )
     results = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
 
@@ -5171,6 +5171,230 @@ def test_map_compound_columns_unique_pd():
     assert metrics[unexpected_values_metric.id] == [{"a": 1, "c": 2}, {"a": 1, "c": 2}]
 
 
+def test_map_compound_columns_unique_sa(sa):
+    engine = build_sa_engine(
+        pd.DataFrame(data={"a": [0, 1, 1], "b": [1, 2, 3], "c": [0, 2, 2]}),
+        sa,
+    )
+
+    metrics: dict = {}
+
+    table_columns_metric: MetricConfiguration
+    results: dict
+
+    table_columns_metric, results = get_table_columns_metric(engine=engine)
+    metrics.update(results)
+
+    """
+    Two tests:
+    1. Pass -- no duplicated compound column keys.
+    2. Fail -- one or more duplicated compound column keys.
+    """
+
+    # Save original metrics for testing unexpected results.
+    metrics_save: dict = copy.deepcopy(metrics)
+
+    prerequisite_function_metric_name: str = "compound_columns.count.map"
+
+    prerequisite_function_metric = MetricConfiguration(
+        metric_name=prerequisite_function_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "b"],
+        },
+        metric_value_kwargs=None,
+        metric_dependencies={
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(prerequisite_function_metric,),
+        metrics=metrics,
+    )
+    metrics.update(results)
+
+    metric_name: str = "compound_columns.unique"
+    condition_metric_name: str = f"{metric_name}.condition"
+    unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
+    unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
+    unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
+
+    # First, assert Pass (no unexpected results).
+
+    condition_metric = MetricConfiguration(
+        metric_name=condition_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "b"],
+        },
+        metric_value_kwargs=None,
+        metric_dependencies={
+            "compound_columns.count.map": prerequisite_function_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(condition_metric,),
+        metrics=metrics,
+    )
+    metrics.update(results)
+
+    unexpected_count_metric = MetricConfiguration(
+        metric_name=unexpected_count_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "b"],
+        },
+        metric_value_kwargs=None,
+        metric_dependencies={
+            "unexpected_condition": condition_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(unexpected_count_metric,), metrics=metrics
+    )
+    metrics.update(results)
+
+    # Condition metrics return SQLAlchemy ColumnElement object.
+    assert metrics[unexpected_count_metric.id] == 0
+
+    unexpected_rows_metric = MetricConfiguration(
+        metric_name=unexpected_rows_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "b"],
+        },
+        metric_value_kwargs={
+            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+        },
+        metric_dependencies={
+            "unexpected_condition": condition_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics
+    )
+    metrics.update(results)
+
+    assert len(metrics[unexpected_rows_metric.id]) == 0
+
+    unexpected_values_metric = MetricConfiguration(
+        metric_name=unexpected_values_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "b"],
+        },
+        metric_value_kwargs={
+            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+        },
+        metric_dependencies={
+            "unexpected_condition": condition_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(unexpected_values_metric,), metrics=metrics
+    )
+    metrics.update(results)
+
+    assert len(metrics[unexpected_values_metric.id]) == 0
+
+    # Restore from saved original metrics in order to start fresh on testing for unexpected results.
+    metrics = copy.deepcopy(metrics_save)
+
+    # Second, assert Fail (one or more unexpected results).
+
+    prerequisite_function_metric = MetricConfiguration(
+        metric_name=prerequisite_function_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "c"],
+        },
+        metric_value_kwargs=None,
+        metric_dependencies={
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(prerequisite_function_metric,),
+        metrics=metrics,
+    )
+    metrics.update(results)
+
+    condition_metric = MetricConfiguration(
+        metric_name=condition_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "c"],
+        },
+        metric_value_kwargs=None,
+        metric_dependencies={
+            "compound_columns.count.map": prerequisite_function_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(condition_metric,),
+        metrics=metrics,
+    )
+    metrics.update(results)
+
+    unexpected_count_metric = MetricConfiguration(
+        metric_name=unexpected_count_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "c"],
+        },
+        metric_value_kwargs=None,
+        metric_dependencies={
+            "unexpected_condition": condition_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(unexpected_count_metric,), metrics=metrics
+    )
+    metrics.update(results)
+
+    # Condition metrics return SQLAlchemy ColumnElement object.
+    assert metrics[unexpected_count_metric.id] == 2
+
+    unexpected_rows_metric = MetricConfiguration(
+        metric_name=unexpected_rows_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "c"],
+        },
+        metric_value_kwargs={
+            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+        },
+        metric_dependencies={
+            "unexpected_condition": condition_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics
+    )
+    metrics.update(results)
+
+    assert metrics[unexpected_rows_metric.id] == [(1, 2, 2), (1, 3, 2)]
+
+    unexpected_values_metric = MetricConfiguration(
+        metric_name=unexpected_values_metric_name,
+        metric_domain_kwargs={
+            "column_list": ["a", "c"],
+        },
+        metric_value_kwargs={
+            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
+        },
+        metric_dependencies={
+            "unexpected_condition": condition_metric,
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(unexpected_values_metric,), metrics=metrics
+    )
+    metrics.update(results)
+
+    assert len(metrics[unexpected_values_metric.id]) == 2
+    assert metrics[unexpected_values_metric.id] == [{"a": 1, "c": 2}, {"a": 1, "c": 2}]
+
+
 def test_map_compound_columns_unique_spark(spark_session):
     engine: SparkDFExecutionEngine = build_spark_engine(
         spark=spark_session,
@@ -5601,230 +5825,6 @@ def test_map_select_column_values_unique_within_record_pd():
         {"a": 1.0, "b": 1.0, "c": 2.0},
         {"a": 4.0, "b": 4.0, "c": 4.0},
     ]
-
-
-def test_map_compound_columns_unique_sa(sa):
-    engine = build_sa_engine(
-        pd.DataFrame(data={"a": [0, 1, 1], "b": [1, 2, 3], "c": [0, 2, 2]}),
-        sa,
-    )
-
-    metrics: dict = {}
-
-    table_columns_metric: MetricConfiguration
-    results: dict
-
-    table_columns_metric, results = get_table_columns_metric(engine=engine)
-    metrics.update(results)
-
-    """
-    Two tests:
-    1. Pass -- no duplicated compound column keys.
-    2. Fail -- one or more duplicated compound column keys.
-    """
-
-    # Save original metrics for testing unexpected results.
-    metrics_save: dict = copy.deepcopy(metrics)
-
-    prerequisite_function_metric_name: str = "compound_columns.count.map"
-
-    prerequisite_function_metric = MetricConfiguration(
-        metric_name=prerequisite_function_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "b"],
-        },
-        metric_value_kwargs=None,
-        metric_dependencies={
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(prerequisite_function_metric,),
-        metrics=metrics,
-    )
-    metrics.update(results)
-
-    metric_name: str = "compound_columns.unique"
-    condition_metric_name: str = f"{metric_name}.condition"
-    unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
-    unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
-    unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
-
-    # First, assert Pass (no unexpected results).
-
-    condition_metric = MetricConfiguration(
-        metric_name=condition_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "b"],
-        },
-        metric_value_kwargs=None,
-        metric_dependencies={
-            "compound_columns.count.map": prerequisite_function_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(condition_metric,),
-        metrics=metrics,
-    )
-    metrics.update(results)
-
-    unexpected_count_metric = MetricConfiguration(
-        metric_name=unexpected_count_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "b"],
-        },
-        metric_value_kwargs=None,
-        metric_dependencies={
-            "unexpected_condition": condition_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(unexpected_count_metric,), metrics=metrics
-    )
-    metrics.update(results)
-
-    # Condition metrics return SQLAlchemy ColumnElement object.
-    assert metrics[unexpected_count_metric.id] == 0
-
-    unexpected_rows_metric = MetricConfiguration(
-        metric_name=unexpected_rows_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "b"],
-        },
-        metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
-        },
-        metric_dependencies={
-            "unexpected_condition": condition_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics
-    )
-    metrics.update(results)
-
-    assert len(metrics[unexpected_rows_metric.id]) == 0
-
-    unexpected_values_metric = MetricConfiguration(
-        metric_name=unexpected_values_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "b"],
-        },
-        metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
-        },
-        metric_dependencies={
-            "unexpected_condition": condition_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(unexpected_values_metric,), metrics=metrics
-    )
-    metrics.update(results)
-
-    assert len(metrics[unexpected_values_metric.id]) == 0
-
-    # Restore from saved original metrics in order to start fresh on testing for unexpected results.
-    metrics = copy.deepcopy(metrics_save)
-
-    # Second, assert Fail (one or more unexpected results).
-
-    prerequisite_function_metric = MetricConfiguration(
-        metric_name=prerequisite_function_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "c"],
-        },
-        metric_value_kwargs=None,
-        metric_dependencies={
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(prerequisite_function_metric,),
-        metrics=metrics,
-    )
-    metrics.update(results)
-
-    condition_metric = MetricConfiguration(
-        metric_name=condition_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "c"],
-        },
-        metric_value_kwargs=None,
-        metric_dependencies={
-            "compound_columns.count.map": prerequisite_function_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(condition_metric,),
-        metrics=metrics,
-    )
-    metrics.update(results)
-
-    unexpected_count_metric = MetricConfiguration(
-        metric_name=unexpected_count_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "c"],
-        },
-        metric_value_kwargs=None,
-        metric_dependencies={
-            "unexpected_condition": condition_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(unexpected_count_metric,), metrics=metrics
-    )
-    metrics.update(results)
-
-    # Condition metrics return SQLAlchemy ColumnElement object.
-    assert metrics[unexpected_count_metric.id] == 2
-
-    unexpected_rows_metric = MetricConfiguration(
-        metric_name=unexpected_rows_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "c"],
-        },
-        metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
-        },
-        metric_dependencies={
-            "unexpected_condition": condition_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(unexpected_rows_metric,), metrics=metrics
-    )
-    metrics.update(results)
-
-    assert metrics[unexpected_rows_metric.id] == [(1, 2, 2), (1, 3, 2)]
-
-    unexpected_values_metric = MetricConfiguration(
-        metric_name=unexpected_values_metric_name,
-        metric_domain_kwargs={
-            "column_list": ["a", "c"],
-        },
-        metric_value_kwargs={
-            "result_format": {"result_format": "SUMMARY", "partial_unexpected_count": 3}
-        },
-        metric_dependencies={
-            "unexpected_condition": condition_metric,
-            "table.columns": table_columns_metric,
-        },
-    )
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(unexpected_values_metric,), metrics=metrics
-    )
-    metrics.update(results)
-
-    assert len(metrics[unexpected_values_metric.id]) == 2
-    assert metrics[unexpected_values_metric.id] == [{"a": 1, "c": 2}, {"a": 1, "c": 2}]
 
 
 def test_map_select_column_values_unique_within_record_sa(sa):


### PR DESCRIPTION
### Scope
Whenever an entity that is not yet serialized undergoes `IDDict().to_id()` operation, the `JSON` operation in the latter encounters an exception.  Hence, these `compute_domain_kwargs` need to be `JSON`-serialized first.  The problem does not manifest itself when `compute_domain_kwargs` contains only a single key (due to the way `IDDict` works).  Hence, one should always add a second key (e.g., `batch_id`) in order to test for such a circumstance.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1216
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!