### PR TITLE
[BUGFIX] Resets static variable after use

### DIFF
--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -342,7 +342,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
                     "profiler_config": {
                         "name": self.name,
                         "config_version": self.config_version,
-                        "variables": convert_variables_to_dict(variables=self.variables),
+                        "variables": convert_variables_to_dict(
+                            variables=self.variables
+                        ),
                         "rules": effective_rules_configs,
                     },
                 },
@@ -912,7 +914,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
         try:
             original_config_rules = self._profiler_config.rules
             rule: Rule
-            self._profiler_config.rules = {rule.name: rule.to_json_dict() for rule in rules}
+            self._profiler_config.rules = {
+                rule.name: rule.to_json_dict() for rule in rules
+            }
             yield
         finally:
             self._profiler_config.rules = original_config_rules

--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -1311,8 +1311,10 @@ def test_default_profiler_config_unchanged_after_custom_profiler_config_used(
 
     assert "profiler_config" not in default_profiler_result.expectation_config.kwargs
     assert "profiler_config" in default_profiler_result.expectation_config.meta
-    assert default_profiler_result.expectation_config.meta["profiler_config"] != custom_profiler_result.expectation_config.meta["profiler_config"]
-
+    assert (
+        default_profiler_result.expectation_config.meta["profiler_config"]
+        != custom_profiler_result.expectation_config.meta["profiler_config"]
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -160,6 +160,7 @@ def quentin_validator(
 
 
 @pytest.mark.slow  # 1.15s
+@pytest.mark.integration
 def test_alice_columnar_table_single_batch_batches_are_accessible(
     alice_columnar_table_single_batch_context,
     alice_columnar_table_single_batch,
@@ -215,6 +216,7 @@ def test_alice_columnar_table_single_batch_batches_are_accessible(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @pytest.mark.slow  # 2.31s
+@pytest.mark.integration
 def test_alice_profiler_user_workflow_single_batch(
     mock_emit,
     caplog,
@@ -406,6 +408,7 @@ def test_alice_profiler_user_workflow_single_batch(
 
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 1.39s
+@pytest.mark.integration
 def test_alice_expect_column_values_to_match_regex_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     alice_validator: Validator,
 ) -> None:
@@ -434,6 +437,7 @@ def test_alice_expect_column_values_to_match_regex_auto_yes_default_profiler_con
 
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 1.33s
+@pytest.mark.integration
 def test_alice_expect_column_values_to_not_match_regex_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     alice_validator: Validator,
 ) -> None:
@@ -464,6 +468,7 @@ def test_alice_expect_column_values_to_not_match_regex_auto_yes_default_profiler
 
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 1.38s
+@pytest.mark.integration
 def test_alice_expect_column_values_to_match_stftime_format_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     alice_validator: Validator,
 ) -> None:
@@ -494,6 +499,7 @@ def test_alice_expect_column_values_to_match_stftime_format_auto_yes_default_pro
 
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 1.26s
+@pytest.mark.integration
 def test_alice_expect_column_value_lengths_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     alice_validator: Validator,
 ) -> None:
@@ -527,6 +533,7 @@ def test_alice_expect_column_value_lengths_to_be_between_auto_yes_default_profil
 
 # noinspection PyUnusedLocal
 @pytest.mark.slow  # 1.16s
+@pytest.mark.integration
 def test_bobby_columnar_table_multi_batch_batches_are_accessible(
     monkeypatch,
     bobby_columnar_table_multi_batch_deterministic_data_context,
@@ -604,6 +611,7 @@ def test_bobby_columnar_table_multi_batch_batches_are_accessible(
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @pytest.mark.slow  # 13.08s
+@pytest.mark.integration
 def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_column_ranges_rule_quantiles_estimator(
     mock_emit,
     caplog,
@@ -877,6 +885,7 @@ def test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_colum
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     bobby_validator: Validator,
@@ -993,6 +1002,7 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_yes(
     bobby_columnar_table_multi_batch_deterministic_data_context,
@@ -1216,6 +1226,7 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 def test_default_profiler_config_unchanged_after_custom_profiler_config_used(
     quentin_validator: Validator,
@@ -1308,6 +1319,7 @@ def test_default_profiler_config_unchanged_after_custom_profiler_config_used(
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_config_no_custom_profiler_config_yes(
     bobby_columnar_table_multi_batch_deterministic_data_context,
@@ -1576,6 +1588,7 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @pytest.mark.slow  # 4.83s
+@pytest.mark.integration
 def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstrap_estimator(
     mock_emit,
     caplog,
@@ -1702,6 +1715,7 @@ def test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstr
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 4.24s
 def test_bobster_expect_table_row_count_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
@@ -1724,6 +1738,7 @@ def test_bobster_expect_table_row_count_to_be_between_auto_yes_default_profiler_
     reason="requires numpy version 1.21.0 or newer",
 )
 @pytest.mark.slow  # 2.02s
+@pytest.mark.integration
 def test_quentin_expect_expect_table_columns_to_match_set_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
     quentin_validator: Validator,
 ):
@@ -1785,6 +1800,7 @@ def test_quentin_expect_expect_table_columns_to_match_set_auto_yes_default_profi
     "great_expectations.core.usage_statistics.usage_statistics.UsageStatisticsHandler.emit"
 )
 @pytest.mark.slow  # 15.07s
+@pytest.mark.integration
 def test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule(
     mock_emit,
     caplog,
@@ -1931,6 +1947,7 @@ def test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule(
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.40s
 def test_quentin_expect_column_quantile_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_yes(
@@ -2114,6 +2131,7 @@ def test_quentin_expect_column_quantile_values_to_be_between_auto_yes_default_pr
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.15s
 def test_quentin_expect_column_values_to_be_in_set_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
@@ -2156,6 +2174,7 @@ def test_quentin_expect_column_values_to_be_in_set_auto_yes_default_profiler_con
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 3.44s
 def test_quentin_expect_column_min_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
@@ -2197,6 +2216,7 @@ def test_quentin_expect_column_min_to_be_between_auto_yes_default_profiler_confi
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.12s
 def test_quentin_expect_column_max_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
@@ -2263,6 +2283,7 @@ def test_quentin_expect_column_max_to_be_between_auto_yes_default_profiler_confi
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.24s
 def test_quentin_expect_column_unique_value_count_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
@@ -2317,6 +2338,7 @@ def test_quentin_expect_column_unique_value_count_to_be_between_auto_yes_default
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.67s
 def test_quentin_expect_column_proportion_of_unique_values_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
@@ -2374,6 +2396,7 @@ def test_quentin_expect_column_proportion_of_unique_values_to_be_between_auto_ye
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.26s
 def test_quentin_expect_column_sum_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(
@@ -2431,6 +2454,7 @@ def test_quentin_expect_column_sum_to_be_between_auto_yes_default_profiler_confi
     version.parse(np.version.version) < version.parse("1.21.0"),
     reason="requires numpy version 1.21.0 or newer",
 )
+@pytest.mark.integration
 @freeze_time(TIMESTAMP)
 @pytest.mark.slow  # 2.29s
 def test_quentin_expect_column_stdev_to_be_between_auto_yes_default_profiler_config_yes_custom_profiler_config_no(


### PR DESCRIPTION
This fixes https://superconductive.atlassian.net/browse/GREAT-1127. We currently update a default static variable but don't reset it after use leading to bug and flaky tests.

I new test was added to specifically test this case which I took from @NathanFarmer 's comment in the ticket above.
I've also labeled all the tests in this file as integration tests.

When looking at the diff you may want to ignore whitespace since most of the changes are indentation from the context manager's `with` statement.

Additionally, I have run the modified test file in random order 21 times and it passes. Previously it would fail due to this bug.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
