### PR TITLE
[BUGFIX] Fix issue with misaligned indentation in docs snippets

### DIFF
--- a/scripts/remark-named-snippets/snippet.js
+++ b/scripts/remark-named-snippets/snippet.js
@@ -116,12 +116,38 @@ function parseFile (file) {
  * @returns {string} The sanitized string.
  */
 function sanitizeText (text) {
+  // Remove leading carriage return
+  if (text.startsWith('\n') || text.startsWith('\r')) {
+    text = text.substring(1, text.length)
+  }
+
+  // Determine indentation
+  let indent = "";
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === " ") {
+      indent += " ";
+    } else {
+      break;
+    }
+  }
+
+  // Remove any Python comment remnants
   text = text.trim()
   if (text.endsWith('#')) {
     text = text.substring(0, text.length - 1)
   }
+
+  // Uniformly remove indentation across snippet
+  function unindent(line) {
+    if (line.startsWith(indent)) {
+      line = line.substring(indent.length, text.length)
+    }
+    return line
+  }
+
   return text
     .split('\n')
+    .map(unindent)
     .filter((l) => !(l.includes('<snippet') || l.includes('snippet>')))
     .join('\n')
     .trim()


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that indentation is respected when leveraging named snippets

Example issue:
<img width="770" alt="Screen Shot 2022-11-10 at 12 13 03 PM" src="https://user-images.githubusercontent.com/49923762/201161924-b259b8b1-61bb-42bf-8b37-22d1221cd7f3.png">

Resolved issue:
<img width="770" alt="Screen Shot 2022-11-10 at 12 13 56 PM" src="https://user-images.githubusercontent.com/49923762/201162150-31ebf599-9d2c-4ad4-8ec6-bd5a1eb982c7.png">

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
