### PR TITLE
[MAINTENANCE] `SqlAlchemyExecutionEngine` case for SQL Alchemy `Select` and `TextualSelect` due to `SADeprecationWarning`

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -87,7 +87,7 @@ try:
         TextClause,
         quoted_name,
     )
-    from sqlalchemy.sql.selectable import Select
+    from sqlalchemy.sql.selectable import Select, TextualSelect
 except ImportError:
     BooleanClauseList = None
     DefaultDialect = None
@@ -99,6 +99,7 @@ except ImportError:
     Select = None
     Selectable = None
     TextClause = None
+    TextualSelect = None
     quoted_name = None
 
 
@@ -965,7 +966,9 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                             selectable.columns().subquery()
                         )
                     ).fetchall()
-                elif Select and isinstance(selectable, Select):
+                elif (Select and isinstance(selectable, Select)) or (
+                    TextualSelect and isinstance(selectable, TextualSelect)
+                ):
                     res = self.engine.execute(
                         sa.select(query["select"]).select_from(selectable.subquery())
                     ).fetchall()

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -87,17 +87,19 @@ try:
         TextClause,
         quoted_name,
     )
+    from sqlalchemy.sql.selectable import Select
 except ImportError:
-    Row = None
-    Dialect = None
-    reflection = None
-    DefaultDialect = None
-    Selectable = None
     BooleanClauseList = None
+    DefaultDialect = None
+    Dialect = None
+    Label = None
+    OperationalError = None
+    reflection = None
+    Row = None
+    Select = None
+    Selectable = None
     TextClause = None
     quoted_name = None
-    OperationalError = None
-    Label = None
 
 
 try:
@@ -962,6 +964,10 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
                         sa.select(query["select"]).select_from(
                             selectable.columns().subquery()
                         )
+                    ).fetchall()
+                elif Select and isinstance(selectable, Select):
+                    res = self.engine.execute(
+                        sa.select(query["select"]).select_from(selectable.subquery())
                     ).fetchall()
                 else:
                     res = self.engine.execute(


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-761/GREAT-1174
- Add case for `sa.sql.selectable.Select` and `sa.sql.selectable.TextualSelect` due to `SADeprecationWarning` regarding coercion of SELECT and textual SELECT constructs into FROM clauses.

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
