### PR TITLE
[BUGFIX] Regression due to `GESqlDialect` `Enum` for Hive

### DIFF
--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -1492,7 +1492,10 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             stmt = 'CREATE VOLATILE TABLE "{table_name}" AS ({custom_sql}) WITH DATA NO PRIMARY INDEX ON COMMIT PRESERVE ROWS'.format(
                 table_name=table_name, custom_sql=custom_sql
             )
-        elif self.sql_engine_dialect.name.lower() in (GESqlDialect.HIVE, b"hive"):
+        elif self.sql_engine_dialect.name.lower() in (
+            GESqlDialect.HIVE,
+            str.encode(GESqlDialect.HIVE),
+        ):
             stmt = "CREATE TEMPORARY TABLE {schema_name}.{table_name} AS {custom_sql}".format(
                 schema_name=schema_name if schema_name is not None else "default",
                 table_name=table_name,

--- a/great_expectations/dataset/sqlalchemy_dataset.py
+++ b/great_expectations/dataset/sqlalchemy_dataset.py
@@ -1492,10 +1492,7 @@ class SqlAlchemyDataset(MetaSqlAlchemyDataset):
             stmt = 'CREATE VOLATILE TABLE "{table_name}" AS ({custom_sql}) WITH DATA NO PRIMARY INDEX ON COMMIT PRESERVE ROWS'.format(
                 table_name=table_name, custom_sql=custom_sql
             )
-        elif self.sql_engine_dialect.name.lower() in (
-            GESqlDialect.HIVE,
-            str.encode(GESqlDialect.HIVE),
-        ):
+        elif self.sql_engine_dialect.name.lower() == GESqlDialect.HIVE:
             stmt = "CREATE TEMPORARY TABLE {schema_name}.{table_name} AS {custom_sql}".format(
                 schema_name=schema_name if schema_name is not None else "default",
                 table_name=table_name,

--- a/great_expectations/execution_engine/sqlalchemy_dialect.py
+++ b/great_expectations/execution_engine/sqlalchemy_dialect.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, List
+from typing import Any, List, Union
 
 
 class GESqlDialect(str, Enum):
@@ -23,6 +23,17 @@ class GESqlDialect(str, Enum):
     TERADATASQL = "teradatasql"
     TRINO = "trino"
     OTHER = "other"
+
+    def __eq__(self, other: Union[str, GESqlDialect]):
+        if isinstance(other, str):
+            return self.value.lower() == other.lower()
+        # Comparison against byte string, e.g. `b"hive"` should be treated as unicode
+        elif isinstance(other, bytes):
+            return self.value.lower() == other.lower().decode("utf-8")
+        return self.value.lower() == other.value.lower()
+
+    def __hash__(self: GESqlDialect):
+        return hash(self.value)
 
     @classmethod
     def _missing_(cls, value: Any) -> None:

--- a/great_expectations/execution_engine/sqlalchemy_dialect.py
+++ b/great_expectations/execution_engine/sqlalchemy_dialect.py
@@ -24,7 +24,7 @@ class GESqlDialect(Enum):
     TRINO = "trino"
     OTHER = "other"
 
-    def __eq__(self, other: Union[str, GESqlDialect]):
+    def __eq__(self, other: Union[str, bytes, GESqlDialect]):
         if isinstance(other, str):
             return self.value.lower() == other.lower()
         # Comparison against byte string, e.g. `b"hive"` should be treated as unicode

--- a/great_expectations/execution_engine/sqlalchemy_dialect.py
+++ b/great_expectations/execution_engine/sqlalchemy_dialect.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import enum
+from enum import Enum
 from typing import Any, List, Union
 
 
-class GESqlDialect(enum.Enum):
+class GESqlDialect(str, Enum):
     """Contains sql dialects that have some level of support in Great Expectations.
     Also contains an unsupported attribute if the dialect is not in the list.
     """
@@ -23,14 +23,6 @@ class GESqlDialect(enum.Enum):
     TERADATASQL = "teradatasql"
     TRINO = "trino"
     OTHER = "other"
-
-    def __eq__(self, other: Union[str, GESqlDialect]):
-        if isinstance(other, str):
-            return self.value.lower() == other.lower()
-        return self.value.lower() == other.value.lower()
-
-    def __hash__(self: GESqlDialect):
-        return hash(self.value)
 
     @classmethod
     def _missing_(cls, value: Any) -> None:

--- a/great_expectations/execution_engine/sqlalchemy_dialect.py
+++ b/great_expectations/execution_engine/sqlalchemy_dialect.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, List, Union
+from typing import Any, List
 
 
 class GESqlDialect(str, Enum):

--- a/great_expectations/execution_engine/sqlalchemy_dialect.py
+++ b/great_expectations/execution_engine/sqlalchemy_dialect.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, List, Union
 
 
-class GESqlDialect(str, Enum):
+class GESqlDialect(Enum):
     """Contains sql dialects that have some level of support in Great Expectations.
     Also contains an unsupported attribute if the dialect is not in the list.
     """

--- a/tests/execution_engine/test_sqlalchemy_dialect.py
+++ b/tests/execution_engine/test_sqlalchemy_dialect.py
@@ -14,6 +14,12 @@ def test_dialect_instantiation_with_byte_string():
 
 
 @pytest.mark.unit
+def test_string_and_byte_string_equivalence():
+    assert GESqlDialect.HIVE == "hive"
+    assert GESqlDialect.HIVE == b"hive"
+
+
+@pytest.mark.unit
 def test_get_all_dialect_names_no_other_dialects():
     assert GESqlDialect.OTHER.value not in GESqlDialect.get_all_dialect_names()
 

--- a/tests/execution_engine/test_sqlalchemy_dialect.py
+++ b/tests/execution_engine/test_sqlalchemy_dialect.py
@@ -14,8 +14,12 @@ def test_dialect_instantiation_with_byte_string():
 
 
 @pytest.mark.unit
-def test_string_and_byte_string_equivalence():
+def test_string_equivalence():
     assert GESqlDialect.HIVE == "hive"
+
+
+@pytest.mark.unit
+def test_byte_string_equivalence():
     assert GESqlDialect.HIVE == b"hive"
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1289
- Remove hard-coded bytes used for Hive dialect
- Add regression test and special case for comparisons against byte string

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
