### PR TITLE
Add metadata to experimental datasource Batch class

### DIFF
--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -177,7 +177,7 @@ class Batch:
         self._data_asset: DataAsset = data_asset
         self._batch_request: BatchRequest = batch_request
         self._data: BatchDataType = data
-        self.metadata = metadata if metadata is not None else {}
+        self.metadata = metadata or {}
 
         # computed property
         # We need to unique identifier. This will likely change as I get more input

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from great_expectations.core.batch import BatchDataType
     from great_expectations.execution_engine import ExecutionEngine
 
-
 # BatchRequestOptions is a dict that is composed into a BatchRequest that specifies the
 # Batches one wants returned. The keys represent dimensions one can slice the data along
 # and the values are the realized. If a value is None or unspecified, the batch_request
@@ -60,7 +59,6 @@ class DataAsset(ExperimentalBaseModel):
 
 
 class Datasource(ExperimentalBaseModel, metaclass=MetaDatasource):
-
     # class attrs
     asset_types: ClassVar[List[Type[DataAsset]]] = []
     # Datasource instance attrs but these will be fed into the `execution_engine` constructor
@@ -155,6 +153,9 @@ class Batch:
     _batch_request: BatchRequest
     _data: BatchDataType
     _id: str
+    # metadata is any arbitrary data one wants to associate with a batch. GX will add arbitrary metadata
+    # to a batch so developers may want to namespace any custom metadata they add.
+    metadata: Dict[str, Any]
 
     def __init__(
         self,
@@ -164,6 +165,7 @@ class Batch:
         # BatchDataType is Union[core.batch.BatchData, pd.DataFrame, SparkDataFrame].  core.batch.Batchdata is the
         # implicit interface that Datasource implementers can use. We can make this explicit if needed.
         data: BatchDataType,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """This represents a batch of data.
 
@@ -175,6 +177,7 @@ class Batch:
         self._data_asset: DataAsset = data_asset
         self._batch_request: BatchRequest = batch_request
         self._data: BatchDataType = data
+        self.metadata = metadata if metadata is not None else {}
 
         # computed property
         # We need to unique identifier. This will likely change as I get more input

--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -273,7 +273,7 @@ class PostgresDatasource(Datasource):
         batch_list: List[Batch] = []
         column_splitter = data_asset.column_splitter
         for request in data_asset.fully_specified_batch_requests(batch_request):
-            batch_metadata = copy.copy(request.options)
+            batch_metadata = copy.deepcopy(request.options)
             batch_spec_kwargs = {
                 "type": "table",
                 "data_asset_name": data_asset.name,

--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import dataclasses
 import itertools
 from datetime import datetime
@@ -272,6 +273,7 @@ class PostgresDatasource(Datasource):
         batch_list: List[Batch] = []
         column_splitter = data_asset.column_splitter
         for request in data_asset.fully_specified_batch_requests(batch_request):
+            batch_metadata = copy.copy(request.options)
             batch_spec_kwargs = {
                 "type": "table",
                 "data_asset_name": data_asset.name,
@@ -297,6 +299,7 @@ class PostgresDatasource(Datasource):
                     data_asset=data_asset,
                     batch_request=request,
                     data=data,
+                    metadata=batch_metadata,
                 )
             )
         return batch_list


### PR DESCRIPTION
Adding metadata dictionary to the Batch class that will let users add arbitrary metadata to a batch. This will also let us support adding `Sorters` which will sort on Batch metadata.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
