### PR TITLE
[MAINTENANCE] Misc cleanup of GX Cloud helpers

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional, Union
 from urllib.parse import urljoin
 
 from great_expectations.core import ExpectationSuiteValidationResult
-from great_expectations.data_context.types.refs import GeCloudResourceRef
+from great_expectations.data_context.types.refs import GXCloudResourceRef
 
 try:
     import pypd
@@ -28,7 +28,7 @@ from great_expectations.checkpoint.util import (
 from great_expectations.data_context.store.metric_store import MetricStore
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
     ValidationResultIdentifier,
 )
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -52,7 +52,7 @@ class ValidationAction:
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset,
         expectation_suite_identifier: Optional[ExpectationSuiteIdentifier] = None,
@@ -82,7 +82,7 @@ class ValidationAction:
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset,
         expectation_suite_identifier=None,
@@ -102,7 +102,7 @@ class NoOpAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset,
         expectation_suite_identifier=None,
@@ -196,7 +196,7 @@ class SlackNotificationAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset=None,
         payload=None,
@@ -213,7 +213,7 @@ class SlackNotificationAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_suite_id must be of type ValidationResultIdentifier or GeCloudIdentifier, "
@@ -301,7 +301,7 @@ class PagerdutyAlertAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset=None,
         payload=None,
@@ -318,7 +318,7 @@ class PagerdutyAlertAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_suite_id must be of type ValidationResultIdentifier or GeCloudIdentifier, "
@@ -422,7 +422,7 @@ class MicrosoftTeamsNotificationAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset=None,
         payload=None,
@@ -439,7 +439,7 @@ class MicrosoftTeamsNotificationAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_suite_id must be of type ValidationResultIdentifier or GeCloudIdentifier, "
@@ -539,7 +539,7 @@ class OpsgenieAlertAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset=None,
         payload=None,
@@ -556,7 +556,7 @@ class OpsgenieAlertAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_suite_id must be of type ValidationResultIdentifier or GeCloudIdentifier, "
@@ -698,7 +698,7 @@ class EmailAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset=None,
         payload=None,
@@ -715,7 +715,7 @@ class EmailAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_suite_id must be of type ValidationResultIdentifier or GeCloudIdentifier, "
@@ -798,7 +798,7 @@ class StoreValidationResultAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset,
         payload=None,
@@ -815,7 +815,7 @@ class StoreValidationResultAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_id must be of type ValidationResultIdentifier or GeCloudIdentifier, not {}".format(
@@ -840,7 +840,7 @@ class StoreValidationResultAction(ValidationAction):
             expectation_suite_id=expectation_suite_ge_cloud_id,
         )
         if self.data_context.ge_cloud_mode:
-            return_val: GeCloudResourceRef
+            return_val: GXCloudResourceRef
             new_ge_cloud_id = return_val.ge_cloud_id
             validation_result_suite_identifier.ge_cloud_id = new_ge_cloud_id
 
@@ -885,7 +885,7 @@ class StoreEvaluationParametersAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset,
         payload=None,
@@ -902,7 +902,7 @@ class StoreEvaluationParametersAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_id must be of type ValidationResultIdentifier or GeCloudIdentifier, not {}".format(
@@ -968,7 +968,7 @@ class StoreMetricsAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset,
         payload=None,
@@ -985,7 +985,7 @@ class StoreMetricsAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_id must be of type ValidationResultIdentifier or GeCloudIdentifier, not {}".format(
@@ -1047,7 +1047,7 @@ class UpdateDataDocsAction(ValidationAction):
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
         validation_result_suite_identifier: Union[
-            ValidationResultIdentifier, GeCloudIdentifier
+            ValidationResultIdentifier, GXCloudIdentifier
         ],
         data_asset,
         payload=None,
