### PR TITLE
[BUGFIX] Parameterize usage stats endpoint in test dockerfile.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,6 @@ variables:
   isRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/')]
   isScheduled: $[and(eq(variables['Build.SourceBranch'], 'refs/heads/develop'), eq(variables['Build.Reason'], 'Schedule'))]
   isManual: $[eq(variables['Build.Reason'], 'Manual')]
-  GE_USAGE_STATISTICS_URL: "https://qa.stats.greatexpectations.io/great_expectations/v1/usage_statistics"
 
 stages:
   - stage: lint
@@ -144,6 +143,7 @@ stages:
               python.version: '3.9'
         variables:
           IMAGE_SUFFIX: $[ dependencies.make_suffix.outputs['suffix.IMAGE_SUFFIX'] ]
+          GE_USAGE_STATISTICS_URL: "https://qa.stats.greatexpectations.io/great_expectations/v1/usage_statistics"
         steps:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
@@ -151,7 +151,8 @@ stages:
               # prune it's depth since we don't need the git history.
               CMD="docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:${DOCKER_TAG} "
               CMD+="--target test --build-arg PYTHON_VERSION=$(python.version) "
-              CMD+=" --build-arg SOURCE=github --build-arg BRANCH=develop ."
+              CMD+="--build-arg GE_USAGE_STATISTICS_URL=\"$(GE_USAGE_STATISTICS_URL)\" "
+              CMD+="--build-arg SOURCE=github --build-arg BRANCH=develop ."
               echo ${CMD}
               eval ${CMD}
             displayName: 'Build python $(python.version) image'

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -20,6 +20,8 @@ RUN git clone --filter=tree:0 --branch ${BRANCH} https://github.com/great-expect
 WORKDIR /great_expectations
 
 FROM build_${SOURCE} AS dev
+ARG GE_USAGE_STATISTICS_URL=""
+env GE_USAGE_STATISTICS_URL="${GE_USAGE_STATISTICS_URL}"
 RUN pip install --no-cache-dir --requirement requirements-dev.txt --constraint constraints-dev.txt
 RUN pip install .
 CMD [ "python", "--version"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,8 @@ they are invoked in the root directory of this repo.
 The template docker command for building an image is:
 ```
 docker buildx build -f docker/Dockerfile.tests --tag <name>:<tag> --target <target> \
-    --build-arg PYTHON_VERSION=<version> --build-arg SOURCE=<src> --build-arg BRANCH=<branch_name> .
+    --build-arg PYTHON_VERSION=<version> --build-arg SOURCE=<src> --build-arg BRANCH=<branch_name> \
+    --build-arg GE_USAGE_STATISTICS_URL="<url>".
 ```
 
 `<name>` and `<tag>` are arbitrary. Examples: `gx39_dev:develop`, `gx37_dev:mybranch`.
@@ -20,12 +21,15 @@ docker buildx build -f docker/Dockerfile.tests --tag <name>:<tag> --target <targ
 `<target>` is in `[dev, test]`. Default is `test`. `dev` installs the dependencies for running Great Expectations with
 any of our supported backends. `test` installs test dependencies on top of these.
 
-`source` is in `[github, local]`. Default is `local` which will copy your local repo into the image while `github` will
+`<src>` is in `[github, local]`. Default is `local` which will copy your local repo into the image while `github` will
 pull a branch from GitHub.
 
-`version` is in `[3.7, 3.8, 3.9]`. Default is `3.8`.
+`<version>` is in `[3.7, 3.8, 3.9]`. Default is `3.8`.
 
-`branch_name` is a Great Expectations branch present on GitHub. This only works when `source` is "github".
+`<branch_name>` is a Great Expectations branch present on GitHub. This only works when `<src>` is "github".
+
+`<usage_url>` is the usage statistic url endpoint one wants to set in the image. The default is "" which sets it
+to the great expectations default value.
 
 ### Running the image
 


### PR DESCRIPTION
Our azure test pipelines should be hitting our `qa` usage statistics endpoint. This PR parameterizes the usage stats endpoint in our Dockerfile. In the build step for our test image, we set the url to our `qa` endpoint. 

I manually ran this pipeline and I see this new variable being set in the build step:
`docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:3.9_develop_1666134761_16296 --target test --build-arg PYTHON_VERSION=3.9 --build-arg GE_USAGE_STATISTICS_URL="https://qa.stats.greatexpectations.io/great_expectations/v1/usage_statistics" --build-arg SOURCE=github --build-arg BRANCH=develop .
`

I also built this image locally and see this get set in my data context:
```
>>> import great_expectations
>>> great_expectations.get_context()
{
  "anonymous_usage_statistics": {
    "data_context_id": "bfd81bb6-71d1-46b8-a24a-029cc4049cec",
    "usage_statistics_url": "https://qa.stats.greatexpectations.io/great_expectations/v1/usage_statistics",
    "explicit_id": true,
    "explicit_url": true,
    "enabled": true
  },
  ...
}
```

I've manually run all the failing tests from https://superconductive.atlassian.net/browse/GREAT-1304 in my docker image and they succeed.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

