### PR TITLE
[MAINTENANCE] M/great 1313/abstract data context changes

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -912,12 +912,10 @@ class AbstractDataContext(ABC):
                     batch_request_list is not None,
                 ]
             )
-            != 1
+            > 1
         ):
             raise ValueError(
-                "Exactly one of batch, batch_list, batch_request, or batch_request_list can be specified: "
-                f"batch = {batch}, batch_list = {batch_list}, batch_request = {batch_request}, "
-                f"batch_request_list = {batch_request_list}"
+                "No more than one of batch, batch_list, batch_request, or batch_request_list can be specified"
             )
 
         if batch_list:
@@ -959,15 +957,16 @@ class AbstractDataContext(ABC):
 
         # For ZEP datasources, we are trying to simplify our datatypes and we don't currently have `batch_definitions`
         # defined on a `Batch`. Because of this, we grab the execution engine using a batch_request object.
+        # Once a ZEP `Batch` gets defined we will clean this up and with a more appropriate type check.
+        # NOTE: for non-ZEP workflows, both branches are equivalent.
         execution_engine: ExecutionEngine
-        if batch_request_list:
-            # either batch_request or batch_request_list was passed in. We previously have made a batch_request_list if
-            # necessary.
+        if batch_request_list and datasource_name:
+            # a datasource name and either batch_request or batch_request_list was passed in. We previously have made a
+            # batch_request_list if necessary.
             execution_engine = self.datasources[  # type: ignore[union-attr]
                 batch_request_list[-1][datasource_name]
             ].execution_engine
         else:
-            # either batch or batch_list was passed in. We previously have created a batch_list from batch if necessary.
             execution_engine = self.datasources[  # type: ignore[union-attr]
                 batch_list[-1].batch_definition.datasource_name
             ].execution_engine

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -959,8 +959,11 @@ class AbstractDataContext(ABC):
         # defined on a `Batch`. Because of this, we grab the execution engine using a batch_request object.
         # Once a ZEP `Batch` gets defined we will clean this up and with a more appropriate type check.
         # NOTE: for non-ZEP workflows, both branches are equivalent.
+        # NOTE: `batch_request_list != [None]` is a workaround when no batch, batch_list, batch_request,
+        # batch_request_list is passed in. This should not be allowed but many tests currently do this and need to be
+        # fixed.
         execution_engine: ExecutionEngine
-        if batch_request_list and datasource_name:
+        if batch_request_list and batch_request_list != [None] and datasource_name:
             # a datasource name and either batch_request or batch_request_list was passed in. We previously have made a
             # batch_request_list if necessary.
             execution_engine = self.datasources[  # type: ignore[union-attr]


### PR DESCRIPTION
Currently 3 properties are accessed on a `Batch` object when computing expectations: `id`, `data`, and `batch_definition`. The purpose of this PR is to eliminate the need to call `batch_definition` since we want to remove it (or greatly simplify it) from a zep `Batch` object.

The `batch_definition` is only used to to get the `execution_engine` in the call to `get_validator` on a data context. My strategy is to factor `get_validator_using_batch_list` into 2 parts. One part that gets the execution engine (the first part of the new `get_validator_using_batch_list`) and the second part, `_get_validator_using_batch_list`, that does everything else. This preserves the public function `get_validator_using_batch_list` while letting us reuse the functionality of the second part.

We don't have a `Batch` zep class defined yet and we are actively working on that. Because of that, I have the if statement on line `967` with a preceding comment which is a bit hacky. When a zep `Batch` is better defined and we understand the specifics of the workflow better this will be made neater.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
