### PR TITLE
[BUGFIX] Spark column.distinct_values no longer returns entire table distinct values

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_distinct_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_distinct_values.py
@@ -86,7 +86,8 @@ class ColumnDistinctValues(ColumnAggregateMetricProvider):
         )
         column_name: str = accessor_domain_kwargs["column"]
         distinct_values: List[pyspark_sql_Row] = (
-            df.distinct()
+            df.select(F.col(column_name))
+            .distinct()
             .where(F.col(column_name).isNotNull())
             .rdd.flatMap(lambda x: x)
             .collect()

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -4004,14 +4004,20 @@ def test_value_counts_metric_pd():
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    "dataframe",
+    [
+        pd.DataFrame({"a": [1, 2, 1, 2, 3, 3, None]}),
+        pd.DataFrame({"a": [1, 2, 1, 2, 3, 3, None], "b": [1, 3, 5, 3, 4, 2, None]}),
+    ],
+)
 def test_distinct_metric_spark(
     spark_session,
+    dataframe,
 ):
     engine: SparkDFExecutionEngine = build_spark_engine(
         spark=spark_session,
-        df=pd.DataFrame(
-            {"a": [1, 2, 1, 2, 3, 3, None]},
-        ),
+        df=dataframe,
         batch_id="my_id",
     )
 


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1242
- Select the column before calling distinct

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.