### PR TITLE
[BUGFIX] MapMetrics now return `partial_unexpected` values for `SUMMARY` format

### DIFF
--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2292,6 +2292,10 @@ class ColumnMapExpectation(TableExpectation, ABC):
                 metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
             )
 
+        if result_format_str in ["BASIC"]:
+            return dependencies
+
+        # only for SUMMARY and COMPLETE
         if isinstance(execution_engine, PandasExecutionEngine):
             metric_kwargs = get_metric_kwargs(
                 f"{self.map_metric}.unexpected_index_list",

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2278,7 +2278,7 @@ class ColumnMapExpectation(TableExpectation, ABC):
                 metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
             )
 
-        if result_format_str in ["BASIC", "SUMMARY"]:
+        if result_format_str in ["BASIC"]:
             return dependencies
 
         if include_unexpected_rows:

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2278,9 +2278,6 @@ class ColumnMapExpectation(TableExpectation, ABC):
                 metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
             )
 
-        if result_format_str in ["BASIC"]:
-            return dependencies
-
         if include_unexpected_rows:
             metric_kwargs = get_metric_kwargs(
                 f"{self.map_metric}.unexpected_rows",

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -202,6 +202,49 @@ def test_pandas_unexpected_rows_basic_result_format(dataframe_for_unexpected_row
     }
 
 
+def test_pandas_unexpected_rows_summary_result_format(dataframe_for_unexpected_rows):
+    expectationConfiguration = ExpectationConfiguration(
+        expectation_type="expect_column_values_to_be_in_set",
+        kwargs={
+            "column": "b",
+            "mostly": 0.9,
+            "value_set": ["cat", "fish", "dog", "giraffe"],
+            "result_format": {
+                "result_format": "SUMMARY",
+                "include_unexpected_rows": True,
+            },
+        },
+    )
+
+    expectation = ExpectColumnValuesToBeInSet(expectationConfiguration)
+    batch = Batch(data=dataframe_for_unexpected_rows)
+    engine = PandasExecutionEngine()
+    validator = Validator(
+        execution_engine=engine,
+        batches=[
+            batch,
+        ],
+    )
+    result = expectation.validate(validator)
+
+    assert convert_to_json_serializable(result.result) == {
+        "element_count": 6,
+        "unexpected_count": 2,
+        "unexpected_percent": 33.33333333333333,
+        "partial_unexpected_counts": [
+            {"count": 1, "value": "lion"},
+            {"count": 1, "value": "zebra"},
+        ],
+        "partial_unexpected_index_list": [4, 5],
+        "partial_unexpected_list": ["lion", "zebra"],
+        "missing_count": 0,
+        "missing_percent": 0.0,
+        "unexpected_percent_total": 33.33333333333333,
+        "unexpected_percent_nonmissing": 33.33333333333333,
+        "unexpected_rows": [{"a": 5, "b": "lion"}, {"a": 10, "b": "zebra"}],
+    }
+
+
 def test_pandas_unexpected_rows_complete_result_format(dataframe_for_unexpected_rows):
     expectationConfiguration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -202,7 +202,53 @@ def test_pandas_unexpected_rows_basic_result_format(dataframe_for_unexpected_row
     }
 
 
-def test_pandas_unexpected_rows_summary_result_format(dataframe_for_unexpected_rows):
+def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_explicitly_false(
+    dataframe_for_unexpected_rows,
+):
+    expectationConfiguration = ExpectationConfiguration(
+        expectation_type="expect_column_values_to_be_in_set",
+        kwargs={
+            "column": "b",
+            "mostly": 0.9,
+            "value_set": ["cat", "fish", "dog", "giraffe"],
+            "result_format": {
+                "result_format": "SUMMARY",
+                "include_unexpected_rows": False,  # this is the default value, but making explicit for testing purposes
+            },
+        },
+    )
+
+    expectation = ExpectColumnValuesToBeInSet(expectationConfiguration)
+    batch = Batch(data=dataframe_for_unexpected_rows)
+    engine = PandasExecutionEngine()
+    validator = Validator(
+        execution_engine=engine,
+        batches=[
+            batch,
+        ],
+    )
+    result = expectation.validate(validator)
+
+    assert convert_to_json_serializable(result.result) == {
+        "element_count": 6,
+        "unexpected_count": 2,
+        "unexpected_percent": 33.33333333333333,
+        "partial_unexpected_counts": [
+            {"count": 1, "value": "lion"},
+            {"count": 1, "value": "zebra"},
+        ],
+        "partial_unexpected_index_list": [4, 5],
+        "partial_unexpected_list": ["lion", "zebra"],
+        "missing_count": 0,
+        "missing_percent": 0.0,
+        "unexpected_percent_total": 33.33333333333333,
+        "unexpected_percent_nonmissing": 33.33333333333333,
+    }
+
+
+def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_including_unexpected_rows(
+    dataframe_for_unexpected_rows,
+):
     expectationConfiguration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
         kwargs={

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_type_list.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_in_type_list.json
@@ -449,6 +449,44 @@
           ]
         },
         {
+          "title": "negative_test_string_and_int_values_summary_output",
+          "exact_match_out": false,
+          "result_format": "SUMMARY",
+          "in": {
+            "column": "s",
+            "type_list": [
+              "bool"
+            ]
+          },
+          "out": {
+            "success": false,
+            "unexpected_list": ["hello", "jello", "1"],
+            "unexpected_index_list": [0, 1, 2]
+          },
+          "only_for": [
+            "pandas"
+          ]
+        },
+                {
+          "title": "negative_test_string_and_int_values_complete_output",
+          "exact_match_out": false,
+          "result_format": "COMPLETE",
+          "in": {
+            "column": "s",
+            "type_list": [
+              "bool"
+            ]
+          },
+          "out": {
+            "success": false,
+            "unexpected_list": ["hello", "jello", "1"],
+            "unexpected_index_list": [0, 1, 2]
+          },
+          "only_for": [
+            "pandas"
+          ]
+        },
+        {
           "title": "positive_test_text_and_integer_values",
           "exact_match_out": false,
           "suppress_test_for": ["bigquery"],

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_be_increasing.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_be_increasing.json
@@ -56,7 +56,10 @@
         "unexpected_list": [4,3,2,1],
         "unexpected_index_list": [6,7,8,9],
         "success": false
-      }
+      },
+      "only_for": [
+            "pandas"
+          ]
     },{
       "title" : "positive_test_with_parse_strings_as_datetimes",
       "exact_match_out" : false,

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_match_regex.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_match_regex.json
@@ -32,6 +32,23 @@
       },
       "suppress_test_for": ["sqlite", "mssql"]
     },