@@ -1064,7 +1064,7 @@ class UpdateDataDocsAction(ValidationAction):
 
         if not isinstance(
             validation_result_suite_identifier,
-            (ValidationResultIdentifier, GeCloudIdentifier),
+            (ValidationResultIdentifier, GXCloudIdentifier),
         ):
             raise TypeError(
                 "validation_result_id must be of type ValidationResultIdentifier or GeCloudIdentifier, not {}".format(
@@ -1119,7 +1119,7 @@ class CloudNotificationAction(ValidationAction):
     def _run(
         self,
         validation_result_suite: ExpectationSuiteValidationResult,
-        validation_result_suite_identifier: GeCloudIdentifier,
+        validation_result_suite_identifier: GXCloudIdentifier,
         data_asset=None,
         payload: Optional[Dict] = None,
         expectation_suite_identifier=None,
@@ -1136,7 +1136,7 @@ class CloudNotificationAction(ValidationAction):
             return Exception(
                 "CloudNotificationActions can only be used in GE Cloud Mode."
             )
-        if not isinstance(validation_result_suite_identifier, GeCloudIdentifier):
+        if not isinstance(validation_result_suite_identifier, GXCloudIdentifier):
             raise TypeError(
                 "validation_result_id must be of type GeCloudIdentifier, not {}".format(
                     type(validation_result_suite_identifier)

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -43,7 +43,7 @@ from great_expectations.data_context.types.base import (
     CheckpointConfig,
     CheckpointValidationConfig,
 )
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.data_context.util import (
     instantiate_class_from_config,
     substitute_all_config_variables,
@@ -396,7 +396,7 @@ class BaseCheckpoint(ConfigPeer):
             )
             checkpoint_identifier = None
             if self.data_context.ge_cloud_mode:
-                checkpoint_identifier = GeCloudIdentifier(
+                checkpoint_identifier = GXCloudIdentifier(
                     resource_type=GXCloudRESTResource.CHECKPOINT,
                     ge_cloud_id=str(self.ge_cloud_id),
                 )

--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -38,7 +38,7 @@ from great_expectations.core.usage_statistics.usage_statistics import (
     usage_statistics_enabled_method,
 )
 from great_expectations.data_asset import DataAsset
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
     CheckpointValidationConfig,
@@ -397,7 +397,7 @@ class BaseCheckpoint(ConfigPeer):
             checkpoint_identifier = None
             if self.data_context.ge_cloud_mode:
                 checkpoint_identifier = GeCloudIdentifier(
-                    resource_type=GeCloudRESTResource.CHECKPOINT,
+                    resource_type=GXCloudRESTResource.CHECKPOINT,
                     ge_cloud_id=str(self.ge_cloud_id),
                 )
 

--- a/great_expectations/core/config_provider.py
+++ b/great_expectations/core/config_provider.py
@@ -156,11 +156,11 @@ class CloudConfigurationProvider(AbstractConfigurationProvider):
 
     def get_values(self) -> Dict[str, str]:
         from great_expectations.data_context.cloud_constants import (
-            GECloudEnvironmentVariable,
+            GXCloudEnvironmentVariable,
         )
 
         return {
-            GECloudEnvironmentVariable.BASE_URL: self._cloud_config.base_url,
-            GECloudEnvironmentVariable.ACCESS_TOKEN: self._cloud_config.access_token,
-            GECloudEnvironmentVariable.ORGANIZATION_ID: self._cloud_config.organization_id,  # type: ignore[dict-item]
+            GXCloudEnvironmentVariable.BASE_URL: self._cloud_config.base_url,
+            GXCloudEnvironmentVariable.ACCESS_TOKEN: self._cloud_config.access_token,
+            GXCloudEnvironmentVariable.ORGANIZATION_ID: self._cloud_config.organization_id,  # type: ignore[dict-item]
         }

--- a/great_expectations/core/config_provider.py
+++ b/great_expectations/core/config_provider.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from typing import Dict, Optional, Type, cast
 
 from great_expectations.core.yaml_handler import YAMLHandler
-from great_expectations.data_context.types.base import GeCloudConfig
+from great_expectations.data_context.types.base import GXCloudConfig
 from great_expectations.data_context.util import (
     substitute_all_config_variables,
     substitute_config_variable,
@@ -151,7 +151,7 @@ class CloudConfigurationProvider(AbstractConfigurationProvider):
     config provider when in a Cloud-backend environment.
     """
 
-    def __init__(self, cloud_config: GeCloudConfig) -> None:
+    def __init__(self, cloud_config: GXCloudConfig) -> None:
         self._cloud_config = cloud_config
 
     def get_values(self) -> Dict[str, str]:

--- a/great_expectations/core/usage_statistics/execution_environment.py
+++ b/great_expectations/core/usage_statistics/execution_environment.py
@@ -101,9 +101,9 @@ class GEExecutionEnvironment:
         if not self._all_installed_packages:
             # Only retrieve once
             self._all_installed_packages = [
-                item.metadata.get("Name")  # type: ignore[attr-defined]
+                item.metadata.get("Name")
                 for item in metadata.distributions()
-                if item.metadata.get("Name") is not None  # type: ignore[attr-defined]
+                if item.metadata.get("Name") is not None
             ]
         return self._all_installed_packages
 

--- a/great_expectations/core/usage_statistics/execution_environment.py
+++ b/great_expectations/core/usage_statistics/execution_environment.py
@@ -101,9 +101,9 @@ class GEExecutionEnvironment:
         if not self._all_installed_packages:
             # Only retrieve once
             self._all_installed_packages = [
-                item.metadata.get("Name")
+                item.metadata.get("Name")  # type: ignore[attr-defined]
                 for item in metadata.distributions()
-                if item.metadata.get("Name") is not None
+                if item.metadata.get("Name") is not None  # type: ignore[attr-defined]
             ]
         return self._all_installed_packages
 

--- a/great_expectations/data_context/cloud_constants.py
+++ b/great_expectations/data_context/cloud_constants.py
@@ -14,8 +14,6 @@ class GECloudEnvironmentVariable(str, Enum):
 class GeCloudRESTResource(str, Enum):
     BATCH = "batch"
     CHECKPOINT = "checkpoint"
-    # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-    CONTRACT = "contract"
     DATASOURCE = "datasource"
     DATA_ASSET = "data_asset"
     DATA_CONTEXT = "data_context"
@@ -25,6 +23,4 @@ class GeCloudRESTResource(str, Enum):
     EXPECTATION_VALIDATION_RESULT = "expectation_validation_result"
     PROFILER = "profiler"
     RENDERED_DATA_DOC = "rendered_data_doc"
-    # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-    SUITE_VALIDATION_RESULT = "suite_validation_result"
     VALIDATION_RESULT = "validation_result"

--- a/great_expectations/data_context/cloud_constants.py
+++ b/great_expectations/data_context/cloud_constants.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from typing_extensions import Final
 
+SUPPORT_EMAIL = "support@greatexpectations.io"
 CLOUD_DEFAULT_BASE_URL: Final[str] = "https://api.greatexpectations.io/"
 
 

--- a/great_expectations/data_context/cloud_constants.py
+++ b/great_expectations/data_context/cloud_constants.py
@@ -5,13 +5,13 @@ from typing_extensions import Final
 CLOUD_DEFAULT_BASE_URL: Final[str] = "https://api.greatexpectations.io/"
 
 
-class GECloudEnvironmentVariable(str, Enum):
+class GXCloudEnvironmentVariable(str, Enum):
     BASE_URL = "GE_CLOUD_BASE_URL"
     ORGANIZATION_ID = "GE_CLOUD_ORGANIZATION_ID"
     ACCESS_TOKEN = "GE_CLOUD_ACCESS_TOKEN"
 
 
-class GeCloudRESTResource(str, Enum):
+class GXCloudRESTResource(str, Enum):
     BATCH = "batch"
     CHECKPOINT = "checkpoint"
     DATASOURCE = "datasource"

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -85,7 +85,7 @@ from great_expectations.data_context.types.base import (
     dataContextConfigSchema,
     datasourceConfigSchema,
 )
-from great_expectations.data_context.types.refs import GXCloudIdAwareRef
+from great_expectations.data_context.types.refs import GXCloudIDAwareRef
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,
@@ -2017,7 +2017,7 @@ class AbstractDataContext(ABC):
             value=validation_results,
         )
 
-        if isinstance(validation_ref, GXCloudIdAwareRef):
+        if isinstance(validation_ref, GXCloudIDAwareRef):
             ge_cloud_id = validation_ref.ge_cloud_id
             validation_results.ge_cloud_id = uuid.UUID(ge_cloud_id)
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -85,7 +85,7 @@ from great_expectations.data_context.types.base import (
     dataContextConfigSchema,
     datasourceConfigSchema,
 )
-from great_expectations.data_context.types.refs import GeCloudIdAwareRef
+from great_expectations.data_context.types.refs import GXCloudIdAwareRef
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,
@@ -131,7 +131,7 @@ if TYPE_CHECKING:
         EvaluationParameterStore,
     )
     from great_expectations.data_context.types.resource_identifiers import (
-        GeCloudIdentifier,
+        GXCloudIdentifier,
     )
     from great_expectations.render.renderer.site_builder import SiteBuilder
     from great_expectations.rule_based_profiler import RuleBasedProfilerResult
@@ -1292,7 +1292,7 @@ class AbstractDataContext(ABC):
 
     def list_expectation_suites(
         self,
-    ) -> Optional[Union[List[str], List[GeCloudIdentifier]]]:
+    ) -> Optional[Union[List[str], List[GXCloudIdentifier]]]:
         """Return a list of available expectation suite keys."""
         try:
             keys = self.expectations_store.list_keys()
@@ -2017,7 +2017,7 @@ class AbstractDataContext(ABC):
             value=validation_results,
         )
 
-        if isinstance(validation_ref, GeCloudIdAwareRef):
+        if isinstance(validation_ref, GXCloudIdAwareRef):
             ge_cloud_id = validation_ref.ge_cloud_id
             validation_results.ge_cloud_id = uuid.UUID(ge_cloud_id)
 

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -21,7 +21,7 @@ from great_expectations.core.usage_statistics.usage_statistics import (
     usage_statistics_enabled_method,
 )
 from great_expectations.data_asset import DataAsset
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
@@ -1085,7 +1085,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if self.ge_cloud_mode:
             key = GeCloudIdentifier(
-                resource_type=GeCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
+                resource_type=GXCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
             )
         else:
             key = ConfigurationIdentifier(configuration_key=name)

--- a/great_expectations/data_context/data_context/base_data_context.py
+++ b/great_expectations/data_context/data_context/base_data_context.py
@@ -35,12 +35,12 @@ from great_expectations.data_context.types.base import (
     DataContextConfig,
     DataContextConfigDefaults,
     DatasourceConfig,
-    GeCloudConfig,
+    GXCloudConfig,
 )
-from great_expectations.data_context.types.refs import GeCloudResourceRef
+from great_expectations.data_context.types.refs import GXCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.data_context.util import (
     instantiate_class_from_config,
@@ -203,7 +203,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         context_root_dir: Optional[str] = None,
         runtime_environment: Optional[dict] = None,
         ge_cloud_mode: bool = False,
-        ge_cloud_config: Optional[GeCloudConfig] = None,
+        ge_cloud_config: Optional[GXCloudConfig] = None,
     ) -> None:
         """DataContext constructor
 
@@ -288,7 +288,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
                 )
 
     @property
-    def ge_cloud_config(self) -> Optional[GeCloudConfig]:
+    def ge_cloud_config(self) -> Optional[GXCloudConfig]:
         return self._ge_cloud_config
 
     @property
@@ -1072,16 +1072,16 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
         name = profiler.name
         ge_cloud_id = profiler.ge_cloud_id
 
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier]
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier]
         if self.ge_cloud_mode:
-            key = GeCloudIdentifier(
+            key = GXCloudIdentifier(
                 resource_type=GXCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
             )
         else:
             key = ConfigurationIdentifier(configuration_key=name)
 
         response = self.profiler_store.set(key=key, value=profiler.config)  # type: ignore[func-returns-value]
-        if isinstance(response, GeCloudResourceRef):
+        if isinstance(response, GXCloudResourceRef):
             ge_cloud_id = response.ge_cloud_id
 
         # If an id is present, we want to prioritize that as our key for object retrieval
@@ -1103,7 +1103,7 @@ class BaseDataContext(EphemeralDataContext, ConfigPeer):
 
     def list_expectation_suites(
         self,
-    ) -> Optional[Union[List[str], List[GeCloudIdentifier]]]:
+    ) -> Optional[Union[List[str], List[GXCloudIdentifier]]]:
         """
         See parent 'AbstractDataContext.list_expectation_suites()` for more information.
         """

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -16,8 +16,8 @@ from great_expectations.core.config_provider import (
 from great_expectations.core.serializer import JsonConfigSerializer
 from great_expectations.data_context.cloud_constants import (
     CLOUD_DEFAULT_BASE_URL,
-    GECloudEnvironmentVariable,
-    GeCloudRESTResource,
+    GXCloudEnvironmentVariable,
+    GXCloudRESTResource,
 )
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
@@ -230,11 +230,11 @@ class CloudDataContext(AbstractDataContext):
                 f"environment or in global configs ({(', ').join(global_config_path_str)})."
             )
 
-        base_url = ge_cloud_config_dict[GECloudEnvironmentVariable.BASE_URL]
+        base_url = ge_cloud_config_dict[GXCloudEnvironmentVariable.BASE_URL]
         assert base_url is not None
-        access_token = ge_cloud_config_dict[GECloudEnvironmentVariable.ACCESS_TOKEN]
+        access_token = ge_cloud_config_dict[GXCloudEnvironmentVariable.ACCESS_TOKEN]
         organization_id = ge_cloud_config_dict[
-            GECloudEnvironmentVariable.ORGANIZATION_ID
+            GXCloudEnvironmentVariable.ORGANIZATION_ID
         ]
 
         return GeCloudConfig(
@@ -249,11 +249,11 @@ class CloudDataContext(AbstractDataContext):
         ge_cloud_base_url: Optional[str] = None,
         ge_cloud_access_token: Optional[str] = None,
         ge_cloud_organization_id: Optional[str] = None,
-    ) -> Dict[GECloudEnvironmentVariable, Optional[str]]:
+    ) -> Dict[GXCloudEnvironmentVariable, Optional[str]]:
         ge_cloud_base_url = (
             ge_cloud_base_url
             or CloudDataContext._get_global_config_value(
-                environment_variable=GECloudEnvironmentVariable.BASE_URL,
+                environment_variable=GXCloudEnvironmentVariable.BASE_URL,
                 conf_file_section="ge_cloud_config",
                 conf_file_option="base_url",
             )
@@ -262,7 +262,7 @@ class CloudDataContext(AbstractDataContext):
         ge_cloud_organization_id = (
             ge_cloud_organization_id
             or CloudDataContext._get_global_config_value(
-                environment_variable=GECloudEnvironmentVariable.ORGANIZATION_ID,
+                environment_variable=GXCloudEnvironmentVariable.ORGANIZATION_ID,
                 conf_file_section="ge_cloud_config",
                 conf_file_option="organization_id",
             )
@@ -270,15 +270,15 @@ class CloudDataContext(AbstractDataContext):
         ge_cloud_access_token = (
             ge_cloud_access_token
             or CloudDataContext._get_global_config_value(
-                environment_variable=GECloudEnvironmentVariable.ACCESS_TOKEN,
+                environment_variable=GXCloudEnvironmentVariable.ACCESS_TOKEN,
                 conf_file_section="ge_cloud_config",
                 conf_file_option="access_token",
             )
         )
         return {
-            GECloudEnvironmentVariable.BASE_URL: ge_cloud_base_url,
-            GECloudEnvironmentVariable.ORGANIZATION_ID: ge_cloud_organization_id,
-            GECloudEnvironmentVariable.ACCESS_TOKEN: ge_cloud_access_token,
+            GXCloudEnvironmentVariable.BASE_URL: ge_cloud_base_url,
+            GXCloudEnvironmentVariable.ORGANIZATION_ID: ge_cloud_organization_id,
+            GXCloudEnvironmentVariable.ACCESS_TOKEN: ge_cloud_access_token,
         }
 
     def _init_datasource_store(self) -> None:
@@ -292,7 +292,7 @@ class CloudDataContext(AbstractDataContext):
         runtime_environment: dict = {
             "root_directory": self.root_directory,
             "ge_cloud_credentials": self.ge_cloud_config.to_dict(),  # type: ignore[union-attr]
-            "ge_cloud_resource_type": GeCloudRESTResource.DATASOURCE,
+            "ge_cloud_resource_type": GXCloudRESTResource.DATASOURCE,
             "ge_cloud_base_url": self.ge_cloud_config.base_url,  # type: ignore[union-attr]
         }
 
@@ -425,7 +425,7 @@ class CloudDataContext(AbstractDataContext):
                             expectation_suite.ge_cloud_id = ge_cloud_id
 
         key = GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=ge_cloud_id,
         )
 
@@ -449,7 +449,7 @@ class CloudDataContext(AbstractDataContext):
             True for Success and False for Failure.
         """
         key = GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=ge_cloud_id,
         )
         if not self.expectations_store.has_key(key):  # noqa: W601
@@ -476,7 +476,7 @@ class CloudDataContext(AbstractDataContext):
             An existing ExpectationSuite
         """
         key = GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=ge_cloud_id,
         )
         if not self.expectations_store.has_key(key):  # noqa: W601
@@ -525,7 +525,7 @@ class CloudDataContext(AbstractDataContext):
             else None
         )
         key = GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=id,
             resource_name=expectation_suite.expectation_suite_name,
         )

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -29,11 +29,11 @@ from great_expectations.data_context.types.base import (
     DEFAULT_USAGE_STATISTICS_URL,
     DataContextConfig,
     DataContextConfigDefaults,
-    GeCloudConfig,
+    GXCloudConfig,
     datasourceConfigSchema,
 )
-from great_expectations.data_context.types.refs import GeCloudResourceRef
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.refs import GXCloudResourceRef
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.data_context.util import substitute_all_config_variables
 from great_expectations.exceptions.exceptions import DataContextError
 
@@ -156,7 +156,7 @@ class CloudDataContext(AbstractDataContext):
 
     @classmethod
     def retrieve_data_context_config_from_ge_cloud(
-        cls, ge_cloud_config: GeCloudConfig
+        cls, ge_cloud_config: GXCloudConfig
     ) -> DataContextConfig:
         """
         Utilizes the GeCloudConfig instantiated in the constructor to create a request to the Cloud API.
@@ -181,7 +181,7 @@ class CloudDataContext(AbstractDataContext):
 
         response = requests.get(ge_cloud_url, headers=headers)
         if response.status_code != 200:
-            raise ge_exceptions.GeCloudError(
+            raise ge_exceptions.GXCloudError(
                 f"Bad request made to GE Cloud; {response.text}"
             )
         config = response.json()
@@ -193,7 +193,7 @@ class CloudDataContext(AbstractDataContext):
         ge_cloud_base_url: Optional[str] = None,
         ge_cloud_access_token: Optional[str] = None,
         ge_cloud_organization_id: Optional[str] = None,
-    ) -> GeCloudConfig:
+    ) -> GXCloudConfig:
         """
         Build a GeCloudConfig object. Config attributes are collected from any combination of args passed in at
         runtime, environment variables, or a global great_expectations.conf file (in order of precedence).
@@ -242,7 +242,7 @@ class CloudDataContext(AbstractDataContext):
             GXCloudEnvironmentVariable.ORGANIZATION_ID
         ]
 
-        return GeCloudConfig(
+        return GXCloudConfig(
             base_url=base_url,
             access_token=access_token,
             organization_id=organization_id,
@@ -317,7 +317,7 @@ class CloudDataContext(AbstractDataContext):
         return [suite_key.resource_name for suite_key in self.list_expectation_suites()]  # type: ignore[union-attr]
 
     @property
-    def ge_cloud_config(self) -> Optional[GeCloudConfig]:
+    def ge_cloud_config(self) -> Optional[GXCloudConfig]:
         return self._ge_cloud_config
 
     @property
@@ -418,24 +418,24 @@ class CloudDataContext(AbstractDataContext):
             )
         elif expectation_suite_name in existing_suite_names and overwrite_existing:
             identifiers: Optional[
-                Union[List[str], List[GeCloudIdentifier]]
+                Union[List[str], List[GXCloudIdentifier]]
             ] = self.list_expectation_suites()
             if identifiers:
                 for ge_cloud_identifier in identifiers:
-                    if isinstance(ge_cloud_identifier, GeCloudIdentifier):
+                    if isinstance(ge_cloud_identifier, GXCloudIdentifier):
                         ge_cloud_identifier_tuple = ge_cloud_identifier.to_tuple()
                         name: str = ge_cloud_identifier_tuple[2]
                         if name == expectation_suite_name:
                             ge_cloud_id = ge_cloud_identifier_tuple[1]
                             expectation_suite.ge_cloud_id = ge_cloud_id
 
-        key = GeCloudIdentifier(
+        key = GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=ge_cloud_id,
         )
 
-        response: Union[bool, GeCloudResourceRef] = self.expectations_store.set(key, expectation_suite, **kwargs)  # type: ignore[func-returns-value]
-        if isinstance(response, GeCloudResourceRef):
+        response: Union[bool, GXCloudResourceRef] = self.expectations_store.set(key, expectation_suite, **kwargs)  # type: ignore[func-returns-value]
+        if isinstance(response, GXCloudResourceRef):
             expectation_suite.ge_cloud_id = response.ge_cloud_id
 
         return expectation_suite
@@ -453,7 +453,7 @@ class CloudDataContext(AbstractDataContext):
         Returns:
             True for Success and False for Failure.
         """
-        key = GeCloudIdentifier(
+        key = GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=ge_cloud_id,
         )
@@ -480,7 +480,7 @@ class CloudDataContext(AbstractDataContext):
         Returns:
             An existing ExpectationSuite
         """
-        key = GeCloudIdentifier(
+        key = GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=ge_cloud_id,
         )
@@ -529,7 +529,7 @@ class CloudDataContext(AbstractDataContext):
             if expectation_suite.ge_cloud_id
             else None
         )
