### PR TITLE
[MAINTENANCE] Clean up `test_migrate=True` Cloud migrator output

### DIFF
--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -185,7 +185,7 @@ class CloudMigrator:
             test_migrate=test_migrate,
         )
 
-        self._print_migration_conclusion_message()
+        self._print_migration_conclusion_message(test_migrate=test_migrate)
 
     def _emit_warnings(
         self, configuration_bundle: ConfigurationBundle, test_migrate: bool
@@ -395,9 +395,15 @@ class CloudMigrator:
             "we will send each of your validation results.\n"
         )
 
-    def _print_migration_conclusion_message(self) -> None:
+    def _print_migration_conclusion_message(self, test_migrate: bool) -> None:
+        if test_migrate:
+            print(
+                "\nTest run completed! Please set `test_migrate=False` to perform an actual migration."
+            )
+            return
+
         if self._unsuccessful_validations:
-            print("\nPartial Success!")
+            print("\nPartial success!")
         else:
             print("\nSuccess!")
 

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -146,15 +146,15 @@ class CloudMigrator:
             ) from e
 
     def retry_unsuccessful_validations(self) -> None:
-        validations = self._unsuccessful_validations
-        if not validations:
+        if not self._unsuccessful_validations:
             print("No unsuccessful validations found!")
             return
 
         self._process_validation_results(
-            serialized_validation_results=validations, test_migrate=False
+            serialized_validation_results=self._unsuccessful_validations,
+            test_migrate=False,
         )
-        if validations:
+        if self._unsuccessful_validations:
             self._print_unsuccessful_validation_message()
 
     def _migrate_to_cloud(self, test_migrate: bool) -> None:

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -301,7 +301,6 @@ def test__migrate_to_cloud_outputs_warnings(
 @pytest.mark.parametrize(
     "test_migrate,expected_statements",
     [
-        pytest.param(True, []),
         pytest.param(
             True,
             [

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -298,9 +298,53 @@ def test__migrate_to_cloud_outputs_warnings(
 
 @pytest.mark.unit
 @pytest.mark.cloud
-@pytest.mark.parametrize("test_migrate", [True, False])
+@pytest.mark.parametrize(
+    "test_migrate,expected_statements",
+    [
+        pytest.param(True, []),
+        pytest.param(
+            True,
+            [
+                "Thank you for using Great Expectations!",
+                "We will now begin the migration process to GX Cloud.",
+                "First we will bundle your existing context configuration and send it to the Cloud backend.",
+                "Then we will send each of your validation results.",
+                "[Step 1/4]: Bundling context configuration",
+                "Bundled 1 Datasource(s):",
+                "Bundled 1 Checkpoint(s):",
+                "Bundled 1 Expectation Suite(s):",
+                "Bundled 1 Profiler(s):",
+                "[Step 2/4]: Preparing validation results",
+                "[Step 3/4]: Sending context configuration",
+                "[Step 4/4]: Sending validation results",
+                "Test run completed!",
+            ],
+        ),
+        pytest.param(
+            False,
+            [
+                "Thank you for using Great Expectations!",
+                "We will now begin the migration process to GX Cloud.",
+                "First we will bundle your existing context configuration and send it to the Cloud backend.",
+                "Then we will send each of your validation results.",
+                "[Step 1/4]: Bundling context configuration",
+                "Bundled 1 Datasource(s):",
+                "Bundled 1 Checkpoint(s):",
+                "Bundled 1 Expectation Suite(s):",
+                "Bundled 1 Profiler(s):",
+                "[Step 2/4]: Preparing validation results",
+                "[Step 3/4]: Sending context configuration",
+                "[Step 4/4]: Sending validation results",
+                "Success!",
+                "Now that you have migrated your Data Context to GX Cloud, you should use your Cloud Data Context from now on to interact with Great Expectations.",
+                "If you continue to use your existing Data Context your configurations could become out of sync.",
+            ],
+        ),
+    ],
+)
 def test__migrate_to_cloud_happy_path_prints_to_stdout(
     test_migrate: bool,
+    expected_statements: List[str],
     migrator_with_stub_base_data_context: CloudMigrator,
     capsys,
 ):
@@ -310,24 +354,6 @@ def test__migrate_to_cloud_happy_path_prints_to_stdout(
         migrator._migrate_to_cloud(test_migrate=test_migrate)
 
     stdout, _ = capsys.readouterr()
-    expected_statements = [
-        "Thank you for using Great Expectations!",
-        "We will now begin the migration process to GX Cloud.",
-        "First we will bundle your existing context configuration and send it to the Cloud backend.",
-        "Then we will send each of your validation results.",
-        "[Step 1/4]: Bundling context configuration",
-        "Bundled 1 Datasource(s):",
-        "Bundled 1 Checkpoint(s):",
-        "Bundled 1 Expectation Suite(s):",
-        "Bundled 1 Profiler(s):",
-        "[Step 2/4]: Preparing validation results",
-        "[Step 3/4]: Sending context configuration",
-        "[Step 4/4]: Sending validation results",
-        "Success!",
-        "Now that you have migrated your Data Context to GX Cloud, you should use your Cloud Data Context from now on to interact with Great Expectations.",
-        "If you continue to use your existing Data Context your configurations could become out of sync.",
-    ]
-
     assert_stdout_is_accurate_and_properly_ordered(
         stdout=stdout, statements=expected_statements
     )
@@ -413,7 +439,7 @@ def test__migrate_to_cloud_bad_validations_request_prints_to_stdout(
         "[Step 3/4]: Sending context configuration",
         "[Step 4/4]: Sending validation results",
         "Error sending validation result 'some_key' (1/1)",
-        "Partial Success!",
+        "Partial success!",
         "Now that you have migrated your Data Context to GX Cloud, you should use your Cloud Data Context from now on to interact with Great Expectations.",
         "If you continue to use your existing Data Context your configurations could become out of sync.",
         "Please note that there were 1 validation result(s) that were not successfully migrated",


### PR DESCRIPTION
Changes proposed in this pull request:
- Minor cleanup of output emitted by migrator

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
