### PR TITLE
[MAINTENANCE] Add reverse assertion for isEquivalentTo tests

### DIFF
--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -332,6 +332,7 @@ class TestIsEquivalentTo:
         suite1 = ExpectationSuite("suite_1", expectations=[StubExpectationConfiguration()])  # type: ignore[arg-type]
         suite2 = ExpectationSuite("suite_2", expectations=[StubExpectationConfiguration()])  # type: ignore[arg-type]
         assert suite1.isEquivalentTo(suite2)
+        assert suite2.isEquivalentTo(suite1)
 
     @pytest.mark.unit
     def test_is_equivalent_to_expectation_suite_classes_true_with_changes_to_non_considered_attributes_unit_test(
@@ -344,6 +345,7 @@ class TestIsEquivalentTo:
         suite1 = ExpectationSuite("suite_1", expectations=[StubExpectationConfiguration()])  # type: ignore[arg-type]
         suite2 = ExpectationSuite("suite_2", expectations=[StubExpectationConfiguration()], data_asset_type="different", meta={"notes": "different"}, ge_cloud_id="different")  # type: ignore[arg-type]
         assert suite1.isEquivalentTo(suite2)
+        assert suite2.isEquivalentTo(suite1)
 
     @pytest.mark.unit
     def test_is_equivalent_to_expectation_suite_classes_false_unit_test(self):
@@ -354,6 +356,7 @@ class TestIsEquivalentTo:
         suite1 = ExpectationSuite("suite_1", expectations=[StubExpectationConfiguration()])  # type: ignore[arg-type]
         suite2 = ExpectationSuite("suite_2", expectations=[StubExpectationConfiguration()])  # type: ignore[arg-type]
         assert not suite1.isEquivalentTo(suite2)
+        assert not suite2.isEquivalentTo(suite1)
 
     @pytest.mark.unit
     def test_is_equivalent_to_expectation_suite_and_dict_true(
@@ -414,6 +417,9 @@ class TestIsEquivalentTo:
         assert suite_with_single_expectation.isEquivalentTo(
             different_but_equivalent_suite
         )
+        assert different_but_equivalent_suite.isEquivalentTo(
+            suite_with_single_expectation
+        )
 
     @pytest.mark.integration
     def test_is_equivalent_to_expectation_suite_classes_false(
@@ -431,6 +437,9 @@ class TestIsEquivalentTo:
         assert not suite_with_single_expectation.isEquivalentTo(
             different_and_not_equivalent_suite
         )
+        assert not different_and_not_equivalent_suite.isEquivalentTo(
+            suite_with_single_expectation
+        )
 
     @pytest.mark.integration
     def test_is_equivalent_to_expectation_suite_classes_false_multiple_equivalent_expectations(
@@ -447,6 +456,9 @@ class TestIsEquivalentTo:
 
         assert not suite_with_single_expectation.isEquivalentTo(
             different_and_not_equivalent_suite
+        )
+        assert not different_and_not_equivalent_suite.isEquivalentTo(
+            suite_with_single_expectation
         )
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Assert `suite1.isEquivalentTo(suite2)` in both directions (e.g. also `suite2.isEquivalentTo(suite1)`)
- Per post merge feedback from https://github.com/great-expectations/great_expectations/pull/5979

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.