### PR TITLE
[BUGFIX] Don't include abstract Expectation classes in _retrieve_expectations_from_module

### DIFF
--- a/contrib/cli/great_expectations_contrib/package.py
+++ b/contrib/cli/great_expectations_contrib/package.py
@@ -295,7 +295,13 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
         expectations: List[Type[Expectation]] = []
         names: List[str] = []
         for name, obj in inspect.getmembers(expectations_module):
-            if inspect.isclass(obj) and issubclass(obj, Expectation):
+            # ProfileNumericColumnsDiffExpectation from capitalone_dataprofiler_expectations
+            # is a base class that the contrib Expectations in that package all inherit from
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, Expectation)
+                and not obj.is_abstract()
+            ):
                 expectations.append(obj)
                 names.append(name)
 


### PR DESCRIPTION
This was causing build_package_gallery.py to show zero Expectations for the CapitalOne package. A piece of code was trying to access the `expectation_type` attribute on an abstract Expectation class and it was causing an AssertionError, which resulted in the entire list of Expectation diagnostics being empty.

Changes proposed in this pull request:
- Don't include abstract Expectation classes in _retrieve_expectations_from_module
