### PR TITLE
[BUGFIX] Fix use of column.partition metric in HistogramSingleBatchParameterBuilder to more accurately handle errors

### DIFF
--- a/great_expectations/rule_based_profiler/parameter_builder/histogram_single_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/histogram_single_batch_parameter_builder.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Optional, Set
 
 import numpy as np
-import pandas as pd
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.rule_based_profiler.config import ParameterBuilderConfig
@@ -130,8 +129,7 @@ class HistogramSingleBatchParameterBuilder(MetricSingleBatchParameterBuilder):
             FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY
         ]
 
-        element: Any
-        if bins is None or all(pd.isnull(element) for element in bins):
+        if bins is None:
             raise ge_exceptions.ProfilerExecutionError(
                 message=f"""Partitioning values for {self.__class__.__name__} by \
 {self._column_partition_metric_single_batch_parameter_builder_config.name} into bins encountered empty or non-existent \

--- a/great_expectations/rule_based_profiler/parameter_builder/histogram_single_batch_parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/histogram_single_batch_parameter_builder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set
 
 import numpy as np
 

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -400,9 +400,9 @@ def test_onboarding_data_assistant_get_metrics_and_expectations_using_implicit_i
 @pytest.mark.integration
 @pytest.mark.slow  # 38.26s
 def test_onboarding_data_assistant_get_metrics_and_expectations_using_implicit_invocation_with_estimation_directive(
-    bobby_columnar_table_multi_batch_deterministic_data_context,
+    quentin_columnar_table_multi_batch_data_context,
 ):
-    context: DataContext = bobby_columnar_table_multi_batch_deterministic_data_context
+    context: DataContext = quentin_columnar_table_multi_batch_data_context
 
     batch_request: dict = {
         "datasource_name": "taxi_pandas",
@@ -422,28 +422,6 @@ def test_onboarding_data_assistant_get_metrics_and_expectations_using_implicit_i
             else True
             for rule_config in data_assistant_result.profiler_config.rules.values()
         ]
-    )
-
-
-@pytest.mark.integration
-@pytest.mark.slow  # 38.26s
-@pytest.mark.xfail(
-    strict=True,
-    reason="Temporarily mark as xfail due to issue with congestion_surcharge column resolving to NaN for column.min and column.max",
-)
-def test_onboarding_data_assistant_get_metrics_and_expectations_quentin(
-    quentin_columnar_table_multi_batch_data_context,
-):
-    context: DataContext = quentin_columnar_table_multi_batch_data_context
-
-    batch_request: dict = {
-        "datasource_name": "taxi_pandas",
-        "data_connector_name": "monthly",
-        "data_asset_name": "my_reports",
-    }
-
-    context.assistants.onboarding.run(
-        batch_request=batch_request,
     )
 
 


### PR DESCRIPTION
### Scope
* When `HistogramSingleBatchParameterBuilder` uses `column.partition` metric, only `None` `bins` should generate an error.  If, however, each `bin` is `np.nan`, that is not an error; rather, it is the accurate reflection of a column's data values.
* Updated existing test and added a new test to reflect the more accurate behavior.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1247
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!