### PR TITLE
[BUGFIX] Patch issue around `DataContext.save_datasource` not sending `class_name` in result payload

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -480,7 +480,7 @@ class AbstractDataContext(ABC):
         """
 
         datasource_config_dict: dict = datasourceConfigSchema.dump(datasource.config)
-        datasource_config = DatasourceConfig(**datasource_config_dict)
+        datasource_config = datasourceConfigSchema.load(datasource_config_dict)
         datasource_name: str = datasource.name
 
         updated_datasource_config_from_store: DatasourceConfig = self._datasource_store.set(  # type: ignore[attr-defined]

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -480,9 +480,10 @@ class AbstractDataContext(ABC):
         """
 
         datasource_config_dict: dict = datasourceConfigSchema.dump(datasource.config)
-        datasource_config = datasourceConfigSchema.load(datasource_config_dict)
         # Manually need to add in class name to the config since it is not part of the runtime obj
-        datasource_config.class_name = datasource.__class__.__name__
+        datasource_config_dict["class_name"] = datasource.__class__.__name__
+
+        datasource_config = datasourceConfigSchema.load(datasource_config_dict)
         datasource_name: str = datasource.name
 
         updated_datasource_config_from_store: DatasourceConfig = self._datasource_store.set(  # type: ignore[attr-defined]

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -481,6 +481,8 @@ class AbstractDataContext(ABC):
 
         datasource_config_dict: dict = datasourceConfigSchema.dump(datasource.config)
         datasource_config = datasourceConfigSchema.load(datasource_config_dict)
+        # Manually need to add in class name to the config since it is not part of the runtime obj
+        datasource_config.class_name = datasource.__class__.__name__
         datasource_name: str = datasource.name
 
         updated_datasource_config_from_store: DatasourceConfig = self._datasource_store.set(  # type: ignore[attr-defined]


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that we're adding `class_name` to the payload we send Cloud so they're aware of the object type to parse

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
