### PR TITLE
[DOCS] Add `yarn snippet-check` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "lint": "standard --fix"
+    "lint": "standard --fix",
+    "snippet-check": "node scripts/remark-named-snippets/snippet.js"
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^0.11.0",

--- a/scripts/remark-named-snippets/snippet.js
+++ b/scripts/remark-named-snippets/snippet.js
@@ -19,6 +19,7 @@ function constructSnippetMap (dir) {
         `A snippet named ${name} has already been defined elsewhere`
       )
     }
+    delete snippet.name // Remove duplicate filename to clean up stdout
     snippetMap[name] = snippet
   }
 

--- a/scripts/remark-named-snippets/snippet.js
+++ b/scripts/remark-named-snippets/snippet.js
@@ -153,4 +153,32 @@ function sanitizeText (text) {
     .trim()
 }
 
+function main() {
+  const snippets = parseDirectory(".")
+  // Remove call to `node scripts/remark-named-snippets/snippet.js`
+  const targetFiles = process.argv.slice(2)
+
+  let out = {}
+  for (const snippet of snippets) {
+    // If no explicit args are provided, default to all snippets
+    // Else, ensure that the snippet's source file was requested by the user
+    const file = snippet.file
+    if (targetFiles.length > 0 && !(targetFiles.includes(file))) {
+      continue
+    }
+    if (!(file in out)) {
+      out[file] = []
+    }
+    delete snippet.file // Remove duplicate filename to clean up stdout
+    out[file].push(snippet)
+  }
+  console.log(out)
+}
+
+
+if (require.main === module) {
+  main();
+}
+
+
 module.exports = constructSnippetMap

--- a/scripts/remark-named-snippets/snippet.js
+++ b/scripts/remark-named-snippets/snippet.js
@@ -153,9 +153,15 @@ function sanitizeText (text) {
     .trim()
 }
 
+/**
+ * Organize parsed snippets by source filename.
+ * If provided, input filenames will filter this output.
+ *
+ * Note that is what is run if this file is invoked by Node.
+ * An alias `yarn snippet-check` should be defined in `package.json` for convenience.
+ */
 function main() {
   const snippets = parseDirectory(".")
-  // Remove call to `node scripts/remark-named-snippets/snippet.js`
   const targetFiles = process.argv.slice(2)
 
   let out = {}

--- a/scripts/remark-named-snippets/snippet.js
+++ b/scripts/remark-named-snippets/snippet.js
@@ -158,8 +158,8 @@ function sanitizeText (text) {
  * Organize parsed snippets by source filename.
  * If provided, input filenames will filter this output.
  *
- * Note that is what is run if this file is invoked by Node.
- * An alias `yarn snippet-check` should be defined in `package.json` for convenience.
+ * Note that this is what is run if this file is invoked by Node.
+ * An alias `yarn snippet-check` is defined in `package.json` for convenience.
  */
 function main() {
   const snippets = parseDirectory(".")


### PR DESCRIPTION
Changes proposed in this pull request:
- Make the `snippet.js` file in our custom Remark plugin invokable to aid with development. 
- `yarn snippet-check <FILE_ARGS>` will show which snippets are contained within the input files. 

Loom: https://www.loom.com/share/6ca4bf2452124dd38f71f4ef07d3ad7a

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas