### PR TITLE
[MAINTENANCE] Remove tuple conversion behavior when working with `GXCloudStoreBackend`

### DIFF
--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -147,6 +147,13 @@ class StoreBackend(metaclass=ABCMeta):
         )
 
     def _validate_key(self, key) -> None:
+        from great_expectations.data_context.store.store import (
+            KEY_BACKED_STORE_BACKENDS,
+        )
+
+        if self.__class__.__name__ in KEY_BACKED_STORE_BACKENDS:
+            return
+
         if isinstance(key, tuple):
             for key_element in key:
                 if not isinstance(key_element, str):

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -6,7 +6,9 @@ from typing import Any, List, Optional, Union
 import pyparsing as pp
 
 from great_expectations.core.data_context_key import DataContextKey
-from great_expectations.data_context.store._util import is_key_backed_store_backend
+from great_expectations.data_context.store._util import (
+    is_DataContextKey_backed_store_backend,
+)
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 
 logger = logging.getLogger(__name__)
@@ -150,7 +152,7 @@ class StoreBackend(metaclass=ABCMeta):
 
     def _validate_key(self, key) -> None:
         # NOTE: This is a temporary fork while we move away from key_to_tuple conversion behavior
-        if is_key_backed_store_backend(self):
+        if is_DataContextKey_backed_store_backend(self):
             if not isinstance(key, DataContextKey):
                 raise TypeError(
                     f"Keys in {self.__class__.__name__} must be instances of {DataContextKey} not {type(key)}"

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional, Union
 
 import pyparsing as pp
 
+from great_expectations.data_context.store._util import is_key_backed_store_backend
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 
 logger = logging.getLogger(__name__)
@@ -147,11 +148,8 @@ class StoreBackend(metaclass=ABCMeta):
         )
 
     def _validate_key(self, key) -> None:
-        from great_expectations.data_context.store.store import (
-            KEY_BACKED_STORE_BACKENDS,
-        )
-
-        if self.__class__.__name__ in KEY_BACKED_STORE_BACKENDS:
+        # NOTE: This is a temporary fork while we move away from key_to_tuple conversion behavior
+        if is_key_backed_store_backend(self):
             return
 
         if isinstance(key, tuple):

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional, Union
 
 import pyparsing as pp
 
+from great_expectations.core.data_context_key import DataContextKey
 from great_expectations.data_context.store._util import is_key_backed_store_backend
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 
@@ -150,6 +151,10 @@ class StoreBackend(metaclass=ABCMeta):
     def _validate_key(self, key) -> None:
         # NOTE: This is a temporary fork while we move away from key_to_tuple conversion behavior
         if is_key_backed_store_backend(self):
+            if not isinstance(key, DataContextKey):
+                raise TypeError(
+                    f"Keys in {self.__class__.__name__} must be instances of {DataContextKey} not {type(key)}"
+                )
             return
 
         if isinstance(key, tuple):
@@ -164,11 +169,7 @@ class StoreBackend(metaclass=ABCMeta):
                     )
         else:
             raise TypeError(
-                "Keys in {} must be instances of {}, not {}".format(
-                    self.__class__.__name__,
-                    tuple,
-                    type(key),
-                )
+                f"Keys in {self.__class__.__name__} must be instances of {tuple}, not {type(key)}"
             )
 
     def _validate_value(self, value) -> None:

--- a/great_expectations/data_context/store/_util.py
+++ b/great_expectations/data_context/store/_util.py
@@ -1,0 +1,19 @@
+"""
+Chetan - 20221116 - This module is to be deleted after all Stores and StoreBackends have been
+refactored to work without `key_to_tuple()` conversion.
+"""
+
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from great_expectations.data_context.store.store_backend import StoreBackend
+
+
+def is_key_backed_store_backend(store_backend: StoreBackend) -> bool:
+    from great_expectations.data_context.store.gx_cloud_store_backend import (
+        GXCloudStoreBackend,
+    )
+
+    key_backed_store_backends = {GXCloudStoreBackend}
+    return store_backend.__class__ in key_backed_store_backends

--- a/great_expectations/data_context/store/_util.py
+++ b/great_expectations/data_context/store/_util.py
@@ -11,6 +11,13 @@ if TYPE_CHECKING:
 
 
 def is_DataContextKey_backed_store_backend(store_backend: StoreBackend) -> bool:
+    """
+    Temporary util to determine whether or not a StoreBackend is compatible with
+    DataContextKey and its subclasses.
+
+    Note that the current support behavior is a conversion from key to tuple, which
+    results in us losing all valuable type information.
+    """
     from great_expectations.data_context.store.gx_cloud_store_backend import (
         GXCloudStoreBackend,
     )

