### PR TITLE
[MAINTENANCE] Adding serialization tests for Spark

### DIFF
--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 from decimal import Decimal
+from typing import Dict, Iterable, Tuple
 
 import pandas as pd
 import pytest
@@ -12,10 +13,17 @@ from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.data_context.types.base import (
     AbstractConfig,
+    AssetConfig,
     CheckpointConfig,
     CheckpointValidationConfig,
+    DataConnectorConfig,
+    DatasourceConfig,
+    ExecutionEngineConfig,
+    ExecutionEngineConfigSchema,
     checkpointConfigSchema,
+    datasourceConfigSchema,
 )
+from great_expectations.execution_engine import SparkDFExecutionEngine
 from great_expectations.util import (
     deep_filter_properties_iterable,
     filter_properties_dict,
@@ -693,6 +701,134 @@ def test_checkpoint_config_and_nested_objects_are_serialized(
     observed_load = CheckpointConfig(**loaded_data)
     assert checkpointConfigSchema.dump(observed_load) == checkpointConfigSchema.dump(
         checkpoint_config
+    )
+
+
+@pytest.mark.unit
+def test_checkpoint_config_and_nested_objects_are_serialized_spark(spark_session):
+    """
+    Why was this test split out?
+
+    This test is split out from test_checkpoint_config_and_nested_objects_are_serialized because it has
+    an additional dependency on spark_session, which we dont want to impose on the rest of the tests
+    """
+    checkpoint_config: CheckpointConfig = CheckpointConfig(
+        name="my_nested_checkpoint",
+        config_version=1,
+        template_name="my_nested_checkpoint_template",
+        expectation_suite_name="users.delivery",
+        validations=[
+            CheckpointValidationConfig(
+                batch_request={
+                    "datasource_name": "my_datasource",
+                    "data_connector_name": "my_data_connector",
+                    "data_asset_name": "users",
+                    "data_connector_query": {"partition_index": -1},
+                    "batch_spec_passthrough": {"reader_options": {"header": True}},
+                },
+                id="06871341-f028-4f1f-b8e8-a559ab9f62e1",
+            ),
+        ],
+    )
+    expected_serialized_checkpoint_config: dict = {
+        "action_list": [],
+        "batch_request": {},
+        "class_name": "Checkpoint",
+        "config_version": 1.0,
+        "evaluation_parameters": {},
+        "expectation_suite_ge_cloud_id": None,
+        "expectation_suite_name": "users.delivery",
+        "ge_cloud_id": None,
+        "module_name": "great_expectations.checkpoint",
+        "name": "my_nested_checkpoint",
+        "profilers": [],
+        "run_name_template": None,
+        "runtime_configuration": {},
+        "template_name": "my_nested_checkpoint_template",
+        "validations": [
+            {
+                "batch_request": {
+                    "data_asset_name": "users",
+                    "data_connector_name": "my_data_connector",
+                    "data_connector_query": {
+                        "partition_index": -1,
+                    },
+                    "batch_spec_passthrough": {"reader_options": {"header": True}},
+                    "datasource_name": "my_datasource",
+                },
+                "id": "06871341-f028-4f1f-b8e8-a559ab9f62e1",
+            },
+        ],
+    }
+
+    """CheckpointConfig and nested objects like CheckpointValidationConfig should be serialized appropriately with/without optional params."""
+    observed_dump = checkpointConfigSchema.dump(checkpoint_config)
+    assert observed_dump == expected_serialized_checkpoint_config
+
+    loaded_data = checkpointConfigSchema.load(observed_dump)
+    observed_load = CheckpointConfig(**loaded_data)
+    assert checkpointConfigSchema.dump(observed_load) == checkpointConfigSchema.dump(
+        checkpoint_config
+    )
+
+
+def test_serialization_of_datasource_with_nested_objects_spark(spark_session):
+    conf: Iterable[Tuple[str, str]] = spark_session.sparkContext.getConf().getAll()
+    datasource_config: DatasourceConfig = DatasourceConfig(
+        name="taxi_data",
+        class_name="Datasource",
+        module_name="great_expectations.datasource",
+        execution_engine=ExecutionEngineConfig(
+            class_name="SparkDFExecutionEngine",
+            module_name="great_expectations.execution_engine.sparkdf_execution_engine",
+        ),
+        data_connectors={
+            "configured_asset_connector": DataConnectorConfig(
+                class_name="ConfiguredAssetFilesystemDataConnector",
+                module_name="great_expectations.datasource.data_connector.configured_asset_filesystem_data_connector",
+                assets={
+                    "my_asset": AssetConfig(
+                        class_name="Asset",
+                        module_name="great_expectations.datasource.data_connector.asset",
+                        batch_spec_passthrough={
+                            "reader_options": {"header": True},
+                        },
+                    )
+                },
+            )
+        },
+    )
+    expected_serialized_datasource_config: dict = {
+        "data_connectors": {
+            "configured_asset_connector": {
+                "assets": {
+                    "my_asset": {
+                        "batch_spec_passthrough": {"reader_options": {"header": True}},
+                        "class_name": "Asset",
+                        "module_name": "great_expectations.datasource.data_connector.asset",
+                    }
+                },
+                "class_name": "ConfiguredAssetFilesystemDataConnector",
+                "module_name": "great_expectations.datasource.data_connector.configured_asset_filesystem_data_connector",
+            }
+        },
+        "execution_engine": {
+            "class_name": "SparkDFExecutionEngine",
+            "module_name": "great_expectations.execution_engine.sparkdf_execution_engine",
+        },
+        "module_name": "great_expectations.datasource",
+        "class_name": "Datasource",
+        "name": "taxi_data",
+    }
+
+    """DatasourceConfigSchema and nested objects like schema appropriately with/without optional params."""
+    observed_dump = datasourceConfigSchema.dump(obj=datasource_config)
+    assert observed_dump == expected_serialized_datasource_config
+
+    loaded_data = datasourceConfigSchema.load(observed_dump)
+    observed_load = DatasourceConfig(**loaded_data)
+    assert checkpointConfigSchema.dump(observed_load) == checkpointConfigSchema.dump(
+        datasource_config
     )
 
 

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -701,7 +701,7 @@ def test_checkpoint_config_and_nested_objects_are_serialized(
     )
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_checkpoint_config_and_nested_objects_are_serialized_spark(spark_session):
     """
     Why was this test split out?
@@ -769,6 +769,7 @@ def test_checkpoint_config_and_nested_objects_are_serialized_spark(spark_session
     )
 
 
+@pytest.mark.integration
 def test_serialization_of_datasource_with_nested_objects_spark(spark_session):
     datasource_config: DatasourceConfig = DatasourceConfig(
         name="taxi_data",

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -821,7 +821,6 @@ def test_serialization_of_datasource_with_nested_objects_spark(spark_session):
         "name": "taxi_data",
     }
 
-    """DatasourceConfigSchema and nested objects like schema appropriately with/without optional params."""
     observed_dump = datasourceConfigSchema.dump(obj=datasource_config)
     assert observed_dump == expected_serialized_datasource_config
 

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 from decimal import Decimal
-from typing import Dict, Iterable, Tuple
 
 import pandas as pd
 import pytest
@@ -19,11 +18,9 @@ from great_expectations.data_context.types.base import (
     DataConnectorConfig,
     DatasourceConfig,
     ExecutionEngineConfig,
-    ExecutionEngineConfigSchema,
     checkpointConfigSchema,
     datasourceConfigSchema,
 )
-from great_expectations.execution_engine import SparkDFExecutionEngine
 from great_expectations.util import (
     deep_filter_properties_iterable,
     filter_properties_dict,
@@ -773,7 +770,6 @@ def test_checkpoint_config_and_nested_objects_are_serialized_spark(spark_session
 
 
 def test_serialization_of_datasource_with_nested_objects_spark(spark_session):
-    conf: Iterable[Tuple[str, str]] = spark_session.sparkContext.getConf().getAll()
     datasource_config: DatasourceConfig = DatasourceConfig(
         name="taxi_data",
         class_name="Datasource",


### PR DESCRIPTION

Changes proposed in this pull request:
- 2 tests added to `test_serialization` for serializing objects with `SparkDFExecutionEngine`.
- 1 is a `Checkpoint` test
- 1 is a `Datasource` test
- Both will be set-up for allowing the serialization to happen automatically with a spark schema object


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
