### PR TITLE
[BUGFIX] Handle case when only one unique "column.histogram" bin value is found with proper type casting

### DIFF
--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
@@ -83,8 +83,10 @@ class ColumnHistogram(ColumnAggregateMetricProvider):
                         [
                             (
                                 sa.and_(
-                                    bins[0] - np.finfo(float).eps < sa.column(column),
-                                    sa.column(column) < bins[0] + np.finfo(float).eps,
+                                    float(bins[0] - np.finfo(float).eps)
+                                    < sa.column(column),
+                                    sa.column(column)
+                                    < float(bins[0] + np.finfo(float).eps),
                                 ),
                                 1,
                             )

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_histogram.py
@@ -69,13 +69,38 @@ class ColumnHistogram(ColumnAggregateMetricProvider):
         column = accessor_domain_kwargs["column"]
         bins = metric_value_kwargs["bins"]
 
-        case_conditions = []
         if isinstance(bins, np.ndarray):
             bins = bins.tolist()
         else:
             bins = list(bins)
 
-        if len(bins) == 1:
+        case_conditions = []
+        if len(bins) == 1 and not (
+            (
+                bins[0]
+                == get_sql_dialect_floating_point_infinity_value(
+                    schema="api_np", negative=True
+                )
+            )
+            or (
+                bins[0]
+                == get_sql_dialect_floating_point_infinity_value(
+                    schema="api_cast", negative=True
+                )
+            )
+            or (
+                bins[0]
+                == get_sql_dialect_floating_point_infinity_value(
+                    schema="api_np", negative=False
+                )
+            )
+            or (
+                bins[0]
+                == get_sql_dialect_floating_point_infinity_value(
+                    schema="api_cast", negative=False
+                )
+            )
+        ):
             # Single-valued column data are modeled using "impulse" (or "sample") distributions (on open interval).
             case_conditions.append(
                 sa.func.sum(
@@ -220,6 +245,7 @@ class ColumnHistogram(ColumnAggregateMetricProvider):
         bins = list(
             copy.deepcopy(bins)
         )  # take a copy since we are inserting and popping
+
         if bins[0] == -np.inf or bins[0] == -float("inf"):
             added_min = False
             bins[0] = -float("inf")

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -529,7 +529,24 @@ def test_quantiles_metric_spark(spark_session):
 
 
 def test_column_histogram_metric_pd():
-    engine = build_pandas_engine(pd.DataFrame({"a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}))
+    engine = build_pandas_engine(
+        pd.DataFrame(
+            {
+                "a": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                ]
+            }
+        )
+    )
 
     metrics: dict = {}
 
@@ -557,7 +574,37 @@ def test_column_histogram_metric_pd():
 
 
 def test_column_histogram_metric_sa(sa):
-    engine = build_sa_engine(pd.DataFrame({"a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}), sa)
+    engine = build_sa_engine(
+        pd.DataFrame(
+            {
+                "a": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                ],
+                "b": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            }
+        ),
+        sa,
+    )
 
     metrics: dict = {}
 
@@ -583,11 +630,42 @@ def test_column_histogram_metric_sa(sa):
     metrics.update(results)
     assert results == {desired_metric.id: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]}
 
+    desired_metric = MetricConfiguration(
+        metric_name="column.histogram",
+        metric_domain_kwargs={"column": "b"},
+        metric_value_kwargs={
+            "bins": [0.0],
+        },
+        metric_dependencies={
+            "table.columns": table_columns_metric,
+        },
+    )
+    results = engine.resolve_metrics(
+        metrics_to_resolve=(desired_metric,), metrics=metrics
+    )
+    metrics.update(results)
+    assert results == {desired_metric.id: [10]}
+
 
 def test_column_histogram_metric_spark(spark_session):
     engine: SparkDFExecutionEngine = build_spark_engine(
         spark=spark_session,
-        df=pd.DataFrame({"a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}),
+        df=pd.DataFrame(
+            {
+                "a": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                ]
+            }
+        ),
         batch_id="my_id",
     )
 


### PR DESCRIPTION
### Scope
* When only one unique bin value is found, SQL implementation of `ColumnHistogram` requires special handling (otherwise, access of index out of bounds exception will occur).  It is important that all arithmetic operations are cast using appropriate type (`float` in the present case).

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-761/GREAT-1245
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!