### PR TITLE
[MAINTENANCE] Clean Up Variable Names In Test Modules, Type Hints, and Minor Refactoring For Better Code Elegance/Readability

### DIFF
--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -265,7 +265,7 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                     Tuple[str, str, str],
                     Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
                 ]
-                resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+                resolved_metrics, aborted_metrics_info = graph.resolve(
                     runtime_configuration=None,
                     min_graph_edges_pbar_enable=0,
                     show_progress_bars=True,

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -197,7 +197,7 @@ class DataAssistantRunner:
             self._get_method_signature_parameters_for_variables_directives()
         )
 
-        func_sig: Signature = Signature(
+        func_sig = Signature(
             parameters=parameters, return_annotation=DataAssistantResult
         )
         # override the runner docstring with the docstring defined in the implemented DataAssistant child-class

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -197,7 +197,7 @@ class DataAssistantRunner:
             self._get_method_signature_parameters_for_variables_directives()
         )
 
-        func_sig = Signature(
+        func_sig: Signature = Signature(
             parameters=parameters, return_annotation=DataAssistantResult
         )
         # override the runner docstring with the docstring defined in the implemented DataAssistant child-class

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -159,7 +159,8 @@ def get_batch_ids(
     num_batch_ids: int = len(batch_ids)
 
     if limit is not None:
-        if not (isinstance(limit, int) and (0 <= limit <= num_batch_ids)):
+        # No need to verify that type of "limit" is "integer", because static type checking already ascertains this.
+        if not (0 <= limit <= num_batch_ids):
             raise ge_exceptions.ProfilerExecutionError(
                 message=f"""{__name__}.get_batch_ids() allows integer limit values between 0 and {num_batch_ids} \
 ({limit} was requested).

--- a/great_expectations/rule_based_profiler/helpers/util.py
+++ b/great_expectations/rule_based_profiler/helpers/util.py
@@ -156,10 +156,17 @@ def get_batch_ids(
 
     batch_ids: List[str] = [batch.id for batch in batch_list]
 
-    if limit is not None:
-        batch_ids = batch_ids[0:limit]
-
     num_batch_ids: int = len(batch_ids)
+
+    if limit is not None:
+        if not (isinstance(limit, int) and (0 <= limit <= num_batch_ids)):
+            raise ge_exceptions.ProfilerExecutionError(
+                message=f"""{__name__}.get_batch_ids() allows integer limit values between 0 and {num_batch_ids} \
+({limit} was requested).
+"""
+            )
+        batch_ids = batch_ids[-limit:]
+
     if num_batch_ids == 0:
         raise ge_exceptions.ProfilerExecutionError(
             message=f"""{__name__}.get_batch_ids() must return at least one batch_id ({num_batch_ids} were retrieved).

--- a/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
+++ b/great_expectations/rule_based_profiler/parameter_builder/parameter_builder.py
@@ -48,6 +48,7 @@ from great_expectations.types.attributes import Attributes
 from great_expectations.util import is_parseable_date
 from great_expectations.validator.computed_metric import MetricValue
 from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.validation_graph import ValidationGraph
 
 if TYPE_CHECKING:
     from great_expectations.data_context.data_context.abstract_data_context import (
@@ -442,25 +443,7 @@ specified (empty "metric_name" value detected)."""
             for kwargs_pair_cursor in kwargs_combinations
         ]
 
-        # Step-4: Sort "MetricConfiguration" directives by "metric_value_kwargs_id" and "batch_id" (in that order).
-        # This precise sort order enables pairing every metric value with its respective "batch_id" (e.g., for display).
-
-        batch_id_idx: int
-        batch_id_ordering: Dict[str, int] = {
-            batch_id: batch_id_idx for batch_id_idx, batch_id in enumerate(batch_ids)
-        }
-
-        metrics_to_resolve = sorted(
-            metrics_to_resolve,
-            key=lambda metric_configuration_element: (
-                metric_configuration_element.metric_value_kwargs_id,
-                batch_id_ordering[
-                    metric_configuration_element.metric_domain_kwargs["batch_id"]
-                ],
-            ),
-        )
-
-        # Step-5: Resolve all metrics in one operation simultaneously.
+        # Step-4: Resolve all metrics in one operation simultaneously.
 
         # The Validator object used for metric calculation purposes.
         validator: Validator = self.get_validator(
@@ -469,38 +452,29 @@ specified (empty "metric_name" value detected)."""
             parameters=parameters,
         )
 
-        resolved_metrics: Dict[
-            Tuple[str, str, str], MetricValue
-        ] = validator.compute_metrics(
-            metric_configurations=metrics_to_resolve,
-            runtime_configuration=None,
+        graph: ValidationGraph = (
+            validator.metrics_calculator.build_metric_dependency_graph(
+                metric_configurations=metrics_to_resolve,
+                runtime_configuration=None,
+            )
         )
 
-        # Step-6: Sort resolved metrics according to same sort order as was applied to "MetricConfiguration" directives.
+        resolved_metrics: Dict[
+            Tuple[str, str, str], MetricValue
+        ] = validator.metrics_calculator.resolve_validation_graph_and_handle_aborted_metrics_info(
+            graph=graph,
+            runtime_configuration=None,
+            min_graph_edges_pbar_enable=0,
+            show_progress_bars=True,
+        )
 
-        resolved_metrics_sorted: Dict[Tuple[str, str, str], MetricValue] = {}
-
-        metric_configuration: MetricConfiguration
-
-        resolved_metric_value: MetricValue
-
-        for metric_configuration in metrics_to_resolve:
-            if metric_configuration.id not in resolved_metrics:
-                logger.warning(
-                    f"{metric_configuration.id[0]} was not found in the resolved Metrics for ParameterBuilder."
-                )
-                continue
-
-            resolved_metrics_sorted[metric_configuration.id] = resolved_metrics[
-                metric_configuration.id
-            ]
-
-        # Step-7: Map resolved metrics to their attributes for identification and recovery by receiver.
+        # Step-5: Map resolved metrics to their attributes for identification and recovery by receiver.
 
         attributed_resolved_metrics_map: Dict[str, AttributedResolvedMetrics] = {}
 
+        resolved_metric_value: MetricValue
         attributed_resolved_metrics: AttributedResolvedMetrics
-
+        metric_configuration: MetricConfiguration
         for metric_configuration in metrics_to_resolve:
             attributed_resolved_metrics = attributed_resolved_metrics_map.get(
                 metric_configuration.metric_value_kwargs_id
@@ -517,16 +491,19 @@ specified (empty "metric_name" value detected)."""
                     metric_configuration.metric_value_kwargs_id
                 ] = attributed_resolved_metrics
 
-            if metric_configuration.id in resolved_metrics_sorted:
-                resolved_metric_value = resolved_metrics_sorted[metric_configuration.id]
+            if metric_configuration.id in resolved_metrics:
+                resolved_metric_value = resolved_metrics[metric_configuration.id]
                 attributed_resolved_metrics.add_resolved_metric(
                     batch_id=metric_configuration.metric_domain_kwargs["batch_id"],
                     value=resolved_metric_value,
                 )
             else:
+                logger.warning(
+                    f"{metric_configuration.id[0]} was not found in the resolved Metrics for ParameterBuilder."
+                )
                 continue
 
-        # Step-8: Convert scalar metric values to vectors to enable uniformity of processing in subsequent operations.
+        # Step-6: Convert scalar metric values to vectors to enable uniformity of processing in subsequent operations.
 
         metric_attributes_id: str
         for (
@@ -535,7 +512,8 @@ specified (empty "metric_name" value detected)."""
         ) in attributed_resolved_metrics_map.items():
             if (
                 isinstance(
-                    attributed_resolved_metrics.conditioned_metric_values, np.ndarray
+                    attributed_resolved_metrics.conditioned_metric_values,
+                    np.ndarray,
                 )
                 and attributed_resolved_metrics.conditioned_metric_values.ndim == 1
             ):
@@ -547,7 +525,7 @@ specified (empty "metric_name" value detected)."""
                     metric_attributes_id
                 ] = attributed_resolved_metrics
 
-        # Step-9: Apply numeric/hygiene flags (e.g., "enforce_numeric_metric", "replace_nan_with_zero") to results.
+        # Step-7: Apply numeric/hygiene flags (e.g., "enforce_numeric_metric", "replace_nan_with_zero") to results.
 
         for (
             metric_attributes_id,
@@ -564,19 +542,21 @@ specified (empty "metric_name" value detected)."""
                 parameters=parameters,
             )
 
-        # Step-10: Build and return result to receiver (apply simplifications to cases of single "metric_value_kwargs").
+        # Step-8: Build and return result to receiver (apply simplifications to cases of single "metric_value_kwargs").
+
+        details: dict = {
+            "metric_configuration": {
+                "metric_name": metric_name,
+                "domain_kwargs": domain_kwargs,
+                "metric_value_kwargs": metric_value_kwargs[0]
+                if len(metric_value_kwargs) == 1
+                else metric_value_kwargs,
+            },
+            "num_batches": len(batch_ids),
+        }
         return MetricComputationResult(
             attributed_resolved_metrics=list(attributed_resolved_metrics_map.values()),
-            details={
-                "metric_configuration": {
-                    "metric_name": metric_name,
-                    "domain_kwargs": domain_kwargs,
-                    "metric_value_kwargs": metric_value_kwargs[0]
-                    if len(metric_value_kwargs) == 1
-                    else metric_value_kwargs,
-                },
-                "num_batches": len(batch_ids),
-            },
+            details=details,
         )
 
     @staticmethod

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -255,7 +255,7 @@ class MetricsCalculator:
         ],
     ]:
         """
-        Calls "ValidationGraph.resolve_validation_graph()" method with supplied arguments.
+        Calls "ValidationGraph.resolve()" method with supplied arguments.
 
         Args:
             graph: "ValidationGraph" object, containing "metric_edge" structures with "MetricConfiguration" objects.
@@ -272,7 +272,7 @@ class MetricsCalculator:
             Tuple[str, str, str],
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
         ]
-        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+        resolved_metrics, aborted_metrics_info = graph.resolve(
             runtime_configuration=runtime_configuration,
             min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
             show_progress_bars=show_progress_bars,

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -130,8 +130,10 @@ class MetricsCalculator:
             Tuple[str, str, str], MetricValue
         ] = self.compute_metrics(
             metric_configurations=list(metrics.values()),
+            runtime_configuration=None,
+            min_graph_edges_pbar_enable=0,
+            show_progress_bars=True,
         )
-
         return {
             metric_configuration.metric_name: resolved_metrics[metric_configuration.id]
             for metric_configuration in metrics.values()
@@ -161,7 +163,7 @@ class MetricsCalculator:
         )
         resolved_metrics: Dict[
             Tuple[str, str, str], MetricValue
-        ] = self.resolve_validation_graph(
+        ] = self.resolve_validation_graph_and_handle_aborted_metrics_info(
             graph=graph,
             runtime_configuration=runtime_configuration,
             min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
@@ -199,7 +201,7 @@ class MetricsCalculator:
         return graph
 
     @staticmethod
-    def resolve_validation_graph(
+    def resolve_validation_graph_and_handle_aborted_metrics_info(
         graph: ValidationGraph,
         runtime_configuration: Optional[dict] = None,
         min_graph_edges_pbar_enable: int = 0,
@@ -224,7 +226,7 @@ class MetricsCalculator:
         (
             resolved_metrics,
             aborted_metrics_info,
-        ) = MetricsCalculator.resolve_validation_graph_and_report_aborted_metrics_info(
+        ) = MetricsCalculator.resolve_validation_graph(
             graph=graph,
             runtime_configuration=runtime_configuration,
             min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
@@ -239,7 +241,7 @@ class MetricsCalculator:
         return resolved_metrics
 
     @staticmethod
-    def resolve_validation_graph_and_report_aborted_metrics_info(
+    def resolve_validation_graph(
         graph: ValidationGraph,
         runtime_configuration: Optional[dict] = None,
         min_graph_edges_pbar_enable: int = 0,
@@ -253,6 +255,8 @@ class MetricsCalculator:
         ],
     ]:
         """
+        Calls "ValidationGraph.resolve_validation_graph()" method with supplied arguments.
+
         Args:
             graph: "ValidationGraph" object, containing "metric_edge" structures with "MetricConfiguration" objects.
             runtime_configuration: Additional run-time settings (see "Validator.DEFAULT_RUNTIME_CONFIGURATION").

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -71,7 +71,7 @@ class ValidationGraph:
 
         self._edge_ids = {edge.id for edge in self._edges}
 
-    def __eq__(self, other: ValidationGraph) -> bool:
+    def __eq__(self, other) -> bool:
         """Supports comparing two "ValidationGraph" objects."""
         return self.edge_ids == other.edge_ids
 

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -71,15 +71,22 @@ class ValidationGraph:
 
         self._edge_ids = {edge.id for edge in self._edges}
 
+    def __eq__(self, other: ValidationGraph) -> bool:
+        """Supports comparing two "ValidationGraph" objects."""
+        return self.edge_ids == other.edge_ids
+
     @property
-    def edges(self):
+    def edges(self) -> List[MetricEdge]:
+        """Returns "MetricEdge" objects, contained within this "ValidationGraph" object (as list)."""
         return self._edges
 
     @property
-    def edge_ids(self):
+    def edge_ids(self) -> Set[Tuple[str, str]]:
+        """Returns "MetricEdge" objects, contained within this "ValidationGraph" object (as set of two-tuples)."""
         return {edge.id for edge in self._edges}
 
     def add(self, edge: MetricEdge) -> None:
+        """Adds supplied "MetricEdge" object to this "ValidationGraph" object (if not already present)."""
         if edge.id not in self._edge_ids:
             self._edges.append(edge)
             self._edge_ids.add(edge.id)

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -167,7 +167,7 @@ class ValidationGraph:
         )
         return metric_impl_klass, metric_provider
 
