### PR TITLE
[MAINTENANCE] Example of `splitter_method` at `Asset` and `DataConnector` level

### DIFF
--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Sql.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Sql.ipynb
@@ -1200,6 +1200,97 @@
   },
   {
    "cell_type": "markdown",
+   "id": "10a27510",
+   "metadata": {},
+   "source": [
+    "## Configuring Splitters at `DataConnector` and `Asset`-Level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fb9c585",
+   "metadata": {},
+   "source": [
+    "For `ConfiguredAssetSqlDataConnectors`, the `splitter_method` and `splitter_kwargs` can be configured at the `DataConnector`-level or `Asset`-level. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "263ed79f",
+   "metadata": {},
+   "source": [
+    "#### Configuration at `DataConnector`-level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baad2c0d",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Here is a configuration with the splitter method `split_on_year_and_month` configured at the `DataConnector`-level for a `DataConnector` with 2 `Assets`, `yellow_tripdata_sample_2020_by_year_and_month` and `yellow_tripdata_sample_2020`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aefcdb93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SqlAlchemyExecutionEngine\",\n",
+    "        \"connection_string\": CONNECTION_STRING,\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetSqlDataConnector\",\n",
+    "            \"splitter_method\": \"split_on_year_and_month\",\n",
+    "            \"splitter_kwargs\": {\n",
+    "                \"column_name\": \"pickup_datetime\",\n",
+    "            },\n",
+    "            \"assets\":{\n",
+    "    \n",
+    "                \"yellow_tripdata_sample_2020_by_year_and_month\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                },\n",
+    "                \"yellow_tripdata_sample_2020\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                },\n",
+    "            },\n",
+    "            \n",
+    "        },\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f36497e",
+   "metadata": {},
+   "source": [
+    "As you can see, both `Assets`, `yellow_tripdata_sample_2020_by_year_and_month` **and** `yellow_tripdata_sample_2020` have the splitter method applied to it, meaning they both have 12 Batches as a result of splitting by `year` and `month`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "162c74bc",
+   "metadata": {},
+   "source": [
+    "#### Configuration at `DataConnector`-level **and** `Asset`-level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "acf37899",
    "metadata": {},
    "source": [

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Sql.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Sql.ipynb
@@ -1234,7 +1234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aefcdb93",
+   "id": "21f102ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1287,6 +1287,71 @@
    "metadata": {},
    "source": [
     "#### Configuration at `DataConnector`-level **and** `Asset`-level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d2134d3",
+   "metadata": {},
+   "source": [
+    "Next we have a similar example, but with a second `splitter_method` also configured at the `Asset`-level. This time we will configure a second `splitter_method`, `split_on_year_and_month_and_day`, for the Asset `yellow_tripdata_sample_2020_by_year_and_month_and_day`. In this case, the `Asset`-level configuration will **override** the configuration at the `DataConnector`-level and produce 366 Batches as a result of splitting by `year`, `month` and `day`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99721406",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SqlAlchemyExecutionEngine\",\n",
+    "        \"connection_string\": CONNECTION_STRING,\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetSqlDataConnector\",\n",
+    "            \"splitter_method\": \"split_on_year_and_month\",\n",
+    "            \"splitter_kwargs\": {\n",
+    "                \"column_name\": \"pickup_datetime\",\n",
+    "            },\n",
+    "            \"assets\":{\n",
+    "    \n",
+    "                \"yellow_tripdata_sample_2020_by_year_and_month\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                },\n",
+    "                \"yellow_tripdata_sample_2020_by_year_and_month_and_day\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                    \"splitter_method\": \"split_on_year_and_month_and_day\",\n",
+    "                    \"splitter_kwargs\": {\n",
+    "                        \"column_name\": \"pickup_datetime\",\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "            \n",
+    "        },\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80ff49fe",
+   "metadata": {},
+   "source": [
+    "As you can see, `yellow_tripdata_sample_2020_by_year_and_month` and `yellow_tripdata_sample_2020_by_year_and_month_and_day` each have a different number of Batches resulting from their different `splitter` configurations. \n",
+    "\n",
+    "* `yellow_tripdata_sample_2020_by_year_and_month` has 12 Batches. \n",
+    "* `yellow_tripdata_sample_2020_by_year_and_month_and_day` has 366 Batches."
    ]
   },
   {

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Sql.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/DataAssistants_Instantiation_And_Running-OnboardingAssistant-Sql.ipynb
@@ -40,7 +40,18 @@
    "execution_count": 1,
    "id": "8362d4be",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/work/Development/great_expectations/great_expectations/execution_engine/sqlalchemy_execution_engine.py:137: UserWarning: Obsolete pybigquery is installed, which is likely to\n",
+      "interfere with sqlalchemy_bigquery.\n",
+      "pybigquery should be uninstalled.\n",
+      "  import sqlalchemy_bigquery as sqla_bigquery\n"
+     ]
+    }
+   ],
    "source": [
     "import great_expectations as ge\n",
     "from great_expectations.core.batch import BatchRequest\n",
@@ -104,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "id": "76dcee57",
    "metadata": {},
    "outputs": [],
@@ -114,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 4,
    "id": "a29fd9a3",
    "metadata": {},
    "outputs": [
@@ -132,8 +143,8 @@
       "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
       "\n",
       "\tAvailable data_asset_names (2 of 2):\n",
-      "\t\tyellow_tripdata_sample_2019 (3 of 12): [{'pickup_datetime': {'year': 2019, 'month': 1}}, {'pickup_datetime': {'year': 2019, 'month': 10}}, {'pickup_datetime': {'year': 2019, 'month': 11}}]\n",
-      "\t\tyellow_tripdata_sample_2020 (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\t\tyellow_tripdata_sample_2019 (3 of 12): [{'pickup_datetime': {'year': 2019, 'month': 2}}, {'pickup_datetime': {'year': 2019, 'month': 5}}, {'pickup_datetime': {'year': 2019, 'month': 6}}]\n",
+      "\t\tyellow_tripdata_sample_2020 (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 2}}, {'pickup_datetime': {'year': 2020, 'month': 7}}, {'pickup_datetime': {'year': 2020, 'month': 12}}]\n",
       "\n",
       "\tUnmatched data_references (0 of 0):[]\n",
       "\n"
@@ -142,10 +153,10 @@
     {
      "data": {
       "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x7f784c488a60>"
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7fa9af4bc5b0>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -197,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 5,
    "id": "ee0be5a2",
    "metadata": {},
    "outputs": [],
@@ -227,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "id": "b790e8b2",
    "metadata": {},
    "outputs": [],
@@ -241,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 7,
    "id": "da5b6cf0",
    "metadata": {},
    "outputs": [],
@@ -251,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 8,
    "id": "0f09894b-8b27-4159-ad7c-ea786b9da396",
    "metadata": {},
    "outputs": [],
@@ -261,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 9,
    "id": "d564f515-ff0d-4218-b568-542e83fa6f2d",
    "metadata": {},
    "outputs": [
@@ -271,7 +282,7 @@
        "12"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -306,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 10,
    "id": "0f1460a6",
    "metadata": {},
    "outputs": [
@@ -320,7 +331,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5147ea31b0144ef4a4160a07bde50ff2",
+       "model_id": "f7087dc65e054ea9ab6f46f0f89b66d3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -402,38 +413,6 @@
      "output_type": "display_data"
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using lossy conversion for decimal 1.3333333333333333 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.3333333333333333 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.3374935098492586 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.5670212364724211 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.96609178307929590491 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.3374935098492586 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.6465452046971292 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.8856180831641267 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.3374935098492586 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.42163702135578391094 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.31622776601683793320 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.6193277068654826 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.5555555555555556 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 1.5555555555555556 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.42163702135578391094 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.69920589878010103133 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.42163702135578391094 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.31622776601683793320 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.52704627669472988867 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.31622776601683793320 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.48304589153964795245 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.67494855771055289778 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.48304589153964795245 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.31622776601683793320 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.52704627669472988867 to float object to support serialization.\n",
-      "Using lossy conversion for decimal 0.52704627669472988867 to float object to support serialization.\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "",
@@ -490,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "id": "80345d4b",
    "metadata": {},
    "outputs": [],
@@ -516,20 +495,188 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "dd4c66e9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                <style>\n",
+       "                span.vega-bind-name {\n",
+       "                    color: #8784FF;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    font-weight: bold;\n",
+       "                }\n",
+       "                form.vega-bindings {\n",
+       "                    color: #1B2A4D;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    position: absolute;\n",
+       "                    left: 75px;\n",
+       "                    top: 28px;\n",
+       "                }\n",
+       "                </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                <style>\n",
+       "                .widget-inline-hbox .widget-label {\n",
+       "                    color: #8784FF;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    font-weight: bold;\n",
+       "                }\n",
+       "                .widget-dropdown > select {\n",
+       "                    padding-right: 21px;\n",
+       "                    padding-left: 3px;\n",
+       "                    color: #1B2A4D;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    height: 20px;\n",
+       "                    line-height: 14px;\n",
+       "                    background-size: 20px;\n",
+       "                    border-radius: 2px;\n",
+       "                }\n",
+       "                </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f35e95e1884048aab84fffc97868f878",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Select Plot Type: ', layout=Layout(margin='0px', width='max-conten…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "result.plot_metrics()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "03353ac8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                <style>\n",
+       "                span.vega-bind-name {\n",
+       "                    color: #8784FF;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    font-weight: bold;\n",
+       "                }\n",
+       "                form.vega-bindings {\n",
+       "                    color: #1B2A4D;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    position: absolute;\n",
+       "                    left: 75px;\n",
+       "                    top: 28px;\n",
+       "                }\n",
+       "                </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                <style>\n",
+       "                .widget-inline-hbox .widget-label {\n",
+       "                    color: #8784FF;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    font-weight: bold;\n",
+       "                }\n",
+       "                .widget-dropdown > select {\n",
+       "                    padding-right: 21px;\n",
+       "                    padding-left: 3px;\n",
+       "                    color: #1B2A4D;\n",
+       "                    font-family: Verdana;\n",
+       "                    font-size: 14px;\n",
+       "                    height: 20px;\n",
+       "                    line-height: 14px;\n",
+       "                    background-size: 20px;\n",
+       "                    border-radius: 2px;\n",
+       "                }\n",
+       "                </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "275269f308e54697b164e9b4f8479791",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Select Plot Type: ', layout=Layout(margin='0px', width='max-conten…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "result.plot_expectations_and_metrics()"
    ]
@@ -556,7 +703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 15,
    "id": "e4db1dfc-defd-4b83-bc65-0e77ccd67cd7",
    "metadata": {},
    "outputs": [],
@@ -566,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 16,
    "id": "eaf5d924-1c10-4eab-b6ed-2063d0a73871",
    "metadata": {},
    "outputs": [],
@@ -576,7 +723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 17,
    "id": "9426227a",
    "metadata": {},
    "outputs": [],
@@ -602,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 18,
    "id": "4cd07f43-53ce-4a32-8e03-d0e2322ecc42",
    "metadata": {},
    "outputs": [],
@@ -620,7 +767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 19,
    "id": "65ab5c11-9716-4a39-88df-6f805d65eca1",
    "metadata": {},
    "outputs": [],
@@ -630,7 +777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 20,
    "id": "2f5c4c37-684b-4b94-b0ea-2ae7dec1884d",
    "metadata": {},
    "outputs": [
@@ -640,7 +787,7 @@
        "{'datasource_name': 'taxi_multi_batch_sql_datasource', 'data_connector_name': 'configured_data_connector_multi_batch_asset', 'data_asset_name': 'yellow_tripdata_sample_2020', 'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}}}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -661,7 +808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 21,
    "id": "40c540fd",
    "metadata": {},
    "outputs": [
@@ -719,7 +866,7 @@
        "}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -749,14 +896,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "id": "3a718ee2-1971-495e-8113-8704752fd3c8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "010d716df10540e991348eb8ed58716f",
+       "model_id": "f22e199f02a34a5e84cdcdea727977cf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -793,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 23,
    "id": "bfc2cc49-cd02-44db-9079-d0baed7ffe73",
    "metadata": {},
    "outputs": [
@@ -803,7 +950,7 @@
        "False"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1233,10 +1380,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "21f102ee",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_sample_2020 (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7fa9b0849a90>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "datasource_config = {\n",
     "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
@@ -1299,10 +1478,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "99721406",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month_and_day (3 of 94): [{'pickup_datetime': {'year': 2020, 'month': 10, 'day': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10, 'day': 10}}, {'pickup_datetime': {'year': 2020, 'month': 10, 'day': 13}}]\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7fa9b298dd30>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "datasource_config = {\n",
     "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
@@ -1351,7 +1562,7 @@
     "As you can see, `yellow_tripdata_sample_2020_by_year_and_month` and `yellow_tripdata_sample_2020_by_year_and_month_and_day` each have a different number of Batches resulting from their different `splitter` configurations. \n",
     "\n",
     "* `yellow_tripdata_sample_2020_by_year_and_month` has 12 Batches. \n",
-    "* `yellow_tripdata_sample_2020_by_year_and_month_and_day` has 366 Batches."
+    "* `yellow_tripdata_sample_2020_by_year_and_month_and_day` has 94 Batches. (The reason it is not 366 is because we did not load the full dataset into the database by setting `load_full_dataset=False`, but you get the picture :) )"
    ]
   },
   {
@@ -1384,78 +1595,78 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from tests.test_utils import load_data_into_test_database\n",
-    "# from typing import List\n",
-    "# import sqlalchemy as sa\n",
-    "# import pandas as pd\n",
-    "# CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
+    "from tests.test_utils import load_data_into_test_database\n",
+    "from typing import List\n",
+    "import sqlalchemy as sa\n",
+    "import pandas as pd\n",
+    "CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
     "\n",
-    "# # 2019 first\n",
-    "# data_paths: List[str] = [\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-02.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-03.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-04.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-05.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-06.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-07.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-08.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-09.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-10.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-11.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-12.csv\",\n",
-    "# ]\n",
+    "# 2019 first\n",
+    "data_paths: List[str] = [\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-01.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-02.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-03.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-04.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-05.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-06.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-07.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-08.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-09.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-10.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-11.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2019-12.csv\",\n",
+    "]\n",
     "\n",
-    "# # adding 2019 table\n",
-    "# engine = sa.create_engine(CONNECTION_STRING)\n",
-    "# connection = engine.connect()\n",
-    "# table_name = \"yellow_tripdata_sample_2019\"\n",
-    "# res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
+    "# adding 2019 table\n",
+    "engine = sa.create_engine(CONNECTION_STRING)\n",
+    "connection = engine.connect()\n",
+    "table_name = \"yellow_tripdata_sample_2019\"\n",
+    "res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
     "\n",
-    "# for data_path in data_paths:\n",
-    "#     # This utility is not for general use. It is only to support testing.\n",
-    "#     load_data_into_test_database(\n",
-    "#         table_name=table_name,\n",
-    "#         csv_path=data_path,\n",
-    "#         connection_string=CONNECTION_STRING,\n",
-    "#         load_full_dataset=False,\n",
-    "#         drop_existing_table=False,\n",
-    "#         convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
-    "#     )\n",
+    "for data_path in data_paths:\n",
+    "    # This utility is not for general use. It is only to support testing.\n",
+    "    load_data_into_test_database(\n",
+    "        table_name=table_name,\n",
+    "        csv_path=data_path,\n",
+    "        connection_string=CONNECTION_STRING,\n",
+    "        load_full_dataset=False,\n",
+    "        drop_existing_table=False,\n",
+    "        convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
+    "    )\n",
     "\n",
     "\n",
-    "# # 2020 next\n",
+    "# 2020 next\n",
     "\n",
-    "# data_paths: List[str] = [\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-01.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-02.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-03.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-04.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-05.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-06.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-07.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-08.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-09.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-10.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-11.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-12.csv\",\n",
-    "# ]\n",
+    "data_paths: List[str] = [\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-01.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-02.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-03.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-04.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-05.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-06.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-07.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-08.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-09.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-10.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-11.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-12.csv\",\n",
+    "]\n",
     "\n",
-    "# engine = sa.create_engine(CONNECTION_STRING)\n",
-    "# connection = engine.connect()\n",
-    "# table_name = \"yellow_tripdata_sample_2020\"\n",
-    "# res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
+    "engine = sa.create_engine(CONNECTION_STRING)\n",
+    "connection = engine.connect()\n",
+    "table_name = \"yellow_tripdata_sample_2020\"\n",
+    "res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
     "\n",
-    "# for data_path in data_paths:\n",
-    "#     # This utility is not for general use. It is only to support testing.\n",
-    "#     load_data_into_test_database(\n",
-    "#         table_name=table_name,\n",
-    "#         csv_path=data_path,\n",
-    "#         connection_string=CONNECTION_STRING,\n",
-    "#         load_full_dataset=False,\n",
-    "#         drop_existing_table=False,\n",
-    "#         convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
-    "#     )\n",
+    "for data_path in data_paths:\n",
+    "    # This utility is not for general use. It is only to support testing.\n",
+    "    load_data_into_test_database(\n",
+    "        table_name=table_name,\n",
+    "        csv_path=data_path,\n",
+    "        connection_string=CONNECTION_STRING,\n",
+    "        load_full_dataset=False,\n",
+    "        drop_existing_table=False,\n",
+    "        convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
+    "    )\n",
     "\n",
     "    "
    ]

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "ee54886b-4f88-46d9-9afe-dfd8bb061e19",
    "metadata": {},
    "outputs": [],
@@ -26,8 +26,7 @@
     "from great_expectations.core.batch import BatchRequest\n",
     "import sqlite3\n",
     "import pprint\n",
-    "\n",
-    "yaml: YAMLHandler = YAMLHandler()"
+    "from ruamel import yaml\n"
    ]
   },
   {
@@ -40,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "45b1854b-2a75-422e-83bb-5509d868e0c5",
    "metadata": {},
    "outputs": [],
@@ -68,10 +67,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "cd29b60b-7e16-4978-acee-0dab368cde3c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['yellow_tripdata_sample_2019', 'yellow_tripdata_sample_2020']\n"
+     ]
+    }
+   ],
    "source": [
     "# connect to sqlite DB, and print the existing tables\n",
     "CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
@@ -108,10 +115,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "84150f65-bbd6-4b45-95ab-9590a29f116a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 5): [{'pickup_datetime': {'year': 2020, 'month': 5}}, {'pickup_datetime': {'year': 2020, 'month': 4}}, {'pickup_datetime': {'year': 2020, 'month': 3}}]\n",
+      "\t\tyellow_tripdata_sample_2020_full (1 of 1): [{}]\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7ff1c46ec160>"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "datasource_config = {\n",
     "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
@@ -161,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "7636ffff-0ddc-48fd-a4cf-f8e139a5e36e",
    "metadata": {},
    "outputs": [],
@@ -199,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "0453cd3c",
    "metadata": {},
    "outputs": [],
@@ -213,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "35df7084",
    "metadata": {},
    "outputs": [],
@@ -223,10 +262,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "d8e74a05-3fd1-4e47-9105-b721dbcf3516",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7ff1c43336a0>]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "batch_list"
    ]
@@ -241,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "c32dbac9-af5d-4677-98f9-f098ef091b6f",
    "metadata": {},
    "outputs": [],
@@ -255,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "3a284bfd-00aa-4068-bc09-71c6dea627e0",
    "metadata": {},
    "outputs": [],
@@ -265,10 +315,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "7bf3e1ff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7ff1c46f4730>,\n",
+       " <great_expectations.core.batch.Batch at 0x7ff1c429b940>,\n",
+       " <great_expectations.core.batch.Batch at 0x7ff1c45794f0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7ff1c469bac0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7ff1c42aa370>]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "multi_batch_batch_list # 12 batches"
    ]
@@ -283,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "16612bb4",
    "metadata": {},
    "outputs": [],
@@ -300,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "6ef1b6a9",
    "metadata": {},
    "outputs": [],
@@ -310,10 +375,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "80a69e96",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7ff1dbe703d0>]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "batch_list # has a length of 1, as expected"
    ]
@@ -328,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "229815cd",
    "metadata": {},
    "outputs": [],
@@ -338,10 +414,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "f2be5bdb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data': '<great_expectations.execution_engine.sqlalchemy_batch_data.SqlAlchemyBatchData object at 0x7ff1c42fb340>',\n",
+       " 'batch_request': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
+       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
+       "  'limit': None,\n",
+       "  'batch_spec_passthrough': None,\n",
+       "  'data_connector_query': {'batch_filter_parameters': {'pickup_datetime': {'year': 2020,\n",
+       "     'month': 1}}}},\n",
+       " 'batch_definition': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
+       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
+       "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}}},\n",
+       " 'batch_spec': {'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
+       "  'table_name': 'yellow_tripdata_sample_2020',\n",
+       "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}},\n",
+       "  'class_name': 'Asset',\n",
+       "  'schema_name': 'public',\n",
+       "  'splitter_method': 'split_on_year_and_month',\n",
+       "  'module_name': 'great_expectations.datasource.data_connector.asset',\n",
+       "  'splitter_kwargs': {'column_name': 'pickup_datetime'},\n",
+       "  'type': None},\n",
+       " 'batch_markers': {'ge_load_time': '20220913T024332.529136Z'}}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "batch.to_dict()"
    ]
@@ -364,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "847ce4a3",
    "metadata": {},
    "outputs": [],
@@ -374,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "a1eca55b",
    "metadata": {},
    "outputs": [],
@@ -384,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "852deba1",
    "metadata": {},
    "outputs": [],
@@ -410,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "11b673bc-8583-4fc5-9aa0-db6ca62e240c",
    "metadata": {},
    "outputs": [],
@@ -420,10 +528,210 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "ffe9cabd-b2bd-46de-9317-ba4e809342fa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7f1f7a3134bc4325b15d750c12b018bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>vendor_id</th>\n",
+       "      <th>pickup_datetime</th>\n",
+       "      <th>dropoff_datetime</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>trip_distance</th>\n",
+       "      <th>rate_code_id</th>\n",
+       "      <th>store_and_fwd_flag</th>\n",
+       "      <th>pickup_location_id</th>\n",
+       "      <th>dropoff_location_id</th>\n",
+       "      <th>payment_type</th>\n",
+       "      <th>fare_amount</th>\n",
+       "      <th>extra</th>\n",
+       "      <th>mta_tax</th>\n",
+       "      <th>tip_amount</th>\n",
+       "      <th>tolls_amount</th>\n",
+       "      <th>improvement_surcharge</th>\n",
+       "      <th>total_amount</th>\n",
+       "      <th>congestion_surcharge</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-04-03 16:23:46</td>\n",
+       "      <td>2020-04-03 16:34:42</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>2.26</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>263</td>\n",
+       "      <td>41</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.86</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>17.16</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2020-04-29 09:45:35</td>\n",
+       "      <td>2020-04-29 09:48:36</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.40</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>43</td>\n",
+       "      <td>151</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>4.80</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2020-04-27 19:21:48</td>\n",
+       "      <td>2020-04-27 19:29:07</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.80</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>140</td>\n",
+       "      <td>107</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>3.55</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>17.85</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-04-23 18:01:29</td>\n",
+       "      <td>2020-04-23 18:06:14</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.03</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>142</td>\n",
+       "      <td>238</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.88</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2020-04-29 09:02:24</td>\n",
+       "      <td>2020-04-29 09:08:48</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.80</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>161</td>\n",
+       "      <td>100</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.30</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>11.60</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   vendor_id     pickup_datetime    dropoff_datetime  passenger_count  \\\n",
+       "0        2.0 2020-04-03 16:23:46 2020-04-03 16:34:42              5.0   \n",
+       "1        1.0 2020-04-29 09:45:35 2020-04-29 09:48:36              0.0   \n",
+       "2        1.0 2020-04-27 19:21:48 2020-04-27 19:29:07              1.0   \n",
+       "3        2.0 2020-04-23 18:01:29 2020-04-23 18:06:14              1.0   \n",
+       "4        1.0 2020-04-29 09:02:24 2020-04-29 09:08:48              1.0   \n",
+       "\n",
+       "   trip_distance  rate_code_id store_and_fwd_flag  pickup_location_id  \\\n",
+       "0           2.26           1.0                  N                 263   \n",
+       "1           0.40           1.0                  N                  43   \n",
+       "2           2.80           1.0                  N                 140   \n",
+       "3           1.03           1.0                  N                 142   \n",
+       "4           0.80           1.0                  N                 161   \n",
+       "\n",
+       "   dropoff_location_id  payment_type  fare_amount  extra  mta_tax  tip_amount  \\\n",
+       "0                   41           1.0         10.0    1.0      0.5        2.86   \n",
+       "1                  151           1.0          4.0    0.0      0.5        0.00   \n",
+       "2                  107           1.0         10.0    3.5      0.5        3.55   \n",
+       "3                  238           1.0          6.0    1.0      0.5        2.58   \n",
+       "4                  100           1.0          6.0    2.5      0.5        2.30   \n",
+       "\n",
+       "   tolls_amount  improvement_surcharge  total_amount  congestion_surcharge  \n",
+       "0           0.0                    0.3         17.16                   2.5  \n",
+       "1           0.0                    0.3          4.80                   0.0  \n",
+       "2           0.0                    0.3         17.85                   2.5  \n",
+       "3           0.0                    0.3         12.88                   2.5  \n",
+       "4           0.0                    0.3         11.60                   2.5  "
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "validator.head()"
    ]
@@ -447,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "d7642647",
    "metadata": {},
    "outputs": [],
@@ -457,10 +765,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "b524a2df",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bdc46d7f52834ae9a8dcea9d19d51689",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"success\": false,\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.99\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "validator.expect_column_median_to_be_between(column=\"trip_distance\", min_value=0, max_value=1)"
    ]
@@ -483,10 +827,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "cdd821c3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7aa4929f2b514494af1dc0ffdf7a9f5f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating Expectations:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "44d2b5cb838845a4a677bb74ad7b45e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"success\": true,\n",
+       "  \"expectation_config\": {\n",
+       "    \"expectation_type\": \"expect_column_median_to_be_between\",\n",
+       "    \"kwargs\": {\n",
+       "      \"column\": \"trip_distance\",\n",
+       "      \"min_value\": 1.6,\n",
+       "      \"max_value\": 1.99,\n",
+       "      \"strict_min\": false,\n",
+       "      \"strict_max\": false\n",
+       "    },\n",
+       "    \"meta\": {\n",
+       "      \"auto_generated_at\": \"20220913T024338.419229Z\",\n",
+       "      \"great_expectations_version\": \"0.15.22+29.g8fc1586df\"\n",
+       "    }\n",
+       "  },\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.99\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "validator.expect_column_median_to_be_between(column=\"trip_distance\", auto=True)"
    ]
@@ -509,7 +938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "eba880ed",
    "metadata": {},
    "outputs": [],
@@ -536,7 +965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "747dea95",
    "metadata": {},
    "outputs": [],
@@ -555,10 +984,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "cb93d87f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"action_list\": [\n",
+       "    {\n",
+       "      \"name\": \"store_validation_result\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreValidationResultAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"store_evaluation_params\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreEvaluationParametersAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"update_data_docs\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"UpdateDataDocsAction\",\n",
+       "        \"site_names\": []\n",
+       "      }\n",
+       "    }\n",
+       "  ],\n",
+       "  \"batch_request\": {},\n",
+       "  \"class_name\": \"Checkpoint\",\n",
+       "  \"config_version\": 1.0,\n",
+       "  \"evaluation_parameters\": {},\n",
+       "  \"module_name\": \"great_expectations.checkpoint\",\n",
+       "  \"name\": \"my_checkpoint\",\n",
+       "  \"profilers\": [],\n",
+       "  \"runtime_configuration\": {},\n",
+       "  \"validations\": [\n",
+       "    {\n",
+       "      \"batch_request\": {\n",
+       "        \"datasource_name\": \"taxi_multi_batch_sql_datasource\",\n",
+       "        \"data_connector_name\": \"configured_data_connector_multi_batch_asset\",\n",
+       "        \"data_asset_name\": \"yellow_tripdata_sample_2020_by_year_and_month\",\n",
+       "        \"data_connector_query\": {\n",
+       "          \"batch_filter_parameters\": {\n",
+       "            \"pickup_datetime\": {\n",
+       "              \"year\": 2020,\n",
+       "              \"month\": 2\n",
+       "            }\n",
+       "          }\n",
+       "        }\n",
+       "      },\n",
+       "      \"expectation_suite_name\": \"example_sql_suite\"\n",
+       "    }\n",
+       "  ]\n",
+       "}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "checkpoint_config = {\n",
     "    \"name\": \"my_checkpoint\",\n",
@@ -576,10 +1064,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "3269dfba",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dda39f32a2424457bb73f1197bd904f3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "results = data_context.run_checkpoint(\n",
     "    checkpoint_name=\"my_checkpoint\"\n",
@@ -588,10 +1091,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "c6234082",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "results.success"
    ]
@@ -674,10 +1188,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "85b9598e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_sample_2020 (3 of 5): [{'pickup_datetime': {'year': 2020, 'month': 5}}, {'pickup_datetime': {'year': 2020, 'month': 4}}, {'pickup_datetime': {'year': 2020, 'month': 3}}]\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 5): [{'pickup_datetime': {'year': 2020, 'month': 5}}, {'pickup_datetime': {'year': 2020, 'month': 4}}, {'pickup_datetime': {'year': 2020, 'month': 3}}]\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7ff1c4564070>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "datasource_config = {\n",
     "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
@@ -820,49 +1366,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "ad91c234-06a2-4e98-9d90-c999c2aad07f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-01.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-02.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-03.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-04.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-05.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-06.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-07.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-08.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-09.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-10.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-11.csv']\n",
+      "Adding to existing table yellow_tripdata_sample_2020 and adding data from ['../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-12.csv']\n"
+     ]
+    }
+   ],
    "source": [
-    "# from tests.test_utils import load_data_into_test_database\n",
-    "# from typing import List\n",
-    "# import sqlalchemy as sa\n",
-    "# import pandas as pd\n",
-    "# CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
+    "from tests.test_utils import load_data_into_test_database\n",
+    "from typing import List\n",
+    "import sqlalchemy as sa\n",
+    "import pandas as pd\n",
+    "CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
     "\n",
-    "# data_paths: List[str] = [\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-01.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-02.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-03.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-04.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-05.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-06.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-07.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-08.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-09.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-10.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-11.csv\",\n",
-    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-12.csv\",\n",
-    "# ]\n",
+    "data_paths: List[str] = [\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-01.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-02.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-03.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-04.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-05.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-06.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-07.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-08.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-09.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-10.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-11.csv\",\n",
+    "     \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-12.csv\",\n",
+    "]\n",
     "\n",
     "    \n",
-    "# engine = sa.create_engine(CONNECTION_STRING)\n",
-    "# connection = engine.connect()\n",
-    "# table_name = \"yellow_tripdata_sample_2020\"\n",
-    "# res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
+    "engine = sa.create_engine(CONNECTION_STRING)\n",
+    "connection = engine.connect()\n",
+    "table_name = \"yellow_tripdata_sample_2020\"\n",
+    "res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
     "\n",
-    "# for data_path in data_paths:\n",
-    "#     # This utility is not for general use. It is only to support testing.\n",
-    "#     load_data_into_test_database(\n",
-    "#         table_name=\"yellow_tripdata_sample_2020\",\n",
-    "#         csv_path=data_path,\n",
-    "#         connection_string=CONNECTION_STRING,\n",
-    "#         load_full_dataset=True,\n",
-    "#         drop_existing_table=False,\n",
-    "#         convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
-    "#     )"
+    "for data_path in data_paths:\n",
+    "    # This utility is not for general use. It is only to support testing.\n",
+    "    load_data_into_test_database(\n",
+    "        table_name=\"yellow_tripdata_sample_2020\",\n",
+    "        csv_path=data_path,\n",
+    "        connection_string=CONNECTION_STRING,\n",
+    "        load_full_dataset=True,\n",
+    "        drop_existing_table=False,\n",
+    "        convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
+    "    )"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d4815f2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
@@ -24,10 +24,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/work/Development/great_expectations/great_expectations/execution_engine/sqlalchemy_execution_engine.py:137: UserWarning: Obsolete pybigquery is installed, which is likely to\n",
-      "interfere with sqlalchemy_bigquery.\n",
-      "pybigquery should be uninstalled.\n",
-      "  import sqlalchemy_bigquery as sqla_bigquery\n"
+      "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/snowflake/connector/options.py:94: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<3.1.0,>=3.0.0; extra == \"pandas\"'\n",
+      "  warn_incompatible_dep(\n"
      ]
     }
    ],
