### PR TITLE
[MAINTENANCE] Add test_expectation_suite_send_usage_message

### DIFF
--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -4,12 +4,12 @@ from copy import copy, deepcopy
 from typing import Any, Dict, List
 
 import pytest
-from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from ruamel.yaml import YAML
 
 from great_expectations import DataContext
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.expectation_suite import ExpectationSuite
+from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from great_expectations.util import filter_properties_dict
 
 
@@ -631,7 +631,7 @@ class DataContextSendUsageMessageSpy:
     [
         pytest.param(True, id="success=True"),
         pytest.param(False, id="success=False"),
-    ]
+    ],
 )
 def test_expectation_suite_send_usage_message(success: bool):
     """Ensure usage stats event is sent on expectation suite."""
@@ -639,9 +639,7 @@ def test_expectation_suite_send_usage_message(success: bool):
     dc_message_spy = DataContextSendUsageMessageSpy()
 
     suite = ExpectationSuite(
-        expectation_suite_name="warning",
-        expectations=[],
-        meta={"notes": "This is an expectation suite."},
+        expectation_suite_name="suite_name",
         data_context=dc_message_spy,
     )
 
@@ -654,5 +652,3 @@ def test_expectation_suite_send_usage_message(success: bool):
         "event_payload": {},
         "success": success,
     }
-
-

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -4,6 +4,7 @@ from copy import copy, deepcopy
 from typing import Any, Dict, List
 
 import pytest
+from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from ruamel.yaml import YAML
 
 from great_expectations import DataContext
@@ -603,3 +604,55 @@ def test_get_expectations_by_domain_type(
         exp4,
         column_pair_expectation,
     ]
+
+
+class DataContextSendUsageMessageSpy:
+    def __init__(self):
+        self.messages = []
+
+    def send_usage_message(
+        self,
+        event,
+        event_payload,
+        success,
+    ):
+        self.messages.append(
+            {
+                "event": event,
+                "event_payload": event_payload,
+                "success": success,
+            }
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "success",
+    [
+        pytest.param(True, id="success=True"),
+        pytest.param(False, id="success=False"),
+    ]
+)
+def test_expectation_suite_send_usage_message(success: bool):
+    """Ensure usage stats event is sent on expectation suite."""
+
+    dc_message_spy = DataContextSendUsageMessageSpy()
+
+    suite = ExpectationSuite(
+        expectation_suite_name="warning",
+        expectations=[],
+        meta={"notes": "This is an expectation suite."},
+        data_context=dc_message_spy,
+    )
+
+    suite.send_usage_event(success=success)
+
+    assert dc_message_spy.messages
+    assert len(dc_message_spy.messages) == 1
+    assert dc_message_spy.messages[0] == {
+        "event": UsageStatsEvents.EXPECTATION_SUITE_ADD_EXPECTATION.value,
+        "event_payload": {},
+        "success": success,
+    }
+
+


### PR DESCRIPTION
Changes proposed in this pull request:
- Add unit test for `ExpectationSuite.send_usage_message()`
- Showing a mock pattern using a mock/spy to ensure the right events are sent.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.