### PR TITLE
[BUGFIX] Ensure `packaging_and_installation` CI tests against latest tag

### DIFF
--- a/azure/dev-install-matrix.yml
+++ b/azure/dev-install-matrix.yml
@@ -17,6 +17,15 @@ jobs:
           displayName: 'Update pip'
 
         - script: |
+            # Get new tags from remote
+            git fetch --tags
+            # Get latest tag name
+            latest=$(git describe --tags `git rev-list --tags --max-count=1`)
+            # Checkout latest tag
+            git checkout $latest
+          displayName: 'Checkout latest tag'
+
+        - script: |
             pip install --requirement requirements-dev.txt --constraint constraints-dev.txt
             pip install .
           displayName: 'Install dependencies'
@@ -49,6 +58,15 @@ jobs:
 
         - bash: python -m pip install --upgrade pip==21.3.1
           displayName: 'Update pip'
+
+        - script: |
+            # Get new tags from remote
+            git fetch --tags
+            # Get latest tag name
+            latest=$(git describe --tags `git rev-list --tags --max-count=1`)
+            # Checkout latest tag
+            git checkout $latest
+          displayName: 'Checkout latest tag'
 
         - script: |
             pip install \


### PR DESCRIPTION
Changes proposed in this pull request:
- Since the `dev_install` part of this CI pipeline runs `pytest` after installing the latest version of GX on PyPI, we can run into an issue where new dependencies are not recognized.
    - This cropped up with our recent addition of `pydantic`

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
