### PR TITLE
[MAINTENANCE] Pin `mypy` to `0.990`

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -752,7 +752,6 @@ class ExpectationSuite(SerializableDictDot):
         pprint.pprint(
             object=pprint_objects,
             indent=2,
-            sort_dicts=False,
         )
 
     def get_grouped_and_ordered_expectations_by_domain_type(

--- a/great_expectations/data_context/config_validator/yaml_config_validator.py
+++ b/great_expectations/data_context/config_validator/yaml_config_validator.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
+from typing_extensions import Literal
 
 from great_expectations.checkpoint import Checkpoint, SimpleCheckpoint
 from great_expectations.core.usage_statistics.anonymizers.anonymizer import Anonymizer
@@ -44,11 +45,6 @@ from great_expectations.util import filter_properties_dict
 if TYPE_CHECKING:
     from great_expectations.data_context import AbstractDataContext
 
-try:
-    from typing import Literal
-except ImportError:
-    # Fallback for python < 3.8
-    from typing_extensions import Literal  # type: ignore[assignment]
 
 # TODO: check if this can be refactored to use YAMLHandler class
 yaml = YAML()

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -24,16 +24,10 @@ from typing import (
     cast,
 )
 
-from marshmallow import ValidationError
-
-try:
-    from typing import Literal
-except ImportError:
-    # Fallback for python < 3.8
-    from typing_extensions import Literal  # type: ignore[assignment]
-
 from dateutil.parser import parse
+from marshmallow import ValidationError
 from ruamel.yaml.comments import CommentedMap
+from typing_extensions import Literal
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core import ExpectationSuite

--- a/great_expectations/data_context/store/ge_cloud_store_backend.py
+++ b/great_expectations/data_context/store/ge_cloud_store_backend.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 from urllib.parse import urljoin
 
 import requests
+from typing_extensions import TypedDict
 
 from great_expectations.core.http import create_session
 from great_expectations.data_context.cloud_constants import (
@@ -16,11 +17,6 @@ from great_expectations.data_context.types.refs import GeCloudResourceRef
 from great_expectations.data_context.types.resource_identifiers import GeCloudIdentifier
 from great_expectations.exceptions import StoreBackendError
 from great_expectations.util import bidict, filter_properties_dict, hyphen
-
-try:
-    from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -304,7 +304,7 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
-        module_spec = importlib.util.find_spec(module_name, package=package_name)  # type: ignore[attr-defined]
+        module_spec = importlib.util.find_spec(module_name, package=package_name)
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/render/renderer/inline_renderer.py
+++ b/great_expectations/render/renderer/inline_renderer.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Callable, List, Optional, Union
 
+from typing_extensions import TypedDict
+
 from great_expectations.core import (
     ExpectationConfiguration,
     ExpectationValidationResult,
@@ -17,11 +19,6 @@ from great_expectations.render import (
 )
 from great_expectations.render.exceptions import InvalidRenderedContentError
 from great_expectations.render.renderer.renderer import Renderer
-
-try:
-    from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)
 

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -268,8 +268,8 @@ def get_project_distribution() -> Optional[Distribution]:
         except ValueError:
             pass
         else:
-            if relative_path in distr.files:  # type: ignore[operator]
-                return distr  # type: ignore[return-value]
+            if relative_path in distr.files:
+                return distr
     return None
 
 
@@ -365,7 +365,7 @@ def verify_dynamic_loading_support(
     """
     try:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[attr-defined]
+        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[assignment]
             module_name, package=package_name
         )
     except ModuleNotFoundError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ skip_gitignore = true
 extend_skip_glob = ['venv/*', 'docs/*']
 
 [tool.mypy]
+python_version = "3.7"
 files = [
     "great_expectations",
     # "contrib" # ignore entire `contrib` package

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -2,7 +2,7 @@ black==22.3.0
 flake8==5.0.4
 invoke>=1.7.1
 isort==5.10.1
-mypy>=0.971
+mypy==0.990
 pre-commit>=2.6.0
 pytest-cov>=2.8.1
 pytest-order>=0.9.5

--- a/tasks.py
+++ b/tasks.py
@@ -159,7 +159,7 @@ def type_check(
     else:
         bin = "mypy"
 
-    ge_pkgs = [f"great_expectations/{p}" for p in packages]
+    ge_pkgs = [f"great_expectations.{p}" for p in packages]
     cmds = [
         bin,
         *ge_pkgs,


### PR DESCRIPTION
## Changes proposed in this pull request:
The following changes should make our typing CI step much more consistent and reliable.

### Pin mypy version to prevent CI breakage - [as recommended by `mypy`](https://mypy.readthedocs.io/en/stable/existing_code.html#run-mypy-consistently-and-prevent-regressions)
  - Fix typing issues related to latest change - https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html
### Update `mypy` config to always run as if it was python 3.7 (our oldest supported version)
  - fix typing issues on python 3.7
  - fixed 1 potential `pprint` related bug - https://docs.python.org/3/library/pprint.html#pprint.PrettyPrinter
