### PR TITLE
[MAINTENANCE] Split up `compatability` and `comprehensive` stages in `dev` CI to improve performance

### DIFF
--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -166,7 +166,7 @@ stages:
       vmImage: 'ubuntu-18.04'
 
     jobs:
-      - job: compatibility_matrix
+      - job: minimal
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
         strategy:
           matrix:
@@ -210,8 +210,7 @@ stages:
 
           - script: |
               # Run pytest
-              pytest tests \
-                $(pytest_args) \
+              pytest $(pytest_args) \
                 --no-sqlalchemy \
                 --ignore 'tests/cli' \
                 --ignore 'contrib/cli/tests' \
@@ -277,8 +276,7 @@ stages:
               pip install pytest-cov pytest-azurepipelines
 
               # Run pytest
-              pytest tests \
-                $(pytest_args) \
+              pytest $(pytest_args) \
                 --postgresql \
                 --spark \
                 --ignore 'tests/cli' \

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -166,9 +166,14 @@ stages:
       vmImage: 'ubuntu-18.04'
 
     jobs:
+      # Runs pytest without any additional flags
       - job: minimal
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
         strategy:
+          # This matrix is intended to split up our sizeable test suite into two distinct components.
+          # By splitting up slow tests from the remainder of the suite, we can parallelize test runs
+          # at the cost of an additional Azure worker.
+          # To work as intendend, "standard" and "slow" should be equally performant
           matrix:
             standard:
               pytest_args: 'tests --ignore "tests/rule_based_profiler"'
@@ -239,10 +244,14 @@ stages:
               summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
+      # Runs pytest with Spark and Postgres enabled
       - job: comprehensive
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
-        timeoutInMinutes: 120
         strategy:
+          # This matrix is intended to split up our sizeable test suite into two distinct components.
+          # By splitting up slow tests from the remainder of the suite, we can parallelize test runs
+          # at the cost of an additional Azure worker.
+          # To work as intendend, "standard" and "slow" should be equally performant
           matrix:
             standard:
               pytest_args: 'tests --ignore "tests/rule_based_profiler"'
@@ -349,7 +358,6 @@ stages:
     jobs:
       - job: mysql
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
-        timeoutInMinutes: 120
 
         services:
           mysql: mysql
@@ -402,7 +410,6 @@ stages:
 
       - job: mssql
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
-        timeoutInMinutes: 120
 
         services:
           mssql: mssql
@@ -445,7 +452,6 @@ stages:
 
       - job: trino
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
-        timeoutInMinutes: 120
 
         services:
           trino: trino

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -173,7 +173,8 @@ stages:
           # This matrix is intended to split up our sizeable test suite into two distinct components.
           # By splitting up slow tests from the remainder of the suite, we can parallelize test runs
           # at the cost of an additional Azure worker.
-          # To work as intendend, "standard" and "slow" should be equally performant
+          #
+          # To work as intended, "standard" and "slow" should be equally performant.
           matrix:
             standard:
               pytest_args: 'tests --ignore "tests/rule_based_profiler"'
@@ -251,7 +252,8 @@ stages:
           # This matrix is intended to split up our sizeable test suite into two distinct components.
           # By splitting up slow tests from the remainder of the suite, we can parallelize test runs
           # at the cost of an additional Azure worker.
-          # To work as intendend, "standard" and "slow" should be equally performant
+          #
+          # To work as intended, "standard" and "slow" should be equally performant.
           matrix:
             standard:
               pytest_args: 'tests --ignore "tests/rule_based_profiler"'

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -168,8 +168,12 @@ stages:
     jobs:
       - job: compatibility_matrix
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
-        variables:
-          GE_pytest_opts: '--no-sqlalchemy'
+        strategy:
+          matrix:
+            standard:
+              pytest_args: 'tests --ignore "tests/rule_based_profiler"'
+            slow:
+              pytest_args: 'tests/rule_based_profiler'
 
         steps:
           - task: UsePythonVersion@0
@@ -206,8 +210,19 @@ stages:
 
           - script: |
               # Run pytest
-              pytest tests --ignore 'tests/cli' --ignore 'contrib/cli/tests' --ignore 'tests/integration/usage_statistics' \
-                $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html -m 'not unit and not e2e' --durations=10
+              pytest tests \
+                $(pytest_args) \
+                --no-sqlalchemy \
+                --ignore 'tests/cli' \
+                --ignore 'contrib/cli/tests' \
+                --ignore 'tests/integration/usage_statistics' \
+                --napoleon-docstrings \
+                --junitxml=junit/test-results.xml \
+                --cov=. \
+                --cov-report=xml \
+                --cov-report=html \
+                -m 'not unit and not e2e' \
+                --durations=10
 
             displayName: 'pytest'
             env:
@@ -228,12 +243,15 @@ stages:
       - job: comprehensive
         condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.GEChanged'], true)
         timeoutInMinutes: 120
+        strategy:
+          matrix:
+            standard:
+              pytest_args: 'tests --ignore "tests/rule_based_profiler"'
+            slow:
+              pytest_args: 'tests/rule_based_profiler'
 
         services:
           postgres: postgres
-
-        variables:
-          GE_pytest_opts: '--postgresql --spark'
 
         steps:
           - task: UsePythonVersion@0
@@ -259,19 +277,23 @@ stages:
               pip install pytest-cov pytest-azurepipelines
 
               # Run pytest
-              pytest tests --ignore 'tests/cli' --ignore 'contrib/cli/tests' --ignore 'tests/integration/usage_statistics' \
-                $(GE_pytest_opts) --napoleon-docstrings --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html -m 'not e2e'
+              pytest tests \
+                $(pytest_args) \
+                --postgresql \
+                --spark \
+                --ignore 'tests/cli' \
+                --ignore 'contrib/cli/tests' \
+                --ignore 'tests/integration/usage_statistics' \
+                --napoleon-docstrings \
+                --junitxml=junit/test-results.xml \
+                --cov=. \
+                --cov-report=xml \
+                --cov-report=html \
+                -m 'not e2e'
 
             displayName: 'pytest'
             env:
               GE_USAGE_STATISTICS_URL: ${{ variables.GE_USAGE_STATISTICS_URL }}
-
-          - script: |
-              # These are tests that are specific to Great Expectations Cloud.
-              # In order to ensure coverage, we run them during each CI/CD cycle.
-              pytest tests --cloud -m "cloud and not e2e"
-
-            displayName: 'cloud-overrides'
 
           - task: PublishTestResults@2
             condition: succeededOrFailed()


### PR DESCRIPTION
Changes proposed in this pull request:
- Split up `pytest tests` in half by using two parallel Azure workers

Proposed performance gains:
<img width="200" alt="Screen Shot 2022-10-28 at 3 29 11 PM" src="https://user-images.githubusercontent.com/49923762/198717331-d6fc5f77-c7bb-4088-9851-5c837d3df33c.png">

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