-        key = GeCloudIdentifier(
+        key = GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=id,
             resource_name=expectation_suite.expectation_suite_name,
@@ -548,11 +548,11 @@ class CloudDataContext(AbstractDataContext):
             expectation_suite.render()
 
         response = self.expectations_store.set(key, expectation_suite, **kwargs)  # type: ignore[func-returns-value]
-        if isinstance(response, GeCloudResourceRef):
+        if isinstance(response, GXCloudResourceRef):
             expectation_suite.ge_cloud_id = response.ge_cloud_id
 
     def _validate_suite_unique_constaints_before_save(
-        self, key: GeCloudIdentifier
+        self, key: GXCloudIdentifier
     ) -> None:
         ge_cloud_id = key.ge_cloud_id
         if ge_cloud_id:

--- a/great_expectations/data_context/data_context/data_context.py
+++ b/great_expectations/data_context/data_context/data_context.py
@@ -26,7 +26,7 @@ from great_expectations.data_context.types.base import (
     MINIMUM_SUPPORTED_CONFIG_VERSION,
     AnonymizedUsageStatisticsConfig,
     DataContextConfig,
-    GeCloudConfig,
+    GXCloudConfig,
 )
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.datasource import LegacyDatasource
@@ -265,7 +265,7 @@ class DataContext(BaseDataContext):
         ge_cloud_base_url: Optional[str],
         ge_cloud_access_token: Optional[str],
         ge_cloud_organization_id: Optional[str],
-    ) -> Optional[GeCloudConfig]:
+    ) -> Optional[GXCloudConfig]:
         if not ge_cloud_mode:
             return None
 

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -16,7 +16,7 @@ from great_expectations.data_context.types.base import (
 )
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.data_context.util import substitute_all_config_variables
 
@@ -388,7 +388,7 @@ class CloudDataContextVariables(DataContextVariables):
         )
         return store
 
-    def get_key(self) -> GeCloudIdentifier:
+    def get_key(self) -> GXCloudIdentifier:
         """
         Generates a GE Cloud-specific key for use with Stores. See parent "DataContextVariables.get_key" for more details.
         """
@@ -396,7 +396,7 @@ class CloudDataContextVariables(DataContextVariables):
             GXCloudRESTResource,
         )
 
-        key = GeCloudIdentifier(
+        key = GXCloudIdentifier(
             resource_type=GXCloudRESTResource.DATA_CONTEXT_VARIABLES
         )
         return key

--- a/great_expectations/data_context/data_context_variables.py
+++ b/great_expectations/data_context/data_context_variables.py
@@ -366,7 +366,7 @@ class CloudDataContextVariables(DataContextVariables):
             )
 
     def _init_store(self) -> DataContextStore:
-        from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+        from great_expectations.data_context.cloud_constants import GXCloudRESTResource
         from great_expectations.data_context.store.data_context_store import (
             DataContextStore,
         )
