### PR TITLE
[MAINTENANCE] Clean up implicit `Optional` errors flagged by `mypy`

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -55,7 +55,7 @@ class ValidationAction:
             ValidationResultIdentifier, GeCloudIdentifier
         ],
         data_asset,
-        expectation_suite_identifier: ExpectationSuiteIdentifier = None,
+        expectation_suite_identifier: Optional[ExpectationSuiteIdentifier] = None,
         checkpoint_identifier=None,
         **kwargs,
     ):

--- a/great_expectations/checkpoint/types/checkpoint_result.py
+++ b/great_expectations/checkpoint/types/checkpoint_result.py
@@ -205,7 +205,7 @@ class CheckpointResult(SerializableDictDot):
         return self._validation_results_by_data_asset_name
 
     def list_data_assets_validated(
-        self, group_by: str = None
+        self, group_by: Optional[str] = None
     ) -> Union[List[dict], dict]:
         if group_by is None:
             if self._data_assets_validated is None:

--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -342,7 +342,7 @@ def load_checkpoint(
 
 
 def select_datasource(
-    context: DataContext, datasource_name: str = None
+    context: DataContext, datasource_name: Optional[str] = None
 ) -> BaseDatasource:
     """Select a datasource interactively."""
     # TODO consolidate all the myriad CLI tests into this

--- a/great_expectations/cli/util.py
+++ b/great_expectations/cli/util.py
@@ -15,7 +15,9 @@ from great_expectations.util import import_library_module, is_library_loadable
 
 
 def verify_library_dependent_modules(
-    python_import_name: str, pip_library_name: str, module_names_to_reload: list = None
+    python_import_name: str,
+    pip_library_name: str,
+    module_names_to_reload: Optional[list] = None,
 ) -> bool:
     library_status_code: Optional[int]
 

--- a/great_expectations/cli/v012/toolkit.py
+++ b/great_expectations/cli/v012/toolkit.py
@@ -381,7 +381,9 @@ def load_checkpoint(
         exit_with_failure_message_and_stats(context, usage_event, f"<red>{e}</red>")
 
 
-def select_datasource(context: DataContext, datasource_name: str = None) -> Datasource:
+def select_datasource(
+    context: DataContext, datasource_name: Optional[str] = None
+) -> Datasource:
     """Select a datasource interactively."""
     # TODO consolidate all the myriad CLI tests into this
     data_source = None

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -123,7 +123,9 @@ CLI_ONLY_SQLALCHEMY_ORDERED_DEPENDENCY_MODULE_NAMES: list = [
 
 
 def verify_library_dependent_modules(
-    python_import_name: str, pip_library_name: str, module_names_to_reload: list = None
+    python_import_name: str,
+    pip_library_name: str,
+    module_names_to_reload: Optional[list] = None,
 ) -> bool:
     library_status_code: Optional[int]
 

--- a/great_expectations/core/batch.py
+++ b/great_expectations/core/batch.py
@@ -532,9 +532,9 @@ class Batch(SerializableDictDot):
         self,
         data: BatchDataType,
         batch_request: Optional[Union[BatchRequestBase, dict]] = None,
-        batch_definition: BatchDefinition = None,
-        batch_spec: BatchSpec = None,
-        batch_markers: BatchMarkers = None,
+        batch_definition: Optional[BatchDefinition] = None,
+        batch_spec: Optional[BatchSpec] = None,
+        batch_markers: Optional[BatchMarkers] = None,
         # The remaining parameters are for backward compatibility.
         data_context=None,
         datasource_name=None,

--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1396,8 +1396,8 @@ class ExpectationConfiguration(SerializableDictDot):
     def metrics_validate(
         self,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
         **kwargs: dict,
     ):
         expectation_impl: Expectation = self._get_expectation_impl()

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -72,13 +72,13 @@ class ExpectationSuite(SerializableDictDot):
     def __init__(
         self,
         expectation_suite_name: str,
-        data_context: "AbstractDataContext" = None,
-        expectations: List[Union[dict, ExpectationConfiguration]] = None,
-        evaluation_parameters: dict = None,
-        data_asset_type: str = None,
-        execution_engine_type: Type["ExecutionEngine"] = None,
-        meta: dict = None,
-        ge_cloud_id: str = None,
+        data_context: Optional[AbstractDataContext] = None,
+        expectations: Optional[List[Union[dict, ExpectationConfiguration]]] = None,
+        evaluation_parameters: Optional[dict] = None,
+        data_asset_type: Optional[str] = None,
+        execution_engine_type: Optional[Type[ExecutionEngine]] = None,
+        meta: Optional[dict] = None,
+        ge_cloud_id: Optional[str] = None,
     ) -> None:
         self.expectation_suite_name = expectation_suite_name
         self.ge_cloud_id = ge_cloud_id
@@ -375,7 +375,7 @@ class ExpectationSuite(SerializableDictDot):
         self,
         expectation_configuration: Optional[ExpectationConfiguration] = None,
         match_type: str = "domain",
-        ge_cloud_id: str = None,
+        ge_cloud_id: Optional[str] = None,
     ) -> List[int]:
         """
         Find indexes of Expectations matching the given ExpectationConfiguration on the given match_type.

--- a/great_expectations/data_context/config_validator/yaml_config_validator.py
+++ b/great_expectations/data_context/config_validator/yaml_config_validator.py
@@ -48,7 +48,7 @@ try:
     from typing import Literal
 except ImportError:
     # Fallback for python < 3.8
-    from typing_extensions import Literal  # type: ignore[misc]
+    from typing_extensions import Literal  # type: ignore[assignment]
 
 # TODO: check if this can be refactored to use YAMLHandler class
 yaml = YAML()

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -29,7 +29,7 @@ try:
     from typing import Literal
 except ImportError:
     # Fallback for python < 3.8
-    from typing_extensions import Literal  # type: ignore[misc]
+    from typing_extensions import Literal  # type: ignore[assignment]
 
 from dateutil.parser import parse
 from ruamel.yaml.comments import CommentedMap

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -197,7 +197,7 @@ class Store:
         # Chetan - 20220831 - Explicit fork in logic to cover legacy behavior (particularly around Checkpoints).
         # Will be removed as part of the effort to rename `ge_cloud_id` to `id` across the codebase.
         if hasattr(config, "ge_cloud_id"):
-            id = config.ge_cloud_id  # type: ignore[attr-defined]
+            id = config.ge_cloud_id
         if hasattr(config, "id"):
             id = config.id
 

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -1838,9 +1838,9 @@ class BaseStoreBackendDefaults(DictDot):
         checkpoint_store_name: str = DataContextConfigDefaults.DEFAULT_CHECKPOINT_STORE_NAME.value,
         profiler_store_name: str = DataContextConfigDefaults.DEFAULT_PROFILER_STORE_NAME.value,
         data_docs_site_name: str = DataContextConfigDefaults.DEFAULT_DATA_DOCS_SITE_NAME.value,
-        validation_operators: dict = None,
-        stores: dict = None,
-        data_docs_sites: dict = None,
+        validation_operators: Optional[dict] = None,
+        stores: Optional[dict] = None,
+        data_docs_sites: Optional[dict] = None,
     ) -> None:
         self.expectations_store_name = expectations_store_name
         self.validations_store_name = validations_store_name

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -67,7 +67,7 @@ class BatchIdentifier(DataContextKey):
     def __init__(
         self,
         batch_identifier: Union[BatchKwargs, dict, str],
-        data_asset_name: str = None,
+        data_asset_name: Optional[str] = None,
     ) -> None:
         super().__init__()
         # if isinstance(batch_identifier, (BatchKwargs, dict)):

--- a/great_expectations/datasource/data_connector/batch_filter.py
+++ b/great_expectations/datasource/data_connector/batch_filter.py
@@ -146,10 +146,10 @@ class BatchFilter:
 
     def __init__(
         self,
-        custom_filter_function: Callable = None,
+        custom_filter_function: Optional[Callable] = None,
         batch_filter_parameters: Optional[IDDict] = None,
         index: Optional[Union[int, slice]] = None,
-        limit: int = None,
+        limit: Optional[int] = None,
     ) -> None:
         self._custom_filter_function = custom_filter_function
         self._batch_filter_parameters = batch_filter_parameters

--- a/great_expectations/datasource/data_connector/batch_filter.py
+++ b/great_expectations/datasource/data_connector/batch_filter.py
@@ -158,7 +158,7 @@ class BatchFilter:
 
     @property
     def custom_filter_function(self) -> Optional[Callable]:
-        return self._custom_filter_function  # type: ignore[return-value]
+        return self._custom_filter_function
 
     @property
     def batch_filter_parameters(self) -> Optional[IDDict]:

--- a/great_expectations/datasource/data_connector/batch_filter.py
+++ b/great_expectations/datasource/data_connector/batch_filter.py
@@ -42,7 +42,7 @@ def build_batch_filter(
 "{str(data_connector_query_keys - BatchFilter.RECOGNIZED_KEYS)}" detected.
             """
         )
-    custom_filter_function: Callable = data_connector_query_dict.get(  # type: ignore[assignment]
+    custom_filter_function: Optional[Callable] = data_connector_query_dict.get(  # type: ignore[assignment]
         "custom_filter_function"
     )
     if custom_filter_function and not isinstance(custom_filter_function, Callable):  # type: ignore[arg-type]
@@ -157,7 +157,7 @@ class BatchFilter:
         self._limit = limit
 
     @property
-    def custom_filter_function(self) -> Callable:
+    def custom_filter_function(self) -> Optional[Callable]:
         return self._custom_filter_function  # type: ignore[return-value]
 
     @property

--- a/great_expectations/datasource/data_connector/configured_asset_aws_glue_data_catalog_data_connector.py
+++ b/great_expectations/datasource/data_connector/configured_asset_aws_glue_data_catalog_data_connector.py
@@ -354,7 +354,7 @@ class ConfiguredAssetAWSGlueDataCatalogDataConnector(DataConnector):
         return data_asset_name
 
     def _map_data_reference_to_batch_definition_list(
-        self, data_reference, data_asset_name: str = None
+        self, data_reference, data_asset_name: Optional[str] = None
     ) -> Optional[List[BatchDefinition]]:
         # Note: data references *are* dictionaries, allowing us to invoke `IDDict(data_reference)`
         return [

--- a/great_expectations/datasource/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/data_connector/file_path_data_connector.py
@@ -213,7 +213,7 @@ class FilePathDataConnector(DataConnector):
         return batch_definition_list
 
     def _map_data_reference_to_batch_definition_list(
-        self, data_reference: str, data_asset_name: str = None
+        self, data_reference: str, data_asset_name: Optional[str] = None
     ) -> Optional[List[BatchDefinition]]:
         regex_config: dict = self._get_regex_config(data_asset_name=data_asset_name)
         pattern: str = regex_config["pattern"]

--- a/great_expectations/datasource/data_connector/inferred_asset_aws_glue_data_catalog_data_connector.py
+++ b/great_expectations/datasource/data_connector/inferred_asset_aws_glue_data_catalog_data_connector.py
@@ -138,7 +138,7 @@ class InferredAssetAWSGlueDataCatalogDataConnector(
             for db in page["DatabaseList"]:
                 yield db["Name"]
 
-    def _introspect_catalog(self, database_name: str = None) -> List[dict]:
+    def _introspect_catalog(self, database_name: Optional[str] = None) -> List[dict]:
         paginator = self.glue_client.get_paginator("get_tables")
         paginator_kwargs = self._get_glue_paginator_kwargs()
 

--- a/great_expectations/datasource/data_connector/sorter/custom_list_sorter.py
+++ b/great_expectations/datasource/data_connector/sorter/custom_list_sorter.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, List
+from typing import Any, List, Optional
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import BatchDefinition
@@ -16,7 +16,10 @@ class CustomListSorter(Sorter):
     """
 
     def __init__(
-        self, name: str, orderby: str = "asc", reference_list: List[str] = None
+        self,
+        name: str,
+        orderby: str = "asc",
+        reference_list: Optional[List[str]] = None,
     ) -> None:
         super().__init__(name=name, orderby=orderby)
 
@@ -25,7 +28,9 @@ class CustomListSorter(Sorter):
         )
 
     @staticmethod
-    def _validate_reference_list(reference_list: List[str] = None) -> List[str]:
+    def _validate_reference_list(
+        reference_list: Optional[List[str]] = None,
+    ) -> List[str]:
         if not (reference_list and isinstance(reference_list, list)):
             raise ge_exceptions.SorterError(
                 "CustomListSorter requires reference_list which was not provided."

--- a/great_expectations/datasource/simple_sqlalchemy_datasource.py
+++ b/great_expectations/datasource/simple_sqlalchemy_datasource.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from typing import Optional
 
 from great_expectations.datasource.data_connector.configured_asset_sql_data_connector import (
     ConfiguredAssetSqlDataConnector,
@@ -24,12 +25,12 @@ class SimpleSqlalchemyDatasource(BaseDatasource):
     def __init__(
         self,
         name: str,
-        connection_string: str = None,
-        url: str = None,
-        credentials: dict = None,
+        connection_string: Optional[str] = None,
+        url: Optional[str] = None,
+        credentials: Optional[dict] = None,
         engine=None,  # sqlalchemy.engine.Engine
-        introspection: dict = None,
-        tables: dict = None,
+        introspection: Optional[dict] = None,
+        tables: Optional[dict] = None,
         **kwargs
     ) -> None:
         introspection = introspection or {}

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -443,9 +443,9 @@ not {batch_spec.__class__.__name__}"""
                 f'Unable to find reader_method "{reader_method}" in pandas.'
             )
 
-    def resolve_metric_bundle(
+    def resolve_metric_bundle(  # type: ignore[empty-body]
         self, metric_fn_bundle
-    ) -> Dict[Tuple[str, str, str], Any]:  # type: ignore[empty-body]
+    ) -> Dict[Tuple[str, str, str], Any]:
         """Resolve a bundle of metrics with the same compute domain as part of a single trip to the compute engine."""
         pass  # This method is NO-OP for PandasExecutionEngine (no bundling for direct execution computational backend).
 

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -445,7 +445,7 @@ not {batch_spec.__class__.__name__}"""
 
     def resolve_metric_bundle(
         self, metric_fn_bundle
-    ) -> Dict[Tuple[str, str, str], Any]:
+    ) -> Dict[Tuple[str, str, str], Any]:  # type: ignore[empty-body]
         """Resolve a bundle of metrics with the same compute domain as part of a single trip to the compute engine."""
         pass  # This method is NO-OP for PandasExecutionEngine (no bundling for direct execution computational backend).
 

--- a/great_expectations/execution_engine/sqlalchemy_batch_data.py
+++ b/great_expectations/execution_engine/sqlalchemy_batch_data.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from great_expectations.core.batch import BatchData
 from great_expectations.execution_engine.sqlalchemy_dialect import GESqlDialect
@@ -25,19 +26,19 @@ class SqlAlchemyBatchData(BatchData):
     def __init__(
         self,
         execution_engine,
-        record_set_name: str = None,
+        record_set_name: Optional[str] = None,
         # Option 1
-        schema_name: str = None,
-        table_name: str = None,
+        schema_name: Optional[str] = None,
+        table_name: Optional[str] = None,
         # Option 2
-        query: str = None,
+        query: Optional[str] = None,
         # Option 3
         selectable=None,
         create_temp_table: bool = True,
-        temp_table_schema_name: str = None,
+        temp_table_schema_name: Optional[str] = None,
         use_quoted_name: bool = False,
-        source_schema_name: str = None,
-        source_table_name: str = None,
+        source_schema_name: Optional[str] = None,
+        source_table_name: Optional[str] = None,
     ) -> None:
         """A Constructor used to initialize and SqlAlchemy Batch, create an id for it, and verify that all necessary
         parameters have been provided. If a Query is given, also builds a temporary table for this query

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_be_in_set.py
@@ -380,8 +380,8 @@ class ExpectColumnDistinctValuesToBeInSet(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         parse_strings_as_datetimes = self.get_success_kwargs(configuration).get(
             "parse_strings_as_datetimes"

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -223,8 +223,8 @@ class ExpectColumnDistinctValuesToContainSet(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         parse_strings_as_datetimes = self.get_success_kwargs(configuration).get(
             "parse_strings_as_datetimes"

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -261,8 +261,8 @@ class ExpectColumnDistinctValuesToEqualSet(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         parse_strings_as_datetimes = self.get_success_kwargs(configuration).get(
             "parse_strings_as_datetimes"

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -357,8 +357,8 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         bucketize_data = configuration.kwargs.get(
             "bucketize_data", self.default_kwarg_values["bucketize_data"]

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -403,8 +403,8 @@ class ExpectColumnMaxToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.max",

--- a/great_expectations/expectations/core/expect_column_mean_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_mean_to_be_between.py
@@ -441,8 +441,8 @@ class ExpectColumnMeanToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.mean",

--- a/great_expectations/expectations/core/expect_column_median_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_median_to_be_between.py
@@ -362,8 +362,8 @@ class ExpectColumnMedianToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.median",

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -405,8 +405,8 @@ class ExpectColumnMinToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.min",

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -258,8 +258,8 @@ class ExpectColumnMostCommonValueToBeInSet(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         most_common_value = metrics.get("column.most_common_value")
         value_set = configuration.kwargs.get("value_set") or []

--- a/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_proportion_of_unique_values_to_be_between.py
@@ -415,8 +415,8 @@ class ExpectColumnProportionOfUniqueValuesToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.unique_proportion",

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -734,8 +734,8 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         quantile_vals = metrics.get("column.quantile_values")
         quantile_ranges = configuration.kwargs.get("quantile_ranges")

--- a/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_stdev_to_be_between.py
@@ -365,8 +365,8 @@ class ExpectColumnStdevToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.standard_deviation",

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -360,8 +360,8 @@ class ExpectColumnSumToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.sum",

--- a/great_expectations/expectations/core/expect_column_to_exist.py
+++ b/great_expectations/expectations/core/expect_column_to_exist.py
@@ -201,8 +201,8 @@ class ExpectColumnToExist(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         actual_columns = metrics.get("table.columns")
         expected_column_name = self.get_success_kwargs().get("column")

--- a/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_unique_value_count_to_be_between.py
@@ -419,8 +419,8 @@ class ExpectColumnUniqueValueCountToBeBetween(ColumnExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="column.distinct_values.count",

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -377,10 +377,10 @@ class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: ExpectationConfiguration = None,
-        result: ExpectationValidationResult = None,
-        language: str = None,
-        runtime_configuration: dict = None,
+        configuration: Optional[ExpectationConfiguration] = None,
+        result: Optional[ExpectationValidationResult] = None,
+        language: Optional[str] = None,
+        runtime_configuration: Optional[dict] = None,
         **kwargs,
     ) -> List[
         Union[

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -540,8 +540,8 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         column_name = configuration.kwargs.get("column")
         expected_types_list = configuration.kwargs.get("type_list")

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -245,8 +245,8 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format = self.get_result_format(
             configuration=configuration, runtime_configuration=runtime_configuration

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -518,8 +518,8 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         column_name = configuration.kwargs.get("column")
         expected_type = configuration.kwargs.get("type_")

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -319,7 +319,7 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
         metrics: Dict,
         metric_domain_kwargs: Dict,
         metric_value_kwargs: Dict,
-        runtime_configuration: dict = None,
+        runtime_configuration: Optional[dict] = None,
         filter_column_isnull: bool = True,
     ):
         value_set = metric_value_kwargs["value_set"]

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -309,8 +309,8 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format = self.get_result_format(
             configuration=configuration, runtime_configuration=runtime_configuration

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -204,8 +204,8 @@ class ExpectTableColumnCountToBeBetween(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="table.column_count",

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -163,8 +163,8 @@ class ExpectTableColumnCountToEqual(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         expected_column_count = configuration.kwargs.get("value")
         actual_column_count = metrics.get("table.column_count")

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -204,8 +204,8 @@ class ExpectTableColumnsToMatchOrderedList(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         # Obtaining columns and ordered list for sake of comparison
         expected_column_list = self.get_success_kwargs(configuration).get("column_list")

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -274,8 +274,8 @@ class ExpectTableColumnsToMatchSet(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         # Obtaining columns and ordered list for sake of comparison
         expected_column_set = self.get_success_kwargs(configuration).get("column_set")

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -299,8 +299,8 @@ class ExpectTableRowCountToBeBetween(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         return self._validate_metric_value_between(
             metric_name="table.row_count",

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -171,8 +171,8 @@ class ExpectTableRowCountToEqual(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         expected_table_row_count = self.get_success_kwargs().get("value")
         actual_table_row_count = metrics.get("table.row_count")

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -195,8 +195,8 @@ class ExpectTableRowCountToEqualOtherTable(TableExpectation):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
-        execution_engine: ExecutionEngine = None,
+        runtime_configuration: Optional[dict] = None,
+        execution_engine: Optional[ExecutionEngine] = None,
     ):
         table_row_count_self = metrics["table.row_count.self"]
         table_row_count_other = metrics["table.row_count.other"]

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -964,7 +964,7 @@ class Expectation(metaclass=MetaExpectation):
     def get_runtime_kwargs(
         self,
         configuration: Optional[ExpectationConfiguration] = None,
-        runtime_configuration: dict = None,
+        runtime_configuration: Optional[dict] = None,
     ) -> dict:
         if not configuration:
             configuration = self.configuration
@@ -990,7 +990,7 @@ class Expectation(metaclass=MetaExpectation):
     def get_result_format(
         self,
         configuration: ExpectationConfiguration,
-        runtime_configuration: dict = None,
+        runtime_configuration: Optional[dict] = None,
     ) -> Union[Dict[str, Union[str, int, bool]], str]:
         default_result_format: Optional[Any] = self.default_kwarg_values.get(
             "result_format"
@@ -2317,7 +2317,7 @@ class ColumnMapExpectation(TableExpectation, ABC):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
+        runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format: Union[
@@ -2537,7 +2537,7 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
         self,
         configuration: ExpectationConfiguration,
         metrics: Dict,
-        runtime_configuration: dict = None,
+        runtime_configuration: Optional[dict] = None,
         execution_engine: Optional[ExecutionEngine] = None,
     ):
         result_format: Union[

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 def column_function_partial(
     engine: Type[ExecutionEngine],
-    partial_fn_type: str = None,
+    partial_fn_type: Optional[str] = None,
     **kwargs,
 ):
     """Provides engine-specific support for authoring a metric_fn with a simplified signature.
@@ -510,7 +510,7 @@ def column_condition_partial(
 
 
 def column_pair_function_partial(
-    engine: Type[ExecutionEngine], partial_fn_type: str = None, **kwargs
+    engine: Type[ExecutionEngine], partial_fn_type: Optional[str] = None, **kwargs
 ):
     """Provides engine-specific support for authoring a metric_fn with a simplified signature.
 
@@ -946,7 +946,7 @@ def column_pair_condition_partial(
 
 
 def multicolumn_function_partial(
-    engine: Type[ExecutionEngine], partial_fn_type: str = None, **kwargs
+    engine: Type[ExecutionEngine], partial_fn_type: Optional[str] = None, **kwargs
 ):
     """Provides engine-specific support for authoring a metric_fn with a simplified signature.
 

--- a/great_expectations/expectations/registry.py
+++ b/great_expectations/expectations/registry.py
@@ -346,7 +346,7 @@ def get_expectation_impl(expectation_name: str):
 
 
 def list_registered_expectation_implementations(
-    expectation_root: Type[Expectation] = None,
+    expectation_root: Optional[Type[Expectation]] = None,
 ) -> List[str]:
     registered_expectation_implementations = []
     for (

--- a/great_expectations/profile/json_schema_profiler.py
+++ b/great_expectations/profile/json_schema_profiler.py
@@ -67,7 +67,9 @@ class JsonSchemaProfiler(Profiler):
         validator.check_schema(schema)
         return True
 
-    def _profile(self, schema: Dict, suite_name: str = None) -> ExpectationSuite:
+    def _profile(
+        self, schema: Dict, suite_name: Optional[str] = None
+    ) -> ExpectationSuite:
         if not suite_name:
             raise ValueError("Please provide a suite name when using this profiler.")
         expectations = []

--- a/great_expectations/self_check/util.py
+++ b/great_expectations/self_check/util.py
@@ -1686,7 +1686,7 @@ def build_sa_engine(
 def build_spark_engine(
     spark: SparkSession,
     df: Union[pd.DataFrame, SparkDataFrame],
-    schema: StructType = None,
+    schema: Optional[StructType] = None,
     batch_id: Optional[str] = None,
     batch_definition: Optional[BatchDefinition] = None,
 ) -> SparkDFExecutionEngine:

--- a/great_expectations/validation_operators/types/validation_operator_result.py
+++ b/great_expectations/validation_operators/types/validation_operator_result.py
@@ -43,7 +43,7 @@ class ValidationOperatorResult(DictDot):
             Dict[str, Union[ExpectationSuiteValidationResult, dict, str]],
         ],
         validation_operator_config: dict,
-        evaluation_parameters: dict = None,
+        evaluation_parameters: Optional[dict] = None,
         success: Optional[bool] = None,
     ) -> None:
         self._run_id = run_id
@@ -194,7 +194,7 @@ class ValidationOperatorResult(DictDot):
         return self._validation_results_by_data_asset_name
 
     def list_data_assets_validated(
-        self, group_by: str = None
+        self, group_by: Optional[str] = None
     ) -> Union[List[dict], dict]:
         if group_by is None:
             if self._data_assets_validated is None:

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -1,5 +1,5 @@
 import json
-from typing import Tuple
+from typing import Optional, Tuple
 
 from great_expectations.core.id_dict import IDDict
 from great_expectations.core.util import convert_to_json_serializable

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -10,8 +10,8 @@ class MetricConfiguration:
         self,
         metric_name: str,
         metric_domain_kwargs: dict,
-        metric_value_kwargs: dict = None,
-        metric_dependencies: dict = None,
+        metric_value_kwargs: Optional[dict] = None,
+        metric_dependencies: Optional[dict] = None,
     ) -> None:
         self._metric_name = metric_name
         if not isinstance(metric_domain_kwargs, IDDict):

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1894,8 +1894,8 @@ class Validator:
 
     def _initialize_expectations(
         self,
-        expectation_suite: ExpectationSuite = None,
-        expectation_suite_name: str = None,
+        expectation_suite: Optional[ExpectationSuite] = None,
+        expectation_suite_name: Optional[str] = None,
     ) -> None:
         """Instantiates `_expectation_suite` as empty by default or with a specified expectation `config`.
         In addition, this always sets the `default_expectation_args` to:
@@ -1936,7 +1936,7 @@ class Validator:
                     **expectation_suite_dict, data_context=self._data_context
                 )
             else:
-                expectation_suite: ExpectationSuite = copy.deepcopy(expectation_suite)
+                expectation_suite = copy.deepcopy(expectation_suite)
             self._expectation_suite = expectation_suite
 
             if expectation_suite_name is not None:


### PR DESCRIPTION
Changes proposed in this pull request:
- Misc `mypy` cleanup

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
