### PR TITLE
[MAINTENANCE] Redshift specific temp table code path

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -542,7 +542,7 @@ class RedshiftCredentialYamlHelper(SQLCredentialYamlHelper):
                 "db": SupportedDatabaseBackends.REDSHIFT.value,
                 "api_version": "v3",
             },
-            driver="postgresql+psycopg2",
+            driver="redshift",
             port=5439,
         )
 

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -276,6 +276,10 @@ class SqlAlchemyBatchData(BatchData):
             stmt = 'CREATE VOLATILE TABLE "{temp_table_name}" AS ({query}) WITH DATA NO PRIMARY INDEX ON COMMIT PRESERVE ROWS'.format(
                 temp_table_name=temp_table_name, query=query
             )
+        elif dialect == GESqlDialect.REDSHIFT:
+            query_str = str(query)
+            query_str = query_str.replace('"', "")
+            stmt = f'CREATE TEMPORARY TABLE "{temp_table_name}" AS {query_str}'
         else:
             stmt = f'CREATE TEMPORARY TABLE "{temp_table_name}" AS {query}'
         if dialect == GESqlDialect.ORACLE:

--- a/tests/cli/test_datasource_new_helpers.py
+++ b/tests/cli/test_datasource_new_helpers.py
@@ -244,7 +244,7 @@ execution_engine:
     schema_name: {schema_name}
     query:
       sslmode: prefer
-    drivername: postgresql+psycopg2
+    drivername: redshift
 data_connectors:
   default_runtime_data_connector_name:
     class_name: RuntimeDataConnector


### PR DESCRIPTION
Replaces #6020

Changes proposed in this pull request:
- Use a redshift specific driver when creating a redshift datsource.
- Use this redshift dialect in a separate code path to strip quotes from the table name.
- Note: This can be improved by instead adding quotes around the schema and table name separately e.g. "schema"."table" since characters like periods are allowed in table and schema names.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.