### PR TITLE
[MAINTENANCE] mypy `warn_unused_ignores`

### DIFF
--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -121,7 +121,7 @@ stages:
       steps:
       - script: |
           pip install mypy invoke
-          invoke type-check --install-types --warn-unused-ignore
+          invoke type-check --install-types --warn-unused-ignore --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -121,7 +121,7 @@ stages:
       steps:
       - script: |
           pip install mypy invoke
-          invoke type-check --install-types
+          invoke type-check --install-types --warn-unused-ignore
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -121,7 +121,7 @@ stages:
       steps:
       - script: |
           pip install mypy invoke
-          invoke type-check --install-types --warn-unused-ignore --pretty
+          invoke type-check --install-types --warn-unused-ignores --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -74,6 +74,8 @@ stages:
 
                 [GEChanged]
                 great_expectations/**/*.py
+                pyproject.toml
+                setup.cfg
                 tests/**
                 /*.txt
                 /*.yml

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -68,6 +68,8 @@ stages:
 
                 [GEChanged]
                 great_expectations/**/*.py
+                pyproject.toml
+                setup.cfg
                 tests/**
 
                 [ScriptsChanged]

--- a/azure-pipelines-os-integration.yml
+++ b/azure-pipelines-os-integration.yml
@@ -66,6 +66,8 @@ stages:
 
                 [GEChanged]
                 great_expectations/**/*.py