+      {
+      "title": "negative_test_insufficient_mostly_and_one_non_matching_value_summary_output",
+      "include_in_gallery": true,
+      "exact_match_out" : false,
+      "result_format": "SUMMARY",
+      "in": {
+        "column": "a",
+        "regex": "^a",
+        "mostly": 0.9
+      },
+      "out": {
+        "success":false,
+        "unexpected_index_list": [4],
+        "unexpected_list": ["bee"]
+      },
+      "only_for": ["pandas"]
+    },
     {
       "title": "positive_test_exact_mostly_w_one_non_matching_value",
       "include_in_gallery": true,

--- a/tests/test_definitions/column_map_expectations/expect_column_values_to_not_be_in_set.json
+++ b/tests/test_definitions/column_map_expectations/expect_column_values_to_not_be_in_set.json
@@ -85,6 +85,23 @@
           "unexpected_list": [1.1, 2.2]
         }
       },
+      {"title": "negative_test_float_set_two_out_of_three_column_values_included_mostly_summary_output",
+        "exact_match_out": false,
+        "result_format": "SUMMARY",
+        "in": {
+          "column": "y",
+          "value_set": [1.1, 2.2],
+          "mostly": 0.65
+        },
+        "out": {
+          "success": false,
+          "unexpected_index_list": [0, 1],
+          "unexpected_list": [1.1, 2.2]
+        },
+        "only_for": [
+            "pandas"
+          ]
+      },
       {
         "title": "positive_test_float_set_two_out_of_three_column_values_included_mostly",
         "exact_match_out": false,


### PR DESCRIPTION
### What was the bug?
- According to [our documentation on result format](https://docs.greatexpectations.io/docs/reference/expectations/result_format#fields-defined-for-column_map_expectation-type-expectations), the `column_map_expectation` type returns `partial_unexpected_index_list` and `partial_unexpected_counts` while `BASIC` and `BOOLEAN_ONLY` does not. 
- Current behavior was the `partial_unexpected_index_list` being `None`, which was caused by the `get_validation_dependencies()` method exiting before `unexpected_index_list` was calculated (for `PandasExecutionEngine`).
    - The function was returning at the same point for both `BASIC` and `SUMMARY`, which should not have been the case
- This PR adjusts the `get_validation_dependencies()` so that `unexpected_index_list` can be calculated if it is available

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
