### PR TITLE
[BUGFIX] Make Spark implementation of "column.value_counts" metric more robust to None/NaN column values

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
@@ -157,15 +157,23 @@ class ColumnValueCounts(ColumnAggregateMetricProvider):
         value_counts_df: pyspark_sql_DataFrame = (
             df.select(column).where(F.col(column).isNotNull()).groupBy(column).count()
         )
+
         if sort == "value":
             value_counts_df = value_counts_df.orderBy(column)
         elif sort == "count":
             value_counts_df = value_counts_df.orderBy(F.desc("count"))
+
         value_counts: List[pyspark_sql_Row] = value_counts_df.collect()
+
         # Numpy does not always infer the correct DataTypes for Spark df, so we cannot use vectorized approach.
-        values: Any
-        counts: int
-        values, counts = zip(*value_counts)
+        values: List[Any]
+        counts: List[int]
+        if len(value_counts) > 0:
+            values, counts = zip(*value_counts)
+        else:
+            values = []
+            counts = []
+
         series = pd.Series(
             counts,
             index=pd.Index(data=values, name="value"),

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -3924,22 +3924,30 @@ def test_median_metric_spark(spark_session):
 
 
 @pytest.mark.integration
-def test_value_counts_metric_spark(spark_session):
-    engine: SparkDFExecutionEngine = build_spark_engine(
-        spark=spark_session,
-        df=pd.DataFrame(
-            {"a": [1, 2, 1, 2, 3, 3, None]},
-        ),
-        batch_id="my_id",
-    )
+def test_value_counts_metric_pd():
+    engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}))
+
+    metrics: dict = {}
+
+    table_columns_metric: MetricConfiguration
+    results: dict
+
+    table_columns_metric, results = get_table_columns_metric(engine=engine)
+    metrics.update(results)
 
     desired_metric = MetricConfiguration(
         metric_name="column.value_counts",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"sort": "value", "collate": None},
+        metric_dependencies={
+            "table.columns": table_columns_metric,
+        },
     )
 
-    metrics = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(desired_metric,), metrics=metrics
+    )
+    metrics.update(results)
     assert pd.Series(index=[1, 2, 3], data=[2, 2, 2]).equals(metrics[desired_metric.id])
 
 
@@ -3976,31 +3984,45 @@ def test_value_counts_metric_sa(sa):
 
 
 @pytest.mark.integration
-def test_value_counts_metric_pd():
-    engine = build_pandas_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}))
+def test_value_counts_metric_spark(spark_session):
+    from great_expectations.expectations.metrics.import_manager import sparktypes
 
-    metrics: dict = {}
-
-    table_columns_metric: MetricConfiguration
-    results: dict
-
-    table_columns_metric, results = get_table_columns_metric(engine=engine)
-    metrics.update(results)
+    engine: SparkDFExecutionEngine = build_spark_engine(
+        spark=spark_session,
+        df=pd.DataFrame(
+            {
+                "a": [1, 2, 1, 2, 3, 3, None],
+                "b": [None, None, None, None, None, None, None],
+            },
+        ),
+        schema=sparktypes.StructType(
+            [
+                sparktypes.StructField("a", sparktypes.FloatType(), True),
+                sparktypes.StructField("b", sparktypes.NullType(), True),
+            ]
+        ),
+        batch_id="my_id",
+    )
 
     desired_metric = MetricConfiguration(
         metric_name="column.value_counts",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"sort": "value", "collate": None},
-        metric_dependencies={
-            "table.columns": table_columns_metric,
-        },
     )
 
-    results = engine.resolve_metrics(
-        metrics_to_resolve=(desired_metric,), metrics=metrics
+    metrics = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
+    assert pd.Series(index=[1.0, 2.0, 3.0, np.nan], data=[2, 2, 2, 1]).equals(
+        metrics[desired_metric.id]
     )
-    metrics.update(results)
-    assert pd.Series(index=[1, 2, 3], data=[2, 2, 2]).equals(metrics[desired_metric.id])
+
+    desired_metric = MetricConfiguration(
+        metric_name="column.value_counts",
+        metric_domain_kwargs={"column": "b"},
+        metric_value_kwargs={"sort": "value", "collate": None},
+    )
+
+    metrics = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
+    assert pd.Series(index=[], data=[]).equals(metrics[desired_metric.id])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Scope
* In "column.value_counts" metric, while `None` values are removed, `np.nan` values are legitimate and should be accounted for properly.  Insure that all-`None`-valued columns are handled properly when returning value counts.
* Update unit tests to represent cases of an all-`None` column.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1249
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!