### PR TITLE
[MAINTENANCE] In ExecutionEngine: Make variable names and usage more descriptive of their purpose.

### DIFF
--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -335,16 +335,16 @@ class ExecutionEngine(ABC):
         accessor_domain_kwargs: dict
         metric_provider_kwargs: dict
         metric_to_resolve: MetricConfiguration
-        metric_dependencies: dict
+        resolved_metrics_by_metric_name: Dict[str, Any]
         k: str
         v: MetricConfiguration
         for metric_to_resolve in metrics_to_resolve:
-            metric_dependencies = {}
+            resolved_metrics_by_metric_name = {}
             for k, v in metric_to_resolve.metric_dependencies.items():
                 if v.id in metrics:
-                    metric_dependencies[k] = metrics[v.id]
+                    resolved_metrics_by_metric_name[k] = metrics[v.id]
                 elif self._caching and v.id in self._metric_cache:  # type: ignore[operator] # TODO: update NoOpDict
-                    metric_dependencies[k] = self._metric_cache[v.id]
+                    resolved_metrics_by_metric_name[k] = self._metric_cache[v.id]
                 else:
                     raise ge_exceptions.MetricError(
                         message=f'Missing metric dependency: {str(k)} for metric "{metric_to_resolve.metric_name}".'
@@ -358,7 +358,7 @@ class ExecutionEngine(ABC):
                 "execution_engine": self,
                 "metric_domain_kwargs": metric_to_resolve.metric_domain_kwargs,
                 "metric_value_kwargs": metric_to_resolve.metric_value_kwargs,
-                "metrics": metric_dependencies,
+                "metrics": resolved_metrics_by_metric_name,
                 "runtime_configuration": runtime_configuration,
             }
             if metric_fn is None:
@@ -367,7 +367,7 @@ class ExecutionEngine(ABC):
                         metric_fn,
                         compute_domain_kwargs,
                         accessor_domain_kwargs,
