### PR TITLE
[MAINTENANCE] Add `data_context_id` property to `ConfigurationBundle`

### DIFF
--- a/great_expectations/data_context/cloud_migrator.py
+++ b/great_expectations/data_context/cloud_migrator.py
@@ -55,6 +55,7 @@ class ConfigurationBundle:
     def __init__(self, context: BaseDataContext) -> None:
 
         self._context = context
+        self._context_id = context.data_context_id
 
         self._data_context_variables: DataContextVariables = context.variables
 
@@ -66,6 +67,10 @@ class ConfigurationBundle:
         self._validation_results: List[
             ExpectationSuiteValidationResult
         ] = self._get_all_validation_results()
+
+    @property
+    def data_context_id(self) -> str:
+        return self._context_id
 
     def is_usage_stats_enabled(self) -> bool:
         """Determine whether usage stats are enabled.
@@ -116,6 +121,8 @@ class ConfigurationBundle:
 
 class ConfigurationBundleSchema(Schema):
     """Marshmallow Schema for the Configuration Bundle."""
+
+    data_context_id = fields.String(allow_none=False, required=True)
 
     _data_context_variables = fields.Nested(
         DataContextConfigSchema, allow_none=False, data_key="data_context_variables"

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -705,46 +705,18 @@ def serialized_configuration_bundle() -> dict:
         ],
         "checkpoints": [
             {
-                "action_list": [
-                    {
-                        "action": {"class_name": "StoreValidationResultAction"},
-                        "name": "store_validation_result",
-                    },
-                    {
-                        "action": {"class_name": "StoreEvaluationParametersAction"},
-                        "name": "store_evaluation_params",
-                    },
-                    {
-                        "action": {
-                            "class_name": "UpdateDataDocsAction",
-                            "site_names": [],
-                        },
-                        "name": "update_data_docs",
-                    },
-                ],
-                "batch_request": {},
                 "class_name": "Checkpoint",
-                "config_version": 1.0,
-                "evaluation_parameters": {},
-                "expectation_suite_ge_cloud_id": None,
-                "expectation_suite_name": None,
-                "ge_cloud_id": None,
+                "config_version": None,
                 "module_name": "great_expectations.checkpoint",
                 "name": "my_checkpoint",
-                "profilers": [],
-                "run_name_template": None,
-                "runtime_configuration": {},
-                "template_name": None,
-                "validations": [],
             }
         ],
         "data_context_variables": {
-            "checkpoint_store_name": "checkpoint_store",
             "config_variables_file_path": None,
             "config_version": 3.0,
-            "data_docs_sites": {},
-            "evaluation_parameter_store_name": "evaluation_parameter_store",
-            "expectations_store_name": "expectations_store",
+            "data_docs_sites": None,
+            "evaluation_parameter_store_name": None,
+            "expectations_store_name": None,
             "include_rendered_content": {
                 "expectation_suite": False,
                 "expectation_validation_result": False,
@@ -752,37 +724,27 @@ def serialized_configuration_bundle() -> dict:
             },
             "notebooks": None,
             "plugins_directory": None,
-            "profiler_store_name": "profiler_store",
-            "stores": {
-                "checkpoint_store": {
-                    "class_name": "CheckpointStore",
-                    "store_backend": {"class_name": "InMemoryStoreBackend"},
-                },
-                "evaluation_parameter_store": {
-                    "class_name": "EvaluationParameterStore"
-                },
-                "expectations_store": {
-                    "class_name": "ExpectationsStore",
-                    "store_backend": {"class_name": "InMemoryStoreBackend"},
-                },
-                "profiler_store": {
-                    "class_name": "ProfilerStore",
-                    "store_backend": {"class_name": "InMemoryStoreBackend"},
-                },
-                "validations_store": {
-                    "class_name": "ValidationsStore",
-                    "store_backend": {"class_name": "InMemoryStoreBackend"},
-                },
-            },
-            "validations_store_name": "validations_store",
+            "stores": None,
+            "validations_store_name": None,
         },
+        "datasources": [
+            {
+                "class_name": "Datasource",
+                "data_connectors": {},
+                "execution_engine": {
+                    "class_name": "PandasExecutionEngine",
+                    "module_name": "great_expectations.execution_engine",
+                },
+                "module_name": "great_expectations.datasource",
+                "name": "my_datasource",
+            }
+        ],
         "expectation_suites": [
             {
                 "data_asset_type": None,
                 "expectation_suite_name": "my_suite",
                 "expectations": [],
                 "ge_cloud_id": None,
-                "meta": {"great_expectations_version": "0.15.24+14.g6eff2678d.dirty"},
             }
         ],
         "profilers": [
@@ -791,44 +753,7 @@ def serialized_configuration_bundle() -> dict:
                 "config_version": 1.0,
                 "module_name": "great_expectations.rule_based_profiler",
                 "name": "my_profiler",
-                "rules": {
-                    "rule_1": {
-                        "domain_builder": {
-                            "class_name": "TableDomainBuilder",
-                            "module_name": "great_expectations.rule_based_profiler.domain_builder",
-                        },
-                        "expectation_configuration_builders": [
-                            {
-                                "class_name": "DefaultExpectationConfigurationBuilder",
-                                "column_A": "$domain.domain_kwargs.column_A",
-                                "column_B": "$domain.domain_kwargs.column_B",
-                                "expectation_type": "expect_column_pair_values_A_to_be_greater_than_B",
-                                "meta": {
-                                    "profiler_details": {
-                                        "my_parameter_estimator": "$parameter.my_parameter.details",
-                                        "note": "Important "
-                                        "remarks "
-                                        "about "
-                                        "estimation "
-                                        "algorithm.",
-                                    }
-                                },
-                                "module_name": "great_expectations.rule_based_profiler.expectation_configuration_builder",
-                                "my_arg": "$parameter.my_parameter.value[0]",
-                                "my_other_arg": "$parameter.my_parameter.value[1]",
-                            }
-                        ],
-                        "parameter_builders": [
-                            {
-                                "class_name": "MetricMultiBatchParameterBuilder",
-                                "metric_name": "my_metric",
-                                "module_name": "great_expectations.rule_based_profiler.parameter_builder",
-                                "name": "my_parameter",
-                            }
-                        ],
-                        "variables": {},
-                    }
-                },
+                "rules": {},
                 "variables": {},
             }
         ],

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -677,6 +677,7 @@ def cloud_data_context_in_cloud_mode_with_datasource_pandas_engine(
 @pytest.fixture
 def serialized_configuration_bundle() -> dict:
     return {
+        "data_context_id": "877166bd-08f2-4d7b-b473-a2b97ab5e36f",
         "checkpoints": [
             {
                 "action_list": [

--- a/tests/data_context/conftest.py
+++ b/tests/data_context/conftest.py
@@ -678,6 +678,31 @@ def cloud_data_context_in_cloud_mode_with_datasource_pandas_engine(
 def serialized_configuration_bundle() -> dict:
     return {
         "data_context_id": "877166bd-08f2-4d7b-b473-a2b97ab5e36f",
+        "datasources": [
+            {
+                "class_name": "Datasource",
+                "data_connectors": {
+                    "my_default_data_connector": {
+                        "assets": {
+                            "": {
+                                "base_directory": "data",
+                                "class_name": "Asset",
+                                "glob_directive": "*.csv",
+                                "group_names": ["batch_num", "total_batches"],
+                                "pattern": "csv_batch_(\\d.+)_of_(\\d.+)\\.csv",
+                            }
+                        },
+                        "base_directory": "data",
+                        "class_name": "ConfiguredAssetFilesystemDataConnector",
+                    }
+                },
+                "execution_engine": {
+                    "class_name": "PandasExecutionEngine",
+                    "module_name": "great_expectations.execution_engine",
+                },
+                "name": "generic_csv_generator",
+            }
+        ],
         "checkpoints": [
             {
                 "action_list": [

--- a/tests/data_context/test_cloud_migrator_configuration_bundle.py
+++ b/tests/data_context/test_cloud_migrator_configuration_bundle.py
@@ -69,6 +69,8 @@ class DummyDatasource:
 class StubBaseDataContext:
     """Stub for testing ConfigurationBundle."""
 
+    DATA_CONTEXT_ID = "27517569-1500-4127-af68-b5bad960a492"
+
     def __init__(
         self,
         anonymous_usage_stats_enabled: bool = True,
@@ -93,7 +95,7 @@ class StubBaseDataContext:
 
     @property
     def data_context_id(self) -> str:
-        return "27517569-1500-4127-af68-b5bad960a492"
+        return self.DATA_CONTEXT_ID
 
     @property
     def variables(self) -> DataContextVariables:
@@ -222,99 +224,13 @@ class TestConfigurationBundleCreate:
 
 
 @pytest.fixture
-def stub_serialized_configuration_bundle():
+def stub_serialized_configuration_bundle(serialized_configuration_bundle: dict) -> dict:
     """Configuration bundle based on StubBaseDataContext."""
-    return {
-        "data_context_id": "27517569-1500-4127-af68-b5bad960a492",
-        "datasources": [
-            {
-                "class_name": "Datasource",
-                "data_connectors": {
-                    "my_default_data_connector": {
-                        "assets": {
-                            "": {
-                                "base_directory": "data",
-                                "class_name": "Asset",
-                                "glob_directive": "*.csv",
-                                "group_names": ["batch_num", "total_batches"],
-                                "pattern": "csv_batch_(\\d.+)_of_(\\d.+)\\.csv",
-                            }
-                        },
-                        "base_directory": "data",
-                        "class_name": "ConfiguredAssetFilesystemDataConnector",
-                    }
-                },
-                "execution_engine": {
-                    "class_name": "PandasExecutionEngine",
-                    "module_name": "great_expectations.execution_engine",
-                },
-                "name": "generic_csv_generator",
-            }
-        ],
-        "checkpoints": [
-            {
-                "class_name": "Checkpoint",
-                "config_version": None,
-                "module_name": "great_expectations.checkpoint",
-                "name": "my_checkpoint",
-            }
-        ],
-        "data_context_variables": {
-            "config_variables_file_path": None,
-            "config_version": 3.0,
-            "data_docs_sites": None,
-            "evaluation_parameter_store_name": None,
-            "expectations_store_name": None,
-            "include_rendered_content": {
-                "expectation_suite": False,
-                "expectation_validation_result": False,
-                "globally": False,
-            },
-            "notebooks": None,
-            "plugins_directory": None,
-            "stores": None,
-            "validations_store_name": None,
-        },
-        "datasources": [
-            {
-                "class_name": "Datasource",
-                "data_connectors": {},
-                "execution_engine": {
-                    "class_name": "PandasExecutionEngine",
-                    "module_name": "great_expectations.execution_engine",
-                },
-                "module_name": "great_expectations.datasource",
-                "name": "my_datasource",
-            }
-        ],
-        "expectation_suites": [
-            {
-                "data_asset_type": None,
-                "expectation_suite_name": "my_suite",
-                "expectations": [],
-                "ge_cloud_id": None,
-            }
-        ],
-        "profilers": [
-            {
-                "class_name": "RuleBasedProfiler",
-                "config_version": 1.0,
-                "module_name": "great_expectations.rule_based_profiler",
-                "name": "my_profiler",
-                "rules": {},
-                "variables": {},
-            }
-        ],
-        "validation_results": [
-            {
-                "evaluation_parameters": {},
-                "meta": {},
-                "results": [],
-                "statistics": {},
-                "success": True,
-            }
-        ],
-    }
+    assert "data_context_id" in serialized_configuration_bundle
+    serialized_configuration_bundle[
+        "data_context_id"
+    ] = StubBaseDataContext.DATA_CONTEXT_ID
+    return serialized_configuration_bundle
 
 
 class TestConfigurationBundleSerialization:

--- a/tests/data_context/test_cloud_migrator_configuration_bundle.py
+++ b/tests/data_context/test_cloud_migrator_configuration_bundle.py
@@ -152,16 +152,18 @@ def test_configuration_bundle_serialization(
     This test is an integration test using a real DataContext to prove out the
     ConfigurationBundle serialization. We can replace this test with unit tests.
     """
-
     context: BaseDataContext = in_memory_runtime_context_with_configs_in_stores.context
+
+    # Overwrite expected data_context_id to match the context we're using
+    expected_serialized_bundle = serialized_configuration_bundle
+    assert "data_context_id" in expected_serialized_bundle
+    expected_serialized_bundle["data_context_id"] = context.data_context_id
 
     config_bundle = ConfigurationBundle(context)
 
     serializer = ConfigurationBundleJsonSerializer(schema=ConfigurationBundleSchema())
 
     serialized_bundle: dict = serializer.serialize(config_bundle)
-
-    expected_serialized_bundle = serialized_configuration_bundle
 
     # Remove meta before comparing since it contains the GX version
     serialized_bundle["expectation_suites"][0].pop("meta", None)


### PR DESCRIPTION
Changes proposed in this pull request:
- Add context id to bundle and external HTTP request made to Cloud

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
