### PR TITLE
Enable AWS_DEFAULT_REGION usage

### DIFF
--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -655,7 +655,7 @@ class TupleS3StoreBackend(TupleStoreBackend):
         else:
             # build s3 endpoint when no endpoint_url is configured
 
-            location = self._create_client().get_bucket_location(Bucket=self.bucket)[
+            location = os.getenv("AWS_DEFAULT_REGION") or self._create_client().get_bucket_location(Bucket=self.bucket)[
                 "LocationConstraint"
             ]
 


### PR DESCRIPTION
Hey Guys,

PR is more of a discussion starter, but why do we ignore this variable?

I only have access to my region, not to locate bucket within all regions, hence code fails for me when trying to locate the bucket. But, I am happy to provide bucket name with environment variable. Is there any other way I am missing?