-                    ) = metric_dependencies.pop("metric_partial_fn")
+                    ) = resolved_metrics_by_metric_name.pop("metric_partial_fn")
                 except KeyError as e:
                     raise ge_exceptions.MetricError(
                         message=f'Missing metric dependency: {str(e)} for metric "{metric_to_resolve.metric_name}".'

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -22,6 +22,7 @@ from great_expectations.core.batch_spec import (
 from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.util import AzureUrl, GCSUrl, S3Url, sniff_s3_compression
 from great_expectations.execution_engine import ExecutionEngine
+from great_expectations.execution_engine.execution_engine import SplitDomainKwargs
 from great_expectations.execution_engine.pandas_batch_data import PandasBatchData
 from great_expectations.execution_engine.split_and_sample.pandas_data_sampler import (
     PandasDataSampler,
@@ -602,15 +603,15 @@ Please use "neither" instead.
               - a dictionary of accessor_domain_kwargs, describing any accessors needed to
                 identify the domain within the compute domain
         """
-        data = self.get_domain_records(domain_kwargs)
-
-        table = domain_kwargs.get("table", None)
+        table: str = domain_kwargs.get("table", None)
         if table:
             raise ValueError(
                 "PandasExecutionEngine does not currently support multiple named tables."
             )
 
-        split_domain_kwargs = self._split_domain_kwargs(
+        data: pd.DataFrame = self.get_domain_records(domain_kwargs=domain_kwargs)
+
+        split_domain_kwargs: SplitDomainKwargs = self._split_domain_kwargs(
             domain_kwargs, domain_type, accessor_keys
         )
 

--- a/great_expectations/execution_engine/sparkdf_execution_engine.py
+++ b/great_expectations/execution_engine/sparkdf_execution_engine.py
@@ -36,6 +36,7 @@ from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.execution_engine.bundled_metric_configuration import (
     BundledMetricConfiguration,
 )
+from great_expectations.execution_engine.execution_engine import SplitDomainKwargs
 from great_expectations.execution_engine.sparkdf_batch_data import SparkDFBatchData
 from great_expectations.execution_engine.split_and_sample.sparkdf_data_sampler import (
     SparkDataSampler,
@@ -614,15 +615,15 @@ illegal.  Please check your config."""
               - a dictionary of accessor_domain_kwargs, describing any accessors needed to
                 identify the domain within the compute domain
         """
-        data = self.get_domain_records(domain_kwargs)
-
-        table = domain_kwargs.get("table", None)
+        table: str = domain_kwargs.get("table", None)
         if table:
             raise ValueError(
                 "SparkDFExecutionEngine does not currently support multiple named tables."
             )
 
-        split_domain_kwargs = self._split_domain_kwargs(
+        data: DataFrame = self.get_domain_records(domain_kwargs=domain_kwargs)
+
+        split_domain_kwargs: SplitDomainKwargs = self._split_domain_kwargs(
             domain_kwargs, domain_type, accessor_keys
         )
 
@@ -721,9 +722,7 @@ illegal.  Please check your config."""
 
         for aggregate in aggregates.values():
             domain_kwargs: dict = aggregate["domain_kwargs"]
-            df: Optional[DataFrame] = self.get_domain_records(
-                domain_kwargs=domain_kwargs,
-            )
+            df: DataFrame = self.get_domain_records(domain_kwargs=domain_kwargs)
 
             assert len(aggregate["column_aggregates"]) == len(aggregate["ids"])
 

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -788,11 +788,11 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
         Returns:
             SqlAlchemy column
         """
-        selectable = self.get_domain_records(domain_kwargs)
-
-        split_domain_kwargs = self._split_domain_kwargs(
+        split_domain_kwargs: SplitDomainKwargs = self._split_domain_kwargs(
             domain_kwargs, domain_type, accessor_keys
         )
+
+        selectable: Selectable = self.get_domain_records(domain_kwargs=domain_kwargs)
 
         return selectable, split_domain_kwargs.compute, split_domain_kwargs.accessor
 
@@ -993,8 +993,8 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
 
         for query in queries.values():
             domain_kwargs: dict = query["domain_kwargs"]
-            selectable: Any = self.get_domain_records(
-                domain_kwargs=domain_kwargs,
+            selectable: Selectable = self.get_domain_records(
+                domain_kwargs=domain_kwargs
             )
 
             assert len(query["select"]) == len(query["ids"])

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -1387,9 +1387,7 @@ def _pandas_column_map_condition_values(
         compute_domain_kwargs,
         accessor_domain_kwargs,
     ) = metrics["unexpected_condition"]
-    df = execution_engine.get_domain_records(
-        domain_kwargs=compute_domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=compute_domain_kwargs)
 
     if "column" not in accessor_domain_kwargs:
         raise ValueError(
@@ -1447,9 +1445,7 @@ def _pandas_column_pair_map_condition_values(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if not ("column_A" in domain_kwargs and "column_B" in domain_kwargs):
         raise ValueError(
@@ -1504,9 +1500,7 @@ def _pandas_column_pair_map_condition_filtered_row_count(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if not ("column_A" in domain_kwargs and "column_B" in domain_kwargs):
         raise ValueError(
@@ -1550,9 +1544,7 @@ def _pandas_multicolumn_map_condition_values(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column_list" not in accessor_domain_kwargs:
         raise ValueError(
@@ -1598,9 +1590,7 @@ def _pandas_multicolumn_map_condition_filtered_row_count(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column_list" not in accessor_domain_kwargs:
         raise ValueError(
@@ -1645,9 +1635,7 @@ def _pandas_column_map_series_and_domain_values(
     assert (
         accessor_domain_kwargs == accessor_domain_kwargs_2
     ), "map_series and condition must have the same accessor kwargs"
-    df = execution_engine.get_domain_records(
-        domain_kwargs=compute_domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=compute_domain_kwargs)
 
     if "column" not in accessor_domain_kwargs:
         raise ValueError(
@@ -1711,9 +1699,7 @@ def _pandas_map_condition_index(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column" in accessor_domain_kwargs:
         column_name = accessor_domain_kwargs["column"]
@@ -1767,9 +1753,7 @@ def _pandas_column_map_condition_value_counts(
         compute_domain_kwargs,
         accessor_domain_kwargs,
     ) = metrics.get("unexpected_condition")
-    df = execution_engine.get_domain_records(
-        domain_kwargs=compute_domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=compute_domain_kwargs)
 
     column_name = accessor_domain_kwargs["column"]
 
@@ -1840,9 +1824,7 @@ def _pandas_map_condition_rows(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column" in accessor_domain_kwargs:
         column_name = accessor_domain_kwargs["column"]
@@ -1926,9 +1908,7 @@ def _sqlalchemy_map_condition_unexpected_count_value(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    selectable = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    selectable = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # The integral values are cast to SQL Numeric in order to avoid a bug in AWS Redshift (converted to integer later).
     count_case_statement: List[Label] = sa.case(
@@ -2021,7 +2001,7 @@ def _sqlalchemy_column_map_condition_values(
         "unexpected_condition"
     )
     selectable = execution_engine.get_domain_records(
-        domain_kwargs=compute_domain_kwargs,
+        domain_kwargs=compute_domain_kwargs
     )
 
     if "column" not in accessor_domain_kwargs:
@@ -2082,9 +2062,7 @@ def _sqlalchemy_column_pair_map_condition_values(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    selectable = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    selectable = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # noinspection PyPep8Naming
     column_A_name = accessor_domain_kwargs["column_A"]
@@ -2135,9 +2113,7 @@ def _sqlalchemy_column_pair_map_condition_filtered_row_count(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    selectable = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    selectable = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # noinspection PyPep8Naming
     column_A_name = accessor_domain_kwargs["column_A"]
@@ -2176,9 +2152,7 @@ def _sqlalchemy_multicolumn_map_condition_values(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    selectable = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    selectable = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column_list" not in accessor_domain_kwargs:
         raise ValueError(
@@ -2223,9 +2197,7 @@ def _sqlalchemy_multicolumn_map_condition_filtered_row_count(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    selectable = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    selectable = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column_list" not in accessor_domain_kwargs:
         raise ValueError(
@@ -2263,7 +2235,7 @@ def _sqlalchemy_column_map_condition_value_counts(
         "unexpected_condition"
     )
     selectable = execution_engine.get_domain_records(
-        domain_kwargs=compute_domain_kwargs,
+        domain_kwargs=compute_domain_kwargs
     )
 
     if "column" not in accessor_domain_kwargs:
@@ -2313,9 +2285,7 @@ def _sqlalchemy_map_condition_rows(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    selectable = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    selectable = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     table_columns = metrics.get("table.columns")
     column_selector = [sa.column(column_name) for column_name in table_columns]
@@ -2371,9 +2341,7 @@ def _spark_map_condition_unexpected_count_value(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
@@ -2394,9 +2362,7 @@ def _spark_column_map_condition_values(
     unexpected_condition, compute_domain_kwargs, accessor_domain_kwargs = metrics.get(
         "unexpected_condition"
     )
-    df = execution_engine.get_domain_records(
-        domain_kwargs=compute_domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=compute_domain_kwargs)
 
     if "column" not in accessor_domain_kwargs:
         raise ValueError(
@@ -2443,9 +2409,7 @@ def _spark_column_map_condition_value_counts(
     unexpected_condition, compute_domain_kwargs, accessor_domain_kwargs = metrics.get(
         "unexpected_condition"
     )
-    df = execution_engine.get_domain_records(
-        domain_kwargs=compute_domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=compute_domain_kwargs)
 
     if "column" not in accessor_domain_kwargs:
         raise ValueError(
@@ -2491,9 +2455,7 @@ def _spark_map_condition_rows(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
@@ -2526,9 +2488,7 @@ def _spark_column_pair_map_condition_values(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # noinspection PyPep8Naming
     column_A_name = accessor_domain_kwargs["column_A"]
@@ -2586,9 +2546,7 @@ def _spark_column_pair_map_condition_filtered_row_count(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # noinspection PyPep8Naming
     column_A_name = accessor_domain_kwargs["column_A"]
@@ -2625,9 +2583,7 @@ def _spark_multicolumn_map_condition_values(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column_list" not in accessor_domain_kwargs:
         raise ValueError(
@@ -2685,9 +2641,7 @@ def _spark_multicolumn_map_condition_filtered_row_count(
     with all of the available "domain_kwargs" keys.
     """
     domain_kwargs = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
-    df = execution_engine.get_domain_records(
-        domain_kwargs=domain_kwargs,
-    )
+    df = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     if "column_list" not in accessor_domain_kwargs:
         raise ValueError(


### PR DESCRIPTION
### Scope
* In ExecutionEngine implementations and usage: Change variable names in order to better reflect their purpose;
* Other stylistic clean up.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1103/GREAT-1364
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!