### PR TITLE
[CONTRIB] add India_zip_code Expectation and not_to_be_future_date Expectation

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_not_to_be_future_date.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_not_to_be_future_date.py
@@ -1,0 +1,165 @@
+"""
+This is a template for creating custom ColumnMapExpectations.
+For detailed instructions on how to use it, please see:
+    https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_map_expectations
+"""
+import json
+from typing import Optional
+
+from datetime import date
+from dateutil.parser import parse
+
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.execution_engine import PandasExecutionEngine
+from great_expectations.expectations.expectation import ColumnMapExpectation
+from great_expectations.expectations.metrics import (
+    ColumnMapMetricProvider,
+    column_condition_partial,
+)
+
+
+def is_not_a_future_date(date_in: str) -> bool:
+    try:
+        today = date.today()
+        if isinstance(date_in, str):
+            d = parse(date_in)
+        else:
+            d = date_in
+        d=d.date()
+        if d>today:
+            return False
+        else:
+            return True
+    except Exception as e:
+        return False
+
+
+# This class defines a Metric to support your Expectation.
+# For most ColumnMapExpectations, the main business logic for calculation will live in this class.
+class ColumnValuesNotToBeFutureDate(ColumnMapMetricProvider):
+
+    # This is the id string that will be used to reference your metric.
+    condition_metric_name = "column_values.valid_date"
+
+    # This method implements the core logic for the PandasExecutionEngine
+    @column_condition_partial(engine=PandasExecutionEngine)
+    def _pandas(cls, column, **kwargs):
+        return column.apply(lambda x: is_not_a_future_date(x))
+
+    # This method defines the business logic for evaluating your metric when using a SqlAlchemyExecutionEngine
+    # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+    # def _sqlalchemy(cls, column, _dialect, **kwargs):
+    #     raise NotImplementedError
+
+    # This method defines the business logic for evaluating your metric when using a SparkDFExecutionEngine
+    # @column_condition_partial(engine=SparkDFExecutionEngine)
+    # def _spark(cls, column, **kwargs):
+    #     raise NotImplementedError
+
+
+# This class defines the Expectation itself
+class ExpectColumnValuesNotToBeFutureDate(ColumnMapExpectation):
+    """Expect column values not to be the future date """
+
+    # These examples will be shown in the public gallery.
+    # They will also be executed as unit tests for your Expectation.
+    examples = [
+        {
+            "data": {
+                "all_valid": [
+                    "2022-01-01",
+                    "2022-01-02",
+                    "2022/03/03",
+                    "01/01/2022",
+                    "2022.01.01",
+                ],
+                "some_other": [
+                    "2022-02-30",
+                    "2022-11-31",
+                    "2022/03/03",
+                    "2222/01/02",
+                    "2322.01.01",
+                ],
+            },
+            "tests": [
+                {
+                    "title": "basic_positive_test",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {"column": "all_valid"},
+                    "out": {
+                        "success": True,
+                    },
+                },
+                {
+                    "title": "basic_negative_test",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {"column": "some_other", "mostly": 1},
+                    "out": {
+                        "success": False,
+                    },
+                },
+            ],
+        }
+    ]
+
+    # This is the id string of the Metric used by this Expectation.
+    # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
+    map_metric = "column_values.valid_date"
+
+    # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
+    success_keys = ("mostly",)
+
+    # This dictionary contains default values for any parameters that should have default values
+    default_kwarg_values = {}
+
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
+        """
+        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+        necessary configuration arguments have been provided for the validation of the expectation.
+
+        Args:
+            configuration (OPTIONAL[ExpectationConfiguration]): \
+                An optional Expectation Configuration entry that will be used to configure the expectation
+        Returns:
+            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
+        """
+
+        super().validate_configuration(configuration)
+        if configuration is None:
+            configuration = self.configuration
+
+        # # Check other things in configuration.kwargs and raise Exceptions if needed
+        # try:
+        #     assert (
+        #         ...
+        #     ), "message"
+        #     assert (
+        #         ...
+        #     ), "message"
+        # except AssertionError as e:
+        #     raise InvalidExpectationConfigurationError(str(e))
+
+        return True
+
+    # This object contains metadata for display in the public Gallery
+    library_metadata = {
+        "maturity": "experimental",
+        "tags": [
+            "experimental",
+            "typed-entities",
+        ],  # Tags for this Expectation in the Gallery
+        "contributors": [  # Github handles for all contributors to this Expectation.
+            "@prachijain136",  # Don't forget to add your github handle here!
+            "@m-Chetan",
+            "@Pritampyaare",
+        ],
+    }
+
+
+if __name__ == "__main__":
+    ExpectColumnValuesNotToBeFutureDate().print_diagnostic_checklist()

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_not_to_be_future_date.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_not_to_be_future_date.py
@@ -4,19 +4,17 @@ For detailed instructions on how to use it, please see:
     https://docs.greatexpectations.io/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_map_expectations
 """
 import json
+from datetime import date
 from typing import Optional
 
-from datetime import date
 from dateutil.parser import parse
-
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.core.expectation_configuration import \
+    ExpectationConfiguration
 from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.execution_engine import PandasExecutionEngine
 from great_expectations.expectations.expectation import ColumnMapExpectation
-from great_expectations.expectations.metrics import (
-    ColumnMapMetricProvider,
-    column_condition_partial,
-)
+from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
+                                                     column_condition_partial)
 
 
 def is_not_a_future_date(date_in: str) -> bool:

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_valid_india_zip.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_valid_india_zip.py
@@ -1,20 +1,18 @@
 import json
 from typing import Optional
 
-import  indiapins
-
-from great_expectations.core.expectation_configuration import ExpectationConfiguration
+import indiapins
+from great_expectations.core.expectation_configuration import \
+    ExpectationConfiguration
 from great_expectations.exceptions import InvalidExpectationConfigurationError
-from great_expectations.execution_engine import (
-    PandasExecutionEngine,
-    SparkDFExecutionEngine,
-    SqlAlchemyExecutionEngine,
-)
+from great_expectations.execution_engine import (PandasExecutionEngine,
+                                                 SparkDFExecutionEngine,
+                                                 SqlAlchemyExecutionEngine)
 from great_expectations.expectations.expectation import ColumnMapExpectation
-from great_expectations.expectations.metrics import (
-    ColumnMapMetricProvider,
-    column_condition_partial,
-)
+from great_expectations.expectations.metrics import (ColumnMapMetricProvider,
+                                                     column_condition_partial)
+
+
 def is_valid_india_zip(zip:str):
     if len(zip)!=6:
         return False

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_valid_india_zip.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_valid_india_zip.py
@@ -1,0 +1,139 @@
+import json
+from typing import Optional
+
+import  indiapins
+
+from great_expectations.core.expectation_configuration import ExpectationConfiguration
+from great_expectations.exceptions import InvalidExpectationConfigurationError
+from great_expectations.execution_engine import (
+    PandasExecutionEngine,
+    SparkDFExecutionEngine,
+    SqlAlchemyExecutionEngine,
+)
+from great_expectations.expectations.expectation import ColumnMapExpectation
+from great_expectations.expectations.metrics import (
+    ColumnMapMetricProvider,
+    column_condition_partial,
+)
+def is_valid_india_zip(zip:str):
+    if len(zip)!=6:
+        return False
+    elif zip.isnumeric()==False:
+        return False
+    elif indiapins.isvalid(zip):
+        return True
+    else:
+        return False
+
+
+
+# This class defines a Metric to support your Expectation.
+# For most ColumnMapExpectations, the main business logic for calculation will live in this class.
+class ColumnValuesToBeValidIndiaZip(ColumnMapMetricProvider):
+
+    # This is the id string that will be used to reference your metric.
+    condition_metric_name = "column_values.valid_india_zip"
+
+    # This method implements the core logic for the PandasExecutionEngine
+    @column_condition_partial(engine=PandasExecutionEngine)
+    def _pandas(cls, column, **kwargs):
+        return column.apply(lambda x: is_valid_india_zip(x))
+
+    # This method defines the business logic for evaluating your metric when using a SqlAlchemyExecutionEngine
+    # @column_condition_partial(engine=SqlAlchemyExecutionEngine)
+    # def _sqlalchemy(cls, column, _dialect, **kwargs):
+    #     raise NotImplementedError
+
+    # This method defines the business logic for evaluating your metric when using a SparkDFExecutionEngine
+    # @column_condition_partial(engine=SparkDFExecutionEngine)
+    # def _spark(cls, column, **kwargs):
+    #     raise NotImplementedError
+
+
+# This class defines the Expectation itself
+class ExpectColumnValuesToBeValidIndiaZip(ColumnMapExpectation):
+    """Expect values in this column to be valid India zipcodes.
+    See https://pypi.org/project/indiapins/ for more information.
+    """
+
+    # These examples will be shown in the public gallery.
+    # They will also be executed as unit tests for your Expectation.
+    examples = [
+          {
+            "data": {
+                "valid_india_zip": ["421306", "421301", "400078", "400051"],
+                "invalid_india_zip": ["-10000", "1234", "099999", "25487"],
+            },
+            "tests": [
+                {
+                    "title": "basic_positive_test",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {"column": "valid_india_zip"},
+                    "out": {"success": True},
+                },
+                {
+                    "title": "basic_negative_test",
+                    "exact_match_out": False,
+                    "include_in_gallery": True,
+                    "in": {"column": "invalid_india_zip","mostly": 1},
+                    "out": {"success": False},
+                },
+            ],
+        }
+    ]
+
+    # This is the id string of the Metric used by this Expectation.
+    # For most Expectations, it will be the same as the `condition_metric_name` defined in your Metric class above.
+    map_metric = "column_values.valid_india_zip"
+
+    # This is a list of parameter names that can affect whether the Expectation evaluates to True or False
+    success_keys = ("mostly",)
+
+    # This dictionary contains default values for any parameters that should have default values
+    default_kwarg_values = {}
+
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
+        """
+        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+        necessary configuration arguments have been provided for the validation of the expectation.
+
+        Args:
+            configuration (OPTIONAL[ExpectationConfiguration]): \
+                An optional Expectation Configuration entry that will be used to configure the expectation
+        Returns:
+            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
+        """
+
+        super().validate_configuration(configuration)
+        if configuration is None:
+            configuration = self.configuration
+
+        # # Check other things in configuration.kwargs and raise Exceptions if needed
+        # try:
+        #     assert (
+        #         ...
+        #     ), "message"
+        #     assert (
+        #         ...
+        #     ), "message"
+        # except AssertionError as e:
+        #     raise InvalidExpectationConfigurationError(str(e))
+
+    # This object contains metadata for display in the public Gallery
+    library_metadata = {
+        "maturity": "experimental", 
+        "tags": [ "typed-entities","india","pincode",],  # Tags for this Expectation in the Gallery
+        "contributors": [  # Github handles for all contributors to this Expectation.
+            "@prachijain136", 
+            "@jainamshahh", # Don't forget to add your github handle here!
+        ],
+         "requirements": ["indiapins"],
+
+    }
+
+
+if __name__ == "__main__":
+    ExpectColumnValuesToBeValidIndiaZip().print_diagnostic_checklist()


### PR DESCRIPTION
###  Expect Value to be valid India zip code
Expectation name : _expect_column_values_to_be_valid_india_zip_
Expect values in this column to be valid India zipcodes. See _https://pypi.org/project/indiapins/_ for more information.
This Expectation is very useful as it validate Zipcodes which are very  fascinating as they can be used to pinpoint the exact location of any post office in India.

### Expect value not to be a future date
Expectation name: _expect_column_values_not_to_be_future_date_
It Validates the column & check if column does not contains the future date .
This expectation can be used to validate  Date of birth column ,transaction date ,debit card expiry date etc

### Definition of Done
Please delete options that are not relevant.

-  My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
-  I have commented my code, particularly in hard-to-understand areas
-  I have made corresponding changes to the documentation
-  I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
-  I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
