### PR TITLE
[FEATURE] Send user validation results to Cloud backend during migration

### DIFF
--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -217,6 +217,7 @@ class CloudMigrator:
             attributes_key="bundle",
             attributes_value=serialized_bundle,
         )
+        print(response)
         # TODO: Handle success/failure cases
 
     def _prepare_validation_results(self, serialized_bundle: dict) -> List[dict]:
@@ -243,6 +244,7 @@ class CloudMigrator:
                 attributes_key=attributes_key,
                 attributes_value=validation_result,
             )
+            print(response)
             # TODO: Handle success/failure cases
 
     def _post_to_cloud_backend(
@@ -276,6 +278,8 @@ class CloudMigrator:
         except requests.exceptions.JSONDecodeError:
             response_json = cast(AnyPayload, {})
             success = False
+
+        print(response_json)
 
         # TODO: Handle success/failure cases and parse errors from Cloud responses
         message = ""

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -1,7 +1,7 @@
 """TODO: Add docstring"""
 import logging
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, cast
+from typing import List, Optional, cast
 
 import requests
 
@@ -174,12 +174,10 @@ class CloudMigrator:
         serialized_validation_results = serialized_bundle.pop("validation_results")
 
         if not test_migrate:
-            return
-
-        self._send_bundle_to_cloud_backend(serialized_bundle=serialized_bundle)
-        self._send_validation_results_to_cloud_backend(
-            serialized_validation_results=serialized_validation_results,
-        )
+            self._send_bundle_to_cloud_backend(serialized_bundle=serialized_bundle)
+            self._send_validation_results_to_cloud_backend(
+                serialized_validation_results=serialized_validation_results,
+            )
 
     def _send_bundle_to_cloud_backend(self, serialized_bundle: dict) -> None:
         self._post_to_cloud_backend(

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -134,6 +134,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         GeCloudRESTResource.DATA_CONTEXT: "data_context_config",
         GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
         GeCloudRESTResource.EXPECTATION_SUITE: "suite",
+        GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "result",
         GeCloudRESTResource.PROFILER: "profiler",
         GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_doc",
         # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -38,11 +38,11 @@ def test__send_configuration_bundle_sends_valid_http_request(
     )
 
     with mock.patch("requests.Session.post", autospec=True) as mock_post:
-        migrator._send_configuration_bundle(
+        _, _ = migrator._send_configuration_bundle(
             configuration_bundle=configuration_bundle, serializer=serializer
         )
 
-    mock_post.assert_called_once_with(
+    mock_post.assert_called_with(
         mock.ANY,  # requests.Session object
         f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/migration",
         json={

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -17,12 +17,10 @@ from great_expectations.data_context.store.ge_cloud_store_backend import (
 @pytest.mark.cloud
 def test__send_configuration_bundle_sends_valid_http_request(
     serialized_configuration_bundle: dict,
+    ge_cloud_base_url: str,
+    ge_cloud_organization_id: str,
+    ge_cloud_access_token: str,
 ):
-    # These values aren't actual creds but resemble values used in production
-    ge_cloud_base_url = "https://app.test.greatexpectations.io"
-    ge_cloud_organization_id = "229616e2-1bbc-4849-8161-4be89b79bd36"
-    ge_cloud_access_token = "d7asdh2efads9afah2e0fadf8eh20da8"
-
     migrator = gx.CloudMigrator(
         context=mock.MagicMock(),
         ge_cloud_base_url=ge_cloud_base_url,
@@ -52,7 +50,11 @@ def test__send_configuration_bundle_sends_valid_http_request(
 
 @pytest.mark.unit
 @pytest.mark.cloud
-def test__send_validation_results_sends_valid_http_request():
+def test__send_validation_results_sends_valid_http_request(
+    ge_cloud_base_url: str,
+    ge_cloud_organization_id: str,
+    ge_cloud_access_token: str,
+):
     # These values aren't actual creds but resemble values used in production
     ge_cloud_base_url = "https://app.test.greatexpectations.io"
     ge_cloud_organization_id = "229616e2-1bbc-4849-8161-4be89b79bd36"


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that we iterate through validation results and send them in sequential requests

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
