### PR TITLE
[MAINTENANCE] Small refactor

### DIFF
--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -141,11 +141,16 @@ class MetricsCalculator:
         self,
         metric_configurations: List[MetricConfiguration],
         runtime_configuration: Optional[dict] = None,
+        min_graph_edges_pbar_enable: int = 0,
+        # Set to low number (e.g., 3) to suppress progress bar for small graphs.
+        show_progress_bars: bool = True,
     ) -> Dict[Tuple[str, str, str], MetricValue]:
         """
         Args:
             metric_configurations: List of desired MetricConfiguration objects to be resolved.
             runtime_configuration: Additional run-time settings (see "Validator.DEFAULT_RUNTIME_CONFIGURATION").
+            min_graph_edges_pbar_enable: Minumum number of graph edges to warrant showing progress bars.
+            show_progress_bars: Directive for whether or not to show progress bars.
 
         Returns:
             Dictionary with requested metrics resolved, with unique metric ID as key and computed metric as value.
@@ -159,6 +164,8 @@ class MetricsCalculator:
         ] = self.resolve_validation_graph(
             graph=graph,
             runtime_configuration=runtime_configuration,
+            min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
+            show_progress_bars=show_progress_bars,
         )
         return resolved_metrics
 
@@ -195,11 +202,16 @@ class MetricsCalculator:
     def resolve_validation_graph(
         graph: ValidationGraph,
         runtime_configuration: Optional[dict] = None,
+        min_graph_edges_pbar_enable: int = 0,
+        # Set to low number (e.g., 3) to suppress progress bar for small graphs.
+        show_progress_bars: bool = True,
     ) -> Dict[Tuple[str, str, str], MetricValue]:
         """
         Args:
             graph: "ValidationGraph" object, containing "metric_edge" structures with "MetricConfiguration" objects.
             runtime_configuration: Additional run-time settings (see "Validator.DEFAULT_RUNTIME_CONFIGURATION").
+            min_graph_edges_pbar_enable: Minumum number of graph edges to warrant showing progress bars.
+            show_progress_bars: Directive for whether or not to show progress bars.
 
         Returns:
             Dictionary with requested metrics resolved, with unique metric ID as key and computed metric as value.
@@ -209,10 +221,14 @@ class MetricsCalculator:
             Tuple[str, str, str],
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
         ]
-        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+        (
+            resolved_metrics,
+            aborted_metrics_info,
+        ) = MetricsCalculator.resolve_validation_graph_and_report_aborted_metrics_info(
+            graph=graph,
             runtime_configuration=runtime_configuration,
-            min_graph_edges_pbar_enable=0,
-            show_progress_bars=True,
+            min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
+            show_progress_bars=show_progress_bars,
         )
 
         if aborted_metrics_info:
@@ -221,3 +237,40 @@ class MetricsCalculator:
             )
 
         return resolved_metrics
+
+    @staticmethod
+    def resolve_validation_graph_and_report_aborted_metrics_info(
+        graph: ValidationGraph,
+        runtime_configuration: Optional[dict] = None,
+        min_graph_edges_pbar_enable: int = 0,
+        # Set to low number (e.g., 3) to suppress progress bar for small graphs.
+        show_progress_bars: bool = True,
+    ) -> Tuple[
+        Dict[Tuple[str, str, str], MetricValue],
+        Dict[
+            Tuple[str, str, str],
+            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
+        ],
+    ]:
+        """
+        Args:
+            graph: "ValidationGraph" object, containing "metric_edge" structures with "MetricConfiguration" objects.
+            runtime_configuration: Additional run-time settings (see "Validator.DEFAULT_RUNTIME_CONFIGURATION").
+            min_graph_edges_pbar_enable: Minumum number of graph edges to warrant showing progress bars.
+            show_progress_bars: Directive for whether or not to show progress bars.
+
+        Returns:
+            Dictionary with requested metrics resolved, with unique metric ID as key and computed metric as value.
+            Aborted metrics information, with metric ID as key.
+        """
+        resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
+        aborted_metrics_info: Dict[
+            Tuple[str, str, str],
+            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
+        ]
+        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+            runtime_configuration=runtime_configuration,
+            min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
+            show_progress_bars=show_progress_bars,
+        )
+        return resolved_metrics, aborted_metrics_info

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -154,23 +154,12 @@ class MetricsCalculator:
             metric_configurations=metric_configurations,
             runtime_configuration=runtime_configuration,
         )
-
-        resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
-        aborted_metrics_info: Dict[
-            Tuple[str, str, str],
-            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
-        ]
-        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+        resolved_metrics: Dict[
+            Tuple[str, str, str], MetricValue
+        ] = self.resolve_validation_graph(
+            graph=graph,
             runtime_configuration=runtime_configuration,
-            min_graph_edges_pbar_enable=0,
-            show_progress_bars=True,
         )
-
-        if aborted_metrics_info:
-            logger.warning(
-                f"Exceptions\n{str(aborted_metrics_info)}\noccurred while resolving metrics."
-            )
-
         return resolved_metrics
 
     def build_metric_dependency_graph(
@@ -201,3 +190,34 @@ class MetricsCalculator:
             )
 
         return graph
+
+    @staticmethod
+    def resolve_validation_graph(
+        graph: ValidationGraph,
+        runtime_configuration: Optional[dict] = None,
+    ) -> Dict[Tuple[str, str, str], MetricValue]:
+        """
+        Args:
+            graph: "ValidationGraph" object, containing "metric_edge" structures with "MetricConfiguration" objects.
+            runtime_configuration: Additional run-time settings (see "Validator.DEFAULT_RUNTIME_CONFIGURATION").
+
+        Returns:
+            Dictionary with requested metrics resolved, with unique metric ID as key and computed metric as value.
+        """
+        resolved_metrics: Dict[Tuple[str, str, str], MetricValue]
+        aborted_metrics_info: Dict[
+            Tuple[str, str, str],
+            Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
+        ]
+        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+            runtime_configuration=runtime_configuration,
+            min_graph_edges_pbar_enable=0,
+            show_progress_bars=True,
+        )
+
+        if aborted_metrics_info:
+            logger.warning(
+                f"Exceptions\n{str(aborted_metrics_info)}\noccurred while resolving metrics."
+            )
+
+        return resolved_metrics


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1347/GREAT-181/GREAT-1413
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!