### PR TITLE
[MAINTENANCE] Rollback setting GE_DATA_CONTEXT_ID in docker image.

### DIFF
--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -20,8 +20,6 @@ RUN git clone --filter=tree:0 --branch ${BRANCH} https://github.com/great-expect
 WORKDIR /great_expectations
 
 FROM build_${SOURCE} AS dev
-# used to filter usage stats coming from CI and dev environments
-ENV GE_DATA_CONTEXT_ID="00000000-0000-0000-0000-00000000e009"
 RUN pip install --no-cache-dir --requirement requirements-dev.txt --constraint constraints-dev.txt
 RUN pip install .
 CMD [ "python", "--version"]


### PR DESCRIPTION
Setting `GE_DATA_CONTEXT_ID` makes some tests fail. We are going to rollback setting this for now.

The failing tests are:
```
FAILED tests/checkpoint/test_checkpoint.py::test_checkpoint_configuration_using_RuntimeDataConnector_with_Airflow_test_yaml_config
FAILED tests/checkpoint/test_checkpoint.py::test_newstyle_checkpoint_instantiates_and_produces_a_validation_result_when_run_batch_request_object_multi_validation_pandasdf[test_backends0]
FAILED tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py::test_quentin_profiler_user_workflow_multi_batch_quantiles_value_ranges_rule
FAILED tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py::test_bobby_profiler_user_workflow_multi_batch_row_count_range_rule_and_column_ranges_rule_quantiles_estimator
FAILED tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py::test_bobster_profiler_user_workflow_multi_batch_row_count_range_rule_bootstrap_estimator
FAILED tests/data_context/test_data_context_in_code_config.py::test_DataContext_construct_data_context_id_uses_id_stored_in_DataContextConfig_if_no_configured_expectations_store
FAILED tests/core/usage_statistics/test_usage_statistics.py::test_consistent_name_anonymization
FAILED tests/core/usage_statistics/test_usage_statistics_handler_methods.py::test_build_init_payload
```