### PR TITLE
[MAINTENANCE] increase the `pytest-timeout` timeout value during unit-testing step

### DIFF
--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -248,7 +248,7 @@ stages:
               pip install pytest-cov pytest-icdiff pytest-mock pytest-azurepipelines invoke
 
               # Run unit-tests
-              invoke tests --ci --cloud  --timeout=4.0
+              invoke tests --ci --cloud  --timeout=3.0
 
             displayName: 'Unit Tests'
 

--- a/azure-pipelines-dependency-graph-testing.yml
+++ b/azure-pipelines-dependency-graph-testing.yml
@@ -248,7 +248,7 @@ stages:
               pip install pytest-cov pytest-icdiff pytest-mock pytest-azurepipelines invoke
 
               # Run unit-tests
-              invoke tests --ci --cloud
+              invoke tests --ci --cloud  --timeout=4.0
 
             displayName: 'Unit Tests'
 


### PR DESCRIPTION
Changes proposed in this pull request:
- set a `--timeout` value of `3.0` seconds

@NathanFarmer noticed that the existing unit-tests are occasionally timing out.
Most of the time `2.0` is enough time but occasionally, the test setup and test function combine to be over 2.0 seconds.

`2.5` seconds would probably be enough of a buffer, but we can re-evaluate this settings after this sprint's unit-testing effort.



