### PR TITLE
[MAINTENANCE] Bundling tests with empty context configs

### DIFF
--- a/tests/data_context/migrator/conftest.py
+++ b/tests/data_context/migrator/conftest.py
@@ -69,3 +69,42 @@ def serialized_configuration_bundle() -> dict:
             }
         ],
     }
+
+
+@pytest.fixture
+def empty_serialized_configuration_bundle() -> dict:
+    return {
+        "data_context_id": "877166bd-08f2-4d7b-b473-a2b97ab5e36f",
+        "checkpoints": [],
+        "data_context_variables": {
+            "config_variables_file_path": None,
+            "config_version": 3.0,
+            "data_docs_sites": None,
+            "evaluation_parameter_store_name": None,
+            "expectations_store_name": None,
+            "include_rendered_content": {
+                "expectation_suite": False,
+                "expectation_validation_result": False,
+                "globally": False,
+            },
+            "notebooks": None,
+            "plugins_directory": None,
+            "stores": None,
+            "validations_store_name": None,
+        },
+        "datasources": [
+            {
+                "class_name": "Datasource",
+                "data_connectors": {},
+                "execution_engine": {
+                    "class_name": "PandasExecutionEngine",
+                    "module_name": "great_expectations.execution_engine",
+                },
+                "module_name": "great_expectations.datasource",
+                "name": "my_datasource",
+            }
+        ],
+        "expectation_suites": [],
+        "profilers": [],
+        "validation_results": [],
+    }

