### PR TITLE
[MAINTENANCE] Cleanup For Better Code Elegance/Readability

### DIFF
--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -305,9 +305,9 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(
-            module_name, package=package_name
-        )
+        module_spec: Optional[
+            importlib.machinery.ModuleSpec
+        ] = importlib.util.find_spec(module_name, package=package_name)
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -2,7 +2,7 @@ import importlib
 import itertools
 import json
 from collections.abc import Iterable
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from marshmallow import ValidationError
 

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -304,7 +304,10 @@ class PluginClassNotFoundError(DataContextError, AttributeError):
 
 class ClassInstantiationError(GreatExpectationsError):
     def __init__(self, module_name, package_name, class_name) -> None:
-        module_spec = importlib.util.find_spec(module_name, package=package_name)  # type: ignore[attr-defined]
+        # noinspection PyUnresolvedReferences
+        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(
+            module_name, package=package_name
+        )
         if not module_spec:
             if not package_name:
                 package_name = ""

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -243,7 +243,7 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
             ):
                 is_categorical = False
                 partition_metric_configuration = MetricConfiguration(
-                    "column.partition",
+                    metric_name="column.partition",
                     metric_domain_kwargs=domain_kwargs,
                     metric_value_kwargs={
                         "bins": "auto",
@@ -278,14 +278,14 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
 
                 bins = resolved_metrics[partition_metric_configuration.id]
                 hist_metric_configuration = MetricConfiguration(
-                    "column.histogram",
+                    metric_name="column.histogram",
                     metric_domain_kwargs=domain_kwargs,
                     metric_value_kwargs={
                         "bins": tuple(bins),
                     },
                 )
                 nonnull_configuration = MetricConfiguration(
-                    "column_values.nonnull.count",
+                    metric_name="column_values.nonnull.count",
                     metric_domain_kwargs=domain_kwargs,
                     metric_value_kwargs=None,
                 )
@@ -309,14 +309,14 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
             else:
                 is_categorical = True
                 counts_configuration = MetricConfiguration(
-                    "column.value_counts",
+                    metric_name="column.value_counts",
                     metric_domain_kwargs=domain_kwargs,
                     metric_value_kwargs={
                         "sort": "value",
                     },
                 )
                 nonnull_configuration = MetricConfiguration(
-                    "column_values.nonnull.count",
+                    metric_name="column_values.nonnull.count",
                     metric_domain_kwargs=domain_kwargs,
                 )
                 validation_dependencies.set_metric_configuration(
@@ -335,7 +335,9 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                 metric_configuration=MetricConfiguration(
                     metric_name="column.value_counts",
                     metric_domain_kwargs=domain_kwargs,
-                    metric_value_kwargs={"sort": "value"},
+                    metric_value_kwargs={
+                        "sort": "value",
+                    },
                 ),
             )
             validation_dependencies.set_metric_configuration(
@@ -355,7 +357,7 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                 bins = partition_object["bins"]
 
             hist_metric_configuration = MetricConfiguration(
-                "column.histogram",
+                metric_name="column.histogram",
                 metric_domain_kwargs=domain_kwargs,
                 metric_value_kwargs={
                     "bins": bins,

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -37,9 +37,11 @@ from great_expectations.render.util import (
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
+from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.exception_info import ExceptionInfo
 from great_expectations.validator.metric_configuration import MetricConfiguration
 from great_expectations.validator.validation_graph import ValidationGraph
+from great_expectations.validator.validator import ValidationDependencies
 
 logger = logging.getLogger(__name__)
 logging.captureWarnings(True)
@@ -225,11 +227,12 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ):
-        all_dependencies = super().get_validation_dependencies(
-            configuration, execution_engine, runtime_configuration
+    ) -> ValidationDependencies:
+        validation_dependencies: ValidationDependencies = (
+            super().get_validation_dependencies(
+                configuration, execution_engine, runtime_configuration
+            )
         )
-        dependencies = all_dependencies["metrics"]
         partition_object = configuration.kwargs["partition_object"]
         domain_kwargs = configuration.get_domain_kwargs()
         is_categorical = None
@@ -249,22 +252,23 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                 )
                 #
                 # Note: 20201116 - JPC - the execution engine doesn't provide capability to evaluate
-                # dependencies, so we use a validator
+                # validation_dependencies, so we use a validator
                 #
-                graph = ValidationGraph(execution_engine=execution_engine)
+                graph: ValidationGraph = ValidationGraph(
+                    execution_engine=execution_engine
+                )
                 graph.build_metric_dependency_graph(
                     metric_configuration=partition_metric_configuration,
                 )
-
-                resolved_metrics: Dict[Tuple[str, str, str], MetricValue] = {}
-
-                # updates graph with aborted metrics
+                resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
                 aborted_metrics_info: Dict[
                     Tuple[str, str, str],
                     Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
-                ] = graph.resolve_validation_graph(
-                    metrics=resolved_metrics,
+                ]
+                resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
                     runtime_configuration=None,
+                    min_graph_edges_pbar_enable=0,
+                    show_progress_bars=True,
                 )
 
                 if aborted_metrics_info:
@@ -288,11 +292,20 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                 #
                 # NOTE 20201117 - JPC - Would prefer not to include partition_metric_configuration here,
                 # since we have already evaluated it, and its result is in the kwargs for the histogram.
-                # However, currently the dependencies' configurations are not passed to the _validate method
+                # However, currently the validation_dependencies' configurations are not passed to the _validate method
                 #
-                dependencies["column.partition"] = partition_metric_configuration
-                dependencies["column.histogram"] = hist_metric_configuration
-                dependencies["column_values.nonnull.count"] = nonnull_configuration
+                validation_dependencies.set_metric_configuration(
+                    metric_name="column.partition",
+                    metric_configuration=partition_metric_configuration,
+                )
+                validation_dependencies.set_metric_configuration(
+                    metric_name="column.histogram",
+                    metric_configuration=hist_metric_configuration,
+                )
+                validation_dependencies.set_metric_configuration(
+                    metric_name="column_values.nonnull.count",
+                    metric_configuration=nonnull_configuration,
+                )
             else:
                 is_categorical = True
                 counts_configuration = MetricConfiguration(
@@ -306,18 +319,32 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                     "column_values.nonnull.count",
                     metric_domain_kwargs=domain_kwargs,
                 )
-                dependencies["column.value_counts"] = counts_configuration
-                dependencies["column_values.nonnull.count"] = nonnull_configuration
+                validation_dependencies.set_metric_configuration(
+                    metric_name="column.value_counts",
+                    metric_configuration=counts_configuration,
+                )
+                validation_dependencies.set_metric_configuration(
+                    metric_name="column_values.nonnull.count",
+                    metric_configuration=nonnull_configuration,
+                )
         if is_categorical is True or is_valid_categorical_partition_object(
             partition_object
         ):
-            dependencies["column.value_counts"] = MetricConfiguration(
-                "column.value_counts",
-                metric_domain_kwargs=domain_kwargs,
-                metric_value_kwargs={"sort": "value"},
+            validation_dependencies.set_metric_configuration(
+                metric_name="column.value_counts",
+                metric_configuration=MetricConfiguration(
+                    metric_name="column.value_counts",
+                    metric_domain_kwargs=domain_kwargs,
+                    metric_value_kwargs={"sort": "value"},
+                ),
             )
-            dependencies["column_values.nonnull.count"] = MetricConfiguration(
-                "column_values.nonnull.count", domain_kwargs
+            validation_dependencies.set_metric_configuration(
+                metric_name="column_values.nonnull.count",
+                metric_configuration=MetricConfiguration(
+                    metric_name="column_values.nonnull.count",
+                    metric_domain_kwargs=domain_kwargs,
+                    metric_value_kwargs=None,
+                ),
             )
         else:
             if (
@@ -326,6 +353,7 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                 if not is_valid_partition_object(partition_object):
                     raise ValueError("Invalid partition_object provided")
                 bins = partition_object["bins"]
+
             hist_metric_configuration = MetricConfiguration(
                 "column.histogram",
                 metric_domain_kwargs=domain_kwargs,
@@ -333,26 +361,37 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                     "bins": bins,
                 },
             )
+            validation_dependencies.set_metric_configuration(
+                metric_name="column.histogram",
+                metric_configuration=hist_metric_configuration,
+            )
             nonnull_configuration = MetricConfiguration(
-                "column_values.nonnull.count",
+                metric_name="column_values.nonnull.count",
                 metric_domain_kwargs=domain_kwargs,
                 metric_value_kwargs=None,
             )
-            dependencies["column.histogram"] = hist_metric_configuration
-            dependencies["column_values.nonnull.count"] = nonnull_configuration
+            validation_dependencies.set_metric_configuration(
+                metric_name="column_values.nonnull.count",
+                metric_configuration=nonnull_configuration,
+            )
             below_partition = MetricConfiguration(
-                "column_values.between.count",
+                metric_name="column_values.between.count",
                 metric_domain_kwargs=domain_kwargs,
                 metric_value_kwargs={"max_value": bins[0], "strict_max": True},
             )
+            validation_dependencies.set_metric_configuration(
+                metric_name="below_partition", metric_configuration=below_partition
+            )
             above_partition = MetricConfiguration(
-                "column_values.between.count",
+                metric_name="column_values.between.count",
                 metric_domain_kwargs=domain_kwargs,
                 metric_value_kwargs={"min_value": bins[-1], "strict_min": True},
             )
-            dependencies["below_partition"] = below_partition
-            dependencies["above_partition"] = above_partition
-        return all_dependencies
+            validation_dependencies.set_metric_configuration(
+                metric_name="above_partition", metric_configuration=above_partition
+            )
+
+        return validation_dependencies
 
     def _validate(
         self,

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -41,6 +41,7 @@ from great_expectations.rule_based_profiler.parameter_container import (
     VARIABLES_KEY,
 )
 from great_expectations.util import isclose
+from great_expectations.validator.validator import ValidationDependencies
 
 
 class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
@@ -721,15 +722,19 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ):
-        all_dependencies = super().get_validation_dependencies(
-            configuration, execution_engine, runtime_configuration
+    ) -> ValidationDependencies:
+        validation_dependencies: ValidationDependencies = (
+            super().get_validation_dependencies(
+                configuration, execution_engine, runtime_configuration
+            )
         )
         # column.quantile_values expects a "quantiles" key
-        all_dependencies["metrics"]["column.quantile_values"].metric_value_kwargs[
+        validation_dependencies.get_metric_configuration(
+            metric_name="column.quantile_values"
+        ).metric_value_kwargs["quantiles"] = configuration.kwargs["quantile_ranges"][
             "quantiles"
-        ] = configuration.kwargs["quantile_ranges"]["quantiles"]
-        return all_dependencies
+        ]
+        return validation_dependencies
 
     def _validate(
         self,

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -36,6 +36,7 @@ from great_expectations.render.util import (
 )
 from great_expectations.util import get_pyathena_potential_type
 from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.validator import ValidationDependencies
 
 logger = logging.getLogger(__name__)
 
@@ -472,14 +473,17 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ):
-        # This calls TableExpectation.get_validation_dependencies to set baseline dependencies for the aggregate version
+        **kwargs,
+    ) -> ValidationDependencies:
+        # This calls TableExpectation.get_validation_dependencies to set baseline validation_dependencies for the aggregate version
         # of the expectation.
         # We need to keep this as super(ColumnMapExpectation, self), which calls
         # TableExpectation.get_validation_dependencies instead of ColumnMapExpectation.get_validation_dependencies.
         # This is because the map version of this expectation is only supported for Pandas, so we want the aggregate
         # version for the other backends.
-        dependencies = super(ColumnMapExpectation, self).get_validation_dependencies(
+        validation_dependencies: ValidationDependencies = super(
+            ColumnMapExpectation, self
+        ).get_validation_dependencies(
             configuration, execution_engine, runtime_configuration
         )
 
@@ -517,8 +521,8 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
                 and actual_column_type.type.__name__ == "object_"
                 and expected_types_list is not None
             ):
-                # this resets dependencies using  ColumnMapExpectation.get_validation_dependencies
-                dependencies = super().get_validation_dependencies(
+                # this resets validation_dependencies using  ColumnMapExpectation.get_validation_dependencies
+                validation_dependencies = super().get_validation_dependencies(
                     configuration, execution_engine, runtime_configuration
                 )
 
@@ -528,13 +532,16 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        dependencies["metrics"]["table.column_types"] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name="table.column_types",
-            metric_domain_kwargs=column_types_metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=column_types_metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name="table.column_types",
+                metric_domain_kwargs=column_types_metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=column_types_metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
-        return dependencies
+        return validation_dependencies
 
     def _validate(
         self,

--- a/great_expectations/expectations/core/expect_column_values_to_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_null.py
@@ -22,6 +22,7 @@ from great_expectations.render.util import (
     parse_row_condition_string_pandas_engine,
     substitute_none_for_missing,
 )
+from great_expectations.validator.validator import ValidationDependencies
 
 
 class ExpectColumnValuesToBeNull(ColumnMapExpectation):
@@ -236,14 +237,18 @@ class ExpectColumnValuesToBeNull(ColumnMapExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ):
-        dependencies = super().get_validation_dependencies(
-            configuration, execution_engine, runtime_configuration
+        **kwargs,
+    ) -> ValidationDependencies:
+        validation_dependencies: ValidationDependencies = (
+            super().get_validation_dependencies(
+                configuration, execution_engine, runtime_configuration
+            )
         )
-
         # We do not need this metric for a null metric
-        del dependencies["metrics"]["column_values.nonnull.unexpected_count"]
-        return dependencies
+        validation_dependencies.remove_metric_configuration(
+            metric_name="column_values.nonnull.unexpected_count"
+        )
+        return validation_dependencies
 
     def _validate(
         self,

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -32,6 +32,7 @@ from great_expectations.render.util import (
 )
 from great_expectations.util import get_pyathena_potential_type
 from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.validator import ValidationDependencies
 
 logger = logging.getLogger(__name__)
 
@@ -444,14 +445,17 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ):
-        # This calls TableExpectation.get_validation_dependencies to set baseline dependencies for the aggregate version
+        **kwargs,
+    ) -> ValidationDependencies:
+        # This calls TableExpectation.get_validation_dependencies to set baseline validation_dependencies for the aggregate version
         # of the expectation.
         # We need to keep this as super(ColumnMapExpectation, self), which calls
         # TableExpectation.get_validation_dependencies instead of ColumnMapExpectation.get_validation_dependencies.
         # This is because the map version of this expectation is only supported for Pandas, so we want the aggregate
         # version for the other backends.
-        dependencies = super(ColumnMapExpectation, self).get_validation_dependencies(
+        validation_dependencies: ValidationDependencies = super(
+            ColumnMapExpectation, self
+        ).get_validation_dependencies(
             configuration, execution_engine, runtime_configuration
         )
 
@@ -495,8 +499,8 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
                     None,
                 ]
             ):
-                # this resets dependencies using  ColumnMapExpectation.get_validation_dependencies
-                dependencies = super().get_validation_dependencies(
+                # this resets validation_dependencies using  ColumnMapExpectation.get_validation_dependencies
+                validation_dependencies = super().get_validation_dependencies(
                     configuration, execution_engine, runtime_configuration
                 )
 
@@ -506,13 +510,16 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        dependencies["metrics"]["table.column_types"] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name="table.column_types",
-            metric_domain_kwargs=column_types_metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=column_types_metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name="table.column_types",
+                metric_domain_kwargs=column_types_metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=column_types_metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
-        return dependencies
+        return validation_dependencies
 
     def _validate(
         self,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -92,7 +92,7 @@ from great_expectations.self_check.util import (
 from great_expectations.util import camel_to_snake, is_parseable_date
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
-from great_expectations.validator.validator import Validator
+from great_expectations.validator.validator import ValidationDependencies, Validator
 
 if TYPE_CHECKING:
     from great_expectations.data_context import DataContext
@@ -948,6 +948,7 @@ class Expectation(metaclass=MetaExpectation):
             key_list.extend(list(cls.runtime_keys))
         return tuple(str(key) for key in key_list)
 
+    # noinspection PyUnusedLocal
     def metrics_validate(
         self,
         metrics: dict,
@@ -959,17 +960,17 @@ class Expectation(metaclass=MetaExpectation):
         if not configuration:
             configuration = self.configuration
 
-        validation_dependencies: dict = self.get_validation_dependencies(
-            configuration=configuration,
-            execution_engine=execution_engine,
-            runtime_configuration=runtime_configuration,
+        validation_dependencies: ValidationDependencies = (
+            self.get_validation_dependencies(
+                configuration=configuration,
+                execution_engine=execution_engine,
+                runtime_configuration=runtime_configuration,
+            )
         )
-        runtime_configuration["result_format"] = validation_dependencies[  # type: ignore[index]
-            "result_format"
-        ]
-        requested_metrics: Dict[str, MetricConfiguration] = validation_dependencies[
-            "metrics"
-        ]
+        runtime_configuration["result_format"] = validation_dependencies.result_format
+        requested_metrics: Dict[
+            str, MetricConfiguration
+        ] = validation_dependencies.metric_configurations
 
         metric_name: str
         metric_configuration: MetricConfiguration
@@ -992,6 +993,7 @@ class Expectation(metaclass=MetaExpectation):
         )
         return evr
 
+    # noinspection PyUnusedLocal
     @staticmethod
     def _build_evr(
         raw_response: Union[ExpectationValidationResult, dict],
@@ -1018,7 +1020,7 @@ class Expectation(metaclass=MetaExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> Dict[str, dict]:
+    ) -> ValidationDependencies:
         """Returns the result format and metrics required to validate this Expectation using the provided result format."""
         runtime_configuration = self.get_runtime_kwargs(
             configuration=configuration,
@@ -1026,10 +1028,9 @@ class Expectation(metaclass=MetaExpectation):
         )
         result_format: dict = runtime_configuration["result_format"]
         result_format = parse_result_format(result_format=result_format)
-        return {
-            "result_format": result_format,
-            "metrics": {},
-        }
+        return ValidationDependencies(
+            metric_configurations={}, result_format=result_format
+        )
 
     def get_domain_kwargs(
         self, configuration: ExpectationConfiguration
@@ -1141,7 +1142,6 @@ class Expectation(metaclass=MetaExpectation):
         )
         evr: ExpectationValidationResult = validator.graph_validate(
             configurations=[configuration],
-            metrics=None,
             runtime_configuration=runtime_configuration,
         )[0]
         if include_rendered_content:
@@ -1837,24 +1837,26 @@ class Expectation(metaclass=MetaExpectation):
         self,
         expectation_config: Optional[ExpectationConfiguration],
     ) -> List[ExpectationMetricDiagnostics]:
-        """Check to see which Metrics are upstream dependencies for this Expectation."""
+        """Check to see which Metrics are upstream validation_dependencies for this Expectation."""
 
         # NOTE: Abe 20210102: Strictly speaking, identifying upstream metrics shouldn't need to rely on an expectation config.
         # There's probably some part of get_validation_dependencies that can be factored out to remove the dependency.
 
         if not expectation_config:
             return []
-        validation_dependencies = self.get_validation_dependencies(
-            configuration=expectation_config
+
+        validation_dependencies: ValidationDependencies = (
+            self.get_validation_dependencies(configuration=expectation_config)
         )
 
-        metric_diagnostics_list = []
-        for metric in validation_dependencies["metrics"].keys():
-            new_metric_diagnostics = ExpectationMetricDiagnostics(
-                name=metric,
+        metric_name: str
+        metric_diagnostics_list: List[ExpectationMetricDiagnostics] = [
+            ExpectationMetricDiagnostics(
+                name=metric_name,
                 has_question_renderer=False,
             )
-            metric_diagnostics_list.append(new_metric_diagnostics)
+            for metric_name in validation_dependencies.get_metric_names()
+        ]
 
         return metric_diagnostics_list
 
@@ -1972,12 +1974,15 @@ class TableExpectation(Expectation, ABC):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> Dict[str, dict]:
-        dependencies = super().get_validation_dependencies(
-            configuration=configuration,
-            execution_engine=execution_engine,
-            runtime_configuration=runtime_configuration,
+    ) -> ValidationDependencies:
+        validation_dependencies: ValidationDependencies = (
+            super().get_validation_dependencies(
+                configuration=configuration,
+                execution_engine=execution_engine,
+                runtime_configuration=runtime_configuration,
+            )
         )
+
         metric_name: str
         for metric_name in self.metric_dependencies:
             metric_kwargs = get_metric_kwargs(
@@ -1985,13 +1990,16 @@ class TableExpectation(Expectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            dependencies["metrics"][metric_name] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=metric_name,
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=metric_name,
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
-        return dependencies
+        return validation_dependencies
 
     @staticmethod
     def validate_metric_value_between_configuration(
@@ -2293,11 +2301,13 @@ class ColumnMapExpectation(TableExpectation, ABC):
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs: dict,
-    ) -> Dict[str, dict]:
-        dependencies = super().get_validation_dependencies(
-            configuration=configuration,
-            execution_engine=execution_engine,
-            runtime_configuration=runtime_configuration,
+    ) -> ValidationDependencies:
+        validation_dependencies: ValidationDependencies = (
+            super().get_validation_dependencies(
+                configuration=configuration,
+                execution_engine=execution_engine,
+                runtime_configuration=runtime_configuration,
+            )
         )
         assert isinstance(
             self.map_metric, str
@@ -2307,32 +2317,34 @@ class ColumnMapExpectation(TableExpectation, ABC):
         ), "ColumnMapExpectation must be configured using map_metric, and cannot have metric_dependencies declared."
         # convenient name for updates
 
-        metric_dependencies: Dict[str, MetricConfiguration] = dependencies["metrics"]
+        metric_kwargs: dict
 
-        metric_kwargs: Dict
         metric_kwargs = get_metric_kwargs(
             metric_name="column_values.nonnull.unexpected_count",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            "column_values.nonnull.unexpected_count"
-        ] = MetricConfiguration(
-            "column_values.nonnull.unexpected_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+        validation_dependencies.set_metric_configuration(
+            metric_name="column_values.nonnull.unexpected_count",
+            metric_configuration=MetricConfiguration(
+                "column_values.nonnull.unexpected_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
+
         metric_kwargs = get_metric_kwargs(
             metric_name=f"{self.map_metric}.unexpected_count",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.unexpected_count"
-        ] = MetricConfiguration(
-            f"{self.map_metric}.unexpected_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+        validation_dependencies.set_metric_configuration(
+            metric_name=f"{self.map_metric}.unexpected_count",
+            metric_configuration=MetricConfiguration(
+                f"{self.map_metric}.unexpected_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         metric_kwargs = get_metric_kwargs(
@@ -2340,33 +2352,37 @@ class ColumnMapExpectation(TableExpectation, ABC):
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies["table.row_count"] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name="table.row_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name="table.row_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
-        result_format_str: Optional[str] = dependencies["result_format"].get(
+        result_format_str: Optional[str] = validation_dependencies.result_format.get(
             "result_format"
         )
-        include_unexpected_rows: Optional[bool] = dependencies["result_format"].get(
-            "include_unexpected_rows"
-        )
+        include_unexpected_rows: Optional[
+            bool
+        ] = validation_dependencies.result_format.get("include_unexpected_rows")
 
         if result_format_str == "BOOLEAN_ONLY":
-            return dependencies
+            return validation_dependencies
 
         metric_kwargs = get_metric_kwargs(
             f"{self.map_metric}.unexpected_values",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.unexpected_values"
-        ] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name=f"{self.map_metric}.unexpected_values",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name=f"{self.map_metric}.unexpected_values",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         if include_unexpected_rows:
@@ -2375,12 +2391,13 @@ class ColumnMapExpectation(TableExpectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            metric_dependencies[
-                f"{self.map_metric}.unexpected_rows"
-            ] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=f"{self.map_metric}.unexpected_rows",
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=f"{self.map_metric}.unexpected_rows",
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
         if include_unexpected_rows:
@@ -2389,16 +2406,17 @@ class ColumnMapExpectation(TableExpectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            metric_dependencies[
-                f"{self.map_metric}.unexpected_rows"
-            ] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=f"{self.map_metric}.unexpected_rows",
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=f"{self.map_metric}.unexpected_rows",
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
         if result_format_str in ["BASIC"]:
-            return dependencies
+            return validation_dependencies
 
         # only for SUMMARY and COMPLETE
         if isinstance(execution_engine, PandasExecutionEngine):
@@ -2407,15 +2425,16 @@ class ColumnMapExpectation(TableExpectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            metric_dependencies[
-                f"{self.map_metric}.unexpected_index_list"
-            ] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=f"{self.map_metric}.unexpected_index_list",
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=f"{self.map_metric}.unexpected_index_list",
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
-        return dependencies
+        return validation_dependencies
 
     def _validate(
         self,
@@ -2527,11 +2546,13 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> Dict[str, dict]:
-        dependencies = super().get_validation_dependencies(
-            configuration=configuration,
-            execution_engine=execution_engine,
-            runtime_configuration=runtime_configuration,
+    ) -> ValidationDependencies:
+        validation_dependencies: ValidationDependencies = (
+            super().get_validation_dependencies(
+                configuration=configuration,
+                execution_engine=execution_engine,
+                runtime_configuration=runtime_configuration,
+            )
         )
         assert isinstance(
             self.map_metric, str
@@ -2541,20 +2562,20 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
         ), "ColumnPairMapExpectation must be configured using map_metric, and cannot have metric_dependencies declared."
         # convenient name for updates
 
-        metric_dependencies: Dict[str, MetricConfiguration] = dependencies["metrics"]
+        metric_kwargs: dict
 
-        metric_kwargs: Dict
         metric_kwargs = get_metric_kwargs(
             metric_name=f"{self.map_metric}.unexpected_count",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.unexpected_count"
-        ] = MetricConfiguration(
-            f"{self.map_metric}.unexpected_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+        validation_dependencies.set_metric_configuration(
+            metric_name=f"{self.map_metric}.unexpected_count",
+            metric_configuration=MetricConfiguration(
+                f"{self.map_metric}.unexpected_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         metric_kwargs = get_metric_kwargs(
@@ -2562,10 +2583,13 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies["table.row_count"] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name="table.row_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name="table.row_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         metric_kwargs = get_metric_kwargs(
@@ -2573,39 +2597,41 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.filtered_row_count"
-        ] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name=f"{self.map_metric}.filtered_row_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name=f"{self.map_metric}.filtered_row_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
-        result_format_str: Optional[str] = dependencies["result_format"].get(
+        result_format_str: Optional[str] = validation_dependencies.result_format.get(
             "result_format"
         )
-        include_unexpected_rows: Optional[bool] = dependencies["result_format"].get(
-            "include_unexpected_rows"
-        )
+        include_unexpected_rows: Optional[
+            bool
+        ] = validation_dependencies.result_format.get("include_unexpected_rows")
 
         if result_format_str == "BOOLEAN_ONLY":
-            return dependencies
+            return validation_dependencies
 
         metric_kwargs = get_metric_kwargs(
             f"{self.map_metric}.unexpected_values",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.unexpected_values"
-        ] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name=f"{self.map_metric}.unexpected_values",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name=f"{self.map_metric}.unexpected_values",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         if result_format_str in ["BASIC", "SUMMARY"]:
-            return dependencies
+            return validation_dependencies
 
         if include_unexpected_rows:
             metric_kwargs = get_metric_kwargs(
@@ -2613,12 +2639,13 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            metric_dependencies[
-                f"{self.map_metric}.unexpected_rows"
-            ] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=f"{self.map_metric}.unexpected_rows",
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=f"{self.map_metric}.unexpected_rows",
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
         if isinstance(execution_engine, PandasExecutionEngine):
@@ -2627,15 +2654,16 @@ class ColumnPairMapExpectation(TableExpectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            metric_dependencies[
-                f"{self.map_metric}.unexpected_index_list"
-            ] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=f"{self.map_metric}.unexpected_index_list",
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=f"{self.map_metric}.unexpected_index_list",
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
-        return dependencies
+        return validation_dependencies
 
     def _validate(
         self,
@@ -2737,11 +2765,13 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> Dict[str, dict]:
-        dependencies = super().get_validation_dependencies(
-            configuration=configuration,
-            execution_engine=execution_engine,
-            runtime_configuration=runtime_configuration,
+    ) -> ValidationDependencies:
+        validation_dependencies: ValidationDependencies = (
+            super().get_validation_dependencies(
+                configuration=configuration,
+                execution_engine=execution_engine,
+                runtime_configuration=runtime_configuration,
+            )
         )
         assert isinstance(
             self.map_metric, str
@@ -2751,20 +2781,20 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
         ), "MulticolumnMapExpectation must be configured using map_metric, and cannot have metric_dependencies declared."
         # convenient name for updates
 
-        metric_dependencies: Dict[str, MetricConfiguration] = dependencies["metrics"]
+        metric_kwargs: dict
 
-        metric_kwargs: Dict
         metric_kwargs = get_metric_kwargs(
             metric_name=f"{self.map_metric}.unexpected_count",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.unexpected_count"
-        ] = MetricConfiguration(
-            f"{self.map_metric}.unexpected_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+        validation_dependencies.set_metric_configuration(
+            metric_name=f"{self.map_metric}.unexpected_count",
+            metric_configuration=MetricConfiguration(
+                f"{self.map_metric}.unexpected_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         metric_kwargs = get_metric_kwargs(
@@ -2772,10 +2802,13 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies["table.row_count"] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name="table.row_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name="table.row_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         metric_kwargs = get_metric_kwargs(
@@ -2783,39 +2816,41 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.filtered_row_count"
-        ] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name=f"{self.map_metric}.filtered_row_count",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name=f"{self.map_metric}.filtered_row_count",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
-        result_format_str: Optional[str] = dependencies["result_format"].get(
+        result_format_str: Optional[str] = validation_dependencies.result_format.get(
             "result_format"
         )
-        include_unexpected_rows: Optional[bool] = dependencies["result_format"].get(
-            "include_unexpected_rows"
-        )
+        include_unexpected_rows: Optional[
+            bool
+        ] = validation_dependencies.result_format.get("include_unexpected_rows")
 
         if result_format_str == "BOOLEAN_ONLY":
-            return dependencies
+            return validation_dependencies
 
         metric_kwargs = get_metric_kwargs(
             f"{self.map_metric}.unexpected_values",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
-        metric_dependencies[
-            f"{self.map_metric}.unexpected_values"
-        ] = MetricConfiguration(
+        validation_dependencies.set_metric_configuration(
             metric_name=f"{self.map_metric}.unexpected_values",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name=f"{self.map_metric}.unexpected_values",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         if result_format_str in ["BASIC", "SUMMARY"]:
-            return dependencies
+            return validation_dependencies
 
         if include_unexpected_rows:
             metric_kwargs = get_metric_kwargs(
@@ -2823,12 +2858,13 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            metric_dependencies[
-                f"{self.map_metric}.unexpected_rows"
-            ] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=f"{self.map_metric}.unexpected_rows",
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=f"{self.map_metric}.unexpected_rows",
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
         if isinstance(execution_engine, PandasExecutionEngine):
@@ -2837,15 +2873,16 @@ class MulticolumnMapExpectation(TableExpectation, ABC):
                 configuration=configuration,
                 runtime_configuration=runtime_configuration,
             )
-            metric_dependencies[
-                f"{self.map_metric}.unexpected_index_list"
-            ] = MetricConfiguration(
+            validation_dependencies.set_metric_configuration(
                 metric_name=f"{self.map_metric}.unexpected_index_list",
-                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                metric_configuration=MetricConfiguration(
+                    metric_name=f"{self.map_metric}.unexpected_index_list",
+                    metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                    metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+                ),
             )
 
-        return dependencies
+        return validation_dependencies
 
     def _validate(
         self,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -90,6 +90,7 @@ from great_expectations.self_check.util import (
     generate_expectation_tests,
 )
 from great_expectations.util import camel_to_snake, is_parseable_date
+from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
 from great_expectations.validator.validator import Validator
 
@@ -966,11 +967,16 @@ class Expectation(metaclass=MetaExpectation):
         runtime_configuration["result_format"] = validation_dependencies[  # type: ignore[index]
             "result_format"
         ]
-        requested_metrics = validation_dependencies["metrics"]
+        requested_metrics: Dict[str, MetricConfiguration] = validation_dependencies[
+            "metrics"
+        ]
 
-        provided_metrics = {}
-        for name, metric_edge_key in requested_metrics.items():
-            provided_metrics[name] = metrics[metric_edge_key.id]
+        metric_name: str
+        metric_configuration: MetricConfiguration
+        provided_metrics: Dict[str, MetricValue] = {
+            metric_name: metrics[metric_configuration.id]
+            for metric_name, metric_configuration in requested_metrics.items()
+        }
 
         expectation_validation_result: Union[
             ExpectationValidationResult, dict
@@ -1135,6 +1141,7 @@ class Expectation(metaclass=MetaExpectation):
         )
         evr: ExpectationValidationResult = validator.graph_validate(
             configurations=[configuration],
+            metrics=None,
             runtime_configuration=runtime_configuration,
         )[0]
         if include_rendered_content:

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -960,6 +960,9 @@ class Expectation(metaclass=MetaExpectation):
         if not configuration:
             configuration = self.configuration
 
+        if runtime_configuration is None:
+            runtime_configuration = {}
+
         validation_dependencies: ValidationDependencies = (
             self.get_validation_dependencies(
                 configuration=configuration,

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -364,7 +364,7 @@ def verify_dynamic_loading_support(
     """
     try:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(  # type: ignore[attr-defined]
+        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(
             module_name, package=package_name
         )
     except ModuleNotFoundError:

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -368,10 +368,12 @@ def verify_dynamic_loading_support(
         # noinspection PyUnresolvedReferences
         module_spec = importlib.util.find_spec(module_name, package=package_name)
     except ModuleNotFoundError:
-        module_spec = None  # type: ignore[assignment]
+        module_spec = None
+
     if not module_spec:
         if not package_name:
             package_name = ""
+
         message: str = f"""No module named "{package_name + module_name}" could be found in the repository. Please \
 make sure that the file, corresponding to this package and module, exists and that dynamic loading of code modules, \
 templates, and assets is supported in your execution environment.  This error is unrecoverable.

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -83,7 +83,7 @@ try:
     import importlib.metadata as importlib_metadata
 except ModuleNotFoundError:
     # Fallback for python < 3.8
-    import importlib_metadata
+    import importlib_metadata  # type: ignore[no-redef]
 
 logger = logging.getLogger(__name__)
 
@@ -362,11 +362,11 @@ def verify_dynamic_loading_support(
     :param module_name: a possibly-relative name of a module
     :param package_name: the name of a package, to which the given module belongs
     """
+    # noinspection PyUnresolvedReferences
+    module_spec: Optional[importlib.machinery.ModuleSpec]
     try:
         # noinspection PyUnresolvedReferences
-        module_spec: importlib.machinery.ModuleSpec = importlib.util.find_spec(
-            module_name, package=package_name
-        )
+        module_spec = importlib.util.find_spec(module_name, package=package_name)
     except ModuleNotFoundError:
         module_spec = None  # type: ignore[assignment]
     if not module_spec:

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -154,9 +154,6 @@ class MetricsCalculator:
 
         metric_configuration: MetricConfiguration
         for metric_configuration in metric_configurations:
-            graph.set_metric_configuration_default_kwargs_if_not_exist(
-                metric_configuration=metric_configuration
-            )
             graph.build_metric_dependency_graph(
                 metric_configuration=metric_configuration,
                 runtime_configuration=None,

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.execution_engine import (
@@ -10,7 +8,6 @@ from great_expectations.execution_engine import (
     SparkDFExecutionEngine,
     SqlAlchemyExecutionEngine,
 )
-from great_expectations.expectations.registry import get_metric_provider
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.exception_info import ExceptionInfo
 from great_expectations.validator.metric_configuration import MetricConfiguration
@@ -27,9 +24,6 @@ except ImportError:
     logger.debug(
         "Unable to load pandas; install optional pandas dependency for support."
     )
-
-if TYPE_CHECKING:
-    from great_expectations.expectations.metrics.metric_provider import MetricProvider
 
 
 class MetricsCalculator:
@@ -160,19 +154,9 @@ class MetricsCalculator:
 
         metric_configuration: MetricConfiguration
         for metric_configuration in metric_configurations:
-            provider_cls, _ = get_metric_provider(
-                metric_configuration.metric_name, self._execution_engine
+            graph.set_metric_configuration_default_kwargs_if_not_exist(
+                metric_configuration=metric_configuration
             )
-
-            self._get_default_domain_kwargs(
-                metric_provider_cls=provider_cls,
-                metric_configuration=metric_configuration,
-            )
-            self._get_default_value_kwargs(
-                metric_provider_cls=provider_cls,
-                metric_configuration=metric_configuration,
-            )
-
             graph.build_metric_dependency_graph(
                 metric_configuration=metric_configuration,
                 runtime_configuration=None,
@@ -195,32 +179,3 @@ class MetricsCalculator:
             )
 
         return resolved_metrics
-
-    @staticmethod
-    def _get_default_domain_kwargs(
-        metric_provider_cls: MetricProvider,
-        metric_configuration: MetricConfiguration,
-    ) -> None:
-        for key in metric_provider_cls.domain_keys:
-            if (
-                key not in metric_configuration.metric_domain_kwargs
-                and key in metric_provider_cls.default_kwarg_values
-            ):
-                metric_configuration.metric_domain_kwargs[
-                    key
-                ] = metric_provider_cls.default_kwarg_values[key]
-
-    @staticmethod
-    def _get_default_value_kwargs(
-        metric_provider_cls: MetricProvider,
-        metric_configuration: MetricConfiguration,
-    ) -> None:
-        key: str
-        for key in metric_provider_cls.value_keys:
-            if (
-                key not in metric_configuration.metric_value_kwargs
-                and key in metric_provider_cls.default_kwarg_values
-            ):
-                metric_configuration.metric_value_kwargs[
-                    key
-                ] = metric_provider_cls.default_kwarg_values[key]

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -178,15 +178,15 @@ class MetricsCalculator:
                 runtime_configuration=None,
             )
 
-        resolved_metrics: Dict[Tuple[str, str, str], MetricValue] = {}
-
-        # updates graph with aborted metrics
+        resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
         aborted_metrics_info: Dict[
             Tuple[str, str, str],
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
-        ] = graph.resolve_validation_graph(
-            metrics=resolved_metrics,
+        ]
+        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
             runtime_configuration=None,
+            min_graph_edges_pbar_enable=0,
+            show_progress_bars=True,
         )
 
         if aborted_metrics_info:

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -118,7 +118,7 @@ class ValidationGraph:
         # Set to low number (e.g., 3) to suppress progress bar for small graphs.
         show_progress_bars: bool = True,
     ) -> Tuple[
-        Optional[Dict[Tuple[str, str, str], MetricValue]],
+        Dict[Tuple[str, str, str], MetricValue],
         Dict[
             Tuple[str, str, str],
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -97,7 +97,7 @@ class ValidationGraph:
         (
             metric_impl_klass,
             metric_provider,
-        ) = self.set_metric_configuration_default_kwargs_if_not_exist(
+        ) = self.set_metric_configuration_default_kwargs_if_absent(
             metric_configuration=metric_configuration
         )
 
@@ -133,7 +133,7 @@ class ValidationGraph:
                     runtime_configuration=runtime_configuration,
                 )
 
-    def set_metric_configuration_default_kwargs_if_not_exist(
+    def set_metric_configuration_default_kwargs_if_absent(
         self, metric_configuration: MetricConfiguration
     ) -> Tuple[MetricProvider, Callable]:
         """
@@ -145,12 +145,12 @@ class ValidationGraph:
             metric_name=metric_configuration.metric_name,
             execution_engine=self._execution_engine,
         )
-        self._set_default_metric_kwargs_if_not_exist(
+        self._set_default_metric_kwargs_if_absent(
             default_kwarg_values=metric_impl_klass.default_kwarg_values,
             metric_kwargs=metric_configuration.metric_domain_kwargs,
             keys=metric_impl_klass.domain_keys,
         )
-        self._set_default_metric_kwargs_if_not_exist(
+        self._set_default_metric_kwargs_if_absent(
             default_kwarg_values=metric_impl_klass.default_kwarg_values,
             metric_kwargs=metric_configuration.metric_value_kwargs,
             keys=metric_impl_klass.value_keys,
@@ -326,7 +326,7 @@ class ValidationGraph:
         return maybe_ready - unmet_dependency, unmet_dependency
 
     @staticmethod
-    def _set_default_metric_kwargs_if_not_exist(
+    def _set_default_metric_kwargs_if_absent(
         default_kwarg_values: dict,
         metric_kwargs: IDDict,
         keys: Tuple[str, ...],

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -111,7 +111,35 @@ class ValidationGraph:
                     runtime_configuration=runtime_configuration,
                 )
 
-    def resolve_validation_graph(  # noqa: C901 - complexity 16
+    def resolve_validation_graph(
+        self,
+        runtime_configuration: Optional[dict] = None,
+        min_graph_edges_pbar_enable: int = 0,
+        # Set to low number (e.g., 3) to suppress progress bar for small graphs.
+        show_progress_bars: bool = True,
+    ) -> Tuple[
+        Optional[Dict[Tuple[str, str, str], MetricValue]],
+        Dict[
+            Tuple[str, str, str],
+            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
+        ],
+    ]:
+        resolved_metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+
+        # updates graph with aborted metrics
+        aborted_metrics_info: Dict[
+            Tuple[str, str, str],
+            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
+        ] = self._resolve_validation_graph(
+            metrics=resolved_metrics,
+            runtime_configuration=runtime_configuration,
+            min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
+            show_progress_bars=show_progress_bars,
+        )
+
+        return resolved_metrics, aborted_metrics_info
+
+    def _resolve_validation_graph(  # noqa: C901 - complexity 16
         self,
         metrics: Dict[Tuple[str, str, str], MetricValue],
         runtime_configuration: Optional[dict] = None,
@@ -121,6 +149,9 @@ class ValidationGraph:
         Tuple[str, str, str],
         Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
     ]:
+        if metrics is None:
+            metrics = {}
+
         if runtime_configuration is None:
             runtime_configuration = {}
 

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -628,17 +628,11 @@ class Validator:
 
             meta["profiler_config"] = profiler.to_json_dict()
 
-            configuration = ExpectationConfiguration(
-                expectation_type=expectation_type,
-                kwargs=expectation_kwargs,
-                meta=meta,
-            )
-        else:
-            configuration = ExpectationConfiguration(
-                expectation_type=expectation_type,
-                kwargs=expectation_kwargs,
-                meta=meta,
-            )
+        configuration = ExpectationConfiguration(
+            expectation_type=expectation_type,
+            kwargs=expectation_kwargs,
+            meta=meta,
+        )
 
         return configuration
 
@@ -946,6 +940,9 @@ class Validator:
         Returns:
             A list of Validations, validating that all necessary metrics are available.
         """
+        if metrics is None:
+            metrics = {}
+
         if runtime_configuration is None:
             runtime_configuration = {}
 
@@ -969,9 +966,6 @@ class Validator:
             catch_exceptions=catch_exceptions,
             runtime_configuration=runtime_configuration,
         )
-
-        if metrics is None:
-            metrics = {}
 
         graph: ValidationGraph = (
             self._generate_suite_level_graph_from_expectation_level_sub_graphs(
@@ -1058,13 +1052,15 @@ class Validator:
             evaluated_config.kwargs.update({"batch_id": self.active_batch_id})
 
             expectation_impl = get_expectation_impl(evaluated_config.expectation_type)
-            validation_dependencies: dict = (
-                expectation_impl().get_validation_dependencies(
-                    configuration=evaluated_config,
-                    execution_engine=self._execution_engine,
-                    runtime_configuration=runtime_configuration,
-                )["metrics"]
-            )
+            validation_dependencies: Dict[
+                str, MetricConfiguration
+            ] = expectation_impl().get_validation_dependencies(
+                configuration=evaluated_config,
+                execution_engine=self._execution_engine,
+                runtime_configuration=runtime_configuration,
+            )[
+                "metrics"
+            ]
 
             try:
                 expectation_validation_graph: ExpectationValidationGraph = (

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1108,16 +1108,16 @@ class Validator:
                         configuration=evaluated_config,
                     )
                 )
+                graph = ValidationGraph(execution_engine=self._execution_engine)
                 for (
                     metric_configuration
                 ) in validation_dependencies.get_metric_configurations():
-                    graph = ValidationGraph(execution_engine=self._execution_engine)
                     graph.build_metric_dependency_graph(
                         metric_configuration=metric_configuration,
                         runtime_configuration=runtime_configuration,
                     )
-                    expectation_validation_graph.update(graph=graph)
 
+                expectation_validation_graph.update(graph=graph)
                 expectation_validation_graphs.append(expectation_validation_graph)
                 processed_configurations.append(evaluated_config)
             except Exception as err:

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1117,6 +1117,7 @@ class Validator:
                         runtime_configuration=runtime_configuration,
                     )
                     expectation_validation_graph.update(graph=graph)
+
                 expectation_validation_graphs.append(expectation_validation_graph)
                 processed_configurations.append(evaluated_config)
             except Exception as err:

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -408,7 +408,6 @@ def test_progress_bar_config(
         "great_expectations.validator.validation_graph.tqdm",
     ) as mock_tqdm:
         call_args = {
-            "metrics": {},
             "runtime_configuration": None,
         }
         if show_progress_bars is not None:

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, Iterable, Optional, Set, Tuple, Union, cast
+from typing import Dict, Iterable, Optional, Set, Tuple, Union, cast
 from unittest import mock
 
 import pytest
@@ -17,6 +17,7 @@ from great_expectations.validator.validation_graph import (
     MetricEdge,
     ValidationGraph,
 )
+from great_expectations.validator.validator import ValidationDependencies
 
 
 @pytest.fixture
@@ -93,14 +94,16 @@ def expect_column_value_z_scores_to_be_less_than_expectation_validation_graph():
             "double_sided": True,
         },
     )
+
     graph = ValidationGraph(execution_engine=execution_engine)
-    validation_dependencies: Dict[
-        str, Union[dict, Dict[str, MetricConfiguration]]
-    ] = ExpectColumnValueZScoresToBeLessThan().get_validation_dependencies(
-        expectation_configuration, execution_engine
+    validation_dependencies: ValidationDependencies = (
+        ExpectColumnValueZScoresToBeLessThan().get_validation_dependencies(
+            expectation_configuration, execution_engine
+        )
     )
 
-    for metric_configuration in validation_dependencies["metrics"].values():
+    metric_configuration: MetricConfiguration
+    for metric_configuration in validation_dependencies.get_metric_configurations():
         graph.build_metric_dependency_graph(
             metric_configuration=metric_configuration,
             runtime_configuration=None,
@@ -329,13 +332,15 @@ def test_resolve_validation_graph_with_bad_config_catch_exceptions_true():
         runtime_configuration=runtime_configuration,
     )
 
-    metrics: Dict[Tuple[str, str, str], MetricValue] = {}
+    resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
     aborted_metrics_info: Dict[
         Tuple[str, str, str],
         Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
-    ] = graph.resolve_validation_graph(
-        metrics=metrics,
+    ]
+    resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
         runtime_configuration=runtime_configuration,
+        min_graph_edges_pbar_enable=0,
+        show_progress_bars=True,
     )
 
     assert len(aborted_metrics_info) == 1
@@ -414,7 +419,15 @@ def test_progress_bar_config(
             )
 
         graph = ValidationGraph(execution_engine=execution_engine)
-        graph.resolve_validation_graph(**call_args)
+        resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
+        aborted_metrics_info: Dict[
+            Tuple[str, str, str],
+            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
+        ]
+        # noinspection PyUnusedLocal
+        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+            **call_args
+        )
         assert mock_tqdm.called is True
         assert mock_tqdm.call_args[1]["disable"] is are_progress_bars_disabled
 


### PR DESCRIPTION
### Scope
* Add type hints in a couple of places in `expectation.py`
* Remove unnecessary code duplication in `validator.py`
* Create formal `ValidationDependencies` `dataclass` object.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-181/GREAT-1406
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!