### PR TITLE
[BUGFIX] Filter out np.nan values (just like None values) as part of ColumnValueCounts._spark() implementation

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_value_counts.py
@@ -155,7 +155,11 @@ class ColumnValueCounts(ColumnAggregateMetricProvider):
         column: str = accessor_domain_kwargs["column"]
 
         value_counts_df: pyspark_sql_DataFrame = (
-            df.select(column).where(F.col(column).isNotNull()).groupBy(column).count()
+            df.select(column)
+            .where(F.col(column).isNotNull())
+            .where(~F.isnan(F.col(column)))
+            .groupBy(column)
+            .count()
         )
 
         if sort == "value":

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -4011,7 +4011,7 @@ def test_value_counts_metric_spark(spark_session):
     )
 
     metrics = engine.resolve_metrics(metrics_to_resolve=(desired_metric,))
-    assert pd.Series(index=[1.0, 2.0, 3.0, np.nan], data=[2, 2, 2, 1]).equals(
+    assert pd.Series(index=[1.0, 2.0, 3.0], data=[2, 2, 2]).equals(
         metrics[desired_metric.id]
     )
 


### PR DESCRIPTION
### Scope
* Correct behavior excludes both `np.nan` and `None` values from column when counting numbers of distinct values.
* Unit tests updated to reflect updated behavior.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1249
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