@@ -35,8 +33,10 @@
     "import great_expectations as gx\n",
     "from great_expectations.core.yaml_handler import YAMLHandler\n",
     "from great_expectations.core.batch import BatchRequest\n",
+    "import sqlite3\n",
     "import pprint\n",
-    "from ruamel import yaml"
+    "\n",
+    "yaml: YAMLHandler = YAMLHandler()"
    ]
   },
   {
@@ -153,7 +153,7 @@
     {
      "data": {
       "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x7f92a0cb78b0>"
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7fb46bcf3ee0>"
       ]
      },
      "execution_count": 4,
@@ -279,7 +279,7 @@
     {
      "data": {
       "text/plain": [
-       "[<great_expectations.core.batch.Batch at 0x7f92a0d77f40>]"
+       "[<great_expectations.core.batch.Batch at 0x7fb46bcb37f0>]"
       ]
      },
      "execution_count": 8,
@@ -332,18 +332,18 @@
     {
      "data": {
       "text/plain": [
-       "[<great_expectations.core.batch.Batch at 0x7f92b7730970>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0d1f4f0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0d38fd0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0d3ab80>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92b9f87220>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92b7774d90>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0d96670>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0d96d00>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0d88220>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0cf51c0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0cf5d00>,\n",
-       " <great_expectations.core.batch.Batch at 0x7f92a0cf5880>]"
+       "[<great_expectations.core.batch.Batch at 0x7fb483701970>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd50610>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd8b460>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd8b970>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd8bc10>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb483701160>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd8bb50>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd8b040>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd8b130>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd8b0d0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd50700>,\n",
+       " <great_expectations.core.batch.Batch at 0x7fb46bd9a6a0>]"
       ]
      },
      "execution_count": 11,
@@ -399,7 +399,7 @@
     {
      "data": {
       "text/plain": [
-       "[<great_expectations.core.batch.Batch at 0x7f92a0d32f70>]"
+       "[<great_expectations.core.batch.Batch at 0x7fb46bd50910>]"
       ]
      },
      "execution_count": 14,
@@ -438,13 +438,13 @@
     {
      "data": {
       "text/plain": [
-       "{'data': '<great_expectations.execution_engine.sqlalchemy_batch_data.SqlAlchemyBatchData object at 0x7f92a0cf5b80>',\n",
+       "{'data': '<great_expectations.execution_engine.sqlalchemy_batch_data.SqlAlchemyBatchData object at 0x7fb46bd9a370>',\n",
        " 'batch_request': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
        "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
        "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
-       "  'limit': None,\n",
        "  'data_connector_query': {'batch_filter_parameters': {'pickup_datetime': {'year': 2020,\n",
        "     'month': 1}}},\n",
+       "  'limit': None,\n",
        "  'batch_spec_passthrough': None},\n",
        " 'batch_definition': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
        "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
@@ -454,12 +454,12 @@
        "  'table_name': 'yellow_tripdata_sample_2020',\n",
        "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}},\n",
        "  'splitter_kwargs': {'column_name': 'pickup_datetime'},\n",
-       "  'class_name': 'Asset',\n",
        "  'splitter_method': 'split_on_year_and_month',\n",
-       "  'schema_name': 'public',\n",
        "  'module_name': 'great_expectations.datasource.data_connector.asset',\n",
+       "  'schema_name': 'public',\n",
+       "  'class_name': 'Asset',\n",
        "  'type': None},\n",
-       " 'batch_markers': {'ge_load_time': '20220913T003918.883626Z'}}"
+       " 'batch_markers': {'ge_load_time': '20220909T055904.147789Z'}}"
       ]
      },
      "execution_count": 16,
@@ -552,7 +552,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "24b934c5d6a74eb1a6481a62112e5062",
+       "model_id": "80745ecb18f7444fb85261e2ed1864b8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -608,107 +608,107 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>2.0</td>\n",
-       "      <td>2020-04-03 16:23:46</td>\n",
-       "      <td>2020-04-03 16:34:42</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>2.26</td>\n",
+       "      <td>2020-12-15 12:20:27</td>\n",
+       "      <td>2020-12-15 12:40:49</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>5.76</td>\n",
        "      <td>1.0</td>\n",
        "      <td>N</td>\n",
-       "      <td>263</td>\n",
-       "      <td>41</td>\n",
+       "      <td>209</td>\n",
+       "      <td>237</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>21.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.5</td>\n",
-       "      <td>2.86</td>\n",
+       "      <td>2.50</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.3</td>\n",
-       "      <td>17.16</td>\n",
+       "      <td>26.80</td>\n",
        "      <td>2.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-28 12:51:25</td>\n",
+       "      <td>2020-12-28 13:15:12</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>2020-04-29 09:45:35</td>\n",
-       "      <td>2020-04-29 09:48:36</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.40</td>\n",
+       "      <td>11.64</td>\n",
        "      <td>1.0</td>\n",
        "      <td>N</td>\n",
-       "      <td>43</td>\n",
-       "      <td>151</td>\n",
+       "      <td>161</td>\n",
+       "      <td>220</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>4.0</td>\n",
+       "      <td>33.5</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.5</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>5.00</td>\n",
+       "      <td>2.8</td>\n",
        "      <td>0.3</td>\n",
-       "      <td>4.80</td>\n",
-       "      <td>0.0</td>\n",
+       "      <td>44.60</td>\n",
+       "      <td>2.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-27 10:43:42</td>\n",
+       "      <td>2020-12-27 10:51:05</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>2020-04-27 19:21:48</td>\n",
-       "      <td>2020-04-27 19:29:07</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.80</td>\n",
+       "      <td>1.22</td>\n",
        "      <td>1.0</td>\n",
        "      <td>N</td>\n",
-       "      <td>140</td>\n",
-       "      <td>107</td>\n",
+       "      <td>163</td>\n",
+       "      <td>48</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>3.5</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.5</td>\n",
-       "      <td>3.55</td>\n",
+       "      <td>2.06</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.3</td>\n",
-       "      <td>17.85</td>\n",
+       "      <td>12.36</td>\n",
        "      <td>2.5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>2.0</td>\n",
-       "      <td>2020-04-23 18:01:29</td>\n",
-       "      <td>2020-04-23 18:06:14</td>\n",
+       "      <td>2020-12-08 13:42:52</td>\n",
+       "      <td>2020-12-08 13:54:45</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>1.03</td>\n",
+       "      <td>1.84</td>\n",
        "      <td>1.0</td>\n",
        "      <td>N</td>\n",
-       "      <td>142</td>\n",
-       "      <td>238</td>\n",
+       "      <td>137</td>\n",
+       "      <td>229</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.30</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-12-19 11:56:43</td>\n",
+       "      <td>2020-12-19 12:08:43</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>6.0</td>\n",
+       "      <td>1.55</td>\n",
        "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>24</td>\n",
+       "      <td>74</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>9.5</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.5</td>\n",
        "      <td>2.58</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.3</td>\n",
        "      <td>12.88</td>\n",
-       "      <td>2.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2020-04-29 09:02:24</td>\n",
-       "      <td>2020-04-29 09:08:48</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.80</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>N</td>\n",
-       "      <td>161</td>\n",
-       "      <td>100</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>6.0</td>\n",
-       "      <td>2.5</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>2.30</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.3</td>\n",
-       "      <td>11.60</td>\n",
-       "      <td>2.5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -716,32 +716,32 @@
       ],
       "text/plain": [
        "   vendor_id     pickup_datetime    dropoff_datetime  passenger_count  \\\n",
-       "0        2.0 2020-04-03 16:23:46 2020-04-03 16:34:42              5.0   \n",
-       "1        1.0 2020-04-29 09:45:35 2020-04-29 09:48:36              0.0   \n",
-       "2        1.0 2020-04-27 19:21:48 2020-04-27 19:29:07              1.0   \n",
-       "3        2.0 2020-04-23 18:01:29 2020-04-23 18:06:14              1.0   \n",
-       "4        1.0 2020-04-29 09:02:24 2020-04-29 09:08:48              1.0   \n",
+       "0        2.0 2020-12-15 12:20:27 2020-12-15 12:40:49              4.0   \n",
+       "1        2.0 2020-12-28 12:51:25 2020-12-28 13:15:12              1.0   \n",
+       "2        2.0 2020-12-27 10:43:42 2020-12-27 10:51:05              1.0   \n",
+       "3        2.0 2020-12-08 13:42:52 2020-12-08 13:54:45              1.0   \n",
+       "4        2.0 2020-12-19 11:56:43 2020-12-19 12:08:43              1.0   \n",
        "\n",
        "   trip_distance  rate_code_id store_and_fwd_flag  pickup_location_id  \\\n",
-       "0           2.26           1.0                  N                 263   \n",
-       "1           0.40           1.0                  N                  43   \n",
-       "2           2.80           1.0                  N                 140   \n",
-       "3           1.03           1.0                  N                 142   \n",
-       "4           0.80           1.0                  N                 161   \n",
+       "0           5.76           1.0                  N                 209   \n",
+       "1          11.64           1.0                  N                 161   \n",
+       "2           1.22           1.0                  N                 163   \n",
+       "3           1.84           1.0                  N                 137   \n",
+       "4           1.55           1.0                  N                  24   \n",
        "\n",
        "   dropoff_location_id  payment_type  fare_amount  extra  mta_tax  tip_amount  \\\n",
-       "0                   41           1.0         10.0    1.0      0.5        2.86   \n",
-       "1                  151           1.0          4.0    0.0      0.5        0.00   \n",
-       "2                  107           1.0         10.0    3.5      0.5        3.55   \n",
-       "3                  238           1.0          6.0    1.0      0.5        2.58   \n",
-       "4                  100           1.0          6.0    2.5      0.5        2.30   \n",
+       "0                  237           1.0         21.0    0.0      0.5        2.50   \n",
+       "1                  220           1.0         33.5    0.0      0.5        5.00   \n",
+       "2                   48           1.0          7.0    0.0      0.5        2.06   \n",
+       "3                  229           2.0          9.0    0.0      0.5        0.00   \n",
+       "4                   74           1.0          9.5    0.0      0.5        2.58   \n",
        "\n",
        "   tolls_amount  improvement_surcharge  total_amount  congestion_surcharge  \n",
-       "0           0.0                    0.3         17.16                   2.5  \n",
-       "1           0.0                    0.3          4.80                   0.0  \n",
-       "2           0.0                    0.3         17.85                   2.5  \n",
-       "3           0.0                    0.3         12.88                   2.5  \n",
-       "4           0.0                    0.3         11.60                   2.5  "
+       "0           0.0                    0.3         26.80                   2.5  \n",
+       "1           2.8                    0.3         44.60                   2.5  \n",
+       "2           0.0                    0.3         12.36                   2.5  \n",
+       "3           0.0                    0.3         12.30                   2.5  \n",
+       "4           0.0                    0.3         12.88                   0.0  "
       ]
      },
      "execution_count": 21,
@@ -789,7 +789,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8c98bf14a0694adf825f06493658edd0",
+       "model_id": "ac4237651dcb4207ae4a3f42d895ad02",
        "version_major": 2,
        "version_minor": 0
       },
@@ -809,11 +809,11 @@
        "    \"exception_traceback\": null,\n",
        "    \"exception_message\": null\n",
        "  },\n",
-       "  \"meta\": {},\n",
+       "  \"success\": false,\n",
        "  \"result\": {\n",
-       "    \"observed_value\": 1.61\n",
+       "    \"observed_value\": 1.75\n",
        "  },\n",
-       "  \"success\": false\n",
+       "  \"meta\": {}\n",
        "}"
       ]
      },
