### PR TITLE
[WIP] Cleanup of `ConfiguredAssetSqlDataConnector` signature and Docstring

### DIFF
--- a/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_sql_data_connector.py
@@ -37,12 +37,6 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
     """
     A DataConnector that requires explicit listing of SQL tables you want to connect to.
 
-    Args:
-        name (str): The name of this DataConnector
-        datasource_name (str): The name of the Datasource that contains it
-        execution_engine (ExecutionEngine): An ExecutionEngine
-        assets (str): assets
-        batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
     """
 
     def __init__(
@@ -50,8 +44,6 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         name: str,
         datasource_name: str,
         execution_engine: Optional[ExecutionEngine] = None,
-        data_asset_name_prefix: str = "",
-        data_asset_name_suffix: str = "",
         include_schema_name: bool = False,
         splitter_method: Optional[str] = None,
         splitter_kwargs: Optional[dict] = None,
@@ -62,20 +54,19 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
         id: Optional[str] = None,
     ) -> None:
         """
-        InferredAssetDataConnector for connecting to data on a SQL database
 
         Args:
             name (str): The name of this DataConnector
             datasource_name (str): The name of the Datasource that contains it
             execution_engine (ExecutionEngine): An ExecutionEngine
-            data_asset_name_prefix (str): An optional prefix to prepend to inferred data_asset_names
-            data_asset_name_suffix (str): An optional suffix to append to inferred data_asset_names
             include_schema_name (bool): Should the data_asset_name include the schema as a prefix?
             splitter_method (str): A method to split the target table into multiple Batches
             splitter_kwargs (dict): Keyword arguments to pass to splitter_method
             sampling_method (str): A method to downsample within a target Batch
             sampling_kwargs (dict): Keyword arguments to pass to sampling_method
+            assets (str): assets
             batch_spec_passthrough (dict): dictionary with keys that will be added directly to batch_spec
+            id (str): optional id for DataConnector
         """
         if execution_engine:
             execution_engine = cast(SqlAlchemyExecutionEngine, execution_engine)
@@ -88,8 +79,6 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             batch_spec_passthrough=batch_spec_passthrough,
         )
 
-        self._data_asset_name_prefix = data_asset_name_prefix
-        self._data_asset_name_suffix = data_asset_name_suffix
         self._include_schema_name = include_schema_name
         self._splitter_method = splitter_method
         self._splitter_kwargs = splitter_kwargs
@@ -105,14 +94,6 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
     @property
     def execution_engine(self) -> SqlAlchemyExecutionEngine:
         return cast(SqlAlchemyExecutionEngine, self._execution_engine)
-
-    @property
-    def data_asset_name_prefix(self) -> str:
-        return self._data_asset_name_prefix
-
-    @property
-    def data_asset_name_suffix(self) -> str:
-        return self._data_asset_name_suffix
 
     @property
     def include_schema_name(self) -> bool:
@@ -335,18 +316,6 @@ class ConfiguredAssetSqlDataConnector(DataConnector):
             schema_name = ""
 
         data_asset_name: str = f"{schema_name}{data_asset_name}"
-
-        data_asset_name_prefix: str = data_asset_config.get(
-            "data_asset_name_prefix", self.data_asset_name_prefix
-        )
-        data_asset_name_suffix: str = data_asset_config.get(
-            "data_asset_name_suffix", self.data_asset_name_suffix
-        )
-
-        data_asset_name: str = (
-            f"{data_asset_name_prefix}{data_asset_name}{data_asset_name_suffix}"
-        )
-
         return data_asset_name
 
     def _refresh_data_references_cache(self) -> None:


### PR DESCRIPTION
Changes proposed in this pull request:
- Clean up as part of GREAT-1226 work. 
- Removing `data_asset_name_prefix` and `data_asset_name_suffix` from `ConfiguredAssetSqlDataConnector` functionality. 
- Clean up of Docstrings, which had some references to `InferredAssetSqlDataConnector`


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
