### PR TITLE
[MAINTENANCE] Refactor out `termcolor` dependency

### DIFF
--- a/docs_rtd/requirements.txt
+++ b/docs_rtd/requirements.txt
@@ -82,7 +82,6 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sybil==1.4.0
-termcolor==1.1.0
 terminado==0.8.3
 testpath==0.4.4
 toml==0.10.1

--- a/great_expectations/cli/pretty_printing.py
+++ b/great_expectations/cli/pretty_printing.py
@@ -3,6 +3,9 @@ import sys
 from typing import List, Optional
 
 import click
+from typing_extensions import Final
+
+SUPPORTED_CLI_COLORS: Final[List[str]] = ["blue", "cyan", "green", "yellow", "red"]
 
 
 def cli_message(string: str) -> None:
@@ -10,10 +13,9 @@ def cli_message(string: str) -> None:
 
 
 def cli_colorize_string(string: str) -> str:
-    colors = ("blue", "cyan", "green", "yellow", "red")
-    for color in colors:
+    for color in SUPPORTED_CLI_COLORS:
         string = re.sub(
-            f"<{color}>(.*?)</{color}>",
+            f"<[ color ]>(.*?)</{color}>",
             click.style(r"\g<1>", fg=color),
             string,
             flags=re.DOTALL,  # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags

--- a/great_expectations/cli/pretty_printing.py
+++ b/great_expectations/cli/pretty_printing.py
@@ -2,7 +2,15 @@ import re
 import sys
 from typing import List, Optional
 
-from termcolor import colored
+import click
+
+try:
+    from typing import Final
+except ImportError:
+    # Fallback for python < 3.8
+    from typing_extensions import Final
+
+SUPPORTED_CLI_COLORS: Final[List[str]] = ["blue", "cyan", "green", "yellow", "red"]
 
 
 def cli_message(string: str) -> None:
@@ -10,25 +18,15 @@ def cli_message(string: str) -> None:
 
 
 def cli_colorize_string(string: str) -> str:
-    # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
-    flags = re.DOTALL
-    mod_string = re.sub(
-        "<blue>(.*?)</blue>", colored(r"\g<1>", "blue"), string, flags=flags
-    )
-    mod_string = re.sub(
-        "<cyan>(.*?)</cyan>", colored(r"\g<1>", "cyan"), mod_string, flags=flags
-    )
-    mod_string = re.sub(
-        "<green>(.*?)</green>", colored(r"\g<1>", "green"), mod_string, flags=flags
-    )
-    mod_string = re.sub(
-        "<yellow>(.*?)</yellow>", colored(r"\g<1>", "yellow"), mod_string, flags=flags
-    )
-    mod_string = re.sub(
-        "<red>(.*?)</red>", colored(r"\g<1>", "red"), mod_string, flags=flags
-    )
-
-    return colored(mod_string)
+    for color in SUPPORTED_CLI_COLORS:
+        string = re.sub(
+            f"<{color}>(.*?)</{color}>",
+            click.style(string, fg=color),
+            string,
+            # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
+            flags=re.DOTALL,
+        )
+    return string
 
 
 def display_not_implemented_message_and_exit() -> None:

--- a/great_expectations/cli/pretty_printing.py
+++ b/great_expectations/cli/pretty_printing.py
@@ -21,7 +21,7 @@ def cli_message(string: str) -> None:
 def cli_colorize_string(string: str) -> str:
     for color in SUPPORTED_CLI_COLORS:
         string = re.sub(
-            f"<[ color ]>(.*?)</{color}>",
+            f"<{color}>(.*?)</{color}>",
             click.style(r"\g<1>", fg=color),
             string,
             flags=re.DOTALL,  # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags

--- a/great_expectations/cli/pretty_printing.py
+++ b/great_expectations/cli/pretty_printing.py
@@ -4,21 +4,13 @@ from typing import List, Optional
 
 import click
 
-try:
-    from typing import Final
-except ImportError:
-    # Fallback for python < 3.8
-    from typing_extensions import Final
-
-SUPPORTED_CLI_COLORS: Final[List[str]] = ["blue", "cyan", "green", "yellow", "red"]
-
 
 def cli_message(string: str) -> None:
     print(cli_colorize_string(string))
 
 
 def cli_colorize_string(string: str) -> str:
-    for color in SUPPORTED_CLI_COLORS:
+    for color in ("blue", "cyan", "green", "yellow", "red"):
         string = re.sub(
             f"<{color}>(.*?)</{color}>",
             click.style(string, fg=color),

--- a/great_expectations/cli/pretty_printing.py
+++ b/great_expectations/cli/pretty_printing.py
@@ -10,13 +10,13 @@ def cli_message(string: str) -> None:
 
 
 def cli_colorize_string(string: str) -> str:
-    for color in ("blue", "cyan", "green", "yellow", "red"):
+    colors = ("blue", "cyan", "green", "yellow", "red")
+    for color in colors:
         string = re.sub(
             f"<{color}>(.*?)</{color}>",
-            click.style(string, fg=color),
+            click.style(r"\g<1>", fg=color),
             string,
-            # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
-            flags=re.DOTALL,
+            flags=re.DOTALL,  # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
         )
     return string
 

--- a/great_expectations/cli/pretty_printing.py
+++ b/great_expectations/cli/pretty_printing.py
@@ -1,11 +1,17 @@
 import re
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import click
 from typing_extensions import Final
 
-SUPPORTED_CLI_COLORS: Final[List[str]] = ["blue", "cyan", "green", "yellow", "red"]
+SUPPORTED_CLI_COLORS: Final[Tuple[str, ...]] = (
+    "blue",
+    "cyan",
+    "green",
+    "yellow",
+    "red",
+)
 
 
 def cli_message(string: str) -> None:

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -13,36 +13,17 @@ from great_expectations.cli.v012.python_subprocess import (
 )
 from great_expectations.util import import_library_module, is_library_loadable
 
-try:
-    from termcolor import colored
-except ImportError:
-    colored = None
-
 
 def cli_message(string) -> None:
-    print(cli_colorize_string(string))
+    from great_expectations.cli.pretty_printing import cli_message as fn
+
+    fn(string)
 
 
 def cli_colorize_string(string):
-    # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
-    flags = re.DOTALL
-    mod_string = re.sub(
-        "<blue>(.*?)</blue>", colored(r"\g<1>", "blue"), string, flags=flags
-    )
-    mod_string = re.sub(
-        "<cyan>(.*?)</cyan>", colored(r"\g<1>", "cyan"), mod_string, flags=flags
-    )
-    mod_string = re.sub(
-        "<green>(.*?)</green>", colored(r"\g<1>", "green"), mod_string, flags=flags
-    )
-    mod_string = re.sub(
-        "<yellow>(.*?)</yellow>", colored(r"\g<1>", "yellow"), mod_string, flags=flags
-    )
-    mod_string = re.sub(
-        "<red>(.*?)</red>", colored(r"\g<1>", "red"), mod_string, flags=flags
-    )
+    from great_expectations.cli.pretty_printing import cli_colorize_string as fn
 
-    return colored(mod_string)
+    return fn(string)
 
 
 def cli_message_list(string_list, list_intro_string=None) -> None:

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -1,8 +1,10 @@
 import importlib
+import re
 import sys
 from types import ModuleType
 from typing import Optional
 
+import click
 import pkg_resources
 from pkg_resources import Distribution, WorkingSet
 
@@ -14,15 +16,19 @@ from great_expectations.util import import_library_module, is_library_loadable
 
 
 def cli_message(string) -> None:
-    from great_expectations.cli.pretty_printing import cli_message as fn
-
-    fn(string)
+    print(cli_colorize_string(string))
 
 
 def cli_colorize_string(string):
-    from great_expectations.cli.pretty_printing import cli_colorize_string as fn
-
-    return fn(string)
+    for color in ("blue", "cyan", "green", "yellow", "red"):
+        string = re.sub(
+            f"<{color}>(.*?)</{color}>",
+            click.style(string, fg=color),
+            string,
+            # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
+            flags=re.DOTALL,
+        )
+    return string
 
 
 def cli_message_list(string_list, list_intro_string=None) -> None:

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -31,7 +31,7 @@ def cli_message(string: str) -> None:
 def cli_colorize_string(string: str) -> str:
     for color in SUPPORTED_CLI_COLORS:
         string = re.sub(
-            f"<[ color ]>(.*?)</{color}>",
+            f"<{color}>(.*?)</{color}>",
             click.style(r"\g<1>", fg=color),
             string,
             flags=re.DOTALL,  # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -2,7 +2,7 @@ import importlib
 import re
 import sys
 from types import ModuleType
-from typing import List, Optional
+from typing import Optional, Tuple
 
 import click
 import pkg_resources
@@ -15,7 +15,13 @@ from great_expectations.cli.v012.python_subprocess import (
 )
 from great_expectations.util import import_library_module, is_library_loadable
 
-SUPPORTED_CLI_COLORS: Final[List[str]] = ["blue", "cyan", "green", "yellow", "red"]
+SUPPORTED_CLI_COLORS: Final[Tuple[str, ...]] = (
+    "blue",
+    "cyan",
+    "green",
+    "yellow",
+    "red",
+)
 
 
 def cli_message(string: str) -> None:

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -1,5 +1,4 @@
 import importlib
-import re
 import sys
 from types import ModuleType
 from typing import Optional

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -19,14 +19,14 @@ def cli_message(string) -> None:
     print(cli_colorize_string(string))
 
 
-def cli_colorize_string(string):
-    for color in ("blue", "cyan", "green", "yellow", "red"):
+def cli_colorize_string(string: str) -> str:
+    colors = ("blue", "cyan", "green", "yellow", "red")
+    for color in colors:
         string = re.sub(
             f"<{color}>(.*?)</{color}>",
-            click.style(string, fg=color),
+            click.style(r"\g<1>", fg=color),
             string,
-            # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
-            flags=re.DOTALL,
+            flags=re.DOTALL,  # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags
         )
     return string
 

--- a/great_expectations/cli/v012/util.py
+++ b/great_expectations/cli/v012/util.py
@@ -2,11 +2,12 @@ import importlib
 import re
 import sys
 from types import ModuleType
-from typing import Optional
+from typing import List, Optional
 
 import click
 import pkg_resources
 from pkg_resources import Distribution, WorkingSet
+from typing_extensions import Final
 
 from great_expectations.cli.v012 import toolkit
 from great_expectations.cli.v012.python_subprocess import (
@@ -14,16 +15,17 @@ from great_expectations.cli.v012.python_subprocess import (
 )
 from great_expectations.util import import_library_module, is_library_loadable
 
+SUPPORTED_CLI_COLORS: Final[List[str]] = ["blue", "cyan", "green", "yellow", "red"]
 
-def cli_message(string) -> None:
+
+def cli_message(string: str) -> None:
     print(cli_colorize_string(string))
 
 
 def cli_colorize_string(string: str) -> str:
-    colors = ("blue", "cyan", "green", "yellow", "red")
-    for color in colors:
+    for color in SUPPORTED_CLI_COLORS:
         string = re.sub(
-            f"<{color}>(.*?)</{color}>",
+            f"<[ color ]>(.*?)</{color}>",
             click.style(r"\g<1>", fg=color),
             string,
             flags=re.DOTALL,  # the DOTALL flag means that `.` includes newlines for multiline comments inside these tags

--- a/great_expectations/core/usage_statistics/package_dependencies.py
+++ b/great_expectations/core/usage_statistics/package_dependencies.py
@@ -54,7 +54,6 @@ class GEDependencies:
             "requests",
             "ruamel.yaml",
             "scipy",
-            "termcolor",
             "tqdm",
             "typing-extensions",
             "urllib3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ pytz>=2021.3
 requests>=2.20
 ruamel.yaml>=0.16,<0.17.18
 scipy>=0.19.0
-termcolor>=1.1.0,<2.1.0 # Temporary pin due to breaking change made in 2.1.0
 tqdm>=4.59.0
 typing-extensions>=3.10.0.0 # Leverage type annotations from recent Python releases
 tzlocal>=1.2

--- a/tests/cli/test_datasource_pandas.py
+++ b/tests/cli/test_datasource_pandas.py
@@ -81,7 +81,7 @@ def test_cli_datasource_list_on_project_with_one_datasource(
  - name: my_datasource
    class_name: Datasource
 """.strip()
-    stdout = escape_ansi(result.stdout.strip())
+    stdout = escape_ansi(result.stdout).strip()
     assert stdout == expected_output
     assert_no_logging_messages_or_tracebacks(caplog, result)
 

--- a/tests/cli/test_datasource_pandas.py
+++ b/tests/cli/test_datasource_pandas.py
@@ -8,7 +8,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
-from tests.cli.utils import assert_no_logging_messages_or_tracebacks
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks, escape_ansi
 
 
 @mock.patch(
@@ -75,13 +75,13 @@ def test_cli_datasource_list_on_project_with_one_datasource(
         catch_exceptions=False,
     )
 
-    expected_output = """Using v3 (Batch Request) API\x1b[0m
-1 Datasource found:[0m
-[0m
- - [36mname:[0m my_datasource[0m
-   [36mclass_name:[0m Datasource[0m
+    expected_output = """Using v3 (Batch Request) API
+1 Datasource found:
+
+ - name: my_datasource
+   class_name: Datasource
 """.strip()
-    stdout = result.stdout.strip()
+    stdout = escape_ansi(result.stdout.strip())
     assert stdout == expected_output
     assert_no_logging_messages_or_tracebacks(caplog, result)
 

--- a/tests/cli/test_datasource_sqlite.py
+++ b/tests/cli/test_datasource_sqlite.py
@@ -52,7 +52,7 @@ Using v3 (Batch Request) API
  - name: wow_a_datasource
    class_name: SqlAlchemyDatasource
 """.strip()
-    stdout = escape_ansi(result.stdout.strip())
+    stdout = escape_ansi(result.stdout).strip()
 
     assert stdout == expected_output
 

--- a/tests/cli/test_datasource_sqlite.py
+++ b/tests/cli/test_datasource_sqlite.py
@@ -9,7 +9,7 @@ from nbconvert.preprocessors import ExecutePreprocessor
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
-from tests.cli.utils import assert_no_logging_messages_or_tracebacks
+from tests.cli.utils import assert_no_logging_messages_or_tracebacks, escape_ansi
 
 
 @mock.patch(
@@ -46,13 +46,13 @@ def test_cli_datasource_list(
         catch_exceptions=False,
     )
     expected_output = """\
-Using v3 (Batch Request) API\x1b[0m
-1 Datasource found:[0m
-[0m
- - [36mname:[0m wow_a_datasource[0m
-   [36mclass_name:[0m SqlAlchemyDatasource[0m
+Using v3 (Batch Request) API
+1 Datasource found:
+
+ - name: wow_a_datasource
+   class_name: SqlAlchemyDatasource
 """.strip()
-    stdout = result.stdout.strip()
+    stdout = escape_ansi(result.stdout.strip())
 
     assert stdout == expected_output
 

--- a/tests/cli/upgrade_helpers/test_upgrade_helper.py
+++ b/tests/cli/upgrade_helpers/test_upgrade_helper.py
@@ -132,8 +132,8 @@ def test_upgrade_helper_intervention_on_cli_command(
         in stdout
     )
     assert (
-        "Ok, exiting now. To upgrade at a later time, use the following command: [36mgreat_expectations project "
-        "upgrade[0m" in stdout
+        "Ok, exiting now. To upgrade at a later time, use the following command: great_expectations project "
+        "upgrade" in stdout
     )
     assert (
         "To learn more about the upgrade process, visit ["
@@ -198,7 +198,7 @@ def test_basic_project_upgrade(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = escape_ansi(result.stdout)
+    stdout: str = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -206,7 +206,7 @@ def test_basic_project_upgrade(v10_project_directory, caplog):
             "../../test_fixtures/upgrade_helper/test_basic_project_upgrade_expected_stdout.fixture",
         )
     ) as f:
-        expected_stdout: str = f.read()
+        expected_stdout: str = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v10_project_directory
         )
@@ -304,7 +304,7 @@ def test_project_upgrade_with_manual_steps(
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = escape_ansi(result.stdout)
+    stdout: str = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -312,7 +312,7 @@ def test_project_upgrade_with_manual_steps(
             "../../test_fixtures/upgrade_helper/test_project_upgrade_with_manual_steps_expected_stdout.fixture",
         )
     ) as f:
-        expected_stdout: str = f.read()
+        expected_stdout: str = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v10_project_directory
         )
@@ -415,7 +415,7 @@ def test_project_upgrade_with_exception(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = escape_ansi(result.stdout)
+    stdout: str = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -423,7 +423,7 @@ def test_project_upgrade_with_exception(v10_project_directory, caplog):
             "../../test_fixtures/upgrade_helper/test_project_upgrade_with_exception_expected_stdout.fixture",
         )
     ) as f:
-        expected_stdout: str = f.read()
+        expected_stdout: str = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v10_project_directory
         )
@@ -512,7 +512,7 @@ def test_v2_to_v3_project_upgrade_with_all_manual_steps_checkpoints_datasources_
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = escape_ansi(result.stdout)
+    stdout: str = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -520,7 +520,7 @@ def test_v2_to_v3_project_upgrade_with_all_manual_steps_checkpoints_datasources_
             "../../test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints_datasources_validation_operators_expected_stdout.fixture",
         )
     ) as f:
-        expected_stdout: str = f.read()
+        expected_stdout: str = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v20_project_directory
         )
@@ -619,7 +619,7 @@ def test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints(
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = escape_ansi(result.stdout)
+    stdout: str = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -627,7 +627,7 @@ def test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints(
             "../../test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints.fixture",
         )
     ) as f:
-        expected_stdout: str = f.read()
+        expected_stdout: str = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR",
             v20_project_directory_with_v30_configuration_and_v20_checkpoints,
@@ -733,7 +733,7 @@ def test_v2_to_v3_project_upgrade_without_manual_steps(
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = escape_ansi(result.stdout)
+    stdout: str = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -741,7 +741,7 @@ def test_v2_to_v3_project_upgrade_without_manual_steps(
             "../../test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_without_manual_steps_expected_stdout.fixture",
         )
     ) as f:
-        expected_stdout: str = f.read()
+        expected_stdout: str = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR",
             v20_project_directory_with_v30_configuration_and_no_checkpoints,

--- a/tests/cli/upgrade_helpers/test_upgrade_helper.py
+++ b/tests/cli/upgrade_helpers/test_upgrade_helper.py
@@ -136,8 +136,8 @@ def test_upgrade_helper_intervention_on_cli_command(
         "upgrade" in stdout
     )
     assert (
-        "To learn more about the upgrade process, visit ["
-        "36mhttps://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide#migrating-to-the-batch-request-v3-api"
+        "To learn more about the upgrade process, visit "
+        "https://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide#migrating-to-the-batch-request-v3-api"
         in stdout
     )
     assert_no_logging_messages_or_tracebacks(

--- a/tests/cli/upgrade_helpers/test_upgrade_helper.py
+++ b/tests/cli/upgrade_helpers/test_upgrade_helper.py
@@ -15,6 +15,7 @@ from great_expectations.util import gen_directory_tree_str
 from tests.cli.utils import (
     VALIDATION_OPERATORS_DEPRECATION_MESSAGE,
     assert_no_logging_messages_or_tracebacks,
+    escape_ansi,
 )
 
 
@@ -197,7 +198,7 @@ def test_basic_project_upgrade(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = result.stdout
+    stdout: str = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -303,7 +304,7 @@ def test_project_upgrade_with_manual_steps(
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = result.stdout
+    stdout: str = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -414,7 +415,7 @@ def test_project_upgrade_with_exception(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = result.stdout
+    stdout: str = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -511,7 +512,7 @@ def test_v2_to_v3_project_upgrade_with_all_manual_steps_checkpoints_datasources_
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = result.stdout
+    stdout: str = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -618,7 +619,7 @@ def test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints(
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = result.stdout
+    stdout: str = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -732,7 +733,7 @@ def test_v2_to_v3_project_upgrade_without_manual_steps(
         input="\n",
         catch_exceptions=False,
     )
-    stdout: str = result.stdout
+    stdout: str = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(

--- a/tests/cli/upgrade_helpers/test_upgrade_helper.py
+++ b/tests/cli/upgrade_helpers/test_upgrade_helper.py
@@ -120,7 +120,7 @@ def test_upgrade_helper_intervention_on_cli_command(
         input="n\n",
         catch_exceptions=False,
     )
-    stdout: str = result.stdout
+    stdout: str = escape_ansi(result.stdout).strip()
 
     assert (
         "Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3."

--- a/tests/cli/utils.py
+++ b/tests/cli/utils.py
@@ -1,3 +1,4 @@
+import re
 import traceback
 
 from _pytest.logging import LogCaptureFixture
@@ -128,3 +129,9 @@ def assert_no_tracebacks(click_result):
     except ValueError as ve:
         # sometimes stderr is not captured separately
         pass
+
+
+def escape_ansi(line: str) -> str:
+    # https://stackoverflow.com/a/38662876
+    ansi_escape = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
+    return ansi_escape.sub("", line)

--- a/tests/cli/v012/test_datasource_pandas.py
+++ b/tests/cli/v012/test_datasource_pandas.py
@@ -79,7 +79,7 @@ def test_cli_datasource_list(caplog, empty_data_context, filesystem_csv_2):
      class_name: PandasDataset""".format(
         base_directory
     ).strip()
-    stdout = escape_ansi(result.stdout.strip())
+    stdout = escape_ansi(result.stdout).strip()
     assert stdout == expected_output
     assert_no_logging_messages_or_tracebacks(caplog, result)
 

--- a/tests/cli/v012/test_datasource_pandas.py
+++ b/tests/cli/v012/test_datasource_pandas.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli.v012 import cli
+from tests.cli.utils import escape_ansi
 from tests.cli.v012.test_cli import yaml
 from tests.cli.v012.utils import (
     assert_no_logging_messages_or_tracebacks,
@@ -64,21 +65,21 @@ def test_cli_datasource_list(caplog, empty_data_context, filesystem_csv_2):
         cli, ["datasource", "list", "-d", project_root_dir], catch_exceptions=False
     )
     expected_output = """
-1 Datasource found:[0m
-[0m
- - [36mname:[0m wow_a_datasource[0m
-   [36mmodule_name:[0m great_expectations.datasource[0m
-   [36mclass_name:[0m PandasDatasource[0m
-   [36mbatch_kwargs_generators:[0m[0m
-     [36msubdir_reader:[0m[0m
-       [36mclass_name:[0m SubdirReaderBatchKwargsGenerator[0m
-       [36mbase_directory:[0m {}[0m
-   [36mdata_asset_type:[0m[0m
-     [36mmodule_name:[0m great_expectations.dataset[0m
-     [36mclass_name:[0m PandasDataset[0m""".format(
+1 Datasource found:
+
+ - name: wow_a_datasource
+   module_name: great_expectations.datasource
+   class_name: PandasDatasource
+   batch_kwargs_generators:
+     subdir_reader:
+       class_name: SubdirReaderBatchKwargsGenerator
+       base_directory: {}
+   data_asset_type:
+     module_name: great_expectations.dataset
+     class_name: PandasDataset""".format(
         base_directory
     ).strip()
-    stdout = result.stdout.strip()
+    stdout = escape_ansi(result.stdout.strip())
     assert stdout == expected_output
     assert_no_logging_messages_or_tracebacks(caplog, result)
 

--- a/tests/cli/v012/test_datasource_sqlite.py
+++ b/tests/cli/v012/test_datasource_sqlite.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli.v012 import cli
+from tests.cli.utils import escape_ansi
 from tests.cli.v012.test_cli import yaml
 from tests.cli.v012.utils import (
     assert_no_logging_messages_or_tracebacks,
@@ -38,23 +39,23 @@ def test_cli_datasource_list(empty_data_context, empty_sqlite_db, caplog):
     )
     url = str(empty_sqlite_db.engine.url)
     expected_output = """\
-1 Datasource found:[0m
-[0m
- - [36mname:[0m wow_a_datasource[0m
-   [36mmodule_name:[0m great_expectations.datasource[0m
-   [36mclass_name:[0m SqlAlchemyDatasource[0m
-   [36mbatch_kwargs_generators:[0m[0m
-     [36mdefault:[0m[0m
-       [36mclass_name:[0m TableBatchKwargsGenerator[0m
-   [36mcredentials:[0m[0m
-     [36murl:[0m {}[0m
-   [36mdata_asset_type:[0m[0m
-     [36mclass_name:[0m SqlAlchemyDataset[0m
-     [36mmodule_name:[0m None[0m
+1 Datasource found:
+
+ - name: wow_a_datasource
+   module_name: great_expectations.datasource
+   class_name: SqlAlchemyDatasource
+   batch_kwargs_generators:
+     default:
+       class_name: TableBatchKwargsGenerator
+   credentials:
+     url: {}
+   data_asset_type:
+     class_name: SqlAlchemyDataset
+     module_name: None
 """.format(
         url
     ).strip()
-    stdout = result.stdout.strip()
+    stdout = escape_ansi(result.stdout.strip())
 
     assert stdout == expected_output
 

--- a/tests/cli/v012/test_datasource_sqlite.py
+++ b/tests/cli/v012/test_datasource_sqlite.py
@@ -55,7 +55,7 @@ def test_cli_datasource_list(empty_data_context, empty_sqlite_db, caplog):
 """.format(
         url
     ).strip()
-    stdout = escape_ansi(result.stdout.strip())
+    stdout = escape_ansi(result.stdout).strip()
 
     assert stdout == expected_output
 

--- a/tests/cli/v012/test_init_pandas.py
+++ b/tests/cli/v012/test_init_pandas.py
@@ -72,7 +72,7 @@ def test_cli_init_on_new_project(
     assert "Generating example Expectation Suite..." in stdout
     assert "Building" in stdout
     assert "Data Docs" in stdout
-    assert "Done generating example Expectation Suite" in stdout
+    assert "Done generating example Expectation Suite" in stdout
     assert "Great Expectations is now set up" in stdout
 
     assert os.path.isdir(os.path.join(project_dir, "great_expectations"))

--- a/tests/cli/v012/test_store.py
+++ b/tests/cli/v012/test_store.py
@@ -63,7 +63,7 @@ def test_store_list_with_two_stores(caplog, empty_data_context):
     )
 
     assert result.exit_code == 0
-    assert escape_ansi(result.output.strip()) == expected_result
+    assert escape_ansi(result.output).strip() == expected_result.strip()
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
@@ -110,6 +110,6 @@ def test_store_list_with_four_stores(caplog, empty_data_context):
     )
     print(result.output)
     assert result.exit_code == 0
-    assert escape_ansi(result.output.strip()) == expected_result
+    assert escape_ansi(result.output).strip() == expected_result.strip()
 
     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/v012/test_store.py
+++ b/tests/cli/v012/test_store.py
@@ -2,6 +2,7 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli.v012 import cli
+from tests.cli.utils import escape_ansi
 from tests.cli.v012.utils import assert_no_logging_messages_or_tracebacks
 
 
@@ -40,20 +41,20 @@ def test_store_list_with_two_stores(caplog, empty_data_context):
     runner = CliRunner(mix_stderr=False)
 
     expected_result = """\
-2 Stores found:[0m
-[0m
- - [36mname:[0m expectations_store[0m
-   [36mclass_name:[0m ExpectationsStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m expectations/[0m
-[0m
- - [36mname:[0m checkpoint_store[0m
-   [36mclass_name:[0m CheckpointStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m checkpoints/[0m
-     [36msuppress_store_backend_id:[0m True[0m"""
+2 Stores found:
+
+ - name: expectations_store
+   class_name: ExpectationsStore
+   store_backend:
+     class_name: TupleFilesystemStoreBackend
+     base_directory: expectations/
+
+ - name: checkpoint_store
+   class_name: CheckpointStore
+   store_backend:
+     class_name: TupleFilesystemStoreBackend
+     base_directory: checkpoints/
+     suppress_store_backend_id: True"""
 
     result = runner.invoke(
         cli,
@@ -62,7 +63,7 @@ def test_store_list_with_two_stores(caplog, empty_data_context):
     )
 
     assert result.exit_code == 0
-    assert result.output.strip() == expected_result
+    assert escape_ansi(result.output.strip()) == expected_result
 
     assert_no_logging_messages_or_tracebacks(caplog, result)
 
@@ -72,36 +73,36 @@ def test_store_list_with_four_stores(caplog, empty_data_context):
     runner = CliRunner(mix_stderr=False)
 
     expected_result = """\
-5 Stores found:[0m
-[0m
- - [36mname:[0m expectations_store[0m
-   [36mclass_name:[0m ExpectationsStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m expectations/[0m
-[0m
- - [36mname:[0m validations_store[0m
-   [36mclass_name:[0m ValidationsStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m uncommitted/validations/[0m
-[0m
- - [36mname:[0m evaluation_parameter_store[0m
-   [36mclass_name:[0m EvaluationParameterStore[0m
-[0m
- - [36mname:[0m checkpoint_store[0m
-   [36mclass_name:[0m CheckpointStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m checkpoints/[0m
-     [36msuppress_store_backend_id:[0m True[0m
-[0m
- - [36mname:[0m profiler_store[0m
-   [36mclass_name:[0m ProfilerStore[0m
-   [36mstore_backend:[0m[0m
-     [36mclass_name:[0m TupleFilesystemStoreBackend[0m
-     [36mbase_directory:[0m profilers/[0m
-     [36msuppress_store_backend_id:[0m True[0m"""
+5 Stores found:
+
+ - name: expectations_store
+   class_name: ExpectationsStore
+   store_backend:
+     class_name: TupleFilesystemStoreBackend
+     base_directory: expectations/
+
+ - name: validations_store
+   class_name: ValidationsStore
+   store_backend:
+     class_name: TupleFilesystemStoreBackend
+     base_directory: uncommitted/validations/
+
+ - name: evaluation_parameter_store
+   class_name: EvaluationParameterStore
+
+ - name: checkpoint_store
+   class_name: CheckpointStore
+   store_backend:
+     class_name: TupleFilesystemStoreBackend
+     base_directory: checkpoints/
+     suppress_store_backend_id: True
+
+ - name: profiler_store
+   class_name: ProfilerStore
+   store_backend:
+     class_name: TupleFilesystemStoreBackend
+     base_directory: profilers/
+     suppress_store_backend_id: True"""
     result = runner.invoke(
         cli,
         f"store list -d {project_dir}",
@@ -109,6 +110,6 @@ def test_store_list_with_four_stores(caplog, empty_data_context):
     )
     print(result.output)
     assert result.exit_code == 0
-    assert result.output.strip() == expected_result
+    assert escape_ansi(result.output.strip()) == expected_result
 
     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/v012/test_validation_operator.py
+++ b/tests/cli/v012/test_validation_operator.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli.v012 import cli
+from tests.cli.utils import escape_ansi
 from tests.cli.v012.utils import (
     VALIDATION_OPERATORS_DEPRECATION_MESSAGE,
     assert_no_logging_messages_or_tracebacks,
@@ -307,12 +308,12 @@ def test_validation_operator_list_with_one_validation_operator(
     project_dir = filesystem_csv_data_context_with_validation_operators.root_directory
     runner = CliRunner(mix_stderr=False)
 
-    expected_result = """[33mHeads up! This feature is Experimental. It may change. Please give us your feedback![0m[0m
-1 Validation Operator found:[0m
-[0m
- - [36mname:[0m action_list_operator[0m
-   [36mclass_name:[0m ActionListValidationOperator[0m
-   [36maction_list:[0m store_validation_result (StoreValidationResultAction) => store_evaluation_params (StoreEvaluationParametersAction) => update_data_docs (UpdateDataDocsAction)[0m"""
+    expected_result = """Heads up! This feature is Experimental. It may change. Please give us your feedback!
+1 Validation Operator found:
+
+ - name: action_list_operator
+   class_name: ActionListValidationOperator
+   action_list: store_validation_result (StoreValidationResultAction) => store_evaluation_params (StoreEvaluationParametersAction) => update_data_docs (UpdateDataDocsAction)"""
 
     result = runner.invoke(
         cli,
@@ -321,7 +322,7 @@ def test_validation_operator_list_with_one_validation_operator(
     )
     assert result.exit_code == 0
     # _capture_ansi_codes_to_file(result)
-    assert result.output.strip() == expected_result
+    assert escape_ansi(result.output.strip()) == expected_result
 
     assert_no_logging_messages_or_tracebacks(
         my_caplog=caplog,
@@ -360,18 +361,18 @@ def test_validation_operator_list_with_multiple_validation_operators(
         },
     )
     context._save_project_config()
-    expected_result = """[33mHeads up! This feature is Experimental. It may change. Please give us your feedback![0m[0m
-2 Validation Operators found:[0m
-[0m
- - [36mname:[0m action_list_operator[0m
-   [36mclass_name:[0m ActionListValidationOperator[0m
-   [36maction_list:[0m store_validation_result (StoreValidationResultAction) => store_evaluation_params (StoreEvaluationParametersAction) => update_data_docs (UpdateDataDocsAction)[0m
-[0m
- - [36mname:[0m my_validation_operator[0m
-   [36mclass_name:[0m WarningAndFailureExpectationSuitesValidationOperator[0m
-   [36maction_list:[0m store_validation_result (StoreValidationResultAction) => store_evaluation_params (StoreEvaluationParametersAction) => update_data_docs (UpdateDataDocsAction)[0m
-   [36mbase_expectation_suite_name:[0m new-years-expectations[0m
-   [36mslack_webhook:[0m https://hooks.slack.com/services/dummy[0m"""
+    expected_result = """Heads up! This feature is Experimental. It may change. Please give us your feedback!
+2 Validation Operators found:
+
+ - name: action_list_operator
+   class_name: ActionListValidationOperator
+   action_list: store_validation_result (StoreValidationResultAction) => store_evaluation_params (StoreEvaluationParametersAction) => update_data_docs (UpdateDataDocsAction)
+
+ - name: my_validation_operator
+   class_name: WarningAndFailureExpectationSuitesValidationOperator
+   action_list: store_validation_result (StoreValidationResultAction) => store_evaluation_params (StoreEvaluationParametersAction) => update_data_docs (UpdateDataDocsAction)
+   base_expectation_suite_name: new-years-expectations
+   slack_webhook: https://hooks.slack.com/services/dummy"""
 
     result = runner.invoke(
         cli,
@@ -379,20 +380,10 @@ def test_validation_operator_list_with_multiple_validation_operators(
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    # _capture_ansi_codes_to_file(result)
-    assert result.output.strip() == expected_result
+    assert escape_ansi(result.output.strip()) == expected_result
 
     assert_no_logging_messages_or_tracebacks(
         my_caplog=caplog,
         click_result=result,
         allowed_deprecation_message=VALIDATION_OPERATORS_DEPRECATION_MESSAGE,
     )
-
-
-def _capture_ansi_codes_to_file(result):
-    """
-    Use this to capture the ANSI color codes when updating snapshots.
-    NOT DEAD CODE.
-    """
-    with open("ansi.txt", "w") as f:
-        f.write(result.output.strip())

--- a/tests/cli/v012/test_validation_operator.py
+++ b/tests/cli/v012/test_validation_operator.py
@@ -322,7 +322,7 @@ def test_validation_operator_list_with_one_validation_operator(
     )
     assert result.exit_code == 0
     # _capture_ansi_codes_to_file(result)
-    assert escape_ansi(result.output.strip()) == expected_result
+    assert escape_ansi(result.output).strip() == expected_result.strip()
 
     assert_no_logging_messages_or_tracebacks(
         my_caplog=caplog,
@@ -380,7 +380,7 @@ def test_validation_operator_list_with_multiple_validation_operators(
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert escape_ansi(result.output.strip()) == expected_result
+    assert escape_ansi(result.output).strip() == expected_result.strip()
 
     assert_no_logging_messages_or_tracebacks(
         my_caplog=caplog,

--- a/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
+++ b/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
@@ -77,8 +77,8 @@ def test_upgrade_helper_intervention_on_cli_command(v10_project_directory, caplo
         "upgrade" in stdout
     )
     assert (
-        "To learn more about the upgrade process, visit ["
-        "36mhttps://docs.greatexpectations.io/en/latest/how_to_guides/migrating_versions.html"
+        "To learn more about the upgrade process, visit "
+        "https://docs.greatexpectations.io/en/latest/how_to_guides/migrating_versions.html"
         in stdout
     )
     assert_no_logging_messages_or_tracebacks(caplog, result)

--- a/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
+++ b/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
@@ -14,6 +14,7 @@ from great_expectations import DataContext
 from great_expectations.cli.v012 import cli
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.util import gen_directory_tree_str
+from tests.cli.utils import escape_ansi
 from tests.cli.v012.utils import (
     VALIDATION_OPERATORS_DEPRECATION_MESSAGE,
     assert_no_logging_messages_or_tracebacks,
@@ -72,8 +73,8 @@ def test_upgrade_helper_intervention_on_cli_command(v10_project_directory, caplo
         in stdout
     )
     assert (
-        "Ok, exiting now. To upgrade at a later time, use the following command: [36mgreat_expectations project "
-        "upgrade[0m" in stdout
+        "Ok, exiting now. To upgrade at a later time, use the following command: great_expectations project "
+        "upgrade" in stdout
     )
     assert (
         "To learn more about the upgrade process, visit ["
@@ -135,7 +136,7 @@ def test_basic_project_upgrade(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout = result.stdout
+    stdout = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -241,7 +242,7 @@ def test_project_upgrade_with_manual_steps(
         input="\n",
         catch_exceptions=False,
     )
-    stdout = result.stdout
+    stdout = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -352,7 +353,7 @@ def test_project_upgrade_with_exception(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout = result.stdout
+    stdout = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(
@@ -449,7 +450,7 @@ def test_v2_to_v3_project_upgrade(v20_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout = result.stdout
+    stdout = escape_ansi(result.stdout)
 
     with open(
         file_relative_path(

--- a/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
+++ b/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
@@ -450,7 +450,7 @@ def test_v2_to_v3_project_upgrade(v20_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout = escape_ansi(result.stdout)
+    stdout = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -458,7 +458,7 @@ def test_v2_to_v3_project_upgrade(v20_project_directory, caplog):
             "../../../test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_expected_v012_stdout.fixture",
         )
     ) as f:
-        expected_stdout = f.read()
+        expected_stdout = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v20_project_directory
         )

--- a/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
+++ b/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
@@ -136,7 +136,7 @@ def test_basic_project_upgrade(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout = escape_ansi(result.stdout)
+    stdout = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -144,7 +144,7 @@ def test_basic_project_upgrade(v10_project_directory, caplog):
             "../../../test_fixtures/upgrade_helper/test_basic_project_upgrade_expected_v012_stdout.fixture",
         )
     ) as f:
-        expected_stdout = f.read()
+        expected_stdout = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v10_project_directory
         )
@@ -242,7 +242,7 @@ def test_project_upgrade_with_manual_steps(
         input="\n",
         catch_exceptions=False,
     )
-    stdout = escape_ansi(result.stdout)
+    stdout = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -250,7 +250,7 @@ def test_project_upgrade_with_manual_steps(
             "../../../test_fixtures/upgrade_helper/test_project_upgrade_with_manual_steps_expected_v012_stdout.fixture",
         )
     ) as f:
-        expected_stdout = f.read()
+        expected_stdout = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v10_project_directory
         )
@@ -353,7 +353,7 @@ def test_project_upgrade_with_exception(v10_project_directory, caplog):
         input="\n",
         catch_exceptions=False,
     )
-    stdout = escape_ansi(result.stdout)
+    stdout = escape_ansi(result.stdout).strip()
 
     with open(
         file_relative_path(
@@ -361,7 +361,7 @@ def test_project_upgrade_with_exception(v10_project_directory, caplog):
             "../../../test_fixtures/upgrade_helper/test_project_upgrade_with_exception_expected_v012_stdout.fixture",
         )
     ) as f:
-        expected_stdout = f.read()
+        expected_stdout = f.read().strip()
         expected_stdout = expected_stdout.replace(
             "GE_PROJECT_DIR", v10_project_directory
         )

--- a/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
+++ b/tests/cli/v012/upgrade_helpers/test_upgrade_helper_pre_v013.py
@@ -61,7 +61,7 @@ def test_upgrade_helper_intervention_on_cli_command(v10_project_directory, caplo
         input="n\n",
         catch_exceptions=False,
     )
-    stdout = result.stdout
+    stdout = escape_ansi(result.stdout).strip()
 
     assert (
         "Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3."

--- a/tests/integration/usage_statistics/usage_stats_event_examples.py
+++ b/tests/integration/usage_statistics/usage_stats_event_examples.py
@@ -206,12 +206,6 @@ data_context_init_with_dependencies: dict = {
             },
             {
                 "install_environment": "required",
-                "package_name": "termcolor",
-                "installed": True,
-                "version": "1.1.0",
-            },
-            {
-                "install_environment": "required",
                 "package_name": "tqdm",
                 "installed": True,
                 "version": "4.63.0",

--- a/tests/test_fixtures/upgrade_helper/test_basic_project_upgrade_expected_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_basic_project_upgrade_expected_stdout.fixture
@@ -1,16 +1,16 @@
-Using v3 (Batch Request) API[0m
+Using v3 (Batch Request) API
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
-[31m
-Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.[0m[0m
+
+
+Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.
 
 Would you like to run the Upgrade Helper to bring your project up-to-date? [Y/n]: 
 
 ================================================================================
-[0m
+
 ++====================================++
 || UpgradeHelperV11: Upgrade Overview ||
 ++====================================++
@@ -42,20 +42,20 @@ to learn more about the automated upgrade process:
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[32mYour project was successfully upgraded to be compatible with Great Expectations 0.11.x.
+++================++
+|| Upgrade Report ||
+++================++
+
+Your project was successfully upgraded to be compatible with Great Expectations 0.11.x.
 The config_version of your great_expectations.yml has been automatically incremented to 2.0.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json
 ++====================================++
 || UpgradeHelperV13: Upgrade Overview ||
 ++====================================++
@@ -91,21 +91,20 @@ Please consult the V3 API migration guide for instructions on how to complete an
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[33mThe Upgrade Helper has performed the automated upgrade steps as part of upgrading your project to be compatible with Great Expectations V3 API, and the config_version of your great_expectations.yml has been automatically incremented to 3.0.  However, manual steps are required in order for the upgrade process to be completed successfully.
+++================++
+|| Upgrade Report ||
+++================++
+
+The Upgrade Helper has performed the automated upgrade steps as part of upgrading your project to be compatible with Great Expectations V3 API, and the config_version of your great_expectations.yml has been automatically incremented to 3.0.  However, manual steps are required in order for the upgrade process to be completed successfully.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20190926T134241.000000Z.json
 
 ================================================================================
-[0m
-[32mUpgrade complete. Exiting...[0m
-[0m
+
+Upgrade complete. Exiting...

--- a/tests/test_fixtures/upgrade_helper/test_basic_project_upgrade_expected_v012_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_basic_project_upgrade_expected_v012_stdout.fixture
@@ -1,15 +1,15 @@
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
-[31m
-Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.[0m[0m
+
+
+Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.
 
 Would you like to run the Upgrade Helper to bring your project up-to-date? [Y/n]: 
 
 ================================================================================
-[0m
+
 ++=====================================================++
 || UpgradeHelperV11: Upgrade Overview (V2-API Version) ||
 ++=====================================================++
@@ -46,20 +46,20 @@ to learn more about the automated upgrade process:
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[32mYour project was successfully upgraded to be compatible with Great Expectations 0.11.x.
+++================++
+|| Upgrade Report ||
+++================++
+
+Your project was successfully upgraded to be compatible with Great Expectations 0.11.x.
 The config_version of your great_expectations.yml has been automatically incremented to 2.0.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json
 ++=====================================================++
 || UpgradeHelperV13: Upgrade Overview (V2-API Version) ||
 ++=====================================================++
@@ -95,22 +95,21 @@ Please consult the V3 API migration guide to learn more about the automated upgr
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[32mYour project was successfully upgraded to be compatible with Great Expectations V3 API.
+++================++
+|| Upgrade Report ||
+++================++
+
+Your project was successfully upgraded to be compatible with Great Expectations V3 API.
 The config_version of your great_expectations.yml has been automatically incremented to 3.0.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20190926T134241.000000Z.json
 
 ================================================================================
-[0m
-[32mUpgrade complete. Exiting...[0m
-[0m
+
+Upgrade complete. Exiting...

--- a/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_exception_expected_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_exception_expected_stdout.fixture
@@ -1,16 +1,16 @@
-Using v3 (Batch Request) API[0m
+Using v3 (Batch Request) API
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
-[31m
-Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.[0m[0m
+
+
+Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.
 
 Would you like to run the Upgrade Helper to bring your project up-to-date? [Y/n]: 
 
 ================================================================================
-[0m
+
 ++====================================++
 || UpgradeHelperV11: Upgrade Overview ||
 ++====================================++
@@ -42,28 +42,27 @@ to learn more about the automated upgrade process:
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[31mThe Upgrade Helper encountered some exceptions during the upgrade process.
+++================++
+|| Upgrade Report ||
+++================++
+
+The Upgrade Helper encountered some exceptions during the upgrade process.
 Please review the exceptions section of the upgrade log and migrate the affected files manually,
 as detailed in the 0.11.x migration guide.
 
 The upgrade log can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json
 
 ================================================================================
-[0m
-[31mThe Upgrade Helper was unable to perform a complete project upgrade. Next steps:[0m
+
+The Upgrade Helper was unable to perform a complete project upgrade. Next steps:
 
     - Please perform any manual steps outlined in the Upgrade Overview and/or Upgrade Report above
-    - When complete, increment the config_version key in your [36mgreat_expectations.yml[0m to [36m2.0[0m
+    - When complete, increment the config_version key in your great_expectations.yml to 2.0
 
-To learn more about the upgrade process, visit [36mhttps://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide#migrating-to-the-batch-request-v3-api[0m
-[0m
+To learn more about the upgrade process, visit https://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide#migrating-to-the-batch-request-v3-api

--- a/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_exception_expected_v012_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_exception_expected_v012_stdout.fixture
@@ -1,15 +1,15 @@
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
-[31m
-Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.[0m[0m
+
+
+Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.
 
 Would you like to run the Upgrade Helper to bring your project up-to-date? [Y/n]: 
 
 ================================================================================
-[0m
+
 ++=====================================================++
 || UpgradeHelperV11: Upgrade Overview (V2-API Version) ||
 ++=====================================================++
@@ -46,28 +46,27 @@ to learn more about the automated upgrade process:
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[31mThe Upgrade Helper encountered some exceptions during the upgrade process.
+++================++
+|| Upgrade Report ||
+++================++
+
+The Upgrade Helper encountered some exceptions during the upgrade process.
 Please review the exceptions section of the upgrade log and migrate the affected files manually,
 as detailed in the 0.11.x migration guide.
 
 The upgrade log can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json
 
 ================================================================================
-[0m
-[31mThe Upgrade Helper was unable to perform a complete project upgrade. Next steps:[0m
+
+The Upgrade Helper was unable to perform a complete project upgrade. Next steps:
 
     - Please perform any manual steps outlined in the Upgrade Overview and/or Upgrade Report above
-    - When complete, increment the config_version key in your [36mgreat_expectations.yml[0m to [36m2.0[0m
+    - When complete, increment the config_version key in your great_expectations.yml to 2.0
 
-To learn more about the upgrade process, visit [36mhttps://docs.greatexpectations.io/en/latest/how_to_guides/migrating_versions.html[0m
-[0m
+To learn more about the upgrade process, visit https://docs.greatexpectations.io/en/latest/how_to_guides/migrating_versions.html

--- a/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_manual_steps_expected_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_manual_steps_expected_stdout.fixture
@@ -1,16 +1,16 @@
-Using v3 (Batch Request) API[0m
+Using v3 (Batch Request) API
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
-[31m
-Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.[0m[0m
+
+
+Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.
 
 Would you like to run the Upgrade Helper to bring your project up-to-date? [Y/n]: 
 
 ================================================================================
-[0m
+
 ++====================================++
 || UpgradeHelperV11: Upgrade Overview ||
 ++====================================++
@@ -47,25 +47,24 @@ to learn more about the automated upgrade process:
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[33mThe Upgrade Helper has completed the automated upgrade steps.
+++================++
+|| Upgrade Report ||
+++================++
+
+The Upgrade Helper has completed the automated upgrade steps.
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json
 
 ================================================================================
-[0m
-[31mThe Upgrade Helper was unable to perform a complete project upgrade. Next steps:[0m
+
+The Upgrade Helper was unable to perform a complete project upgrade. Next steps:
 
     - Please perform any manual steps outlined in the Upgrade Overview and/or Upgrade Report above
-    - When complete, increment the config_version key in your [36mgreat_expectations.yml[0m to [36m2.0[0m
+    - When complete, increment the config_version key in your great_expectations.yml to 2.0
 
-To learn more about the upgrade process, visit [36mhttps://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide#migrating-to-the-batch-request-v3-api[0m
-[0m
+To learn more about the upgrade process, visit https://docs.greatexpectations.io/docs/guides/miscellaneous/migration_guide#migrating-to-the-batch-request-v3-api

--- a/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_manual_steps_expected_v012_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_project_upgrade_with_manual_steps_expected_v012_stdout.fixture
@@ -1,15 +1,15 @@
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
-[31m
-Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.[0m[0m
+
+
+Your project appears to have an out-of-date config version (1.0) - the version number must be at least 3.
 
 Would you like to run the Upgrade Helper to bring your project up-to-date? [Y/n]: 
 
 ================================================================================
-[0m
+
 ++=====================================================++
 || UpgradeHelperV11: Upgrade Overview (V2-API Version) ||
 ++=====================================================++
@@ -51,25 +51,24 @@ to learn more about the automated upgrade process:
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[33mThe Upgrade Helper has completed the automated upgrade steps.
+++================++
+|| Upgrade Report ||
+++================++
+
+The Upgrade Helper has completed the automated upgrade steps.
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV11_20190926T134241.000000Z.json
 
 ================================================================================
-[0m
-[31mThe Upgrade Helper was unable to perform a complete project upgrade. Next steps:[0m
+
+The Upgrade Helper was unable to perform a complete project upgrade. Next steps:
 
     - Please perform any manual steps outlined in the Upgrade Overview and/or Upgrade Report above
-    - When complete, increment the config_version key in your [36mgreat_expectations.yml[0m to [36m2.0[0m
+    - When complete, increment the config_version key in your great_expectations.yml to 2.0
 
-To learn more about the upgrade process, visit [36mhttps://docs.greatexpectations.io/en/latest/how_to_guides/migrating_versions.html[0m
-[0m
+To learn more about the upgrade process, visit https://docs.greatexpectations.io/en/latest/how_to_guides/migrating_versions.html

--- a/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_expected_v012_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_expected_v012_stdout.fixture
@@ -1,8 +1,8 @@
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
+
 ++=====================================================++
 || UpgradeHelperV13: Upgrade Overview (V2-API Version) ||
 ++=====================================================++
@@ -38,19 +38,18 @@ Please consult the V3 API migration guide to learn more about the automated upgr
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[32mYour project was successfully upgraded to be compatible with Great Expectations V3 API.
+++================++
+|| Upgrade Report ||
+++================++
+
+Your project was successfully upgraded to be compatible with Great Expectations V3 API.
 The config_version of your great_expectations.yml has been automatically incremented to 3.0.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json[0m[0m
-[32mYour project is up-to-date - no further upgrade is necessary.
-[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json
+Your project is up-to-date - no further upgrade is necessary.

--- a/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints.fixture
@@ -1,9 +1,9 @@
-Using v3 (Batch Request) API[0m
+Using v3 (Batch Request) API
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
+
 ++====================================++
 || UpgradeHelperV13: Upgrade Overview ||
 ++====================================++
@@ -36,18 +36,17 @@ Please consult the V3 API migration guide for instructions on how to complete an
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[33mThe Upgrade Helper has performed the automated upgrade steps as part of upgrading your project to be compatible with Great Expectations V3 API, and the config_version of your great_expectations.yml has been automatically incremented to 3.0.  However, manual steps are required in order for the upgrade process to be completed successfully.
+++================++
+|| Upgrade Report ||
+++================++
+
+The Upgrade Helper has performed the automated upgrade steps as part of upgrading your project to be compatible with Great Expectations V3 API, and the config_version of your great_expectations.yml has been automatically incremented to 3.0.  However, manual steps are required in order for the upgrade process to be completed successfully.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json[0m[0m
-[33mYour project requires manual upgrade steps in order to be up-to-date.
-[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json
+Your project requires manual upgrade steps in order to be up-to-date.

--- a/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints_datasources_validation_operators_expected_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_with_manual_steps_checkpoints_datasources_validation_operators_expected_stdout.fixture
@@ -1,9 +1,9 @@
-Using v3 (Batch Request) API[0m
+Using v3 (Batch Request) API
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
+
 ++====================================++
 || UpgradeHelperV13: Upgrade Overview ||
 ++====================================++
@@ -43,18 +43,17 @@ Please consult the V3 API migration guide for instructions on how to complete an
 
 Would you like to proceed with the project upgrade? [Y/n]: 
 
-Upgrading project...[0m
+Upgrading project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[33mThe Upgrade Helper has performed the automated upgrade steps as part of upgrading your project to be compatible with Great Expectations V3 API, and the config_version of your great_expectations.yml has been automatically incremented to 3.0.  However, manual steps are required in order for the upgrade process to be completed successfully.
+++================++
+|| Upgrade Report ||
+++================++
+
+The Upgrade Helper has performed the automated upgrade steps as part of upgrading your project to be compatible with Great Expectations V3 API, and the config_version of your great_expectations.yml has been automatically incremented to 3.0.  However, manual steps are required in order for the upgrade process to be completed successfully.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json[0m[0m
-[33mYour project requires manual upgrade steps in order to be up-to-date.
-[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json
+Your project requires manual upgrade steps in order to be up-to-date.

--- a/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_without_manual_steps_expected_stdout.fixture
+++ b/tests/test_fixtures/upgrade_helper/test_v2_to_v3_project_upgrade_without_manual_steps_expected_stdout.fixture
@@ -1,17 +1,16 @@
-Using v3 (Batch Request) API[0m
+Using v3 (Batch Request) API
 
-Checking project...[0m
+Checking project...
 
 ================================================================================
-[0m
-[36m++================++
-|| Upgrade Report ||
-++================++[0m
 
-[32mYour project was successfully upgraded to be compatible with Great Expectations V3 API.  The config_version of your great_expectations.yml has been automatically incremented to 3.0.
+++================++
+|| Upgrade Report ||
+++================++
+
+Your project was successfully upgraded to be compatible with Great Expectations V3 API.  The config_version of your great_expectations.yml has been automatically incremented to 3.0.
 
 A log detailing the upgrade can be found here:
 
-    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json[0m[0m
-[32mYour project is up-to-date - no further upgrade is necessary.
-[0m[0m
+    - GE_PROJECT_DIR/uncommitted/logs/project_upgrades/UpgradeHelperV13_20210119T132639.000000Z.json
+Your project is up-to-date - no further upgrade is necessary.


### PR DESCRIPTION
Changes proposed in this pull request:
- Use built-in `click` functionality so we can get rid of `termcolor`
    - This seems to be the more robust of the two libraries and we already need `click` for CLI processing.

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
