### PR TITLE
[MAINTENANCE] Include git commit info when building docker image.

### DIFF
--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -15,7 +15,8 @@ COPY . .
 FROM base AS build_github
 # BRANCH is the branch name you want to build
 ARG BRANCH=develop
-RUN git clone --depth 1 --branch ${BRANCH} https://github.com/great-expectations/great_expectations.git
+# We use --filter=tree:0 instead of --depth 1 because we really on git to get version information
+RUN git clone --filter=tree:0 --branch ${BRANCH} https://github.com/great-expectations/great_expectations.git
 WORKDIR /great_expectations
 
 FROM build_${SOURCE} AS dev


### PR DESCRIPTION
Previously we used `--depth 1` when building our docker image. However we really on `git` to get version information in `_version.py` so we now use `--filter=tree:0`. The git clone size is now 220M instead of 214M. Our docker image is much bigger since our dependencies are the biggest factor there.