-    def resolve_validation_graph(
+    def resolve(
         self,
         runtime_configuration: Optional[dict] = None,
         min_graph_edges_pbar_enable: int = 0,
@@ -186,7 +186,7 @@ class ValidationGraph:
         aborted_metrics_info: Dict[
             Tuple[str, str, str],
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
-        ] = self._resolve_validation_graph(
+        ] = self._resolve(
             metrics=resolved_metrics,
             runtime_configuration=runtime_configuration,
             min_graph_edges_pbar_enable=min_graph_edges_pbar_enable,
@@ -195,7 +195,7 @@ class ValidationGraph:
 
         return resolved_metrics, aborted_metrics_info
 
-    def _resolve_validation_graph(  # noqa: C901 - complexity 16
+    def _resolve(  # noqa: C901 - complexity 16
         self,
         metrics: Dict[Tuple[str, str, str], MetricValue],
         runtime_configuration: Optional[dict] = None,

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -69,8 +69,6 @@ class ValidationGraph:
         else:
             self._edges = []
 
-        self._edge_ids = {edge.id for edge in self._edges}
-
     def __eq__(self, other) -> bool:
         """Supports comparing two "ValidationGraph" objects."""
         return self.edge_ids == other.edge_ids
@@ -87,9 +85,8 @@ class ValidationGraph:
 
     def add(self, edge: MetricEdge) -> None:
         """Adds supplied "MetricEdge" object to this "ValidationGraph" object (if not already present)."""
-        if edge.id not in self._edge_ids:
+        if edge.id not in self.edge_ids:
             self._edges.append(edge)
-            self._edge_ids.add(edge.id)
 
     def build_metric_dependency_graph(
         self,

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -69,6 +69,8 @@ class ValidationGraph:
         else:
             self._edges = []
 
+        self._edge_ids = {edge.id for edge in self._edges}
+
     def __eq__(self, other) -> bool:
         """Supports comparing two "ValidationGraph" objects."""
         return self.edge_ids == other.edge_ids
@@ -85,8 +87,9 @@ class ValidationGraph:
 
     def add(self, edge: MetricEdge) -> None:
         """Adds supplied "MetricEdge" object to this "ValidationGraph" object (if not already present)."""
-        if edge.id not in self.edge_ids:
+        if edge.id not in self._edge_ids:
             self._edges.append(edge)
+            self._edge_ids.add(edge.id)
 
     def build_metric_dependency_graph(
         self,

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1111,16 +1111,16 @@ class Validator:
                         configuration=evaluated_config,
                     )
                 )
-                graph = ValidationGraph(execution_engine=self._execution_engine)
                 for (
                     metric_configuration
                 ) in validation_dependencies.get_metric_configurations():
+                    graph = ValidationGraph(execution_engine=self._execution_engine)
                     graph.build_metric_dependency_graph(
                         metric_configuration=metric_configuration,
                         runtime_configuration=runtime_configuration,
                     )
+                    expectation_validation_graph.update(graph=graph)
 
-                expectation_validation_graph.update(graph=graph)
                 expectation_validation_graphs.append(expectation_validation_graph)
                 processed_configurations.append(evaluated_config)
             except Exception as err:

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1030,7 +1030,7 @@ class Validator:
                 processed_configurations=processed_configurations,
             )
         except Exception as err:
-            # If a general Exception occurs during the execution of "ValidationGraph.resolve_validation_graph()", then
+            # If a general Exception occurs during the execution of "ValidationGraph.resolve()", then
             # all expectations in the suite are impacted, because it is impossible to attribute the failure to a metric.
             if catch_exceptions:
                 exception_traceback: str = traceback.format_exc()
@@ -1179,7 +1179,7 @@ class Validator:
             Tuple[str, str, str],
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
         ]
-        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+        resolved_metrics, aborted_metrics_info = graph.resolve(
             runtime_configuration=runtime_configuration,
             min_graph_edges_pbar_enable=0,
             show_progress_bars=True,

--- a/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
+++ b/tests/integration/profiling/rule_based_profiler/test_profiler_user_workflows.py
@@ -433,13 +433,21 @@ def test_alice_expect_column_values_to_match_regex_auto_yes_default_profiler_con
     assert result.success
 
     expectation_config_kwargs: dict = result.expectation_config.kwargs
+
+    assert expectation_config_kwargs["regex"] in [
+        r"\d+",
+        r"-?\d+",
+        r"-?\d+(?:\.\d*)?",
+        r"[A-Za-z0-9\.,;:!?()\"'%\-]+",
+    ]
+
+    expectation_config_kwargs.pop("regex")
     assert expectation_config_kwargs == {
         "auto": True,
         "batch_id": "cf28d8229c247275c8cc0f41b4ceb62d",
         "column": "id",
         "include_config": True,
         "mostly": 1.0,
-        "regex": "-?\\d+",
         "result_format": "SUMMARY",
     }
 
@@ -463,13 +471,21 @@ def test_alice_expect_column_values_to_not_match_regex_auto_yes_default_profiler
     assert not result.success
 
     expectation_config_kwargs: dict = result.expectation_config.kwargs
+
+    assert expectation_config_kwargs["regex"] in [
+        r"\d+",
+        r"-?\d+",
+        r"-?\d+(?:\.\d*)?",
+        r"[A-Za-z0-9\.,;:!?()\"'%\-]+",
+    ]
+
+    expectation_config_kwargs.pop("regex")
     assert expectation_config_kwargs == {
         "auto": True,
         "batch_id": "cf28d8229c247275c8cc0f41b4ceb62d",
         "column": "id",
         "include_config": True,
         "mostly": 1.0,
-        "regex": "-?\\d+",
         "result_format": "SUMMARY",
     }
 

--- a/tests/rule_based_profiler/parameter_builder/test_histogram_single_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_histogram_single_batch_parameter_builder.py
@@ -75,7 +75,7 @@ def test_histogram_single_batch_parameter_builder_alice(
         batch_request=batch_request,
     )
 
-    expected_parameter_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": {
             "bins": [397433.0, 4942918.5, 9488404.0],
             "weights": [0.6666666666666666, 0.3333333333333333],
@@ -99,7 +99,7 @@ def test_histogram_single_batch_parameter_builder_alice(
         parameters=parameters,
     )
 
-    assert parameter_node == expected_parameter_value
+    assert parameter_node == expected_parameter_node_as_dict
 
 
 @pytest.mark.integration
@@ -211,7 +211,7 @@ def test_histogram_single_batch_parameter_builder_alice_nan_valued_bins(
             batch_request=batch_request,
         )
 
-        expected_parameter_value: dict = {
+        expected_parameter_node_as_dict: dict = {
             "value": {"bins": [None], "weights": [], "tail_weights": [0.5, 0.5]},
             "details": {
                 "metric_configuration": {
@@ -231,7 +231,7 @@ def test_histogram_single_batch_parameter_builder_alice_nan_valued_bins(
             parameters=parameters,
         )
 
-        assert parameter_node == expected_parameter_value
+        assert parameter_node == expected_parameter_node_as_dict
 
 
 @pytest.mark.integration
@@ -350,7 +350,7 @@ def test_histogram_single_batch_parameter_builder_alice_reduced_bins_count(
 
     variables: Optional[ParameterContainer] = None
 
-    expected_parameter_value: dict
+    expected_parameter_node_as_dict: dict
     parameter_node: ParameterNode
 
     with mock.patch(
@@ -369,7 +369,7 @@ def test_histogram_single_batch_parameter_builder_alice_reduced_bins_count(
             batch_request=batch_request,
         )
 
-        expected_parameter_value = {
+        expected_parameter_node_as_dict = {
             "value": {"bins": bins, "weights": [], "tail_weights": [0.5, 0.5]},
             "details": {
                 "metric_configuration": {
@@ -391,7 +391,7 @@ def test_histogram_single_batch_parameter_builder_alice_reduced_bins_count(
             parameters=parameters,
         )
 
-        assert parameter_node == expected_parameter_value
+        assert parameter_node == expected_parameter_node_as_dict
 
 
 @pytest.mark.integration

--- a/tests/rule_based_profiler/parameter_builder/test_mean_table_columns_set_match_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_mean_table_columns_set_match_multi_batch_parameter_builder.py
@@ -74,7 +74,7 @@ def test_execution_mean_table_columns_set_match_multi_batch_parameter_builder(
         domain.id: parameter_container,
     }
 
-    expected_parameter_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": {
             "VendorID",
             "pickup_datetime",
@@ -116,10 +116,10 @@ def test_execution_mean_table_columns_set_match_multi_batch_parameter_builder(
     )
 
     assert len(parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY]) == len(
-        expected_parameter_value[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY]
+        expected_parameter_node_as_dict[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY]
     )
 
     parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY] = set(
         parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY]
     )
-    assert parameter_node == expected_parameter_value
+    assert parameter_node == expected_parameter_node_as_dict

--- a/tests/rule_based_profiler/parameter_builder/test_metric_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_metric_multi_batch_parameter_builder.py
@@ -35,7 +35,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_default(
 
     # Omitting "single_batch_mode" argument in order to exercise default (False) behavior.
     metric_multi_batch_parameter_builder = MetricMultiBatchParameterBuilder(
-        name="row_count_range",
+        name="row_count",
         metric_name="table.row_count",
         metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
         metric_value_kwargs=None,
@@ -71,8 +71,8 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_default(
     )
     assert len(parameter_nodes) == 1
 
-    fully_qualified_parameter_name_for_value: str = "$parameter.row_count_range"
-    expected_value_dict: Dict[str, Optional[str]] = {
+    fully_qualified_parameter_name: str = "$parameter.row_count"
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "attributed_value": None,
         "details": {
@@ -87,7 +87,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_default(
 
     parameter_node: ParameterNode = (
         get_parameter_value_by_fully_qualified_parameter_name(
-            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            fully_qualified_parameter_name=fully_qualified_parameter_name,
             domain=domain,
             parameters=parameters,
         )
@@ -96,7 +96,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_default(
     parameter_node["value"] = None
     parameter_node["attributed_value"] = None
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
 
 @pytest.mark.integration
@@ -115,7 +115,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_no(
     }
 
     metric_multi_batch_parameter_builder = MetricMultiBatchParameterBuilder(
-        name="row_count_range",
+        name="row_count",
         metric_name="table.row_count",
         metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
         metric_value_kwargs=None,
@@ -156,8 +156,8 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_no(
     )
     assert len(parameter_nodes) == 1
 
-    fully_qualified_parameter_name_for_value: str = "$parameter.row_count_range"
-    expected_value_dict: Dict[str, Optional[str]] = {
+    fully_qualified_parameter_name: str = "$parameter.row_count"
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "attributed_value": None,
         "details": {
@@ -172,7 +172,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_no(
 
     parameter_node: ParameterNode = (
         get_parameter_value_by_fully_qualified_parameter_name(
-            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            fully_qualified_parameter_name=fully_qualified_parameter_name,
             domain=domain,
             parameters=parameters,
         )
@@ -181,7 +181,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_no(
     parameter_node["value"] = None
     parameter_node["attributed_value"] = None
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
 
 @pytest.mark.integration
@@ -200,7 +200,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_yes(
     }
 
     metric_multi_batch_parameter_builder = MetricMultiBatchParameterBuilder(
-        name="row_count_range",
+        name="row_count",
         metric_name="table.row_count",
         metric_domain_kwargs=DOMAIN_KWARGS_PARAMETER_FULLY_QUALIFIED_NAME,
         metric_value_kwargs=None,
@@ -241,8 +241,8 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_yes(
     )
     assert len(parameter_nodes) == 1
 
-    fully_qualified_parameter_name_for_value: str = "$parameter.row_count_range"
-    expected_value_dict: Dict[str, Optional[str]] = {
+    fully_qualified_parameter_name: str = "$parameter.row_count"
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "attributed_value": None,
         "details": {
@@ -257,7 +257,7 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_yes(
 
     parameter_node: ParameterNode = (
         get_parameter_value_by_fully_qualified_parameter_name(
-            fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
+            fully_qualified_parameter_name=fully_qualified_parameter_name,
             domain=domain,
             parameters=parameters,
         )
@@ -266,4 +266,4 @@ def test_metric_multi_batch_parameter_builder_bobby_single_batch_yes(
     parameter_node["value"] = None
     parameter_node["attributed_value"] = None
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict

--- a/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_numeric_metric_range_multi_batch_parameter_builder.py
@@ -80,7 +80,7 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby(
     assert len(parameter_nodes) == 1
 
     fully_qualified_parameter_name_for_value: str = "$parameter.row_count_range"
-    expected_value_dict: Dict[str, Optional[str]] = {
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "details": {
             "metric_configuration": {
@@ -107,7 +107,7 @@ def test_bootstrap_numeric_metric_range_multi_batch_parameter_builder_bobby(
         "estimation_histogram"
     )
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
     expected_value: np.ndarray = np.asarray([7510, 8806])
 
@@ -210,7 +210,7 @@ def test_quantiles_numeric_metric_range_multi_batch_parameter_builder_bobby(
     )
     assert len(parameter_nodes) == 1
 
-    expected_value_dict: Dict[str, Optional[str]] = {
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "details": {
             "metric_configuration": {
@@ -237,7 +237,7 @@ def test_quantiles_numeric_metric_range_multi_batch_parameter_builder_bobby(
         "estimation_histogram"
     )
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
     actual_value_01_lower: float = actual_values_01[0]
     actual_value_01_upper: float = actual_values_01[1]
@@ -309,7 +309,7 @@ def test_quantiles_numeric_metric_range_multi_batch_parameter_builder_bobby(
         "estimation_histogram"
     )
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
     actual_value_05_lower: float = actual_values_05[0]
     actual_value_05_upper: float = actual_values_05[1]
@@ -407,7 +407,7 @@ def test_exact_numeric_metric_range_multi_batch_parameter_builder_bobby(
     )
     assert len(parameter_nodes) == 1
 
-    expected_value_dict: Dict[str, Optional[str]] = {
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "details": {
             "metric_configuration": {
@@ -434,7 +434,7 @@ def test_exact_numeric_metric_range_multi_batch_parameter_builder_bobby(
         "estimation_histogram"
     )
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
     actual_value_01_lower: float = actual_values_01[0]
     actual_value_01_upper: float = actual_values_01[1]
@@ -543,7 +543,7 @@ def test_quantiles_numeric_metric_range_multi_batch_parameter_builder_with_evalu
     )
     assert len(parameter_nodes) == 1
 
-    expected_value_dict: Dict[str, Optional[str]] = {
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "details": {
             "metric_configuration": {
@@ -570,7 +570,7 @@ def test_quantiles_numeric_metric_range_multi_batch_parameter_builder_with_evalu
         "estimation_histogram"
     )
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
     actual_value_01_lower: float = actual_values_01[0]
     actual_value_01_upper: float = actual_values_01[1]
@@ -642,7 +642,7 @@ def test_quantiles_numeric_metric_range_multi_batch_parameter_builder_with_evalu
         "estimation_histogram"
     )
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
     actual_value_05_lower: float = actual_values_05[0]
     actual_value_05_upper: float = actual_values_05[1]
@@ -977,7 +977,7 @@ def test_kde_numeric_metric_range_multi_batch_parameter_builder_bobby(
     assert len(parameter_nodes) == 1
 
     fully_qualified_parameter_name_for_value: str = "$parameter.row_count_range"
-    expected_value_dict: Dict[str, Optional[str]] = {
+    expected_parameter_node_as_dict: dict = {
         "value": None,
         "details": {
             "metric_configuration": {
@@ -1004,7 +1004,7 @@ def test_kde_numeric_metric_range_multi_batch_parameter_builder_bobby(
         "estimation_histogram"
     )
 
-    assert parameter_node == expected_value_dict
+    assert parameter_node == expected_parameter_node_as_dict
 
     expected_value: np.ndarray = np.asarray([6180, 10277])
 

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -167,7 +167,7 @@ def test_regex_pattern_string_parameter_builder_alice(
     fully_qualified_parameter_name_for_value: str = (
         "$parameter.my_regex_pattern_string_parameter_builder"
     )
-    expected_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": r"^\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$",
         "details": {
             "evaluated_regexes": {
@@ -185,7 +185,7 @@ def test_regex_pattern_string_parameter_builder_alice(
             domain=domain,
             parameters=parameters,
         )
-        == expected_value
+        == expected_parameter_node_as_dict
     )
 
 
@@ -248,7 +248,7 @@ def test_regex_pattern_string_parameter_builder_bobby_multiple_matches(
     fully_qualified_parameter_name_for_value: str = (
         "$parameter.my_regex_pattern_string_parameter_builder"
     )
-    expected_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": r"^\d{1}$",
         "details": {
             "evaluated_regexes": {
@@ -266,8 +266,8 @@ def test_regex_pattern_string_parameter_builder_bobby_multiple_matches(
         parameters=parameters,
     )
     assert results is not None
-    assert sorted(results["value"]) == sorted(expected_value["value"])
-    assert results["details"] == expected_value["details"]
+    assert sorted(results["value"]) == sorted(expected_parameter_node_as_dict["value"])
+    assert results["details"] == expected_parameter_node_as_dict["details"]
 
 
 @pytest.mark.integration
@@ -320,7 +320,7 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
     fully_qualified_parameter_name_for_value: str = (
         "$parameter.my_regex_pattern_string_parameter_builder"
     )
-    expected_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": "-?\\d+",
         "details": {
             "evaluated_regexes": {
@@ -345,7 +345,7 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
             domain=domain,
             parameters=parameters,
         )
-        == expected_value
+        == expected_parameter_node_as_dict
     )
 
 

--- a/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_regex_pattern_string_parameter_builder.py
@@ -24,7 +24,10 @@ from great_expectations.rule_based_profiler.parameter_builder import (
     RegexPatternStringParameterBuilder,
 )
 from great_expectations.rule_based_profiler.parameter_container import (
+    FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY,
+    FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY,
     ParameterContainer,
+    ParameterNode,
     get_parameter_value_by_fully_qualified_parameter_name,
 )
 from great_expectations.validator.validator import Validator
@@ -339,13 +342,31 @@ def test_regex_pattern_string_parameter_builder_bobby_no_match(
         },
     }
 
-    assert (
+    parameter_node: ParameterNode = (
         get_parameter_value_by_fully_qualified_parameter_name(
             fully_qualified_parameter_name=fully_qualified_parameter_name_for_value,
             domain=domain,
             parameters=parameters,
         )
-        == expected_parameter_node_as_dict
+    )
+
+    assert parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY] in [
+        r"\d+",
+        r"-?\d+",
+        r"-?\d+(?:\.\d*)?",
+        r"[A-Za-z0-9\.,;:!?()\"'%\-]+",
+    ]
+    assert (
+        parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY].items()
+        == expected_parameter_node_as_dict[
+            FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY
+        ].items()
+    )
+    assert (
+        parameter_node[FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY].success_ratio
+        == expected_parameter_node_as_dict[FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY][
+            "success_ratio"
+        ]
     )
 
 

--- a/tests/rule_based_profiler/parameter_builder/test_simple_date_format_string_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_simple_date_format_string_parameter_builder.py
@@ -123,7 +123,7 @@ def test_simple_date_format_parameter_builder_alice(
     assert len(parameter_container.parameter_nodes) == 1
 
     fully_qualified_parameter_name_for_value: str = "$parameter.my_date_format"
-    expected_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": "%Y-%m-%d %H:%M:%S",
         "details": {
             "success_ratio": 1.0,
@@ -198,7 +198,7 @@ def test_simple_date_format_parameter_builder_alice(
         parameters=parameters,
     )
 
-    assert parameter_node == expected_value
+    assert parameter_node == expected_parameter_node_as_dict
 
 
 @pytest.mark.integration

--- a/tests/rule_based_profiler/parameter_builder/test_value_counts_single_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_value_counts_single_batch_parameter_builder.py
@@ -71,7 +71,7 @@ def test_value_counts_single_batch_parameter_builder_alice(
         batch_request=batch_request,
     )
 
-    expected_parameter_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": {
             "values": [19, 22, 73],
             "weights": [0.3333333333333333, 0.3333333333333333, 0.3333333333333333],
@@ -94,4 +94,4 @@ def test_value_counts_single_batch_parameter_builder_alice(
         parameters=parameters,
     )
 
-    assert parameter_node == expected_parameter_value
+    assert parameter_node == expected_parameter_node_as_dict

--- a/tests/rule_based_profiler/parameter_builder/test_value_set_multi_batch_parameter_builder.py
+++ b/tests/rule_based_profiler/parameter_builder/test_value_set_multi_batch_parameter_builder.py
@@ -101,7 +101,7 @@ def test_value_set_multi_batch_parameter_builder_alice_single_batch_numeric(
     )
 
     expected_value_set: List[int] = [19, 22, 73]
-    expected_parameter_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": expected_value_set,
         "details": {
             "parse_strings_as_datetimes": False,
@@ -123,8 +123,8 @@ def test_value_set_multi_batch_parameter_builder_alice_single_batch_numeric(
         parameters=parameters,
     )
 
-    assert sorted(parameter_node.value) == expected_parameter_value["value"]
-    assert parameter_node.details == expected_parameter_value["details"]
+    assert sorted(parameter_node.value) == expected_parameter_node_as_dict["value"]
+    assert parameter_node.details == expected_parameter_node_as_dict["details"]
 
 
 @pytest.mark.integration
@@ -181,7 +181,7 @@ def test_value_set_multi_batch_parameter_builder_alice_single_batch_string(
     expected_value_set: List[str] = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",
     ]
-    expected_parameter_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": expected_value_set,
         "details": {
             "parse_strings_as_datetimes": False,
@@ -203,8 +203,8 @@ def test_value_set_multi_batch_parameter_builder_alice_single_batch_string(
         parameters=parameters,
     )
 
-    assert sorted(parameter_node.value) == expected_parameter_value["value"]
-    assert parameter_node.details == expected_parameter_value["details"]
+    assert sorted(parameter_node.value) == expected_parameter_node_as_dict["value"]
+    assert parameter_node.details == expected_parameter_node_as_dict["details"]
 
 
 @pytest.mark.integration
@@ -257,7 +257,7 @@ def test_value_set_multi_batch_parameter_builder_bobby_numeric(
     )
 
     expected_value_set: List[int] = [0, 1, 2, 3, 4, 5, 6]
-    expected_parameter_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": expected_value_set,
         "details": {
             "parse_strings_as_datetimes": False,
@@ -281,8 +281,8 @@ def test_value_set_multi_batch_parameter_builder_bobby_numeric(
         parameters=parameters,
     )
 
-    assert sorted(parameter_node.value) == expected_parameter_value["value"]
-    assert parameter_node.details == expected_parameter_value["details"]
+    assert sorted(parameter_node.value) == expected_parameter_node_as_dict["value"]
+    assert parameter_node.details == expected_parameter_node_as_dict["details"]
 
 
 @pytest.mark.integration
@@ -335,7 +335,7 @@ def test_value_set_multi_batch_parameter_builder_bobby_string(
     )
 
     expected_value_set: List[str] = ["N", "Y"]
-    expected_parameter_value: dict = {
+    expected_parameter_node_as_dict: dict = {
         "value": expected_value_set,
         "details": {
             "parse_strings_as_datetimes": False,
@@ -359,8 +359,8 @@ def test_value_set_multi_batch_parameter_builder_bobby_string(
         parameters=parameters,
     )
 
-    assert sorted(parameter_node.value) == expected_parameter_value["value"]
-    assert parameter_node.details == expected_parameter_value["details"]
+    assert sorted(parameter_node.value) == expected_parameter_node_as_dict["value"]
+    assert parameter_node.details == expected_parameter_node_as_dict["details"]
 
 
 @pytest.mark.parametrize(

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -300,8 +300,8 @@ def test_resolve_validation_graph_with_bad_config_catch_exceptions_true():
             """
             This stub method implementation insures that specified "MetricConfiguration", designed to fail, will cause
             appropriate exception to be raised, while its dependencies resolve to actual values ("my_value" is used here
-            as placeholder).  This makes "ValidationGraph.resolve_validation_graph()" -- method under test -- evaluate
-            every "MetricConfiguration" of parsed "ValidationGraph" successfully, except "failed" "MetricConfiguration".
+            as placeholder).  This makes "ValidationGraph.resolve()" -- method under test -- evaluate every
+            "MetricConfiguration" of parsed "ValidationGraph" successfully, except "failed" "MetricConfiguration".
             """
             metric_configuration: MetricConfiguration
             if failed_metric_configuration.id in [
@@ -337,7 +337,7 @@ def test_resolve_validation_graph_with_bad_config_catch_exceptions_true():
         Tuple[str, str, str],
         Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
     ]
-    resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
+    resolved_metrics, aborted_metrics_info = graph.resolve(
         runtime_configuration=runtime_configuration,
         min_graph_edges_pbar_enable=0,
         show_progress_bars=True,
@@ -377,7 +377,7 @@ def test_progress_bar_config(
 ):
     """
     This test creates mocked environment for progress bar tests; it then executes the method under test that utilizes
-    the progress bar, "ValidationGraph.resolve_validation_graph()", with composed arguments, and verifies result.
+    the progress bar, "ValidationGraph.resolve()", with composed arguments, and verifies result.
     """
 
     class DummyMetricConfiguration:
@@ -424,9 +424,7 @@ def test_progress_bar_config(
             Dict[str, Union[MetricConfiguration, Set[ExceptionInfo], int]],
         ]
         # noinspection PyUnusedLocal
-        resolved_metrics, aborted_metrics_info = graph.resolve_validation_graph(
-            **call_args
-        )
+        resolved_metrics, aborted_metrics_info = graph.resolve(**call_args)
         assert mock_tqdm.called is True
         assert mock_tqdm.call_args[1]["disable"] is are_progress_bars_disabled
 


### PR DESCRIPTION
### Scope
* Modify names of variables in `ParameterBuilder` test modules to better communicate their meanings.
* Refactor `MetricCalculator.compute_metrics()`, `Validator.graph_validate()`, and `ParameterBuilder.get_metrics()` for better separability of `ValidationGraph` construction, graph resolution, and error reporting. 
* Remove unnecessary `MetricConfiguration` sorting from `ParameterBuilder.get_metrics()` (this is done later by `AttributedResolvedMetrics` anyway).
* Make `ParameterBuilder.get_batch_ids()` use the “latest” `Batch` more reliably.
* Update tests of `RegexPatternStringParameterBuilder` to properly reflect all results that can get a 1.0 score.
* Fix type hints in several modules.
* Add return types and docstrings for several methods.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1347/GREAT-181/GREAT-1414
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!