### PR TITLE
[DOCS] fix get context instructions

### DIFF
--- a/docs/terms/data_context.md
+++ b/docs/terms/data_context.md
@@ -90,7 +90,7 @@ Alternatively, you might call:
 
 ```python title="Python code"
 import great_expectations as ge
-context = ge.get_context(filepath=”something”)
+context = ge.data_context.DataContext(context_root_dir=”path/to/my/context/root/directory/great_expectations”)
 ```
 
 If you’re using Great Expectations Cloud, you’d call:


### PR DESCRIPTION
Changes proposed in this pull request:
- get_context doesn't take any parameters, so I changed the instructions to another way that can initialize data context from a path