@@ -858,7 +858,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b2fcf761f6f54148a5d2657029301911",
+       "model_id": "ab19e0cad1de4977adf1229d461e6580",
        "version_major": 2,
        "version_minor": 0
       },
@@ -886,7 +886,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e785044d2b7742bd87d896dd8d142724",
+       "model_id": "9d6ffcecc85c48c8a8b3f5cf8bd1554a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -906,12 +906,13 @@
        "    \"exception_traceback\": null,\n",
        "    \"exception_message\": null\n",
        "  },\n",
+       "  \"success\": true,\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.75\n",
+       "  },\n",
        "  \"meta\": {},\n",
        "  \"expectation_config\": {\n",
-       "    \"meta\": {\n",
-       "      \"auto_generated_at\": \"20220913T003923.223388Z\",\n",
-       "      \"great_expectations_version\": \"0.15.22+24.g6a8d2d59f.dirty\"\n",
-       "    },\n",
+       "    \"expectation_type\": \"expect_column_median_to_be_between\",\n",
        "    \"kwargs\": {\n",
        "      \"column\": \"trip_distance\",\n",
        "      \"min_value\": 1.6,\n",
@@ -919,12 +920,11 @@
        "      \"strict_min\": false,\n",
        "      \"strict_max\": false\n",
        "    },\n",
-       "    \"expectation_type\": \"expect_column_median_to_be_between\"\n",
-       "  },\n",
-       "  \"result\": {\n",
-       "    \"observed_value\": 1.61\n",
-       "  },\n",
-       "  \"success\": true\n",
+       "    \"meta\": {\n",
+       "      \"auto_generated_at\": \"20220909T055905.990908Z\",\n",
+       "      \"great_expectations_version\": \"0.15.21+44.gf0e35fabd.dirty\"\n",
+       "    }\n",
+       "  }\n",
        "}"
       ]
      },
