### PR TITLE
[BUGFIX] Standardize `ConfiguredAssetSqlDataConnector` config in `datasource new` CLI workflow

### DIFF
--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -460,18 +460,15 @@ data_connectors:
     include_schema_name: True
     introspection_directives:
       schema_name: {{schema_name}}
-  default_configured_data_connector_name:{self._configured_asset_sql_data_connector_yaml_snippet()}
+  default_configured_data_connector_name:
+    class_name: ConfiguredAssetSqlDataConnector
+    assets:
+      {{table_name}}:
+        class_name: Asset
+        schema_name: {{schema_name}}
 """'''
 
         return yaml_str
-
-    def _configured_asset_sql_data_connector_yaml_snippet(self) -> str:
-        """Differs for different backends - override if needed."""
-        return """
-    class_name: ConfiguredAssetSqlDataConnector
-    assets:
-      {schema_name}.{table_name}:
-        class_name: Asset"""
 
     def _yaml_innards(self) -> str:
         """Override if needed."""
@@ -583,14 +580,6 @@ class RedshiftCredentialYamlHelper(SQLCredentialYamlHelper):
             module_names_to_reload=CLI_ONLY_SQLALCHEMY_ORDERED_DEPENDENCY_MODULE_NAMES,
         )
         return redshift_success or postgresql_success
-
-    def _configured_asset_sql_data_connector_yaml_snippet(self) -> str:
-        return """
-    class_name: ConfiguredAssetSqlDataConnector
-    assets:
-      {table_name}:
-        schema_name: {schema_name}
-        class_name: Asset"""
 
     def _yaml_innards(self) -> str:
         return (

--- a/tests/cli/test_datasource_new_helpers.py
+++ b/tests/cli/test_datasource_new_helpers.py
@@ -59,8 +59,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
 
@@ -112,8 +113,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
 
@@ -165,8 +167,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
 
@@ -234,8 +237,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
     helper.send_backend_choice_usage_message(empty_data_context_stats_enabled)
@@ -303,8 +307,8 @@ data_connectors:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
       {table_name}:
-        schema_name: {schema_name}
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
 
@@ -382,8 +386,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
     helper.send_backend_choice_usage_message(empty_data_context_stats_enabled)
@@ -446,8 +451,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
     helper.send_backend_choice_usage_message(empty_data_context_stats_enabled)
@@ -511,8 +517,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
     helper.send_backend_choice_usage_message(empty_data_context_stats_enabled)
@@ -575,8 +582,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
     helper.send_backend_choice_usage_message(empty_data_context_stats_enabled)
@@ -629,8 +637,9 @@ data_connectors:
   default_configured_data_connector_name:
     class_name: ConfiguredAssetSqlDataConnector
     assets:
-      {schema_name}.{table_name}:
+      {table_name}:
         class_name: Asset
+        schema_name: {schema_name}
 """'''
     )
 

--- a/tests/cli/test_datasource_sqlite.py
+++ b/tests/cli/test_datasource_sqlite.py
@@ -333,9 +333,10 @@ def test_cli_datasource_new_connection_string(
                 },
                 "default_configured_data_connector_name": {
                     "assets": {
-                        "YOUR_SCHEMA.YOUR_TABLE_NAME": {
+                        "YOUR_TABLE_NAME": {
                             "class_name": "Asset",
                             "module_name": "great_expectations.datasource.data_connector.asset",
+                            "schema_name": "YOUR_SCHEMA",
                         },
                     },
                     "class_name": "ConfiguredAssetSqlDataConnector",


### PR DESCRIPTION
Changes proposed in this pull request:
- Modify generated config for `ConfiguredAssetSqlDataConnetor` in the CLI workflow to work with all backend types.
- Remove explicit fork for Redshift through helper method.

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
