### PR TITLE
[MAINTENANCE] Remove AWS config file dependencies and use existing env vars in CI/CD

### DIFF
--- a/azure-pipelines-docs-integration.yml
+++ b/azure-pipelines-docs-integration.yml
@@ -110,12 +110,6 @@ stages:
           inputs:
               secureFile: 'superconductive-service-acct_ge-oss-ci-cd.json'
               retryCount: '2'
-        - task: DownloadSecureFile@1
-          name: aws_authkey
-          displayName: 'Download AWS Credentials'
-          inputs:
-              secureFile: 'aws_config_sandbox'
-              retryCount: '2'
         - script: |
             # install google cloud storage dependency
             pip install google-cloud-bigquery-storage
@@ -157,7 +151,9 @@ stages:
             REDSHIFT_DATABASE: $(REDSHIFT_DATABASE)
             REDSHIFT_SSLMODE: $(REDSHIFT_SSLMODE)
             # AWS credentials
-            AWS_CONFIG_FILE: $(aws_authkey.secureFilePath)
+            AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+            AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+            AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
             ATHENA_DB_NAME: $(ATHENA_DB_NAME)
             ATHENA_STAGING_S3: $(ATHENA_STAGING_S3)
             ATHENA_DATA_BUCKET: $(ATHENA_DATA_BUCKET)

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -138,13 +138,6 @@ stages:
               secureFile: 'superconductive-service-acct_ge-oss-ci-cd.json'
               retryCount: '2'
 
-          - task: DownloadSecureFile@1
-            name: aws_authkey
-            displayName: 'Download AWS Credentials'
-            inputs:
-              secureFile: 'aws_config_sandbox'
-              retryCount: '2'
-
           - bash: python ./build_gallery.py --backends "pandas" --outfile-name "quick_check.json" ; exp_count=$(grep "^ *\"expect_" quick_check.json | wc -l); package_summary=$(grep "\"package\":" quick_check.json | sort | uniq -c | sort -nr) ; echo -e "\n\n$exp_count Expectations in quick_check.json\n";  echo -e "$package_summary"; [[ $exp_count -lt 298 ]] && echo "Fewer than 298 Expectations" && exit 1 ; [[ $(echo -e "$package_summary" | wc -l) -lt 6 ]] && echo "Fewer than 6 packages" && exit 1 ; echo "ok"
             workingDirectory: $(Build.SourcesDirectory)/assets/scripts/
             displayName: 'Build Gallery Quick Check'
@@ -169,7 +162,9 @@ stages:
               REDSHIFT_DATABASE: $(REDSHIFT_DATABASE)
               REDSHIFT_SSLMODE: $(REDSHIFT_SSLMODE)
               # AWS credentials
-              AWS_CONFIG_FILE: $(aws_authkey.secureFilePath)
+              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
               ATHENA_DB_NAME: $(ATHENA_DB_NAME)
               ATHENA_STAGING_S3: $(ATHENA_STAGING_S3)
               ATHENA_DATA_BUCKET: $(ATHENA_DATA_BUCKET)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,7 +190,9 @@ stages:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
               mkdir coverage
-              PYTEST="docker run --network=host --mount type=bind,source=${PWD}/coverage,target=/coverage "
+              PYTEST="docker run -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} "
+              PYTEST+="-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} "
+              PYTEST+="--network=host --mount type=bind,source=${PWD}/coverage,target=/coverage "
               # We don't run e2e because we don't want to test connections to external dependencies here.
               PYTEST+="greatexpectations/test:${DOCKER_TAG} /bin/bash -c \"pytest -m 'not e2e' "
               PYTEST+="--random-order --postgresql --cloud "
@@ -202,9 +204,14 @@ stages:
               PYTEST+="--ignore=tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py "
               # The last \" closes the quote from bash -c \"
               PYTEST+="&& mv coverage.xml /coverage/coverage.xml\""
+
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest $(python.version)'
+            env:
+              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
 
           - task: PublishTestResults@2
             condition: succeededOrFailed()
@@ -296,7 +303,9 @@ stages:
               mkdir script
               echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" > script/mysql_setup.sql
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
-              PYTEST="docker run --network=host --mount type=bind,source=${PWD}/script,target=/script "
+              PYTEST="docker run -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} "
+              PYTEST+="-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} "
+              PYTEST+="--network=host --mount type=bind,source=${PWD}/script,target=/script "
               PYTEST+="greatexpectations/test:${DOCKER_TAG} /bin/bash -c \""
               PYTEST+="mysql --host=localhost --protocol=TCP --port=3306 --user=root --password='' --reconnect < /script/mysql_setup.sql && "
               PYTEST+="pytest --mysql --random-order --ignore=tests/cli --ignore=tests/integration/usage_statistics "
@@ -305,6 +314,10 @@ stages:
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest MySQL'
+            env:
+              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
 
       - job: test_trino
         dependsOn: [make_suffix, build_push]
@@ -329,12 +342,18 @@ stages:
             displayName: 'Wait for Trino'
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
-              PYTEST="docker run --network=host greatexpectations/test:${DOCKER_TAG} "
+              PYTEST="docker run -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} "
+              PYTEST+="-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} "
+              PYTEST+="--network=host greatexpectations/test:${DOCKER_TAG} "
               PYTEST+="pytest --trino --random-order --ignore=tests/cli --ignore=tests/integration/usage_statistics "
               PYTEST+="--ignore=tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant.py"
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest Trino'
+            env:
+              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
 
       - job: test_cli
         dependsOn: [make_suffix, build_push]


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove AWS config file dependencies and use existing env vars in CI/CD

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
