### PR TITLE
[MAINTENANCE] Rename cfe to v3_api

### DIFF
--- a/docs/contributing/contributing_test.md
+++ b/docs/contributing/contributing_test.md
@@ -146,7 +146,7 @@ The test fixture files are stored in subdirectories of `tests/test_definitions/`
 
 By convention, the name of the the file is the name of the Expectation, with a .json suffix. Creating a new json file will automatically add the new Expectation tests to the test suite.
 
-Note: If you are implementing a new Expectation, but don’t plan to immediately implement it for all execution environments, you should add the new test to the appropriate list(s) in the `candidate_test_is_on_temporary_notimplemented_list` method within `tests/test_utils.py`. Often, we see Expectations developed first for pandas, then later extended to SqlAlchemy and Spark.
+Note: If you are implementing a new Expectation, but don’t plan to immediately implement it for all execution environments, you should add the new test to the appropriate list(s) in the `candidate_test_is_on_temporary_notimplemented_list_v2_api` method within `tests/test_utils.py`. Often, we see Expectations developed first for pandas, then later extended to SqlAlchemy and Spark.
 
 You can run just the Expectation tests with `pytest tests/test_definitions/test_expectations.py`.
 

--- a/docs_rtd/contributing/testing.rst
+++ b/docs_rtd/contributing/testing.rst
@@ -172,7 +172,7 @@ The test fixture files are stored in subdirectories of ``tests/test_definitions/
 
 By convention, the name of the the file is the name of the Expectation, with a ``.json`` suffix. Creating a new json file will automatically add the new Expectation tests to the test suite.
 
-Note: If you are implementing a new Expectation, but don't plan to immediately implement it for all execution environments, you should add the new test to the appropriate list(s) in the ``candidate_test_is_on_temporary_notimplemented_list`` method within ``tests/test_utils.py``. Often, we see Expectations developed first for pandas, then later extended to SqlAlchemy and Spark.
+Note: If you are implementing a new Expectation, but don't plan to immediately implement it for all execution environments, you should add the new test to the appropriate list(s) in the ``candidate_test_is_on_temporary_notimplemented_list_v2_api`` method within ``tests/test_utils.py``. Often, we see Expectations developed first for pandas, then later extended to SqlAlchemy and Spark.
 
 You can run just the Expectation tests with ``pytest tests/test_definitions/test_expectations.py``.
 

--- a/docs_rtd/guides/how_to_guides/miscellaneous/how_to_add_and_test_a_new_sqlalchemydataset_class.rst
+++ b/docs_rtd/guides/how_to_guides/miscellaneous/how_to_add_and_test_a_new_sqlalchemydataset_class.rst
@@ -78,7 +78,7 @@ The core team will not be able to merge your contribution until they're able to 
                 help="If set, suppress tests against presto",
             )
 
-    * **In build_test_backends_list, add a variable and if clause**
+    * **In build_test_backends_list_v2_api, add a variable and if clause**
 
         .. code-block:: python
 

--- a/docs_rtd/guides/how_to_guides/miscellaneous/how_to_add_and_test_a_new_sqlalchemydataset_class.rst
+++ b/docs_rtd/guides/how_to_guides/miscellaneous/how_to_add_and_test_a_new_sqlalchemydataset_class.rst
@@ -18,9 +18,9 @@ Steps
 ####################################
 
     * **Install the python dependencies for your dialect.**  While you're at it, please add a line(s) to ``requirements-dev-sqlalchemy.txt``. Examples:
-    
+
         .. code-block:: bash
-        
+
             pyhive[presto]>=0.6.2
             PyAthena[SQLAlchemy]>=1.1
             pybigquery>=0.4.15
@@ -180,11 +180,11 @@ The core team will not be able to merge your contribution until they're able to 
                 )
 
 
-    * **Add your dialect to candidate_test_is_on_temporary_notimplemented_list**.
+    * **Add your dialect to candidate_test_is_on_temporary_notimplemented_list_v2_api**.
 
         .. code-block:: python
 
-            def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type):
+            def candidate_test_is_on_temporary_notimplemented_list_v2_api(context, expectation_type):
                 if context in ["sqlite", "postgresql", "mysql", "presto"]:
 
 5. Use tests to verify consistency with other databases
