### PR TITLE
[DOCS] Update `docs-integration` test due to new `whole_table` splitter behavior

### DIFF
--- a/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/sql_database/yaml_example_complete.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/how_to_introspect_and_partition_your_data/sql_database/yaml_example_complete.py
@@ -89,7 +89,7 @@ context.add_datasource(**yaml.load(datasource_yaml))
 available_data_asset_names = context.datasources[
     "taxi_datasource"
 ].get_available_data_asset_names(data_connector_names="whole_table")["whole_table"]
-assert len(available_data_asset_names) == 2
+assert len(available_data_asset_names) == 3
 # Here is a BatchRequest referring to an un-partitioned inferred data_asset.
 batch_request = BatchRequest(
     datasource_name="taxi_datasource",


### PR DESCRIPTION
Changes proposed in this pull request:
- There are 3 available data assets now that one has been created with the prefixes and suffixes


### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
