### PR TITLE
[BUGFIX] Add env vars to Pytest min versions Azure stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -401,7 +401,9 @@ stages:
         steps:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
-              PYTEST="docker run --network=host greatexpectations/test:${DOCKER_TAG} bash -c \""
+              PYTEST="docker run -e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) "
+              PYTEST+="-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) -e AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) "
+              PYTEST+="--network=host greatexpectations/test:${DOCKER_TAG} bash -c \""
               PYTEST+="printf 'Y\nY\n' | pip uninstall numpy pandas && "
               PYTEST+="printf 'Y\nY\n' | pip install numpy==$(min_numpy) pandas==$(min_pandas) && "
               PYTEST+="pytest --no-sqlalchemy --random-order --ignore=tests/cli --ignore=tests/integration/usage_statistic "
@@ -409,6 +411,10 @@ stages:
               echo ${PYTEST}
               eval ${PYTEST}
             displayName: 'Pytest min versions'
+            env:
+              AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+              AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+              AWS_DEFAULT_REGION: $(AWS_DEFAULT_REGION)
 
       - job: test_usage_stats
         dependsOn: [make_suffix, build_push]


### PR DESCRIPTION
Changes proposed in this pull request:
- Add env vars to Pytest min versions Azure stage

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.