### PR TITLE
[FEATURE] DataAssistants Example Notebook - Spark

### DIFF
--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
@@ -1,0 +1,1215 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "834eb3b0",
+   "metadata": {},
+   "source": [
+    "# How to use `DataAssistants`\n",
+    "\n",
+    "* A `DataAssistant` enables you to quickly profile your data by providing a thin API over a pre-constructed `RuleBasedProfiler` configuration.\n",
+    "* As a result of the profiling, you get back a result object consisting of \n",
+    "    * `Metrics` that describe the current state of the data\n",
+    "    * `Expectations` that are able to alert you if the data deviates from the expected state in the future. \n",
+    "    \n",
+    "* `DataAssistant` results can also be plotted to help you understand their data visually.\n",
+    "* There are multiple `DataAssistants` centered around a theme (volume, nullity etc), and this notebook walks you through an example `OnboardingDataAssistant`, which is the most general and extensive `DataAssistant`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26b3aab6",
+   "metadata": {},
+   "source": [
+    "The `OnboardingDataAssistant` is considered to be the \"starting point\" for profiling and is generally applicable for numerical, categorial, or datetime data.  In our example we will be using `taxi_trip` data, building our `ExpectationSuite` using data from 2019, and validating the Suite on January 2020 data, to see if our more-recent data falls within the range of previous months.\n",
+    "\n",
+    "In our example, the `OnboardingDataAssistant` will take in a `batch_request` describing data from 2019 and calculating upper and lower bounds for the following `Expectations` across the sample `Batches`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8362d4be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import great_expectations as ge\n",
+    "from great_expectations.core.batch import BatchRequest\n",
+    "from great_expectations.core import ExpectationSuite\n",
+    "from great_expectations.core.expectation_configuration import ExpectationConfiguration\n",
+    "from great_expectations.validator.validator import Validator\n",
+    "from great_expectations.rule_based_profiler.data_assistant import (\n",
+    "    DataAssistant,\n",
+    "    VolumeDataAssistant,\n",
+    ")\n",
+    "from great_expectations.rule_based_profiler.data_assistant_result import (\n",
+    "    VolumeDataAssistantResult,\n",
+    ")\n",
+    "from typing import List\n",
+    "from ruamel import yaml\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36ce18b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import great_expectations as ge\n",
+    "from ruamel import yaml\n",
+    "from great_expectations.core.batch import BatchRequest\n",
+    "import logging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1df5289b",
+   "metadata": {},
+   "source": [
+    "### Example Directory\n",
+    "\n",
+    "Imagine we have a directory of 24 csv files, each corresponding to 1 month of NYC taxi rider data from 2019 to 2020.\n",
+    "\n",
+    "```\n",
+    "\n",
+    "yellow_tripdata_sample_2019-01.csv\n",
+    "yellow_tripdata_sample_2019-02.csv\n",
+    "yellow_tripdata_sample_2019-03.csv\n",
+    "yellow_tripdata_sample_2019-04.csv\n",
+    "yellow_tripdata_sample_2019-05.csv\n",
+    "yellow_tripdata_sample_2019-06.csv\n",
+    "yellow_tripdata_sample_2019-07.csv\n",
+    "yellow_tripdata_sample_2019-08.csv\n",
+    "yellow_tripdata_sample_2019-09.csv\n",
+    "yellow_tripdata_sample_2019-10.csv\n",
+    "yellow_tripdata_sample_2019-11.csv\n",
+    "yellow_tripdata_sample_2019-12.csv\n",
+    "yellow_tripdata_sample_2020-01.csv\n",
+    "yellow_tripdata_sample_2020-02.csv\n",
+    "yellow_tripdata_sample_2020-03.csv\n",
+    "yellow_tripdata_sample_2020-04.csv\n",
+    "yellow_tripdata_sample_2020-05.csv\n",
+    "yellow_tripdata_sample_2020-06.csv\n",
+    "yellow_tripdata_sample_2020-07.csv\n",
+    "yellow_tripdata_sample_2020-08.csv\n",
+    "yellow_tripdata_sample_2020-09.csv\n",
+    "yellow_tripdata_sample_2020-10.csv\n",
+    "yellow_tripdata_sample_2020-11.csv\n",
+    "yellow_tripdata_sample_2020-12.csv\n",
+    "\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fdc0ab6",
+   "metadata": {},
+   "source": [
+    "## Set-up: Importing `pyspark`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bd176ee",
+   "metadata": {},
+   "source": [
+    "* Great Expectations contains a helper util function called `get_or_create_spark_application()` which can be used to begin a `SparkSession`.\n",
+    "* You can also create your own `SparkSession` if you prefer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44ea10d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from pyspark.sql import SparkSession\n",
+    "except ImportError:\n",
+    "    logger.debug(\n",
+    "        \"Unable to load spark context; install optional spark dependency for support.\"\n",
+    "    )\n",
+    "    \n",
+    "from great_expectations.core.util import get_or_create_spark_application\n",
+    "spark: SparkSession = get_or_create_spark_application()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d33c07eb",
+   "metadata": {},
+   "source": [
+    "## Set-up: Importing Data and Setting up `schema`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73533fff",
+   "metadata": {},
+   "source": [
+    "In order for `DataAssistants` to accurately configure Expectations for your data, there may be a need to explicitly define a `schema` as a `StructType()`. \n",
+    "\n",
+    "In the case of `taxi_data`, using `inferSchema` to detect the column types will result in an inaccurate detection of `timestamp`. Notice that `pickup_datetime` and `dropoff_datetime` columns are defined as `string`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4680225f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_name: str = \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ecc3faa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = spark.read.format(\"csv\").option(\"inferSchema\",True).option(\"header\", True).load(file_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03fa3702",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0038c32",
+   "metadata": {},
+   "source": [
+    "* To ensure that `DataAssistants` are able to correctly configure Expectations for `timestamp` columns, we will define our `schema` explicitly using the following code. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27407161",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql.types import StructType, StructField, StringType, IntegerType, TimestampType"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df8c81ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql.types import StructType,StructField, StringType, IntegerType, DoubleType, TimestampType\n",
+    "\n",
+    "schema: StructType = StructType([\n",
+    "    StructField(\"vendor_id\",IntegerType(),True),\n",
+    "    StructField(\"pickup_datetime\",TimestampType(),True), \n",
+    "    StructField(\"dropoff_datetime\",TimestampType(),True),\n",
+    "    StructField(\"passenger_count\",IntegerType(),True),\n",
+    "    StructField(\"trip_distance\", DoubleType(),True),\n",
+    "    StructField(\"rate_code_id\", IntegerType(),True),\n",
+    "    StructField(\"store_and_fwd_flag\", StringType(),True),\n",
+    "    StructField(\"pickup_location_id\", IntegerType(),True),\n",
+    "    StructField(\"dropoff_location_id\", IntegerType(),True),\n",
+    "    StructField(\"payment_type\", IntegerType(),True),\n",
+    "    StructField(\"fare_amount\", DoubleType(),True),\n",
+    "    StructField(\"extra\", DoubleType(),True),\n",
+    "    StructField(\"mta_tax\", DoubleType(),True),\n",
+    "    StructField(\"tip_amount\", DoubleType(),True),\n",
+    "    StructField(\"tolls_amount\", DoubleType(),True),\n",
+    "    StructField(\"improvement_surcharge\", DoubleType(),True),\n",
+    "    StructField(\"total_amount\", DoubleType(),True),\n",
+    "    StructField(\"congestion_surcharge\", DoubleType(),True),\n",
+    "  ])\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247a6073",
+   "metadata": {},
+   "source": [
+    "## Set-up: Adding `taxi_data` `Datasource`\n",
+    "In our example, we add a `Datasource` named `taxi_data` with 2 data_assets, `yellow_tripdata_2019` and `yellow_tripdata_2020`\n",
+    "\n",
+    "Here is the output, which shows each data asset : `yellow_tripdata_sample_2019` and `yellow_tripdata_sample_2020` with 12 batches, each associated with a different filename. These become our `batch_identifiers` that distinguish one `Batch` from another.\n",
+    "\n",
+    "```bash\n",
+    "\n",
+    "Data Connectors:\n",
+    "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetFilesystemDataConnector\n",
+    "\tAvailable data_asset_names (2 of 2):\n",
+    "\t\tyellow_tripdata_2019 (3 of 12): ['yellow_tripdata_sample_2019-01.csv', 'yellow_tripdata_sample_2019-02.csv', 'yellow_tripdata_sample_2019-03.csv']\n",
+    "\t\tyellow_tripdata_2020 (3 of 12): ['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-02.csv', 'yellow_tripdata_sample_2020-03.csv']\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d731942e",
+   "metadata": {},
+   "source": [
+    "**Where do we pass in the `schema`?**\n",
+    "\n",
+    "The `schema` defined above, along with other options for `spark.read()` function, can be passed in through the `batch_spec_passthrough` parameter. \n",
+    "\n",
+    "The `batch_spec_passthrough` parameter can either be defined at the\n",
+    "- `DataConnector`-level\n",
+    "- `Asset`-level \n",
+    "- `BatchRequest`-level.\n",
+    "\n",
+    "\n",
+    "And can be used to pass in `reader_method` (`csv`), or `reader_options` like (`header = True`)\n",
+    "\n",
+    "```python\n",
+    "\"batch_spec_passthrough\":{\n",
+    "    \"reader_method\": \"csv\",\n",
+    "    \"reader_options\":{\n",
+    "        \"header\": True,\n",
+    "        \"schema\": schema # the schema we defined earlier\n",
+    "    }\n",
+    "```\n",
+    "\n",
+    "For our example we will be defining the `batch_spec_passthrough` parameter at the `BatchRequest`-level meaning we won't be including it at the `DataConnector`-level or `Asset`-level (which require an additional step). Those configurations can be found in the **Appendix** below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76dcee57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context: ge.DataContext = ge.get_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a29fd9a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_path: str = \"../../../../test_sets/taxi_yellow_tripdata_samples\"\n",
+    "\n",
+    "datasource_config: dict = {\n",
+    "    \"name\": \"taxi_data\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SparkDFExecutionEngine\",\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"assets\":{\n",
+    "                \"yellow_tripdata_2019\":{\n",
+    "                    \"group_names\": [\"year\", \"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_(2019)-(\\\\d.*)\\\\.csv\",\n",
+    "                },\n",
+    "                \"yellow_tripdata_2020\":{\n",
+    "                    \"group_names\": [\"year\", \"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_(2020)-(\\\\d.*)\\\\.csv\",\n",
+    "                }\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee0be5a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_datasource only if it doesn't already exist in our configuration\n",
+    "try:\n",
+    "    data_context.get_datasource(datasource_config[\"name\"])\n",
+    "except ValueError:\n",
+    "    data_context.add_datasource(**datasource_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4aa73e4",
+   "metadata": {},
+   "source": [
+    "#  Configure `BatchRequest`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61e86821",
+   "metadata": {},
+   "source": [
+    "In this example, we will be using a `BatchRequest` that will return all 12 batches of data from the `yellow_tripdata_sample_2019_data` table.  We will refer to the `Datasource` and `DataConnector` configured in the previous step. \n",
+    "\n",
+    "We also include the `batch_spec_passthrough` parameter with the `reader_method` and `reader_options` defined. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b790e8b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_data\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_2019\",\n",
+    "    batch_spec_passthrough={\n",
+    "                        \"reader_method\": \"csv\",\n",
+    "                        \"reader_options\":{\n",
+    "                            \"header\": True,\n",
+    "                            \"schema\": schema\n",
+    "                        }\n",
+    "                    },\n",
+    "    \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da5b6cf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_request: BatchRequest = multi_batch_batch_request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f09894b-8b27-4159-ad7c-ea786b9da396",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d564f515-ff0d-4218-b568-542e83fa6f2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list # len = 12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9a38c3a",
+   "metadata": {},
+   "source": [
+    "# Run the `VolumeDataAssistant`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c1b2796",
+   "metadata": {},
+   "source": [
+    "* The `VolumeDataAssistant` can be run directly from the `DataContext` by specifying `assistants` and `onboarding`, and passing in the `BatchRequest` from the previous step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0cf15e6",
+   "metadata": {},
+   "source": [
+    "**Note**: In the simplest way that we can run this is just by passing in our `batch_request` from our previous step, which corresponds to 2019 data. The appendix will show how the run can be further configured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f1460a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = data_context.assistants.onboarding.run(batch_request=multi_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7608bf80",
+   "metadata": {},
+   "source": [
+    "If you would like to see the `ExpectationSuite` that was generated, then you can run the `get_expectation_suite()` method on the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80345d4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_suite = result.get_expectation_suite(expectation_suite_name=\"temp_suite\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6646fd0b",
+   "metadata": {},
+   "source": [
+    "# Explore `DataAssistantResult` by plotting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21c28857",
+   "metadata": {},
+   "source": [
+    "The resulting `DataAssistantResult` can be explored by Plotting. The `plot_metrics()` function will plot the statistical metrics, and `plot_expectations_and_metrics()` will plot the generated min and max values overlayed on the statistical metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd4c66e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.plot_metrics()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03353ac8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.plot_expectations_and_metrics()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0437017f",
+   "metadata": {},
+   "source": [
+    "# Save `ExpectationSuite`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "090b0dbc",
+   "metadata": {},
+   "source": [
+    "Next, we can save the `ExpectationConfiguration` object resulting from the `DataAssistant` by:\n",
+    "\n",
+    "1. Creating an `ExpecationSuite`, which is `taxi_data_2019_suite` in our example\n",
+    "2. Adding `ExpectationConfiguration` to the `ExpectationSuite`\n",
+    "3. Saving the `ExpectationSuite` using `DataContext`'s `save_expectation_suite()` method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4db1dfc-defd-4b83-bc65-0e77ccd67cd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "suite: ExpectationSuite = ExpectationSuite(expectation_suite_name=\"taxi_data_2019_suite\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eaf5d924-1c10-4eab-b6ed-2063d0a73871",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resulting_configurations: List[ExpectationConfiguration] = suite.add_expectation_configurations(expectation_configurations=result.expectation_configurations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9426227a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context.save_expectation_suite(expectation_suite=suite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e916a0f-f68a-4221-a66a-5f9919bfa538",
+   "metadata": {},
+   "source": [
+    "#  Running Checkpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26b1550b",
+   "metadata": {},
+   "source": [
+    "Finally, we want to take the `ExpectationSuite` that was automatically generated by the `DataAssistant` and use it to validate some new data. As part of the set up, we trained our Expectations based on our 2019 data, and we are running the validation on one month of data from 2020, namely January. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cd07f43-53ce-4a32-8e03-d0e2322ecc42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_data\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_2020\",\n",
+    "        data_connector_query={ \n",
+    "        \"batch_filter_parameters\": {\"year\": \"2020\", \"month\": \"01\"}},\n",
+    "    batch_spec_passthrough={\n",
+    "            \"reader_method\": \"csv\",\n",
+    "            \"reader_options\":{\n",
+    "                \"header\": True,\n",
+    "                \"schema\": schema,\n",
+    "        }\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65ab5c11-9716-4a39-88df-6f805d65eca1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f5c4c37-684b-4b94-b0ea-2ae7dec1884d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list[0].batch_definition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62c3153f",
+   "metadata": {},
+   "source": [
+    "Our `SimpleCheckpoint` configuration includes our `batch_request` and `ExpectationSuiteName` (which is `taxi_data_suite` in our example. \n",
+    "\n",
+    "We also include the `UpdateDataDocsAction`, so we can visualize the results of our Checkpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40c540fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checkpoint_config: dict = {\n",
+    "    \"name\": \"my_checkpoint\",\n",
+    "    \"config_version\": 1,\n",
+    "    \"class_name\": \"SimpleCheckpoint\",\n",
+    "    \"validations\": [\n",
+    "        {\n",
+    "            \"batch_request\": single_batch_batch_request,\n",
+    "            \"expectation_suite_name\": \"taxi_data_2019_suite\",\n",
+    "        }\n",
+    "    ],\n",
+    "     \"action_list\":[\n",
+    "            {\n",
+    "                \"name\": \"update_data_docs\",\n",
+    "                \"action\": {\n",
+    "                    \"class_name\": \"UpdateDataDocsAction\",\n",
+    "                },\n",
+    "            },\n",
+    "        ],\n",
+    "}\n",
+    "data_context.add_checkpoint(**checkpoint_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a718ee2-1971-495e-8113-8704752fd3c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context.add_checkpoint(**checkpoint_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42a4d45d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = data_context.run_checkpoint(\n",
+    "    checkpoint_name=\"my_checkpoint\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10a18e22",
+   "metadata": {},
+   "source": [
+    "### Examine results by looking at DataDocs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b353ea25",
+   "metadata": {},
+   "source": [
+    "As you can see the results of the `Checkpoint` were not successful, which means the January 2020 data did not fall within the ranges predicted by the 2019 data. To examine this more closely, you can [open Data Docs here](great_expectations/uncommitted/data_docs/local_site/index.html). If the link doesn't work, from the location where this Notebook is located, you can go to `great_expectations/uncommitted/data_docs/local_site/index.html`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfc2cc49-cd02-44db-9079-d0baed7ffe73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results.success"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ef7f096-5b28-4a0a-81c1-829d57c9be23",
+   "metadata": {},
+   "source": [
+    "# Appendix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eff94a73-740a-4a1d-b5cc-636ae6226cb5",
+   "metadata": {},
+   "source": [
+    "## What Expectation are included in the `OnboardingDataAssistant`?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e597e3e3",
+   "metadata": {},
+   "source": [
+    "The `OnboardingDataAssistant` is built with the following `Rules` that are run internally by the `RuleBasedProfiler`. \n",
+    "\n",
+    "- `TableRule`\n",
+    "- `Column Uniqueness and Nullity Rules`\n",
+    "- `NumericColumnRule`\n",
+    "- `DateColumnRule`\n",
+    "- `TextColumnRule`\n",
+    "- `CategoricalColumnRule`\n",
+    "\n",
+    "\n",
+    "#### Table Rule\n",
+    "This Rule will take the data as a table and try to calculate the following parameter values for Expectations across batches that we pass in. \n",
+    "\n",
+    "* `expect_table_row_count_to_be_between`: \n",
+    "    - `min_value` : maximum threshold for table row count.\n",
+    "    - `max_value` : minimum threshold for table row count.\n",
+    "* `expect_table_columns_to_match_set`:\n",
+    "    - `column_set`: Either a list or set of strings, that describe the columns of the Table\n",
+    "    - `exact_match`: Boolean (default=True) which determines whether the list of columns must exactly match the observed columns. \n",
+    "    \n",
+    "#### Column Uniqueness and Nullity\n",
+    "This is not a `Rule` in the strictest sense, but the `DataAssistant` will generate `ExpectationConfigurations` for the following `Expectations` for each column in our data. \n",
+    "\n",
+    "* `expect_column_values_to_be_unique`\n",
+    "* `expect_column_values_to_be_null`\n",
+    "* `expect_column_values_to_not_be_null`\n",
+    " \n",
+    "They each take 2 parameters. `column`, which is the name of the column being validated, and `mostly`, which is an optional `float` value between `0` and `1` which specifies the fraction of values that match the expectation. Default for the `DataAssistant` is `1.0`. \n",
+    "\n",
+    "#### NumericColumnRule\n",
+    "The `NumericColumnRule` will calculate the `min_value` and `max_value` for the following expectations. \n",
+    "\n",
+    "* `expect_column_min_to_be_between`\n",
+    "* `expect_column_max_to_be_between`\n",
+    "* `expect_column_values_to_be_between`\n",
+    "* `expect_column_median_to_be_between`\n",
+    "* `expect_column_mean_to_be_between`\n",
+    "* `expect_column_stdev_to_be_between`\n",
+    "\n",
+    "By default the estimation will be done by the `exact` estimator by default, which takes in the values across all Batches in the batch list (in our example 12 months of data from 2019).\n",
+    "\n",
+    "If you do `data_assistant.run()` with the `estimator` parameter set to `drop_outliers` then `bootstrapping` will be done done behind-the-scenes to estimate outliers.\n",
+    "\n",
+    "The parameters for `bootstrapping` are:\n",
+    "\n",
+    "* `n_resamples` : It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.htm\n",
+    "\n",
+    "* `false_positive_rate`: A user-configured fraction between 0 and 1 expressing desired false positive rate for\n",
+    "    identifying unexpected values as judged by the upper- and lower- quantiles of the observed metric data. Set by default to be `0.05`.\n",
+    "* `random_seed`: Seed for randomization. If omitted (which is the default), then we use `np.random.choice`. otherwise, we use `np.random.Generator(np.random.PCG64(random_seed))`.\n",
+    "* `round_decimals`: A user-configured non-negative integer indicating the number of decimals of\n",
+    "    rounding precision of the computed parameter values (i.e., `min_value`, `max_value`) prior to packaging them\n",
+    "    on output. For `NumericColumnRule` the default is `15` which means calculations are done 15 digits after the decimal point.\n",
+    "* `mostly`: is `1.0` by default\n",
+    "* `strict_min` and `strict_max` are `False`, and these are parameters that determine whether the minimum proportion of unique values must be strictly smaller than max or min value.\n",
+    "* `truncate_values`:  User-configured directive for whether or not to allow the computed parameter values (i.e.,`lower_bound`, `upper_bound`) to take on values outside the specified bounds when packaged on output\n",
+    "* `allow_relative_error`:  Whether to allow relative error in quantile communications on backends that support or require it.\n",
+    "\n",
+    "In addition, the `expect_column_quantile_values_to_be_between` Expectation takes in the following parameters: \n",
+    "\n",
+    "* `quantiles` : Quantiles and associated value ranges for the column, with the default being`[0.25, 0.5, 0.75]`\n",
+    "* `quantile_statistic_interpolation_method`: which is used when estimating quantile values. Recognized values include `auto`, `nearest`, and `linear`. (default is `nearest`).\n",
+    "* `quantile_bias_correction`: Used when determining whether to correct for quantile bias. Recognized values are `True` and  `False` with default being `False`.\n",
+    "* `quantile_bias_std_error_ratio_threshold`: If omitted\n",
+    "    (default), then 0.25 is used (as minimum ratio of bias to standard error for applying bias correction).\n",
+    "* `include_estimator_samples_histogram_in_details`: Determines whether the estimator samples are included in the results. (default is `False`).\n",
+    "  \n",
+    "\n",
+    "#### DateColumnRules\n",
+    "The `DateColumnRule` will take a `datetime` column and calculate the `min_value` and `max_value` for the following Expectations.\n",
+    "\n",
+    "* `expect_column_min_to_be_between`\n",
+    "* `expect_column_max_to_be_between`\n",
+    "* `expect_column_values_to_be_between`\n",
+    "\n",
+    "Estimation will be done using the `exact` estimator by default, but if you select `drop_outliers` then `bootstrapping` will use the following parameters: \n",
+    "\n",
+    "* `n_resamples` : For bootstrapping. It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.htm\n",
+    "* `false_positive_rate`: user-configured fraction between 0 and 1 expressing desired false positive rate for\n",
+    "    identifying unexpected values as judged by the upper- and lower- quantiles of the observed metric data. Default is `0.05`.\n",
+    "* `random_seed`: Seed for randomization. If omitted (which is the default), then we use `np.random.choice`. otherwise, we use `np.random.Generator(np.random.PCG64(random_seed))`.\n",
+    "* `round_decimals` A user-configured non-negative integer indicating the number of decimals of the\n",
+    "    rounding precision of the computed parameter values (i.e., `min_value`, `max_value`) prior to packaging them\n",
+    "    on output. Default for `DateColumnRules` is  `1` which means calculations are done 1 digit after the decimal point\n",
+    "\n",
+    "\n",
+    "#### TextColumnsRule\n",
+    "\n",
+    "The `TextColumnRule` will generate parameters for the following 2 `Expectations`.\n",
+    "\n",
+    "* `expect_column_value_lengths_to_be_between`\n",
+    "* `expect_column_values_to_match_regex`\n",
+    "\n",
+    "For `expect_column_value_lengths_to_be_between` will have the parameters `min_value` and `max_value` estimated. \n",
+    "\n",
+    "Estimation will be done using the `exact` estimator by default, but if you select `drop_outliers` then the following parameters are set by default for `bootstrap` estimation\n",
+    "\n",
+    "* `n_resamples` : For bootstrapping. It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.htm\n",
+    "* `false_positive_rate`: user-configured fraction between 0 and 1 expressing desired false positive rate for\n",
+    "    identifying unexpected values as judged by the upper- and lower- quantiles of the observed metric data. Default is `0.05`.\n",
+    "* `random_seed`: Seed for randomization. If omitted (which is the default), then we use `np.random.choice`. otherwise, we use `np.random.Generator(np.random.PCG64(random_seed))`.\n",
+    "* `round_decimals` A user-configured non-negative integer indicating the number of decimals of the\n",
+    "    rounding precision of the computed parameter values (i.e., `min_value`, `max_value`) prior to packaging them\n",
+    "    on output. Default for `TextColumnRule` is  `0` which means calculations are done to the nearest integer.\n",
+    "    \n",
+    "For `expect_column_values_to_match_regex`, the values in the column be matched against a candidate list of common `regex` values which were built from the following sources: \n",
+    "\n",
+    "   - [20 Most Common Regular Expressions](https://regexland.com/most-common-regular-expressions/)\n",
+    "   - [Stackoverflow on how to test for valid uuid](https://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid/13653180#13653180)\n",
+    "\n",
+    "* This is the regex list used by the `TextColumnsRule`.\n",
+    "\n",
+    "```python\n",
+    "CANDIDATE_REGEX: Set[str] = {\n",
+    "    r\"\\d+\",  # whole number with 1 or more digits\n",
+    "    r\"-?\\d+\",  # negative whole numbers\n",
+    "    r\"-?\\d+(?:\\.\\d*)?\",  # decimal numbers with . (period) separator\n",
+    "    r\"[A-Za-z0-9\\.,;:!?()\\\"'%\\-]+\",  # general text\n",
+    "    r\"^\\s+\",  # leading space\n",
+    "    r\"\\s+$\",  # trailing space\n",
+    "    r\"https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b(?:[-a-zA-Z0-9@:%_\\+.~#()?&//=]*)\",  # Matching URL (including http(s) protocol)\n",
+    "    r\"<\\/?(?:p|a|b|img)(?: \\/)?>\",  # HTML tags\n",
+    "    r\"(?:25[0-5]|2[0-4]\\d|[01]\\d{2}|\\d{1,2})(?:.(?:25[0-5]|2[0-4]\\d|[01]\\d{2}|\\d{1,2})){3}\",  # IPv4 IP address\n",
+    "    r\"(?:[A-Fa-f0-9]){0,4}(?: ?:? ?(?:[A-Fa-f0-9]){0,4}){0,7}\",  # IPv6 IP address,\n",
+    "    r\"\\b[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}-[0-5][0-9a-fA-F]{3}-[089ab][0-9a-fA-F]{3}-\\b[0-9a-fA-F]{12}\\b \",  # UUID\n",
+    "    }\n",
+    "```\n",
+    "\n",
+    "**Note**: The above list can be found in the [great_expectations repo here](https://github.com/great-expectations/great_expectations/blob/da2376b613843844afc041538269bb7683444b1f/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py#L38)\n",
+    "\n",
+    "#### CategoricalColumnsRule\n",
+    "\n",
+    "The CategoricalColumnsRule will generate parameters for the following 3 Expectations:\n",
+    "\n",
+    "* `expect_column_values_to_be_in_set`\n",
+    "* `expect_column_unique_value_count_to_be_between`\n",
+    "* `expect_column_proportion_of_unique_values_to_be_between`\n",
+    "\n",
+    "\n",
+    "Categorical columns are determined to be ones that meet a certain cardinality threshold. This prevents us from calculating the number of `unique` value in a column with millions of rows, with each value being slightly different from another (which is theoretically possible). \n",
+    "\n",
+    "Great Expectations gets around this by only building the unique value set for columns that have less than a certain number of unique values, which is determined by the cardinality threshold. The default threshold is `FEW` which means Great Expectations will generate parameters for `expect_column_values_to_be_in_set()` for columns where the number of unique values are less than or equal to 100. \n",
+    "\n",
+    "Other values for cardinality values include: \n",
+    "\n",
+    "```python \n",
+    "ZERO = AbsoluteCardinalityLimit(\"ZERO\", 0)\n",
+    "ONE = AbsoluteCardinalityLimit(\"ONE\", 1)\n",
+    "TWO = AbsoluteCardinalityLimit(\"TWO\", 2)\n",
+    "VERY_FEW = AbsoluteCardinalityLimit(\"VERY_FEW\", 10)\n",
+    "FEW = AbsoluteCardinalityLimit(\"FEW\", 100)\n",
+    "SOME = AbsoluteCardinalityLimit(\"SOME\", 1000)\n",
+    "MANY = AbsoluteCardinalityLimit(\"MANY\", 10000)\n",
+    "VERY_MANY = AbsoluteCardinalityLimit(\"VERY_MANY\", 100000)\n",
+    "UNIQUE = RelativeCardinalityLimit(\"UNIQUE\", 1.0)\n",
+    "\n",
+    "... # and more\n",
+    "```\n",
+    "\n",
+    "The full list of cardinality values used by Great Expectations can be found in the [great_expectations repo here](https://github.com/great-expectations/great_expectations/blob/da2376b613843844afc041538269bb7683444b1f/great_expectations/rule_based_profiler/helpers/cardinality_checker.py#L55). \n",
+    "\n",
+    "The three Expectations each have their own parameters\n",
+    "\n",
+    "`expect_column_values_to_be_in_set` requires `column` (column name) and `value_set`, which is calculated for all columns that meet the cardinality threshold. \n",
+    "\n",
+    "`expect_column_unique_value_count_to_be_between` has `column` (column name) and `min_value` and `max_value`.\n",
+    "\n",
+    "Estimation will be done using the `exact` estimator by default, but if you select `drop_outliers` then the following parameters are set by default for `bootstrap` estimation\n",
+    "\n",
+    "* `n_resamples` : For bootstrapping. It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.htm\n",
+    "* `false_positive_rate`: user-configured fraction between 0 and 1 expressing desired false positive rate for\n",
+    "    identifying unexpected values as judged by the upper- and lower- quantiles of the observed metric data. Default is `0.05`.\n",
+    "* `random_seed`: Seed for randomization. If omitted (which is the default), then we use `np.random.choice`. otherwise, we use `np.random.Generator(np.random.PCG64(random_seed))`.\n",
+    "\n",
+    "`expect_column_proportion_of_unique_values_to_be_between` has the following parameters\n",
+    "   \n",
+    "* `column`: column name\n",
+    "* `min_value`:  minimum proportion of unique values, ranging from 0 to 1\n",
+    "* `max_value`:  minimum proportion of unique values, ranging from 0 to 1\n",
+    "* `strict_min`: determine whether the minimum proportion of unique values must be strictly greater than min value, with the `default=False`\n",
+    "*`strict_max`: determine whether the minimum proportion of unique values must be strictly smaller than max value, with the `default=False`\n",
+    "\n",
+    "Estimation will be done using the `exact` estimator by default, but if you select `drop_outliers` then the following parameters are set by default for `bootstrap` estimation\n",
+    "\n",
+    "* `n_resamples` : For bootstrapping. It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.htm\n",
+    "* `false_positive_rate`: user-configured fraction between 0 and 1 expressing desired false positive rate for\n",
+    "    identifying unexpected values as judged by the upper- and lower- quantiles of the observed metric data. Default is `0.05`.\n",
+    "* `random_seed`: Seed for randomization. If omitted (which is the default), then then we use `np.random.choice`. otherwise, we use `np.random.Generator(np.random.PCG64(random_seed))`.\n",
+    "* `round_decimals`: A user-configured non-negative integer indicating the number of decimals of the\n",
+    "    rounding precision of the computed parameter values (i.e., `min_value`, `max_value`) prior to packaging them\n",
+    "    on output. For `CategoricalColumnsRule` the default is `15` which means calculations are done 15 digits after the decimal point.\n",
+    "* `mostly`: is `1.0` by default\n",
+    "* `strict_min` and `strict_max` are `False`, and these are parameters that determine whether the minimum proportion of unique values must be strictly smaller than max or min value.\n",
+    "* `truncate_values`:  User-configured directive for whether or not to allow the computed parameter values (i.e.,`lower_bound`, `upper_bound`) to take on values outside the specified bounds when packaged on output\n",
+    "* `allow_relative_error`:  Whether to allow relative error in quantile communications on backends that support or require it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaaca746",
+   "metadata": {},
+   "source": [
+    "# Adjusting `DataAssistant` Parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9946defb",
+   "metadata": {},
+   "source": [
+    "Now that you can run the profiler, you may want more control over the specifics of how the `DataAssistant` is run. \n",
+    "\n",
+    "The first major parameter that you may want to set is is `estimation`, which you will be inputting directly into the `run()` method.\n",
+    "\n",
+    "* if set to `flag_outliers` then the DataAssistant will use `bootstrapping` on the Batches returned by the `batch_request` to estimate outliers. The parameters will be `n_resamples`, `false_positive` rate etc with more details in the above section above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d61fa54a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the following code will run the onboarding assistant with bootstrapping\n",
+    "data_context.assistants.onboarding.run(batch_request=single_batch_batch_request, estimation=\"flag_outliers\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4aac5be3",
+   "metadata": {},
+   "source": [
+    "Now what if you need more granular control? For instance, how would you set the `cardinality_threshold` for the CategoricalColumnsRule. First you can see the full list of parameters that are passed into the DataAssistant by calling the `run` directly, with no parameters. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a406851d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context.assistants.onboarding.run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c8edb40",
+   "metadata": {},
+   "source": [
+    "If you look closely at the output, you will see that it is broken up into `rules` with one of the rules being the `categorical_columns_rule`. You'll see that it is type hinted as a `dict`. With parameters like `cardinality_limit_mode`, `mostly`, etc. \n",
+    "\n",
+    "```python\n",
+    "categorical_columns_rule = {\n",
+    "     'cardinality_limit_mode': 'FEW',\n",
+    "     'mostly': 1.0,\n",
+    "     'strict_min': False, \n",
+    "     'strict_max': False, \n",
+    "     'false_positive_rate': 0.05, \n",
+    "     'estimator': 'bootstrap', \n",
+    "     'n_resamples': 9999,\n",
+    "     'random_seed': None, \n",
+    "     'quantile_statistic_interpolation_method': 'nearest', \n",
+    "     'quantile_bias_correction': False, \n",
+    "     'quantile_bias_std_error_ratio_threshold': None,\n",
+    "     'include_estimator_samples_histogram_in_details': False, \n",
+    "     'truncate_values': {\n",
+    "     'lower_bound': 0.0,\n",
+    "       'upper_bound': None\n",
+    "     }, \n",
+    "    'round_decimals': 15\n",
+    "  }\n",
+    "\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9993a59",
+   "metadata": {},
+   "source": [
+    "If you copy the dictionary and set the key-value pair you are interested in, then `categorical_columns_rule` can be passed into the `assistants.onboarding.run()` method as a dictionary. \n",
+    "\n",
+    "In the following example we have set the `cardinality_limit_mode` from `FEW` to `VERY_MANY`. The remaining parameters can either be kept or commented out. Both calls below will work. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12d40c77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# this will work \n",
+    "data_context.assistants.onboarding.run(\n",
+    "          batch_request=multi_batch_batch_request,\n",
+    "          categorical_columns_rule = {\n",
+    "              'cardinality_limit_mode': 'VERY_MANY',\n",
+    "             #'mostly': 1.0,\n",
+    "             #'strict_min': False, \n",
+    "             #'strict_max': False, \n",
+    "             #'false_positive_rate': 0.05, \n",
+    "             #'estimator': 'bootstrap', \n",
+    "             #'n_resamples': 9999,\n",
+    "             #'random_seed': None, \n",
+    "             #'quantile_statistic_interpolation_method': 'nearest', \n",
+    "             #'quantile_bias_correction': False, \n",
+    "             #'quantile_bias_std_error_ratio_threshold': None,\n",
+    "             #'include_estimator_samples_histogram_in_details': False, \n",
+    "             #'truncate_values': {\n",
+    "             #    'lower_bound': 0.0,\n",
+    "             #   'upper_bound': None\n",
+    "             #}, \n",
+    "             #'round_decimals': 15\n",
+    "          }\n",
+    "    )\n",
+    "\n",
+    "# and so will this \n",
+    "data_context.assistants.onboarding.run(\n",
+    "          batch_request=multi_batch_batch_request,\n",
+    "          categorical_columns_rule = {\n",
+    "              'cardinality_limit_mode': 'VERY_MANY',\n",
+    "          }\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "788358ff",
+   "metadata": {},
+   "source": [
+    "# Alternate configurations of `batch_spec_passthrough` "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35b04f19",
+   "metadata": {},
+   "source": [
+    "As mentioned in the previous section, options for `spark.read()` function, can be passed in through the `batch_spec_passthrough` parameter.\n",
+    "\n",
+    "The `batch_spec_passthrough` parameter can either be defined at the\n",
+    "\n",
+    "- `DataConnector`-level\n",
+    "- `Asset`-level\n",
+    "- `BatchRequest`-level.\n",
+    "\n",
+    "And can be used to pass in `reader_method` (csv), or `reader_options` like (`header = True`)\n",
+    "\n",
+    "```python\n",
+    "\"batch_spec_passthrough\":{\n",
+    "    \"reader_method\": \"csv\",\n",
+    "    \"reader_options\":{\n",
+    "        \"header\": True,\n",
+    "        \"schema\": schema # the schema we defined earlier\n",
+    "    }\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f0d1045",
+   "metadata": {},
+   "source": [
+    "When loading in a `Datasource` configuration through ` data_context.add_datasource(**datasource_config)`, we need to serialize the `schema` by calling the `jsonValue()` function of the `StructType` object [More information here](https://spark.apache.org/docs/3.1.3/api/python/reference/api/pyspark.sql.types.StructType.html#pyspark.sql.types.StructType.jsonValue)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e9cd53a",
+   "metadata": {},
+   "source": [
+    "### `batch_spec_passthrough` defined at the `DataConnector`-level"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ede6c598",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasource_config: dict = {\n",
+    "    \"name\": \"taxi_data\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SparkDFExecutionEngine\",\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"batch_spec_passthrough\":{\n",
+    "                        \"reader_method\": \"csv\",\n",
+    "                        \"reader_options\":{\n",
+    "                            \"header\": True,\n",
+    "                            \"schema\": schema.jsonValue() \n",
+    "                        }\n",
+    "                    },\n",
+    "            \"assets\":{\n",
+    "                \"yellow_tripdata_2019\":{\n",
+    "                    \"group_names\": [\"year\", \"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_(2019)-(\\\\d.*)\\\\.csv\",\n",
+    "                },\n",
+    "                \"yellow_tripdata_2020\":{\n",
+    "                    \"group_names\": [\"year\", \"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_(2020)-(\\\\d.*)\\\\.csv\",\n",
+    "                }\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "}\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf0c440",
+   "metadata": {},
+   "source": [
+    "### `batch_spec_passthrough` defined at the `Asset`-level"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80e7d330",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasource_config: dict = {\n",
+    "    \"name\": \"taxi_data\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SparkDFExecutionEngine\",\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetFilesystemDataConnector\",\n",
+    "            \"base_directory\": data_path,\n",
+    "            \"assets\":{\n",
+    "                \"yellow_tripdata_2019\":{\n",
+    "                    \"group_names\": [\"year\", \"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_(2019)-(\\\\d.*)\\\\.csv\",\n",
+    "                },\n",
+    "                \"yellow_tripdata_2020\":{\n",
+    "                    \"group_names\": [\"year\", \"month\"],\n",
+    "                    \"pattern\": \"yellow_tripdata_sample_(2020)-(\\\\d.*)\\\\.csv\",\n",
+    "                     \"batch_spec_passthrough\":{\n",
+    "                        \"reader_method\": \"csv\",\n",
+    "                        \"reader_options\":{\n",
+    "                            \"header\": True,\n",
+    "                            \"schema\": schema.jsonValue()\n",
+    "                        }\n",
+    "                    },\n",
+    "                }\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "}\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
@@ -28,10 +28,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "8362d4be",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/snowflake/connector/options.py:94: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<3.1.0,>=3.0.0; extra == \"pandas\"'\n",
+      "  warn_incompatible_dep(\n"
+     ]
+    }
+   ],
    "source": [
     "import great_expectations as ge\n",
     "from great_expectations.core.batch import BatchRequest\n",
@@ -47,19 +56,6 @@
     ")\n",
     "from typing import List\n",
     "from ruamel import yaml\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "36ce18b6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import great_expectations as ge\n",
-    "from ruamel import yaml\n",
-    "from great_expectations.core.batch import BatchRequest\n",
-    "import logging"
    ]
   },
   {
@@ -110,6 +106,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e26983f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install findspark"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "2bd176ee",
    "metadata": {},
@@ -120,20 +126,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "44ea10d3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    from pyspark.sql import SparkSession\n",
-    "except ImportError:\n",
-    "    logger.debug(\n",
-    "        \"Unable to load spark context; install optional spark dependency for support.\"\n",
-    "    )\n",
-    "    \n",
-    "from great_expectations.core.util import get_or_create_spark_application\n",
-    "spark: SparkSession = get_or_create_spark_application()"
+    "import findspark\n",
+    "import pyspark\n",
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "findspark.init()\n",
+    "spark: SparkSession = SparkSession \\\n",
+    "    .builder \\\n",
+    "    .appName(\"Python Spark SQL basic example\") \\\n",
+    "    .config(\"spark.some.config.option\", \"some-value\") \\\n",
+    "    .getOrCreate()"
    ]
   },
   {
@@ -156,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "4680225f",
    "metadata": {},
    "outputs": [],
@@ -166,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "3ecc3faa",
    "metadata": {},
    "outputs": [],
@@ -176,10 +183,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "03fa3702",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- vendor_id: integer (nullable = true)\n",
+      " |-- pickup_datetime: string (nullable = true)\n",
+      " |-- dropoff_datetime: string (nullable = true)\n",
+      " |-- passenger_count: integer (nullable = true)\n",
+      " |-- trip_distance: double (nullable = true)\n",
+      " |-- rate_code_id: integer (nullable = true)\n",
+      " |-- store_and_fwd_flag: string (nullable = true)\n",
+      " |-- pickup_location_id: integer (nullable = true)\n",
+      " |-- dropoff_location_id: integer (nullable = true)\n",
+      " |-- payment_type: integer (nullable = true)\n",
+      " |-- fare_amount: double (nullable = true)\n",
+      " |-- extra: double (nullable = true)\n",
+      " |-- mta_tax: double (nullable = true)\n",
+      " |-- tip_amount: double (nullable = true)\n",
+      " |-- tolls_amount: double (nullable = true)\n",
+      " |-- improvement_surcharge: double (nullable = true)\n",
+      " |-- total_amount: double (nullable = true)\n",
+      " |-- congestion_surcharge: double (nullable = true)\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "res.printSchema()"
    ]
@@ -194,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "27407161",
    "metadata": {},
    "outputs": [],
@@ -204,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "df8c81ec",
    "metadata": {},
    "outputs": [],
@@ -286,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "76dcee57",
    "metadata": {},
    "outputs": [],
@@ -296,10 +330,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "a29fd9a3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SparkDFExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetFilesystemDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_2019 (3 of 12): ['yellow_tripdata_sample_2019-01.csv', 'yellow_tripdata_sample_2019-02.csv', 'yellow_tripdata_sample_2019-03.csv']\n",
+      "\t\tyellow_tripdata_2020 (3 of 12): ['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-02.csv', 'yellow_tripdata_sample_2020-03.csv']\n",
+      "\n",
+      "\tUnmatched data_references (3 of 104):['.DS_Store', 'first_3_files', 'first_3_files/.DS_Store']\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7f8483a8f370>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data_path: str = \"../../../../test_sets/taxi_yellow_tripdata_samples\"\n",
     "\n",
@@ -334,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "ee0be5a2",
    "metadata": {},
    "outputs": [],
@@ -366,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b790e8b2",
    "metadata": {},
    "outputs": [],
@@ -388,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "da5b6cf0",
    "metadata": {},
    "outputs": [],
@@ -398,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "0f09894b-8b27-4159-ad7c-ea786b9da396",
    "metadata": {},
    "outputs": [],
@@ -408,10 +474,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "d564f515-ff0d-4218-b568-542e83fa6f2d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7f846bf7f4c0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f8483b1bee0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f8483b16fd0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f8483a8f340>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f846c80a790>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f8483bf3ca0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f846c802f40>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f846c802280>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f846bfc1f10>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f846bfc1fd0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f846bfc1dc0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f846c802910>]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "batch_list # len = 12"
    ]
@@ -442,10 +530,205 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "0f1460a6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e954d96ccae84652bfa20b5c56765ded",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating Expectations:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/0 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/0 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/12 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.                                  \n",
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.\n",
+      "Discarding histogram values above highest bin.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e4451c4c8d714f83ba999449f4eb4262",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "ename": "TypeError",
+     "evalue": "'<' not supported between instances of 'datetime.datetime' and 'int'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Input \u001b[0;32mIn [21]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[43mdata_context\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massistants\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43monboarding\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmulti_batch_batch_request\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m<makefun-gen-0>:2\u001b[0m, in \u001b[0;36mrun\u001b[0;34m(batch_request, estimation, include_column_names, exclude_column_names, include_column_name_suffixes, semantic_type_filter_module_name, semantic_type_filter_class_name, max_unexpected_values, max_unexpected_ratio, min_max_unexpected_values_proportion, allowed_semantic_types_passthrough, cardinality_limit_mode, max_unique_values, max_proportion_unique, table_rule, column_value_uniqueness_rule, column_value_nullity_rule, column_value_nonnullity_rule, numeric_columns_rule, datetime_columns_rule, text_columns_rule, categorical_columns_rule)\u001b[0m\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py:165\u001b[0m, in \u001b[0;36mDataAssistantRunner.run_impl.<locals>.run\u001b[0;34m(batch_request, estimation, **kwargs)\u001b[0m\n\u001b[1;32m    155\u001b[0m variables_directives_list: List[\n\u001b[1;32m    156\u001b[0m     RuntimeEnvironmentVariablesDirectives\n\u001b[1;32m    157\u001b[0m ] \u001b[38;5;241m=\u001b[39m build_variables_directives(\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    160\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mvariables_directives_kwargs,\n\u001b[1;32m    161\u001b[0m )\n\u001b[1;32m    162\u001b[0m domain_type_directives_list: List[\n\u001b[1;32m    163\u001b[0m     RuntimeEnvironmentDomainTypeDirectives\n\u001b[1;32m    164\u001b[0m ] \u001b[38;5;241m=\u001b[39m build_domain_type_directives(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mdomain_type_directives_kwargs)\n\u001b[0;32m--> 165\u001b[0m data_assistant_result: DataAssistantResult \u001b[38;5;241m=\u001b[39m \u001b[43mdata_assistant\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    166\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    167\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    168\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m data_assistant_result\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/data_assistant/data_assistant.py:471\u001b[0m, in \u001b[0;36mDataAssistant.run\u001b[0;34m(self, variables, rules, variables_directives_list, domain_type_directives_list)\u001b[0m\n\u001b[1;32m    465\u001b[0m     batches \u001b[38;5;241m=\u001b[39m {}\n\u001b[1;32m    467\u001b[0m data_assistant_result \u001b[38;5;241m=\u001b[39m DataAssistantResult(\n\u001b[1;32m    468\u001b[0m     _batch_id_to_batch_identifier_display_name_map\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_batch_id_to_batch_identifier_display_name_map(),\n\u001b[1;32m    469\u001b[0m     _usage_statistics_handler\u001b[38;5;241m=\u001b[39musage_statistics_handler,\n\u001b[1;32m    470\u001b[0m )\n\u001b[0;32m--> 471\u001b[0m \u001b[43mrun_profiler_on_data\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    472\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata_assistant\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    473\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata_assistant_result\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdata_assistant_result\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    474\u001b[0m \u001b[43m    \u001b[49m\u001b[43mprofiler\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_profiler\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    475\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    476\u001b[0m \u001b[43m    \u001b[49m\u001b[43mrules\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrules\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    477\u001b[0m \u001b[43m    \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mlist\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mbatches\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalues\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    478\u001b[0m \u001b[43m    \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    479\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    480\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    481\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    482\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_build_data_assistant_result(\n\u001b[1;32m    483\u001b[0m     data_assistant_result\u001b[38;5;241m=\u001b[39mdata_assistant_result\n\u001b[1;32m    484\u001b[0m )\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/util.py:193\u001b[0m, in \u001b[0;36mmeasure_execution_time.<locals>.execution_time_decorator.<locals>.compute_delta_t\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    191\u001b[0m time_begin: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n\u001b[1;32m    192\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 193\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    194\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[1;32m    195\u001b[0m     time_end: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/data_assistant/data_assistant.py:659\u001b[0m, in \u001b[0;36mrun_profiler_on_data\u001b[0;34m(data_assistant, data_assistant_result, profiler, variables, rules, batch_list, batch_request, variables_directives_list, domain_type_directives_list)\u001b[0m\n\u001b[1;32m    653\u001b[0m     rules_configs: Optional[Dict[\u001b[38;5;28mstr\u001b[39m, Dict[\u001b[38;5;28mstr\u001b[39m, Any]]] \u001b[38;5;241m=\u001b[39m {\n\u001b[1;32m    654\u001b[0m         rule\u001b[38;5;241m.\u001b[39mname: rule\u001b[38;5;241m.\u001b[39mto_json_dict() \u001b[38;5;28;01mfor\u001b[39;00m rule \u001b[38;5;129;01min\u001b[39;00m rules\n\u001b[1;32m    655\u001b[0m     }\n\u001b[1;32m    656\u001b[0m     comment: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\"\"\u001b[39m\u001b[38;5;124mCreated by effective Rule-Based Profiler of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdata_assistant\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m with the \u001b[39m\u001b[38;5;130;01m\\\u001b[39;00m\n\u001b[1;32m    657\u001b[0m \u001b[38;5;124mconfiguration included.\u001b[39m\n\u001b[1;32m    658\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m--> 659\u001b[0m     rule_based_profiler_result: RuleBasedProfilerResult \u001b[38;5;241m=\u001b[39m \u001b[43mprofiler\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    660\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    661\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrules\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrules_configs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    662\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    663\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    664\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    665\u001b[0m \u001b[43m        \u001b[49m\u001b[43mreconciliation_directives\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mDEFAULT_RECONCILATION_DIRECTIVES\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    666\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    667\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    668\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcomment\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcomment\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    669\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    670\u001b[0m     result: DataAssistantResult \u001b[38;5;241m=\u001b[39m data_assistant_result\n\u001b[1;32m    671\u001b[0m     result\u001b[38;5;241m.\u001b[39mprofiler_config \u001b[38;5;241m=\u001b[39m profiler\u001b[38;5;241m.\u001b[39mconfig\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/core/usage_statistics/usage_statistics.py:294\u001b[0m, in \u001b[0;36musage_statistics_enabled_method.<locals>.usage_statistics_wrapped_method\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m args_payload_fn \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    292\u001b[0m         nested_update(event_payload, args_payload_fn(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs))\n\u001b[0;32m--> 294\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    295\u001b[0m     message[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msuccess\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[1;32m    296\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m:\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/rule_based_profiler.py:318\u001b[0m, in \u001b[0;36mBaseRuleBasedProfiler.run\u001b[0;34m(self, variables, rules, batch_list, batch_request, recompute_existing_parameter_values, reconciliation_directives, variables_directives_list, domain_type_directives_list, comment)\u001b[0m\n\u001b[1;32m    309\u001b[0m rule: Rule\n\u001b[1;32m    310\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m rule \u001b[38;5;129;01min\u001b[39;00m pbar_method(\n\u001b[1;32m    311\u001b[0m     effective_rules,\n\u001b[1;32m    312\u001b[0m     desc\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mGenerating Expectations:\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    316\u001b[0m     bar_format\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{desc:25}\u001b[39;00m\u001b[38;5;132;01m{percentage:3.0f}\u001b[39;00m\u001b[38;5;124m%\u001b[39m\u001b[38;5;124m|\u001b[39m\u001b[38;5;132;01m{bar}\u001b[39;00m\u001b[38;5;132;01m{r_bar}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    317\u001b[0m ):\n\u001b[0;32m--> 318\u001b[0m     rule_state \u001b[38;5;241m=\u001b[39m \u001b[43mrule\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    319\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43meffective_variables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    320\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    321\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    322\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    323\u001b[0m \u001b[43m        \u001b[49m\u001b[43mreconciliation_directives\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mreconciliation_directives\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    324\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrule_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mRuleState\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    325\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    326\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrule_states\u001b[38;5;241m.\u001b[39mappend(rule_state)\n\u001b[1;32m    328\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m RuleBasedProfilerResult(\n\u001b[1;32m    329\u001b[0m     fully_qualified_parameter_names_by_domain\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_fully_qualified_parameter_names_by_domain(),\n\u001b[1;32m    330\u001b[0m     parameter_values_for_fully_qualified_parameter_names_by_domain\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_parameter_values_for_fully_qualified_parameter_names_by_domain(),\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    356\u001b[0m     _usage_statistics_handler\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_usage_statistics_handler,\n\u001b[1;32m    357\u001b[0m )\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/util.py:193\u001b[0m, in \u001b[0;36mmeasure_execution_time.<locals>.execution_time_decorator.<locals>.compute_delta_t\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    191\u001b[0m time_begin: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n\u001b[1;32m    192\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 193\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    194\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[1;32m    195\u001b[0m     time_end: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/rule/rule.py:169\u001b[0m, in \u001b[0;36mRule.run\u001b[0;34m(self, variables, batch_list, batch_request, recompute_existing_parameter_values, reconciliation_directives, rule_state)\u001b[0m\n\u001b[1;32m    166\u001b[0m     expectation_configuration_builder: ExpectationConfigurationBuilder\n\u001b[1;32m    168\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m expectation_configuration_builder \u001b[38;5;129;01min\u001b[39;00m expectation_configuration_builders:\n\u001b[0;32m--> 169\u001b[0m         \u001b[43mexpectation_configuration_builder\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_validation_dependencies\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    170\u001b[0m \u001b[43m            \u001b[49m\u001b[43mdomain\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    171\u001b[0m \u001b[43m            \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    172\u001b[0m \u001b[43m            \u001b[49m\u001b[43mparameters\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrule_state\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    173\u001b[0m \u001b[43m            \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    174\u001b[0m \u001b[43m            \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    175\u001b[0m \u001b[43m            \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    176\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    178\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m rule_state\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py:115\u001b[0m, in \u001b[0;36mExpectationConfigurationBuilder.resolve_validation_dependencies\u001b[0;34m(self, domain, variables, parameters, batch_list, batch_request, recompute_existing_parameter_values)\u001b[0m\n\u001b[1;32m    113\u001b[0m validation_parameter_builder: ParameterBuilder\n\u001b[1;32m    114\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m validation_parameter_builder \u001b[38;5;129;01min\u001b[39;00m validation_parameter_builders:\n\u001b[0;32m--> 115\u001b[0m     \u001b[43mvalidation_parameter_builder\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbuild_parameters\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    116\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdomain\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    117\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    118\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparameters\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    119\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparameter_computation_impl\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    120\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    121\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    122\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    123\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py:160\u001b[0m, in \u001b[0;36mParameterBuilder.build_parameters\u001b[0;34m(self, domain, variables, parameters, parameter_computation_impl, batch_list, batch_request, recompute_existing_parameter_values)\u001b[0m\n\u001b[1;32m    157\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m parameter_computation_impl \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    158\u001b[0m     parameter_computation_impl \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_build_parameters\n\u001b[0;32m--> 160\u001b[0m parameter_computation_result: Attributes \u001b[38;5;241m=\u001b[39m \u001b[43mparameter_computation_impl\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    161\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdomain\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    162\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    163\u001b[0m \u001b[43m    \u001b[49m\u001b[43mparameters\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    164\u001b[0m \u001b[43m    \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    165\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    167\u001b[0m parameter_values: Dict[\u001b[38;5;28mstr\u001b[39m, Any] \u001b[38;5;241m=\u001b[39m {\n\u001b[1;32m    168\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mraw_fully_qualified_parameter_name: parameter_computation_result,\n\u001b[1;32m    169\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjson_serialized_fully_qualified_parameter_name: convert_to_json_serializable(\n\u001b[1;32m    170\u001b[0m         data\u001b[38;5;241m=\u001b[39mparameter_computation_result\n\u001b[1;32m    171\u001b[0m     ),\n\u001b[1;32m    172\u001b[0m }\n\u001b[1;32m    174\u001b[0m build_parameter_container(\n\u001b[1;32m    175\u001b[0m     parameter_container\u001b[38;5;241m=\u001b[39mparameters[domain\u001b[38;5;241m.\u001b[39mid],\n\u001b[1;32m    176\u001b[0m     parameter_values\u001b[38;5;241m=\u001b[39mparameter_values,\n\u001b[1;32m    177\u001b[0m )\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py:131\u001b[0m, in \u001b[0;36mValueSetMultiBatchParameterBuilder._build_parameters\u001b[0;34m(self, domain, variables, parameters, recompute_existing_parameter_values)\u001b[0m\n\u001b[1;32m    116\u001b[0m parameter_node: ParameterNode \u001b[38;5;241m=\u001b[39m get_parameter_value_and_validate_return_type(\n\u001b[1;32m    117\u001b[0m     domain\u001b[38;5;241m=\u001b[39mdomain,\n\u001b[1;32m    118\u001b[0m     parameter_reference\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mraw_fully_qualified_parameter_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    121\u001b[0m     parameters\u001b[38;5;241m=\u001b[39mparameters,\n\u001b[1;32m    122\u001b[0m )\n\u001b[1;32m    123\u001b[0m metric_values: MetricValues \u001b[38;5;241m=\u001b[39m AttributedResolvedMetrics\u001b[38;5;241m.\u001b[39mget_conditioned_metric_values_from_attributed_metric_values(\n\u001b[1;32m    124\u001b[0m     attributed_metric_values\u001b[38;5;241m=\u001b[39mparameter_node[\n\u001b[1;32m    125\u001b[0m         FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY\n\u001b[1;32m    126\u001b[0m     ]\n\u001b[1;32m    127\u001b[0m )\n\u001b[1;32m    129\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m Attributes(\n\u001b[1;32m    130\u001b[0m     {\n\u001b[0;32m--> 131\u001b[0m         FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY: \u001b[43m_get_unique_values_from_nested_collection_of_sets\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    132\u001b[0m \u001b[43m            \u001b[49m\u001b[43mcollection\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmetric_values\u001b[49m\n\u001b[1;32m    133\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m,\n\u001b[1;32m    134\u001b[0m         FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY: parameter_node[\n\u001b[1;32m    135\u001b[0m             FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY\n\u001b[1;32m    136\u001b[0m         ],\n\u001b[1;32m    137\u001b[0m     }\n\u001b[1;32m    138\u001b[0m )\n",
+      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py:167\u001b[0m, in \u001b[0;36m_get_unique_values_from_nested_collection_of_sets\u001b[0;34m(collection)\u001b[0m\n\u001b[1;32m    159\u001b[0m     flattened \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mset\u001b[39m()\u001b[38;5;241m.\u001b[39munion(\u001b[38;5;241m*\u001b[39mflattened)\n\u001b[1;32m    161\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    162\u001b[0m \u001b[38;5;124;03mIn multi-batch data analysis, values can be empty and missin, resulting in \"None\" added to set.  However, due to\u001b[39;00m\n\u001b[1;32m    163\u001b[0m \u001b[38;5;124;03mreliance on \"np.ndarray\", \"None\" gets converted to \"numpy.Inf\", whereas \"numpy.Inf == numpy.Inf\" returns False,\u001b[39;00m\n\u001b[1;32m    164\u001b[0m \u001b[38;5;124;03mresulting in numerous \"None\" elements in final set.  For this reason, all \"None\" elements must be filtered out.\u001b[39;00m\n\u001b[1;32m    165\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    166\u001b[0m unique_values: Set[Any] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mset\u001b[39m(\n\u001b[0;32m--> 167\u001b[0m     \u001b[38;5;28;43msorted\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[1;32m    168\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43mfilter\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[1;32m    169\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43;01mlambda\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43melement\u001b[49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mnot\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    170\u001b[0m \u001b[43m                \u001b[49m\u001b[43m(\u001b[49m\u001b[43melement\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mis\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m    171\u001b[0m \u001b[43m                \u001b[49m\u001b[38;5;129;43;01mor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43misinstance\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43melement\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mfloat\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mand\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43misnan\u001b[49m\u001b[43m(\u001b[49m\u001b[43melement\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    172\u001b[0m \u001b[43m            \u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    173\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43mset\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mflattened\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    174\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    175\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    176\u001b[0m )\n\u001b[1;32m    178\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m unique_values\n",
+      "\u001b[0;31mTypeError\u001b[0m: '<' not supported between instances of 'datetime.datetime' and 'int'"
+     ]
+    }
+   ],
    "source": [
     "result = data_context.assistants.onboarding.run(batch_request=multi_batch_batch_request)"
    ]

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
@@ -5,7 +5,7 @@
    "id": "834eb3b0",
    "metadata": {},
    "source": [
-    "# How to use `DataAssistants`\n",
+    "# How to use `DataAssistants` - Spark\n",
     "\n",
     "* A `DataAssistant` enables you to quickly profile your data by providing a thin API over a pre-constructed `RuleBasedProfiler` configuration.\n",
     "* As a result of the profiling, you get back a result object consisting of \n",
@@ -31,13 +31,7 @@
    "execution_count": 1,
    "id": "8362d4be",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "import great_expectations as ge\n",
     "from great_expectations.core.batch import BatchRequest\n",
@@ -46,10 +40,10 @@
     "from great_expectations.validator.validator import Validator\n",
     "from great_expectations.rule_based_profiler.data_assistant import (\n",
     "    DataAssistant,\n",
-    "    VolumeDataAssistant,\n",
+    "    OboardingDataAssistant,\n",
     ")\n",
     "from great_expectations.rule_based_profiler.data_assistant_result import (\n",
-    "    VolumeDataAssistantResult,\n",
+    "    OnboardingDataAssistantResult,\n",
     ")\n",
     "from typing import List\n",
     "from ruamel import yaml\n"
@@ -107,7 +101,7 @@
    "id": "2eea8376",
    "metadata": {},
    "source": [
-    "Spark can be imported into your python environment in a number of ways, and the `findspark` package has been helpful in simplifying the process of importing the `pyspark` package in your python environment. \n",
+    "Spark can be imported into your python environment in a number of ways, and the `findspark` package could be helpful in simplifying the process of importing the `pyspark` package in your python environment. \n",
     "\n",
     "More information can be found in the [project's website](https://github.com/minrk/findspark). \n"
    ]
@@ -121,12 +115,7 @@
     {
      "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "22/09/02 16:46:28 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
-      "Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\n",
-      "Setting default log level to \"WARN\".\n",
-      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
-     ]
+     "text": []
     }
    ],
    "source": [

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
@@ -1282,7 +1282,7 @@
    "source": [
     "If you copy the dictionary and set the key-value pair you are interested in, then `categorical_columns_rule` can be passed into the `assistants.onboarding.run()` method as a dictionary. \n",
     "\n",
-    "In the following example we have set the `cardinality_limit_mode` from `FEW` to `VERY_MANY`. The remaining parameters can either be kept or commented out. Both calls below will work. "
+    "In the following example we have set the `cardinality_limit_mode` from `FEW` to `VERY_MANY` ([more information in the great_expectations repo here](https://github.com/great-expectations/great_expectations/blob/da2376b613843844afc041538269bb7683444b1f/great_expectations/rule_based_profiler/parameter_builder/regex_pattern_string_parameter_builder.py#L38)). The remaining parameters can either be kept or commented out. Both calls below will work. "
    ]
   },
   {

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb
@@ -13,7 +13,7 @@
     "    * `Expectations` that are able to alert you if the data deviates from the expected state in the future. \n",
     "    \n",
     "* `DataAssistant` results can also be plotted to help you understand their data visually.\n",
-    "* There are multiple `DataAssistants` centered around a theme (volume, nullity etc), and this notebook walks you through an example `OnboardingDataAssistant`, which is the most general and extensive `DataAssistant`.\n"
+    "* There are multiple `DataAssistants` centered around a theme (volume, nullity, etc), and this notebook walks you through an example `OnboardingDataAssistant`, which is the most general and extensive `DataAssistant`.\n"
    ]
   },
   {
@@ -21,24 +21,21 @@
    "id": "26b3aab6",
    "metadata": {},
    "source": [
-    "The `OnboardingDataAssistant` is considered to be the \"starting point\" for profiling and is generally applicable for numerical, categorial, or datetime data.  In our example we will be using `taxi_trip` data, building our `ExpectationSuite` using data from 2019, and validating the Suite on January 2020 data, to see if our more-recent data falls within the range of previous months.\n",
+    "The `OnboardingDataAssistant` is considered to be the \"starting point\" for profiling and is generally applicable for numerical, categorial, or datetime data.  In our example we will be using `taxi_trip` data, building our `ExpectationSuite` using data from 2019, and validating the suite on January 2020 data, to see if our more-recent data falls within the range of previous months.\n",
     "\n",
     "In our example, the `OnboardingDataAssistant` will take in a `batch_request` describing data from 2019 and calculating upper and lower bounds for the following `Expectations` across the sample `Batches`. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "id": "8362d4be",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/snowflake/connector/options.py:94: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<3.1.0,>=3.0.0; extra == \"pandas\"'\n",
-      "  warn_incompatible_dep(\n"
-     ]
+     "text": []
     }
    ],
    "source": [
@@ -106,30 +103,32 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0e26983f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pip install findspark"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "2bd176ee",
+   "id": "2eea8376",
    "metadata": {},
    "source": [
-    "* Great Expectations contains a helper util function called `get_or_create_spark_application()` which can be used to begin a `SparkSession`.\n",
-    "* You can also create your own `SparkSession` if you prefer."
+    "Spark can be imported into your python environment in a number of ways, and the `findspark` package has been helpful in simplifying the process of importing the `pyspark` package in your python environment. \n",
+    "\n",
+    "More information can be found in the [project's website](https://github.com/minrk/findspark). \n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "44ea10d3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "22/09/02 16:46:28 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\n",
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+     ]
+    }
+   ],
    "source": [
     "import findspark\n",
     "import pyspark\n",
@@ -163,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "4680225f",
    "metadata": {},
    "outputs": [],
@@ -173,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "3ecc3faa",
    "metadata": {},
    "outputs": [],
@@ -183,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "03fa3702",
    "metadata": {},
    "outputs": [
@@ -228,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "27407161",
    "metadata": {},
    "outputs": [],
@@ -238,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "df8c81ec",
    "metadata": {},
    "outputs": [],
@@ -274,19 +273,7 @@
    "metadata": {},
    "source": [
     "## Set-up: Adding `taxi_data` `Datasource`\n",
-    "In our example, we add a `Datasource` named `taxi_data` with 2 data_assets, `yellow_tripdata_2019` and `yellow_tripdata_2020`\n",
-    "\n",
-    "Here is the output, which shows each data asset : `yellow_tripdata_sample_2019` and `yellow_tripdata_sample_2020` with 12 batches, each associated with a different filename. These become our `batch_identifiers` that distinguish one `Batch` from another.\n",
-    "\n",
-    "```bash\n",
-    "\n",
-    "Data Connectors:\n",
-    "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetFilesystemDataConnector\n",
-    "\tAvailable data_asset_names (2 of 2):\n",
-    "\t\tyellow_tripdata_2019 (3 of 12): ['yellow_tripdata_sample_2019-01.csv', 'yellow_tripdata_sample_2019-02.csv', 'yellow_tripdata_sample_2019-03.csv']\n",
-    "\t\tyellow_tripdata_2020 (3 of 12): ['yellow_tripdata_sample_2020-01.csv', 'yellow_tripdata_sample_2020-02.csv', 'yellow_tripdata_sample_2020-03.csv']\n",
-    "\n",
-    "```"
+    "In our example, we add a `Datasource` named `taxi_data` with 2 data_assets, `yellow_tripdata_2019` and `yellow_tripdata_2020`"
    ]
   },
   {
@@ -320,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "76dcee57",
    "metadata": {},
    "outputs": [],
@@ -330,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "a29fd9a3",
    "metadata": {},
    "outputs": [
@@ -358,10 +345,10 @@
     {
      "data": {
       "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x7f8483a8f370>"
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7f9976336a30>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -399,8 +386,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6be45bda",
+   "metadata": {},
+   "source": [
+    "We see we have successfully configured this because the output shows 2 data assets `yellow_tripdata_sample_2019` and `yellow_tripdata_sample_2020` with 12 batches, each associated with a different filename. These become our `batch_identifiers` that distinguish one `Batch` from another."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "id": "ee0be5a2",
    "metadata": {},
    "outputs": [],
@@ -432,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "id": "b790e8b2",
    "metadata": {},
    "outputs": [],
@@ -454,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "id": "da5b6cf0",
    "metadata": {},
    "outputs": [],
@@ -464,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
    "id": "0f09894b-8b27-4159-ad7c-ea786b9da396",
    "metadata": {},
    "outputs": [],
@@ -474,28 +469,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "id": "d564f515-ff0d-4218-b568-542e83fa6f2d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<great_expectations.core.batch.Batch at 0x7f846bf7f4c0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f8483b1bee0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f8483b16fd0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f8483a8f340>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f846c80a790>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f8483bf3ca0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f846c802f40>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f846c802280>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f846bfc1f10>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f846bfc1fd0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f846bfc1dc0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f846c802910>]"
+       "[<great_expectations.core.batch.Batch at 0x7f9976299a00>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f9976503910>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f99763f8910>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f99762a35b0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f997653cbb0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f997653cbe0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f9976543730>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f997653ca60>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f997653c8b0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f997653c040>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f9976503b50>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f9976333250>]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -509,7 +504,7 @@
    "id": "f9a38c3a",
    "metadata": {},
    "source": [
-    "# Run the `VolumeDataAssistant`"
+    "# Run the `OnboardingDataAssistant`"
    ]
   },
   {
@@ -517,7 +512,7 @@
    "id": "4c1b2796",
    "metadata": {},
    "source": [
-    "* The `VolumeDataAssistant` can be run directly from the `DataContext` by specifying `assistants` and `onboarding`, and passing in the `BatchRequest` from the previous step."
+    "* The `OnboardingDataAssistant` can be run directly from the `DataContext` by specifying `assistants` and `onboarding`, and passing in the `BatchRequest` from the previous step."
    ]
   },
   {
@@ -526,211 +521,6 @@
    "metadata": {},
    "source": [
     "**Note**: In the simplest way that we can run this is just by passing in our `batch_request` from our previous step, which corresponds to 2019 data. The appendix will show how the run can be further configured."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "0f1460a6",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e954d96ccae84652bfa20b5c56765ded",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Generating Expectations:   0%|          | 0/8 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/0 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/0 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/12 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/11 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.                                  \n",
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.\n",
-      "Discarding histogram values above highest bin.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/2 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e4451c4c8d714f83ba999449f4eb4262",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/8 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
-    },
-    {
-     "ename": "TypeError",
-     "evalue": "'<' not supported between instances of 'datetime.datetime' and 'int'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [21]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[43mdata_context\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massistants\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43monboarding\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmulti_batch_batch_request\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m<makefun-gen-0>:2\u001b[0m, in \u001b[0;36mrun\u001b[0;34m(batch_request, estimation, include_column_names, exclude_column_names, include_column_name_suffixes, semantic_type_filter_module_name, semantic_type_filter_class_name, max_unexpected_values, max_unexpected_ratio, min_max_unexpected_values_proportion, allowed_semantic_types_passthrough, cardinality_limit_mode, max_unique_values, max_proportion_unique, table_rule, column_value_uniqueness_rule, column_value_nullity_rule, column_value_nonnullity_rule, numeric_columns_rule, datetime_columns_rule, text_columns_rule, categorical_columns_rule)\u001b[0m\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py:165\u001b[0m, in \u001b[0;36mDataAssistantRunner.run_impl.<locals>.run\u001b[0;34m(batch_request, estimation, **kwargs)\u001b[0m\n\u001b[1;32m    155\u001b[0m variables_directives_list: List[\n\u001b[1;32m    156\u001b[0m     RuntimeEnvironmentVariablesDirectives\n\u001b[1;32m    157\u001b[0m ] \u001b[38;5;241m=\u001b[39m build_variables_directives(\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    160\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mvariables_directives_kwargs,\n\u001b[1;32m    161\u001b[0m )\n\u001b[1;32m    162\u001b[0m domain_type_directives_list: List[\n\u001b[1;32m    163\u001b[0m     RuntimeEnvironmentDomainTypeDirectives\n\u001b[1;32m    164\u001b[0m ] \u001b[38;5;241m=\u001b[39m build_domain_type_directives(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mdomain_type_directives_kwargs)\n\u001b[0;32m--> 165\u001b[0m data_assistant_result: DataAssistantResult \u001b[38;5;241m=\u001b[39m \u001b[43mdata_assistant\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    166\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    167\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    168\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    169\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m data_assistant_result\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/data_assistant/data_assistant.py:471\u001b[0m, in \u001b[0;36mDataAssistant.run\u001b[0;34m(self, variables, rules, variables_directives_list, domain_type_directives_list)\u001b[0m\n\u001b[1;32m    465\u001b[0m     batches \u001b[38;5;241m=\u001b[39m {}\n\u001b[1;32m    467\u001b[0m data_assistant_result \u001b[38;5;241m=\u001b[39m DataAssistantResult(\n\u001b[1;32m    468\u001b[0m     _batch_id_to_batch_identifier_display_name_map\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_batch_id_to_batch_identifier_display_name_map(),\n\u001b[1;32m    469\u001b[0m     _usage_statistics_handler\u001b[38;5;241m=\u001b[39musage_statistics_handler,\n\u001b[1;32m    470\u001b[0m )\n\u001b[0;32m--> 471\u001b[0m \u001b[43mrun_profiler_on_data\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    472\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata_assistant\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    473\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdata_assistant_result\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdata_assistant_result\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    474\u001b[0m \u001b[43m    \u001b[49m\u001b[43mprofiler\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_profiler\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    475\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    476\u001b[0m \u001b[43m    \u001b[49m\u001b[43mrules\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrules\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    477\u001b[0m \u001b[43m    \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mlist\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mbatches\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalues\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    478\u001b[0m \u001b[43m    \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    479\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    480\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    481\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    482\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_build_data_assistant_result(\n\u001b[1;32m    483\u001b[0m     data_assistant_result\u001b[38;5;241m=\u001b[39mdata_assistant_result\n\u001b[1;32m    484\u001b[0m )\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/util.py:193\u001b[0m, in \u001b[0;36mmeasure_execution_time.<locals>.execution_time_decorator.<locals>.compute_delta_t\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    191\u001b[0m time_begin: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n\u001b[1;32m    192\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 193\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    194\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[1;32m    195\u001b[0m     time_end: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/data_assistant/data_assistant.py:659\u001b[0m, in \u001b[0;36mrun_profiler_on_data\u001b[0;34m(data_assistant, data_assistant_result, profiler, variables, rules, batch_list, batch_request, variables_directives_list, domain_type_directives_list)\u001b[0m\n\u001b[1;32m    653\u001b[0m     rules_configs: Optional[Dict[\u001b[38;5;28mstr\u001b[39m, Dict[\u001b[38;5;28mstr\u001b[39m, Any]]] \u001b[38;5;241m=\u001b[39m {\n\u001b[1;32m    654\u001b[0m         rule\u001b[38;5;241m.\u001b[39mname: rule\u001b[38;5;241m.\u001b[39mto_json_dict() \u001b[38;5;28;01mfor\u001b[39;00m rule \u001b[38;5;129;01min\u001b[39;00m rules\n\u001b[1;32m    655\u001b[0m     }\n\u001b[1;32m    656\u001b[0m     comment: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\"\"\u001b[39m\u001b[38;5;124mCreated by effective Rule-Based Profiler of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdata_assistant\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m with the \u001b[39m\u001b[38;5;130;01m\\\u001b[39;00m\n\u001b[1;32m    657\u001b[0m \u001b[38;5;124mconfiguration included.\u001b[39m\n\u001b[1;32m    658\u001b[0m \u001b[38;5;124m\"\"\"\u001b[39m\n\u001b[0;32m--> 659\u001b[0m     rule_based_profiler_result: RuleBasedProfilerResult \u001b[38;5;241m=\u001b[39m \u001b[43mprofiler\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    660\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    661\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrules\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrules_configs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    662\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    663\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    664\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    665\u001b[0m \u001b[43m        \u001b[49m\u001b[43mreconciliation_directives\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mDEFAULT_RECONCILATION_DIRECTIVES\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    666\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    667\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain_type_directives_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    668\u001b[0m \u001b[43m        \u001b[49m\u001b[43mcomment\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcomment\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    669\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    670\u001b[0m     result: DataAssistantResult \u001b[38;5;241m=\u001b[39m data_assistant_result\n\u001b[1;32m    671\u001b[0m     result\u001b[38;5;241m.\u001b[39mprofiler_config \u001b[38;5;241m=\u001b[39m profiler\u001b[38;5;241m.\u001b[39mconfig\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/core/usage_statistics/usage_statistics.py:294\u001b[0m, in \u001b[0;36musage_statistics_enabled_method.<locals>.usage_statistics_wrapped_method\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m args_payload_fn \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    292\u001b[0m         nested_update(event_payload, args_payload_fn(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs))\n\u001b[0;32m--> 294\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    295\u001b[0m     message[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msuccess\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[1;32m    296\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m:\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/rule_based_profiler.py:318\u001b[0m, in \u001b[0;36mBaseRuleBasedProfiler.run\u001b[0;34m(self, variables, rules, batch_list, batch_request, recompute_existing_parameter_values, reconciliation_directives, variables_directives_list, domain_type_directives_list, comment)\u001b[0m\n\u001b[1;32m    309\u001b[0m rule: Rule\n\u001b[1;32m    310\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m rule \u001b[38;5;129;01min\u001b[39;00m pbar_method(\n\u001b[1;32m    311\u001b[0m     effective_rules,\n\u001b[1;32m    312\u001b[0m     desc\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mGenerating Expectations:\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    316\u001b[0m     bar_format\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{desc:25}\u001b[39;00m\u001b[38;5;132;01m{percentage:3.0f}\u001b[39;00m\u001b[38;5;124m%\u001b[39m\u001b[38;5;124m|\u001b[39m\u001b[38;5;132;01m{bar}\u001b[39;00m\u001b[38;5;132;01m{r_bar}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    317\u001b[0m ):\n\u001b[0;32m--> 318\u001b[0m     rule_state \u001b[38;5;241m=\u001b[39m \u001b[43mrule\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    319\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43meffective_variables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    320\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    321\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    322\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    323\u001b[0m \u001b[43m        \u001b[49m\u001b[43mreconciliation_directives\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mreconciliation_directives\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    324\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrule_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mRuleState\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    325\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    326\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrule_states\u001b[38;5;241m.\u001b[39mappend(rule_state)\n\u001b[1;32m    328\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m RuleBasedProfilerResult(\n\u001b[1;32m    329\u001b[0m     fully_qualified_parameter_names_by_domain\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_fully_qualified_parameter_names_by_domain(),\n\u001b[1;32m    330\u001b[0m     parameter_values_for_fully_qualified_parameter_names_by_domain\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_parameter_values_for_fully_qualified_parameter_names_by_domain(),\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    356\u001b[0m     _usage_statistics_handler\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_usage_statistics_handler,\n\u001b[1;32m    357\u001b[0m )\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/util.py:193\u001b[0m, in \u001b[0;36mmeasure_execution_time.<locals>.execution_time_decorator.<locals>.compute_delta_t\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    191\u001b[0m time_begin: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n\u001b[1;32m    192\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 193\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    194\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[1;32m    195\u001b[0m     time_end: \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m=\u001b[39m (\u001b[38;5;28mgetattr\u001b[39m(time, method))()\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/rule/rule.py:169\u001b[0m, in \u001b[0;36mRule.run\u001b[0;34m(self, variables, batch_list, batch_request, recompute_existing_parameter_values, reconciliation_directives, rule_state)\u001b[0m\n\u001b[1;32m    166\u001b[0m     expectation_configuration_builder: ExpectationConfigurationBuilder\n\u001b[1;32m    168\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m expectation_configuration_builder \u001b[38;5;129;01min\u001b[39;00m expectation_configuration_builders:\n\u001b[0;32m--> 169\u001b[0m         \u001b[43mexpectation_configuration_builder\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresolve_validation_dependencies\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    170\u001b[0m \u001b[43m            \u001b[49m\u001b[43mdomain\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    171\u001b[0m \u001b[43m            \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    172\u001b[0m \u001b[43m            \u001b[49m\u001b[43mparameters\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrule_state\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    173\u001b[0m \u001b[43m            \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    174\u001b[0m \u001b[43m            \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    175\u001b[0m \u001b[43m            \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    176\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    178\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m rule_state\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/expectation_configuration_builder/expectation_configuration_builder.py:115\u001b[0m, in \u001b[0;36mExpectationConfigurationBuilder.resolve_validation_dependencies\u001b[0;34m(self, domain, variables, parameters, batch_list, batch_request, recompute_existing_parameter_values)\u001b[0m\n\u001b[1;32m    113\u001b[0m validation_parameter_builder: ParameterBuilder\n\u001b[1;32m    114\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m validation_parameter_builder \u001b[38;5;129;01min\u001b[39;00m validation_parameter_builders:\n\u001b[0;32m--> 115\u001b[0m     \u001b[43mvalidation_parameter_builder\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbuild_parameters\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    116\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdomain\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    117\u001b[0m \u001b[43m        \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    118\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparameters\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    119\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparameter_computation_impl\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    120\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_list\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_list\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    121\u001b[0m \u001b[43m        \u001b[49m\u001b[43mbatch_request\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch_request\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    122\u001b[0m \u001b[43m        \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    123\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py:160\u001b[0m, in \u001b[0;36mParameterBuilder.build_parameters\u001b[0;34m(self, domain, variables, parameters, parameter_computation_impl, batch_list, batch_request, recompute_existing_parameter_values)\u001b[0m\n\u001b[1;32m    157\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m parameter_computation_impl \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    158\u001b[0m     parameter_computation_impl \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_build_parameters\n\u001b[0;32m--> 160\u001b[0m parameter_computation_result: Attributes \u001b[38;5;241m=\u001b[39m \u001b[43mparameter_computation_impl\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    161\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdomain\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdomain\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    162\u001b[0m \u001b[43m    \u001b[49m\u001b[43mvariables\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mvariables\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    163\u001b[0m \u001b[43m    \u001b[49m\u001b[43mparameters\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mparameters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    164\u001b[0m \u001b[43m    \u001b[49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecompute_existing_parameter_values\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    165\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    167\u001b[0m parameter_values: Dict[\u001b[38;5;28mstr\u001b[39m, Any] \u001b[38;5;241m=\u001b[39m {\n\u001b[1;32m    168\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mraw_fully_qualified_parameter_name: parameter_computation_result,\n\u001b[1;32m    169\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjson_serialized_fully_qualified_parameter_name: convert_to_json_serializable(\n\u001b[1;32m    170\u001b[0m         data\u001b[38;5;241m=\u001b[39mparameter_computation_result\n\u001b[1;32m    171\u001b[0m     ),\n\u001b[1;32m    172\u001b[0m }\n\u001b[1;32m    174\u001b[0m build_parameter_container(\n\u001b[1;32m    175\u001b[0m     parameter_container\u001b[38;5;241m=\u001b[39mparameters[domain\u001b[38;5;241m.\u001b[39mid],\n\u001b[1;32m    176\u001b[0m     parameter_values\u001b[38;5;241m=\u001b[39mparameter_values,\n\u001b[1;32m    177\u001b[0m )\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py:131\u001b[0m, in \u001b[0;36mValueSetMultiBatchParameterBuilder._build_parameters\u001b[0;34m(self, domain, variables, parameters, recompute_existing_parameter_values)\u001b[0m\n\u001b[1;32m    116\u001b[0m parameter_node: ParameterNode \u001b[38;5;241m=\u001b[39m get_parameter_value_and_validate_return_type(\n\u001b[1;32m    117\u001b[0m     domain\u001b[38;5;241m=\u001b[39mdomain,\n\u001b[1;32m    118\u001b[0m     parameter_reference\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mraw_fully_qualified_parameter_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    121\u001b[0m     parameters\u001b[38;5;241m=\u001b[39mparameters,\n\u001b[1;32m    122\u001b[0m )\n\u001b[1;32m    123\u001b[0m metric_values: MetricValues \u001b[38;5;241m=\u001b[39m AttributedResolvedMetrics\u001b[38;5;241m.\u001b[39mget_conditioned_metric_values_from_attributed_metric_values(\n\u001b[1;32m    124\u001b[0m     attributed_metric_values\u001b[38;5;241m=\u001b[39mparameter_node[\n\u001b[1;32m    125\u001b[0m         FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY\n\u001b[1;32m    126\u001b[0m     ]\n\u001b[1;32m    127\u001b[0m )\n\u001b[1;32m    129\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m Attributes(\n\u001b[1;32m    130\u001b[0m     {\n\u001b[0;32m--> 131\u001b[0m         FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY: \u001b[43m_get_unique_values_from_nested_collection_of_sets\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    132\u001b[0m \u001b[43m            \u001b[49m\u001b[43mcollection\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmetric_values\u001b[49m\n\u001b[1;32m    133\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m,\n\u001b[1;32m    134\u001b[0m         FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY: parameter_node[\n\u001b[1;32m    135\u001b[0m             FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY\n\u001b[1;32m    136\u001b[0m         ],\n\u001b[1;32m    137\u001b[0m     }\n\u001b[1;32m    138\u001b[0m )\n",
-      "File \u001b[0;32m~/Development/great_expectations/great_expectations/rule_based_profiler/parameter_builder/value_set_multi_batch_parameter_builder.py:167\u001b[0m, in \u001b[0;36m_get_unique_values_from_nested_collection_of_sets\u001b[0;34m(collection)\u001b[0m\n\u001b[1;32m    159\u001b[0m     flattened \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mset\u001b[39m()\u001b[38;5;241m.\u001b[39munion(\u001b[38;5;241m*\u001b[39mflattened)\n\u001b[1;32m    161\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    162\u001b[0m \u001b[38;5;124;03mIn multi-batch data analysis, values can be empty and missin, resulting in \"None\" added to set.  However, due to\u001b[39;00m\n\u001b[1;32m    163\u001b[0m \u001b[38;5;124;03mreliance on \"np.ndarray\", \"None\" gets converted to \"numpy.Inf\", whereas \"numpy.Inf == numpy.Inf\" returns False,\u001b[39;00m\n\u001b[1;32m    164\u001b[0m \u001b[38;5;124;03mresulting in numerous \"None\" elements in final set.  For this reason, all \"None\" elements must be filtered out.\u001b[39;00m\n\u001b[1;32m    165\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    166\u001b[0m unique_values: Set[Any] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mset\u001b[39m(\n\u001b[0;32m--> 167\u001b[0m     \u001b[38;5;28;43msorted\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[1;32m    168\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43mfilter\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[1;32m    169\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43;01mlambda\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43melement\u001b[49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mnot\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    170\u001b[0m \u001b[43m                \u001b[49m\u001b[43m(\u001b[49m\u001b[43melement\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mis\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m    171\u001b[0m \u001b[43m                \u001b[49m\u001b[38;5;129;43;01mor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43misinstance\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43melement\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mfloat\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mand\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43misnan\u001b[49m\u001b[43m(\u001b[49m\u001b[43melement\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    172\u001b[0m \u001b[43m            \u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    173\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43mset\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mflattened\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    174\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    175\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    176\u001b[0m )\n\u001b[1;32m    178\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m unique_values\n",
-      "\u001b[0;31mTypeError\u001b[0m: '<' not supported between instances of 'datetime.datetime' and 'int'"
-     ]
-    }
-   ],
-   "source": [
-    "result = data_context.assistants.onboarding.run(batch_request=multi_batch_batch_request)"
    ]
   },
   {
@@ -743,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "80345d4b",
    "metadata": {},
    "outputs": [],
@@ -769,20 +559,188 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "dd4c66e9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "            span.vega-bind-name {\n",
+       "                color: #8784FF;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                font-weight: bold;\n",
+       "            }\n",
+       "            form.vega-bindings {\n",
+       "                color: #1B2A4D;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                position: absolute;\n",
+       "                left: 75px;\n",
+       "                top: 28px;\n",
+       "            }\n",
+       "            </style>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "            .widget-inline-hbox .widget-label {\n",
+       "                color: #8784FF;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                font-weight: bold;\n",
+       "            }\n",
+       "            .widget-dropdown > select {\n",
+       "                padding-right: 21px;\n",
+       "                padding-left: 3px;\n",
+       "                color: #1B2A4D;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                height: 20px;\n",
+       "                line-height: 14px;\n",
+       "                background-size: 20px;\n",
+       "                border-radius: 2px;\n",
+       "            }\n",
+       "            </style>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "baab0454933c46c0b9b90fdae53bac46",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Select Plot Type: ', layout=Layout(margin='0px', width='max-conten…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "result.plot_metrics()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "03353ac8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "            span.vega-bind-name {\n",
+       "                color: #8784FF;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                font-weight: bold;\n",
+       "            }\n",
+       "            form.vega-bindings {\n",
+       "                color: #1B2A4D;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                position: absolute;\n",
+       "                left: 75px;\n",
+       "                top: 28px;\n",
+       "            }\n",
+       "            </style>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "            .widget-inline-hbox .widget-label {\n",
+       "                color: #8784FF;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                font-weight: bold;\n",
+       "            }\n",
+       "            .widget-dropdown > select {\n",
+       "                padding-right: 21px;\n",
+       "                padding-left: 3px;\n",
+       "                color: #1B2A4D;\n",
+       "                font-family: Verdana;\n",
+       "                font-size: 14px;\n",
+       "                height: 20px;\n",
+       "                line-height: 14px;\n",
+       "                background-size: 20px;\n",
+       "                border-radius: 2px;\n",
+       "            }\n",
+       "            </style>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2399dd275bf44408f1640cbae360de5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Select Plot Type: ', layout=Layout(margin='0px', width='max-conten…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "result.plot_expectations_and_metrics()"
    ]
@@ -802,14 +760,14 @@
    "source": [
     "Next, we can save the `ExpectationConfiguration` object resulting from the `DataAssistant` by:\n",
     "\n",
-    "1. Creating an `ExpecationSuite`, which is `taxi_data_2019_suite` in our example\n",
+    "1. Creating an `ExpectationSuite`, which is `taxi_data_2019_suite` in our example\n",
     "2. Adding `ExpectationConfiguration` to the `ExpectationSuite`\n",
     "3. Saving the `ExpectationSuite` using `DataContext`'s `save_expectation_suite()` method"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "e4db1dfc-defd-4b83-bc65-0e77ccd67cd7",
    "metadata": {},
    "outputs": [],
@@ -819,7 +777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "eaf5d924-1c10-4eab-b6ed-2063d0a73871",
    "metadata": {},
    "outputs": [],
@@ -829,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "9426227a",
    "metadata": {},
    "outputs": [],
@@ -850,12 +808,12 @@
    "id": "26b1550b",
    "metadata": {},
    "source": [
-    "Finally, we want to take the `ExpectationSuite` that was automatically generated by the `DataAssistant` and use it to validate some new data. As part of the set up, we trained our Expectations based on our 2019 data, and we are running the validation on one month of data from 2020, namely January. "
+    "We have just trained our Expectation Suite on the 2019 data. Now we will run a validation using this ExpectationSuite on data from January of 2020."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "4cd07f43-53ce-4a32-8e03-d0e2322ecc42",
    "metadata": {},
    "outputs": [],
@@ -878,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "65ab5c11-9716-4a39-88df-6f805d65eca1",
    "metadata": {},
    "outputs": [],
@@ -888,10 +846,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "2f5c4c37-684b-4b94-b0ea-2ae7dec1884d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'datasource_name': 'taxi_data', 'data_connector_name': 'configured_data_connector_multi_batch_asset', 'data_asset_name': 'yellow_tripdata_2020', 'batch_identifiers': {'year': '2020', 'month': '01'}}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "batch_list[0].batch_definition"
    ]
@@ -901,14 +870,14 @@
    "id": "62c3153f",
    "metadata": {},
    "source": [
-    "Our `SimpleCheckpoint` configuration includes our `batch_request` and `ExpectationSuiteName` (which is `taxi_data_suite` in our example. \n",
+    "Our `SimpleCheckpoint` configuration includes our `batch_request` and `ExpectationSuiteName` (which is `taxi_data_suite` in our example)\n",
     "\n",
     "We also include the `UpdateDataDocsAction`, so we can visualize the results of our Checkpoint."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "40c540fd",
    "metadata": {},
    "outputs": [],
@@ -932,17 +901,7 @@
     "            },\n",
     "        ],\n",
     "}\n",
-    "data_context.add_checkpoint(**checkpoint_config)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a718ee2-1971-495e-8113-8704752fd3c8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_context.add_checkpoint(**checkpoint_config)"
+    "checkpoint_config_added = data_context.add_checkpoint(**checkpoint_config)"
    ]
   },
   {
@@ -970,17 +929,36 @@
    "id": "b353ea25",
    "metadata": {},
    "source": [
-    "As you can see the results of the `Checkpoint` were not successful, which means the January 2020 data did not fall within the ranges predicted by the 2019 data. To examine this more closely, you can [open Data Docs here](great_expectations/uncommitted/data_docs/local_site/index.html). If the link doesn't work, from the location where this Notebook is located, you can go to `great_expectations/uncommitted/data_docs/local_site/index.html`."
+    "We can check the results by evaluating:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "bfc2cc49-cd02-44db-9079-d0baed7ffe73",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "results.success"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c189c83d",
+   "metadata": {},
+   "source": [
+    "As you can see the results of the `Checkpoint` were not successful, which means the January 2020 data did not fall within the ranges predicted by the 2019 data. To examine this more closely, you can [open Data Docs here](great_expectations/uncommitted/data_docs/local_site/index.html). If the link doesn't work, from the location where this Notebook is located, you can go to `great_expectations/uncommitted/data_docs/local_site/index.html`.\n"
    ]
   },
   {
@@ -1022,16 +1000,16 @@
     "    - `max_value` : minimum threshold for table row count.\n",
     "* `expect_table_columns_to_match_set`:\n",
     "    - `column_set`: Either a list or set of strings, that describe the columns of the Table\n",
-    "    - `exact_match`: Boolean (default=True) which determines whether the list of columns must exactly match the observed columns. \n",
+    "    - `exact_match`: Boolean (`default=True`) which determines whether the list of columns must exactly match the observed columns. \n",
     "    \n",
-    "#### Column Uniqueness and Nullity\n",
-    "This is not a `Rule` in the strictest sense, but the `DataAssistant` will generate `ExpectationConfigurations` for the following `Expectations` for each column in our data. \n",
+    "#### Rules for Uniqueness, Nullity and Non-nullity\n",
+    "These `Rules` each have 1 `Expectations` associated with them, and will be used by the `DataAssistant` to generate `ExpectationConfigurations` for the following `Expectations` for each column in our data. \n",
     "\n",
     "* `expect_column_values_to_be_unique`\n",
     "* `expect_column_values_to_be_null`\n",
     "* `expect_column_values_to_not_be_null`\n",
     " \n",
-    "They each take 2 parameters. `column`, which is the name of the column being validated, and `mostly`, which is an optional `float` value between `0` and `1` which specifies the fraction of values that match the expectation. Default for the `DataAssistant` is `1.0`. \n",
+    "They each take 2 parameters. `column`, which is the name of the column being validated, and `mostly`, which is an optional `float` value between `0.0` and `1.0` which specifies the fraction of values that match the expectation. Default for the `DataAssistant` is `1.0`. \n",
     "\n",
     "#### NumericColumnRule\n",
     "The `NumericColumnRule` will calculate the `min_value` and `max_value` for the following expectations. \n",
@@ -1043,9 +1021,9 @@
     "* `expect_column_mean_to_be_between`\n",
     "* `expect_column_stdev_to_be_between`\n",
     "\n",
-    "By default the estimation will be done by the `exact` estimator by default, which takes in the values across all Batches in the batch list (in our example 12 months of data from 2019).\n",
+    "The estimation will be done by the `exact` estimator by default, which takes in the values across all Batches in the batch list (in our example 12 months of data from 2019).\n",
     "\n",
-    "If you do `data_assistant.run()` with the `estimator` parameter set to `drop_outliers` then `bootstrapping` will be done done behind-the-scenes to estimate outliers.\n",
+    "If you do `data_assistant.run()` with the `estimator` parameter set to `drop_outliers` then `bootstrapping` will be done behind-the-scenes to estimate outliers.\n",
     "\n",
     "The parameters for `bootstrapping` are:\n",
     "\n",
@@ -1079,7 +1057,11 @@
     "* `expect_column_max_to_be_between`\n",
     "* `expect_column_values_to_be_between`\n",
     "\n",
-    "Estimation will be done using the `exact` estimator by default, but if you select `drop_outliers` then `bootstrapping` will use the following parameters: \n",
+    "The estimation will be done by the `exact` estimator by default, which takes in the values across all Batches in the batch list (in our example 12 months of data from 2019).\n",
+    "\n",
+    "If you do `data_assistant.run()` with the `estimator` parameter set to `drop_outliers` then `bootstrapping` will be done behind-the-scenes to estimate outliers.\n",
+    "\n",
+    "The parameters for `bootstrapping` are:\n",
     "\n",
     "* `n_resamples` : For bootstrapping. It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.htm\n",
     "* `false_positive_rate`: user-configured fraction between 0 and 1 expressing desired false positive rate for\n",
@@ -1101,7 +1083,7 @@
     "\n",
     "Estimation will be done using the `exact` estimator by default, but if you select `drop_outliers` then the following parameters are set by default for `bootstrap` estimation\n",
     "\n",
-    "* `n_resamples` : For bootstrapping. It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.htm\n",
+    "* `n_resamples` : For bootstrapping. It is set by default to `9999` which is the default in https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html\n",
     "* `false_positive_rate`: user-configured fraction between 0 and 1 expressing desired false positive rate for\n",
     "    identifying unexpected values as judged by the upper- and lower- quantiles of the observed metric data. Default is `0.05`.\n",
     "* `random_seed`: Seed for randomization. If omitted (which is the default), then we use `np.random.choice`. otherwise, we use `np.random.Generator(np.random.PCG64(random_seed))`.\n",
@@ -1184,7 +1166,7 @@
     "* `min_value`:  minimum proportion of unique values, ranging from 0 to 1\n",
     "* `max_value`:  minimum proportion of unique values, ranging from 0 to 1\n",
     "* `strict_min`: determine whether the minimum proportion of unique values must be strictly greater than min value, with the `default=False`\n",
-    "*`strict_max`: determine whether the minimum proportion of unique values must be strictly smaller than max value, with the `default=False`\n",
+    "* `strict_max`: determine whether the minimum proportion of unique values must be strictly smaller than max value, with the `default=False`\n",
     "\n",
     "Estimation will be done using the `exact` estimator by default, but if you select `drop_outliers` then the following parameters are set by default for `bootstrap` estimation\n",
     "\n",
@@ -1243,10 +1225,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "a406851d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<function great_expectations.rule_based_profiler.data_assistant.data_assistant_runner.DataAssistantRunner.run_impl.<locals>.run(batch_request: Union[great_expectations.core.batch.BatchRequestBase, dict], estimation: Union[str, great_expectations.rule_based_profiler.data_assistant.data_assistant_runner.NumericRangeEstimatorType, NoneType] = 'exact', include_column_names: Union[str, List[str], NoneType] = None, exclude_column_names: Union[str, List[str], NoneType] = ['id'], include_column_name_suffixes: Union[str, Iterable, List[str], NoneType] = None, semantic_type_filter_module_name: Union[str, NoneType] = None, semantic_type_filter_class_name: Union[str, NoneType] = None, max_unexpected_values: Union[str, int] = 0, max_unexpected_ratio: Union[str, float, NoneType] = None, min_max_unexpected_values_proportion: Union[str, float, NoneType] = 0.975, allowed_semantic_types_passthrough: Union[str, great_expectations.rule_based_profiler.domain.SemanticDomainTypes, List[Union[str, great_expectations.rule_based_profiler.domain.SemanticDomainTypes]], NoneType] = ['logic'], cardinality_limit_mode: Union[str, great_expectations.rule_based_profiler.helpers.cardinality_checker.CardinalityLimitMode, dict, NoneType] = '$variables.cardinality_limit_mode', max_unique_values: Union[str, int, NoneType] = None, max_proportion_unique: Union[str, float, NoneType] = None, table_rule: dict = {'false_positive_rate': 0.05, 'estimator': 'bootstrap', 'n_resamples': 9999, 'random_seed': None, 'quantile_statistic_interpolation_method': 'nearest', 'quantile_bias_correction': False, 'quantile_bias_std_error_ratio_threshold': None, 'include_estimator_samples_histogram_in_details': False, 'truncate_values': {'lower_bound': 0, 'upper_bound': None}, 'round_decimals': 0, 'exact_match': None, 'success_ratio': 1.0}, column_value_uniqueness_rule: dict = {'success_ratio': 0.75}, column_value_nullity_rule: dict = {'success_ratio': 0.75}, column_value_nonnullity_rule: dict = {'success_ratio': 0.75}, numeric_columns_rule: dict = {'mostly': 1.0, 'strict_min': False, 'strict_max': False, 'quantiles': [0.25, 0.5, 0.75], 'allow_relative_error': False, 'false_positive_rate': 0.05, 'estimator': 'bootstrap', 'n_resamples': 9999, 'random_seed': None, 'quantile_statistic_interpolation_method': 'nearest', 'quantile_bias_correction': False, 'quantile_bias_std_error_ratio_threshold': None, 'include_estimator_samples_histogram_in_details': False, 'truncate_values': {'lower_bound': None, 'upper_bound': None}, 'round_decimals': 15}, datetime_columns_rule: dict = {'mostly': 1.0, 'strict_min': False, 'strict_max': False, 'false_positive_rate': 0.05, 'estimator': 'bootstrap', 'n_resamples': 9999, 'random_seed': None, 'quantile_statistic_interpolation_method': 'nearest', 'quantile_bias_correction': False, 'quantile_bias_std_error_ratio_threshold': None, 'include_estimator_samples_histogram_in_details': False, 'truncate_values': {'lower_bound': None, 'upper_bound': None}, 'round_decimals': 1}, text_columns_rule: dict = {'mostly': 1.0, 'strict_min': False, 'strict_max': False, 'false_positive_rate': 0.05, 'estimator': 'bootstrap', 'n_resamples': 9999, 'random_seed': None, 'quantile_statistic_interpolation_method': 'nearest', 'quantile_bias_correction': False, 'quantile_bias_std_error_ratio_threshold': None, 'include_estimator_samples_histogram_in_details': False, 'truncate_values': {'lower_bound': 0, 'upper_bound': None}, 'round_decimals': 0, 'success_ratio': 0.75}, categorical_columns_rule: dict = {'cardinality_limit_mode': 'FEW', 'mostly': 1.0, 'strict_min': False, 'strict_max': False, 'false_positive_rate': 0.05, 'estimator': 'bootstrap', 'n_resamples': 9999, 'random_seed': None, 'quantile_statistic_interpolation_method': 'nearest', 'quantile_bias_correction': False, 'quantile_bias_std_error_ratio_threshold': None, 'include_estimator_samples_histogram_in_details': False, 'truncate_values': {'lower_bound': 0.0, 'upper_bound': None}, 'round_decimals': 15}) -> great_expectations.rule_based_profiler.data_assistant_result.data_assistant_result.DataAssistantResult>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data_context.assistants.onboarding.run"
    ]
@@ -1371,7 +1364,7 @@
    "id": "6f0d1045",
    "metadata": {},
    "source": [
-    "When loading in a `Datasource` configuration through ` data_context.add_datasource(**datasource_config)`, we need to serialize the `schema` by calling the `jsonValue()` function of the `StructType` object [More information here](https://spark.apache.org/docs/3.1.3/api/python/reference/api/pyspark.sql.types.StructType.html#pyspark.sql.types.StructType.jsonValue)\n"
+    "When loading in a `Datasource` configuration through ` data_context.add_datasource(**datasource_config)`, we need to serialize the `schema` by calling the `jsonValue()` function of the `StructType` object. [More information here.](https://spark.apache.org/docs/3.1.3/api/python/reference/api/pyspark.sql.types.StructType.html#pyspark.sql.types.StructType.jsonValue)\n"
    ]
   },
   {
@@ -1384,7 +1377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "ede6c598",
    "metadata": {},
    "outputs": [],
@@ -1434,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "80e7d330",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
### Changes proposed in this pull request:

Update `tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Spark.ipynb` to include the most recent workflow 

* This includes being able to define `schema` which was enabled by PR #5917 and #5900 

The Workflow looks like this: 

- Running DataAssistant on 2019 Taxi Data (our "training set")
- Running Checkpoint on 2020 January Taxi Data (our "test set")
- Update Appendix to include parameter descriptions for DataAssistant, and how they can be adjusted / modified
- Update Appendix to include alternate configurations where `batch_spec_passthrough` is defined at the `DataConnector`-level and `Asset`-level


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
