### PR TITLE
[MAINTENANCE] Move Cloud-specific enums to `cloud_constants.py`

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -38,9 +38,7 @@ from great_expectations.core.usage_statistics.usage_statistics import (
     usage_statistics_enabled_method,
 )
 from great_expectations.data_asset import DataAsset
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
     CheckpointValidationConfig,

--- a/great_expectations/core/config_provider.py
+++ b/great_expectations/core/config_provider.py
@@ -155,7 +155,7 @@ class CloudConfigurationProvider(AbstractConfigurationProvider):
         self._cloud_config = cloud_config
 
     def get_values(self) -> Dict[str, str]:
-        from great_expectations.data_context.data_context.cloud_data_context import (
+        from great_expectations.data_context.cloud_constants import (
             GECloudEnvironmentVariable,
         )
 

--- a/great_expectations/data_context/cloud_constants.py
+++ b/great_expectations/data_context/cloud_constants.py
@@ -1,3 +1,26 @@
+from enum import Enum
+
 from typing_extensions import Final
 
 CLOUD_DEFAULT_BASE_URL: Final[str] = "https://api.greatexpectations.io/"
+
+
+class GECloudEnvironmentVariable(str, Enum):
+    BASE_URL = "GE_CLOUD_BASE_URL"
+    ORGANIZATION_ID = "GE_CLOUD_ORGANIZATION_ID"
+    ACCESS_TOKEN = "GE_CLOUD_ACCESS_TOKEN"
+
+
+class GeCloudRESTResource(str, Enum):
+    BATCH = "batch"
+    CHECKPOINT = "checkpoint"
+    DATASOURCE = "datasource"
+    DATA_ASSET = "data_asset"
+    DATA_CONTEXT = "data_context"
+    DATA_CONTEXT_VARIABLES = "data_context_variables"
+    EXPECTATION = "expectation"
+    EXPECTATION_SUITE = "expectation_suite"
+    EXPECTATION_VALIDATION_RESULT = "expectation_validation_result"
+    PROFILER = "profiler"
+    RENDERED_DATA_DOC = "rendered_data_doc"
+    VALIDATION_RESULT = "validation_result"

--- a/great_expectations/data_context/cloud_constants.py
+++ b/great_expectations/data_context/cloud_constants.py
@@ -14,6 +14,8 @@ class GECloudEnvironmentVariable(str, Enum):
 class GeCloudRESTResource(str, Enum):
     BATCH = "batch"
     CHECKPOINT = "checkpoint"
+    # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
+    CONTRACT = "contract"
     DATASOURCE = "datasource"
     DATA_ASSET = "data_asset"
     DATA_CONTEXT = "data_context"
@@ -23,4 +25,6 @@ class GeCloudRESTResource(str, Enum):
     EXPECTATION_VALIDATION_RESULT = "expectation_validation_result"
     PROFILER = "profiler"
     RENDERED_DATA_DOC = "rendered_data_doc"
+    # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
+    SUITE_VALIDATION_RESULT = "suite_validation_result"
     VALIDATION_RESULT = "validation_result"

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -21,6 +21,7 @@ from great_expectations.core.usage_statistics.usage_statistics import (
     usage_statistics_enabled_method,
 )
 from great_expectations.data_asset import DataAsset
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
@@ -29,9 +30,6 @@ from great_expectations.data_context.data_context.ephemeral_data_context import 
 )
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
-)
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
 )
 from great_expectations.data_context.templates import CONFIG_VARIABLES_TEMPLATE
 from great_expectations.data_context.types.base import (

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union, cast
 
 import requests
@@ -15,15 +14,16 @@ from great_expectations.core.config_provider import (
     ConfigurationProvider,
 )
 from great_expectations.core.serializer import JsonConfigSerializer
-from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
+from great_expectations.data_context.cloud_constants import (
+    CLOUD_DEFAULT_BASE_URL,
+    GECloudEnvironmentVariable,
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
 from great_expectations.data_context.data_context_variables import (
     CloudDataContextVariables,
-)
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
 )
 from great_expectations.data_context.types.base import (
     DEFAULT_USAGE_STATISTICS_URL,
@@ -41,12 +41,6 @@ if TYPE_CHECKING:
     from great_expectations.checkpoint.checkpoint import Checkpoint
 
 logger = logging.getLogger(__name__)
-
-
-class GECloudEnvironmentVariable(str, Enum):
-    BASE_URL = "GE_CLOUD_BASE_URL"
-    ORGANIZATION_ID = "GE_CLOUD_ORGANIZATION_ID"
-    ACCESS_TOKEN = "GE_CLOUD_ACCESS_TOKEN"
 
 
 class CloudDataContext(AbstractDataContext):

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -366,11 +366,9 @@ class CloudDataContextVariables(DataContextVariables):
             )
 
     def _init_store(self) -> DataContextStore:
+        from great_expectations.data_context.cloud_constants import GeCloudRESTResource
         from great_expectations.data_context.store.data_context_store import (
             DataContextStore,
-        )
-        from great_expectations.data_context.store.ge_cloud_store_backend import (
-            GeCloudRESTResource,
         )
 
         store_backend: dict = {

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -29,6 +29,7 @@ from great_expectations.core.configuration import AbstractConfig
 from great_expectations.core.http import create_session
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from great_expectations.core.usage_statistics.usage_statistics import send_usage_message
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
@@ -41,7 +42,6 @@ from great_expectations.data_context.migrator.configuration_bundle import (
     ConfigurationBundleSchema,
 )
 from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
     GeCloudStoreBackend,
     construct_json_payload,
     construct_url,

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -9,10 +9,8 @@ from marshmallow import ValidationError
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.data_context_key import DataContextKey
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store import ConfigurationStore
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
     DataContextConfigDefaults,

--- a/great_expectations/data_context/store/configuration_store.py
+++ b/great_expectations/data_context/store/configuration_store.py
@@ -5,9 +5,7 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
 import great_expectations.exceptions as ge_exceptions
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.base import BaseYamlConfig

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -4,11 +4,9 @@ from typing import Dict
 
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.expectation_suite import ExpectationSuiteSchema
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store.database_store_backend import (
     DatabaseStoreBackend,
-)
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
 )
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -1,14 +1,16 @@
 import json
 import logging
 from abc import ABCMeta
-from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 from urllib.parse import urljoin
 
 import requests
 
 from great_expectations.core.http import create_session
-from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
+from great_expectations.data_context.cloud_constants import (
+    CLOUD_DEFAULT_BASE_URL,
+    GeCloudRESTResource,
+)
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
@@ -107,30 +109,9 @@ def get_user_friendly_error_message(
     return " ".join(support_message)
 
 
-class GeCloudRESTResource(str, Enum):
-    BATCH = "batch"
-    CHECKPOINT = "checkpoint"
-    # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-    CONTRACT = "contract"
-    DATASOURCE = "datasource"
-    DATA_ASSET = "data_asset"
-    DATA_CONTEXT = "data_context"
-    DATA_CONTEXT_VARIABLES = "data_context_variables"
-    EXPECTATION = "expectation"
-    EXPECTATION_SUITE = "expectation_suite"
-    EXPECTATION_VALIDATION_RESULT = "expectation_validation_result"
-    PROFILER = "profiler"
-    RENDERED_DATA_DOC = "rendered_data_doc"
-    # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-    SUITE_VALIDATION_RESULT = "suite_validation_result"
-    VALIDATION_RESULT = "validation_result"
-
-
 class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     PAYLOAD_ATTRIBUTES_KEYS: Dict[GeCloudRESTResource, str] = {
         GeCloudRESTResource.CHECKPOINT: "checkpoint_config",
-        # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-        GeCloudRESTResource.CONTRACT: "checkpoint_config",
         GeCloudRESTResource.DATASOURCE: "datasource_config",
         GeCloudRESTResource.DATA_CONTEXT: "data_context_config",
         GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
@@ -138,19 +119,12 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "result",
         GeCloudRESTResource.PROFILER: "profiler",
         GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_doc",
-        # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-        GeCloudRESTResource.SUITE_VALIDATION_RESULT: "result",
         GeCloudRESTResource.VALIDATION_RESULT: "result",
     }
 
     ALLOWED_SET_KWARGS_BY_RESOURCE_TYPE: Dict[GeCloudRESTResource, Set[str]] = {
         GeCloudRESTResource.EXPECTATION_SUITE: {"clause_id"},
         GeCloudRESTResource.RENDERED_DATA_DOC: {"source_type", "source_id"},
-        # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-        GeCloudRESTResource.SUITE_VALIDATION_RESULT: {
-            "checkpoint_id",
-            "expectation_suite_id",
-        },
         GeCloudRESTResource.VALIDATION_RESULT: {
             "checkpoint_id",
             "expectation_suite_id",
@@ -161,8 +135,6 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         **{  # type: ignore[arg-type]
             GeCloudRESTResource.BATCH: "batches",
             GeCloudRESTResource.CHECKPOINT: "checkpoints",
-            # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-            GeCloudRESTResource.CONTRACT: "contracts",
             GeCloudRESTResource.DATA_ASSET: "data_assets",
             GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
             GeCloudRESTResource.DATASOURCE: "datasources",
@@ -171,8 +143,6 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "expectation_validation_results",
             GeCloudRESTResource.PROFILER: "profilers",
             GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_docs",
-            # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-            GeCloudRESTResource.SUITE_VALIDATION_RESULT: "suite_validation_results",
             GeCloudRESTResource.VALIDATION_RESULT: "validation_results",
         }
     )

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -144,6 +144,8 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         **{  # type: ignore[arg-type]
             GeCloudRESTResource.BATCH: "batches",
             GeCloudRESTResource.CHECKPOINT: "checkpoints",
+            # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
+            GeCloudRESTResource.CONTRACT: "contracts",
             GeCloudRESTResource.DATA_ASSET: "data_assets",
             GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
             GeCloudRESTResource.DATASOURCE: "datasources",
@@ -152,6 +154,8 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "expectation_validation_results",
             GeCloudRESTResource.PROFILER: "profilers",
             GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_docs",
+            # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
+            GeCloudRESTResource.SUITE_VALIDATION_RESULT: "suite_validation_results",
             GeCloudRESTResource.VALIDATION_RESULT: "validation_results",
         }
     )

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -112,6 +112,8 @@ def get_user_friendly_error_message(
 class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     PAYLOAD_ATTRIBUTES_KEYS: Dict[GeCloudRESTResource, str] = {
         GeCloudRESTResource.CHECKPOINT: "checkpoint_config",
+        # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
+        GeCloudRESTResource.CONTRACT: "checkpoint_config",
         GeCloudRESTResource.DATASOURCE: "datasource_config",
         GeCloudRESTResource.DATA_CONTEXT: "data_context_config",
         GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
@@ -119,12 +121,19 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "result",
         GeCloudRESTResource.PROFILER: "profiler",
         GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_doc",
+        # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
+        GeCloudRESTResource.SUITE_VALIDATION_RESULT: "result",
         GeCloudRESTResource.VALIDATION_RESULT: "result",
     }
 
     ALLOWED_SET_KWARGS_BY_RESOURCE_TYPE: Dict[GeCloudRESTResource, Set[str]] = {
         GeCloudRESTResource.EXPECTATION_SUITE: {"clause_id"},
         GeCloudRESTResource.RENDERED_DATA_DOC: {"source_type", "source_id"},
+        # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
+        GeCloudRESTResource.SUITE_VALIDATION_RESULT: {
+            "checkpoint_id",
+            "expectation_suite_id",
+        },
         GeCloudRESTResource.VALIDATION_RESULT: {
             "checkpoint_id",
             "expectation_suite_id",

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -2,10 +2,8 @@ import random
 import uuid
 from typing import Union
 
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store.configuration_store import ConfigurationStore
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
     GeCloudIdentifier,

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -6,11 +6,9 @@ from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
     ExpectationSuiteValidationResultSchema,
 )
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store.database_store_backend import (
     DatabaseStoreBackend,
-)
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
 )
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -14,9 +14,7 @@ from great_expectations.core.run_identifier import RunIdentifier, RunIdentifierS
 from great_expectations.exceptions import DataContextError, InvalidDataContextKeyError
 
 if TYPE_CHECKING:
-    from great_expectations.data_context.store.ge_cloud_store_backend import (
-        GeCloudRESTResource,
-    )
+    from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -7,9 +7,7 @@ from typing import Any, List, Optional, Tuple
 import great_expectations.exceptions as exceptions
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.util import nested_update
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store.html_site_store import (
     HtmlSiteStore,
     SiteSectionIdentifier,

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -26,9 +26,7 @@ from great_expectations.core.util import (
     determine_progress_bar_method_by_environment,
     nested_update,
 )
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -12,9 +12,7 @@ from great_expectations.core.batch import Batch
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import parse_result_format
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     GeCloudIdentifier,

--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -7,9 +7,7 @@ from moto import mock_sns
 
 from great_expectations.core import ExpectationSuiteValidationResult, RunIdentifier
 from great_expectations.data_context import BaseDataContext
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.types.resource_identifiers import (
     BatchIdentifier,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,9 +30,7 @@ from great_expectations.core.usage_statistics.usage_statistics import (
 )
 from great_expectations.core.util import get_or_create_spark_application
 from great_expectations.data_context import BaseDataContext, CloudDataContext
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store.profiler_store import ProfilerStore
 from great_expectations.data_context.types.base import (
     AnonymizedUsageStatisticsConfig,

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
@@ -14,9 +15,6 @@ from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
 from great_expectations.data_context.data_context.data_context import DataContext
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
     DataContextConfig,

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -4,11 +4,9 @@ from unittest import mock
 import pytest
 
 from great_expectations.core.expectation_suite import ExpectationSuite
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
-)
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
 )
 from great_expectations.data_context.types.base import DataContextConfig, GeCloudConfig
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier

--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -9,9 +9,7 @@ from great_expectations.core import (
     ExpectationValidationResult,
 )
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.render import RenderedAtomicContent
 from great_expectations.validator.validator import Validator

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -3,13 +3,11 @@ from unittest import mock
 
 import pytest
 
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
 from great_expectations.data_context.data_context.data_context import DataContext
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import DataContextConfig, GeCloudConfig
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 from great_expectations.rule_based_profiler.config.base import (

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -9,10 +9,8 @@ import great_expectations as gx
 import great_expectations.exceptions as ge_exceptions
 from great_expectations import CloudMigrator
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.migrator.cloud_migrator import MigrationResponse
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import AnonymizedUsageStatisticsConfig
 from tests.data_context.migrator.conftest import StubBaseDataContext
 

--- a/tests/data_context/store/conftest.py
+++ b/tests/data_context/store/conftest.py
@@ -1,10 +1,8 @@
 import pytest
 
 from great_expectations.core.serializer import JsonConfigSerializer
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store import DatasourceStore
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import datasourceConfigSchema
 
 

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -9,11 +9,9 @@ from marshmallow.exceptions import ValidationError
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.core.util import convert_to_json_serializable
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.data_context.data_context import DataContext
 from great_expectations.data_context.store import CheckpointStore
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,

--- a/tests/data_context/store/test_configuration_store.py
+++ b/tests/data_context/store/test_configuration_store.py
@@ -10,17 +10,8 @@ from ruamel.yaml.comments import CommentedMap
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.data_context_key import DataContextKey
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store import ConfigurationStore
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
-from great_expectations.data_context.store.in_memory_store_backend import (
-    InMemoryStoreBackend,
-)
-from great_expectations.data_context.store.tuple_store_backend import (
-    TupleFilesystemStoreBackend,
-    TupleStoreBackend,
-)
 from great_expectations.data_context.types.base import BaseYamlConfig
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -12,14 +12,12 @@ from great_expectations.core.serializer import (
     JsonConfigSerializer,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.data_context.data_context import DataContext
 from great_expectations.data_context.data_context_variables import (
     DataContextVariableSchema,
 )
 from great_expectations.data_context.store.datasource_store import DatasourceStore
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import (
     DatasourceConfig,
     datasourceConfigSchema,

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -4,10 +4,8 @@ from unittest import mock
 import pytest
 
 from great_expectations.core.serializer import DictConfigSerializer
+from great_expectations.data_context.cloud_constants import GeCloudRESTResource
 from great_expectations.data_context.store import DatasourceStore
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.types.base import (
     DatasourceConfig,
     datasourceConfigSchema,

--- a/tests/data_context/store/test_ge_cloud_store_backend.py
+++ b/tests/data_context/store/test_ge_cloud_store_backend.py
@@ -16,9 +16,11 @@ from unittest import mock
 
 import pytest
 
-from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
-from great_expectations.data_context.store.ge_cloud_store_backend import (
+from great_expectations.data_context.cloud_constants import (
+    CLOUD_DEFAULT_BASE_URL,
     GeCloudRESTResource,
+)
+from great_expectations.data_context.store.ge_cloud_store_backend import (
     GeCloudStoreBackend,
     construct_json_payload,
     construct_url,

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import os
-from collections import OrderedDict
 from unittest.mock import patch
 
 import boto3
@@ -20,7 +19,6 @@ from great_expectations.data_context.data_context_variables import (
     DataContextVariableSchema,
 )
 from great_expectations.data_context.store import (
-    GeCloudStoreBackend,
     InMemoryStoreBackend,
     StoreBackend,
     TupleAzureBlobStoreBackend,
@@ -28,16 +26,10 @@ from great_expectations.data_context.store import (
     TupleGCSStoreBackend,
     TupleS3StoreBackend,
 )
-from great_expectations.data_context.store.ge_cloud_store_backend import (
-    GeCloudRESTResource,
-)
 from great_expectations.data_context.store.inline_store_backend import (
     InlineStoreBackend,
 )
-from great_expectations.data_context.types.base import (
-    CheckpointConfig,
-    DataContextConfig,
-)
+from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,


### PR DESCRIPTION
Changes proposed in this pull request:
- These enums are shared across a few files so let's put them in a central location


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