--- a/great_expectations/data_context/store/_util.py
+++ b/great_expectations/data_context/store/_util.py
@@ -2,7 +2,7 @@
 Chetan - 20221116 - This module is to be deleted after all Stores and StoreBackends have been
 refactored to work without `key_to_tuple()` conversion.
 """
-
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from great_expectations.data_context.store.store_backend import StoreBackend
 
 
-def is_key_backed_store_backend(store_backend: StoreBackend) -> bool:
+def is_DataContextKey_backed_store_backend(store_backend: StoreBackend) -> bool:
     from great_expectations.data_context.store.gx_cloud_store_backend import (
         GXCloudStoreBackend,
     )

--- a/great_expectations/data_context/store/_util.py
+++ b/great_expectations/data_context/store/_util.py
@@ -15,5 +15,8 @@ def is_key_backed_store_backend(store_backend: StoreBackend) -> bool:
         GXCloudStoreBackend,
     )
 
-    key_backed_store_backends = {GXCloudStoreBackend}
+    # List will be populated over time
+    key_backed_store_backends = {
+        GXCloudStoreBackend,
+    }
     return store_backend.__class__ in key_backed_store_backends

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 from great_expectations.core.configuration import AbstractConfig
 from great_expectations.core.data_context_key import DataContextKey
+from great_expectations.data_context.store._util import is_key_backed_store_backend
 from great_expectations.data_context.store.gx_cloud_store_backend import (
     GXCloudStoreBackend,
 )
@@ -12,9 +13,6 @@ from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.exceptions import ClassInstantiationError, DataContextError
 
 logger = logging.getLogger(__name__)
-
-
-KEY_BACKED_STORE_BACKENDS = ["GXCloudStoreBackend"]
 
 
 class Store:
@@ -169,7 +167,8 @@ class Store:
 
         self._validate_key(key)
 
-        if self._store_backend.__class__.__name__ not in KEY_BACKED_STORE_BACKENDS:
+        # NOTE: This is a temporary fork while we move away from key_to_tuple conversion behavior
+        if not is_key_backed_store_backend(self._store_backend):
             key = self.key_to_tuple(key)
 
         return self._store_backend.set(key, self.serialize(value), **kwargs)

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -3,7 +3,9 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 from great_expectations.core.configuration import AbstractConfig
 from great_expectations.core.data_context_key import DataContextKey
-from great_expectations.data_context.store._util import is_key_backed_store_backend
+from great_expectations.data_context.store._util import (
+    is_DataContextKey_backed_store_backend,
+)
 from great_expectations.data_context.store.gx_cloud_store_backend import (
     GXCloudStoreBackend,
 )
@@ -168,9 +170,10 @@ class Store:
         self._validate_key(key)
 
         # NOTE: This is a temporary fork while we move away from key_to_tuple conversion behavior
-        if not is_key_backed_store_backend(self._store_backend):
-            key = self.key_to_tuple(key)
-
+        if not is_DataContextKey_backed_store_backend(self._store_backend):
+            return self._store_backend.set(
+                self.key_to_tuple(key), self.serialize(value), **kwargs
+            )
         return self._store_backend.set(key, self.serialize(value), **kwargs)
 
     def list_keys(self) -> List[DataContextKey]:

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -215,7 +215,6 @@ def test_datasource_store_set_cloud_mode(
         autospec=True,
         side_effect=mocked_datasource_get_response,
     ):
-
         retrieved_datasource_config = store.set(key=None, value=datasource_config)
 
         serializer = NamedDatasourceSerializer(schema=datasourceConfigSchema)

--- a/tests/data_context/store/test_datasource_store.py
+++ b/tests/data_context/store/test_datasource_store.py
@@ -215,6 +215,7 @@ def test_datasource_store_set_cloud_mode(
         autospec=True,
         side_effect=mocked_datasource_get_response,
     ):
+
         retrieved_datasource_config = store.set(key=None, value=datasource_config)
 
         serializer = NamedDatasourceSerializer(schema=datasourceConfigSchema)

--- a/tests/data_context/store/test_gx_cloud_store_backend.py
+++ b/tests/data_context/store/test_gx_cloud_store_backend.py
@@ -26,6 +26,7 @@ from great_expectations.data_context.store.gx_cloud_store_backend import (
     construct_url,
 )
 from great_expectations.data_context.types.base import CheckpointConfig
+from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 
 
 @pytest.fixture
@@ -226,8 +227,9 @@ def test_set(
         )
     )
 
+    key = GXCloudIdentifier(resource_type=GXCloudRESTResource.CHECKPOINT)
     with mock.patch("requests.Session.post", autospec=True) as mock_post:
-        store_backend.set(("checkpoint", ""), my_simple_checkpoint_config_serialized)
+        store_backend.set(key, my_simple_checkpoint_config_serialized)
         mock_post.assert_called_with(
             mock.ANY,  # requests.Session object
             f"{CLOUD_DEFAULT_BASE_URL}organizations/51379b8b-86d3-4fe7-84e9-e1a52f4a414c/checkpoints",


### PR DESCRIPTION
Changes proposed in this pull request:
- Instead of using `self.key_to_tuple()`, losing us the value of a rich type, let's just use the key as-is


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
