### PR TITLE
[MAINTENANCE] Remove temporary dependency on `py`

### DIFF
--- a/requirements-dev-contrib.txt
+++ b/requirements-dev-contrib.txt
@@ -4,7 +4,6 @@ invoke>=1.7.1
 isort==5.10.1
 mypy>=0.971
 pre-commit>=2.6.0
-py>=1.8.2 # Until a new pytest-benchmark release is cut (see https://github.com/ionelmc/pytest-benchmark/issues/226)
 pytest-cov>=2.8.1
 pytest-order>=0.9.5
 pytest-random-order>=1.0.4


### PR DESCRIPTION
Changes proposed in this pull request:
- Undo changes made in https://github.com/great-expectations/great_expectations/pull/6202
- New release of `pytest-benchmark` resolves this matter


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
