### PR TITLE
[MAINTENANCE] Add missing one-line docstrings and try to make the others consistent

### DIFF
--- a/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_contain_set.py
@@ -21,6 +21,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnDistinctValuesToContainSet(ColumnExpectation):
+    """Expect the set of distinct column values to contain a given set."""
 
     # This dictionary contains metadata for display in the public gallery
     library_metadata = {

--- a/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
+++ b/great_expectations/expectations/core/expect_column_distinct_values_to_equal_set.py
@@ -18,6 +18,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnDistinctValuesToEqualSet(ColumnExpectation):
+    """Expect the set of distinct column values to equal a given set."""
 
     # This dictionary contains metadata for display in the public gallery
     library_metadata = {

--- a/great_expectations/expectations/core/expect_column_max_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_max_to_be_between.py
@@ -39,7 +39,7 @@ from great_expectations.render.renderer.renderer import renderer
 
 
 class ExpectColumnMaxToBeBetween(ColumnExpectation):
-    """Expect the column max to be between an min and max value
+    """Expect the column maximum to be between a minimum value and a maximum value.
 
            expect_column_max_to_be_between is a \
            :func:`column_aggregate_expectation

--- a/great_expectations/expectations/core/expect_column_min_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_min_to_be_between.py
@@ -32,7 +32,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
 
 
 class ExpectColumnMinToBeBetween(ColumnExpectation):
-    """Expect the column minimum to be between an min and max value
+    """Expect the column minimum to be between a minimum value and a maximum value.
 
             expect_column_min_to_be_between is a \
             :func:`column_aggregate_expectation

--- a/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_most_common_value_to_be_in_set.py
@@ -17,7 +17,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnMostCommonValueToBeInSet(ColumnExpectation):
-    """Expect the most common value to be within the designated value set
+    """Expect the most common value to be within the designated value set.
 
             expect_column_most_common_value_to_be_in_set is a \
             :func:`column_aggregate_expectation

--- a/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_a_to_be_greater_than_b.py
@@ -17,7 +17,7 @@ from great_expectations.render.util import (
 
 class ExpectColumnPairValuesAToBeGreaterThanB(ColumnPairMapExpectation):
     """
-    Expect values in column A to be greater than column B.
+    Expect the values in column A to be greater than column B.
 
     Args:
         column_A (str): The first column name

--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_in_set.py
@@ -9,7 +9,7 @@ from great_expectations.expectations.expectation import (
 
 class ExpectColumnPairValuesToBeInSet(ColumnPairMapExpectation):
     """
-    Expect paired values from columns A and B to belong to a set of valid pairs.
+    Expect the paired values from columns A and B to belong to a set of valid pairs.
 
         For example:
         ::

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -42,7 +42,7 @@ from great_expectations.util import isclose
 
 class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
     # noinspection PyUnresolvedReferences
-    """Expect specific provided column quantiles to be between provided minimum and maximum values.
+    """Expect the specific provided column quantiles to be between a minimum value and a maximum value.
 
            ``quantile_ranges`` must be a dictionary with two keys:
 

--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -28,7 +28,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
 
 
 class ExpectColumnSumToBeBetween(ColumnExpectation):
-    """Expect the column to sum to be between an min and max value
+    """Expect the column to sum to be between a minimum value and a maximum value.
 
            expect_column_sum_to_be_between is a \
            :func:`column_aggregate_expectation

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_be_between.py
@@ -42,7 +42,7 @@ from great_expectations.expectations.expectation import (
 
 
 class ExpectColumnValueLengthsToBeBetween(ColumnMapExpectation):
-    """Expect column entries to be strings with length between a minimum value and a maximum value (inclusive).
+    """Expect the column entries to be strings with length between a minimum value and a maximum value (inclusive).
 
     This expectation only works for string-type values. Invoking it on ints or floats will raise a TypeError.
 

--- a/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
+++ b/great_expectations/expectations/core/expect_column_value_lengths_to_equal.py
@@ -16,7 +16,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnValueLengthsToEqual(ColumnMapExpectation):
-    """Expect column entries to be strings with length equal to the provided value.
+    """Expect the column entries to be strings with length equal to the provided value.
 
     This expectation only works for string-type values. Invoking it on ints or floats will raise a TypeError.
 

--- a/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_value_z_scores_to_be_less_than.py
@@ -9,7 +9,7 @@ from great_expectations.expectations.expectation import (
 
 class ExpectColumnValueZScoresToBeLessThan(ColumnMapExpectation):
     """
-    Expect the Z-scores of a columns values to be less than a given threshold
+    Expect the Z-scores of a column's values to be less than a given threshold.
 
             expect_column_values_to_be_of_type is a :func:`column_map_expectation \
             <great_expectations.execution_engine.execution_engine.MetaExecutionEngine.column_map_expectation>` for

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -28,7 +28,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
 
 
 class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
-    """Expect column entries to be between a minimum value and a maximum value (inclusive).
+    """Expect the column entries to be between a minimum value and a maximum value (inclusive).
 
     expect_column_values_to_be_between is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
@@ -15,7 +15,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnValuesToBeDateutilParseable(ColumnMapExpectation):
-    """Expect column entries to be parsable using dateutil.
+    """Expect the column entries to be parsable using dateutil.
 
     expect_column_values_to_be_dateutil_parseable is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
@@ -15,7 +15,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):
-    """Expect column values to be decreasing.
+    """Expect the column values to be decreasing.
 
     By default, this expectation only works for numeric or datetime data.
     When `parse_strings_as_datetimes=True`, it can also parse strings to datetimes.

--- a/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExpectColumnValuesToBeIncreasing(ColumnMapExpectation):
-    """Expect column values to be increasing.
+    """Expect the column values to be increasing.
 
     By default, this expectation only works for numeric or datetime data.
     When `parse_strings_as_datetimes=True`, it can also parse strings to datetimes.

--- a/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 class ExpectColumnValuesToBeJsonParseable(ColumnMapExpectation):
-    """Expect column entries to be data written in JavaScript Object Notation.
+    """Expect the column entries to be data written in JavaScript Object Notation.
 
     expect_column_values_to_be_json_parseable is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -22,7 +22,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnValuesToBeNull(ColumnMapExpectation):
-    """Expect column values to be null.
+    """Expect the column values to be null.
 
     expect_column_values_to_be_null is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 class ExpectColumnValuesToMatchJsonSchema(ColumnMapExpectation):
-    """Expect column entries to be JSON objects matching a given JSON schema.
+    """Expect the column entries to be JSON objects matching a given JSON schema.
 
     expect_column_values_to_match_json_schema is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern.py
@@ -17,6 +17,8 @@ except ImportError:
 
 
 class ExpectColumnValuesToMatchLikePattern(ColumnMapExpectation):
+    """Expect the column entries to be strings that match a given like pattern expression."""
+
     library_metadata = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],

--- a/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_like_pattern_list.py
@@ -12,6 +12,8 @@ from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectColumnValuesToMatchLikePatternList(ColumnMapExpectation):
+    """Expect the column entries to be strings that match any of a provided list of like pattern expressions."""
+
     library_metadata = {
         "maturity": "production",
         "tags": ["core expectation", "column map expectation"],

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -28,7 +28,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
 
 
 class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
-    """Expect column entries to be strings that match a given regular expression.
+    """Expect the column entries to be strings that match a given regular expression.
 
     Valid matches can be found \
     anywhere in the string, for example "[at]+" will identify the following strings as expected: "cat", "hat", \

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -17,8 +17,9 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):
-    """Expect the column entries to be strings that can be matched to either any of or all of a list of regular
-    expressions. Matches can be anywhere in the string.
+    """Expect the column entries to be strings that can be matched to either any of or all of a list of regular expressions.
+
+    Matches can be anywhere in the string.
 
     expect_column_values_to_match_regex_list is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
@@ -29,7 +29,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
 
 
 class ExpectColumnValuesToMatchStrftimeFormat(ColumnMapExpectation):
-    """Expect column entries to be strings representing a date or time with a given format.
+    """Expect the column entries to be strings representing a date or time with a given format.
 
     expect_column_values_to_match_strftime_format is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -23,7 +23,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
-    """Expect column values to not be null.
+    """Expect the column values to not be null.
 
     To be counted as an exception, values must be explicitly null or missing, such as a NULL in PostgreSQL or an
     np.NaN in pandas. Empty strings don't count as null unless they have been coerced to a null type.

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern.py
@@ -12,7 +12,7 @@ from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectColumnValuesToNotMatchLikePattern(ColumnMapExpectation):
-    """Expect column entries to be strings that do NOT match a given like pattern expression.
+    """Expect the column entries to be strings that do NOT match a given like pattern expression.
 
     expect_column_values_to_not_match_like_pattern_list is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_like_pattern_list.py
@@ -12,7 +12,7 @@ from great_expectations.render.util import substitute_none_for_missing
 
 
 class ExpectColumnValuesToNotMatchLikePatternList(ColumnMapExpectation):
-    """Expect column entries to be strings that do NOT match any of a provided list of like patterns expressions.
+    """Expect the column entries to be strings that do NOT match any of a provided list of like pattern expressions.
 
     expect_column_values_to_not_match_like_pattern_list is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -37,7 +37,9 @@ except ImportError:
 
 
 class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
-    """Expect column entries to be strings that do NOT match a given regular expression. The regex must not match \
+    """Expect the column entries to be strings that do NOT match a given regular expression.
+
+    The regex must not match \
     any portion of the provided string. For example, "[at]+" would identify the following strings as expected: \
     "fish", "dog", and the following as unexpected: "cat", "hat".
 

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -17,8 +17,7 @@ from great_expectations.render.util import (
 
 
 class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):
-    """Expect the column entries to be strings that do not match any of a list of regular expressions. Matches can
-    be anywhere in the string.
+    """Expect the column entries to be strings that do not match any of a list of regular expressions. Matches can be anywhere in the string.
 
     expect_column_values_to_not_match_regex_list is a \
     :func:`column_map_expectation <great_expectations.execution_engine.execution_engine.MetaExecutionEngine

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -15,6 +15,8 @@ from great_expectations.render.util import (
 
 
 class ExpectCompoundColumnsToBeUnique(MulticolumnMapExpectation):
+    """Expect the compound columns to be unique."""
+
     # This dictionary contains metadata for display in the public gallery
     library_metadata = {
         "maturity": "production",

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -11,7 +11,7 @@ from great_expectations.render.renderer.renderer import renderer
 
 class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
     """
-    Expects that the sum of row values is the same for each row, summing only values in columns specified in
+    Expect that the sum of row values is the same for each row, summing only values in columns specified in \
     column_list, and equal to the specific value, sum_total.
 
     Args:


### PR DESCRIPTION

Changes proposed in this pull request:
- Add missing one-line docstrings and try to make the others consistent with each other