+                pyproject.toml
+                setup.cfg
                 tests/**
                 /*.txt
                 /*.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
       steps:
       - script: |
           pip install mypy invoke
-          invoke type-check --install-types --warn-unused-ignore --pretty 
+          invoke type-check --install-types --warn-unused-ignores --pretty 
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
       steps:
       - script: |
           pip install mypy invoke
-          invoke type-check --install-types --warn-unused-ignore
+          invoke type-check --install-types --warn-unused-ignore --pretty 
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
       steps:
       - script: |
           pip install mypy invoke
-          invoke type-check --install-types
+          invoke type-check --install-types --warn-unused-ignore
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/great_expectations/core/evaluation_parameters.py
+++ b/great_expectations/core/evaluation_parameters.py
@@ -340,11 +340,11 @@ def parse_evaluation_parameter(  # noqa: C901 - complexity 19
         # NOTE: 20211122 - Chetan - Any future built-ins that are zero arity functions will match this behavior
         pass
 
-    elif len(parse_results) == 1 and parse_results[0] not in evaluation_parameters:  # type: ignore[index, arg-type]
+    elif len(parse_results) == 1 and parse_results[0] not in evaluation_parameters:
         # In this special case there were no operations to find, so only one value, but we don't have something to
         # substitute for that value
         try:
-            res = ge_urn.parseString(parse_results[0])  # type: ignore[index]
+            res = ge_urn.parseString(parse_results[0])
             if res["urn_type"] == "stores":
                 store = data_context.stores.get(res["store_name"])  # type: ignore[union-attr]
                 return store.get_query_result(  # type: ignore[union-attr]
@@ -355,29 +355,29 @@ def parse_evaluation_parameter(  # noqa: C901 - complexity 19
                     "Unrecognized urn_type in ge_urn: must be 'stores' to use a metric store."
                 )
                 raise EvaluationParameterError(
-                    f"No value found for $PARAMETER {str(parse_results[0])}"  # type: ignore[index]
+                    f"No value found for $PARAMETER {str(parse_results[0])}"
                 )
         except ParseException as e:
             logger.debug(
                 f"Parse exception while parsing evaluation parameter: {str(e)}"
             )
             raise EvaluationParameterError(
-                f"No value found for $PARAMETER {str(parse_results[0])}"  # type: ignore[index]
+                f"No value found for $PARAMETER {str(parse_results[0])}"
             ) from e
         except AttributeError as e:
             logger.warning("Unable to get store for store-type valuation parameter.")
             raise EvaluationParameterError(
-                f"No value found for $PARAMETER {str(parse_results[0])}"  # type: ignore[index]
+                f"No value found for $PARAMETER {str(parse_results[0])}"
             ) from e
 
-    elif len(parse_results) == 1:  # type: ignore[arg-type]
+    elif len(parse_results) == 1:
         # In this case, we *do* have a substitution for a single type. We treat this specially because in this
         # case, we allow complex type substitutions (i.e. do not coerce to string as part of parsing)
         # NOTE: 20201023 - JPC - to support MetricDefinition as an evaluation parameter type, we need to handle that
         # case here; is the evaluation parameter provided here in fact a metric definition?
-        return evaluation_parameters[parse_results[0]]  # type: ignore[index]
+        return evaluation_parameters[parse_results[0]]
 
-    elif len(parse_results) == 0 or parse_results[0] != "Parse Failure":  # type: ignore[index, arg-type]
+    elif len(parse_results) == 0 or parse_results[0] != "Parse Failure":
         # we have a stack to evaluate and there was no parse failure.
         # iterate through values and look for URNs pointing to a store:
         for i, ob in enumerate(EXPR.exprStack):
@@ -404,7 +404,7 @@ def parse_evaluation_parameter(  # noqa: C901 - complexity 19
                     pass
 
     else:
-        err_str, err_line, err_col = parse_results[-1]  # type: ignore[index]
+        err_str, err_line, err_col = parse_results[-1]
         raise EvaluationParameterError(
             f"Parse Failure: {err_str}\nStatement: {err_line}\nColumn: {err_col}"
         )

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import json
 import logging
@@ -740,7 +742,7 @@ class ExpectationSuite(SerializableDictDot):
                     }
                 }
             )
-        pprint.pprint(  # type: ignore[call-arg]
+        pprint.pprint(
             object=pprint_objects,
             indent=2,
             sort_dicts=False,
@@ -819,7 +821,7 @@ class ExpectationSuite(SerializableDictDot):
 
         expectation_configuration: ExpectationConfiguration
         for expectation_configuration in expectation_configurations:
-            expectation_configuration.kwargs = deep_filter_properties_iterable(  # type: ignore[assignment]
+            expectation_configuration.kwargs = deep_filter_properties_iterable(
                 properties=expectation_configuration.kwargs, clean_falsy=True
             )
 
@@ -838,7 +840,7 @@ class ExpectationSuite(SerializableDictDot):
         kwargs: dict
         column_name: str
         for expectation_configuration in expectation_configurations:
-            kwargs = deep_filter_properties_iterable(  # type: ignore[assignment]
+            kwargs = deep_filter_properties_iterable(
                 properties=expectation_configuration.kwargs, clean_falsy=True
             )
             column_name = kwargs.pop("column")
@@ -862,7 +864,7 @@ class ExpectationSuite(SerializableDictDot):
         column_A_name: str
         column_B_name: str
         for expectation_configuration in expectation_configurations:
-            kwargs = deep_filter_properties_iterable(  # type: ignore[assignment]
+            kwargs = deep_filter_properties_iterable(
                 properties=expectation_configuration.kwargs, clean_falsy=True
             )
             column_A_name = kwargs.pop("column_A")
@@ -889,7 +891,7 @@ class ExpectationSuite(SerializableDictDot):
         kwargs: dict
         column_list: str
         for expectation_configuration in expectation_configurations:
-            kwargs = deep_filter_properties_iterable(  # type: ignore[assignment]
+            kwargs = deep_filter_properties_iterable(
                 properties=expectation_configuration.kwargs, clean_falsy=True
             )
             column_list = kwargs.pop("column_list")
@@ -969,7 +971,7 @@ class ExpectationSuite(SerializableDictDot):
            this ExpectationSuite to ExpectationConfiguration.rendered_content.
         """
         for expectation_configuration in self.expectations:
-            inline_renderer_config: "InlineRendererConfig" = {  # type: ignore[assignment]
+            inline_renderer_config: InlineRendererConfig = {
                 "class_name": "InlineRenderer",
                 "render_object": expectation_configuration,
             }

--- a/great_expectations/data_context/config_validator/yaml_config_validator.py
+++ b/great_expectations/data_context/config_validator/yaml_config_validator.py
@@ -137,7 +137,7 @@ class _YamlConfigValidator:
         class_name: Optional[str] = None,
         runtime_environment: Optional[dict] = None,
         pretty_print: bool = True,
-        return_mode: Union[  # type: ignore[name-defined]
+        return_mode: Union[
             Literal["instantiated_class"], Literal["report_object"]
         ] = "instantiated_class",
         shorten_tracebacks: bool = False,
@@ -332,7 +332,7 @@ class _YamlConfigValidator:
             raise e
 
         try:
-            config: CommentedMap = yaml.load(config_str_with_substituted_variables)  # type: ignore[arg-type]
+            config: CommentedMap = yaml.load(config_str_with_substituted_variables)
             return config
 
         except Exception as e:
@@ -364,7 +364,7 @@ class _YamlConfigValidator:
             ),
         )
         store_name = instantiated_class.store_name or store_name
-        self._data_context.config["stores"][store_name] = config  # type: ignore[index]
+        self._data_context.config["stores"][store_name] = config
 
         anonymizer = Anonymizer(self._data_context.data_context_id)
         usage_stats_event_payload = anonymizer.anonymize(

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -26,7 +26,7 @@ from typing import (
 )
 
 try:
-    from typing import Literal  # type: ignore[attr-defined]
+    from typing import Literal
 except ImportError:
     # Fallback for python < 3.8
     from typing_extensions import Literal  # type: ignore[misc]
@@ -768,7 +768,7 @@ class AbstractDataContext(ABC):
         else:
             expectation_suite = self.get_expectation_suite(expectation_suite_name)
 
-        datasource = self.get_datasource(batch_kwargs.get("datasource"))  # type: ignore[union-attr,arg-type]
+        datasource = self.get_datasource(batch_kwargs.get("datasource"))  # type: ignore[arg-type]
         batch = datasource.get_batch(  # type: ignore[union-attr]
             batch_kwargs=batch_kwargs, batch_parameters=batch_parameters
         )
@@ -1013,7 +1013,7 @@ class AbstractDataContext(ABC):
         datasource_config: Union[dict, DatasourceConfig]
         serializer = NamedDatasourceSerializer(schema=datasourceConfigSchema)
 
-        for datasource_name, datasource_config in self.config.datasources.items():  # type: ignore[union-attr,assignment]
+        for datasource_name, datasource_config in self.config.datasources.items():  # type: ignore[union-attr]
             if isinstance(datasource_config, dict):
                 datasource_config = DatasourceConfig(**datasource_config)
             datasource_config.name = datasource_name
@@ -1354,7 +1354,7 @@ class AbstractDataContext(ABC):
                 batch_request_list = [batch_request]  # type: ignore[list-item]
 
             for batch_request in batch_request_list:
-                batch_list.extend(  # type: ignore[union-attr]
+                batch_list.extend(
                     self.get_batch_list(
                         datasource_name=datasource_name,
                         data_connector_name=data_connector_name,
@@ -1381,7 +1381,7 @@ class AbstractDataContext(ABC):
 
         return self.get_validator_using_batch_list(
             expectation_suite=expectation_suite,  # type: ignore[arg-type]
-            batch_list=batch_list,  # type: ignore[arg-type]
+            batch_list=batch_list,
             include_rendered_content=include_rendered_content,
         )
 
@@ -1567,7 +1567,7 @@ class AbstractDataContext(ABC):
                     expectation_suite_name
                 )
             )
-        self.expectations_store.set(key, expectation_suite, **kwargs)  # type: ignore[arg-type]
+        self.expectations_store.set(key, expectation_suite, **kwargs)
         return expectation_suite
 
     def delete_expectation_suite(
@@ -2783,7 +2783,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             "BaseDatasource",
             "Datasource",
         ]:
-            config_dict.update({"data_context_root_directory": self.root_directory})  # type: ignore[union-attr]
+            config_dict.update({"data_context_root_directory": self.root_directory})
         module_name: str = "great_expectations.datasource"
         datasource: Datasource = instantiate_class_from_config(
             config=config_dict,

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -254,7 +254,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
             self._data_context = CloudDataContext(
                 project_config=project_config,
                 runtime_environment=runtime_environment,
-                context_root_dir=context_root_dir,  # type: ignore[arg-type]
+                context_root_dir=context_root_dir,
                 ge_cloud_base_url=ge_cloud_base_url,
                 ge_cloud_access_token=ge_cloud_access_token,
                 ge_cloud_organization_id=ge_cloud_organization_id,
@@ -725,7 +725,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         )
         return res
 
-    def delete_expectation_suite(  # type: ignore[override]
+    def delete_expectation_suite(
         self,
         expectation_suite_name: Optional[str] = None,
         ge_cloud_id: Optional[str] = None,
@@ -1226,7 +1226,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         Returns:
             If initialize=True return an instantiated Datasource object, else None.
         """
-        datasource: Datasource = self._data_context._instantiate_datasource_from_config_and_update_project_config(  # type: ignore[assignment,union-attr,arg-type]
+        datasource: Datasource = self._data_context._instantiate_datasource_from_config_and_update_project_config(  # type: ignore[assignment,union-attr]
             config=config,
             initialize=initialize,
             save_changes=save_changes,

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -153,14 +153,14 @@ class CloudDataContext(AbstractDataContext):
 
         :return: the configuration object retrieved from the Cloud API
         """
-        base_url = ge_cloud_config.base_url  # type: ignore[union-attr]
-        organization_id = ge_cloud_config.organization_id  # type: ignore[union-attr]
+        base_url = ge_cloud_config.base_url
+        organization_id = ge_cloud_config.organization_id
         ge_cloud_url = (
             f"{base_url}/organizations/{organization_id}/data-context-configuration"
         )
         headers = {
             "Content-Type": "application/vnd.api+json",
-            "Authorization": f"Bearer {ge_cloud_config.access_token}",  # type: ignore[union-attr]
+            "Authorization": f"Bearer {ge_cloud_config.access_token}",
             "Gx-Version": __version__,
         }
 
@@ -311,7 +311,7 @@ class CloudDataContext(AbstractDataContext):
 
     def _init_variables(self) -> CloudDataContextVariables:
         ge_cloud_base_url: str = self._ge_cloud_config.base_url
-        ge_cloud_organization_id: str = self._ge_cloud_config.organization_id  # type: ignore[union-attr,assignment]
+        ge_cloud_organization_id: str = self._ge_cloud_config.organization_id  # type: ignore[assignment]
         ge_cloud_access_token: str = self._ge_cloud_config.access_token
 
         variables = CloudDataContextVariables(

--- a/great_expectations/data_context/data_context/ephemeral_data_context.py
+++ b/great_expectations/data_context/data_context/ephemeral_data_context.py
@@ -118,4 +118,4 @@ class EphemeralDataContext(AbstractDataContext):
         )
         if include_rendered_content:
             expectation_suite.render()
-        return self.expectations_store.set(key, expectation_suite, **kwargs)  # type: ignore[arg-type]
+        return self.expectations_store.set(key, expectation_suite, **kwargs)

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -131,7 +131,7 @@ class FileDataContext(AbstractDataContext):
         )
         if include_rendered_content:
             expectation_suite.render()
-        return self.expectations_store.set(key, expectation_suite, **kwargs)  # type: ignore[arg-type]
+        return self.expectations_store.set(key, expectation_suite, **kwargs)
 
     @property
     def root_directory(self) -> Optional[str]:

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -55,7 +55,7 @@ class DataContextVariableSchema(str, enum.Enum):
         return value in cls._value2member_map_
 
 
-@dataclass  # type: ignore[misc]
+@dataclass
 class DataContextVariables(ABC):
     """
     Wrapper object around data context variables set in the `great_expectations.yml` config file.

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -173,7 +173,7 @@ class CheckpointStore(ConfigurationStore):
         key: Union[GeCloudIdentifier, ConfigurationIdentifier] = self.determine_key(
             name=name, ge_cloud_id=ge_cloud_id
         )
-        checkpoint_config: CheckpointConfig = checkpoint.get_config()  # type: ignore[assignment,func-returns-value]
+        checkpoint_config: CheckpointConfig = checkpoint.get_config()  # type: ignore[assignment]
         checkpoint_ref = self.set(key=key, value=checkpoint_config)  # type: ignore[func-returns-value]
         if isinstance(checkpoint_ref, GeCloudIdAwareRef):
             ge_cloud_id = checkpoint_ref.ge_cloud_id

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -74,7 +74,7 @@ class DatasourceStore(Store):
         """
         See parent 'Store.serialize()' for more information
         """
-        return self._serializer.serialize(value)  # type: ignore[return-value]
+        return self._serializer.serialize(value)
 
     def deserialize(self, value: Union[dict, DatasourceConfig]) -> DatasourceConfig:
         """
@@ -172,7 +172,7 @@ class DatasourceStore(Store):
 
         # Make two separate requests to set and get in order to obtain any additional
         # values that may have been added to the config by the StoreBackend (i.e. object ids)
-        ref: Optional[Union[bool, GeCloudResourceRef]] = super().set(key, value)  # type: ignore[func-returns-value]
+        ref: Optional[Union[bool, GeCloudResourceRef]] = super().set(key, value)
         if ref and isinstance(ref, GeCloudResourceRef):
             key.ge_cloud_id = ref.ge_cloud_id  # type: ignore[attr-defined]
 
@@ -182,7 +182,7 @@ class DatasourceStore(Store):
             # configs and can be refactored (e.g. into `get()`)
             return_value.name = key.resource_name
 
-        return return_value  # type: ignore[return-value]
+        return return_value
 
     def update_by_name(
         self, datasource_name: str, datasource_config: DatasourceConfig

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -16,7 +16,7 @@ from great_expectations.exceptions import StoreBackendError
 from great_expectations.util import bidict, filter_properties_dict, hyphen
 
 try:
-    from typing import TypedDict  # type: ignore[attr-defined]
+    from typing import TypedDict
 except ImportError:
     from typing_extensions import TypedDict
 
@@ -530,7 +530,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
                 f"Unable to delete object in GE Cloud Store Backend: {e}"
             )
 
-    def _has_key(self, key: Tuple[str, ...]) -> bool:  # type: ignore[override]
+    def _has_key(self, key: Tuple[str, ...]) -> bool:
         # Due to list_keys being inconsistently sized (due to the possible of resource names),
         # we remove any resource names and assert against key ids.
 

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -18,7 +18,7 @@ class ProfilerStore(ConfigurationStore):
     A ProfilerStore manages Profilers for the DataContext.
     """
 
-    _configuration_class = RuleBasedProfilerConfig  # type: ignore[assignment]
+    _configuration_class = RuleBasedProfilerConfig
 
     def serialization_self_check(self, pretty_print: bool) -> None:
         """

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -859,7 +859,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         return gcs_object_key
 
     def _move(self, source_key, dest_key, **kwargs) -> None:
-        from google.cloud import storage  # type: ignore
+        from google.cloud import storage
 
         gcs = storage.Client(project=self.project)
         bucket = gcs.bucket(self.bucket)

--- a/great_expectations/data_context/store/tuple_store_backend.py
+++ b/great_expectations/data_context/store/tuple_store_backend.py
@@ -878,7 +878,7 @@ class TupleGCSStoreBackend(TupleStoreBackend):
         # Note that the prefix arg is only included to maintain consistency with the parent class signature
         key_list = []
 
-        from google.cloud import storage  # type: ignore
+        from google.cloud import storage
 
         gcs = storage.Client(self.project)
 
@@ -1002,7 +1002,7 @@ class TupleAzureBlobStoreBackend(TupleStoreBackend):
         self.container = container
         self.account_url = account_url or os.environ.get("AZURE_STORAGE_ACCOUNT_URL")
 
-    @property  # type: ignore[misc] # Decorated property not supported
+    @property
     @functools.lru_cache()
     def _container_client(self) -> Any:
 

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -95,7 +95,7 @@ class ValidationsStore(Store):
     --ge-feature-maturity-info--
     """
 
-    _key_class = ValidationResultIdentifier  # type: ignore[assignment]
+    _key_class: type = ValidationResultIdentifier
 
     def __init__(
         self, store_backend=None, runtime_environment=None, store_name=None

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -40,7 +40,7 @@ from great_expectations.util import deep_filter_properties_iterable
 try:
     from pyspark.sql.types import StructType
 except ImportError:
-    StructType = None  # type: ignore
+    StructType = None
 
 if TYPE_CHECKING:
     from io import TextIOWrapper
@@ -62,7 +62,7 @@ DEFAULT_USAGE_STATISTICS_URL = (
 )
 
 
-def object_to_yaml_str(obj):  # type: ignore[no-untyped-def]
+def object_to_yaml_str(obj):
     output_str: str
     with StringIO() as string_stream:
         yaml.dump(obj, string_stream)
@@ -153,16 +153,16 @@ class BaseYamlConfig(SerializableDictDot):
         return self._get_schema_validated_updated_commented_map()
 
     @classmethod
-    def get_config_class(cls):  # type: ignore[no-untyped-def]
+    def get_config_class(cls):
         raise NotImplementedError
 
     @classmethod
-    def get_schema_class(cls):  # type: ignore[no-untyped-def]
+    def get_schema_class(cls):
         raise NotImplementedError
 
 
 class SorterConfig(DictDot):
-    def __init__(  # type: ignore[no-untyped-def]
+    def __init__(
         self,
         name,
         class_name=None,
@@ -194,35 +194,35 @@ class SorterConfig(DictDot):
             self._datetime_format = datetime_format
 
     @property
-    def name(self):  # type: ignore[no-untyped-def]
+    def name(self):
         return self._name
 
     @property
-    def module_name(self):  # type: ignore[no-untyped-def]
+    def module_name(self):
         return self._module_name
 
     @property
-    def class_name(self):  # type: ignore[no-untyped-def]
+    def class_name(self):
         return self._class_name
 
     @property
-    def orderby(self):  # type: ignore[no-untyped-def]
+    def orderby(self):
         return self._orderby
 
     @property
-    def reference_list(self):  # type: ignore[no-untyped-def]
+    def reference_list(self):
         return self._reference_list
 
     @property
-    def order_keys_by(self):  # type: ignore[no-untyped-def]
+    def order_keys_by(self):
         return self._order_keys_by
 
     @property
-    def key_reference_list(self):  # type: ignore[no-untyped-def]
+    def key_reference_list(self):
         return self._key_reference_list
 
     @property
-    def datetime_format(self):  # type: ignore[no-untyped-def]
+    def datetime_format(self):
         return self._datetime_format
 
 
@@ -422,7 +422,7 @@ class AssetConfigSchema(Schema):
     reader_options = fields.Dict(keys=fields.Str(), required=False, allow_none=True)
 
     @validates_schema
-    def validate_schema(self, data, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def validate_schema(self, data, **kwargs) -> None:
         pass
 
     @pre_dump
@@ -448,7 +448,7 @@ class AssetConfigSchema(Schema):
 
     # noinspection PyUnusedLocal
     @post_load
-    def make_asset_config(self, data, **kwargs):  # type: ignore[no-untyped-def]
+    def make_asset_config(self, data, **kwargs):
         return AssetConfig(**data)
 
 
@@ -1621,7 +1621,7 @@ class DataContextConfigSchema(Schema):
                 data.pop(key)
         return data
 
-    def handle_error(self, exc, data, **kwargs) -> None:  # type: ignore[override]
+    def handle_error(self, exc, data, **kwargs) -> None:
         """Log and raise our custom exception when (de)serialization fails."""
         if (
             exc
@@ -2378,11 +2378,11 @@ class DataContextConfig(BaseYamlConfig):
 
     # TODO: <Alex>ALEX (we still need the next two properties)</Alex>
     @classmethod
-    def get_config_class(cls):  # type: ignore[no-untyped-def]
+    def get_config_class(cls):
         return cls  # DataContextConfig
 
     @classmethod
-    def get_schema_class(cls):  # type: ignore[no-untyped-def]
+    def get_schema_class(cls):
         return DataContextConfigSchema
 
     @property
@@ -2461,7 +2461,7 @@ class CheckpointValidationConfigSchema(AbstractConfigSchema):
 
     id = fields.String(required=False, allow_none=False)
 
-    def dump(self, obj: dict, *, many: Optional[bool] = None) -> dict:  # type: ignore[override]
+    def dump(self, obj: dict, *, many: Optional[bool] = None) -> dict:
         """
         Chetan - 20220803 - By design, Marshmallow accepts unknown fields through the
         `unknown = INCLUDE` directive but only upon load. When dumping, it validates
@@ -2696,11 +2696,11 @@ class CheckpointConfig(BaseYamlConfig):
 
     # TODO: <Alex>ALEX (we still need the next two properties)</Alex>
     @classmethod
-    def get_config_class(cls):  # type: ignore[no-untyped-def]
+    def get_config_class(cls):
         return cls  # CheckpointConfig
 
     @classmethod
-    def get_schema_class(cls):  # type: ignore[no-untyped-def]
+    def get_schema_class(cls):
         return CheckpointConfigSchema
 
     @property

--- a/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_sql_data_connector.py
@@ -218,7 +218,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
 
                 tables.append(
                     {
-                        "schema_name": schema_name,  # type: ignore[dict-item]
+                        "schema_name": schema_name,
                         "table_name": table_name,
                         "type": "table",
                     }
@@ -241,7 +241,7 @@ class InferredAssetSqlDataConnector(ConfiguredAssetSqlDataConnector):
 
                         tables.append(
                             {
-                                "schema_name": schema_name,  # type: ignore[dict-item]
+                                "schema_name": schema_name,
                                 "table_name": view_name,
                                 "type": "view",
                             }

--- a/great_expectations/render/__init__.py
+++ b/great_expectations/render/__init__.py
@@ -263,7 +263,7 @@ class RenderedAtomicContent(RenderedContent):
 
 class RenderedAtomicContentSchema(Schema):
     class Meta:
-        unknown: INCLUDE  # type: ignore[valid-type]
+        unknown: INCLUDE
 
     name = fields.String(required=False, allow_none=True)
     value = fields.Nested(RenderedAtomicValueSchema(), required=True, allow_none=False)

--- a/great_expectations/render/renderer/inline_renderer.py
+++ b/great_expectations/render/renderer/inline_renderer.py
@@ -19,7 +19,7 @@ from great_expectations.render.exceptions import InvalidRenderedContentError
 from great_expectations.render.renderer.renderer import Renderer
 
 try:
-    from typing import TypedDict  # type: ignore[attr-defined]
+    from typing import TypedDict
 except ImportError:
     from typing_extensions import TypedDict
 

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -204,14 +204,14 @@ except ImportError:
             from collections import namedtuple
 
             BigQueryTypes = namedtuple("BigQueryTypes", sorted(sqla_bigquery._type_map))  # type: ignore[misc]
-            bigquery_types_tuple = BigQueryTypes(**sqla_bigquery._type_map)  # type: ignore[assignment]
+            bigquery_types_tuple = BigQueryTypes(**sqla_bigquery._type_map)
             BIGQUERY_TYPES = {}
 
     except (ImportError, AttributeError):
         sqla_bigquery = None
-        bigquery_types_tuple = None  # type: ignore[assignment]
+        bigquery_types_tuple = None
         BigQueryDialect = None
-        pybigquery = None  # type: ignore[var-annotated]
+        pybigquery = None
         BIGQUERY_TYPES = {}
 
 

--- a/great_expectations/types/__init__.py
+++ b/great_expectations/types/__init__.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 try:
     import pyspark
 except ImportError:
-    pyspark = None  # type: ignore
+    pyspark = None
     logger.debug(
         "Unable to load pyspark; install optional spark dependency if you will be working with Spark dataframes"
     )

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -76,7 +76,7 @@ except ImportError:
 try:
     import black
 except ImportError:
-    black = None  # type: ignore[assignment]
+    black = None
 
 try:
     # This library moved in python 3.8
@@ -364,7 +364,7 @@ def verify_dynamic_loading_support(
     """
     try:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[assignment,attr-defined]
+        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(
             module_name, package=package_name
         )
     except ModuleNotFoundError:
@@ -1514,8 +1514,8 @@ def isclose(
     return cast(
         bool,
         np.isclose(
-            a=np.float64(operand_a),  # type: ignore[arg-type]
-            b=np.float64(operand_b),  # type: ignore[arg-type]
+            a=np.float64(operand_a),
+            b=np.float64(operand_b),
             rtol=rtol,
             atol=atol,
             equal_nan=equal_nan,
@@ -1926,14 +1926,14 @@ def numpy_quantile(
     """
     quantile: np.ndarray
     if version.parse(np.__version__) >= version.parse("1.22.0"):
-        quantile = np.quantile(  # type: ignore[call-arg,call-overload]
+        quantile = np.quantile(
             a=a,
             q=q,
             axis=axis,
             method=method,
         )
     else:
-        quantile = np.quantile(  # type: ignore[call-overload]
+        quantile = np.quantile(
             a=a,
             q=q,
             axis=axis,

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -364,7 +364,7 @@ def verify_dynamic_loading_support(
     """
     try:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(
+        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[attr-defined]
             module_name, package=package_name
         )
     except ModuleNotFoundError:

--- a/great_expectations/zep/context.py
+++ b/great_expectations/zep/context.py
@@ -100,7 +100,7 @@ class _SourceFactories:
 
         cls.type_lookup[ds_type] = simplified_name
         LOGGER.debug(f"'{simplified_name}' added to `type_lookup`")
-        cls.__source_factories[method_name] = fn  # type: ignore[assignment]
+        cls.__source_factories[method_name] = fn
 
     @property
     def factories(self) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ files = [
     # "contrib" # ignore entire `contrib` package
     ]
 warn_unused_configs = true
-warn_unused_ignores = true
 ignore_missing_imports = true
 # TODO: change this to 'normal' once we have 'full' type coverage
 follow_imports = 'silent'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ files = [
     # "contrib" # ignore entire `contrib` package
     ]
 warn_unused_configs = true
+warn_unused_ignores = true
 ignore_missing_imports = true
 # TODO: change this to 'normal' once we have 'full' type coverage
 follow_imports = 'silent'

--- a/tasks.py
+++ b/tasks.py
@@ -139,7 +139,7 @@ def type_check(
     packages,
     install_types=False,
     pretty=False,
-    warn_unused_ignore=False,
+    warn_unused_ignores=False,
     daemon=False,
     clear_cache=False,
     report=False,
@@ -173,8 +173,8 @@ def type_check(
         cmds.extend(["--txt-report", "type_cov", "--html-report", "type_cov"])
     if pretty:
         cmds.extend(["--pretty"])
-    if warn_unused_ignore:
-        cmds.extend(["--warn-unsused-ignore"])
+    if warn_unused_ignores:
+        cmds.extend(["--warn-unused-ignores"])
     # use pseudo-terminal for colorized output
     ctx.run(" ".join(cmds), echo=True, pty=True)
 

--- a/tasks.py
+++ b/tasks.py
@@ -139,6 +139,7 @@ def type_check(
     packages,
     install_types=False,
     pretty=False,
+    warn_unused_ignore=False,
     daemon=False,
     clear_cache=False,
     report=False,
@@ -172,6 +173,8 @@ def type_check(
         cmds.extend(["--txt-report", "type_cov", "--html-report", "type_cov"])
     if pretty:
         cmds.extend(["--pretty"])
+    if warn_unused_ignore:
+        cmds.extend(["--warn-unsused-ignore"])
     # use pseudo-terminal for colorized output
     ctx.run(" ".join(cmds), echo=True, pty=True)
 

--- a/tasks.py
+++ b/tasks.py
@@ -138,6 +138,7 @@ def type_check(
     ctx,
     packages,
     install_types=False,
+    pretty=False,
     daemon=False,
     clear_cache=False,
     report=False,
@@ -169,6 +170,8 @@ def type_check(
         cmds.extend(["--follow-imports=normal"])
     if report:
         cmds.extend(["--txt-report", "type_cov", "--html-report", "type_cov"])
+    if pretty:
+        cmds.extend(["--pretty"])
     # use pseudo-terminal for colorized output
     ctx.run(" ".join(cmds), echo=True, pty=True)
 


### PR DESCRIPTION
Changes proposed in this pull request:
- ~update `mypy` config setting `warn_unused_ignores = true`~
  - https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_unused_ignores
- pass `--warn-unused-ignores` as CLI arg in CI
- remove unused ignores
- update `scope_change` rules to consider changes to `setup.cfg` and `pyproject.toml`

I've opted to pass `--warn-unused-ignores` as a CLI argument for our type-checking step instead of making the change in the config. This is because devs could get different `unused-ignore` errors based on their version of python and the installed dependencies and lead to a fair amount of churn where they remove ignores they are seeing locally, only to add them back when the CI complains. Open to any objections, there are some trade-offs to consider here.

As follow-up PR I plan to add a `invoke type-check --ci` flag that devs can use if they want to always ensure they are running the type-checker with the exact parameters as the CI step.