@@ -374,7 +374,7 @@ class CloudDataContextVariables(DataContextVariables):
         store_backend: dict = {
             "class_name": "GeCloudStoreBackend",
             "ge_cloud_base_url": self.ge_cloud_base_url,
-            "ge_cloud_resource_type": GeCloudRESTResource.DATA_CONTEXT_VARIABLES,
+            "ge_cloud_resource_type": GXCloudRESTResource.DATA_CONTEXT_VARIABLES,
             "ge_cloud_credentials": {
                 "access_token": self.ge_cloud_access_token,
                 "organization_id": self.ge_cloud_organization_id,
@@ -393,10 +393,10 @@ class CloudDataContextVariables(DataContextVariables):
         Generates a GE Cloud-specific key for use with Stores. See parent "DataContextVariables.get_key" for more details.
         """
         from great_expectations.data_context.store.ge_cloud_store_backend import (
-            GeCloudRESTResource,
+            GXCloudRESTResource,
         )
 
         key = GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.DATA_CONTEXT_VARIABLES
+            resource_type=GXCloudRESTResource.DATA_CONTEXT_VARIABLES
         )
         return key

--- a/great_expectations/data_context/migrator/cloud_migrator.py
+++ b/great_expectations/data_context/migrator/cloud_migrator.py
@@ -29,7 +29,7 @@ from great_expectations.core.configuration import AbstractConfig
 from great_expectations.core.http import create_session
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
 from great_expectations.core.usage_statistics.usage_statistics import send_usage_message
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
@@ -313,7 +313,7 @@ class CloudMigrator:
         # 20220928 - Chetan - We want to use the static lookup tables in GeCloudStoreBackend
         # to ensure the appropriate URL and payload shape. This logic should be moved to
         # a more central location.
-        resource_type = GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT
+        resource_type = GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT
         resource_name = GeCloudStoreBackend.RESOURCE_PLURALITY_LOOKUP_DICT[
             resource_type
         ]

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -9,7 +9,7 @@ from marshmallow import ValidationError
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.data_context_key import DataContextKey
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store import ConfigurationStore
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
@@ -62,7 +62,7 @@ class CheckpointStore(ConfigurationStore):
         )
         if self.ge_cloud_mode:
             test_key: GeCloudIdentifier = self.key_class(  # type: ignore[call-arg,assignment]
-                resource_type=GeCloudRESTResource.CHECKPOINT,
+                resource_type=GXCloudRESTResource.CHECKPOINT,
                 ge_cloud_id=str(uuid.uuid4()),
             )
         else:

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -16,12 +16,12 @@ from great_expectations.data_context.types.base import (
     DataContextConfigDefaults,
 )
 from great_expectations.data_context.types.refs import (
-    GeCloudIdAwareRef,
-    GeCloudResourceRef,
+    GXCloudIdAwareRef,
+    GXCloudResourceRef,
 )
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 
 if TYPE_CHECKING:
@@ -61,7 +61,7 @@ class CheckpointStore(ConfigurationStore):
             **{"name": test_checkpoint_name}  # type: ignore[arg-type]
         )
         if self.ge_cloud_mode:
-            test_key: GeCloudIdentifier = self.key_class(  # type: ignore[call-arg,assignment]
+            test_key: GXCloudIdentifier = self.key_class(  # type: ignore[call-arg,assignment]
                 resource_type=GXCloudRESTResource.CHECKPOINT,
                 ge_cloud_id=str(uuid.uuid4()),
             )
@@ -116,7 +116,7 @@ class CheckpointStore(ConfigurationStore):
         name: Optional[str] = None,
         ge_cloud_id: Optional[str] = None,
     ) -> None:
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier] = self.determine_key(
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier] = self.determine_key(
             name=name, ge_cloud_id=ge_cloud_id
         )
         try:
@@ -129,7 +129,7 @@ class CheckpointStore(ConfigurationStore):
     def get_checkpoint(
         self, name: Optional[str], ge_cloud_id: Optional[str]
     ) -> CheckpointConfig:
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier] = self.determine_key(
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier] = self.determine_key(
             name=name, ge_cloud_id=ge_cloud_id
         )
         try:
@@ -168,12 +168,12 @@ class CheckpointStore(ConfigurationStore):
     def add_checkpoint(
         self, checkpoint: "Checkpoint", name: Optional[str], ge_cloud_id: Optional[str]
     ) -> None:
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier] = self.determine_key(
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier] = self.determine_key(
             name=name, ge_cloud_id=ge_cloud_id
         )
         checkpoint_config: CheckpointConfig = checkpoint.get_config()  # type: ignore[assignment]
         checkpoint_ref = self.set(key=key, value=checkpoint_config)  # type: ignore[func-returns-value]
-        if isinstance(checkpoint_ref, GeCloudIdAwareRef):
+        if isinstance(checkpoint_ref, GXCloudIdAwareRef):
             ge_cloud_id = checkpoint_ref.ge_cloud_id
             checkpoint.ge_cloud_id = uuid.UUID(ge_cloud_id)  # type: ignore[misc]
 
@@ -193,8 +193,8 @@ class CheckpointStore(ConfigurationStore):
 
         # Make two separate requests to set and get in order to obtain any additional
         # values that may have been added to the config by the StoreBackend (i.e. object ids)
-        ref: Optional[Union[bool, GeCloudResourceRef]] = self.set(key, checkpoint_config)  # type: ignore[func-returns-value]
-        if ref and isinstance(ref, GeCloudResourceRef):
+        ref: Optional[Union[bool, GXCloudResourceRef]] = self.set(key, checkpoint_config)  # type: ignore[func-returns-value]
+        if ref and isinstance(ref, GXCloudResourceRef):
             key.ge_cloud_id = ref.ge_cloud_id  # type: ignore[attr-defined]
 
         config = self.get(key=key)

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -16,7 +16,7 @@ from great_expectations.data_context.types.base import (
     DataContextConfigDefaults,
 )
 from great_expectations.data_context.types.refs import (
-    GXCloudIdAwareRef,
+    GXCloudIDAwareRef,
     GXCloudResourceRef,
 )
 from great_expectations.data_context.types.resource_identifiers import (
@@ -173,7 +173,7 @@ class CheckpointStore(ConfigurationStore):
         )
         checkpoint_config: CheckpointConfig = checkpoint.get_config()  # type: ignore[assignment]
         checkpoint_ref = self.set(key=key, value=checkpoint_config)  # type: ignore[func-returns-value]
-        if isinstance(checkpoint_ref, GXCloudIdAwareRef):
+        if isinstance(checkpoint_ref, GXCloudIDAwareRef):
             ge_cloud_id = checkpoint_ref.ge_cloud_id
             checkpoint.ge_cloud_id = uuid.UUID(ge_cloud_id)  # type: ignore[misc]
 

--- a/great_expectations/data_context/store/configuration_store.py
+++ b/great_expectations/data_context/store/configuration_store.py
@@ -11,7 +11,7 @@ from great_expectations.data_context.store.tuple_store_backend import TupleStore
 from great_expectations.data_context.types.base import BaseYamlConfig
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.data_context.util import load_class
 from great_expectations.util import (
@@ -153,14 +153,14 @@ class ConfigurationStore(Store):
     @staticmethod
     def determine_key(
         name: Optional[str], ge_cloud_id: Optional[str]
-    ) -> Union[GeCloudIdentifier, ConfigurationIdentifier]:
+    ) -> Union[GXCloudIdentifier, ConfigurationIdentifier]:
         assert bool(name) ^ bool(
             ge_cloud_id
         ), "Must provide either name or ge_cloud_id."
 
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier]
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier]
         if ge_cloud_id:
-            key = GeCloudIdentifier(
+            key = GXCloudIdentifier(
                 resource_type=GXCloudRESTResource.CHECKPOINT, ge_cloud_id=ge_cloud_id
             )
         else:

--- a/great_expectations/data_context/store/configuration_store.py
+++ b/great_expectations/data_context/store/configuration_store.py
@@ -5,7 +5,7 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
 import great_expectations.exceptions as ge_exceptions
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.base import BaseYamlConfig
@@ -161,7 +161,7 @@ class ConfigurationStore(Store):
         key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if ge_cloud_id:
             key = GeCloudIdentifier(
-                resource_type=GeCloudRESTResource.CHECKPOINT, ge_cloud_id=ge_cloud_id
+                resource_type=GXCloudRESTResource.CHECKPOINT, ge_cloud_id=ge_cloud_id
             )
         else:
             key = ConfigurationIdentifier(configuration_key=name)  # type: ignore[arg-type]

--- a/great_expectations/data_context/store/datasource_store.py
+++ b/great_expectations/data_context/store/datasource_store.py
@@ -14,8 +14,8 @@ from great_expectations.data_context.types.base import (
     DatasourceConfig,
     datasourceConfigSchema,
 )
-from great_expectations.data_context.types.refs import GeCloudResourceRef
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.refs import GXCloudResourceRef
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.util import filter_properties_dict
 
 
@@ -64,7 +64,7 @@ class DatasourceStore(Store):
         )
         return keys_without_store_backend_id
 
-    def remove_key(self, key: Union[DataContextVariableKey, GeCloudIdentifier]) -> None:
+    def remove_key(self, key: Union[DataContextVariableKey, GXCloudIdentifier]) -> None:
         """
         See parent `Store.remove_key()` for more information
         """
@@ -115,7 +115,7 @@ class DatasourceStore(Store):
             ValueError if a DatasourceConfig is not found.
         """
         datasource_key: Union[
-            DataContextVariableKey, GeCloudIdentifier
+            DataContextVariableKey, GXCloudIdentifier
         ] = self.store_backend.build_key(name=datasource_name)
         if not self.has_key(datasource_key):  # noqa: W601
             raise ValueError(
@@ -136,7 +136,7 @@ class DatasourceStore(Store):
 
     def _build_key_from_config(  # type: ignore[override]
         self, datasource_config: DatasourceConfig
-    ) -> Union[GeCloudIdentifier, DataContextVariableKey]:
+    ) -> Union[GXCloudIdentifier, DataContextVariableKey]:
         return self.store_backend.build_key(
             name=datasource_config.name,
             id=datasource_config.id,
@@ -172,8 +172,8 @@ class DatasourceStore(Store):
 
         # Make two separate requests to set and get in order to obtain any additional
         # values that may have been added to the config by the StoreBackend (i.e. object ids)
-        ref: Optional[Union[bool, GeCloudResourceRef]] = super().set(key, value)
-        if ref and isinstance(ref, GeCloudResourceRef):
+        ref: Optional[Union[bool, GXCloudResourceRef]] = super().set(key, value)
+        if ref and isinstance(ref, GXCloudResourceRef):
             key.ge_cloud_id = ref.ge_cloud_id  # type: ignore[attr-defined]
 
         return_value: DatasourceConfig = self.get(key)  # type: ignore[assignment]

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.expectation_suite import ExpectationSuiteSchema
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.database_store_backend import (
     DatabaseStoreBackend,
 )
@@ -216,7 +216,7 @@ class ExpectationsStore(Store):
         )
         if self.ge_cloud_mode:
             test_key: GeCloudIdentifier = self.key_class(
-                resource_type=GeCloudRESTResource.CHECKPOINT,
+                resource_type=GXCloudRESTResource.CHECKPOINT,
                 ge_cloud_id=str(uuid.uuid4()),
             )
         else:

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -12,7 +12,7 @@ from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.data_context.util import load_class
 from great_expectations.util import (
@@ -215,7 +215,7 @@ class ExpectationsStore(Store):
             [random.choice(list("0123456789ABCDEF")) for i in range(20)]
         )
         if self.ge_cloud_mode:
-            test_key: GeCloudIdentifier = self.key_class(
+            test_key: GXCloudIdentifier = self.key_class(
                 resource_type=GXCloudRESTResource.CHECKPOINT,
                 ge_cloud_id=str(uuid.uuid4()),
             )

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -9,7 +9,7 @@ import requests
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import (
     CLOUD_DEFAULT_BASE_URL,
-    GeCloudRESTResource,
+    GXCloudRESTResource,
 )
 from great_expectations.data_context.store.store_backend import StoreBackend
 from great_expectations.data_context.types.refs import GeCloudResourceRef
@@ -110,22 +110,22 @@ def get_user_friendly_error_message(
 
 
 class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
-    PAYLOAD_ATTRIBUTES_KEYS: Dict[GeCloudRESTResource, str] = {
-        GeCloudRESTResource.CHECKPOINT: "checkpoint_config",
-        GeCloudRESTResource.DATASOURCE: "datasource_config",
-        GeCloudRESTResource.DATA_CONTEXT: "data_context_config",
-        GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
-        GeCloudRESTResource.EXPECTATION_SUITE: "suite",
-        GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "result",
-        GeCloudRESTResource.PROFILER: "profiler",
-        GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_doc",
-        GeCloudRESTResource.VALIDATION_RESULT: "result",
+    PAYLOAD_ATTRIBUTES_KEYS: Dict[GXCloudRESTResource, str] = {
+        GXCloudRESTResource.CHECKPOINT: "checkpoint_config",
+        GXCloudRESTResource.DATASOURCE: "datasource_config",
+        GXCloudRESTResource.DATA_CONTEXT: "data_context_config",
+        GXCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
+        GXCloudRESTResource.EXPECTATION_SUITE: "suite",
+        GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "result",
+        GXCloudRESTResource.PROFILER: "profiler",
+        GXCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_doc",
+        GXCloudRESTResource.VALIDATION_RESULT: "result",
     }
 
-    ALLOWED_SET_KWARGS_BY_RESOURCE_TYPE: Dict[GeCloudRESTResource, Set[str]] = {
-        GeCloudRESTResource.EXPECTATION_SUITE: {"clause_id"},
-        GeCloudRESTResource.RENDERED_DATA_DOC: {"source_type", "source_id"},
-        GeCloudRESTResource.VALIDATION_RESULT: {
+    ALLOWED_SET_KWARGS_BY_RESOURCE_TYPE: Dict[GXCloudRESTResource, Set[str]] = {
+        GXCloudRESTResource.EXPECTATION_SUITE: {"clause_id"},
+        GXCloudRESTResource.RENDERED_DATA_DOC: {"source_type", "source_id"},
+        GXCloudRESTResource.VALIDATION_RESULT: {
             "checkpoint_id",
             "expectation_suite_id",
         },
@@ -133,17 +133,17 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     RESOURCE_PLURALITY_LOOKUP_DICT: bidict = bidict(  # type: ignore[misc] # Keywords must be str
         **{  # type: ignore[arg-type]
-            GeCloudRESTResource.BATCH: "batches",
-            GeCloudRESTResource.CHECKPOINT: "checkpoints",
-            GeCloudRESTResource.DATA_ASSET: "data_assets",
-            GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
-            GeCloudRESTResource.DATASOURCE: "datasources",
-            GeCloudRESTResource.EXPECTATION: "expectations",
-            GeCloudRESTResource.EXPECTATION_SUITE: "expectation_suites",
-            GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "expectation_validation_results",
-            GeCloudRESTResource.PROFILER: "profilers",
-            GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_docs",
-            GeCloudRESTResource.VALIDATION_RESULT: "validation_results",
+            GXCloudRESTResource.BATCH: "batches",
+            GXCloudRESTResource.CHECKPOINT: "checkpoints",
+            GXCloudRESTResource.DATA_ASSET: "data_assets",
+            GXCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
+            GXCloudRESTResource.DATASOURCE: "datasources",
+            GXCloudRESTResource.EXPECTATION: "expectations",
+            GXCloudRESTResource.EXPECTATION_SUITE: "expectation_suites",
+            GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "expectation_validation_results",
+            GXCloudRESTResource.PROFILER: "profilers",
+            GXCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_docs",
+            GXCloudRESTResource.VALIDATION_RESULT: "validation_results",
         }
     )
 
@@ -151,7 +151,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         self,
         ge_cloud_credentials: Dict,
         ge_cloud_base_url: str = CLOUD_DEFAULT_BASE_URL,
-        ge_cloud_resource_type: Optional[Union[str, GeCloudRESTResource]] = None,
+        ge_cloud_resource_type: Optional[Union[str, GXCloudRESTResource]] = None,
         ge_cloud_resource_name: Optional[str] = None,
         suppress_store_backend_id: bool = True,
         manually_initialize_store_backend_id: str = "",
@@ -178,7 +178,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         # as strings and require manual casting.
         if ge_cloud_resource_type and isinstance(ge_cloud_resource_type, str):
             ge_cloud_resource_type = ge_cloud_resource_type.upper()
-            ge_cloud_resource_type = GeCloudRESTResource[ge_cloud_resource_type]
+            ge_cloud_resource_type = GXCloudRESTResource[ge_cloud_resource_type]
 
         self._ge_cloud_resource_type = (
             ge_cloud_resource_type
@@ -280,7 +280,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             # ensure that legacy PATCH behavior is supported.
             if (
                 response_status_code == 405
-                and resource_type is GeCloudRESTResource.EXPECTATION_SUITE
+                and resource_type is GXCloudRESTResource.EXPECTATION_SUITE
             ):
                 response = self._session.patch(url, json=data)
                 response_status_code = response.status_code
@@ -322,7 +322,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
     def _set(  # type: ignore[override]
         self,
-        key: Tuple[GeCloudRESTResource, ...],
+        key: Tuple[GXCloudRESTResource, ...],
         value: Any,
         **kwargs: dict,
     ) -> Union[bool, GeCloudResourceRef]:
@@ -337,7 +337,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         # and always necessitate a PUT.
         if (
             ge_cloud_id
-            or ge_cloud_resource is GeCloudRESTResource.DATA_CONTEXT_VARIABLES
+            or ge_cloud_resource is GXCloudRESTResource.DATA_CONTEXT_VARIABLES
         ):
             return self._update(ge_cloud_id=ge_cloud_id, value=value)
 
@@ -398,14 +398,14 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         return self._ge_cloud_resource_name
 
     @property
-    def ge_cloud_resource_type(self) -> GeCloudRESTResource:
+    def ge_cloud_resource_type(self) -> GXCloudRESTResource:
         return self._ge_cloud_resource_type  # type: ignore[return-value]
 
     @property
     def ge_cloud_credentials(self) -> dict:
         return self._ge_cloud_credentials
 
-    def list_keys(self, prefix: Tuple = ()) -> List[Tuple[GeCloudRESTResource, str, Optional[str]]]:  # type: ignore[override]
+    def list_keys(self, prefix: Tuple = ()) -> List[Tuple[GXCloudRESTResource, str, Optional[str]]]:  # type: ignore[override]
         url = construct_url(
             base_url=self.ge_cloud_base_url,
             organization_id=self.ge_cloud_credentials["organization_id"],
@@ -423,7 +423,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             # Chetan - 20220824 - Explicit fork due to ExpectationSuite using a different name field.
             # Once 'expectation_suite_name' is renamed, this can be removed.
             name_attr: str
-            if resource_type is GeCloudRESTResource.EXPECTATION_SUITE:
+            if resource_type is GXCloudRESTResource.EXPECTATION_SUITE:
                 name_attr = "expectation_suite_name"
             else:
                 name_attr = "name"

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -13,8 +13,8 @@ from great_expectations.data_context.cloud_constants import (
     GXCloudRESTResource,
 )
 from great_expectations.data_context.store.store_backend import StoreBackend
-from great_expectations.data_context.types.refs import GeCloudResourceRef
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.refs import GXCloudResourceRef
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.exceptions import StoreBackendError
 from great_expectations.util import bidict, filter_properties_dict, hyphen
 
@@ -323,7 +323,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         key: Tuple[GXCloudRESTResource, ...],
         value: Any,
         **kwargs: dict,
-    ) -> Union[bool, GeCloudResourceRef]:
+    ) -> Union[bool, GXCloudResourceRef]:
         # Each resource type has corresponding attribute key to include in POST body
         ge_cloud_resource = key[0]
         ge_cloud_id: str = key[1]
@@ -366,7 +366,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
             object_id = response_json["data"]["id"]
             object_url = self.get_url_for_key((self.ge_cloud_resource_type, object_id))
-            return GeCloudResourceRef(
+            return GXCloudResourceRef(
                 resource_type=resource_type,
                 ge_cloud_id=object_id,
                 url=object_url,
@@ -521,9 +521,9 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         self,
         id: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> GeCloudIdentifier:
+    ) -> GXCloudIdentifier:
         """Get the store backend specific implementation of the key. ignore resource_type since it is defined when initializing the cloud store backend."""
-        return GeCloudIdentifier(
+        return GXCloudIdentifier(
             resource_type=self.ge_cloud_resource_type,
             ge_cloud_id=id,
             resource_name=name,

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -9,6 +9,7 @@ import requests
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import (
     CLOUD_DEFAULT_BASE_URL,
+    SUPPORT_EMAIL,
     GXCloudRESTResource,
 )
 from great_expectations.data_context.store.store_backend import StoreBackend
@@ -23,8 +24,6 @@ except ImportError:
     from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)
-
-SUPPORT_EMAIL = "support@greatexpectations.io"
 
 
 class ErrorDetail(TypedDict):

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -112,8 +112,6 @@ def get_user_friendly_error_message(
 class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
     PAYLOAD_ATTRIBUTES_KEYS: Dict[GeCloudRESTResource, str] = {
         GeCloudRESTResource.CHECKPOINT: "checkpoint_config",
-        # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-        GeCloudRESTResource.CONTRACT: "checkpoint_config",
         GeCloudRESTResource.DATASOURCE: "datasource_config",
         GeCloudRESTResource.DATA_CONTEXT: "data_context_config",
         GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
@@ -121,19 +119,12 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "result",
         GeCloudRESTResource.PROFILER: "profiler",
         GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_doc",
-        # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-        GeCloudRESTResource.SUITE_VALIDATION_RESULT: "result",
         GeCloudRESTResource.VALIDATION_RESULT: "result",
     }
 
     ALLOWED_SET_KWARGS_BY_RESOURCE_TYPE: Dict[GeCloudRESTResource, Set[str]] = {
         GeCloudRESTResource.EXPECTATION_SUITE: {"clause_id"},
         GeCloudRESTResource.RENDERED_DATA_DOC: {"source_type", "source_id"},
-        # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-        GeCloudRESTResource.SUITE_VALIDATION_RESULT: {
-            "checkpoint_id",
-            "expectation_suite_id",
-        },
         GeCloudRESTResource.VALIDATION_RESULT: {
             "checkpoint_id",
             "expectation_suite_id",
@@ -144,8 +135,6 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         **{  # type: ignore[arg-type]
             GeCloudRESTResource.BATCH: "batches",
             GeCloudRESTResource.CHECKPOINT: "checkpoints",
-            # Chetan - 20220811 - CONTRACT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-            GeCloudRESTResource.CONTRACT: "contracts",
             GeCloudRESTResource.DATA_ASSET: "data_assets",
             GeCloudRESTResource.DATA_CONTEXT_VARIABLES: "data_context_variables",
             GeCloudRESTResource.DATASOURCE: "datasources",
@@ -154,8 +143,6 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT: "expectation_validation_results",
             GeCloudRESTResource.PROFILER: "profilers",
             GeCloudRESTResource.RENDERED_DATA_DOC: "rendered_data_docs",
-            # Chetan - 20220812 - SUITE_VALIDATION_RESULT is deprecated by GX Cloud and is to be removed upon migration of E2E tests
-            GeCloudRESTResource.SUITE_VALIDATION_RESULT: "suite_validation_results",
             GeCloudRESTResource.VALIDATION_RESULT: "validation_results",
         }
     )
@@ -287,6 +274,7 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             response = self._session.put(url, json=data)
             response_status_code = response.status_code
 
+            # Is this still true? - Pending Cloud response
             # 2022-07-28 - Chetan - GX Cloud does not currently support PUT requests
             # for the ExpectationSuite endpoint. As such, this is a temporary fork to
             # ensure that legacy PATCH behavior is supported.
@@ -343,6 +331,8 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
         ge_cloud_id: str = key[1]
 
         # if key has ge_cloud_id, perform _update instead
+
+        # Is this still true? - Pending Cloud response
         # Chetan - 20220713 - DataContextVariables are a special edge case for the Cloud product
         # and always necessitate a PUT.
         if (

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -274,7 +274,6 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
             response = self._session.put(url, json=data)
             response_status_code = response.status_code
 
-            # Is this still true? - Pending Cloud response
             # 2022-07-28 - Chetan - GX Cloud does not currently support PUT requests
             # for the ExpectationSuite endpoint. As such, this is a temporary fork to
             # ensure that legacy PATCH behavior is supported.
@@ -332,7 +331,6 @@ class GeCloudStoreBackend(StoreBackend, metaclass=ABCMeta):
 
         # if key has ge_cloud_id, perform _update instead
 
-        # Is this still true? - Pending Cloud response
         # Chetan - 20220713 - DataContextVariables are a special edge case for the Cloud product
         # and always necessitate a PUT.
         if (

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -6,7 +6,7 @@ from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.configuration_store import ConfigurationStore
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.rule_based_profiler.config import RuleBasedProfilerConfig
 
@@ -30,7 +30,7 @@ class ProfilerStore(ConfigurationStore):
             rules={},
         )
 
-        test_key: Union[GeCloudIdentifier, ConfigurationIdentifier]
+        test_key: Union[GXCloudIdentifier, ConfigurationIdentifier]
         if self.ge_cloud_mode:
             test_key = self.key_class(  # type: ignore[assignment,call-arg]
                 resource_type=GXCloudRESTResource.PROFILER,

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -2,7 +2,7 @@ import random
 import uuid
 from typing import Union
 
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.configuration_store import ConfigurationStore
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
@@ -33,7 +33,7 @@ class ProfilerStore(ConfigurationStore):
         test_key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if self.ge_cloud_mode:
             test_key = self.key_class(  # type: ignore[assignment,call-arg]
-                resource_type=GeCloudRESTResource.PROFILER,
+                resource_type=GXCloudRESTResource.PROFILER,
                 ge_cloud_id=str(uuid.uuid4()),
             )
         else:

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -7,7 +7,7 @@ from great_expectations.data_context.store.ge_cloud_store_backend import (
     GeCloudStoreBackend,
 )
 from great_expectations.data_context.store.store_backend import StoreBackend
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.exceptions import ClassInstantiationError, DataContextError
 
@@ -105,7 +105,7 @@ class Store:
     @property
     def key_class(self) -> Type[DataContextKey]:
         if self.ge_cloud_mode:
-            return GeCloudIdentifier
+            return GXCloudIdentifier
         return self._key_class
 
     @property

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -6,7 +6,7 @@ from great_expectations.core.expectation_validation_result import (
     ExpectationSuiteValidationResult,
     ExpectationSuiteValidationResultSchema,
 )
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.database_store_backend import (
     DatabaseStoreBackend,
 )
@@ -204,7 +204,7 @@ class ValidationsStore(Store):
 
         if self.ge_cloud_mode:
             test_key: GeCloudIdentifier = self.key_class(
-                resource_type=GeCloudRESTResource.CHECKPOINT,
+                resource_type=GXCloudRESTResource.CHECKPOINT,
                 ge_cloud_id=str(uuid.uuid4()),
             )
 

--- a/great_expectations/data_context/store/validations_store.py
+++ b/great_expectations/data_context/store/validations_store.py
@@ -14,7 +14,7 @@ from great_expectations.data_context.store.store import Store
 from great_expectations.data_context.store.tuple_store_backend import TupleStoreBackend
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
     ValidationResultIdentifier,
 )
 from great_expectations.data_context.util import load_class
@@ -203,7 +203,7 @@ class ValidationsStore(Store):
         )
 
         if self.ge_cloud_mode:
-            test_key: GeCloudIdentifier = self.key_class(
+            test_key: GXCloudIdentifier = self.key_class(
                 resource_type=GXCloudRESTResource.CHECKPOINT,
                 ge_cloud_id=str(uuid.uuid4()),
             )

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -1540,7 +1540,7 @@ class ConcurrencyConfigSchema(Schema):
     enabled = fields.Boolean(default=False)
 
 
-class GeCloudConfig(DictDot):
+class GXCloudConfig(DictDot):
     def __init__(
         self,
         base_url: str,

--- a/great_expectations/data_context/types/refs.py
+++ b/great_expectations/data_context/types/refs.py
@@ -1,4 +1,4 @@
-class GXCloudIdAwareRef:
+class GXCloudIDAwareRef:
     """
     This class serves as a base class for refs tied to a Great Expectations Cloud ID.
     """
@@ -11,7 +11,7 @@ class GXCloudIdAwareRef:
         return self._ge_cloud_id
 
 
-class GXCloudResourceRef(GXCloudIdAwareRef):
+class GXCloudResourceRef(GXCloudIDAwareRef):
     """
     This class represents a reference to a Great Expectations object persisted to Great Expectations Cloud.
     """

--- a/great_expectations/data_context/types/refs.py
+++ b/great_expectations/data_context/types/refs.py
@@ -1,4 +1,4 @@
-class GeCloudIdAwareRef:
+class GXCloudIdAwareRef:
     """
     This class serves as a base class for refs tied to a Great Expectations Cloud ID.
     """
@@ -11,7 +11,7 @@ class GeCloudIdAwareRef:
         return self._ge_cloud_id
 
 
-class GeCloudResourceRef(GeCloudIdAwareRef):
+class GXCloudResourceRef(GXCloudIdAwareRef):
     """
     This class represents a reference to a Great Expectations object persisted to Great Expectations Cloud.
     """

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -200,7 +200,7 @@ class ValidationResultIdentifier(DataContextKey):
         )
 
 
-class GeCloudIdentifier(DataContextKey):
+class GXCloudIdentifier(DataContextKey):
     def __init__(
         self,
         resource_type: GXCloudRESTResource,

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -14,7 +14,7 @@ from great_expectations.core.run_identifier import RunIdentifier, RunIdentifierS
 from great_expectations.exceptions import DataContextError, InvalidDataContextKeyError
 
 if TYPE_CHECKING:
-    from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+    from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +203,7 @@ class ValidationResultIdentifier(DataContextKey):
 class GeCloudIdentifier(DataContextKey):
     def __init__(
         self,
-        resource_type: GeCloudRESTResource,
+        resource_type: GXCloudRESTResource,
         ge_cloud_id: Optional[str] = None,
         resource_name: Optional[str] = None,
     ) -> None:

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -429,13 +429,13 @@ class MetricResolutionError(MetricError):
         self.failed_metrics = failed_metrics
 
 
-class GeCloudError(GreatExpectationsError):
+class GXCloudError(GreatExpectationsError):
     """
     Generic error used to provide additional context around Cloud-specific issues.
     """
 
 
-class GeCloudConfigurationError(GreatExpectationsError):
+class GXCloudConfigurationError(GreatExpectationsError):
     """
     Error finding and verifying the required configuration values when preparing to connect to GX Cloud
     """

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -304,7 +304,7 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
-        module_spec = importlib.util.find_spec(module_name, package=package_name)  # type: ignore[attr-defined]
+        module_spec = importlib.util.find_spec(module_name, package=package_name)
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -7,7 +7,7 @@ from typing import Any, List, Optional, Tuple
 import great_expectations.exceptions as exceptions
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.util import nested_update
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.html_site_store import (
     HtmlSiteStore,
     SiteSectionIdentifier,
@@ -464,7 +464,7 @@ class DefaultSiteSectionBuilder:
                 if self.ge_cloud_mode:
                     self.target_store.set(
                         GeCloudIdentifier(
-                            resource_type=GeCloudRESTResource.RENDERED_DATA_DOC
+                            resource_type=GXCloudRESTResource.RENDERED_DATA_DOC
                         ),
                         rendered_content,
                         source_type=resource_key.resource_type,

--- a/great_expectations/render/renderer/site_builder.py
+++ b/great_expectations/render/renderer/site_builder.py
@@ -15,7 +15,7 @@ from great_expectations.data_context.store.html_site_store import (
 from great_expectations.data_context.store.json_site_store import JsonSiteStore
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
     ValidationResultIdentifier,
 )
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -419,7 +419,7 @@ class DefaultSiteSectionBuilder:
             if resource_identifiers and resource_key not in resource_identifiers:
                 continue
 
-            if self.run_name_filter and not isinstance(resource_key, GeCloudIdentifier):
+            if self.run_name_filter and not isinstance(resource_key, GXCloudIdentifier):
                 if not resource_key_passes_run_name_filter(
                     resource_key, self.run_name_filter
                 ):
@@ -463,7 +463,7 @@ class DefaultSiteSectionBuilder:
 
                 if self.ge_cloud_mode:
                     self.target_store.set(
-                        GeCloudIdentifier(
+                        GXCloudIdentifier(
                             resource_type=GXCloudRESTResource.RENDERED_DATA_DOC
                         ),
                         rendered_content,

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -26,7 +26,7 @@ from great_expectations.core.util import (
     determine_progress_bar_method_by_environment,
     nested_update,
 )
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
@@ -1139,7 +1139,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if data_context.ge_cloud_mode:
-            key = GeCloudIdentifier(resource_type=GeCloudRESTResource.PROFILER)
+            key = GeCloudIdentifier(resource_type=GXCloudRESTResource.PROFILER)
         else:
             key = ConfigurationIdentifier(
                 configuration_key=config.name,
@@ -1191,7 +1191,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if ge_cloud_id:
             key = GeCloudIdentifier(
-                resource_type=GeCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
+                resource_type=GXCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
             )
         else:
             key = ConfigurationIdentifier(
@@ -1241,7 +1241,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         key: Union[GeCloudIdentifier, ConfigurationIdentifier]
         if ge_cloud_id:
             key = GeCloudIdentifier(
-                resource_type=GeCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
+                resource_type=GXCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
             )
         else:
             key = ConfigurationIdentifier(configuration_key=name)

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -27,10 +27,10 @@ from great_expectations.core.util import (
     nested_update,
 )
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
-from great_expectations.data_context.types.refs import GeCloudResourceRef
+from great_expectations.data_context.types.refs import GXCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.rule_based_profiler import RuleBasedProfilerResult
@@ -1137,16 +1137,16 @@ class BaseRuleBasedProfiler(ConfigPeer):
             },
         )
 
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier]
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier]
         if data_context.ge_cloud_mode:
-            key = GeCloudIdentifier(resource_type=GXCloudRESTResource.PROFILER)
+            key = GXCloudIdentifier(resource_type=GXCloudRESTResource.PROFILER)
         else:
             key = ConfigurationIdentifier(
                 configuration_key=config.name,
             )
 
         response = profiler_store.set(key=key, value=config)
-        if isinstance(response, GeCloudResourceRef):
+        if isinstance(response, GXCloudResourceRef):
             new_profiler.ge_cloud_id = response.ge_cloud_id
 
         return new_profiler
@@ -1188,9 +1188,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
             ge_cloud_id
         ), "Must provide either name or ge_cloud_id (but not both)"
 
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier]
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier]
         if ge_cloud_id:
-            key = GeCloudIdentifier(
+            key = GXCloudIdentifier(
                 resource_type=GXCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
             )
         else:
@@ -1200,7 +1200,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         try:
             profiler_config: RuleBasedProfilerConfig = profiler_store.get(key=key)
         except ge_exceptions.InvalidKeyError as exc_ik:
-            id: Union[GeCloudIdentifier, ConfigurationIdentifier] = (
+            id: Union[GXCloudIdentifier, ConfigurationIdentifier] = (
                 key.configuration_key
                 if isinstance(key, ConfigurationIdentifier)
                 else key
@@ -1238,9 +1238,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
             ge_cloud_id
         ), "Must provide either name or ge_cloud_id (but not both)"
 
-        key: Union[GeCloudIdentifier, ConfigurationIdentifier]
+        key: Union[GXCloudIdentifier, ConfigurationIdentifier]
         if ge_cloud_id:
-            key = GeCloudIdentifier(
+            key = GXCloudIdentifier(
                 resource_type=GXCloudRESTResource.PROFILER, ge_cloud_id=ge_cloud_id
             )
         else:

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
     from great_expectations.data_context.types.base import DataContextConfig
 
 try:
-    from typing import TypeGuard  # type: ignore[attr-defined]
+    from typing import TypeGuard
 except ImportError:
     from typing_extensions import TypeGuard
 
@@ -365,7 +365,7 @@ def verify_dynamic_loading_support(
     """
     try:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[attr-defined]
+        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[assignment]
             module_name, package=package_name
         )
     except ModuleNotFoundError:

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -52,7 +52,7 @@ from packaging import version
 from pkg_resources import Distribution
 
 from great_expectations.exceptions import (
-    GeCloudConfigurationError,
+    GXCloudConfigurationError,
     PluginClassNotFoundError,
     PluginModuleNotFoundError,
 )
@@ -1754,7 +1754,7 @@ def get_context(
         )
 
     if ge_cloud_mode and not config_available:
-        raise GeCloudConfigurationError(
+        raise GXCloudConfigurationError(
             "GE Cloud Mode enabled, but missing env vars: GE_CLOUD_ORGANIZATION_ID, GE_CLOUD_ACCESS_TOKEN"
         )
 

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
     from great_expectations.data_context.types.base import DataContextConfig
 
 try:
-    from typing import TypeGuard
+    from typing import TypeGuard  # type: ignore[attr-defined]
 except ImportError:
     from typing_extensions import TypeGuard
 

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -12,7 +12,7 @@ from great_expectations.core.batch import Batch
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_asset import DataAsset
 from great_expectations.data_asset.util import parse_result_format
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     GeCloudIdentifier,
@@ -372,11 +372,11 @@ class ActionListValidationOperator(ValidationOperator):
             for batch, async_batch_validation_result in batch_and_async_result_tuples:
                 if self.data_context.ge_cloud_mode:
                     expectation_suite_identifier = GeCloudIdentifier(
-                        resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+                        resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
                         ge_cloud_id=batch._expectation_suite.ge_cloud_id,
                     )
                     validation_result_id = GeCloudIdentifier(
-                        resource_type=GeCloudRESTResource.VALIDATION_RESULT
+                        resource_type=GXCloudRESTResource.VALIDATION_RESULT
                     )
                 else:
                     expectation_suite_identifier = ExpectationSuiteIdentifier(

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -15,7 +15,7 @@ from great_expectations.data_asset.util import parse_result_format
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
     ValidationResultIdentifier,
 )
 from great_expectations.data_context.util import instantiate_class_from_config
@@ -371,11 +371,11 @@ class ActionListValidationOperator(ValidationOperator):
             run_results = {}
             for batch, async_batch_validation_result in batch_and_async_result_tuples:
                 if self.data_context.ge_cloud_mode:
-                    expectation_suite_identifier = GeCloudIdentifier(
+                    expectation_suite_identifier = GXCloudIdentifier(
                         resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
                         ge_cloud_id=batch._expectation_suite.ge_cloud_id,
                     )
-                    validation_result_id = GeCloudIdentifier(
+                    validation_result_id = GXCloudIdentifier(
                         resource_type=GXCloudRESTResource.VALIDATION_RESULT
                     )
                 else:

--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -7,7 +7,7 @@ from moto import mock_sns
 
 from great_expectations.core import ExpectationSuiteValidationResult, RunIdentifier
 from great_expectations.data_context import BaseDataContext
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.types.resource_identifiers import (
     BatchIdentifier,
@@ -115,7 +115,7 @@ def validation_result_suite():
 @pytest.fixture(scope="module")
 def validation_result_suite_ge_cloud_identifier(validation_result_suite_ge_cloud_id):
     return GeCloudIdentifier(
-        resource_type=GeCloudRESTResource.CHECKPOINT,
+        resource_type=GXCloudRESTResource.CHECKPOINT,
         ge_cloud_id=validation_result_suite_ge_cloud_id,
     )
 

--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -12,7 +12,7 @@ from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.types.resource_identifiers import (
     BatchIdentifier,
     ExpectationSuiteIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
     ValidationResultIdentifier,
 )
 
@@ -114,7 +114,7 @@ def validation_result_suite():
 
 @pytest.fixture(scope="module")
 def validation_result_suite_ge_cloud_identifier(validation_result_suite_ge_cloud_id):
-    return GeCloudIdentifier(
+    return GXCloudIdentifier(
         resource_type=GXCloudRESTResource.CHECKPOINT,
         ge_cloud_id=validation_result_suite_ge_cloud_id,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,13 +37,13 @@ from great_expectations.data_context.types.base import (
     CheckpointConfig,
     DataContextConfig,
     DatasourceConfig,
-    GeCloudConfig,
+    GXCloudConfig,
     InMemoryStoreBackendDefaults,
 )
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
     ExpectationSuiteIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.data_context.util import (
     file_relative_path,
@@ -2440,7 +2440,7 @@ def request_headers(ge_cloud_access_token: str) -> Dict[str, str]:
 
 @pytest.fixture
 def ge_cloud_config(ge_cloud_base_url, ge_cloud_organization_id, ge_cloud_access_token):
-    return GeCloudConfig(
+    return GXCloudConfig(
         base_url=ge_cloud_base_url,
         organization_id=ge_cloud_organization_id,
         access_token=ge_cloud_access_token,
@@ -2514,14 +2514,14 @@ include_rendered_content:
 
 
 @pytest.fixture
-def ge_cloud_config_e2e() -> GeCloudConfig:
+def ge_cloud_config_e2e() -> GXCloudConfig:
     """
     Uses live credentials stored in the Great Expectations Cloud backend.
     """
     base_url = os.environ["GE_CLOUD_BASE_URL"]
     organization_id = os.environ["GE_CLOUD_ORGANIZATION_ID"]
     access_token = os.environ["GE_CLOUD_ACCESS_TOKEN"]
-    ge_cloud_config = GeCloudConfig(
+    ge_cloud_config = GXCloudConfig(
         base_url=base_url,
         organization_id=organization_id,
         access_token=access_token,
@@ -2538,7 +2538,7 @@ def empty_base_data_context_in_cloud_mode(
     mock_list_keys: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
 ) -> BaseDataContext:
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
@@ -2557,7 +2557,7 @@ def empty_base_data_context_in_cloud_mode(
 @pytest.fixture
 def empty_data_context_in_cloud_mode(
     tmp_path: pathlib.Path,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
     empty_ge_cloud_data_context_config: DataContextConfig,
 ):
     """This fixture is a DataContext in cloud mode that mocks calls to the cloud backend during setup so that it can be instantiated in tests."""
@@ -2568,7 +2568,7 @@ def empty_data_context_in_cloud_mode(
     def mocked_config(*args, **kwargs) -> DataContextConfig:
         return empty_ge_cloud_data_context_config
 
-    def mocked_get_ge_cloud_config(*args, **kwargs) -> GeCloudConfig:
+    def mocked_get_ge_cloud_config(*args, **kwargs) -> GXCloudConfig:
         return ge_cloud_config
 
     with mock.patch(
@@ -2593,7 +2593,7 @@ def empty_data_context_in_cloud_mode(
 def empty_cloud_data_context(
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
 ) -> CloudDataContext:
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
@@ -2618,7 +2618,7 @@ def empty_base_data_context_in_cloud_mode_custom_base_url(
     mock_list_keys: mock.MagicMock,  # Avoid making a call to Cloud backend during datasource instantiation
     tmp_path: pathlib.Path,
     empty_ge_cloud_data_context_config: DataContextConfig,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
 ) -> BaseDataContext:
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
@@ -2758,8 +2758,8 @@ def ge_cloud_profiler_id() -> str:
 
 
 @pytest.fixture
-def ge_cloud_profiler_key() -> GeCloudIdentifier:
-    return GeCloudIdentifier(resource_type=GXCloudRESTResource.PROFILER)
+def ge_cloud_profiler_key() -> GXCloudIdentifier:
+    return GXCloudIdentifier(resource_type=GXCloudRESTResource.PROFILER)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ from great_expectations.core.usage_statistics.usage_statistics import (
 )
 from great_expectations.core.util import get_or_create_spark_application
 from great_expectations.data_context import BaseDataContext, CloudDataContext
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.profiler_store import ProfilerStore
 from great_expectations.data_context.types.base import (
     AnonymizedUsageStatisticsConfig,
@@ -2759,7 +2759,7 @@ def ge_cloud_profiler_id() -> str:
 
 @pytest.fixture
 def ge_cloud_profiler_key() -> GeCloudIdentifier:
-    return GeCloudIdentifier(resource_type=GeCloudRESTResource.PROFILER)
+    return GeCloudIdentifier(resource_type=GXCloudRESTResource.PROFILER)
 
 
 @pytest.fixture

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
 )
@@ -464,12 +464,12 @@ def test_list_checkpoints(
 
     assert checkpoints == [
         GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.CHECKPOINT,
+            resource_type=GXCloudRESTResource.CHECKPOINT,
             ge_cloud_id=checkpoint_id_1,
             resource_name=checkpoint_name_1,
         ),
         GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.CHECKPOINT,
+            resource_type=GXCloudRESTResource.CHECKPOINT,
             ge_cloud_id=checkpoint_id_2,
             resource_name=checkpoint_name_2,
         ),

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -18,10 +18,10 @@ from great_expectations.data_context.data_context.data_context import DataContex
 from great_expectations.data_context.types.base import (
     CheckpointConfig,
     DataContextConfig,
-    GeCloudConfig,
+    GXCloudConfig,
     checkpointConfigSchema,
 )
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from tests.data_context.conftest import MockResponse
 
 
@@ -439,7 +439,7 @@ def mock_get_all_checkpoints_json(
 @pytest.mark.cloud
 def test_list_checkpoints(
     empty_ge_cloud_data_context_config: DataContextConfig,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
     checkpoint_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]],
     mock_get_all_checkpoints_json: dict,
 ) -> None:
@@ -463,12 +463,12 @@ def test_list_checkpoints(
         checkpoints = context.list_checkpoints()
 
     assert checkpoints == [
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             resource_type=GXCloudRESTResource.CHECKPOINT,
             ge_cloud_id=checkpoint_id_1,
             resource_name=checkpoint_name_1,
         ),
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             resource_type=GXCloudRESTResource.CHECKPOINT,
             ge_cloud_id=checkpoint_id_2,
             resource_name=checkpoint_name_2,

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -8,8 +8,8 @@ from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
-from great_expectations.data_context.types.base import DataContextConfig, GeCloudConfig
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.base import DataContextConfig, GXCloudConfig
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.exceptions.exceptions import DataContextError
 from tests.data_context.conftest import MockResponse
 
@@ -200,7 +200,7 @@ def mock_expectations_store_has_key() -> mock.MagicMock:
 @pytest.mark.cloud
 def test_list_expectation_suites(
     empty_ge_cloud_data_context_config: DataContextConfig,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
     suite_1: SuiteIdentifierTuple,
     suite_2: SuiteIdentifierTuple,
     mock_get_all_suites_json: dict,
@@ -221,12 +221,12 @@ def test_list_expectation_suites(
         suites = context.list_expectation_suites()
 
     assert suites == [
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=suite_1.id,
             resource_name=suite_1.name,
         ),
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=suite_2.id,
             resource_name=suite_2.name,
@@ -274,7 +274,7 @@ def test_create_expectation_suite_overwrites_existing_suite(
     ):
         mock_list_expectation_suite_names.return_value = existing_suite_names
         mock_list_expectation_suites.return_value = [
-            GeCloudIdentifier(
+            GXCloudIdentifier(
                 resource_type=GXCloudRESTResource.EXPECTATION,
                 ge_cloud_id=suite_id,
                 resource_name=suite_name,
@@ -320,7 +320,7 @@ def test_delete_expectation_suite_deletes_suite_in_cloud(
         context.delete_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GXCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert mock_delete.call_args[1]["json"] == {
         "data": {
@@ -346,7 +346,7 @@ def test_delete_expectation_suite_nonexistent_suite_raises_error(
         context.delete_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GXCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert f"expectation_suite with id {suite_id} does not exist" in str(e.value)
 
@@ -369,7 +369,7 @@ def test_get_expectation_suite_retrieves_suite_from_cloud(
         suite = context.get_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GXCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert str(suite.ge_cloud_id) == str(suite_id)
 
@@ -389,7 +389,7 @@ def test_get_expectation_suite_nonexistent_suite_raises_error(
         context.get_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GXCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert f"expectation_suite with id {suite_id} not found" in str(e.value)
 
@@ -495,7 +495,7 @@ def test_save_expectation_suite_no_overwrite_id_collision_raises_error(
         )
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=suite_id,
             resource_name=suite_name,

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from great_expectations.core.expectation_suite import ExpectationSuite
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
@@ -222,12 +222,12 @@ def test_list_expectation_suites(
 
     assert suites == [
         GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=suite_1.id,
             resource_name=suite_1.name,
         ),
         GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+            resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=suite_2.id,
             resource_name=suite_2.name,
         ),
@@ -275,7 +275,7 @@ def test_create_expectation_suite_overwrites_existing_suite(
         mock_list_expectation_suite_names.return_value = existing_suite_names
         mock_list_expectation_suites.return_value = [
             GeCloudIdentifier(
-                resource_type=GeCloudRESTResource.EXPECTATION,
+                resource_type=GXCloudRESTResource.EXPECTATION,
                 ge_cloud_id=suite_id,
                 resource_name=suite_name,
             )
@@ -320,11 +320,11 @@ def test_delete_expectation_suite_deletes_suite_in_cloud(
         context.delete_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GeCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert mock_delete.call_args[1]["json"] == {
         "data": {
-            "type": GeCloudRESTResource.EXPECTATION_SUITE,
+            "type": GXCloudRESTResource.EXPECTATION_SUITE,
             "id": suite_id,
             "attributes": {"deleted": True},
         }
@@ -346,7 +346,7 @@ def test_delete_expectation_suite_nonexistent_suite_raises_error(
         context.delete_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GeCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert f"expectation_suite with id {suite_id} does not exist" in str(e.value)
 
@@ -369,7 +369,7 @@ def test_get_expectation_suite_retrieves_suite_from_cloud(
         suite = context.get_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GeCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert str(suite.ge_cloud_id) == str(suite_id)
 
@@ -389,7 +389,7 @@ def test_get_expectation_suite_nonexistent_suite_raises_error(
         context.get_expectation_suite(ge_cloud_id=suite_id)
 
     mock_expectations_store_has_key.assert_called_once_with(
-        GeCloudIdentifier(GeCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
+        GeCloudIdentifier(GXCloudRESTResource.EXPECTATION_SUITE, ge_cloud_id=suite_id)
     )
     assert f"expectation_suite with id {suite_id} not found" in str(e.value)
 
@@ -496,7 +496,7 @@ def test_save_expectation_suite_no_overwrite_id_collision_raises_error(
 
     mock_expectations_store_has_key.assert_called_once_with(
         GeCloudIdentifier(
-            GeCloudRESTResource.EXPECTATION_SUITE,
+            GXCloudRESTResource.EXPECTATION_SUITE,
             ge_cloud_id=suite_id,
             resource_name=suite_name,
         )

--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -10,7 +10,7 @@ from great_expectations.core import (
 )
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
-from great_expectations.data_context.types.refs import GeCloudResourceRef
+from great_expectations.data_context.types.refs import GXCloudResourceRef
 from great_expectations.render import RenderedAtomicContent
 from great_expectations.validator.validator import Validator
 
@@ -43,7 +43,7 @@ def test_cloud_backed_data_context_save_expectation_suite_include_rendered_conte
     context = request.getfixturevalue(data_context_fixture_name)
 
     ge_cloud_id = "d581305a-cdce-483b-84ba-5c673d2ce009"
-    cloud_ref = GeCloudResourceRef(
+    cloud_ref = GXCloudResourceRef(
         resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
         ge_cloud_id=ge_cloud_id,
         url="foo/bar/baz",

--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -9,7 +9,7 @@ from great_expectations.core import (
     ExpectationValidationResult,
 )
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.render import RenderedAtomicContent
 from great_expectations.validator.validator import Validator
@@ -44,7 +44,7 @@ def test_cloud_backed_data_context_save_expectation_suite_include_rendered_conte
 
     ge_cloud_id = "d581305a-cdce-483b-84ba-5c673d2ce009"
     cloud_ref = GeCloudResourceRef(
-        resource_type=GeCloudRESTResource.EXPECTATION_SUITE,
+        resource_type=GXCloudRESTResource.EXPECTATION_SUITE,
         ge_cloud_id=ge_cloud_id,
         url="foo/bar/baz",
     )

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -8,8 +8,8 @@ from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
 from great_expectations.data_context.data_context.data_context import DataContext
-from great_expectations.data_context.types.base import DataContextConfig, GeCloudConfig
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.base import DataContextConfig, GXCloudConfig
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.rule_based_profiler.config.base import (
     ruleBasedProfilerConfigSchema,
 )
@@ -338,7 +338,7 @@ def mock_get_all_profilers_json(
 @pytest.mark.cloud
 def test_list_profilers(
     empty_ge_cloud_data_context_config: DataContextConfig,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
     profiler_names_and_ids: Tuple[Tuple[str, str], Tuple[str, str]],
     mock_get_all_profilers_json: dict,
 ) -> None:
@@ -362,12 +362,12 @@ def test_list_profilers(
         profilers = context.list_profilers()
 
     assert profilers == [
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             resource_type=GXCloudRESTResource.PROFILER,
             ge_cloud_id=profiler_id_1,
             resource_name=profiler_name_1,
         ),
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             resource_type=GXCloudRESTResource.PROFILER,
             ge_cloud_id=profiler_id_2,
             resource_name=profiler_name_2,

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.base_data_context import (
     BaseDataContext,
 )
@@ -363,12 +363,12 @@ def test_list_profilers(
 
     assert profilers == [
         GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.PROFILER,
+            resource_type=GXCloudRESTResource.PROFILER,
             ge_cloud_id=profiler_id_1,
             resource_name=profiler_name_1,
         ),
         GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.PROFILER,
+            resource_type=GXCloudRESTResource.PROFILER,
             ge_cloud_id=profiler_id_2,
             resource_name=profiler_name_2,
         ),

--- a/tests/data_context/migrator/test_cloud_migrator.py
+++ b/tests/data_context/migrator/test_cloud_migrator.py
@@ -9,7 +9,7 @@ import great_expectations as gx
 import great_expectations.exceptions as ge_exceptions
 from great_expectations import CloudMigrator
 from great_expectations.core.usage_statistics.events import UsageStatsEvents
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.migrator.cloud_migrator import MigrationResponse
 from great_expectations.data_context.types.base import AnonymizedUsageStatisticsConfig
 from tests.data_context.migrator.conftest import StubBaseDataContext
@@ -181,7 +181,7 @@ def test__send_validation_results_sends_valid_http_request(
         f"{ge_cloud_base_url}/organizations/{ge_cloud_organization_id}/expectation-validation-results",
         json={
             "data": {
-                "type": GeCloudRESTResource.EXPECTATION_VALIDATION_RESULT,
+                "type": GXCloudRESTResource.EXPECTATION_VALIDATION_RESULT,
                 "attributes": {
                     "organization_id": ge_cloud_organization_id,
                     "result": validation_results[keys[0]],

--- a/tests/data_context/store/conftest.py
+++ b/tests/data_context/store/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from great_expectations.core.serializer import JsonConfigSerializer
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store import DatasourceStore
 from great_expectations.data_context.types.base import datasourceConfigSchema
 
@@ -16,7 +16,7 @@ def datasource_store_ge_cloud_backend(
     ge_cloud_store_backend_config: dict = {
         "class_name": "GeCloudStoreBackend",
         "ge_cloud_base_url": ge_cloud_base_url,
-        "ge_cloud_resource_type": GeCloudRESTResource.DATASOURCE,
+        "ge_cloud_resource_type": GXCloudRESTResource.DATASOURCE,
         "ge_cloud_credentials": {
             "access_token": ge_cloud_access_token,
             "organization_id": ge_cloud_organization_id,

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -15,7 +15,7 @@ from great_expectations.data_context.store import CheckpointStore
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.util import filter_properties_dict, gen_directory_tree_str
@@ -416,7 +416,7 @@ def test_delete_checkpoint_with_cloud_id(
     store.delete_checkpoint(ge_cloud_id="abc123")
 
     mock_backend.remove_key.assert_called_once_with(
-        GeCloudIdentifier(
+        GXCloudIdentifier(
             resource_type=GXCloudRESTResource.CHECKPOINT, ge_cloud_id="abc123"
         )
     )

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -9,7 +9,7 @@ from marshmallow.exceptions import ValidationError
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.core.util import convert_to_json_serializable
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.data_context import DataContext
 from great_expectations.data_context.store import CheckpointStore
 from great_expectations.data_context.types.base import CheckpointConfig
@@ -417,7 +417,7 @@ def test_delete_checkpoint_with_cloud_id(
 
     mock_backend.remove_key.assert_called_once_with(
         GeCloudIdentifier(
-            resource_type=GeCloudRESTResource.CHECKPOINT, ge_cloud_id="abc123"
+            resource_type=GXCloudRESTResource.CHECKPOINT, ge_cloud_id="abc123"
         )
     )
 

--- a/tests/data_context/store/test_configuration_store.py
+++ b/tests/data_context/store/test_configuration_store.py
@@ -15,7 +15,7 @@ from great_expectations.data_context.store import ConfigurationStore
 from great_expectations.data_context.types.base import BaseYamlConfig
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.exceptions.exceptions import DataContextError
 from great_expectations.util import gen_directory_tree_str
@@ -314,7 +314,7 @@ def test_self_check(capsys) -> None:
         pytest.param(
             None,
             "abc123",
-            GeCloudIdentifier(
+            GXCloudIdentifier(
                 resource_type=GXCloudRESTResource.CHECKPOINT, ge_cloud_id="abc123"
             ),
             id="id",

--- a/tests/data_context/store/test_configuration_store.py
+++ b/tests/data_context/store/test_configuration_store.py
@@ -10,7 +10,7 @@ from ruamel.yaml.comments import CommentedMap
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.data_context_key import DataContextKey
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store import ConfigurationStore
 from great_expectations.data_context.types.base import BaseYamlConfig
 from great_expectations.data_context.types.resource_identifiers import (
@@ -315,7 +315,7 @@ def test_self_check(capsys) -> None:
             None,
             "abc123",
             GeCloudIdentifier(
-                resource_type=GeCloudRESTResource.CHECKPOINT, ge_cloud_id="abc123"
+                resource_type=GXCloudRESTResource.CHECKPOINT, ge_cloud_id="abc123"
             ),
             id="id",
         ),

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -12,7 +12,7 @@ from great_expectations.core.serializer import (
     JsonConfigSerializer,
 )
 from great_expectations.core.yaml_handler import YAMLHandler
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.data_context.data_context import DataContext
 from great_expectations.data_context.data_context_variables import (
     DataContextVariableSchema,
@@ -189,7 +189,7 @@ def test_datasource_store_set_cloud_mode(
     ge_cloud_store_backend_config: dict = {
         "class_name": "GeCloudStoreBackend",
         "ge_cloud_base_url": ge_cloud_base_url,
-        "ge_cloud_resource_type": GeCloudRESTResource.DATASOURCE,
+        "ge_cloud_resource_type": GXCloudRESTResource.DATASOURCE,
         "ge_cloud_credentials": {
             "access_token": ge_cloud_access_token,
             "organization_id": ge_cloud_organization_id,

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -10,7 +10,7 @@ from great_expectations.data_context.types.base import (
     DatasourceConfig,
     datasourceConfigSchema,
 )
-from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.exceptions import StoreBackendError
 from tests.data_context.conftest import MockResponse
 
@@ -32,7 +32,7 @@ def test_datasource_store_set(
     """
 
     # Note: id will be provided by the backend on create
-    key = GeCloudIdentifier(
+    key = GXCloudIdentifier(
         resource_type=GXCloudRESTResource.DATASOURCE,
     )
 
@@ -87,7 +87,7 @@ def test_datasource_store_get_by_id(
 
     id: str = "example_id_normally_uuid"
 
-    key = GeCloudIdentifier(
+    key = GXCloudIdentifier(
         resource_type=GXCloudRESTResource.DATASOURCE, ge_cloud_id=id
     )
 
@@ -176,7 +176,7 @@ def test_datasource_store_delete_by_id(
     """
     id: str = "example_id_normally_uuid"
 
-    key = GeCloudIdentifier(
+    key = GXCloudIdentifier(
         resource_type=GXCloudRESTResource.DATASOURCE, ge_cloud_id=id
     )
 
@@ -223,7 +223,7 @@ def test_datasource_http_error_handling(
 ):
     id: str = "example_id_normally_uuid"
 
-    key = GeCloudIdentifier(
+    key = GXCloudIdentifier(
         resource_type=GXCloudRESTResource.DATASOURCE, ge_cloud_id=id
     )
     with pytest.raises(

--- a/tests/data_context/store/test_datasource_store_cloud_backend.py
+++ b/tests/data_context/store/test_datasource_store_cloud_backend.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from great_expectations.core.serializer import DictConfigSerializer
-from great_expectations.data_context.cloud_constants import GeCloudRESTResource
+from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store import DatasourceStore
 from great_expectations.data_context.types.base import (
     DatasourceConfig,
@@ -33,7 +33,7 @@ def test_datasource_store_set(
 
     # Note: id will be provided by the backend on create
     key = GeCloudIdentifier(
-        resource_type=GeCloudRESTResource.DATASOURCE,
+        resource_type=GXCloudRESTResource.DATASOURCE,
     )
 
     with mock.patch(
@@ -88,7 +88,7 @@ def test_datasource_store_get_by_id(
     id: str = "example_id_normally_uuid"
 
     key = GeCloudIdentifier(
-        resource_type=GeCloudRESTResource.DATASOURCE, ge_cloud_id=id
+        resource_type=GXCloudRESTResource.DATASOURCE, ge_cloud_id=id
     )
 
     def mocked_response(*args, **kwargs):
@@ -177,7 +177,7 @@ def test_datasource_store_delete_by_id(
     id: str = "example_id_normally_uuid"
 
     key = GeCloudIdentifier(
-        resource_type=GeCloudRESTResource.DATASOURCE, ge_cloud_id=id
+        resource_type=GXCloudRESTResource.DATASOURCE, ge_cloud_id=id
     )
 
     with mock.patch("requests.Session.delete", autospec=True) as mock_delete:
@@ -224,7 +224,7 @@ def test_datasource_http_error_handling(
     id: str = "example_id_normally_uuid"
 
     key = GeCloudIdentifier(
-        resource_type=GeCloudRESTResource.DATASOURCE, ge_cloud_id=id
+        resource_type=GXCloudRESTResource.DATASOURCE, ge_cloud_id=id
     )
     with pytest.raises(
         StoreBackendError, match=r"Unable to \w+ object in GE Cloud Store Backend: .*"

--- a/tests/data_context/store/test_ge_cloud_store_backend.py
+++ b/tests/data_context/store/test_ge_cloud_store_backend.py
@@ -18,7 +18,7 @@ import pytest
 
 from great_expectations.data_context.cloud_constants import (
     CLOUD_DEFAULT_BASE_URL,
-    GeCloudRESTResource,
+    GXCloudRESTResource,
 )
 from great_expectations.data_context.store.ge_cloud_store_backend import (
     GeCloudStoreBackend,
@@ -31,8 +31,8 @@ from great_expectations.data_context.types.base import CheckpointConfig
 @pytest.fixture
 def construct_ge_cloud_store_backend(
     ge_cloud_access_token: str,
-) -> Callable[[GeCloudRESTResource], GeCloudStoreBackend]:
-    def _closure(resource_type: GeCloudRESTResource) -> GeCloudStoreBackend:
+) -> Callable[[GXCloudRESTResource], GeCloudStoreBackend]:
+    def _closure(resource_type: GXCloudRESTResource) -> GeCloudStoreBackend:
         ge_cloud_base_url = CLOUD_DEFAULT_BASE_URL
         ge_cloud_credentials = {
             "access_token": ge_cloud_access_token,
@@ -210,10 +210,10 @@ def test_construct_json_payload(
 @pytest.mark.unit
 def test_set(
     construct_ge_cloud_store_backend: Callable[
-        [GeCloudRESTResource], GeCloudStoreBackend
+        [GXCloudRESTResource], GeCloudStoreBackend
     ],
 ) -> None:
-    store_backend = construct_ge_cloud_store_backend(GeCloudRESTResource.CHECKPOINT)
+    store_backend = construct_ge_cloud_store_backend(GXCloudRESTResource.CHECKPOINT)
 
     my_simple_checkpoint_config: CheckpointConfig = CheckpointConfig(
         name="my_minimal_simple_checkpoint",
@@ -265,10 +265,10 @@ def test_set(
 @pytest.mark.unit
 def test_list_keys(
     construct_ge_cloud_store_backend: Callable[
-        [GeCloudRESTResource], GeCloudStoreBackend
+        [GXCloudRESTResource], GeCloudStoreBackend
     ],
 ) -> None:
-    store_backend = construct_ge_cloud_store_backend(GeCloudRESTResource.CHECKPOINT)
+    store_backend = construct_ge_cloud_store_backend(GXCloudRESTResource.CHECKPOINT)
 
     with mock.patch("requests.Session.get", autospec=True) as mock_get:
         store_backend.list_keys()
@@ -282,10 +282,10 @@ def test_list_keys(
 @pytest.mark.unit
 def test_remove_key(
     construct_ge_cloud_store_backend: Callable[
-        [GeCloudRESTResource], GeCloudStoreBackend
+        [GXCloudRESTResource], GeCloudStoreBackend
     ],
 ) -> None:
-    store_backend = construct_ge_cloud_store_backend(GeCloudRESTResource.CHECKPOINT)
+    store_backend = construct_ge_cloud_store_backend(GXCloudRESTResource.CHECKPOINT)
 
     with mock.patch("requests.Session.delete", autospec=True) as mock_delete:
         mock_response = mock_delete.return_value
@@ -316,24 +316,24 @@ def test_remove_key(
 @pytest.mark.unit
 def test_appropriate_casting_of_str_resource_type_to_GeCloudRESTResource(
     construct_ge_cloud_store_backend: Callable[
-        [GeCloudRESTResource], GeCloudStoreBackend
+        [GXCloudRESTResource], GeCloudStoreBackend
     ],
 ) -> None:
-    store_backend = construct_ge_cloud_store_backend(GeCloudRESTResource.CHECKPOINT)
+    store_backend = construct_ge_cloud_store_backend(GXCloudRESTResource.CHECKPOINT)
 
-    assert store_backend.ge_cloud_resource_type is GeCloudRESTResource.CHECKPOINT
+    assert store_backend.ge_cloud_resource_type is GXCloudRESTResource.CHECKPOINT
 
 
 @pytest.mark.parametrize(
     "resource_type,expected_set_kwargs",
     [
         pytest.param(
-            GeCloudRESTResource.VALIDATION_RESULT,
+            GXCloudRESTResource.VALIDATION_RESULT,
             {"checkpoint_id", "expectation_suite_id"},
             id="resource_with_allowed_set_kwargs",
         ),
         pytest.param(
-            GeCloudRESTResource.CHECKPOINT,
+            GXCloudRESTResource.CHECKPOINT,
             set(),
             id="resource_without_allowed_set_kwargs",
         ),
@@ -342,10 +342,10 @@ def test_appropriate_casting_of_str_resource_type_to_GeCloudRESTResource(
 @pytest.mark.cloud
 @pytest.mark.unit
 def test_allowed_set_kwargs(
-    resource_type: GeCloudRESTResource,
+    resource_type: GXCloudRESTResource,
     expected_set_kwargs: Set[str],
     construct_ge_cloud_store_backend: Callable[
-        [GeCloudRESTResource], GeCloudStoreBackend
+        [GXCloudRESTResource], GeCloudStoreBackend
     ],
 ) -> None:
     store_backend = construct_ge_cloud_store_backend(resource_type)
@@ -385,11 +385,11 @@ def test_validate_set_kwargs(
     kwargs: dict,
     expected: Union[bool, None],
     construct_ge_cloud_store_backend: Callable[
-        [GeCloudRESTResource], GeCloudStoreBackend
+        [GXCloudRESTResource], GeCloudStoreBackend
     ],
 ) -> None:
     store_backend = construct_ge_cloud_store_backend(
-        GeCloudRESTResource.VALIDATION_RESULT
+        GXCloudRESTResource.VALIDATION_RESULT
     )
     store_backend.validate_set_kwargs(kwargs) == expected
 
@@ -398,16 +398,16 @@ def test_validate_set_kwargs(
 @pytest.mark.unit
 def test_config_property_and_defaults(
     construct_ge_cloud_store_backend: Callable[
-        [GeCloudRESTResource], GeCloudStoreBackend
+        [GXCloudRESTResource], GeCloudStoreBackend
     ],
 ) -> None:
-    store_backend = construct_ge_cloud_store_backend(GeCloudRESTResource.CHECKPOINT)
+    store_backend = construct_ge_cloud_store_backend(GXCloudRESTResource.CHECKPOINT)
 
     assert store_backend.config == {
         "class_name": "GeCloudStoreBackend",
         "fixed_length_key": True,
         "ge_cloud_base_url": CLOUD_DEFAULT_BASE_URL,
-        "ge_cloud_resource_type": GeCloudRESTResource.CHECKPOINT,
+        "ge_cloud_resource_type": GXCloudRESTResource.CHECKPOINT,
         "manually_initialize_store_backend_id": "",
         "module_name": "great_expectations.data_context.store.ge_cloud_store_backend",
         "suppress_store_backend_id": True,

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -16,7 +16,7 @@ from great_expectations.data_context.store.inline_store_backend import (
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     DatasourceConfig,
-    GeCloudConfig,
+    GXCloudConfig,
 )
 from great_expectations.datasource import Datasource
 
@@ -52,7 +52,7 @@ def pandas_enabled_datasource_config() -> dict:
 def test_data_context_instantiates_ge_cloud_store_backend_with_cloud_config(
     tmp_path: pathlib,
     data_context_config_with_datasources: DataContextConfig,
-    ge_cloud_config: GeCloudConfig,
+    ge_cloud_config: GXCloudConfig,
 ) -> None:
     project_path = tmp_path / "my_data_context"
     project_path.mkdir()

--- a/tests/data_context/test_data_context_ge_cloud_mode.py
+++ b/tests/data_context/test_data_context_ge_cloud_mode.py
@@ -4,7 +4,7 @@ import pytest
 
 from great_expectations.data_context import BaseDataContext, DataContext
 from great_expectations.data_context.cloud_constants import CLOUD_DEFAULT_BASE_URL
-from great_expectations.exceptions import DataContextError, GeCloudError
+from great_expectations.exceptions import DataContextError, GXCloudError
 
 
 @pytest.mark.cloud
@@ -59,7 +59,7 @@ def test_data_context_ge_cloud_mode_with_bad_request_to_cloud_api_should_throw_e
     # Ensure that the request fails
     mock_request.return_value.status_code = 401
 
-    with pytest.raises(GeCloudError):
+    with pytest.raises(GXCloudError):
         DataContext(
             ge_cloud_mode=True,
             ge_cloud_base_url=ge_cloud_runtime_base_url,

--- a/tests/data_context/test_data_context_variables.py
+++ b/tests/data_context/test_data_context_variables.py
@@ -26,7 +26,7 @@ from great_expectations.data_context.types.base import (
     AnonymizedUsageStatisticsConfig,
     ConcurrencyConfig,
     DataContextConfig,
-    GeCloudConfig,
+    GXCloudConfig,
     IncludeRenderedContentConfig,
     NotebookConfig,
     NotebookTemplateConfig,
@@ -138,7 +138,7 @@ def file_data_context(
 def cloud_data_context(
     tmp_path: pathlib.Path,
     data_context_config: DataContextConfig,
-    ge_cloud_config_e2e: GeCloudConfig,
+    ge_cloud_config_e2e: GXCloudConfig,
 ) -> CloudDataContext:
     project_path = tmp_path / "cloud_data_context"
     project_path.mkdir()

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -6,6 +6,7 @@ import pytest
 import great_expectations as gx
 from great_expectations import DataContext
 from great_expectations.data_context import BaseDataContext, CloudDataContext
+from great_expectations.data_context.cloud_constants import GECloudEnvironmentVariable
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.exceptions import ConfigNotFoundError
 from tests.test_utils import working_directory
@@ -158,6 +159,10 @@ def test_cloud_context_disabled(set_up_cloud_envs, tmp_path: pathlib.Path):
 def test_cloud_missing_env_throws_exception(
     monkeypatch, empty_ge_cloud_data_context_config
 ):
+    # Delete local env vars (if present)
+    for env_var in GECloudEnvironmentVariable:
+        monkeypatch.delenv(env_var, raising=False)
+
     with pytest.raises(Exception):
         gx.get_context(ge_cloud_mode=True),
 

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -31,8 +31,15 @@ def set_up_cloud_envs(monkeypatch):
     monkeypatch.setenv("GE_CLOUD_ACCESS_TOKEN", "i_am_a_token")
 
 
+@pytest.fixture
+def clear_env_vars(monkeypatch):
+    # Delete local env vars (if present)
+    for env_var in GXCloudEnvironmentVariable:
+        monkeypatch.delenv(env_var, raising=False)
+
+
 @pytest.mark.unit
-def test_base_context():
+def test_base_context(clear_env_vars):
     config: DataContextConfig = DataContextConfig(
         config_version=3.0,
         plugins_directory=None,
@@ -52,7 +59,7 @@ def test_base_context():
 
 
 @pytest.mark.unit
-def test_base_context__with_overridden_yml(tmp_path: pathlib.Path):
+def test_base_context__with_overridden_yml(tmp_path: pathlib.Path, clear_env_vars):
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
     project_path_str = str(project_path)
@@ -85,7 +92,7 @@ def test_base_context__with_overridden_yml(tmp_path: pathlib.Path):
 
 
 @pytest.mark.unit
-def test_data_context(tmp_path: pathlib.Path):
+def test_data_context(tmp_path: pathlib.Path, clear_env_vars):
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
     project_path_str = str(project_path)
@@ -97,6 +104,7 @@ def test_data_context(tmp_path: pathlib.Path):
 @pytest.mark.unit
 def test_data_context_root_dir_returns_data_context(
     tmp_path: pathlib.Path,
+    clear_env_vars,
 ):
     project_path = tmp_path / "empty_data_context"
     project_path.mkdir()
@@ -107,7 +115,7 @@ def test_data_context_root_dir_returns_data_context(
 
 
 @pytest.mark.unit
-def test_base_context_invalid_root_dir():
+def test_base_context_invalid_root_dir(clear_env_vars):
     config: DataContextConfig = DataContextConfig(
         config_version=3.0,
         plugins_directory=None,
@@ -157,12 +165,8 @@ def test_cloud_context_disabled(set_up_cloud_envs, tmp_path: pathlib.Path):
 
 @pytest.mark.cloud
 def test_cloud_missing_env_throws_exception(
-    monkeypatch, empty_ge_cloud_data_context_config
+    clear_env_vars, empty_ge_cloud_data_context_config
 ):
-    # Delete local env vars (if present)
-    for env_var in GXCloudEnvironmentVariable:
-        monkeypatch.delenv(env_var, raising=False)
-
     with pytest.raises(Exception):
         gx.get_context(ge_cloud_mode=True),
 
@@ -226,6 +230,6 @@ def test_cloud_context_with_in_memory_config_overrides(
 
 
 @pytest.mark.unit
-def test_invalid_root_dir_gives_error():
+def test_invalid_root_dir_gives_error(clear_env_vars):
     with pytest.raises(ConfigNotFoundError):
         gx.get_context(context_root_dir="i/dont/exist")

--- a/tests/data_context/test_get_data_context.py
+++ b/tests/data_context/test_get_data_context.py
@@ -6,7 +6,7 @@ import pytest
 import great_expectations as gx
 from great_expectations import DataContext
 from great_expectations.data_context import BaseDataContext, CloudDataContext
-from great_expectations.data_context.cloud_constants import GECloudEnvironmentVariable
+from great_expectations.data_context.cloud_constants import GXCloudEnvironmentVariable
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.exceptions import ConfigNotFoundError
 from tests.test_utils import working_directory
@@ -160,7 +160,7 @@ def test_cloud_missing_env_throws_exception(
     monkeypatch, empty_ge_cloud_data_context_config
 ):
     # Delete local env vars (if present)
-    for env_var in GECloudEnvironmentVariable:
+    for env_var in GXCloudEnvironmentVariable:
         monkeypatch.delenv(env_var, raising=False)
 
     with pytest.raises(Exception):

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -10,7 +10,7 @@ from great_expectations.core.batch import BatchRequest
 from great_expectations.data_context.store.profiler_store import ProfilerStore
 from great_expectations.data_context.types.resource_identifiers import (
     ConfigurationIdentifier,
-    GeCloudIdentifier,
+    GXCloudIdentifier,
 )
 from great_expectations.exceptions.exceptions import InvalidConfigError
 from great_expectations.rule_based_profiler import (
@@ -1187,7 +1187,7 @@ def test_add_profiler(
 def test_add_profiler_ge_cloud_mode(
     mock_data_context: mock.MagicMock,
     ge_cloud_profiler_id: str,
-    ge_cloud_profiler_key: GeCloudIdentifier,
+    ge_cloud_profiler_key: GXCloudIdentifier,
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
     mock_data_context.ge_cloud_mode.return_value = True


### PR DESCRIPTION
Changes proposed in this pull request:
- `CONTRACT` and `SUITE_VALIDATION_RESULT` are legacy and have been slated for removal for some time.
- Classes should utilize the `GX` prefix
- `get_context()` tests should work when you have env vars set
    - Let's delete them using `monkeypatch` so this is the case


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
