### PR TITLE
[MAINTENANCE] Update range of allowable sqlalchemy versions

### DIFF
--- a/reqs/requirements-dev-lite.txt
+++ b/reqs/requirements-dev-lite.txt
@@ -13,4 +13,4 @@ pytest-timeout>=2.1.0
 requirements-parser>=0.2.0
 s3fs>=0.5.1
 snapshottest==0.6.0 # GE Cloud atomic renderer tests
-sqlalchemy>=1.3.18,<1.4.42  # pinning sqlalchemy as 1.4.42 until trino-python-client 0.319.0. Change back to <2.0.0 afterwards.
+sqlalchemy>=1.3.18,<2.0.0


### PR DESCRIPTION

Changes proposed in this pull request:
- Update range of allowable sqlalchemy versions since trino 0.319.0 has been released
