### PR TITLE
[BUGFIX] Defer `pprint` in `ExpectationSuite.show_expectations_by_expectation_type()` due to Jupyter rate limit

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -720,19 +720,23 @@ class ExpectationSuite(SerializableDictDot):
         expectation_configuration: ExpectationConfiguration
         domain_type: MetricDomainTypes
         kwargs: dict
+        pprint_objects: List[dict] = []
         for expectation_configuration in expectation_configurations:
             domain_type = expectation_configuration.get_domain_type()
             kwargs = expectation_configuration.kwargs
-            pprint.pprint(  # type: ignore[call-arg]
-                object={
+            pprint_objects.append(
+                {
                     expectation_configuration.expectation_type: {
                         "domain": domain_type.value,
                         **kwargs,
                     }
-                },
-                indent=2,
-                sort_dicts=False,
+                }
             )
+        pprint.pprint(  # type: ignore[call-arg]
+            object=pprint_objects,
+            indent=2,
+            sort_dicts=False,
+        )
 
     def get_grouped_and_ordered_expectations_by_domain_type(
         self,

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -169,11 +169,15 @@ class DataAssistantResult(SerializableDictDot):
         Populates named "ExpectationSuite" with "ExpectationConfiguration" list, stored in "DataAssistantResult" object,
         and displays this "ExpectationConfiguration" list, grouped by "domain_type", in predetermined order.
         """
-        self.get_expectation_suite(
+        expectation_suite: ExpectationSuite = self.get_expectation_suite(
             expectation_suite_name=expectation_suite_name,
             include_profiler_config=include_profiler_config,
             send_usage_event=send_usage_event,
-        ).show_expectations_by_domain_type()
+        )
+        if in_jupyter_notebook():
+            display(expectation_suite.show_expectations_by_domain_type())
+        else:
+            expectation_suite.show_expectations_by_domain_type()
 
     def show_expectations_by_expectation_type(
         self,
@@ -185,11 +189,15 @@ class DataAssistantResult(SerializableDictDot):
         Populates named "ExpectationSuite" with "ExpectationConfiguration" list, stored in "DataAssistantResult" object,
         and displays this "ExpectationConfiguration" list, grouped by "expectation_type", in predetermined order.
         """
-        self.get_expectation_suite(
+        expectation_suite: ExpectationSuite = self.get_expectation_suite(
             expectation_suite_name=expectation_suite_name,
             include_profiler_config=include_profiler_config,
             send_usage_event=send_usage_event,
-        ).show_expectations_by_expectation_type()
+        )
+        if in_jupyter_notebook():
+            display(expectation_suite.show_expectations_by_expectation_type())
+        else:
+            expectation_suite.show_expectations_by_expectation_type()
 
     def get_expectation_suite(
         self,

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -169,15 +169,11 @@ class DataAssistantResult(SerializableDictDot):
         Populates named "ExpectationSuite" with "ExpectationConfiguration" list, stored in "DataAssistantResult" object,
         and displays this "ExpectationConfiguration" list, grouped by "domain_type", in predetermined order.
         """
-        expectation_suite: ExpectationSuite = self.get_expectation_suite(
+        self.get_expectation_suite(
             expectation_suite_name=expectation_suite_name,
             include_profiler_config=include_profiler_config,
             send_usage_event=send_usage_event,
-        )
-        if in_jupyter_notebook():
-            display(expectation_suite.show_expectations_by_domain_type())
-        else:
-            expectation_suite.show_expectations_by_domain_type()
+        ).show_expectations_by_domain_type()
 
     def show_expectations_by_expectation_type(
         self,
@@ -189,15 +185,11 @@ class DataAssistantResult(SerializableDictDot):
         Populates named "ExpectationSuite" with "ExpectationConfiguration" list, stored in "DataAssistantResult" object,
         and displays this "ExpectationConfiguration" list, grouped by "expectation_type", in predetermined order.
         """
-        expectation_suite: ExpectationSuite = self.get_expectation_suite(
+        self.get_expectation_suite(
             expectation_suite_name=expectation_suite_name,
             include_profiler_config=include_profiler_config,
             send_usage_event=send_usage_event,
-        )
-        if in_jupyter_notebook():
-            display(expectation_suite.show_expectations_by_expectation_type())
-        else:
-            expectation_suite.show_expectations_by_expectation_type()
+        ).show_expectations_by_expectation_type()
 
     def get_expectation_suite(
         self,


### PR DESCRIPTION
Changes proposed in this pull request:
- Defer `pprint` in `ExpectationSuite.show_expectations_by_expectation_type()` due to Jupyter rate limit

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
