### PR TITLE
[BUGFIX] Use filepath for rendering expectation suite url in validation results

### DIFF
--- a/great_expectations/render/renderer/site_index_page_renderer.py
+++ b/great_expectations/render/renderer/site_index_page_renderer.py
@@ -248,7 +248,7 @@ class SiteIndexPageRenderer(Renderer):
                     "_batch_identifier_sort": dict_.get("batch_identifier"),
                     "expectation_suite_name": cls._render_expectation_suite_cell(
                         dict_.get("expectation_suite_name"),
-                        dict_.get("expectation_suite_filepath"),
+                        dict_.get("filepath"),
                     ),
                     "_expectation_suite_name_sort": dict_.get("expectation_suite_name"),
                     "_table_row_link_path": dict_.get("filepath"),


### PR DESCRIPTION
Changes proposed in this pull request:
- Use `"filepath"` key for rendering "Expectation Suite" anchor links on the Validation Results page instead of `expectation_suite_filepath` to match `_table_row_link_path` (used on "Expectation Suites" tab, where links are not broken)

I have not deployed a test locally to ensure that this works, but intend to.

Fixes [Issue #5291](https://github.com/great-expectations/great_expectations/issues/5921) (hopefully)

### Definition of Done
Please delete options that are not relevant.

- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
