### PR TITLE
[FEATURE] Data Assistant plot method indication of total metrics and expectations count

### DIFF
--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -592,7 +592,7 @@ class DataAssistantResult(SerializableDictDot):
         display_charts.extend(column_domain_display_charts)
         return_charts.extend(column_domain_return_charts)
 
-        self._display(charts=display_charts, theme=theme)
+        self._display(charts=display_charts, plot_mode=plot_mode, theme=theme)
 
         return_charts = self._apply_theme(charts=return_charts, theme=theme)
         return PlotResult(charts=return_charts)
@@ -600,6 +600,7 @@ class DataAssistantResult(SerializableDictDot):
     @staticmethod
     def _display(
         charts: Union[List[alt.Chart], List[alt.VConcatChart]],
+        plot_mode: PlotMode,
         theme: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
@@ -627,6 +628,16 @@ class DataAssistantResult(SerializableDictDot):
         )
 
         if len(chart_titles) > 0:
+            if plot_mode.PRESCRIPTIVE:
+                print(
+                    f"""Y Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented: Use DataAssistantResult.__name__.show_expectations_by_domain_type()
+or DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations."""
+                )
+            else:
+                print(
+                    f"W Metrics calculated, {len(chart_titles)} Metric plots implemented: Use DataAssistantResult.metrics_by_domain to show all calculated Metrics."
+                )
+
             display_chart_dict: Dict[str, Union[alt.Chart, alt.LayerChart]] = {
                 " ": None
             }

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -597,8 +597,8 @@ class DataAssistantResult(SerializableDictDot):
         return_charts = self._apply_theme(charts=return_charts, theme=theme)
         return PlotResult(charts=return_charts)
 
