### PR TITLE
[DOCS] [WIP] How to add Polars support for Custom Expectations

### DIFF
--- a/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_aggregate_expectations.md
+++ b/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_aggregate_expectations.md
@@ -93,7 +93,7 @@ Replace the Expectation class name
 ```
 
 with your real Expectation class name, in upper camel case:
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L94
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L104
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
@@ -101,7 +101,7 @@ You can also go ahead and write a new one-line docstring, replacing
 ```
 
 with something like:
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L97
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L107
 ```
 
 You'll also need to change the class name at the bottom of the file, by replacing this line:
@@ -109,7 +109,7 @@ You'll also need to change the class name at the bottom of the file, by replacin
 ```
 
 with this one:
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L344
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L358
 ```
 
 Later, you can go back and write a more thorough docstring.
@@ -138,7 +138,7 @@ Next, we're going to search for `examples = []` in your file, and replace it wit
 
 Your examples will look something like this:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L102-L152
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L112-L162
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -231,7 +231,7 @@ Second, in the Expectation class, replace
 
 with
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L156
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L166
 ```
 
 It's essential to make sure to use matching Metric Identifier strings across your Metric class and Expectation class. This is how the Expectation knows which Metric to use for its internal logic.
@@ -263,7 +263,7 @@ and performs a simple validation against your success keys (i.e. important thres
 To do so, we'll be accessing our success keys, as well as the result of our previously-calculated Metrics.
 For example, here is the definition of a `_validate(...)` method to validate the results of our `column.custom_max` Metric against our success keys:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L219-L254
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L233-L268
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -327,7 +327,7 @@ If you plan to contribute your Expectation to the public open source project, yo
 
 would become
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L333-L336
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L347-L350
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_aggregate_expectations.md
+++ b/docs/guides/expectations/creating_custom_expectations/how_to_create_custom_column_aggregate_expectations.md
@@ -93,7 +93,7 @@ Replace the Expectation class name
 ```
 
 with your real Expectation class name, in upper camel case:
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L82
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L94
 ```
 
 You can also go ahead and write a new one-line docstring, replacing
@@ -101,7 +101,7 @@ You can also go ahead and write a new one-line docstring, replacing
 ```
 
 with something like:
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L83
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L97
 ```
 
 You'll also need to change the class name at the bottom of the file, by replacing this line:
@@ -109,7 +109,7 @@ You'll also need to change the class name at the bottom of the file, by replacin
 ```
 
 with this one:
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L315
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L344
 ```
 
 Later, you can go back and write a more thorough docstring.
@@ -138,7 +138,7 @@ Next, we're going to search for `examples = []` in your file, and replace it wit
 
 Your examples will look something like this:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L86-L132
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L102-L152
 ```
 
 Here's a quick overview of how to create test cases to populate `examples`. The overall structure is a list of dictionaries. Each dictionary has two keys:
@@ -190,7 +190,7 @@ Metrics answer questions about your data posed by your Expectation, <br/> and al
 
 Your Metric function will have the `@column_aggregate_value` decorator, with the appropriate `engine`. Metric functions can be as complex as you like, but they're often very short. For example, here's the definition for a Metric function to calculate the max of a column using the PandasExecutionEngine.
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L41-L44
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L45-L48
 ```
 
 This is all that you need to define for now. In the next step, we will implement the method to validate the results of this Metric.
@@ -221,7 +221,7 @@ You'll need to substitute this metric into two places in the code. First, in the
 
 with
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L39
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L42
 ```
 
 Second, in the Expectation class, replace
@@ -231,7 +231,7 @@ Second, in the Expectation class, replace
 
 with
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L135
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L156
 ```
 
 It's essential to make sure to use matching Metric Identifier strings across your Metric class and Expectation class. This is how the Expectation knows which Metric to use for its internal logic.
@@ -245,7 +245,7 @@ For example, replace:
 
 with 
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L36
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L38
 ```
 
 ### 7. Validate
@@ -263,7 +263,7 @@ and performs a simple validation against your success keys (i.e. important thres
 To do so, we'll be accessing our success keys, as well as the result of our previously-calculated Metrics.
 For example, here is the definition of a `_validate(...)` method to validate the results of our `column.custom_max` Metric against our success keys:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L196-L231
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L219-L254
 ```
 
 Running your diagnostic checklist at this point should return something like this:
@@ -327,7 +327,7 @@ If you plan to contribute your Expectation to the public open source project, yo
 
 would become
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L308-L311
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L333-L336
 ```
 
 This is particularly important because ***we*** want to make sure that ***you*** get credit for all your hard work!

--- a/docs/guides/expectations/features_custom_expectations/how_to_add_example_cases_for_an_expectation.md
+++ b/docs/guides/expectations/features_custom_expectations/how_to_add_example_cases_for_an_expectation.md
@@ -91,7 +91,7 @@ Each example is a dictionary with two keys:
 
 In our example, `data` will have two columns, "x" and "y", each with five rows. If you define multiple columns, make sure that they have the same number of rows. When possible, include test data and tests that includes null values (`None` in the Python test definition).
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L88
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L114
 ```
 
 When you define data in your examples, we will mostly guess the type of the columns. 
@@ -134,9 +134,9 @@ You will need to:
 3. Decide how precisely you want to test the output of your tests (`exact_match_out`)
 4. Define the expected output for your tests (`out`)
 
-If you are interested in contributing your Custom Expectation back to Great Expectations, you will also need to decide if you want these tests publically displayed to demonstrate the functionality of your Custom Expectation (`include_in_gallery`).
+If you are interested in contributing your Custom Expectation back to Great Expectations, you will also need to decide if you want these tests publicly displayed to demonstrate the functionality of your Custom Expectation (`include_in_gallery`).
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L86-L132
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L112-L162
 ```
 
 :::note

--- a/docs/guides/expectations/features_custom_expectations/how_to_add_input_validation_for_an_expectation.md
+++ b/docs/guides/expectations/features_custom_expectations/how_to_add_input_validation_for_an_expectation.md
@@ -43,7 +43,7 @@ To do this, we're going to write a series of `assert` statements to catch invali
 
 To begin with, we want to create our `validate_configuration(...)` method and ensure that a configuration is set:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L149-L165
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L181-L197
 ```
 
 Next, we're going to implement the logic for validating the four parameters we identified above.
@@ -52,45 +52,91 @@ Next, we're going to implement the logic for validating the four parameters we i
 
 First we need to access the parameters to be evaluated:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L167-L170
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L200-L203
 ```
 
 Now we can begin writing the assertions to validate these parameters. 
 
 We're going to ensure that at least one of `min_value` or `max_value` is set:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L173-L176
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L207-L210
 ```
 
 Check that `min_value` and `max_value` are of the correct type:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L177-L179
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L211-L213
 ```
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L180-L182
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L214-L216
 ```
 
 Verify that, if both `min_value` and `max_value` are set, `min_value` does not exceed `max_value`:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L183-L186
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L217-L220
 ```
 
 And assert that `strict_min` and `strict_max`, if provided, are of the correct type:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L187-L189
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L221-L223
 ```
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L190-L192
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L224-L226
 ```
 
 If any of these fail, we raise an exception:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L193-L194
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L227-L228
 ```
 
 Putting this all together, our `validate_configuration(...)` method looks like:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L149-L194
+```python 
+def validate_configuration(
+    self, configuration: Optional[ExpectationConfiguration]
+) -> None:
+    """
+    Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+    necessary configuration arguments have been provided for the validation of the expectation.
+    Args:
+        configuration (OPTIONAL[ExpectationConfiguration]): \
+            An optional Expectation Configuration entry that will be used to configure the expectation
+    Returns:
+        None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
+    """
+
+    # Setting up a configuration
+    super().validate_configuration(configuration)
+    if configuration is None:
+        configuration = self.configuration
+
+    min_value = configuration.kwargs["min_value"]
+    max_value = configuration.kwargs["max_value"]
+    strict_min = configuration.kwargs["strict_min"]
+    strict_max = configuration.kwargs["strict_max"]
+
+    # Validating that min_val, max_val, strict_min, and strict_max are of the proper format and type
+    try:
+        assert (
+            min_value is not None or max_value is not None
+        ), "min_value and max_value cannot both be none"
+        assert min_value is None or isinstance(
+            min_value, (float, int)
+        ), "Provided min threshold must be a number"
+        assert max_value is None or isinstance(
+            max_value, (float, int)
+        ), "Provided max threshold must be a number"
+        if min_value and max_value:
+            assert (
+                min_value <= max_value
+            ), "Provided min threshold must be less than or equal to max threshold"
+        assert strict_min is None or isinstance(
+            strict_min, bool
+        ), "strict_min must be a boolean value"
+        assert strict_max is None or isinstance(
+            strict_max, bool
+        ), "strict_max must be a boolean value"
+    except AssertionError as e:
+        raise InvalidExpectationConfigurationError(str(e))
 ```
 
 ### 4. Verifying our method

--- a/docs/guides/expectations/features_custom_expectations/how_to_add_polars_support_for_an_expectation.md
+++ b/docs/guides/expectations/features_custom_expectations/how_to_add_polars_support_for_an_expectation.md
@@ -1,0 +1,127 @@
+---
+title: How to add Spark support for Custom Expectations
+---
+import Prerequisites from '../creating_custom_expectations/components/prerequisites.jsx'
+import TechnicalTag from '@site/docs/term_tags/_tag.mdx';
+
+This guide will help you implement native Polars support for your <TechnicalTag tag="custom_expectation" text="Custom Expectation" />. 
+
+<Prerequisites>
+
+ - [Created a Custom Expectation](../creating_custom_expectations/overview.md)
+    
+</Prerequisites>
+
+Great Expectations supports a number of <TechnicalTag tag="execution_engine" text="Execution Engines" />, including a Polars Execution Engine. These Execution Engines provide the computing resources used to calculate the <TechnicalTag tag="metric" text="Metrics" /> defined in the Metric class of your Custom Expectation.
+
+If you decide to contribute your <TechnicalTag tag="expectation" text="Expectation" />, its entry in the [Expectations Gallery](https://greatexpectations.io/expectations/) will reflect the Execution Engines that it supports.
+
+We will add Polars support for the Custom Expectations implemented in our guide on [how to create Custom Column Aggregate Expectations](../creating_custom_expectations/how_to_create_custom_column_aggregate_expectations.md).
+
+## Steps
+
+### 1. Specify your backends
+
+To avoid surprises and help clearly define your Custom Expectation, it can be helpful to determine beforehand what backends you plan to support, and test them along the way.
+
+Within the `examples` defined inside your Expectation class, the `test_backends` key specifies which backends and SQLAlchemy dialects to run tests for. Add entries corresponding to the functionality you want to add: 
+    
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L86-L132
+```
+
+:::note
+You may have noticed that specifying `test_backends` isn't required for successfully testing your Custom Expectation.
+
+If not specified, Great Expectations will attempt to determine the implemented backends automatically, but wll only run SQLAlchemy tests against sqlite.
+:::
+
+### 2. Implement the Spark logic for your Custom Expectation
+
+Great Expectations provides a variety of ways to implement an Expectation in Spark. Two of the most common include: 
+
+1.  Defining a partial function that takes a Spark DataFrame column as input
+2.  Directly executing queries on Spark DataFrames to determine the value of your Expectation's metric directly
+
+Great Expectations allows for much of the PySpark DataFrame logic to be abstracted away by specifying metric behavior as a partial function. 
+
+To do this, we use one of the `@column_*_partial` decorators:
+
+- `@column_aggregate_partial` for Column Aggregate Expectations
+- `@column_condition_partial` for Column Map Expectations
+- `@column_pair_condition_partial` for Column Pair Map Expectations
+- `@multicolumn_condition_partial` for Multicolumn Map Expectations
+
+These decorators expect an appropriate `engine` argument. In this case, we'll pass our `SparkDFExecutionEngine`.
+
+The decorated method takes in a Spark `Column` object and will either return a `pyspark.sql.functions.function` or a `pyspark.sql.Column.function` that Great Expectations will use to generate the appropriate SQL queries.
+
+For our Custom Column Aggregate Expectation `ExpectColumnMaxToBeBetweenCustom`, we're going to leverage PySpark's `max` SQL Function and the `@column_aggregate_partial` decorator.
+
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L76-L79
+```
+
+If we need a builtin function from `pyspark.sql.functions`, usually aliased to `F`, the import logic in 
+`from great_expectations.expectations.metrics.import_manager import F`
+allows us to access these functions even when PySpark is not installed.
+
+<details>
+<summary>Applying Python Functions</summary>
+<code>F.udf</code> allows us to use a Python function as a Spark User Defined Function for Column Map Expectations, 
+giving us the ability to define custom functions and apply them to our data.
+<br/><br/>
+Here is an example of <code>F.udf</code> applied to <code>ExpectColumnValuesToEqualThree</code>:
+
+```python
+@column_condition_partial(engine=SparkDFExecutionEngine)
+def _spark(cls, column, strftime_format, **kwargs):
+    def is_equal_to_three(val):
+        return (val == 3)
+
+    success_udf = F.udf(is_equal_to_three, sparktypes.BooleanType())
+    return success_udf(column)
+```
+
+For more on <code>F.udf</code> and the functionality it provides, see the <a href="https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.functions.udf.html">Apache Spark UDF documentation</a>.
+</details>
+
+
+### 3. Verifying your implementation
+
+If you now run your file, `print_diagnostic_checklist()` will attempt to execute your example cases using this new backend.
+
+If your implementation is correctly defined, and the rest of the core logic in your Custom Expectation is already complete, you will see the following in your Diagnostic Checklist:
+
+```console
+✔ Has at least one positive and negative example case, and all test cases pass
+```
+
+If you've already implemented the Pandas backend covered in our How-To guides for creating [Custom Expectations](../creating_custom_expectations/overview.md) 
+and the SQLAlchemy backend covered in our guide on [how to add SQLAlchemy support for Custom Expectations](./how_to_add_sqlalchemy_support_for_an_expectation.md), 
+you should see the following in your Diagnostic Checklist:
+
+```console
+✔ Has core logic that passes tests for all applicable Execution Engines and SQL dialects
+```
+
+<div style={{"text-align":"center"}}>
+<p style={{"color":"#8784FF","font-size":"1.4em"}}><b>
+Congratulations!<br/>&#127881; You've successfully implemented Spark support for a Custom Expectation! &#127881;
+</b></p>
+</div>
+
+### 4. Contribution (Optional)
+
+This guide will leave you with core functionality sufficient for [contribution](../contributing/how_to_contribute_a_custom_expectation_to_great_expectations.md) back to Great Expectations at an Experimental level.
+
+If you're interested in having your contribution accepted at a Beta level, your Custom Expectation will need to support SQLAlchemy, Spark, and Pandas.
+
+For full acceptance into the Great Expectations codebase at a Production level, we require that your Custom Expectation meets our code standards, including test coverage and style. 
+If you believe your Custom Expectation is otherwise ready for contribution at a Production level, please submit a [Pull Request](https://github.com/great-expectations/great_expectations/pulls), and we will work with you to ensure your Custom Expectation meets these standards.
+
+:::note
+For more information on our code standards and contribution, see our guide on [Levels of Maturity](../../../contributing/contributing_maturity.md#contributing-expectations) for Expectations.
+
+To view the full scripts used in this page, see them on GitHub:
+- [expect_column_max_to_be_between_custom.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py)
+- [expect_column_values_to_equal_three.py](https://github.com/great-expectations/great_expectations/blob/develop/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_values_to_equal_three.py)
+:::

--- a/docs/guides/expectations/features_custom_expectations/how_to_add_spark_support_for_an_expectation.md
+++ b/docs/guides/expectations/features_custom_expectations/how_to_add_spark_support_for_an_expectation.md
@@ -29,7 +29,7 @@ To avoid surprises and help clearly define your Custom Expectation, it can be he
 
 Within the `examples` defined inside your Expectation class, the `test_backends` key specifies which backends and SQLAlchemy dialects to run tests for. Add entries corresponding to the functionality you want to add: 
     
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L86-L132
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L112-L162
 ```
 
 :::note
@@ -70,7 +70,7 @@ The decorated method takes in a Spark `Column` object and will either return a `
 
 For our Custom Column Aggregate Expectation `ExpectColumnMaxToBeBetweenCustom`, we're going to leverage PySpark's `max` SQL Function and the `@column_aggregate_partial` decorator.
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L76-L79
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L94-L97
 ```
 
 If we need a builtin function from `pyspark.sql.functions`, usually aliased to `F`, the import logic in 

--- a/docs/guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation.md
+++ b/docs/guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation.md
@@ -31,7 +31,7 @@ To avoid surprises, it can be helpful to determine beforehand what backends and 
 
 Within the `examples` defined inside your Expectation class, the `test_backends` key specifies which backends and SQLAlchemy dialects to run tests for. Add entries corresponding to the functionality you want to add: 
     
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L86-L132
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L112-L162
 ```
 
 :::note
@@ -105,7 +105,7 @@ While this approach can result in extra roundtrips to your database, it can also
 For our Custom Column Aggregate Expectation `ExpectColumnMaxToBeBetweenCustom`, we're going to implement the `@metric_value` decorator, 
 specifying the type of value we're computing (`AGGREGATE_VALUE`) and the domain over which we're computing (`COLUMN`):
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L46-L58
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L59-L71
 ```
 
 The decorated method takes in a valid <TechnicalTag tag="execution_engine" text="Execution Engine"/> and relevant key word arguments,
@@ -113,12 +113,12 @@ and will return a computed value.
 
 To do this, we need to access our Compute Domain directly:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L59-L69
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L74-L84
 ```
 
 This allows us to build a query and use our Execution Engine to execute that query against our data to return the actual value we're looking for, instead of returning a query to find that value:
 
-```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L71-L74
+```python file=../../../../tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py#L87-L90
 ```
 
 <details>

--- a/docs/guides/expectations/index.md
+++ b/docs/guides/expectations/index.md
@@ -37,3 +37,4 @@ title: "Create Expectations: Index"
 - [How to add input validation and type checking for a Custom Expectation](../../guides/expectations/features_custom_expectations/how_to_add_input_validation_for_an_expectation.md)
 - [How to add Spark support for Custom Expectations](../../guides/expectations/features_custom_expectations/how_to_add_spark_support_for_an_expectation.md)
 - [How to add SQLAlchemy support for Custom Expectations](../../guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation.md)
+- [How to add Polars support for Custom Expectations](../../guides/expectations/features_custom_expectations/how_to_add_polars_support_for_an_expectation.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -224,7 +224,7 @@ module.exports = {
                 'guides/expectations/features_custom_expectations/how_to_add_example_cases_for_an_expectation',
                 'guides/expectations/features_custom_expectations/how_to_add_input_validation_for_an_expectation',
                 'guides/expectations/features_custom_expectations/how_to_add_spark_support_for_an_expectation',
-                'guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation'
+                'guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation',
                 'guides/expectations/features_custom_expectations/how_to_add_polars_support_for_an_expectation'
               ]
             }

--- a/sidebars.js
+++ b/sidebars.js
@@ -225,6 +225,7 @@ module.exports = {
                 'guides/expectations/features_custom_expectations/how_to_add_input_validation_for_an_expectation',
                 'guides/expectations/features_custom_expectations/how_to_add_spark_support_for_an_expectation',
                 'guides/expectations/features_custom_expectations/how_to_add_sqlalchemy_support_for_an_expectation'
+                'guides/expectations/features_custom_expectations/how_to_add_polars_support_for_an_expectation'
               ]
             }
           ]

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
@@ -7,6 +7,7 @@ from great_expectations.exceptions.exceptions import (
 from great_expectations.execution_engine import (
     ExecutionEngine,
     PandasExecutionEngine,
+    PolarsExecutionEngine,
     SparkDFExecutionEngine,
     SqlAlchemyExecutionEngine,
 )
@@ -33,13 +34,23 @@ from great_expectations.render.util import (
 )
 
 
+# <snippet>
 class ColumnCustomMax(ColumnAggregateMetricProvider):
+    # </snippet>
     """MetricProvider Class for Custom Aggregate Max MetricProvider"""
-
+    # <snippet>
     metric_name = "column.custom_max"
-
+    # </snippet>
+    # <snippet>
     @column_aggregate_value(engine=PandasExecutionEngine)
     def _pandas(cls, column, **kwargs):
+        """Pandas Max Implementation"""
+        return column.max()
+
+    # </snippet>
+
+    @column_aggregate_value(engine=PolarsExecutionEngine)
+    def _polars(cls, column, **kwargs):
         """Pandas Max Implementation"""
         return column.max()
 
@@ -79,10 +90,15 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
         return F.max(column)
 
 
+# <snippet>
 class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
+    # </snippet
+    # <snippet>
     """Expect column max to be between a given range."""
+    # </snippet>
 
     # Defining test cases
+    # <snippet>
     examples = [
         {
             "data": {"x": [1, 2, 3, 4, 5], "y": [0, -1, -2, 4, None]},
@@ -127,12 +143,18 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
                     "backend": "spark",
                     "dialects": None,
                 },
+                {
+                    "backend": "polars",
+                    "dialects": None,
+                },
             ],
         }
     ]
-
+    # </snippet>
     # Setting necessary computation metric dependencies and defining kwargs, as well as assigning kwargs default values
+    # <snippet>
     metric_dependencies = ("column.custom_max",)
+    # </snippet>
     success_keys = ("min_value", "strict_min", "max_value", "strict_max")
 
     # Default values
@@ -193,6 +215,7 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
 
+    # <snippet>
     def _validate(
         self,
         configuration: ExpectationConfiguration,
@@ -230,6 +253,7 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
 
         return {"success": success, "result": {"observed_value": column_max}}
 
+    # </snippet>
     @renderer(renderer_type="render.prescriptive")
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
@@ -305,14 +329,20 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
         ]
 
     # This dictionary contains metadata for display in the public gallery
+    # <snippet>
     library_metadata = {
         "tags": ["flexible max comparisons"],
         "contributors": ["@joegargery"],
     }
 
 
+# </snippet>
+
+
 if __name__ == "__main__":
+    # <snippet>
     ExpectColumnMaxToBeBetweenCustom().print_diagnostic_checklist()
+#     < /snippet>
 
 # Note to users: code below this line is only for integration testing -- ignore!
 

--- a/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
+++ b/tests/integration/docusaurus/expectations/creating_custom_expectations/expect_column_max_to_be_between_custom.py
@@ -48,12 +48,14 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
         return column.max()
 
     # </snippet>
-
+    # <snippet>
     @column_aggregate_value(engine=PolarsExecutionEngine)
     def _polars(cls, column, **kwargs):
         """Pandas Max Implementation"""
         return column.max()
 
+    # </snippet>
+    # <snippet>
     @metric_value(
         engine=SqlAlchemyExecutionEngine,
         metric_fn_type=MetricFunctionTypes.AGGREGATE_VALUE,
@@ -67,6 +69,8 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
         metrics,
         runtime_configuration,
     ):
+        # </snippet>
+        # <snippet>
         (
             selectable,
             compute_domain_kwargs,
@@ -78,16 +82,22 @@ class ColumnCustomMax(ColumnAggregateMetricProvider):
         column_name = accessor_domain_kwargs["column"]
         column = sa.column(column_name)
         sqlalchemy_engine = execution_engine.engine
-
+        # </snippet>
+        # <snippet>
         query = sa.select([sa.func.max(column)]).select_from(selectable)
         result = sqlalchemy_engine.execute(query).fetchone()
 
         return result[0]
 
+    # </snippet>
+    # <snippet>
     @column_aggregate_partial(engine=SparkDFExecutionEngine)
     def _spark(cls, column, _table, _column_name, **kwargs):
         """Spark Max Implementation"""
         return F.max(column)
+
+
+#     </snippet>
 
 
 # <snippet>
@@ -167,7 +177,7 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
         "strict_max": None,
         "mostly": 1,
     }
-
+    # <snippet>
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration]
     ) -> None:
@@ -185,13 +195,15 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
         super().validate_configuration(configuration)
         if configuration is None:
             configuration = self.configuration
-
+        # </snippet>
+        # <snippet>
         min_value = configuration.kwargs["min_value"]
         max_value = configuration.kwargs["max_value"]
         strict_min = configuration.kwargs["strict_min"]
         strict_max = configuration.kwargs["strict_max"]
-
+        # </snippet>
         # Validating that min_val, max_val, strict_min, and strict_max are of the proper format and type
+        # <snippet>
         try:
             assert (
                 min_value is not None or max_value is not None
@@ -214,6 +226,8 @@ class ExpectColumnMaxToBeBetweenCustom(ColumnExpectation):
             ), "strict_max must be a boolean value"
         except AssertionError as e:
             raise InvalidExpectationConfigurationError(str(e))
+
+    #     </snippet>
 
     # <snippet>
     def _validate(


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- Implements polars in reference script
- Updates reference script with snippet tags
- Creates how-to doc for polars support
- Updates code refs for affected docs


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
- Supports #5914 


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