--- a/tests/data_context/migrator/conftest.py
+++ b/tests/data_context/migrator/conftest.py
@@ -74,7 +74,7 @@ def serialized_configuration_bundle() -> dict:
 @pytest.fixture
 def empty_serialized_configuration_bundle() -> dict:
     return {
-        "data_context_id": "877166bd-08f2-4d7b-b473-a2b97ab5e36f",
+        "data_context_id": "27517569-1500-4127-af68-b5bad960a492",
         "checkpoints": [],
         "data_context_variables": {
             "config_variables_file_path": None,

--- a/tests/data_context/migrator/conftest.py
+++ b/tests/data_context/migrator/conftest.py
@@ -5,31 +5,6 @@ import pytest
 def serialized_configuration_bundle() -> dict:
     return {
         "data_context_id": "877166bd-08f2-4d7b-b473-a2b97ab5e36f",
-        "datasources": [
-            {
-                "class_name": "Datasource",
-                "data_connectors": {
-                    "my_default_data_connector": {
-                        "assets": {
-                            "": {
-                                "base_directory": "data",
-                                "class_name": "Asset",
-                                "glob_directive": "*.csv",
-                                "group_names": ["batch_num", "total_batches"],
-                                "pattern": "csv_batch_(\\d.+)_of_(\\d.+)\\.csv",
-                            }
-                        },
-                        "base_directory": "data",
-                        "class_name": "ConfiguredAssetFilesystemDataConnector",
-                    }
-                },
-                "execution_engine": {
-                    "class_name": "PandasExecutionEngine",
-                    "module_name": "great_expectations.execution_engine",
-                },
-                "name": "generic_csv_generator",
-            }
-        ],
         "checkpoints": [
             {
                 "class_name": "Checkpoint",

--- a/tests/data_context/migrator/conftest.py
+++ b/tests/data_context/migrator/conftest.py
@@ -92,18 +92,7 @@ def empty_serialized_configuration_bundle() -> dict:
             "stores": None,
             "validations_store_name": None,
         },
-        "datasources": [
-            {
-                "class_name": "Datasource",
-                "data_connectors": {},
-                "execution_engine": {
-                    "class_name": "PandasExecutionEngine",
-                    "module_name": "great_expectations.execution_engine",
-                },
-                "module_name": "great_expectations.datasource",
-                "name": "my_datasource",
-            }
-        ],
+        "datasources": [],
         "expectation_suites": [],
         "profilers": [],
         "validation_results": [],

--- a/tests/data_context/migrator/test_configuration_bundle.py
+++ b/tests/data_context/migrator/test_configuration_bundle.py
@@ -163,9 +163,9 @@ def stub_base_data_context_no_anonymous_usage_stats() -> StubBaseDataContext:
     return StubBaseDataContext(anonymous_usage_stats_is_none=True)
 
 
+@pytest.mark.cloud
+@pytest.mark.unit
 class TestConfigurationBundleCreate:
-    @pytest.mark.cloud
-    @pytest.mark.unit
     def test_configuration_bundle_created(
         self,
         stub_base_data_context: StubBaseDataContext,
@@ -187,8 +187,22 @@ class TestConfigurationBundleCreate:
         assert len(config_bundle.validation_results) == 1
         assert len(config_bundle.datasources) == 1
 
-    @pytest.mark.cloud
-    @pytest.mark.unit
+    def test_is_usage_statistics_key_set_if_key_not_present(
+        self, stub_base_data_context_no_anonymous_usage_stats: StubBaseDataContext
+    ):
+        """What does this test and why?
+
+        The ConfigurationBundle should handle a context that has not set the config for
+         anonymous_usage_statistics.
+        """
+        context: BaseDataContext = stub_base_data_context_no_anonymous_usage_stats
+
+        config_bundle = ConfigurationBundle(context)
+
+        # If not supplied, an AnonymizedUsageStatisticsConfig is created in a
+        # DataContextConfig
+        assert config_bundle.is_usage_stats_enabled()
+
     def test_configuration_bundle_created_usage_stats_disabled(
         self,
         stub_base_data_context_anonymous_usage_stats_present_but_disabled: StubBaseDataContext,
@@ -206,22 +220,6 @@ class TestConfigurationBundleCreate:
 
         assert not config_bundle.is_usage_stats_enabled()
 
-    def test_is_usage_statistics_key_set_if_key_not_present(
-        self, stub_base_data_context_no_anonymous_usage_stats: StubBaseDataContext
-    ):
-        """What does this test and why?
-
-        The ConfigurationBundle should handle a context that has not set the config for
-         anonymous_usage_statistics.
-        """
-        context: BaseDataContext = stub_base_data_context_no_anonymous_usage_stats
-
-        config_bundle = ConfigurationBundle(context)
-
-        # If not supplied, an AnonymizedUsageStatisticsConfig is created in a
-        # DataContextConfig
-        assert config_bundle.is_usage_stats_enabled()
-
 
 @pytest.fixture
 def stub_serialized_configuration_bundle(serialized_configuration_bundle: dict) -> dict:
@@ -233,9 +231,9 @@ def stub_serialized_configuration_bundle(serialized_configuration_bundle: dict) 
     return serialized_configuration_bundle
 
 
+@pytest.mark.cloud
+@pytest.mark.unit
 class TestConfigurationBundleSerialization:
-    @pytest.mark.cloud
-    @pytest.mark.unit
     def test_configuration_bundle_serialization(
         self,
         stub_base_data_context: StubBaseDataContext,
@@ -264,8 +262,6 @@ class TestConfigurationBundleSerialization:
 
         assert serialized_bundle == expected_serialized_bundle
 
-    @pytest.mark.cloud
-    @pytest.mark.unit
     def test_anonymous_usage_statistics_removed_during_serialization(
         self,
         stub_base_data_context: StubBaseDataContext,

--- a/tests/data_context/migrator/test_configuration_bundle.py
+++ b/tests/data_context/migrator/test_configuration_bundle.py
@@ -88,6 +88,7 @@ class StubBaseDataContext:
         expectation_suite_names: Tuple[Optional[str]] = ("my_suite",),
         profiler_names: Tuple[Optional[str]] = ("my_profiler", ),
         validation_results_keys: Tuple[Optional[str]] = ("some_key", ),
+        datasource_names: Tuple[Optional[str]] = ("my_datasource", ),
     ):
         """Set the configuration of the stub data context.
 
@@ -99,6 +100,7 @@ class StubBaseDataContext:
         self._expectation_suite_names = expectation_suite_names
         self._profiler_names = profiler_names
         self._validation_results_keys = validation_results_keys
+        self._datasource_names = datasource_names
 
     @property
     def _data_context_variables(self) -> StubUsageStats:
@@ -130,7 +132,7 @@ class StubBaseDataContext:
     def datasources(self) -> Dict[str, Union[LegacyDatasource, BaseDatasource]]:
         # Datasource is a dummy since we just want the DatasourceConfig from the store, not an
         # actual initialized datasource.
-        return {"my_datasource": DummyDatasource()}
+        return {datasource_name: DummyDatasource() for datasource_name in self._datasource_names}
 
     @property
     def checkpoint_store(self) -> StubCheckpointStore:
@@ -291,6 +293,7 @@ class TestConfigurationBundleSerialization:
             expectation_suite_names=tuple(),
             profiler_names=tuple(),
             validation_results_keys=tuple(),
+            datasource_names=tuple(),
         )
 
         config_bundle = ConfigurationBundle(context)

--- a/tests/data_context/migrator/test_configuration_bundle.py
+++ b/tests/data_context/migrator/test_configuration_bundle.py
@@ -25,9 +25,11 @@ from great_expectations.rule_based_profiler import RuleBasedProfiler
 
 
 class StubUsageStats:
-
-    def __init__(self, anonymized_usage_statistics_config: AnonymizedUsageStatisticsConfig):
+    def __init__(
+        self, anonymized_usage_statistics_config: AnonymizedUsageStatisticsConfig
+    ):
         self._anonymized_usage_statistics_config = anonymized_usage_statistics_config
+
     @property
     def anonymous_usage_statistics(self) -> AnonymizedUsageStatisticsConfig:
         return self._anonymized_usage_statistics_config
@@ -76,7 +78,9 @@ class StubBaseDataContext:
 
     def __init__(
         self,
-        anonymized_usage_statistics_config: Optional[AnonymizedUsageStatisticsConfig] = None,
+        anonymized_usage_statistics_config: Optional[
+            AnonymizedUsageStatisticsConfig
+        ] = None,
     ):
         """Set the anonymous usage statistics configuration.
 
@@ -87,7 +91,9 @@ class StubBaseDataContext:
 
     @property
     def _data_context_variables(self) -> StubUsageStats:
-        return StubUsageStats(anonymized_usage_statistics_config=self._anonymized_usage_statistics_config)
+        return StubUsageStats(
+            anonymized_usage_statistics_config=self._anonymized_usage_statistics_config
+        )
 
     @property
     def anonymous_usage_statistics(self) -> AnonymizedUsageStatisticsConfig:
@@ -141,12 +147,18 @@ class StubBaseDataContext:
 
 @pytest.fixture
 def stub_base_data_context() -> StubBaseDataContext:
-    return StubBaseDataContext(anonymized_usage_statistics_config=AnonymizedUsageStatisticsConfig(enabled=True))
+    return StubBaseDataContext(
+        anonymized_usage_statistics_config=AnonymizedUsageStatisticsConfig(enabled=True)
+    )
 
 
 @pytest.fixture
 def stub_base_data_context_anonymous_usage_stats_present_but_disabled() -> StubBaseDataContext:
-    return StubBaseDataContext(anonymized_usage_statistics_config=AnonymizedUsageStatisticsConfig(enabled=False))
+    return StubBaseDataContext(
+        anonymized_usage_statistics_config=AnonymizedUsageStatisticsConfig(
+            enabled=False
+        )
+    )
 
 
 @pytest.fixture
@@ -191,7 +203,7 @@ class TestConfigurationBundleCreate:
         config_bundle = ConfigurationBundle(context)
 
         # If not supplied, an AnonymizedUsageStatisticsConfig is created in a
-        # DataContextConfig
+        # DataContextConfig and enabled by default.
         assert config_bundle.is_usage_stats_enabled()
 
     def test_configuration_bundle_created_usage_stats_disabled(

--- a/tests/data_context/migrator/test_configuration_bundle.py
+++ b/tests/data_context/migrator/test_configuration_bundle.py
@@ -1,5 +1,5 @@
 """These tests exercise ConfigurationBundle including Serialization."""
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import pytest
 
@@ -41,7 +41,7 @@ class StubCheckpointStore:
 
 
 class StubValidationsStore:
-    def __init__(self, keys: Tuple[Optional[str]] = ("some_key", )):
+    def __init__(self, keys: Tuple[Optional[str]] = ("some_key",)):
         self._keys = keys
 
     def list_keys(self):
@@ -77,18 +77,18 @@ class DummyDatasource:
 class StubBaseDataContext:
     """Stub for testing ConfigurationBundle."""
 
-    DATA_CONTEXT_ID = "877166bd-08f2-4d7b-b473-a2b97ab5e36f"
+    DATA_CONTEXT_ID = "27517569-1500-4127-af68-b5bad960a492"
 
     def __init__(
         self,
         anonymized_usage_statistics_config: Optional[
             AnonymizedUsageStatisticsConfig
         ] = AnonymizedUsageStatisticsConfig(enabled=True),
-        checkpoint_names: Tuple[Optional[str]] = ("my_checkpoint", ),
+        checkpoint_names: Tuple[Optional[str]] = ("my_checkpoint",),
         expectation_suite_names: Tuple[Optional[str]] = ("my_suite",),
-        profiler_names: Tuple[Optional[str]] = ("my_profiler", ),
-        validation_results_keys: Tuple[Optional[str]] = ("some_key", ),
-        datasource_names: Tuple[Optional[str]] = ("my_datasource", ),
+        profiler_names: Tuple[Optional[str]] = ("my_profiler",),
+        validation_results_keys: Tuple[Optional[str]] = ("some_key",),
+        datasource_names: Tuple[Optional[str]] = ("my_datasource",),
     ):
         """Set the configuration of the stub data context.
 
@@ -132,7 +132,10 @@ class StubBaseDataContext:
     def datasources(self) -> Dict[str, Union[LegacyDatasource, BaseDatasource]]:
         # Datasource is a dummy since we just want the DatasourceConfig from the store, not an
         # actual initialized datasource.
-        return {datasource_name: DummyDatasource() for datasource_name in self._datasource_names}
+        return {
+            datasource_name: DummyDatasource()
+            for datasource_name in self._datasource_names
+        }
 
     @property
     def checkpoint_store(self) -> StubCheckpointStore:
@@ -278,7 +281,6 @@ class TestConfigurationBundleSerialization:
 
         assert serialized_bundle == expected_serialized_bundle
 
-
     def test_configuration_bundle_serialization_empty_fields(
         self,
         empty_serialized_configuration_bundle: dict,
@@ -305,7 +307,6 @@ class TestConfigurationBundleSerialization:
         serialized_bundle: dict = serializer.serialize(config_bundle)
 
         assert serialized_bundle == empty_serialized_configuration_bundle
-
 
     def test_anonymous_usage_statistics_removed_during_serialization(
         self,

--- a/tests/data_context/migrator/test_configuration_bundle.py
+++ b/tests/data_context/migrator/test_configuration_bundle.py
@@ -25,9 +25,12 @@ from great_expectations.rule_based_profiler import RuleBasedProfiler
 
 
 class StubUsageStats:
+
+    def __init__(self, anonymized_usage_statistics_config: AnonymizedUsageStatisticsConfig):
+        self._anonymized_usage_statistics_config = anonymized_usage_statistics_config
     @property
     def anonymous_usage_statistics(self) -> AnonymizedUsageStatisticsConfig:
-        return AnonymizedUsageStatisticsConfig(enabled=True)
+        return self._anonymized_usage_statistics_config
 
 
 class StubCheckpointStore:
@@ -73,21 +76,18 @@ class StubBaseDataContext:
 
     def __init__(
         self,
-        anonymous_usage_stats_enabled: bool = True,
-        anonymous_usage_stats_is_none: bool = False,
+        anonymized_usage_statistics_config: Optional[AnonymizedUsageStatisticsConfig] = None,
     ):
         """Set the anonymous usage statistics configuration.
 
         Args:
-            anonymous_usage_stats_enabled: Set usage stats "enabled" flag in config.
-            anonymous_usage_stats_is_none: Set usage stats to None, overrides anonymous_usage_stats_enabled.
+            anonymized_usage_statistics_config: Config to use for anonymous usage statistics
         """
-        self._anonymous_usage_stats_enabled = anonymous_usage_stats_enabled
-        self._anonymous_usage_stats_is_none = anonymous_usage_stats_is_none
+        self._anonymized_usage_statistics_config = anonymized_usage_statistics_config
 
     @property
     def _data_context_variables(self) -> StubUsageStats:
-        return StubUsageStats()
+        return StubUsageStats(anonymized_usage_statistics_config=self._anonymized_usage_statistics_config)
 
     @property
     def anonymous_usage_statistics(self) -> AnonymizedUsageStatisticsConfig:
@@ -100,17 +100,8 @@ class StubBaseDataContext:
     @property
     def variables(self) -> DataContextVariables:
 
-        # anonymous_usage_statistics set based on constructor parameters.
-        anonymous_usage_statistics: Optional[AnonymizedUsageStatisticsConfig]
-        if self._anonymous_usage_stats_is_none:
-            anonymous_usage_statistics = None
-        else:
-            anonymous_usage_statistics = AnonymizedUsageStatisticsConfig(
-                enabled=self._anonymous_usage_stats_enabled
-            )
-
         config = DataContextConfig(
-            anonymous_usage_statistics=anonymous_usage_statistics
+            anonymous_usage_statistics=self._anonymized_usage_statistics_config
         )
         return EphemeralDataContextVariables(config=config)
 
@@ -150,17 +141,17 @@ class StubBaseDataContext:
 
 @pytest.fixture
 def stub_base_data_context() -> StubBaseDataContext:
-    return StubBaseDataContext()
+    return StubBaseDataContext(anonymized_usage_statistics_config=AnonymizedUsageStatisticsConfig(enabled=True))
 
 
 @pytest.fixture
 def stub_base_data_context_anonymous_usage_stats_present_but_disabled() -> StubBaseDataContext:
-    return StubBaseDataContext(anonymous_usage_stats_enabled=False)
+    return StubBaseDataContext(anonymized_usage_statistics_config=AnonymizedUsageStatisticsConfig(enabled=False))
 
 
 @pytest.fixture
 def stub_base_data_context_no_anonymous_usage_stats() -> StubBaseDataContext:
-    return StubBaseDataContext(anonymous_usage_stats_is_none=True)
+    return StubBaseDataContext(anonymized_usage_statistics_config=None)
 
 
 @pytest.mark.cloud


### PR DESCRIPTION
Changes proposed in this pull request:
- Modify the stub data context fixture to change store contents
- Add a test for serialization of the config bundle in the case of an empty context

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.