@@ -1088,7 +1088,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df95ba9c21ce4bd8a73fdfc91c161ba7",
+       "model_id": "72d5ae521bde405fb5dbb666eae4926b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1205,42 +1205,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "80c6ac3e",
+   "execution_count": null,
+   "id": "f6d5d03f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Attempting to instantiate class from config...\n",
-      "\tInstantiating as a Datasource, since class_name is Datasource\n",
-      "\tSuccessfully instantiated Datasource\n",
-      "\n",
-      "\n",
-      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
-      "Data Connectors:\n",
-      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
-      "\n",
-      "\tAvailable data_asset_names (2 of 2):\n",
-      "\t\tyellow_tripdata_sample_2020 (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
-      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
-      "\n",
-      "\tUnmatched data_references (0 of 0):[]\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x7f92a0e85820>"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "datasource_config = {\n",
     "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
@@ -1303,42 +1271,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "4a823855",
+   "execution_count": null,
+   "id": "475f3e92",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Attempting to instantiate class from config...\n",
-      "\tInstantiating as a Datasource, since class_name is Datasource\n",
-      "\tSuccessfully instantiated Datasource\n",
-      "\n",
-      "\n",
-      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
-      "Data Connectors:\n",
-      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
-      "\n",
-      "\tAvailable data_asset_names (2 of 2):\n",
-      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
-      "\t\tyellow_tripdata_sample_2020_by_year_and_month_and_day (3 of 366): [{'pickup_datetime': {'year': 2020, 'month': 10, 'day': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10, 'day': 10}}, {'pickup_datetime': {'year': 2020, 'month': 10, 'day': 11}}]\n",
-      "\n",
-      "\tUnmatched data_references (0 of 0):[]\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x7f92a1943460>"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "datasource_config = {\n",
     "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
@@ -1415,7 +1351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "ad91c234-06a2-4e98-9d90-c999c2aad07f",
    "metadata": {},
    "outputs": [],

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
@@ -16,19 +16,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "ee54886b-4f88-46d9-9afe-dfd8bb061e19",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/snowflake/connector/options.py:94: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<3.1.0,>=3.0.0; extra == \"pandas\"'\n",
-      "  warn_incompatible_dep(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import great_expectations as gx\n",
     "from great_expectations.core.yaml_handler import YAMLHandler\n",
@@ -49,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "45b1854b-2a75-422e-83bb-5509d868e0c5",
    "metadata": {},
    "outputs": [],
@@ -77,18 +68,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "cd29b60b-7e16-4978-acee-0dab368cde3c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['yellow_tripdata_sample_2020']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# connect to sqlite DB, and print the existing tables\n",
     "CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
@@ -125,42 +108,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "84150f65-bbd6-4b45-95ab-9590a29f116a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Attempting to instantiate class from config...\n",
-      "\tInstantiating as a Datasource, since class_name is Datasource\n",
-      "\tSuccessfully instantiated Datasource\n",
-      "\n",
-      "\n",
-      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
-      "Data Connectors:\n",
-      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
-      "\n",
-      "\tAvailable data_asset_names (2 of 2):\n",
-      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
-      "\t\tyellow_tripdata_sample_2020_full (1 of 1): [{}]\n",
-      "\n",
-      "\tUnmatched data_references (0 of 0):[]\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<great_expectations.datasource.new_datasource.Datasource at 0x7fb46bcf3ee0>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "datasource_config = {\n",
     "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
@@ -210,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "7636ffff-0ddc-48fd-a4cf-f8e139a5e36e",
    "metadata": {},
    "outputs": [],
@@ -248,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0453cd3c",
    "metadata": {},
    "outputs": [],
@@ -262,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "35df7084",
    "metadata": {},
    "outputs": [],
@@ -272,21 +223,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "d8e74a05-3fd1-4e47-9105-b721dbcf3516",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<great_expectations.core.batch.Batch at 0x7fb46bcb37f0>]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "batch_list"
    ]
@@ -301,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "c32dbac9-af5d-4677-98f9-f098ef091b6f",
    "metadata": {},
    "outputs": [],
@@ -315,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "3a284bfd-00aa-4068-bc09-71c6dea627e0",
    "metadata": {},
    "outputs": [],
@@ -325,32 +265,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "7bf3e1ff",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<great_expectations.core.batch.Batch at 0x7fb483701970>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd50610>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd8b460>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd8b970>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd8bc10>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb483701160>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd8bb50>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd8b040>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd8b130>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd8b0d0>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd50700>,\n",
-       " <great_expectations.core.batch.Batch at 0x7fb46bd9a6a0>]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "multi_batch_batch_list # 12 batches"
    ]
@@ -365,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "16612bb4",
    "metadata": {},
    "outputs": [],
@@ -382,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "6ef1b6a9",
    "metadata": {},
    "outputs": [],
@@ -392,21 +310,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "80a69e96",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<great_expectations.core.batch.Batch at 0x7fb46bd50910>]"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "batch_list # has a length of 1, as expected"
    ]
@@ -421,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "229815cd",
    "metadata": {},
    "outputs": [],
@@ -431,42 +338,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "f2be5bdb",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'data': '<great_expectations.execution_engine.sqlalchemy_batch_data.SqlAlchemyBatchData object at 0x7fb46bd9a370>',\n",
-       " 'batch_request': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
-       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
-       "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
-       "  'data_connector_query': {'batch_filter_parameters': {'pickup_datetime': {'year': 2020,\n",
-       "     'month': 1}}},\n",
-       "  'limit': None,\n",
-       "  'batch_spec_passthrough': None},\n",
-       " 'batch_definition': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
-       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
-       "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
-       "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}}},\n",
-       " 'batch_spec': {'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
-       "  'table_name': 'yellow_tripdata_sample_2020',\n",
-       "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}},\n",
-       "  'splitter_kwargs': {'column_name': 'pickup_datetime'},\n",
-       "  'splitter_method': 'split_on_year_and_month',\n",
-       "  'module_name': 'great_expectations.datasource.data_connector.asset',\n",
-       "  'schema_name': 'public',\n",
-       "  'class_name': 'Asset',\n",
-       "  'type': None},\n",
-       " 'batch_markers': {'ge_load_time': '20220909T055904.147789Z'}}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "batch.to_dict()"
    ]
@@ -489,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "847ce4a3",
    "metadata": {},
    "outputs": [],
@@ -499,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "a1eca55b",
    "metadata": {},
    "outputs": [],
@@ -509,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "852deba1",
    "metadata": {},
    "outputs": [],
@@ -535,7 +410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "11b673bc-8583-4fc5-9aa0-db6ca62e240c",
    "metadata": {},
    "outputs": [],
@@ -545,210 +420,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "ffe9cabd-b2bd-46de-9317-ba4e809342fa",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "80745ecb18f7444fb85261e2ed1864b8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>vendor_id</th>\n",
-       "      <th>pickup_datetime</th>\n",
-       "      <th>dropoff_datetime</th>\n",
-       "      <th>passenger_count</th>\n",
-       "      <th>trip_distance</th>\n",
-       "      <th>rate_code_id</th>\n",
-       "      <th>store_and_fwd_flag</th>\n",
-       "      <th>pickup_location_id</th>\n",
-       "      <th>dropoff_location_id</th>\n",
-       "      <th>payment_type</th>\n",
-       "      <th>fare_amount</th>\n",
-       "      <th>extra</th>\n",
-       "      <th>mta_tax</th>\n",
-       "      <th>tip_amount</th>\n",
-       "      <th>tolls_amount</th>\n",
-       "      <th>improvement_surcharge</th>\n",
-       "      <th>total_amount</th>\n",
-       "      <th>congestion_surcharge</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2020-12-15 12:20:27</td>\n",
-       "      <td>2020-12-15 12:40:49</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>5.76</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>N</td>\n",
-       "      <td>209</td>\n",
-       "      <td>237</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>21.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>2.50</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.3</td>\n",
-       "      <td>26.80</td>\n",
-       "      <td>2.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2020-12-28 12:51:25</td>\n",
-       "      <td>2020-12-28 13:15:12</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>11.64</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>N</td>\n",
-       "      <td>161</td>\n",
-       "      <td>220</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>33.5</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>5.00</td>\n",
-       "      <td>2.8</td>\n",
-       "      <td>0.3</td>\n",
-       "      <td>44.60</td>\n",
-       "      <td>2.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2020-12-27 10:43:42</td>\n",
-       "      <td>2020-12-27 10:51:05</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.22</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>N</td>\n",
-       "      <td>163</td>\n",
-       "      <td>48</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>7.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>2.06</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.3</td>\n",
-       "      <td>12.36</td>\n",
-       "      <td>2.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2020-12-08 13:42:52</td>\n",
-       "      <td>2020-12-08 13:54:45</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.84</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>N</td>\n",
-       "      <td>137</td>\n",
-       "      <td>229</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.3</td>\n",
-       "      <td>12.30</td>\n",
-       "      <td>2.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2020-12-19 11:56:43</td>\n",
-       "      <td>2020-12-19 12:08:43</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.55</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>N</td>\n",
-       "      <td>24</td>\n",
-       "      <td>74</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>9.5</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>2.58</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.3</td>\n",
-       "      <td>12.88</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   vendor_id     pickup_datetime    dropoff_datetime  passenger_count  \\\n",
-       "0        2.0 2020-12-15 12:20:27 2020-12-15 12:40:49              4.0   \n",
-       "1        2.0 2020-12-28 12:51:25 2020-12-28 13:15:12              1.0   \n",
-       "2        2.0 2020-12-27 10:43:42 2020-12-27 10:51:05              1.0   \n",
-       "3        2.0 2020-12-08 13:42:52 2020-12-08 13:54:45              1.0   \n",
-       "4        2.0 2020-12-19 11:56:43 2020-12-19 12:08:43              1.0   \n",
-       "\n",
-       "   trip_distance  rate_code_id store_and_fwd_flag  pickup_location_id  \\\n",
-       "0           5.76           1.0                  N                 209   \n",
-       "1          11.64           1.0                  N                 161   \n",
-       "2           1.22           1.0                  N                 163   \n",
-       "3           1.84           1.0                  N                 137   \n",
-       "4           1.55           1.0                  N                  24   \n",
-       "\n",
-       "   dropoff_location_id  payment_type  fare_amount  extra  mta_tax  tip_amount  \\\n",
-       "0                  237           1.0         21.0    0.0      0.5        2.50   \n",
-       "1                  220           1.0         33.5    0.0      0.5        5.00   \n",
-       "2                   48           1.0          7.0    0.0      0.5        2.06   \n",
-       "3                  229           2.0          9.0    0.0      0.5        0.00   \n",
-       "4                   74           1.0          9.5    0.0      0.5        2.58   \n",
-       "\n",
-       "   tolls_amount  improvement_surcharge  total_amount  congestion_surcharge  \n",
-       "0           0.0                    0.3         26.80                   2.5  \n",
-       "1           2.8                    0.3         44.60                   2.5  \n",
-       "2           0.0                    0.3         12.36                   2.5  \n",
-       "3           0.0                    0.3         12.30                   2.5  \n",
-       "4           0.0                    0.3         12.88                   0.0  "
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "validator.head()"
    ]
@@ -772,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "d7642647",
    "metadata": {},
    "outputs": [],
@@ -782,46 +457,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "b524a2df",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ac4237651dcb4207ae4a3f42d895ad02",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{\n",
-       "  \"exception_info\": {\n",
-       "    \"raised_exception\": false,\n",
-       "    \"exception_traceback\": null,\n",
-       "    \"exception_message\": null\n",
-       "  },\n",
-       "  \"success\": false,\n",
-       "  \"result\": {\n",
-       "    \"observed_value\": 1.75\n",
-       "  },\n",
-       "  \"meta\": {}\n",
-       "}"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "validator.expect_column_median_to_be_between(column=\"trip_distance\", min_value=0, max_value=1)"
    ]
@@ -844,95 +483,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "cdd821c3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab19e0cad1de4977adf1229d461e6580",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Generating Expectations:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d6ffcecc85c48c8a8b3f5cf8bd1554a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{\n",
-       "  \"exception_info\": {\n",
-       "    \"raised_exception\": false,\n",
-       "    \"exception_traceback\": null,\n",
-       "    \"exception_message\": null\n",
-       "  },\n",
-       "  \"success\": true,\n",
-       "  \"result\": {\n",
-       "    \"observed_value\": 1.75\n",
-       "  },\n",
-       "  \"meta\": {},\n",
-       "  \"expectation_config\": {\n",
-       "    \"expectation_type\": \"expect_column_median_to_be_between\",\n",
-       "    \"kwargs\": {\n",
-       "      \"column\": \"trip_distance\",\n",
-       "      \"min_value\": 1.6,\n",
-       "      \"max_value\": 1.99,\n",
-       "      \"strict_min\": false,\n",
-       "      \"strict_max\": false\n",
-       "    },\n",
-       "    \"meta\": {\n",
-       "      \"auto_generated_at\": \"20220909T055905.990908Z\",\n",
-       "      \"great_expectations_version\": \"0.15.21+44.gf0e35fabd.dirty\"\n",
-       "    }\n",
-       "  }\n",
-       "}"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "validator.expect_column_median_to_be_between(column=\"trip_distance\", auto=True)"
    ]
@@ -955,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "eba880ed",
    "metadata": {},
    "outputs": [],
@@ -982,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "747dea95",
    "metadata": {},
    "outputs": [],
@@ -1001,69 +555,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "cb93d87f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{\n",
-       "  \"action_list\": [\n",
-       "    {\n",
-       "      \"name\": \"store_validation_result\",\n",
-       "      \"action\": {\n",
-       "        \"class_name\": \"StoreValidationResultAction\"\n",
-       "      }\n",
-       "    },\n",
-       "    {\n",
-       "      \"name\": \"store_evaluation_params\",\n",
-       "      \"action\": {\n",
-       "        \"class_name\": \"StoreEvaluationParametersAction\"\n",
-       "      }\n",
-       "    },\n",
-       "    {\n",
-       "      \"name\": \"update_data_docs\",\n",
-       "      \"action\": {\n",
-       "        \"class_name\": \"UpdateDataDocsAction\",\n",
-       "        \"site_names\": []\n",
-       "      }\n",
-       "    }\n",
-       "  ],\n",
-       "  \"batch_request\": {},\n",
-       "  \"class_name\": \"Checkpoint\",\n",
-       "  \"config_version\": 1.0,\n",
-       "  \"evaluation_parameters\": {},\n",
-       "  \"module_name\": \"great_expectations.checkpoint\",\n",
-       "  \"name\": \"my_checkpoint\",\n",
-       "  \"profilers\": [],\n",
-       "  \"runtime_configuration\": {},\n",
-       "  \"validations\": [\n",
-       "    {\n",
-       "      \"batch_request\": {\n",
-       "        \"datasource_name\": \"taxi_multi_batch_sql_datasource\",\n",
-       "        \"data_connector_name\": \"configured_data_connector_multi_batch_asset\",\n",
-       "        \"data_asset_name\": \"yellow_tripdata_sample_2020_by_year_and_month\",\n",
-       "        \"data_connector_query\": {\n",
-       "          \"batch_filter_parameters\": {\n",
-       "            \"pickup_datetime\": {\n",
-       "              \"year\": 2020,\n",
-       "              \"month\": 2\n",
-       "            }\n",
-       "          }\n",
-       "        }\n",
-       "      },\n",
-       "      \"expectation_suite_name\": \"example_sql_suite\"\n",
-       "    }\n",
-       "  ]\n",
-       "}"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "checkpoint_config = {\n",
     "    \"name\": \"my_checkpoint\",\n",
