### PR TITLE
[BUGFIX] Patch issue with empty config variables file raising `TypeError`

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -2007,8 +2007,11 @@ class AbstractDataContext(ABC):
                     root_directory = ""
                 var_path = os.path.join(root_directory, defined_path)
                 with open(var_path) as config_variables_file:
-                    res = dict(yaml.load(config_variables_file.read()))
-                    return res or {}
+                    contents = config_variables_file.read()
+
+                variables = yaml.load(contents) or {}
+                return dict(variables)
+
             except OSError as e:
                 if e.errno != errno.ENOENT:
                     raise


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that we aren't trying to convert `None` to `dict`

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
