### PR TITLE
[DOCS] add `pypi` release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![PyPI](https://img.shields.io/pypi/v/great_expectations)
+[![PyPI](https://img.shields.io/pypi/v/great_expectations)](https://pypi.org/project/great-expectations/#history)
 [![Build Status](https://dev.azure.com/great-expectations/great_expectations/_apis/build/status/great_expectations?branchName=develop&stageName=required)](https://dev.azure.com/great-expectations/great_expectations/_build/latest?definitionId=1&branchName=develop)
 ![Coverage](https://img.shields.io/azure-devops/coverage/great-expectations/great_expectations/1/main)
 [![Documentation Status](https://readthedocs.org/projects/great-expectations/badge/?version=latest)](http://great-expectations.readthedocs.io/en/latest/?badge=latest)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![PyPI](https://img.shields.io/pypi/v/great_expectations)
 [![Build Status](https://dev.azure.com/great-expectations/great_expectations/_apis/build/status/great_expectations?branchName=develop&stageName=required)](https://dev.azure.com/great-expectations/great_expectations/_build/latest?definitionId=1&branchName=develop)
 ![Coverage](https://img.shields.io/azure-devops/coverage/great-expectations/great_expectations/1/main)
 [![Documentation Status](https://readthedocs.org/projects/great-expectations/badge/?version=latest)](http://great-expectations.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
## Changes proposed in this pull request:
- adds a https://shields.io/ pypi release badge which shows the latest `pypi` version and links to the [pypi versions page](https://pypi.org/project/great-expectations/#history).


![image](https://user-images.githubusercontent.com/13108583/200643914-a61c948f-364b-4900-89c0-a7167e94468f.png)


## Branch Readme
https://github.com/great-expectations/great_expectations/blob/pypi-badge/README.md
