### PR TITLE
[MAINTENANCE] Reset globals modified in tests

### DIFF
--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -2,7 +2,7 @@ import contextlib
 import copy
 import datetime
 from numbers import Number
-from typing import Any, Dict, Iterator, List, Optional, Protocol, Tuple, Type, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, cast
 from unittest import mock
 
 import numpy as np
@@ -12,6 +12,9 @@ from freezegun import freeze_time
 from packaging import version
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
+
+# To support python 3.7 we must import Protocol from typing_extensions instead of typing
+from typing_extensions import Protocol
 
 from great_expectations import DataContext
 from great_expectations.core import (

--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -1006,6 +1006,11 @@ def test_bobby_expect_column_values_to_be_between_auto_yes_default_profiler_conf
 
 class HasStaticDefaultProfiler(Protocol):
     default_profiler_config: RuleBasedProfilerConfig
+    # I'd like to force the key "profiler_config" to be present in the following dict.
+    # While its absence doesn't break functionality, I do expect it to exist. TypeDicts
+    # unfortunately don't help us here since one needs to list all potential keys in a
+    # TypeDict since they don't allow extras keys to be present. See the discussion here:
+    # https://github.com/python/mypy/issues/4617#issuecomment-367647383
     default_kwarg_values: Dict[str, Any]
 
 


### PR DESCRIPTION
Please `hide whitespace` when looking at this diff is I'm using a contextmanager which indents a large block of code confusing the diff.

Some of our tests update the default profiler configs which are a class variable. Since they don't reset it, these remain set for all other tests run in this session. Some of these tests rely on having the default config.

The "real" fix would be to make the default config immutable. However that is a bigger effort and our current goal is to remove dependencies between tests and run them in a random order.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