-    @staticmethod
     def _display(
+        self,
         charts: Union[List[alt.Chart], List[alt.VConcatChart]],
         plot_mode: PlotMode,
         theme: Optional[Dict[str, Any]] = None,
@@ -615,30 +615,25 @@ class DataAssistantResult(SerializableDictDot):
         """
         altair_theme: Dict[str, Any]
         if theme:
-            altair_theme = DataAssistantResult._get_theme(theme=theme)
+            altair_theme = self._get_theme(theme=theme)
         else:
             altair_theme = copy.deepcopy(AltairThemes.DEFAULT_THEME.value)
 
-        themed_charts: List[alt.Chart] = DataAssistantResult._apply_theme(
+        themed_charts: List[alt.Chart] = self._apply_theme(
             charts=charts, theme=altair_theme
         )
 
-        chart_titles: List[str] = DataAssistantResult._get_chart_titles(
-            charts=themed_charts
-        )
+        chart_titles: List[str] = self._get_chart_titles(charts=themed_charts)
 
         if len(chart_titles) > 0:
             if plot_mode.PRESCRIPTIVE:
                 print(
-                    f"""{len(DataAssistantResult.expectation_configurations)} Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented: Use DataAssistantResult.__name__.show_expectations_by_domain_type()
+                    f"""{len(self.expectation_configurations)} Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented: Use DataAssistantResult.__name__.show_expectations_by_domain_type()
 or DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations."""
                 )
             else:
                 metrics_count: int = sum(
-                    [
-                        len(metrics)
-                        for _, metrics in DataAssistantResult.metrics_by_domain.items()
-                    ]
+                    [len(metrics) for _, metrics in self.metrics_by_domain.items()]
                 )
                 print(
                     f"{metrics_count} Metrics calculated, {len(chart_titles)} Metric plots implemented: Use DataAssistantResult.metrics_by_domain to show all calculated Metrics."

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -626,17 +626,19 @@ class DataAssistantResult(SerializableDictDot):
         chart_titles: List[str] = self._get_chart_titles(charts=themed_charts)
 
         if len(chart_titles) > 0:
-            if plot_mode.PRESCRIPTIVE:
+            if plot_mode == plot_mode.DIAGNOSTIC:
                 print(
-                    f"""{len(self.expectation_configurations)} Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented: Use DataAssistantResult.__name__.show_expectations_by_domain_type()
-or DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations."""
+                    f"""{len(self.expectation_configurations)} Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented
+Use DataAssistantResult.show_expectations_by_domain_type() or
+DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations"""
                 )
             else:
                 metrics_count: int = sum(
                     [len(metrics) for _, metrics in self.metrics_by_domain.items()]
                 )
                 print(
-                    f"{metrics_count} Metrics calculated, {len(chart_titles)} Metric plots implemented: Use DataAssistantResult.metrics_by_domain to show all calculated Metrics."
+                    f"""{metrics_count} Metrics calculated, {len(chart_titles)} Metric plots implemented
+Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
                 )
 
             display_chart_dict: Dict[str, Union[alt.Chart, alt.LayerChart]] = {

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -630,12 +630,18 @@ class DataAssistantResult(SerializableDictDot):
         if len(chart_titles) > 0:
             if plot_mode.PRESCRIPTIVE:
                 print(
-                    f"""Y Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented: Use DataAssistantResult.__name__.show_expectations_by_domain_type()
+                    f"""{len(DataAssistantResult.expectation_configurations)} Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented: Use DataAssistantResult.__name__.show_expectations_by_domain_type()
 or DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations."""
                 )
             else:
+                metrics_count: int = sum(
+                    [
+                        len(metrics)
+                        for _, metrics in DataAssistantResult.metrics_by_domain.items()
+                    ]
+                )
                 print(
-                    f"W Metrics calculated, {len(chart_titles)} Metric plots implemented: Use DataAssistantResult.metrics_by_domain to show all calculated Metrics."
+                    f"{metrics_count} Metrics calculated, {len(chart_titles)} Metric plots implemented: Use DataAssistantResult.metrics_by_domain to show all calculated Metrics."
                 )
 
             display_chart_dict: Dict[str, Union[alt.Chart, alt.LayerChart]] = {

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -626,9 +626,10 @@ class DataAssistantResult(SerializableDictDot):
         chart_titles: List[str] = self._get_chart_titles(charts=themed_charts)
 
         if len(chart_titles) > 0:
+            metric_plot_count = self._get_metric_plot_count(charts=themed_charts)
             if plot_mode == plot_mode.DIAGNOSTIC:
                 print(
-                    f"""{len(self.expectation_configurations)} Expectations produced, {len(chart_titles)} Expectation and Metric plots implemented
+                    f"""{len(self.expectation_configurations)} Expectations produced, {metric_plot_count} Expectation and Metric plots implemented
 Use DataAssistantResult.show_expectations_by_domain_type() or
 DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations"""
                 )
@@ -637,7 +638,7 @@ DataAssistantResult.show_expectations_by_expectation_type() to show all produced
                     [len(metrics) for _, metrics in self.metrics_by_domain.items()]
                 )
                 print(
-                    f"""{metrics_count} Metrics calculated, {len(chart_titles)} Metric plots implemented
+                    f"""{metrics_count} Metrics calculated, {metric_plot_count} Metric plots implemented
 Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
                 )
 
@@ -764,6 +765,16 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
             chart_titles.append(chart_title)
 
         return chart_titles
+
+    @staticmethod
+    def _get_metric_plot_count(charts: List[Union[alt.Chart, alt.LayerChart]]) -> int:
+        plot_count = 0
+        for chart in charts:
+            if "column" in chart.data.columns:
+                plot_count += chart.data.column.nunique()
+            else:
+                plot_count += 1
+        return plot_count
 
     @staticmethod
     def _apply_theme(

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -879,21 +879,27 @@ def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectati
         bobby_onboarding_data_assistant_result
     )
 
+    metrics_calculated = 150
+    metrics_plots_implemented = 102
+
     f = io.StringIO()
     with redirect_stdout(f):
         data_assistant_result.plot_metrics()
     stdout = f.getvalue()
     assert (
-        """150 Metrics calculated, 102 Metric plots implemented
+        f"""{metrics_calculated} Metrics calculated, {metrics_plots_implemented} Metric plots implemented
 Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
         in stdout
     )
+
+    expectations_produced = 160
+    expectations_and_metrics_plots_implemented = 117
 
     with redirect_stdout(f):
         data_assistant_result.plot_expectations_and_metrics()
     stdout = f.getvalue()
     assert (
-        """160 Expectations produced, 117 Expectation and Metric plots implemented
+        f"""{expectations_produced} Expectations produced, {expectations_and_metrics_plots_implemented} Expectation and Metric plots implemented
 Use DataAssistantResult.show_expectations_by_domain_type() or
 DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations"""
         in stdout

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -1,4 +1,6 @@
+import io
 import os
+from contextlib import redirect_stdout
 from typing import Any, Dict, List, Optional, cast
 from unittest import mock
 
@@ -867,3 +869,32 @@ def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectati
         assert (
             False
         ), f"DataAssistantResult.plot_expectations_and_metrics raised an exception '{exc}'"
+
+
+@pytest.mark.integration
+def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectations(
+    bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
+):
+    data_assistant_result: OnboardingDataAssistantResult = (
+        bobby_onboarding_data_assistant_result
+    )
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        data_assistant_result.plot_metrics()
+    stdout = f.getvalue()
+    assert (
+        """150 Metrics calculated, 102 Metric plots implemented
+Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
+        in stdout
+    )
+
+    with redirect_stdout(f):
+        data_assistant_result.plot_expectations_and_metrics()
+    stdout = f.getvalue()
+    assert (
+        """160 Expectations produced, 117 Expectation and Metric plots implemented
+Use DataAssistantResult.show_expectations_by_domain_type() or
+DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations"""
+        in stdout
+    )

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -895,6 +895,7 @@ Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
     expectations_produced = 160
     expectations_and_metrics_plots_implemented = 117
 
+    f = io.StringIO()
     with redirect_stdout(f):
         data_assistant_result.plot_expectations_and_metrics()
     stdout = f.getvalue()

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -891,26 +891,3 @@ def test_onboarding_data_assistant_plot_metrics_stdout(
 Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
         in stdout
     )
-
-
-@pytest.mark.integration
-def test_onboarding_data_assistant_plot_expectations_and_metrics_stdout(
-    bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
-):
-    data_assistant_result: OnboardingDataAssistantResult = (
-        bobby_onboarding_data_assistant_result
-    )
-
-    expectations_produced = 160
-    expectations_and_metrics_plots_implemented = 117
-
-    f = io.StringIO()
-    with redirect_stdout(f):
-        data_assistant_result.plot_expectations_and_metrics()
-    stdout = f.getvalue()
-    assert (
-        f"""{expectations_produced} Expectations produced, {expectations_and_metrics_plots_implemented} Expectation and Metric plots implemented
-Use DataAssistantResult.show_expectations_by_domain_type() or
-DataAssistantResult.show_expectations_by_expectation_type() to show all produced Expectations"""
-        in stdout
-    )

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -872,7 +872,7 @@ def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectati
 
 
 @pytest.mark.integration
-def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectations(
+def test_onboarding_data_assistant_plot_stdout(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ):
     data_assistant_result: OnboardingDataAssistantResult = (

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -872,7 +872,7 @@ def test_onboarding_data_assistant_result_empty_suite_plot_metrics_and_expectati
 
 
 @pytest.mark.integration
-def test_onboarding_data_assistant_plot_stdout(
+def test_onboarding_data_assistant_plot_metrics_stdout(
     bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
 ):
     data_assistant_result: OnboardingDataAssistantResult = (
@@ -890,6 +890,15 @@ def test_onboarding_data_assistant_plot_stdout(
         f"""{metrics_calculated} Metrics calculated, {metrics_plots_implemented} Metric plots implemented
 Use DataAssistantResult.metrics_by_domain to show all calculated Metrics"""
         in stdout
+    )
+
+
+@pytest.mark.integration
+def test_onboarding_data_assistant_plot_expectations_and_metrics_stdout(
+    bobby_onboarding_data_assistant_result: OnboardingDataAssistantResult,
+):
+    data_assistant_result: OnboardingDataAssistantResult = (
+        bobby_onboarding_data_assistant_result
     )
 
     expectations_produced = 160


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-761/GREAT-1136
- Tell the user how many plots have been implemented vs how many metrics/expectations were computed/produced

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.