### PR TITLE
[MAINTENANCE] Clean up Spark schema tests to have proper names

### DIFF
--- a/tests/checkpoint/test_checkpoint.py
+++ b/tests/checkpoint/test_checkpoint.py
@@ -5420,7 +5420,7 @@ def test_running_spark_checkpoint(
 
 
 @pytest.mark.integration
-def run_spark_checkpoint_with_schema(
+def test_run_spark_checkpoint_with_schema(
     context_with_single_csv_spark_and_suite, spark_df_taxi_data_schema
 ):
     context = context_with_single_csv_spark_and_suite

--- a/tests/checkpoint/test_simple_checkpoint.py
+++ b/tests/checkpoint/test_simple_checkpoint.py
@@ -3551,7 +3551,7 @@ def test_running_spark_simplecheckpoint(
 
 
 @pytest.mark.integration
-def run_spark_checkpoint_with_schema(
+def test_run_spark_checkpoint_with_schema(
     context_with_single_csv_spark_and_suite, spark_df_taxi_data_schema
 ):
     context = context_with_single_csv_spark_and_suite


### PR DESCRIPTION
- Small PR that updates 2 tests to have proper names (they were missing the `test_` prefix)


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review]
Thank you for submitting!
