### PR TITLE
[BUGFIX] Use `requirements.txt` file when installing linting/static check dependencies in CI

### DIFF
--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -110,17 +110,22 @@ stages:
       vmImage: 'ubuntu-latest'
 
     jobs:
+    - job: install_dependencies
+      steps:
+      - script: |
+          pip install --requirements reqs/requirements-dev-contrib.txt
+          invoke type-coverage
+        name: TypeHintChecker
+
     - job: type_hint_checker
       steps:
       - script: |
-          pip install mypy invoke # Prereq for type hint script
           invoke type-coverage
         name: TypeHintChecker
 
     - job: static_type_check
       steps:
       - script: |
-          pip install mypy invoke
           invoke type-check --install-types --warn-unused-ignores --pretty
         name: StaticTypeCheck
 
@@ -132,7 +137,6 @@ stages:
     - job: unused_import_checker
       steps:
       - script: |
-          pip install flake8
           # https://www.flake8rules.com/rules/F401.html
           flake8 --select F401 great_expectations tests
         name: UnusedImportChecker

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -114,8 +114,7 @@ stages:
       steps:
       - script: |
           pip install --requirements reqs/requirements-dev-contrib.txt
-          invoke type-coverage
-        name: TypeHintChecker
+        name: InstallDependencies
 
     - job: type_hint_checker
       steps:

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -117,23 +117,27 @@ stages:
         name: InstallDependencies
 
     - job: type_hint_checker
+      dependsOn: install_dependencies
       steps:
       - script: |
           invoke type-coverage
         name: TypeHintChecker
 
     - job: static_type_check
+      dependsOn: install_dependencies
       steps:
       - script: |
           invoke type-check --install-types --warn-unused-ignores --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker
+      dependsOn: install_dependencies
       steps:
       - bash: python scripts/check_docstring_coverage.py
         name: DocstringChecker
 
     - job: unused_import_checker
+      dependsOn: install_dependencies
       steps:
       - script: |
           # https://www.flake8rules.com/rules/F401.html

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -113,7 +113,7 @@ stages:
     - job: install_dependencies
       steps:
       - script: |
-          pip install --requirements reqs/requirements-dev-contrib.txt
+          pip install --requirement reqs/requirements-dev-contrib.txt
         name: InstallDependencies
 
     - job: type_hint_checker

--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -110,36 +110,29 @@ stages:
       vmImage: 'ubuntu-latest'
 
     jobs:
-    - job: install_dependencies
+    - job: type_hint_checker
       steps:
       - script: |
           pip install --requirement reqs/requirements-dev-contrib.txt
-        name: InstallDependencies
-
-    - job: type_hint_checker
-      dependsOn: install_dependencies
-      steps:
-      - script: |
           invoke type-coverage
         name: TypeHintChecker
 
     - job: static_type_check
-      dependsOn: install_dependencies
       steps:
       - script: |
+          pip install --requirement reqs/requirements-dev-contrib.txt
           invoke type-check --install-types --warn-unused-ignores --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker
-      dependsOn: install_dependencies
       steps:
       - bash: python scripts/check_docstring_coverage.py
         name: DocstringChecker
 
     - job: unused_import_checker
-      dependsOn: install_dependencies
       steps:
       - script: |
+          pip install --requirement reqs/requirements-dev-contrib.txt
           # https://www.flake8rules.com/rules/F401.html
           flake8 --select F401 great_expectations tests
         name: UnusedImportChecker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
-          pip install --requirements reqs/requirements-dev-contrib.txt
+          pip install --requirement reqs/requirements-dev-contrib.txt
         name: InstallDependencies
 
     - job: type_hint_checker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,11 +84,17 @@ stages:
       vmImage: 'ubuntu-latest'
 
     jobs:
+    - job: install_dependencies
+      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
+      steps:
+      - script: |
+          pip install --requirements reqs/requirements-dev-contrib.txt
+        name: InstallDependencies
+
     - job: type_hint_checker
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
-          pip install mypy invoke # Prereq for type hint script
           invoke type-coverage
         name: TypeHintChecker
 
@@ -96,8 +102,7 @@ stages:
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
-          pip install mypy invoke
-          invoke type-check --install-types --warn-unused-ignores --pretty 
+          invoke type-check --install-types --warn-unused-ignores --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,7 @@ stages:
         name: InstallDependencies
 
     - job: type_hint_checker
+      dependsOn: install_dependencies
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
@@ -99,6 +100,7 @@ stages:
         name: TypeHintChecker
 
     - job: static_type_check
+      dependsOn: install_dependencies
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
@@ -106,12 +108,14 @@ stages:
         name: StaticTypeCheck
 
     - job: docstring_checker
+      dependsOn: install_dependencies
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - bash: python scripts/check_docstring_coverage.py
         name: DocstringChecker
 
     - job: unused_import_checker
+      dependsOn: install_dependencies
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,41 +84,33 @@ stages:
       vmImage: 'ubuntu-latest'
 
     jobs:
-    - job: install_dependencies
+    - job: type_hint_checker
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
           pip install --requirement reqs/requirements-dev-contrib.txt
-        name: InstallDependencies
-
-    - job: type_hint_checker
-      dependsOn: install_dependencies
-      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
-      steps:
-      - script: |
           invoke type-coverage
         name: TypeHintChecker
 
     - job: static_type_check
-      dependsOn: install_dependencies
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
+          pip install --requirement reqs/requirements-dev-contrib.txt
           invoke type-check --install-types --warn-unused-ignores --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker
-      dependsOn: install_dependencies
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - bash: python scripts/check_docstring_coverage.py
         name: DocstringChecker
 
     - job: unused_import_checker
-      dependsOn: install_dependencies
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
+          pip install --requirement reqs/requirements-dev-contrib.txt
           # https://www.flake8rules.com/rules/F401.html - Prunes the dgtest graph to improve accuracy
           flake8 --select F401 great_expectations tests
         name: UnusedImportChecker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,6 @@ stages:
       condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
       - script: |
-          pip install flake8
           # https://www.flake8rules.com/rules/F401.html - Prunes the dgtest graph to improve accuracy
           flake8 --select F401 great_expectations tests
         name: UnusedImportChecker

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -304,7 +304,7 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
-        module_spec = importlib.util.find_spec(module_name, package=package_name)
+        module_spec = importlib.util.find_spec(module_name, package=package_name)  # type: ignore[attr-defined]
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -77,14 +77,14 @@ except ImportError:
 try:
     import black
 except ImportError:
-    black = None
+    black = None  # type: ignore[assignment]
 
 try:
     # This library moved in python 3.8
     import importlib.metadata as importlib_metadata
 except ModuleNotFoundError:
     # Fallback for python < 3.8
-    import importlib_metadata  # type: ignore[no-redef]
+    import importlib_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -365,7 +365,7 @@ def verify_dynamic_loading_support(
     """
     try:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[assignment]
+        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[attr-defined]
             module_name, package=package_name
         )
     except ModuleNotFoundError:

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -2,7 +2,7 @@ black==22.3.0
 flake8==5.0.4
 invoke>=1.7.1
 isort==5.10.1
-mypy==0.990
+mypy==0.991
 pre-commit>=2.6.0
 pytest-cov>=2.8.1
 pytest-order>=0.9.5


### PR DESCRIPTION
Changes proposed in this pull request:
- Use pinned requirements in CI (instead of always pulling the latest).
    - Our CI should reflect our local environments - if we have a pin in our requirements, let's use that.

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
