### PR TITLE
[DOCS] fix source activate command

### DIFF
--- a/docs_rtd/contributing/setting_up_your_dev_environment.rst
+++ b/docs_rtd/contributing/setting_up_your_dev_environment.rst
@@ -55,7 +55,7 @@ Install python dependencies
 **5. Create a new virtual environment**
 
     * Make a new virtual environment (e.g. using virtualenv or conda), name it "great_expectations_dev" or similar.
-    * Ex virtualenv: ``python3 -m venv <path_to_environments_folder>/great_expectations_dev`` and then ``<source path_to_environments_folder>/great_expectations_dev/bin/activate``
+    * Ex virtualenv: ``python3 -m venv <path_to_environments_folder>/great_expectations_dev`` and then ``source <path_to_environments_folder>/great_expectations_dev/bin/activate``
     * Ex conda: ``conda create --name great_expectations_dev python=3.7`` and then ``conda activate great_expectations_dev`` (we support multiple python versions, you may select something other than 3.7).
     * This is not required, but highly recommended.
 


### PR DESCRIPTION
Changes proposed in this pull request:
- fix typo in source command in _Setting up your Dev Environment_ guide: `source <path_to_environments_folder\>` instead of `<source path_to_environments_folder\>`

### Definition of Done
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation

