### PR TITLE
[MAINTENANCE] Add validate_configuration method to expect_table_row_count_to_equal_other_table

### DIFF
--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -55,6 +55,8 @@ class ExpectTableRowCountToEqualOtherTable(TableExpectation):
             "@great_expectations",
         ],
         "requirements": [],
+        "has_full_test_suite": True,
+        "manually_reviewed_code": True,
     }
 
     metric_dependencies = ("table.row_count",)
@@ -183,6 +185,11 @@ class ExpectTableRowCountToEqualOtherTable(TableExpectation):
         ] = table_row_count_metric_config_other
 
         return dependencies
+
+    def validate_configuration(
+        self, configuration: Optional[ExpectationConfiguration]
+    ) -> None:
+        super().validate_configuration(configuration)
 
     def _validate(
         self,


### PR DESCRIPTION

Changes proposed in this pull request:
- Add validate_configuration method to expect_table_row_count_to_equal_other_table
- Set the manual flags in library_metadata to True for production status