@@ -1081,25 +576,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "3269dfba",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "72d5ae521bde405fb5dbb666eae4926b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "results = data_context.run_checkpoint(\n",
     "    checkpoint_name=\"my_checkpoint\"\n",
@@ -1108,21 +588,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "c6234082",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "results.success"
    ]
@@ -1351,7 +820,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "ad91c234-06a2-4e98-9d90-c999c2aad07f",
    "metadata": {},
    "outputs": [],

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
@@ -1,1264 +1,1484 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "7f0a5264-b003-4101-862f-45653f2aed1b",
-      "metadata": {},
-      "source": [
-        "# How to write multi-batch `BatchRequest` - Configured `Sql` Example\n",
-        "* A `BatchRequest` facilitates the return of a `batch` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_a_batch_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
-        "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
-        "   1. Self-Initializing Expectations to estimate parameters\n",
-        "   2. DataAssistants to profile your data and create and Expectation suite with self-intialized parameters.\n",
-        "   \n",
-        "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "ee54886b-4f88-46d9-9afe-dfd8bb061e19",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/Users/work/Development/ENVs/supercon_ge/lib/python3.8/site-packages/snowflake/connector/options.py:94: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<3.1.0,>=3.0.0; extra == \"pandas\"'\n",
-            "  warn_incompatible_dep(\n"
-          ]
-        }
-      ],
-      "source": [
-        "import great_expectations as gx\n",
-        "from great_expectations.core.yaml_handler import YAMLHandler\n",
-        "from great_expectations.core.batch import BatchRequest\n",
-        "import sqlite3\n",
-        "import pprint\n",
-        "\n",
-        "yaml: YAMLHandler = YAMLHandler()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "bfa243d2-6905-403a-b47a-d89ba834b951",
-      "metadata": {},
-      "source": [
-        "* Load `DataContext`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "45b1854b-2a75-422e-83bb-5509d868e0c5",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "data_context: gx.DataContext = gx.get_context()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c4462320-d76e-492c-96fb-f0ff8f788851",
-      "metadata": {},
-      "source": [
-        "## Sql Example"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a6e04726",
-      "metadata": {},
-      "source": [
-        "### Example Database\n",
-        "\n",
-        "Imagine we have a database of 1 table, with `yellow_tripdata_sample_2020`, corresponding to all 12 months' `taxi_trip` data for 2020.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "cd29b60b-7e16-4978-acee-0dab368cde3c",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "['yellow_tripdata_sample_2020']\n"
-          ]
-        }
-      ],
-      "source": [
-        "# connect to sqlite DB, and print the existing tables\n",
-        "CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
-        "from sqlalchemy import create_engine\n",
-        "from sqlalchemy import inspect\n",
-        "engine = create_engine(CONNECTION_STRING)\n",
-        "insp = inspect(engine)\n",
-        "print(insp.get_table_names())"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "49515697-83a2-432d-8b74-33e2f01db72c",
-      "metadata": {},
-      "source": [
-        "## Example Configuration"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "df19a29c",
-      "metadata": {},
-      "source": [
-        "In our example, we add a `Datasource` named `taxi_multi_batch_sql_datasource` with 1 table. We also have a `ConfiguredAssetSqlDataConnector` named `configured_data_connector_multi_batch_asset`.\n",
-        "\n",
-        "The DataConnector contains 2 `assets`, both associated with the `table_name` named`yellow_tripdata_sample_2020`.\n",
-        "\n",
-        "The asset `yellow_tripdata_sample_2020_full` contains no other parameter other than the `table_name` and optional `schema_name`, which mean the whole table will be loaded as one Batch in the asset. \n",
-        "\n",
-        "The asset `yellow_tripdata_sample_2020_by_year_and_month` contains `table_name` and `schema_name`, as well as a splitter configuration. The splitter we use is `split_on_year_and_month`, which creates Batches according to the `pickup_datetime` column which is of type timestamp in the database schema.\n",
-        "\n",
-        "**Note**: This example only uses `splitters` but sampling can also be used. For more information, please refer to the document [How to configure a DataConnector for splitting and sampling tables in SQL](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/advanced/how_to_configure_a_dataconnector_for_splitting_and_sampling_tables_in_sql)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "84150f65-bbd6-4b45-95ab-9590a29f116a",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Attempting to instantiate class from config...\n",
-            "\tInstantiating as a Datasource, since class_name is Datasource\n",
-            "\tSuccessfully instantiated Datasource\n",
-            "\n",
-            "\n",
-            "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
-            "Data Connectors:\n",
-            "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
-            "\n",
-            "\tAvailable data_asset_names (2 of 2):\n",
-            "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
-            "\t\tyellow_tripdata_sample_2020_full (1 of 1): [{}]\n",
-            "\n",
-            "\tUnmatched data_references (0 of 0):[]\n",
-            "\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "<great_expectations.datasource.new_datasource.Datasource at 0x7fb46bcf3ee0>"
-            ]
-          },
-          "execution_count": 4,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "datasource_config = {\n",
-        "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
-        "    \"class_name\": \"Datasource\",\n",
-        "    \"module_name\": \"great_expectations.datasource\",\n",
-        "    \"execution_engine\": {\n",
-        "        \"module_name\": \"great_expectations.execution_engine\",\n",
-        "        \"class_name\": \"SqlAlchemyExecutionEngine\",\n",
-        "        \"connection_string\": CONNECTION_STRING,\n",
-        "    },\n",
-        "    \"data_connectors\": {\n",
-        "        \"configured_data_connector_multi_batch_asset\": {\n",
-        "            \"class_name\": \"ConfiguredAssetSqlDataConnector\",\n",
-        "            \"assets\":{\n",
-        "                \"yellow_tripdata_sample_2020_full\":\n",
-        "                {\n",
-        "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
-        "                    \"schema_name\": \"public\",\n",
-        "                },\n",
-        "    \n",
-        "                \"yellow_tripdata_sample_2020_by_year_and_month\":{\n",
-        "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
-        "                    \"schema_name\": \"public\",\n",
-        "                    \"splitter_method\": \"split_on_year_and_month\",\n",
-        "                    \"splitter_kwargs\": {\n",
-        "                        \"column_name\": \"pickup_datetime\",\n",
-        "                        },\n",
-        "                    },\n",
-        "                },\n",
-        "            },\n",
-        "            \n",
-        "        },\n",
-        "}\n",
-        "\n",
-        "data_context.test_yaml_config(yaml.dump(datasource_config))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "635755a4-36b1-442f-968a-2fbdb9b146d8",
-      "metadata": {},
-      "source": [
-        "We see we have successfully configured this because the output shows a 2 data assets\n",
-        "- `yellow_tripdata_sample_2020_full` associated with 1 batch. \n",
-        "- `yellow_tripdata_sample_2020_by_year_and_month` with 12 batches, each associated with a different month in our `pickup_datetime` column. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "7636ffff-0ddc-48fd-a4cf-f8e139a5e36e",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# add_datasource only if it doesn't already exist in our configuration\n",
-        "try:\n",
-        "    data_context.get_datasource(datasource_config[\"name\"])\n",
-        "except ValueError:\n",
-        "    data_context.add_datasource(**datasource_config)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "438146be",
-      "metadata": {},
-      "source": [
-        "## BatchRequest"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "117cdb0d",
-      "metadata": {},
-      "source": [
-        "Depending on how we configured our assets, when you send a `BatchRequest`, you will retrieve a different number of `Batches`"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "87bc9c59",
-      "metadata": {},
-      "source": [
-        "Single Batch returned by `yellow_tripdata_sample_2020_full`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "0453cd3c",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "single_batch_batch_request: BatchRequest = BatchRequest(\n",
-        "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
-        "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
-        "    data_asset_name=\"yellow_tripdata_sample_2020_full\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "35df7084",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "id": "d8e74a05-3fd1-4e47-9105-b721dbcf3516",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[<great_expectations.core.batch.Batch at 0x7fb46bcb37f0>]"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "batch_list"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "be7f4fa5",
-      "metadata": {},
-      "source": [
-        "Multi Batch returned by `yellow_tripdata_sample_2020_by_year_and_month`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "id": "c32dbac9-af5d-4677-98f9-f098ef091b6f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "multi_batch_batch_request: BatchRequest = BatchRequest(\n",
-        "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
-        "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
-        "    data_asset_name=\"yellow_tripdata_sample_2020_by_year_and_month\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "id": "3a284bfd-00aa-4068-bc09-71c6dea627e0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "id": "7bf3e1ff",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[<great_expectations.core.batch.Batch at 0x7fb483701970>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd50610>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd8b460>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd8b970>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd8bc10>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb483701160>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd8bb50>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd8b040>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd8b130>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd8b0d0>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd50700>,\n",
-              " <great_expectations.core.batch.Batch at 0x7fb46bd9a6a0>]"
-            ]
-          },
-          "execution_count": 11,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "multi_batch_batch_list # 12 batches"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "790746ee",
-      "metadata": {},
-      "source": [
-        "You can also get a single Batch from a multi-batch DataConnector by passing in `data_connector_query`. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "id": "16612bb4",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "single_batch_batch_request_from_multi: BatchRequest = BatchRequest(\n",
-        "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
-        "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
-        "    data_asset_name=\"yellow_tripdata_sample_2020_by_year_and_month\",\n",
-        "    data_connector_query={ \n",
-        "        \"batch_filter_parameters\": {\"pickup_datetime\": {\"year\": 2020, \"month\": 1}}\n",
-        "    }\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "id": "6ef1b6a9",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request_from_multi)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "id": "80a69e96",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[<great_expectations.core.batch.Batch at 0x7fb46bd50910>]"
-            ]
-          },
-          "execution_count": 14,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "batch_list # has a length of 1, as expected"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "26cd5a37",
-      "metadata": {},
-      "source": [
-        "Let's review our batch:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "id": "229815cd",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "batch = batch_list[0]  # our single filtered batch with 'batch_identifiers': {'pickup_datetime': '2020-01'}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "id": "f2be5bdb",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{'data': '<great_expectations.execution_engine.sqlalchemy_batch_data.SqlAlchemyBatchData object at 0x7fb46bd9a370>',\n",
-              " 'batch_request': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
-              "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
-              "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
-              "  'data_connector_query': {'batch_filter_parameters': {'pickup_datetime': {'year': 2020,\n",
-              "     'month': 1}}},\n",
-              "  'limit': None,\n",
-              "  'batch_spec_passthrough': None},\n",
-              " 'batch_definition': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
-              "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
-              "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
-              "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}}},\n",
-              " 'batch_spec': {'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
-              "  'table_name': 'yellow_tripdata_sample_2020',\n",
-              "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}},\n",
-              "  'splitter_kwargs': {'column_name': 'pickup_datetime'},\n",
-              "  'splitter_method': 'split_on_year_and_month',\n",
-              "  'module_name': 'great_expectations.datasource.data_connector.asset',\n",
-              "  'schema_name': 'public',\n",
-              "  'class_name': 'Asset',\n",
-              "  'type': None},\n",
-              " 'batch_markers': {'ge_load_time': '20220909T055904.147789Z'}}"
-            ]
-          },
-          "execution_count": 16,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "batch.to_dict()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "907a6ef5",
-      "metadata": {},
-      "source": [
-        "# Using auto-initializing `Expectations` to generate parameters"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6efe9c76",
-      "metadata": {},
-      "source": [
-        "We will generate a `Validator` using our `multi_batch_batch_list`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "id": "847ce4a3",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "id": "a1eca55b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "example_suite = data_context.create_expectation_suite(expectation_suite_name=\"example_sql_suite\", overwrite_existing=True)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "id": "852deba1",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "validator = data_context.get_validator_using_batch_list(batch_list=multi_batch_batch_list, expectation_suite=example_suite)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ee01a0e9",
-      "metadata": {},
-      "source": [
-        "When you run methods on the validator, it will typically run on the most recent batch (index `-1`), even if the Validator has access to a longer Batch list. For example, notice that rows below are all associated with `pickup_datetime` being `9` (September, 2020). This is because the datetime values are stored lexicographically, meaning `1` and `11`, `12` values will appear **before** `2` and `3`."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d8d7d827-ed51-4f83-ac41-33ae58416ef1",
-      "metadata": {},
-      "source": [
-        "For simplicity, let's get a `validator` with the December `Batch`, which is in index `\"3\"` (after `1`, `10`, `11`). Notice that we are also casting the value as a `list` using the square brackets. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "id": "11b673bc-8583-4fc5-9aa0-db6ca62e240c",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "validator = data_context.get_validator_using_batch_list(batch_list=[multi_batch_batch_list[3]], expectation_suite=example_suite)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 21,
-      "id": "ffe9cabd-b2bd-46de-9317-ba4e809342fa",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "80745ecb18f7444fb85261e2ed1864b8",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>vendor_id</th>\n",
-              "      <th>pickup_datetime</th>\n",
-              "      <th>dropoff_datetime</th>\n",
-              "      <th>passenger_count</th>\n",
-              "      <th>trip_distance</th>\n",
-              "      <th>rate_code_id</th>\n",
-              "      <th>store_and_fwd_flag</th>\n",
-              "      <th>pickup_location_id</th>\n",
-              "      <th>dropoff_location_id</th>\n",
-              "      <th>payment_type</th>\n",
-              "      <th>fare_amount</th>\n",
-              "      <th>extra</th>\n",
-              "      <th>mta_tax</th>\n",
-              "      <th>tip_amount</th>\n",
-              "      <th>tolls_amount</th>\n",
-              "      <th>improvement_surcharge</th>\n",
-              "      <th>total_amount</th>\n",
-              "      <th>congestion_surcharge</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>2.0</td>\n",
-              "      <td>2020-12-15 12:20:27</td>\n",
-              "      <td>2020-12-15 12:40:49</td>\n",
-              "      <td>4.0</td>\n",
-              "      <td>5.76</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>N</td>\n",
-              "      <td>209</td>\n",
-              "      <td>237</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>21.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.5</td>\n",
-              "      <td>2.50</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.3</td>\n",
-              "      <td>26.80</td>\n",
-              "      <td>2.5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>2.0</td>\n",
-              "      <td>2020-12-28 12:51:25</td>\n",
-              "      <td>2020-12-28 13:15:12</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>11.64</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>N</td>\n",
-              "      <td>161</td>\n",
-              "      <td>220</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>33.5</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.5</td>\n",
-              "      <td>5.00</td>\n",
-              "      <td>2.8</td>\n",
-              "      <td>0.3</td>\n",
-              "      <td>44.60</td>\n",
-              "      <td>2.5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>2.0</td>\n",
-              "      <td>2020-12-27 10:43:42</td>\n",
-              "      <td>2020-12-27 10:51:05</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>1.22</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>N</td>\n",
-              "      <td>163</td>\n",
-              "      <td>48</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>7.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.5</td>\n",
-              "      <td>2.06</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.3</td>\n",
-              "      <td>12.36</td>\n",
-              "      <td>2.5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>2.0</td>\n",
-              "      <td>2020-12-08 13:42:52</td>\n",
-              "      <td>2020-12-08 13:54:45</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>1.84</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>N</td>\n",
-              "      <td>137</td>\n",
-              "      <td>229</td>\n",
-              "      <td>2.0</td>\n",
-              "      <td>9.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.5</td>\n",
-              "      <td>0.00</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.3</td>\n",
-              "      <td>12.30</td>\n",
-              "      <td>2.5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>2.0</td>\n",
-              "      <td>2020-12-19 11:56:43</td>\n",
-              "      <td>2020-12-19 12:08:43</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>1.55</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>N</td>\n",
-              "      <td>24</td>\n",
-              "      <td>74</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>9.5</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.5</td>\n",
-              "      <td>2.58</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.3</td>\n",
-              "      <td>12.88</td>\n",
-              "      <td>0.0</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "   vendor_id     pickup_datetime    dropoff_datetime  passenger_count  \\\n",
-              "0        2.0 2020-12-15 12:20:27 2020-12-15 12:40:49              4.0   \n",
-              "1        2.0 2020-12-28 12:51:25 2020-12-28 13:15:12              1.0   \n",
-              "2        2.0 2020-12-27 10:43:42 2020-12-27 10:51:05              1.0   \n",
-              "3        2.0 2020-12-08 13:42:52 2020-12-08 13:54:45              1.0   \n",
-              "4        2.0 2020-12-19 11:56:43 2020-12-19 12:08:43              1.0   \n",
-              "\n",
-              "   trip_distance  rate_code_id store_and_fwd_flag  pickup_location_id  \\\n",
-              "0           5.76           1.0                  N                 209   \n",
-              "1          11.64           1.0                  N                 161   \n",
-              "2           1.22           1.0                  N                 163   \n",
-              "3           1.84           1.0                  N                 137   \n",
-              "4           1.55           1.0                  N                  24   \n",
-              "\n",
-              "   dropoff_location_id  payment_type  fare_amount  extra  mta_tax  tip_amount  \\\n",
-              "0                  237           1.0         21.0    0.0      0.5        2.50   \n",
-              "1                  220           1.0         33.5    0.0      0.5        5.00   \n",
-              "2                   48           1.0          7.0    0.0      0.5        2.06   \n",
-              "3                  229           2.0          9.0    0.0      0.5        0.00   \n",
-              "4                   74           1.0          9.5    0.0      0.5        2.58   \n",
-              "\n",
-              "   tolls_amount  improvement_surcharge  total_amount  congestion_surcharge  \n",
-              "0           0.0                    0.3         26.80                   2.5  \n",
-              "1           2.8                    0.3         44.60                   2.5  \n",
-              "2           0.0                    0.3         12.36                   2.5  \n",
-              "3           0.0                    0.3         12.30                   2.5  \n",
-              "4           0.0                    0.3         12.88                   0.0  "
-            ]
-          },
-          "execution_count": 21,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "validator.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8be66602",
-      "metadata": {},
-      "source": [
-        "### Typical Workflow\n",
-        "A `batch_list` becomes really useful when you are calculating parameters for auto-initializing Expectations, as they use a `RuleBasedProfiler` under-the-hood to calculate parameters."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "fdef9ad7",
-      "metadata": {},
-      "source": [
-        "Let's say we don't know the `min_value` and `max_value` for `expect_column_median_to_be_between()` so we \"guess\" at the `min_value` and `max_value`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 22,
-      "id": "d7642647",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "validator = data_context.get_validator_using_batch_list(batch_list=multi_batch_batch_list, expectation_suite=example_suite)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "id": "b524a2df",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "ac4237651dcb4207ae4a3f42d895ad02",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/plain": [
-              "{\n",
-              "  \"exception_info\": {\n",
-              "    \"raised_exception\": false,\n",
-              "    \"exception_traceback\": null,\n",
-              "    \"exception_message\": null\n",
-              "  },\n",
-              "  \"success\": false,\n",
-              "  \"result\": {\n",
-              "    \"observed_value\": 1.75\n",
-              "  },\n",
-              "  \"meta\": {}\n",
-              "}"
-            ]
-          },
-          "execution_count": 23,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "validator.expect_column_median_to_be_between(column=\"trip_distance\", min_value=0, max_value=1)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f18d096f",
-      "metadata": {},
-      "source": [
-        "The observed value of `trip_distance` for our `yellow_tripdata_sample_2020` going to be `1.75`, which means the Expectation fails. We guessed wrong - but we can do better!"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9c5016d8",
-      "metadata": {},
-      "source": [
-        "Now we run the same expectation again, but this time with `auto=True`. This means the median values are going to calculated across the `batch_list` associated with the `Validator` (ie 12 Batches for `yellow_tripdata_sample_2020`), which gives the min value of `1.6` and the max value of `1.99`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 24,
-      "id": "cdd821c3",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "ab19e0cad1de4977adf1229d461e6580",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Generating Expectations:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "9d6ffcecc85c48c8a8b3f5cf8bd1554a",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/plain": [
-              "{\n",
-              "  \"exception_info\": {\n",
-              "    \"raised_exception\": false,\n",
-              "    \"exception_traceback\": null,\n",
-              "    \"exception_message\": null\n",
-              "  },\n",
-              "  \"success\": true,\n",
-              "  \"result\": {\n",
-              "    \"observed_value\": 1.75\n",
-              "  },\n",
-              "  \"meta\": {},\n",
-              "  \"expectation_config\": {\n",
-              "    \"expectation_type\": \"expect_column_median_to_be_between\",\n",
-              "    \"kwargs\": {\n",
-              "      \"column\": \"trip_distance\",\n",
-              "      \"min_value\": 1.6,\n",
-              "      \"max_value\": 1.99,\n",
-              "      \"strict_min\": false,\n",
-              "      \"strict_max\": false\n",
-              "    },\n",
-              "    \"meta\": {\n",
-              "      \"auto_generated_at\": \"20220909T055905.990908Z\",\n",
-              "      \"great_expectations_version\": \"0.15.21+44.gf0e35fabd.dirty\"\n",
-              "    }\n",
-              "  }\n",
-              "}"
-            ]
-          },
-          "execution_count": 24,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "validator.expect_column_median_to_be_between(column=\"trip_distance\", auto=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c6a6c277",
-      "metadata": {},
-      "source": [
-        "The auto=True will also automatically run the Expectation against the most recent Batch (which has an observed value of `1.75`) and the Expectation will pass."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "90b8b938",
-      "metadata": {},
-      "source": [
-        "You can now save the `ExpectationSuite`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 25,
-      "id": "eba880ed",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "validator.save_expectation_suite()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1b7ec631",
-      "metadata": {},
-      "source": [
-        "### Running the `ExpectationSuite` against single `Batch`"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "477381f5",
-      "metadata": {},
-      "source": [
-        "Now the ExpectationSuite we built using all batches can be used to validate single batches using a Checkpoint. For example, we can run this checkpoint on new data when it comes in next month. In our example, let's validatidate a different batch from February 2020, using the ExpectationSuite we built from `yellow_tripdata_sample_2020`.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 26,
-      "id": "747dea95",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "single_batch_batch_request_from_multi: BatchRequest = BatchRequest(\n",
-        "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
-        "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
-        "    data_asset_name=\"yellow_tripdata_sample_2020_by_year_and_month\",\n",
-        "    data_connector_query={ \n",
-        "        \"batch_filter_parameters\": {\"pickup_datetime\": {\"year\": 2020, \"month\": 2}}\n",
-        "    }\n",
-        "\n",
-        "\n",
-        ")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 27,
-      "id": "cb93d87f",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{\n",
-              "  \"action_list\": [\n",
-              "    {\n",
-              "      \"name\": \"store_validation_result\",\n",
-              "      \"action\": {\n",
-              "        \"class_name\": \"StoreValidationResultAction\"\n",
-              "      }\n",
-              "    },\n",
-              "    {\n",
-              "      \"name\": \"store_evaluation_params\",\n",
-              "      \"action\": {\n",
-              "        \"class_name\": \"StoreEvaluationParametersAction\"\n",
-              "      }\n",
-              "    },\n",
-              "    {\n",
-              "      \"name\": \"update_data_docs\",\n",
-              "      \"action\": {\n",
-              "        \"class_name\": \"UpdateDataDocsAction\",\n",
-              "        \"site_names\": []\n",
-              "      }\n",
-              "    }\n",
-              "  ],\n",
-              "  \"batch_request\": {},\n",
-              "  \"class_name\": \"Checkpoint\",\n",
-              "  \"config_version\": 1.0,\n",
-              "  \"evaluation_parameters\": {},\n",
-              "  \"module_name\": \"great_expectations.checkpoint\",\n",
-              "  \"name\": \"my_checkpoint\",\n",
-              "  \"profilers\": [],\n",
-              "  \"runtime_configuration\": {},\n",
-              "  \"validations\": [\n",
-              "    {\n",
-              "      \"batch_request\": {\n",
-              "        \"datasource_name\": \"taxi_multi_batch_sql_datasource\",\n",
-              "        \"data_connector_name\": \"configured_data_connector_multi_batch_asset\",\n",
-              "        \"data_asset_name\": \"yellow_tripdata_sample_2020_by_year_and_month\",\n",
-              "        \"data_connector_query\": {\n",
-              "          \"batch_filter_parameters\": {\n",
-              "            \"pickup_datetime\": {\n",
-              "              \"year\": 2020,\n",
-              "              \"month\": 2\n",
-              "            }\n",
-              "          }\n",
-              "        }\n",
-              "      },\n",
-              "      \"expectation_suite_name\": \"example_sql_suite\"\n",
-              "    }\n",
-              "  ]\n",
-              "}"
-            ]
-          },
-          "execution_count": 27,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "checkpoint_config = {\n",
-        "    \"name\": \"my_checkpoint\",\n",
-        "    \"config_version\": 1,\n",
-        "    \"class_name\": \"SimpleCheckpoint\",\n",
-        "    \"validations\": [\n",
-        "        {\n",
-        "            \"batch_request\": single_batch_batch_request_from_multi,\n",
-        "            \"expectation_suite_name\": \"example_sql_suite\",            \n",
-        "        }\n",
-        "    ],\n",
-        "}\n",
-        "data_context.add_checkpoint(**checkpoint_config)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 28,
-      "id": "3269dfba",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "72d5ae521bde405fb5dbb666eae4926b",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "results = data_context.run_checkpoint(\n",
-        "    checkpoint_name=\"my_checkpoint\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 29,
-      "id": "c6234082",
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "True"
-            ]
-          },
-          "execution_count": 29,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "results.success"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6737ccdd",
-      "metadata": {},
-      "source": [
-        "# Appendix\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6914725d-85cc-4c9d-a93d-2d1c329eac74",
-      "metadata": {},
-      "source": [
-        "## Other Parameters for `ConfiguredAssetSqlDataConnector`"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f8e62691",
-      "metadata": {},
-      "source": [
-        "The signature of the `ConfiguredAssetSqlDataConnector` also contains the following parameters: \n",
-        "\n",
-        "The following required parameters:\n",
-        "* `name`: The name of this DataConnector.\n",
-        "* `datasource_name`: The name of the Datasource that contains it.\n",
-        "* `execution_engine`: the type of ExecutionEngine to use.\n",
-        "* `assets`: The dictionary containing the asset configurations.\n",
-        "\n",
-        "The `assets` dictionary can contain the following keys and values:\n",
-        "* `table_name`: string that defines the `table_name` associated with the asset. If table_name is omitted, then the `table_name` defaults to the asset name.\n",
-        "* `schema_name`: optional string that defines the `schema` for the asset.\n",
-        "* `include_schema_name`: A `bool` that determines, \"Should the `data_asset_name` include the `schema` as a prefix?\"\n",
-        "* `splitter_method`: string that names method to split the target table into multiple `Batches`.\n",
-        "* `splitter_kwargs`: a dict containing arguments to pass to `splitter_method`.\n",
-        "* `sampling_method`: string that names method to downsample within a target `Batch`.\n",
-        "* `sampling_kwargs` : dictionary with keyword arguments to pass to `sampling_method`.\n",
-        "* `batch_spec_passthrough`: dictionary with keys that will be added directly to `batch_spec`.\n",
-        "\n",
-        "\n",
-        "For more information on `splitters` and `samplers` please consider the following documentation: [How to configure a DataConnector for splitting and sampling tables in SQL](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/advanced/how_to_configure_a_dataconnector_for_splitting_and_sampling_tables_in_sql)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "83ecebdc",
-      "metadata": {},
-      "source": [
-        "# Loading Data into Postgresql Database"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9f4a183e-f0df-40f4-b64f-439666e32ab4",
-      "metadata": {},
-      "source": [
-        "* The following code can be used to build the postgres database used in this notebook. It is included (and commented out) for reference.\n",
-        "* In order to load the data into a local `postgresql` database, please feel free to use the `docker-compose.yml` file available at `great_expectations/assets/docker/postgresql/`. \n",
-        "\n",
-        "### To spin up the `postgresql` database\n",
-        "* Have [Docker Desktop](https://www.docker.com/products/docker-desktop/) running locally.\n",
-        "* Navigate to `great_expectations/assets/docker/postgresql/`\n",
-        "* Type `docker-compose up`\n",
-        "* Then uncomment and run the following snippet"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 30,
-      "id": "ad91c234-06a2-4e98-9d90-c999c2aad07f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# from tests.test_utils import load_data_into_test_database\n",
-        "# from typing import List\n",
-        "# import sqlalchemy as sa\n",
-        "# import pandas as pd\n",
-        "# CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
-        "\n",
-        "# data_paths: List[str] = [\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-01.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-02.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-03.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-04.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-05.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-06.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-07.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-08.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-09.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-10.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-11.csv\",\n",
-        "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-12.csv\",\n",
-        "# ]\n",
-        "\n",
-        "    \n",
-        "# engine = sa.create_engine(CONNECTION_STRING)\n",
-        "# connection = engine.connect()\n",
-        "# table_name = \"yellow_tripdata_sample_2020\"\n",
-        "# res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
-        "\n",
-        "# for data_path in data_paths:\n",
-        "#     # This utility is not for general use. It is only to support testing.\n",
-        "#     load_data_into_test_database(\n",
-        "#         table_name=\"yellow_tripdata_sample_2020\",\n",
-        "#         csv_path=data_path,\n",
-        "#         connection_string=CONNECTION_STRING,\n",
-        "#         load_full_dataset=True,\n",
-        "#         drop_existing_table=False,\n",
-        "#         convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
-        "#     )"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f0a5264-b003-4101-862f-45653f2aed1b",
+   "metadata": {},
+   "source": [
+    "# How to write multi-batch `BatchRequest` - Configured `Sql` Example\n",
+    "* A `BatchRequest` facilitates the return of a `batch` of data from a configured `Datasource`. To find more about `Batches`, please refer to the [related documentation](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/how_to_get_a_batch_of_data_from_a_configured_datasource#1-construct-a-batchrequest). \n",
+    "* A `BatchRequest` can return 0 or more Batches of data depending on the underlying data, and how it is configured. This guide will help you configure `BatchRequests` to return multiple batches, which can be used by\n",
+    "   1. Self-Initializing Expectations to estimate parameters\n",
+    "   2. DataAssistants to profile your data and create and Expectation suite with self-intialized parameters.\n",
+    "   \n",
+    "* Note : Multi-batch BatchRequests are not supported in `RuntimeDataConnector`."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ee54886b-4f88-46d9-9afe-dfd8bb061e19",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/work/Development/great_expectations/great_expectations/execution_engine/sqlalchemy_execution_engine.py:137: UserWarning: Obsolete pybigquery is installed, which is likely to\n",
+      "interfere with sqlalchemy_bigquery.\n",
+      "pybigquery should be uninstalled.\n",
+      "  import sqlalchemy_bigquery as sqla_bigquery\n"
+     ]
+    }
+   ],
+   "source": [
+    "import great_expectations as gx\n",
+    "from great_expectations.core.yaml_handler import YAMLHandler\n",
+    "from great_expectations.core.batch import BatchRequest\n",
+    "import pprint\n",
+    "from ruamel import yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfa243d2-6905-403a-b47a-d89ba834b951",
+   "metadata": {},
+   "source": [
+    "* Load `DataContext`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "45b1854b-2a75-422e-83bb-5509d868e0c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_context: gx.DataContext = gx.get_context()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4462320-d76e-492c-96fb-f0ff8f788851",
+   "metadata": {},
+   "source": [
+    "## Sql Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6e04726",
+   "metadata": {},
+   "source": [
+    "### Example Database\n",
+    "\n",
+    "Imagine we have a database of 1 table, with `yellow_tripdata_sample_2020`, corresponding to all 12 months' `taxi_trip` data for 2020.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cd29b60b-7e16-4978-acee-0dab368cde3c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['yellow_tripdata_sample_2020']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# connect to sqlite DB, and print the existing tables\n",
+    "CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
+    "from sqlalchemy import create_engine\n",
+    "from sqlalchemy import inspect\n",
+    "engine = create_engine(CONNECTION_STRING)\n",
+    "insp = inspect(engine)\n",
+    "print(insp.get_table_names())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49515697-83a2-432d-8b74-33e2f01db72c",
+   "metadata": {},
+   "source": [
+    "## Example Configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df19a29c",
+   "metadata": {},
+   "source": [
+    "In our example, we add a `Datasource` named `taxi_multi_batch_sql_datasource` with 1 table. We also have a `ConfiguredAssetSqlDataConnector` named `configured_data_connector_multi_batch_asset`.\n",
+    "\n",
+    "The DataConnector contains 2 `assets`, both associated with the `table_name` named`yellow_tripdata_sample_2020`.\n",
+    "\n",
+    "The asset `yellow_tripdata_sample_2020_full` contains no other parameter other than the `table_name` and optional `schema_name`, which mean the whole table will be loaded as one Batch in the asset. \n",
+    "\n",
+    "The asset `yellow_tripdata_sample_2020_by_year_and_month` contains `table_name` and `schema_name`, as well as a splitter configuration. The splitter we use is `split_on_year_and_month`, which creates Batches according to the `pickup_datetime` column which is of type timestamp in the database schema.\n",
+    "\n",
+    "**Note**: This example only uses `splitters` but sampling can also be used. For more information, please refer to the document [How to configure a DataConnector for splitting and sampling tables in SQL](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/advanced/how_to_configure_a_dataconnector_for_splitting_and_sampling_tables_in_sql)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "84150f65-bbd6-4b45-95ab-9590a29f116a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\t\tyellow_tripdata_sample_2020_full (1 of 1): [{}]\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7f92a0cb78b0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SqlAlchemyExecutionEngine\",\n",
+    "        \"connection_string\": CONNECTION_STRING,\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetSqlDataConnector\",\n",
+    "            \"assets\":{\n",
+    "                \"yellow_tripdata_sample_2020_full\":\n",
+    "                {\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                },\n",
+    "    \n",
+    "                \"yellow_tripdata_sample_2020_by_year_and_month\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                    \"splitter_method\": \"split_on_year_and_month\",\n",
+    "                    \"splitter_kwargs\": {\n",
+    "                        \"column_name\": \"pickup_datetime\",\n",
+    "                        },\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "            \n",
+    "        },\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "635755a4-36b1-442f-968a-2fbdb9b146d8",
+   "metadata": {},
+   "source": [
+    "We see we have successfully configured this because the output shows a 2 data assets\n",
+    "- `yellow_tripdata_sample_2020_full` associated with 1 batch. \n",
+    "- `yellow_tripdata_sample_2020_by_year_and_month` with 12 batches, each associated with a different month in our `pickup_datetime` column. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7636ffff-0ddc-48fd-a4cf-f8e139a5e36e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_datasource only if it doesn't already exist in our configuration\n",
+    "try:\n",
+    "    data_context.get_datasource(datasource_config[\"name\"])\n",
+    "except ValueError:\n",
+    "    data_context.add_datasource(**datasource_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "438146be",
+   "metadata": {},
+   "source": [
+    "## BatchRequest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "117cdb0d",
+   "metadata": {},
+   "source": [
+    "Depending on how we configured our assets, when you send a `BatchRequest`, you will retrieve a different number of `Batches`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87bc9c59",
+   "metadata": {},
+   "source": [
+    "Single Batch returned by `yellow_tripdata_sample_2020_full`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0453cd3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020_full\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "35df7084",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d8e74a05-3fd1-4e47-9105-b721dbcf3516",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7f92a0d77f40>]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be7f4fa5",
+   "metadata": {},
+   "source": [
+    "Multi Batch returned by `yellow_tripdata_sample_2020_by_year_and_month`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c32dbac9-af5d-4677-98f9-f098ef091b6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_request: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020_by_year_and_month\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3a284bfd-00aa-4068-bc09-71c6dea627e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7bf3e1ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7f92b7730970>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0d1f4f0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0d38fd0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0d3ab80>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92b9f87220>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92b7774d90>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0d96670>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0d96d00>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0d88220>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0cf51c0>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0cf5d00>,\n",
+       " <great_expectations.core.batch.Batch at 0x7f92a0cf5880>]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_batch_batch_list # 12 batches"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "790746ee",
+   "metadata": {},
+   "source": [
+    "You can also get a single Batch from a multi-batch DataConnector by passing in `data_connector_query`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "16612bb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request_from_multi: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020_by_year_and_month\",\n",
+    "    data_connector_query={ \n",
+    "        \"batch_filter_parameters\": {\"pickup_datetime\": {\"year\": 2020, \"month\": 1}}\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "6ef1b6a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_list = data_context.get_batch_list(batch_request=single_batch_batch_request_from_multi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "80a69e96",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<great_expectations.core.batch.Batch at 0x7f92a0d32f70>]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch_list # has a length of 1, as expected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26cd5a37",
+   "metadata": {},
+   "source": [
+    "Let's review our batch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "229815cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch = batch_list[0]  # our single filtered batch with 'batch_identifiers': {'pickup_datetime': '2020-01'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f2be5bdb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data': '<great_expectations.execution_engine.sqlalchemy_batch_data.SqlAlchemyBatchData object at 0x7f92a0cf5b80>',\n",
+       " 'batch_request': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
+       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
+       "  'limit': None,\n",
+       "  'data_connector_query': {'batch_filter_parameters': {'pickup_datetime': {'year': 2020,\n",
+       "     'month': 1}}},\n",
+       "  'batch_spec_passthrough': None},\n",
+       " 'batch_definition': {'datasource_name': 'taxi_multi_batch_sql_datasource',\n",
+       "  'data_connector_name': 'configured_data_connector_multi_batch_asset',\n",
+       "  'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
+       "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}}},\n",
+       " 'batch_spec': {'data_asset_name': 'yellow_tripdata_sample_2020_by_year_and_month',\n",
+       "  'table_name': 'yellow_tripdata_sample_2020',\n",
+       "  'batch_identifiers': {'pickup_datetime': {'year': 2020, 'month': 1}},\n",
+       "  'splitter_kwargs': {'column_name': 'pickup_datetime'},\n",
+       "  'class_name': 'Asset',\n",
+       "  'splitter_method': 'split_on_year_and_month',\n",
+       "  'schema_name': 'public',\n",
+       "  'module_name': 'great_expectations.datasource.data_connector.asset',\n",
+       "  'type': None},\n",
+       " 'batch_markers': {'ge_load_time': '20220913T003918.883626Z'}}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "batch.to_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "907a6ef5",
+   "metadata": {},
+   "source": [
+    "# Using auto-initializing `Expectations` to generate parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6efe9c76",
+   "metadata": {},
+   "source": [
+    "We will generate a `Validator` using our `multi_batch_batch_list`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "847ce4a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_batch_batch_list = data_context.get_batch_list(batch_request=multi_batch_batch_request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a1eca55b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_suite = data_context.create_expectation_suite(expectation_suite_name=\"example_sql_suite\", overwrite_existing=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "852deba1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator = data_context.get_validator_using_batch_list(batch_list=multi_batch_batch_list, expectation_suite=example_suite)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee01a0e9",
+   "metadata": {},
+   "source": [
+    "When you run methods on the validator, it will typically run on the most recent batch (index `-1`), even if the Validator has access to a longer Batch list. For example, notice that rows below are all associated with `pickup_datetime` being `9` (September, 2020). This is because the datetime values are stored lexicographically, meaning `1` and `11`, `12` values will appear **before** `2` and `3`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8d7d827-ed51-4f83-ac41-33ae58416ef1",
+   "metadata": {},
+   "source": [
+    "For simplicity, let's get a `validator` with the December `Batch`, which is in index `\"3\"` (after `1`, `10`, `11`). Notice that we are also casting the value as a `list` using the square brackets. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "11b673bc-8583-4fc5-9aa0-db6ca62e240c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator = data_context.get_validator_using_batch_list(batch_list=[multi_batch_batch_list[3]], expectation_suite=example_suite)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "ffe9cabd-b2bd-46de-9317-ba4e809342fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "24b934c5d6a74eb1a6481a62112e5062",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>vendor_id</th>\n",
+       "      <th>pickup_datetime</th>\n",
+       "      <th>dropoff_datetime</th>\n",
+       "      <th>passenger_count</th>\n",
+       "      <th>trip_distance</th>\n",
+       "      <th>rate_code_id</th>\n",
+       "      <th>store_and_fwd_flag</th>\n",
+       "      <th>pickup_location_id</th>\n",
+       "      <th>dropoff_location_id</th>\n",
+       "      <th>payment_type</th>\n",
+       "      <th>fare_amount</th>\n",
+       "      <th>extra</th>\n",
+       "      <th>mta_tax</th>\n",
+       "      <th>tip_amount</th>\n",
+       "      <th>tolls_amount</th>\n",
+       "      <th>improvement_surcharge</th>\n",
+       "      <th>total_amount</th>\n",
+       "      <th>congestion_surcharge</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-04-03 16:23:46</td>\n",
+       "      <td>2020-04-03 16:34:42</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>2.26</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>263</td>\n",
+       "      <td>41</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.86</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>17.16</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2020-04-29 09:45:35</td>\n",
+       "      <td>2020-04-29 09:48:36</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.40</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>43</td>\n",
+       "      <td>151</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>4.80</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2020-04-27 19:21:48</td>\n",
+       "      <td>2020-04-27 19:29:07</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.80</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>140</td>\n",
+       "      <td>107</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>3.55</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>17.85</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2020-04-23 18:01:29</td>\n",
+       "      <td>2020-04-23 18:06:14</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.03</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>142</td>\n",
+       "      <td>238</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>12.88</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2020-04-29 09:02:24</td>\n",
+       "      <td>2020-04-29 09:08:48</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.80</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>N</td>\n",
+       "      <td>161</td>\n",
+       "      <td>100</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>2.30</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>11.60</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   vendor_id     pickup_datetime    dropoff_datetime  passenger_count  \\\n",
+       "0        2.0 2020-04-03 16:23:46 2020-04-03 16:34:42              5.0   \n",
+       "1        1.0 2020-04-29 09:45:35 2020-04-29 09:48:36              0.0   \n",
+       "2        1.0 2020-04-27 19:21:48 2020-04-27 19:29:07              1.0   \n",
+       "3        2.0 2020-04-23 18:01:29 2020-04-23 18:06:14              1.0   \n",
+       "4        1.0 2020-04-29 09:02:24 2020-04-29 09:08:48              1.0   \n",
+       "\n",
+       "   trip_distance  rate_code_id store_and_fwd_flag  pickup_location_id  \\\n",
+       "0           2.26           1.0                  N                 263   \n",
+       "1           0.40           1.0                  N                  43   \n",
+       "2           2.80           1.0                  N                 140   \n",
+       "3           1.03           1.0                  N                 142   \n",
+       "4           0.80           1.0                  N                 161   \n",
+       "\n",
+       "   dropoff_location_id  payment_type  fare_amount  extra  mta_tax  tip_amount  \\\n",
+       "0                   41           1.0         10.0    1.0      0.5        2.86   \n",
+       "1                  151           1.0          4.0    0.0      0.5        0.00   \n",
+       "2                  107           1.0         10.0    3.5      0.5        3.55   \n",
+       "3                  238           1.0          6.0    1.0      0.5        2.58   \n",
+       "4                  100           1.0          6.0    2.5      0.5        2.30   \n",
+       "\n",
+       "   tolls_amount  improvement_surcharge  total_amount  congestion_surcharge  \n",
+       "0           0.0                    0.3         17.16                   2.5  \n",
+       "1           0.0                    0.3          4.80                   0.0  \n",
+       "2           0.0                    0.3         17.85                   2.5  \n",
+       "3           0.0                    0.3         12.88                   2.5  \n",
+       "4           0.0                    0.3         11.60                   2.5  "
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8be66602",
+   "metadata": {},
+   "source": [
+    "### Typical Workflow\n",
+    "A `batch_list` becomes really useful when you are calculating parameters for auto-initializing Expectations, as they use a `RuleBasedProfiler` under-the-hood to calculate parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdef9ad7",
+   "metadata": {},
+   "source": [
+    "Let's say we don't know the `min_value` and `max_value` for `expect_column_median_to_be_between()` so we \"guess\" at the `min_value` and `max_value`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "d7642647",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator = data_context.get_validator_using_batch_list(batch_list=multi_batch_batch_list, expectation_suite=example_suite)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "b524a2df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8c98bf14a0694adf825f06493658edd0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.61\n",
+       "  },\n",
+       "  \"success\": false\n",
+       "}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.expect_column_median_to_be_between(column=\"trip_distance\", min_value=0, max_value=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f18d096f",
+   "metadata": {},
+   "source": [
+    "The observed value of `trip_distance` for our `yellow_tripdata_sample_2020` going to be `1.75`, which means the Expectation fails. We guessed wrong - but we can do better!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c5016d8",
+   "metadata": {},
+   "source": [
+    "Now we run the same expectation again, but this time with `auto=True`. This means the median values are going to calculated across the `batch_list` associated with the `Validator` (ie 12 Batches for `yellow_tripdata_sample_2020`), which gives the min value of `1.6` and the max value of `1.99`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "cdd821c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b2fcf761f6f54148a5d2657029301911",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating Expectations:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Profiling Dataset:         0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e785044d2b7742bd87d896dd8d142724",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"exception_info\": {\n",
+       "    \"raised_exception\": false,\n",
+       "    \"exception_traceback\": null,\n",
+       "    \"exception_message\": null\n",
+       "  },\n",
+       "  \"meta\": {},\n",
+       "  \"expectation_config\": {\n",
+       "    \"meta\": {\n",
+       "      \"auto_generated_at\": \"20220913T003923.223388Z\",\n",
+       "      \"great_expectations_version\": \"0.15.22+24.g6a8d2d59f.dirty\"\n",
+       "    },\n",
+       "    \"kwargs\": {\n",
+       "      \"column\": \"trip_distance\",\n",
+       "      \"min_value\": 1.6,\n",
+       "      \"max_value\": 1.99,\n",
+       "      \"strict_min\": false,\n",
+       "      \"strict_max\": false\n",
+       "    },\n",
+       "    \"expectation_type\": \"expect_column_median_to_be_between\"\n",
+       "  },\n",
+       "  \"result\": {\n",
+       "    \"observed_value\": 1.61\n",
+       "  },\n",
+       "  \"success\": true\n",
+       "}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validator.expect_column_median_to_be_between(column=\"trip_distance\", auto=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6a6c277",
+   "metadata": {},
+   "source": [
+    "The auto=True will also automatically run the Expectation against the most recent Batch (which has an observed value of `1.75`) and the Expectation will pass."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90b8b938",
+   "metadata": {},
+   "source": [
+    "You can now save the `ExpectationSuite`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "eba880ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator.save_expectation_suite()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b7ec631",
+   "metadata": {},
+   "source": [
+    "### Running the `ExpectationSuite` against single `Batch`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "477381f5",
+   "metadata": {},
+   "source": [
+    "Now the ExpectationSuite we built using all batches can be used to validate single batches using a Checkpoint. For example, we can run this checkpoint on new data when it comes in next month. In our example, let's validatidate a different batch from February 2020, using the ExpectationSuite we built from `yellow_tripdata_sample_2020`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "747dea95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_batch_batch_request_from_multi: BatchRequest = BatchRequest(\n",
+    "    datasource_name=\"taxi_multi_batch_sql_datasource\",\n",
+    "    data_connector_name=\"configured_data_connector_multi_batch_asset\",\n",
+    "    data_asset_name=\"yellow_tripdata_sample_2020_by_year_and_month\",\n",
+    "    data_connector_query={ \n",
+    "        \"batch_filter_parameters\": {\"pickup_datetime\": {\"year\": 2020, \"month\": 2}}\n",
+    "    }\n",
+    "\n",
+    "\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "cb93d87f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{\n",
+       "  \"action_list\": [\n",
+       "    {\n",
+       "      \"name\": \"store_validation_result\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreValidationResultAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"store_evaluation_params\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"StoreEvaluationParametersAction\"\n",
+       "      }\n",
+       "    },\n",
+       "    {\n",
+       "      \"name\": \"update_data_docs\",\n",
+       "      \"action\": {\n",
+       "        \"class_name\": \"UpdateDataDocsAction\",\n",
+       "        \"site_names\": []\n",
+       "      }\n",
+       "    }\n",
+       "  ],\n",
+       "  \"batch_request\": {},\n",
+       "  \"class_name\": \"Checkpoint\",\n",
+       "  \"config_version\": 1.0,\n",
+       "  \"evaluation_parameters\": {},\n",
+       "  \"module_name\": \"great_expectations.checkpoint\",\n",
+       "  \"name\": \"my_checkpoint\",\n",
+       "  \"profilers\": [],\n",
+       "  \"runtime_configuration\": {},\n",
+       "  \"validations\": [\n",
+       "    {\n",
+       "      \"batch_request\": {\n",
+       "        \"datasource_name\": \"taxi_multi_batch_sql_datasource\",\n",
+       "        \"data_connector_name\": \"configured_data_connector_multi_batch_asset\",\n",
+       "        \"data_asset_name\": \"yellow_tripdata_sample_2020_by_year_and_month\",\n",
+       "        \"data_connector_query\": {\n",
+       "          \"batch_filter_parameters\": {\n",
+       "            \"pickup_datetime\": {\n",
+       "              \"year\": 2020,\n",
+       "              \"month\": 2\n",
+       "            }\n",
+       "          }\n",
+       "        }\n",
+       "      },\n",
+       "      \"expectation_suite_name\": \"example_sql_suite\"\n",
+       "    }\n",
+       "  ]\n",
+       "}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "checkpoint_config = {\n",
+    "    \"name\": \"my_checkpoint\",\n",
+    "    \"config_version\": 1,\n",
+    "    \"class_name\": \"SimpleCheckpoint\",\n",
+    "    \"validations\": [\n",
+    "        {\n",
+    "            \"batch_request\": single_batch_batch_request_from_multi,\n",
+    "            \"expectation_suite_name\": \"example_sql_suite\",            \n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "data_context.add_checkpoint(**checkpoint_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "3269dfba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df95ba9c21ce4bd8a73fdfc91c161ba7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Calculating Metrics:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results = data_context.run_checkpoint(\n",
+    "    checkpoint_name=\"my_checkpoint\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "c6234082",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results.success"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6737ccdd",
+   "metadata": {},
+   "source": [
+    "# Appendix\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6914725d-85cc-4c9d-a93d-2d1c329eac74",
+   "metadata": {},
+   "source": [
+    "## Other Parameters for `ConfiguredAssetSqlDataConnector`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8e62691",
+   "metadata": {},
+   "source": [
+    "The signature of the `ConfiguredAssetSqlDataConnector` also contains the following parameters: \n",
+    "\n",
+    "The following required parameters:\n",
+    "* `name`: The name of this DataConnector.\n",
+    "* `datasource_name`: The name of the Datasource that contains it.\n",
+    "* `execution_engine`: the type of ExecutionEngine to use.\n",
+    "* `assets`: The dictionary containing the asset configurations.\n",
+    "\n",
+    "The `assets` dictionary can contain the following keys and values:\n",
+    "* `table_name`: string that defines the `table_name` associated with the asset. If table_name is omitted, then the `table_name` defaults to the asset name.\n",
+    "* `schema_name`: optional string that defines the `schema` for the asset.\n",
+    "* `include_schema_name`: A `bool` that determines, \"Should the `data_asset_name` include the `schema` as a prefix?\"\n",
+    "* `splitter_method`: string that names method to split the target table into multiple `Batches`.\n",
+    "* `splitter_kwargs`: a dict containing arguments to pass to `splitter_method`.\n",
+    "* `sampling_method`: string that names method to downsample within a target `Batch`.\n",
+    "* `sampling_kwargs` : dictionary with keyword arguments to pass to `sampling_method`.\n",
+    "* `batch_spec_passthrough`: dictionary with keys that will be added directly to `batch_spec`.\n",
+    "\n",
+    "\n",
+    "For more information on `splitters` and `samplers` please consider the following documentation: [How to configure a DataConnector for splitting and sampling tables in SQL](https://docs.greatexpectations.io/docs/guides/connecting_to_your_data/advanced/how_to_configure_a_dataconnector_for_splitting_and_sampling_tables_in_sql)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10a27510",
+   "metadata": {},
+   "source": [
+    "## Configuring Splitters at `DataConnector` and `Asset`-Level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fb9c585",
+   "metadata": {},
+   "source": [
+    "For `ConfiguredAssetSqlDataConnectors`, the `splitter_method` and `splitter_kwargs` can be configured at the `DataConnector`-level or `Asset`-level. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "263ed79f",
+   "metadata": {},
+   "source": [
+    "#### Configuration at `DataConnector`-level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baad2c0d",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Here is a configuration with the splitter method `split_on_year_and_month` configured at the `DataConnector`-level for a `DataConnector` with 2 `Assets`, `yellow_tripdata_sample_2020_by_year_and_month` and `yellow_tripdata_sample_2020`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "80c6ac3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_sample_2020 (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7f92a0e85820>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SqlAlchemyExecutionEngine\",\n",
+    "        \"connection_string\": CONNECTION_STRING,\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetSqlDataConnector\",\n",
+    "            \"splitter_method\": \"split_on_year_and_month\",\n",
+    "            \"splitter_kwargs\": {\n",
+    "                \"column_name\": \"pickup_datetime\",\n",
+    "            },\n",
+    "            \"assets\":{\n",
+    "    \n",
+    "                \"yellow_tripdata_sample_2020_by_year_and_month\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                },\n",
+    "                \"yellow_tripdata_sample_2020\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                },\n",
+    "            },\n",
+    "            \n",
+    "        },\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f36497e",
+   "metadata": {},
+   "source": [
+    "As you can see, both `Assets`, `yellow_tripdata_sample_2020_by_year_and_month` **and** `yellow_tripdata_sample_2020` have the splitter method applied to it, meaning they both have 12 Batches as a result of splitting by `year` and `month`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "162c74bc",
+   "metadata": {},
+   "source": [
+    "#### Configuration at `DataConnector`-level **and** `Asset`-level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d2134d3",
+   "metadata": {},
+   "source": [
+    "Next we have a similar example, but with a second `splitter_method` also configured at the `Asset`-level. This time we will configure a second `splitter_method`, `split_on_year_and_month_and_day`, for the Asset `yellow_tripdata_sample_2020_by_year_and_month_and_day`. In this case, the `Asset`-level configuration will **override** the configuration at the `DataConnector`-level and produce 366 Batches as a result of splitting by `year`, `month` and `day`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "4a823855",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempting to instantiate class from config...\n",
+      "\tInstantiating as a Datasource, since class_name is Datasource\n",
+      "\tSuccessfully instantiated Datasource\n",
+      "\n",
+      "\n",
+      "ExecutionEngine class name: SqlAlchemyExecutionEngine\n",
+      "Data Connectors:\n",
+      "\tconfigured_data_connector_multi_batch_asset : ConfiguredAssetSqlDataConnector\n",
+      "\n",
+      "\tAvailable data_asset_names (2 of 2):\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month (3 of 12): [{'pickup_datetime': {'year': 2020, 'month': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10}}, {'pickup_datetime': {'year': 2020, 'month': 11}}]\n",
+      "\t\tyellow_tripdata_sample_2020_by_year_and_month_and_day (3 of 366): [{'pickup_datetime': {'year': 2020, 'month': 10, 'day': 1}}, {'pickup_datetime': {'year': 2020, 'month': 10, 'day': 10}}, {'pickup_datetime': {'year': 2020, 'month': 10, 'day': 11}}]\n",
+      "\n",
+      "\tUnmatched data_references (0 of 0):[]\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<great_expectations.datasource.new_datasource.Datasource at 0x7f92a1943460>"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datasource_config = {\n",
+    "    \"name\": \"taxi_multi_batch_sql_datasource\",\n",
+    "    \"class_name\": \"Datasource\",\n",
+    "    \"module_name\": \"great_expectations.datasource\",\n",
+    "    \"execution_engine\": {\n",
+    "        \"module_name\": \"great_expectations.execution_engine\",\n",
+    "        \"class_name\": \"SqlAlchemyExecutionEngine\",\n",
+    "        \"connection_string\": CONNECTION_STRING,\n",
+    "    },\n",
+    "    \"data_connectors\": {\n",
+    "        \"configured_data_connector_multi_batch_asset\": {\n",
+    "            \"class_name\": \"ConfiguredAssetSqlDataConnector\",\n",
+    "            \"splitter_method\": \"split_on_year_and_month\",\n",
+    "            \"splitter_kwargs\": {\n",
+    "                \"column_name\": \"pickup_datetime\",\n",
+    "            },\n",
+    "            \"assets\":{\n",
+    "    \n",
+    "                \"yellow_tripdata_sample_2020_by_year_and_month\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                },\n",
+    "                \"yellow_tripdata_sample_2020_by_year_and_month_and_day\":{\n",
+    "                    \"table_name\": \"yellow_tripdata_sample_2020\",\n",
+    "                    \"schema_name\": \"public\",\n",
+    "                    \"splitter_method\": \"split_on_year_and_month_and_day\",\n",
+    "                    \"splitter_kwargs\": {\n",
+    "                        \"column_name\": \"pickup_datetime\",\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "            \n",
+    "        },\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "data_context.test_yaml_config(yaml.dump(datasource_config))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80ff49fe",
+   "metadata": {},
+   "source": [
+    "As you can see, `yellow_tripdata_sample_2020_by_year_and_month` and `yellow_tripdata_sample_2020_by_year_and_month_and_day` each have a different number of Batches resulting from their different `splitter` configurations. \n",
+    "\n",
+    "* `yellow_tripdata_sample_2020_by_year_and_month` has 12 Batches. \n",
+    "* `yellow_tripdata_sample_2020_by_year_and_month_and_day` has 366 Batches."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83ecebdc",
+   "metadata": {},
+   "source": [
+    "# Loading Data into Postgresql Database"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f4a183e-f0df-40f4-b64f-439666e32ab4",
+   "metadata": {},
+   "source": [
+    "* The following code can be used to build the postgres database used in this notebook. It is included (and commented out) for reference.\n",
+    "* In order to load the data into a local `postgresql` database, please feel free to use the `docker-compose.yml` file available at `great_expectations/assets/docker/postgresql/`. \n",
+    "\n",
+    "### To spin up the `postgresql` database\n",
+    "* Have [Docker Desktop](https://www.docker.com/products/docker-desktop/) running locally.\n",
+    "* Navigate to `great_expectations/assets/docker/postgresql/`\n",
+    "* Type `docker-compose up`\n",
+    "* Then uncomment and run the following snippet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad91c234-06a2-4e98-9d90-c999c2aad07f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from tests.test_utils import load_data_into_test_database\n",
+    "# from typing import List\n",
+    "# import sqlalchemy as sa\n",
+    "# import pandas as pd\n",
+    "# CONNECTION_STRING = \"postgresql+psycopg2://postgres:@localhost/test_ci\"\n",
+    "\n",
+    "# data_paths: List[str] = [\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-01.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-02.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-03.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-04.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-05.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-06.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-07.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-08.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-09.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-10.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-11.csv\",\n",
+    "#      \"../../../test_sets/taxi_yellow_tripdata_samples/yellow_tripdata_sample_2020-12.csv\",\n",
+    "# ]\n",
+    "\n",
+    "    \n",
+    "# engine = sa.create_engine(CONNECTION_STRING)\n",
+    "# connection = engine.connect()\n",
+    "# table_name = \"yellow_tripdata_sample_2020\"\n",
+    "# res = connection.execute(f\"DROP TABLE IF EXISTS {table_name}\")\n",
+    "\n",
+    "# for data_path in data_paths:\n",
+    "#     # This utility is not for general use. It is only to support testing.\n",
+    "#     load_data_into_test_database(\n",
+    "#         table_name=\"yellow_tripdata_sample_2020\",\n",
+    "#         csv_path=data_path,\n",
+    "#         connection_string=CONNECTION_STRING,\n",
+    "#         load_full_dataset=True,\n",
+    "#         drop_existing_table=False,\n",
+    "#         convert_colnames_to_datetime=[\"pickup_datetime\", \"dropoff_datetime\"]\n",
+    "#     )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
+++ b/tests/test_fixtures/rule_based_profiler/example_notebooks/MultiBatchExample_ConfiguredAssetSQLExample_SQL.ipynb
@@ -1206,7 +1206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6d5d03f",
+   "id": "85b9598e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1272,7 +1272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "475f3e92",
+   "id": "bd803494",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
- After pairing with @Rachel-Reverie, the Notebooks that use `ConfiguredAssetSqlDataConnector` were updated for `splitter_method` arguments. 
- `splitter_methods` can be configured at the `DataConnector`-level and `Asset`-level. 
- This PR updates 2 Notebooks `DataAssistants_Instantiation_And_Running-OnboardingAssistant-Sql` and `MultiBatchExample_ConfiguredAssetSQLExample_SQL` to add a section to the `Appendix` so that the 2 alternate configurations can be seen as well (one with DataConnector-level and one with Asset-level configuration, with the Asset-level config overriding)

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
