### PR TITLE
[BUGFIX] Patch broken `CloudNotificationAction` tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2663,10 +2663,11 @@ def cloud_data_context_with_datasource_pandas_engine(
         "great_expectations.data_context.store.ge_cloud_store_backend.GeCloudStoreBackend.list_keys"
     ), mock.patch(
         "great_expectations.data_context.store.ge_cloud_store_backend.GeCloudStoreBackend._set"
-    ):
+    ), pytest.deprecated_call():
         context.add_datasource(
             "my_datasource",
             **config,
+            save_changes=False,
         )
     return context
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2663,14 +2663,14 @@ def cloud_data_context_with_datasource_pandas_engine(
     # DatasourceStore.set() in a Cloud-back env usually makes an external HTTP request
     # and returns the config it persisted. This side effect enables us to mimick that
     # behavior while avoiding requests.
-    def mock_set_side_effect(key, value):
+    def set_side_effect(key, value):
         return value
 
     with mock.patch(
         "great_expectations.data_context.store.ge_cloud_store_backend.GeCloudStoreBackend.list_keys"
     ), mock.patch(
         "great_expectations.data_context.store.datasource_store.DatasourceStore.set",
-        side_effect=mock_set_side_effect,
+        side_effect=set_side_effect,
     ):
         context.add_datasource(
             "my_datasource",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2659,15 +2659,22 @@ def cloud_data_context_with_datasource_pandas_engine(
                 - default_identifier_name
         """,
     )
+
+    # DatasourceStore.set() in a Cloud-back env usually makes an external HTTP request
+    # and returns the config it persisted. This side effect enables us to mimick that
+    # behavior while avoiding requests.
+    def mock_set_side_effect(key, value):
+        return value
+
     with mock.patch(
         "great_expectations.data_context.store.ge_cloud_store_backend.GeCloudStoreBackend.list_keys"
     ), mock.patch(
-        "great_expectations.data_context.store.ge_cloud_store_backend.GeCloudStoreBackend._set"
-    ), pytest.deprecated_call():
+        "great_expectations.data_context.store.datasource_store.DatasourceStore.set",
+        side_effect=mock_set_side_effect,
+    ):
         context.add_datasource(
             "my_datasource",
             **config,
-            save_changes=False,
         )
     return context
 


### PR DESCRIPTION
Changes proposed in this pull request:
- By removing `save_changes` here, we accidentally make an HTTP request. Adding it back to ensure the build passes.

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