@@ -215,6 +215,6 @@ Once Expectation tests pass, make sure all the remaining tests pass:
 .. warning::
 
    This guide covers steps to add support for a new SQL dialect to SqlAlchemyDataset, and make it testable. To fully enable this SQL dialect in the Great Expectations ecosystem, you may also want to:
-   
+
    - develop a Datasource for this dialect
    - develop a CLI integration for this dialect

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -87,7 +87,7 @@ from great_expectations.render.types import (
 )
 from great_expectations.render.util import num_to_str
 from great_expectations.self_check.util import (
-    evaluate_json_test_cfe,
+    evaluate_json_test_v3_api,
     generate_expectation_tests,
 )
 from great_expectations.util import camel_to_snake, is_parseable_date
@@ -1444,7 +1444,7 @@ class Expectation(metaclass=MetaExpectation):
             exp_combined_test_name = f"{exp_test['backend']}--{exp_test['test']['title']}--{expectation_type}"
             _debug(f"Starting {exp_combined_test_name}")
             _start = time.time()
-            validation_result, error_message, stack_trace = evaluate_json_test_cfe(
+            validation_result, error_message, stack_trace = evaluate_json_test_v3_api(
                 validator=exp_test["validator_with_data"],
                 expectation_type=exp_test["expectation_type"],
                 test=exp_test["test"],
@@ -1454,7 +1454,7 @@ class Expectation(metaclass=MetaExpectation):
             _duration = _end - _start
             backend_test_times[exp_test["backend"]].append(_duration)
             _debug(
-                f"Took {_duration} seconds to evaluate_json_test_cfe for {exp_combined_test_name}"
+                f"Took {_duration} seconds to evaluate_json_test_v3_api for {exp_combined_test_name}"
             )
             if error_message is None:
                 _debug(f"PASSED {exp_combined_test_name}")

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -2618,7 +2618,7 @@ def sort_unexpected_values(test_value_list, result_value_list):
     return test_value_list, result_value_list
 
 
-def evaluate_json_test(data_asset, expectation_type, test) -> None:
+def evaluate_json_test_v2_api(data_asset, expectation_type, test) -> None:
     """
     This method will evaluate the result of a test build using the Great Expectations json test format.
 

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1806,8 +1806,10 @@ def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type
     return False
 
 
-def candidate_test_is_on_temporary_notimplemented_list_cfe(context, expectation_type):
-    candidate_test_is_on_temporary_notimplemented_list_cfe_trino = [
+def candidate_test_is_on_temporary_notimplemented_list_v3_api(
+    context, expectation_type
+):
+    candidate_test_is_on_temporary_notimplemented_list_v3_api_trino = [
         "expect_column_distinct_values_to_contain_set",
         "expect_column_max_to_be_between",
         "expect_column_mean_to_be_between",
@@ -1843,7 +1845,7 @@ def candidate_test_is_on_temporary_notimplemented_list_cfe(context, expectation_
         "expect_table_row_count_to_be_between",
         "expect_table_row_count_to_equal",
     ]
-    candidate_test_is_on_temporary_notimplemented_list_cfe_other_sql = [
+    candidate_test_is_on_temporary_notimplemented_list_v3_api_other_sql = [
         "expect_column_values_to_be_increasing",
         "expect_column_values_to_be_decreasing",
         "expect_column_values_to_match_strftime_format",
@@ -1871,8 +1873,10 @@ def candidate_test_is_on_temporary_notimplemented_list_cfe(context, expectation_
     ]
     if context in ["trino"]:
         return expectation_type in set(
-            candidate_test_is_on_temporary_notimplemented_list_cfe_trino
-        ).union(set(candidate_test_is_on_temporary_notimplemented_list_cfe_other_sql))
+            candidate_test_is_on_temporary_notimplemented_list_v3_api_trino
+        ).union(
+            set(candidate_test_is_on_temporary_notimplemented_list_v3_api_other_sql)
+        )
     if context in SQL_DIALECT_NAMES:
         expectations_not_implemented_v3_sql = [
             "expect_column_values_to_be_increasing",

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1736,7 +1736,9 @@ def candidate_getter_is_on_temporary_notimplemented_list(context, getter):
         return getter in []
 
 
-def candidate_test_is_on_temporary_notimplemented_list(context, expectation_type):
+def candidate_test_is_on_temporary_notimplemented_list_v2_api(
+    context, expectation_type
+):
     if context in SQL_DIALECT_NAMES:
         expectations_not_implemented_v2_sql = [
             "expect_column_values_to_be_increasing",

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -2679,7 +2679,7 @@ def evaluate_json_test(data_asset, expectation_type, test) -> None:
     check_json_test_result(test=test, result=result, data_asset=data_asset)
 
 
-def evaluate_json_test_cfe(validator, expectation_type, test, raise_exception=True):
+def evaluate_json_test_v3_api(validator, expectation_type, test, raise_exception=True):
     """
     This method will evaluate the result of a test build using the Great Expectations json test format.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ def pytest_addoption(parser):
 
 
 def build_test_backends_list(metafunc):
-    test_backend_names: List[str] = build_test_backends_list_cfe(metafunc)
+    test_backend_names: List[str] = build_test_backends_list_v2_api(metafunc)
     backend_name_class_name_map: Dict[str, str] = {
         "pandas": "PandasDataset",
         "spark": "SparkDFDataset",
@@ -223,7 +223,7 @@ def build_test_backends_list(metafunc):
     ]
 
 
-def build_test_backends_list_cfe(metafunc):
+def build_test_backends_list_v2_api(metafunc):
     # adding deprecation warnings
     if metafunc.config.getoption("--no-postgresql"):
         warnings.warn(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,8 +206,8 @@ def pytest_addoption(parser):
     )
 
 
-def build_test_backends_list(metafunc):
-    test_backend_names: List[str] = build_test_backends_list_v2_api(metafunc)
+def build_test_backends_list_v2_api(metafunc):
+    test_backend_names: List[str] = build_test_backends_list_v3_api(metafunc)
     backend_name_class_name_map: Dict[str, str] = {
         "pandas": "PandasDataset",
         "spark": "SparkDFDataset",
@@ -223,7 +223,7 @@ def build_test_backends_list(metafunc):
     ]
 
 
-def build_test_backends_list_v2_api(metafunc):
+def build_test_backends_list_v3_api(metafunc):
     # adding deprecation warnings
     if metafunc.config.getoption("--no-postgresql"):
         warnings.warn(
@@ -267,7 +267,7 @@ def build_test_backends_list_v2_api(metafunc):
 
 
 def pytest_generate_tests(metafunc):
-    test_backends = build_test_backends_list(metafunc)
+    test_backends = build_test_backends_list_v2_api(metafunc)
     if "test_backend" in metafunc.fixturenames:
         metafunc.parametrize("test_backend", test_backends, scope="module")
     if "test_backends" in metafunc.fixturenames:

--- a/tests/test_definitions/column_aggregate_expectations/expect_column_stdev_to_be_between.json
+++ b/tests/test_definitions/column_aggregate_expectations/expect_column_stdev_to_be_between.json
@@ -83,7 +83,7 @@
             "observed_value": 1.1547005383792517
           },
           "only_for": [
-            "bigquery_cfe"
+            "bigquery_v3_api"
           ]
         },
         {

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_unique.json
@@ -151,7 +151,7 @@
       {
         "title": "negative_case_all_null_values_bigquery_nones",
         "exact_match_out": false,
-        "only_for": ["bigquery_cfe"],
+        "only_for": ["bigquery_v3_api"],
         "in": {
           "column": "null"
         },

--- a/tests/test_definitions/test_expectations_v2_api.py
+++ b/tests/test_definitions/test_expectations_v2_api.py
@@ -19,7 +19,7 @@ from great_expectations.self_check.util import (
     postgresqlDialect,
     sqliteDialect,
 )
-from tests.conftest import build_test_backends_list
+from tests.conftest import build_test_backends_list_v2_api
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def pytest_generate_tests(metafunc):
         test_configuration_files = glob.glob(
             dir_path + "/" + expectation_category + "/*.json"
         )
-        backends = build_test_backends_list(metafunc)
+        backends = build_test_backends_list_v2_api(metafunc)
         for c in backends:
             if c in [
                 "trino",

--- a/tests/test_definitions/test_expectations_v2_api.py
+++ b/tests/test_definitions/test_expectations_v2_api.py
@@ -2,8 +2,6 @@ import glob
 import json
 import logging
 import os
-import random
-import string
 from collections import OrderedDict
 
 import pandas as pd
@@ -12,7 +10,7 @@ import pytest
 from great_expectations.dataset import PandasDataset, SparkDFDataset, SqlAlchemyDataset
 from great_expectations.self_check.util import (
     BigQueryDialect,
-    candidate_test_is_on_temporary_notimplemented_list,
+    candidate_test_is_on_temporary_notimplemented_list_v2_api,
     evaluate_json_test_v2_api,
     generate_sqlite_db_path,
     get_dataset,
@@ -66,7 +64,7 @@ def pytest_generate_tests(metafunc):
                     if suppress_test_for and not isinstance(suppress_test_for, list):
                         # coerce into list if passed in as string
                         suppress_test_for = [suppress_test_for]
-                    if candidate_test_is_on_temporary_notimplemented_list(
+                    if candidate_test_is_on_temporary_notimplemented_list_v2_api(
                         c, test_configuration["expectation_type"]
                     ):
                         skip_expectation = True

--- a/tests/test_definitions/test_expectations_v2_api.py
+++ b/tests/test_definitions/test_expectations_v2_api.py
@@ -155,7 +155,7 @@ def pytest_generate_tests(metafunc):
                                 ):
                                     generate_test = True
                                 elif (
-                                    "bigquery_v2" in only_for
+                                    "bigquery_v2_api" in only_for
                                     and BigQueryDialect is not None
                                     and isinstance(data_asset, SqlAlchemyDataset)
                                     and hasattr(data_asset.engine.dialect, "name")
@@ -236,6 +236,14 @@ def pytest_generate_tests(metafunc):
                                 )
                                 or (
                                     "bigquery" in suppress_test_for
+                                    and BigQueryDialect is not None
+                                    and isinstance(data_asset, SqlAlchemyDataset)
+                                    and hasattr(data_asset.engine.dialect, "name")
+                                    and data_asset.engine.dialect.name.lower()
+                                    == "bigquery"
+                                )
+                                or (
+                                    "bigquery_v2_api" in suppress_test_for
                                     and BigQueryDialect is not None
                                     and isinstance(data_asset, SqlAlchemyDataset)
                                     and hasattr(data_asset.engine.dialect, "name")

--- a/tests/test_definitions/test_expectations_v2_api.py
+++ b/tests/test_definitions/test_expectations_v2_api.py
@@ -287,7 +287,8 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.order(index=1)
 @pytest.mark.integration
 @pytest.mark.slow  # 14.90s
-def test_case_runner(test_case):
+@pytest.mark.v2_api
+def test_case_runner_v2_api(test_case):
     if test_case["skip"]:
         pytest.skip()
 

--- a/tests/test_definitions/test_expectations_v2_api.py
+++ b/tests/test_definitions/test_expectations_v2_api.py
@@ -13,7 +13,7 @@ from great_expectations.dataset import PandasDataset, SparkDFDataset, SqlAlchemy
 from great_expectations.self_check.util import (
     BigQueryDialect,
     candidate_test_is_on_temporary_notimplemented_list,
-    evaluate_json_test,
+    evaluate_json_test_v2_api,
     generate_sqlite_db_path,
     get_dataset,
     mssqlDialect,
@@ -295,6 +295,6 @@ def test_case_runner_v2_api(test_case):
     # Note: this should never be done in practice, but we are wiping expectations to reuse datasets during testing.
     test_case["dataset"]._initialize_expectations()
 
-    evaluate_json_test(
+    evaluate_json_test_v2_api(
         test_case["dataset"], test_case["expectation_type"], test_case["test"]
     )

--- a/tests/test_definitions/test_expectations_v3_api.py
+++ b/tests/test_definitions/test_expectations_v3_api.py
@@ -22,7 +22,7 @@ from great_expectations.self_check.util import (
     sqliteDialect,
     trinoDialect,
 )
-from tests.conftest import build_test_backends_list_v2_api
+from tests.conftest import build_test_backends_list_v3_api
 
 
 def pytest_generate_tests(metafunc):
@@ -35,7 +35,7 @@ def pytest_generate_tests(metafunc):
     ]
     parametrized_tests = []
     ids = []
-    backends = build_test_backends_list_v2_api(metafunc)
+    backends = build_test_backends_list_v3_api(metafunc)
     validator_with_data = None
     for expectation_category in expectation_dirs:
 

--- a/tests/test_definitions/test_expectations_v3_api.py
+++ b/tests/test_definitions/test_expectations_v3_api.py
@@ -154,7 +154,7 @@ def pytest_generate_tests(metafunc):
                                 ):
                                     generate_test = True
                                 elif (
-                                    "bigquery_cfe" in only_for
+                                    "bigquery_v3_api" in only_for
                                     and BigQueryDialect is not None
                                     and hasattr(
                                         validator_with_data.active_batch_data.sql_engine_dialect,
@@ -293,7 +293,7 @@ def pytest_generate_tests(metafunc):
                                     == "bigquery"
                                 )
                                 or (
-                                    "bigquery_cfe" in suppress_test_for
+                                    "bigquery_v3_api" in suppress_test_for
                                     and BigQueryDialect is not None
                                     and validator_with_data
                                     and isinstance(

--- a/tests/test_definitions/test_expectations_v3_api.py
+++ b/tests/test_definitions/test_expectations_v3_api.py
@@ -377,7 +377,7 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.order(index=0)
 @pytest.mark.integration
 @pytest.mark.slow  # 12.68s
-def test_case_runner_cfe(test_case):
+def test_case_runner_v3_api(test_case):
     if test_case["skip"]:
         pytest.skip()
 

--- a/tests/test_definitions/test_expectations_v3_api.py
+++ b/tests/test_definitions/test_expectations_v3_api.py
@@ -12,7 +12,7 @@ from great_expectations.execution_engine.sqlalchemy_batch_data import (
 )
 from great_expectations.self_check.util import (
     BigQueryDialect,
-    candidate_test_is_on_temporary_notimplemented_list_cfe,
+    candidate_test_is_on_temporary_notimplemented_list_v3_api,
     evaluate_json_test_v3_api,
     generate_sqlite_db_path,
     get_test_validator_with_data,
@@ -22,7 +22,7 @@ from great_expectations.self_check.util import (
     sqliteDialect,
     trinoDialect,
 )
-from tests.conftest import build_test_backends_list_cfe
+from tests.conftest import build_test_backends_list_v2_api
 
 
 def pytest_generate_tests(metafunc):
@@ -35,7 +35,7 @@ def pytest_generate_tests(metafunc):
     ]
     parametrized_tests = []
     ids = []
-    backends = build_test_backends_list_cfe(metafunc)
+    backends = build_test_backends_list_v2_api(metafunc)
     validator_with_data = None
     for expectation_category in expectation_dirs:
 
@@ -59,7 +59,7 @@ def pytest_generate_tests(metafunc):
                     if suppress_test_for and not isinstance(suppress_test_for, list):
                         # coerce into list if passed in as string
                         suppress_test_for = [suppress_test_for]
-                    if candidate_test_is_on_temporary_notimplemented_list_cfe(
+                    if candidate_test_is_on_temporary_notimplemented_list_v3_api(
                         c, test_configuration["expectation_type"]
                     ):
                         skip_expectation = True

--- a/tests/test_definitions/test_expectations_v3_api.py
+++ b/tests/test_definitions/test_expectations_v3_api.py
@@ -13,7 +13,7 @@ from great_expectations.execution_engine.sqlalchemy_batch_data import (
 from great_expectations.self_check.util import (
     BigQueryDialect,
     candidate_test_is_on_temporary_notimplemented_list_cfe,
-    evaluate_json_test_cfe,
+    evaluate_json_test_v3_api,
     generate_sqlite_db_path,
     get_test_validator_with_data,
     mssqlDialect,
@@ -385,13 +385,13 @@ def test_case_runner_v3_api(test_case):
     # test_case["batch"]._initialize_expectations()
     if "parse_strings_as_datetimes" in test_case["test"]["in"]:
         with pytest.deprecated_call():
-            evaluate_json_test_cfe(
+            evaluate_json_test_v3_api(
                 validator=test_case["validator_with_data"],
                 expectation_type=test_case["expectation_type"],
                 test=test_case["test"],
             )
     else:
-        evaluate_json_test_cfe(
+        evaluate_json_test_v3_api(
             validator=test_case["validator_with_data"],
             expectation_type=test_case["expectation_type"],
             test=test_case["test"],


### PR DESCRIPTION
Changes proposed in this pull request:
- Renamed modules and methods to make clear which tests are related to expectations written in the v2_api vs v3_api
- CFE or Class First Expectations was a name used internally but we changed to use v2/v3 api.


### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.