### PR TITLE
[MAINTENANCE] Make `UsageStatsEvents` a `StrEnum`

### DIFF
--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
@@ -171,7 +171,7 @@ def test_growth_numeric_data_assistant_result_get_expectation_suite(
     actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
     assert (
         actual_events[-1][0][0]["event"]
-        == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value
+        == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE
     )
 
 

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -93,7 +93,7 @@ class BaseCheckpoint(ConfigPeer):
     #  recent"). Currently, environment variable substitution is the only processing applied to evaluation parameters,
     #  while run_name_template also undergoes strftime datetime substitution
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.CHECKPOINT_RUN.value,
+        event_name=UsageStatsEvents.CHECKPOINT_RUN,
         args_payload_fn=get_checkpoint_run_usage_statistics,
     )
     def run(

--- a/great_expectations/cli/datasource.py
+++ b/great_expectations/cli/datasource.py
@@ -273,7 +273,7 @@ class BaseDatasourceNewYamlHelper:
     def send_backend_choice_usage_message(self, context: DataContext) -> None:
         send_usage_message(
             data_context=context,
-            event=UsageStatsEvents.CLI_NEW_DS_CHOICE.value,
+            event=UsageStatsEvents.CLI_NEW_DS_CHOICE,
             event_payload={
                 "type": self.datasource_type.value,
                 **self.usage_stats_payload,

--- a/great_expectations/cli/init.py
+++ b/great_expectations/cli/init.py
@@ -105,7 +105,7 @@ def init(ctx: click.Context, usage_stats: bool) -> None:
             )
             send_usage_message(
                 data_context=context,
-                event=UsageStatsEvents.CLI_INIT_CREATE.value,
+                event=UsageStatsEvents.CLI_INIT_CREATE,
                 success=True,
             )
         except DataContextError as e:

--- a/great_expectations/cli/project.py
+++ b/great_expectations/cli/project.py
@@ -39,7 +39,7 @@ def project_check_config(ctx: click.Context) -> None:
 
     send_usage_message(
         data_context=context,
-        event=UsageStatsEvents.CLI_PROJECT_CHECK_CONFIG.value,
+        event=UsageStatsEvents.CLI_PROJECT_CHECK_CONFIG,
         success=True,
     )
 

--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -471,7 +471,7 @@ def upgrade_project_strictly_multiple_versions_increment(
         try:
             send_usage_message(
                 data_context=context,
-                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END.value,
+                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END,
                 success=True,
             )
         except Exception:
@@ -518,7 +518,7 @@ def upgrade_project(
         confirm_prompt=upgrade_prompt,
         continuation_message=EXIT_UPGRADE_CONTINUATION_MESSAGE,
         data_context=data_context,
-        usage_stats_event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END.value,
+        usage_stats_event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END,
     )
     cli_message(string=SECTION_SEPARATOR)
 
@@ -560,7 +560,7 @@ To learn more about the upgrade process, visit \
         data_context = DataContext(context_root_dir=context_root_dir)
         send_usage_message(
             data_context=data_context,
-            event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END.value,
+            event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END,
             success=True,
         )
     except Exception:
@@ -580,7 +580,7 @@ def upgrade_project_one_or_multiple_versions_increment(
     try:
         send_usage_message(
             data_context=context,
-            event=UsageStatsEvents.CLI_PROJECT_UPGRADE_BEGIN.value,
+            event=UsageStatsEvents.CLI_PROJECT_UPGRADE_BEGIN,
             success=True,
         )
     except Exception:
@@ -641,7 +641,7 @@ def upgrade_project_one_or_multiple_versions_increment(
         try:
             send_usage_message(
                 data_context=context,
-                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END.value,
+                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END,
                 success=True,
             )
         except Exception:
@@ -682,7 +682,7 @@ def upgrade_project_zero_versions_increment(
         try:
             send_usage_message(
                 data_context=context,
-                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_BEGIN.value,
+                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_BEGIN,
                 success=True,
             )
         except Exception:
@@ -717,7 +717,7 @@ def upgrade_project_zero_versions_increment(
         try:
             send_usage_message(
                 data_context=context,
-                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END.value,
+                event=UsageStatsEvents.CLI_PROJECT_UPGRADE_END,
                 success=True,
             )
         except Exception:

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -621,7 +621,7 @@ class ExpectationSuite(SerializableDictDot):
         usage_stats_event_payload: dict = {}
         if self._data_context is not None:
             self._data_context.send_usage_message(
-                event=UsageStatsEvents.EXPECTATION_SUITE_ADD_EXPECTATION.value,
+                event=UsageStatsEvents.EXPECTATION_SUITE_ADD_EXPECTATION,
                 event_payload=usage_stats_event_payload,
                 success=success,
             )

--- a/great_expectations/core/usage_statistics/events.py
+++ b/great_expectations/core/usage_statistics/events.py
@@ -9,7 +9,7 @@ programmatically create new enum values if run as a module.
         In send_usage_message() as an event name:
 
         handler.send_usage_message(
-            event=UsageStatsEvents.EXECUTION_ENGINE_SQLALCHEMY_CONNECT.value,
+            event=UsageStatsEvents.EXECUTION_ENGINE_SQLALCHEMY_CONNECT,
             event_payload={
                 "anonymized_name": handler.anonymizer.anonymize(self.name),
                 "sqlalchemy_dialect": self.engine.name,
@@ -36,7 +36,7 @@ import enum
 from typing import List, Optional
 
 
-class UsageStatsEvents(enum.Enum):
+class UsageStatsEvents(str, enum.Enum):
     """Event names for all Great Expectations usage stats events.
 
     Note: These should be used in place of strings, or retrieved

--- a/great_expectations/core/usage_statistics/schemas.py
+++ b/great_expectations/core/usage_statistics/schemas.py
@@ -1136,7 +1136,7 @@ anonymized_usage_statistics_record_schema = {
         {
             "type": "object",
             "properties": {
-                "event": {"enum": [UsageStatsEvents.CLOUD_MIGRATE.value]},
+                "event": {"enum": [UsageStatsEvents.CLOUD_MIGRATE]},
                 "event_payload": {"$ref": "#/definitions/cloud_migrate"},
             },
         },

--- a/great_expectations/core/usage_statistics/usage_statistics.py
+++ b/great_expectations/core/usage_statistics/usage_statistics.py
@@ -23,6 +23,7 @@ from great_expectations.core.usage_statistics.anonymizers.anonymizer import Anon
 from great_expectations.core.usage_statistics.anonymizers.types.base import (
     CLISuiteInteractiveFlagCombinations,
 )
+from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from great_expectations.core.usage_statistics.execution_environment import (
     GEExecutionEnvironment,
     PackageInfo,
@@ -265,7 +266,7 @@ def get_usage_statistics_handler(args_array: list) -> Optional[UsageStatisticsHa
 
 def usage_statistics_enabled_method(
     func: Optional[Callable] = None,
-    event_name: Optional[str] = None,
+    event_name: Optional[UsageStatsEvents] = None,
     args_payload_fn: Optional[Callable] = None,
     result_payload_fn: Optional[Callable] = None,
 ) -> Callable:

--- a/great_expectations/data_asset/data_asset.py
+++ b/great_expectations/data_asset/data_asset.py
@@ -872,7 +872,7 @@ class DataAsset:
                 if getattr(data_context, "_usage_statistics_handler", None):
                     handler = data_context._usage_statistics_handler
                     handler.send_usage_message(
-                        event=UsageStatsEvents.DATA_ASSET_VALIDATE.value,
+                        event=UsageStatsEvents.DATA_ASSET_VALIDATE,
                         event_payload=handler.anonymizer.anonymize(obj=self),
                         success=False,
                     )
@@ -1029,7 +1029,7 @@ class DataAsset:
             if getattr(data_context, "_usage_statistics_handler", None):
                 handler = data_context._usage_statistics_handler
                 handler.send_usage_message(
-                    event=UsageStatsEvents.DATA_ASSET_VALIDATE.value,
+                    event=UsageStatsEvents.DATA_ASSET_VALIDATE,
                     event_payload=handler.anonymizer.anonymize(obj=self),
                     success=False,
                 )
@@ -1040,7 +1040,7 @@ class DataAsset:
         if getattr(data_context, "_usage_statistics_handler", None):
             handler = data_context._usage_statistics_handler
             handler.send_usage_message(
-                event=UsageStatsEvents.DATA_ASSET_VALIDATE.value,
+                event=UsageStatsEvents.DATA_ASSET_VALIDATE,
                 event_payload=handler.anonymizer.anonymize(obj=self),
                 success=True,
             )

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -499,7 +499,7 @@ class AbstractDataContext(ABC):
         return updated_datasource
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_ADD_DATASOURCE.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_ADD_DATASOURCE,
         args_payload_fn=add_datasource_usage_statistics,
     )
     def add_datasource(
@@ -1137,7 +1137,7 @@ class AbstractDataContext(ABC):
         )
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_CHECKPOINT.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_CHECKPOINT,
     )
     def run_checkpoint(
         self,
@@ -1424,7 +1424,7 @@ class AbstractDataContext(ABC):
         return validator
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_GET_BATCH_LIST.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_GET_BATCH_LIST,
         args_payload_fn=get_batch_list_usage_statistics,
     )
     def get_batch_list(
@@ -1679,7 +1679,7 @@ class AbstractDataContext(ABC):
         )
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_RULE_BASED_PROFILER_WITH_DYNAMIC_ARGUMENTS.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_RULE_BASED_PROFILER_WITH_DYNAMIC_ARGUMENTS,
     )
     def run_profiler_with_dynamic_arguments(
         self,
@@ -1719,7 +1719,7 @@ class AbstractDataContext(ABC):
         )
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_RULE_BASED_PROFILER_ON_DATA.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_RULE_BASED_PROFILER_ON_DATA,
     )
     def run_profiler_on_data(
         self,
@@ -2110,7 +2110,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         return batch_kwargs
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_OPEN_DATA_DOCS.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_OPEN_DATA_DOCS,
     )
     def open_data_docs(
         self,

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -210,7 +210,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         return True
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT___INIT__.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT___INIT__,
     )
     def __init__(
         self,
@@ -463,7 +463,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         self._synchronize_self_with_underlying_data_context()
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_VALIDATION_OPERATOR.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_RUN_VALIDATION_OPERATOR,
         args_payload_fn=run_validation_operator_usage_statistics,
     )
     def run_validation_operator(
@@ -740,7 +740,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         return res
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_SAVE_EXPECTATION_SUITE.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_SAVE_EXPECTATION_SUITE,
         args_payload_fn=save_expectation_suite_usage_statistics,
     )
     def save_expectation_suite(
@@ -785,7 +785,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         return None
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_CONTEXT_BUILD_DATA_DOCS.value,
+        event_name=UsageStatsEvents.DATA_CONTEXT_BUILD_DATA_DOCS,
     )
     def build_data_docs(
         self,

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -116,7 +116,7 @@ class CloudMigrator:
         Returns:
             CloudMigrator instance
         """
-        event = UsageStatsEvents.CLOUD_MIGRATE.value
+        event = UsageStatsEvents.CLOUD_MIGRATE
         event_payload = {"organization_id": ge_cloud_organization_id}
         try:
             cloud_migrator: CloudMigrator = cls(

--- a/great_expectations/datasource/sqlalchemy_datasource.py
+++ b/great_expectations/datasource/sqlalchemy_datasource.py
@@ -289,7 +289,7 @@ class SqlAlchemyDatasource(LegacyDatasource):
             ):
                 handler = data_context._usage_statistics_handler
                 handler.send_usage_message(
-                    event=UsageStatsEvents.DATASOURCE_SQLALCHEMY_CONNECT.value,
+                    event=UsageStatsEvents.DATASOURCE_SQLALCHEMY_CONNECT,
                     event_payload={
                         "anonymized_name": handler.anonymizer.anonymize(obj=self.name),
                         "sqlalchemy_dialect": self.engine.name,

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -407,7 +407,7 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         ):
             handler = data_context._usage_statistics_handler
             handler.send_usage_message(
-                event=UsageStatsEvents.EXECUTION_ENGINE_SQLALCHEMY_CONNECT.value,
+                event=UsageStatsEvents.EXECUTION_ENGINE_SQLALCHEMY_CONNECT,
                 event_payload={
                     "anonymized_name": handler.anonymizer.anonymize(self.name),
                     "sqlalchemy_dialect": self.engine.name,

--- a/great_expectations/profile/user_configurable_profiler.py
+++ b/great_expectations/profile/user_configurable_profiler.py
@@ -281,7 +281,7 @@ type detected is "{str(type(self.profile_dataset))}", which is illegal.
         }
         send_usage_message(
             data_context=self.profile_dataset._data_context,
-            event=UsageStatsEvents.LEGACY_PROFILER_BUILD_SUITE.value,
+            event=UsageStatsEvents.LEGACY_PROFILER_BUILD_SUITE,
             event_payload=event_payload,
             api_version="v2",
             success=True,

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -411,7 +411,7 @@ class DataAssistantResult(SerializableDictDot):
         return auxiliary_info
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value,
+        event_name=UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE,
         args_payload_fn=get_expectation_suite_usage_statistics,
     )
     def _get_expectation_suite_with_usage_statistics(

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -228,7 +228,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         return domain_builder
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.RULE_BASED_PROFILER_RUN.value,
+        event_name=UsageStatsEvents.RULE_BASED_PROFILER_RUN,
         args_payload_fn=get_profiler_run_usage_statistics,
     )
     def run(

--- a/great_expectations/rule_based_profiler/rule_based_profiler_result.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler_result.py
@@ -80,7 +80,7 @@ class RuleBasedProfilerResult(SerializableDictDot):
         return self.to_dict()
 
     @usage_statistics_enabled_method(
-        event_name=UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE.value,
+        event_name=UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE,
         args_payload_fn=get_expectation_suite_usage_statistics,
     )
     def get_expectation_suite(self, expectation_suite_name: str) -> ExpectationSuite:

--- a/tests/core/test_expectation_suite.py
+++ b/tests/core/test_expectation_suite.py
@@ -1035,7 +1035,7 @@ def test_expectation_suite_send_usage_message(success: bool):
     assert dc_message_spy.messages
     assert len(dc_message_spy.messages) == 1
     assert dc_message_spy.messages[0] == {
-        "event": UsageStatsEvents.EXPECTATION_SUITE_ADD_EXPECTATION.value,
+        "event": UsageStatsEvents.EXPECTATION_SUITE_ADD_EXPECTATION,
         "event_payload": {},
         "success": success,
     }

--- a/tests/core/usage_statistics/test_usage_stats_schema.py
+++ b/tests/core/usage_statistics/test_usage_stats_schema.py
@@ -416,7 +416,7 @@ def test_rule_based_profiler_run_message():
 
 def test_cloud_migrate_event():
     usage_stats_records_messages = [
-        UsageStatsEvents.CLOUD_MIGRATE.value,
+        UsageStatsEvents.CLOUD_MIGRATE,
     ]
     for message_type in usage_stats_records_messages:
         for message in valid_usage_statistics_messages[message_type]:

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -206,7 +206,7 @@ class TestUsageStats:
 
         mock_send_usage_message.assert_called_once_with(
             data_context=mock.ANY,
-            event=UsageStatsEvents.CLOUD_MIGRATE.value,
+            event=UsageStatsEvents.CLOUD_MIGRATE,
             event_payload={"organization_id": ge_cloud_organization_id},
             success=True,
         )
@@ -220,7 +220,7 @@ class TestUsageStats:
 
         mock_send_usage_message.assert_called_once_with(
             data_context=mock.ANY,
-            event=UsageStatsEvents.CLOUD_MIGRATE.value,
+            event=UsageStatsEvents.CLOUD_MIGRATE,
             event_payload={"organization_id": ge_cloud_organization_id},
             success=False,
         )

--- a/tests/integration/profiling/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/integration/profiling/rule_based_profiler/test_rule_based_profiler.py
@@ -173,10 +173,7 @@ def test_profile_includes_citations(
 
     # noinspection PyUnresolvedReferences
     actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
-    assert (
-        actual_events[-1][0][0]["event"]
-        == UsageStatsEvents.RULE_BASED_PROFILER_RUN.value
-    )
+    assert actual_events[-1][0][0]["event"] == UsageStatsEvents.RULE_BASED_PROFILER_RUN
 
 
 @mock.patch(
@@ -230,5 +227,5 @@ def test_profile_get_expectation_suite(
     actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
     assert (
         actual_events[-1][0][0]["event"]
-        == UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE.value
+        == UsageStatsEvents.RULE_BASED_PROFILER_RESULT_GET_EXPECTATION_SUITE
     )

--- a/tests/integration/usage_statistics/example_events/cloud_migrate_example_events.py
+++ b/tests/integration/usage_statistics/example_events/cloud_migrate_example_events.py
@@ -5,7 +5,7 @@ This file contains example events primarily for usage stats schema validation te
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
 
 cloud_migrate: dict = {
-    "event": UsageStatsEvents.CLOUD_MIGRATE.value,
+    "event": UsageStatsEvents.CLOUD_MIGRATE,
     "event_payload": {"organization_id": "some_organization_id_probably_uuid"},
     "success": True,
     "version": "1.0.0",

--- a/tests/integration/usage_statistics/test_usage_statistics_messages.py
+++ b/tests/integration/usage_statistics/test_usage_statistics_messages.py
@@ -2710,7 +2710,7 @@ valid_usage_statistics_messages = {
             "x-forwarded-for": "00.000.00.000, 00.000.000.000",
         },
     ],
-    UsageStatsEvents.CLOUD_MIGRATE.value: [cloud_migrate],
+    UsageStatsEvents.CLOUD_MIGRATE: [cloud_migrate],
 }
 
 test_messages = []

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py
@@ -255,7 +255,7 @@ def test_onboarding_data_assistant_result_get_expectation_suite(
     actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
     assert (
         actual_events[-1][0][0]["event"]
-        == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value
+        == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE
     )
 
 

--- a/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
+++ b/tests/rule_based_profiler/data_assistant/test_volume_data_assistant.py
@@ -1693,7 +1693,7 @@ def test_volume_data_assistant_result_get_expectation_suite(
     actual_events: List[unittest.mock._Call] = mock_emit.call_args_list
     assert (
         actual_events[-1][0][0]["event"]
-        == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE.value
+        == UsageStatsEvents.DATA_ASSISTANT_RESULT_GET_EXPECTATION_SUITE
     )
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Intead of doing `Event.value`, let's inherit from `str` so we can just use `Event`

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
