### PR TITLE
[MAINTENANCE] Logo URI ref in `data_docs`

### DIFF
--- a/great_expectations/render/view/templates/top_navbar.j2
+++ b/great_expectations/render/view/templates/top_navbar.j2
@@ -21,7 +21,7 @@
         <a href="{{ home_url }}">
           <img
             class="NO-CACHE"
-            src="{{ static_images_dir + "logo-long.png" | add_data_context_id_to_url }}"
+            src="{{ static_images_dir + "great-expectations-long-logo.png" | add_data_context_id_to_url }}"
             alt="Great Expectations"
             style="width: auto; height: 50px"
           />

--- a/great_expectations/render/view/templates/top_navbar.j2
+++ b/great_expectations/render/view/templates/top_navbar.j2
@@ -12,7 +12,7 @@
   {% set home_url = "#" -%}
 {% endif %}
 
-{% set static_images_dir = "https://great-expectations-web-assets.s3.us-east-2.amazonaws.com/" -%}
+{% set static_images_dir = "https://company-visual-assets.s3.amazonaws.com/logos/" -%}
 
 <nav class="navbar navbar-expand-md sticky-top border-bottom" style="height: 70px">
   <div class="mr-auto">


### PR DESCRIPTION
🌸 
Changes proposed in this pull request:
- change logo Uri as old one is invalid.


Previous Design Review notes:
- n/a


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
