### PR TITLE
[MAINTENANCE] Mark existing tests as unit or integration

### DIFF
--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -237,6 +237,7 @@ def profiler_config():
     return yaml.load(yaml_config)
 
 
+@pytest.mark.unit
 def test_expectation_suite_equality(baseline_suite, identical_suite, equivalent_suite):
     """Equality should depend on all defined properties of a configuration object, but not on whether the *instances*
     are the same."""
@@ -250,6 +251,7 @@ def test_expectation_suite_equality(baseline_suite, identical_suite, equivalent_
     assert baseline_suite != equivalent_suite  # ne works properly
 
 
+@pytest.mark.unit
 def test_expectation_suite_equivalence(
     baseline_suite,
     identical_suite,
@@ -267,6 +269,7 @@ def test_expectation_suite_equivalence(
     assert not single_expectation_suite.isEquivalentTo(baseline_suite)
 
 
+@pytest.mark.unit
 def test_expectation_suite_dictionary_equivalence(baseline_suite):
     assert (
         baseline_suite.isEquivalentTo(
@@ -329,6 +332,7 @@ def test_expectation_suite_dictionary_equivalence(baseline_suite):
     )
 
 
+@pytest.mark.unit
 def test_expectation_suite_copy(baseline_suite):
     suite_copy = copy(baseline_suite)
     assert suite_copy == baseline_suite
@@ -342,6 +346,7 @@ def test_expectation_suite_copy(baseline_suite):
     )  # copy on deep attributes does propagate
 
 
+@pytest.mark.unit
 def test_expectation_suite_deepcopy(baseline_suite):
     suite_deepcopy = deepcopy(baseline_suite)
     assert suite_deepcopy == baseline_suite
@@ -354,6 +359,7 @@ def test_expectation_suite_deepcopy(baseline_suite):
     assert baseline_suite.expectations[0].meta["notes"] == "This is an expectation."
 
 
+@pytest.mark.integration
 def test_suite_without_metadata_includes_ge_version_metadata_if_none_is_provided(
     empty_data_context,
 ):
@@ -362,6 +368,7 @@ def test_suite_without_metadata_includes_ge_version_metadata_if_none_is_provided
     assert "great_expectations_version" in suite.meta.keys()
 
 
+@pytest.mark.integration
 def test_suite_does_not_overwrite_existing_version_metadata(empty_data_context):
     context: DataContext = empty_data_context
     suite = ExpectationSuite(
@@ -371,10 +378,12 @@ def test_suite_does_not_overwrite_existing_version_metadata(empty_data_context):
     assert suite.meta["great_expectations_version"] == "0.0.0"
 
 
+@pytest.mark.unit
 def test_suite_with_metadata_includes_ge_version_metadata(baseline_suite):
     assert "great_expectations_version" in baseline_suite.meta.keys()
 
 
+@pytest.mark.unit
 def test_add_citation(baseline_suite):
     assert (
         "citations" not in baseline_suite.meta
@@ -384,6 +393,7 @@ def test_add_citation(baseline_suite):
     assert baseline_suite.meta["citations"][0].get("comment") == "hello!"
 
 
+@pytest.mark.unit
 def test_add_citation_with_profiler_config(baseline_suite, profiler_config):
     assert (
         "citations" not in baseline_suite.meta
@@ -396,11 +406,13 @@ def test_add_citation_with_profiler_config(baseline_suite, profiler_config):
     assert baseline_suite.meta["citations"][0].get("profiler_config") == profiler_config
 
 
+@pytest.mark.unit
 def test_get_citations_with_no_citations(baseline_suite):
     assert "citations" not in baseline_suite.meta
     assert baseline_suite.get_citations() == []
 
 
+@pytest.mark.unit
 def test_get_citations_not_sorted(baseline_suite):
     assert "citations" not in baseline_suite.meta
 
@@ -423,6 +435,7 @@ def test_get_citations_not_sorted(baseline_suite):
     ]
 
 
+@pytest.mark.unit
 def test_get_citations_sorted(baseline_suite):
     assert "citations" not in baseline_suite.meta
 
@@ -454,6 +467,7 @@ def test_get_citations_sorted(baseline_suite):
     ]
 
 
+@pytest.mark.unit
 def test_get_citations_with_multiple_citations_containing_batch_kwargs(baseline_suite):
     assert "citations" not in baseline_suite.meta
 
@@ -488,6 +502,7 @@ def test_get_citations_with_multiple_citations_containing_batch_kwargs(baseline_
     ]
 
 
+@pytest.mark.unit
 def test_get_citations_with_multiple_citations_containing_profiler_config(
     baseline_suite, profiler_config
 ):
@@ -528,14 +543,17 @@ def test_get_citations_with_multiple_citations_containing_profiler_config(
     ]
 
 
+@pytest.mark.unit
 def test_get_table_expectations_returns_empty_list_on_empty_suite(empty_suite):
     assert empty_suite.get_table_expectations() == []
 
 
+@pytest.mark.unit
 def test_get_table_expectations_returns_empty_list_on_suite_without_any(baseline_suite):
     assert baseline_suite.get_table_expectations() == []
 
 
+@pytest.mark.unit
 def test_get_table_expectations(
     suite_with_table_and_column_expectations, table_exp1, table_exp2, table_exp3
 ):
@@ -543,10 +561,12 @@ def test_get_table_expectations(
     assert obs == [table_exp1, table_exp2, table_exp3]
 
 
+@pytest.mark.unit
 def test_get_column_expectations_returns_empty_list_on_empty_suite(empty_suite):
     assert empty_suite.get_column_expectations() == []
 
 
+@pytest.mark.unit
 def test_get_column_expectations(
     suite_with_table_and_column_expectations, exp1, exp2, exp3, exp4
 ):
@@ -554,6 +574,7 @@ def test_get_column_expectations(
     assert obs == [exp1, exp2, exp3, exp4]
 
 
+@pytest.mark.unit
 def test_get_expectations_by_expectation_type(
     suite_with_table_and_column_expectations,
     exp1,
@@ -580,6 +601,7 @@ def test_get_expectations_by_expectation_type(
     ]
 
 
+@pytest.mark.unit
 def test_get_expectations_by_domain_type(
     suite_with_table_and_column_expectations,
     exp1,


### PR DESCRIPTION
Changes proposed in this pull request:
- Mark existing tests in test_expectation_suite.py as unit or integration
- Two tests are marked as integration tests that use the data context incidentally, these are good examples of tests that can benefit from using a data context test double (in an upcoming PR).

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code