### PR TITLE
[MAINTENANCE] Update and Simplify Pandas tests for MapMetrics

### DIFF
--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -26,7 +26,7 @@ from great_expectations.validator.validator import Validator
 
 
 @pytest.fixture
-def pandas_animals_dataframe():
+def pandas_animals_dataframe_for_unexpected_rows_and_index():
     return pd.DataFrame(
         {
             "pk_1": [0, 1, 2, 3, 4, 5],
@@ -206,7 +206,9 @@ def test_is_sqlalchemy_metric_selectable():
     )
 
 
-def test_pandas_unexpected_rows_basic_result_format(pandas_animals_dataframe):
+def test_pandas_unexpected_rows_basic_result_format(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
         kwargs={
@@ -221,7 +223,7 @@ def test_pandas_unexpected_rows_basic_result_format(pandas_animals_dataframe):
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch = Batch(data=pandas_animals_dataframe)
+    batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -249,7 +251,7 @@ def test_pandas_unexpected_rows_basic_result_format(pandas_animals_dataframe):
 
 
 def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_explicitly_false(
-    pandas_animals_dataframe,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -265,7 +267,7 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_explicitly
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch = Batch(data=pandas_animals_dataframe)
+    batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -294,7 +296,7 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_explicitly
 
 
 def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_including_unexpected_rows(
-    pandas_animals_dataframe,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -310,7 +312,7 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_including_
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch = Batch(data=pandas_animals_dataframe)
+    batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -343,7 +345,9 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_including_
     }
 
 
-def test_pandas_unexpected_rows_complete_result_format(pandas_animals_dataframe):
+def test_pandas_unexpected_rows_complete_result_format(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
         kwargs={
@@ -357,7 +361,7 @@ def test_pandas_unexpected_rows_complete_result_format(pandas_animals_dataframe)
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch = Batch(data=pandas_animals_dataframe)
+    batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -392,7 +396,7 @@ def test_pandas_unexpected_rows_complete_result_format(pandas_animals_dataframe)
 
 
 def test_pandas_default_complete_result_format(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -406,7 +410,7 @@ def test_pandas_default_complete_result_format(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -436,7 +440,7 @@ def test_pandas_default_complete_result_format(
 
 
 def test_pandas_single_unexpected_index_column_names_complete_result_format(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -451,7 +455,7 @@ def test_pandas_single_unexpected_index_column_names_complete_result_format(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -489,7 +493,7 @@ def test_pandas_single_unexpected_index_column_names_complete_result_format(
 
 
 def test_pandas_multiple_unexpected_index_column_names_complete_result_format(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -504,7 +508,7 @@ def test_pandas_multiple_unexpected_index_column_names_complete_result_format(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -542,7 +546,7 @@ def test_pandas_multiple_unexpected_index_column_names_complete_result_format(
 
 
 def test_pandas_multiple_unexpected_index_column_names_complete_result_format_limit_1(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -558,7 +562,7 @@ def test_pandas_multiple_unexpected_index_column_names_complete_result_format_li
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -588,7 +592,7 @@ def test_pandas_multiple_unexpected_index_column_names_complete_result_format_li
 
 
 def test_pandas_multiple_unexpected_index_column_names_summary_result_format(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -603,7 +607,7 @@ def test_pandas_multiple_unexpected_index_column_names_summary_result_format(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -635,7 +639,7 @@ def test_pandas_multiple_unexpected_index_column_names_summary_result_format(
 
 
 def test_pandas_multiple_unexpected_index_column_names_summary_result_format_limit_1(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -651,7 +655,7 @@ def test_pandas_multiple_unexpected_index_column_names_summary_result_format_lim
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -677,7 +681,7 @@ def test_pandas_multiple_unexpected_index_column_names_summary_result_format_lim
 
 
 def test_pandas_multiple_unexpected_index_column_names_basic_result_format(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -692,7 +696,7 @@ def test_pandas_multiple_unexpected_index_column_names_basic_result_format(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -714,7 +718,7 @@ def test_pandas_multiple_unexpected_index_column_names_basic_result_format(
 
 
 def test_pandas_single_unexpected_index_column_names_complete_result_format_non_existing_column(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -729,7 +733,7 @@ def test_pandas_single_unexpected_index_column_names_complete_result_format_non_
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -747,7 +751,7 @@ def test_pandas_single_unexpected_index_column_names_complete_result_format_non_
 
 
 def test_pandas_multiple_unexpected_index_column_names_complete_result_format_non_existing_column(
-    pandas_animals_dataframe: pd.DataFrame,
+    pandas_animals_dataframe_for_unexpected_rows_and_index: pd.DataFrame,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -764,7 +768,7 @@ def test_pandas_multiple_unexpected_index_column_names_complete_result_format_no
         },
     )
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch: Batch = Batch(data=pandas_animals_dataframe)
+    batch: Batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -782,7 +786,8 @@ def test_pandas_multiple_unexpected_index_column_names_complete_result_format_no
 
 
 def test_pandas_default_to_not_include_unexpected_rows(
-    pandas_animals_dataframe, expected_evr_without_unexpected_rows
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    expected_evr_without_unexpected_rows,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -796,7 +801,7 @@ def test_pandas_default_to_not_include_unexpected_rows(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch = Batch(data=pandas_animals_dataframe)
+    batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -809,7 +814,8 @@ def test_pandas_default_to_not_include_unexpected_rows(
 
 
 def test_pandas_specify_not_include_unexpected_rows(
-    pandas_animals_dataframe, expected_evr_without_unexpected_rows
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    expected_evr_without_unexpected_rows,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -824,7 +830,7 @@ def test_pandas_specify_not_include_unexpected_rows(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch = Batch(data=pandas_animals_dataframe)
+    batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,
@@ -837,7 +843,7 @@ def test_pandas_specify_not_include_unexpected_rows(
 
 
 def test_include_unexpected_rows_without_explicit_result_format_raises_error(
-    pandas_animals_dataframe,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
 ):
     expectation_configuration = ExpectationConfiguration(
         expectation_type="expect_column_values_to_be_in_set",
@@ -851,7 +857,7 @@ def test_include_unexpected_rows_without_explicit_result_format_raises_error(
     )
 
     expectation = ExpectColumnValuesToBeInSet(expectation_configuration)
-    batch = Batch(data=pandas_animals_dataframe)
+    batch = Batch(data=pandas_animals_dataframe_for_unexpected_rows_and_index)
     engine = PandasExecutionEngine()
     validator = Validator(
         execution_engine=engine,

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -258,7 +258,7 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_explicitly
             "mostly": 0.9,
             "value_set": ["cat", "fish", "dog"],
             "result_format": {
-                "result_format": "SUMMARY",
+                "result_format": "SUMMARY",  # SUMMARY will include partial_unexpected* values only
                 "include_unexpected_rows": False,  # this is the default value, but making explicit for testing purposes
             },
         },
@@ -303,7 +303,7 @@ def test_pandas_unexpected_rows_summary_result_format_unexpected_rows_including_
             "mostly": 0.9,
             "value_set": ["cat", "fish", "dog"],
             "result_format": {
-                "result_format": "SUMMARY",
+                "result_format": "SUMMARY",  # SUMMARY will include partial_unexpected* values only
                 "include_unexpected_rows": True,
             },
         },
@@ -469,10 +469,18 @@ def test_pandas_single_unexpected_index_column_names_complete_result_format(
             {"count": 1, "value": "lion"},
             {"count": 1, "value": "zebra"},
         ],
-        "partial_unexpected_index_list": [{"pk_1": 3}, {"pk_1": 4}, {"pk_1": 5}],
+        "partial_unexpected_index_list": [
+            {"pk_1": 3},
+            {"pk_1": 4},
+            {"pk_1": 5},
+        ],  # Dict since a column was provided
         "partial_unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_count": 3,
-        "unexpected_index_list": [{"pk_1": 3}, {"pk_1": 4}, {"pk_1": 5}],
+        "unexpected_index_list": [
+            {"pk_1": 3},
+            {"pk_1": 4},
+            {"pk_1": 5},
+        ],  # Dict since a column was provided
         "unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_percent": 50.0,
         "unexpected_percent_nonmissing": 50.0,
@@ -518,14 +526,14 @@ def test_pandas_multiple_unexpected_index_column_names_complete_result_format(
             {"pk_1": 3, "pk_2": "three"},
             {"pk_1": 4, "pk_2": "four"},
             {"pk_1": 5, "pk_2": "five"},
-        ],
+        ],  # Dicts since columns were provided
         "partial_unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_count": 3,
         "unexpected_index_list": [
             {"pk_1": 3, "pk_2": "three"},
             {"pk_1": 4, "pk_2": "four"},
             {"pk_1": 5, "pk_2": "five"},
-        ],
+        ],  # Dicts since columns were provided
         "unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_percent": 50.0,
         "unexpected_percent_nonmissing": 50.0,
@@ -612,12 +620,12 @@ def test_pandas_multiple_unexpected_index_column_names_summary_result_format(
             {"count": 1, "value": "giraffe"},
             {"count": 1, "value": "lion"},
             {"count": 1, "value": "zebra"},
-        ],
+        ],  # Dicts since columns were provided
         "partial_unexpected_index_list": [
             {"pk_1": 3, "pk_2": "three"},
             {"pk_1": 4, "pk_2": "four"},
             {"pk_1": 5, "pk_2": "five"},
-        ],
+        ],  # Dicts since columns were provided
         "partial_unexpected_list": ["giraffe", "lion", "zebra"],
         "unexpected_count": 3,
         "unexpected_percent": 50.0,
@@ -657,7 +665,9 @@ def test_pandas_multiple_unexpected_index_column_names_summary_result_format_lim
         "missing_count": 0,
         "missing_percent": 0.0,
         "partial_unexpected_counts": [{"count": 1, "value": "giraffe"}],
-        "partial_unexpected_index_list": [{"pk_1": 3, "pk_2": "three"}],
+        "partial_unexpected_index_list": [
+            {"pk_1": 3, "pk_2": "three"}
+        ],  # Dicts since columns were provided
         "partial_unexpected_list": ["giraffe"],
         "unexpected_count": 3,
         "unexpected_percent": 50.0,
@@ -675,7 +685,7 @@ def test_pandas_multiple_unexpected_index_column_names_basic_result_format(
             "column": "animals",
             "value_set": ["cat", "fish", "dog"],
             "result_format": {
-                "result_format": "BASIC",  # SUMMARY will include partial_unexpected_list only, which means unexpected_index_column_names will have no effect
+                "result_format": "BASIC",  # BASIC will not include index information
                 "unexpected_index_column_names": ["pk_1", "pk_2"],
             },
         },


### PR DESCRIPTION
# Proposed Changes
This is a small PR that cleans up the `MapMetrics` tests for `Pandas` in preparation for adding `Spark` and `Sql` test. This PR proposes a consolidation of 2 `Dataframes` that were used for Pandas MapMetrics tests: `dataframe_for_unexpected_rows` and `pandas_dataframe_for_unexpected_rows_with_index`. 

The new dataframe is named `pandas_animals_dataframe_for_unexpected_rows_and_index` and looks like the following: 

```python
pd.DataFrame(
        {
            "pk_1": [0, 1, 2, 3, 4, 5],
            "pk_2": ["zero", "one", "two", "three", "four", "five"],
            "animals": [
                "cat",
                "fish",
                "dog",
                "giraffe",
                "lion",
                "zebra",
            ],
        }
    )
```

Basically the tests now use the `expect_column_values_to_be_in_set` while giving the `value_set` of `["cat", "fish", "dog"]`, domestic pets. The non-domestic animals will always come up as the `unexpected_list`: `["giraffe", "lion", "zebra"]`

* The PR does not add any new tests, but just adjusts existing Pandas ones to use the consolidated Dataframe. 