### PR TITLE
[MAINTENANCE] Remove xfails from passing tests in preparation for 0.15.21 release

### DIFF
--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -203,11 +203,6 @@ def test_profiler_save_with_new_profiler_retrieves_obj_with_id_from_store(
     assert return_profiler.ge_cloud_id == profiler_id
 
 
-@pytest.mark.xfail(
-    reason="GX Cloud E2E tests are currently failing due to env vars not being recognized by Docker; xfailing for purposes of the 0.15.20 release",
-    run=True,
-    strict=True,
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -590,11 +590,6 @@ def test_cloud_data_context_variables_successfully_hits_cloud_endpoint(
     assert success is True
 
 
-@pytest.mark.xfail(
-    reason="GX Cloud E2E tests are currently failing due to env vars not being recognized by Docker; xfailing for purposes of the 0.15.20 release",
-    run=True,
-    strict=True,
-)
 @pytest.mark.e2e
 @pytest.mark.cloud
 @mock.patch("great_expectations.data_context.DataContext._save_project_config")


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove xfail from now-passing tests


### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
