### PR TITLE
[BUGFIX] Patch issue with call to `ExpectationAnonymizer` to ensure `DataContext` init events are captured

### DIFF
--- a/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/anonymizer.py
@@ -202,7 +202,7 @@ class Anonymizer(BaseAnonymizer):
 
         anonymized_values: List[dict] = []
         for suite in payload:
-            anonymize_value: dict = anonymizer.anonymize(expectation_suite=suite)
+            anonymize_value: dict = anonymizer.anonymize(obj=suite)
             anonymized_values.append(anonymize_value)
 
         return anonymized_values

--- a/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
@@ -16,9 +16,6 @@ class ExpectationSuiteAnonymizer(BaseAnonymizer):
     def anonymize(
         self, obj: Optional["ExpectationSuite"] = None, **kwargs  # noqa: F821
     ) -> dict:
-        if obj is None:
-            raise ValueError("Cannot anonymize a null payload")
-
         expectation_suite = obj
         anonymized_info_dict = {}
         anonymized_expectation_counts = list()

--- a/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
@@ -16,6 +16,9 @@ class ExpectationSuiteAnonymizer(BaseAnonymizer):
     def anonymize(
         self, obj: Optional["ExpectationSuite"] = None, **kwargs  # noqa: F821
     ) -> dict:
+        if obj is None:
+            raise ValueError("Cannot anonymize a null payload")
+
         expectation_suite = obj
         anonymized_info_dict = {}
         anonymized_expectation_counts = list()


### PR DESCRIPTION
Changes proposed in this pull request:
- The `anonymize` method of `ExpectationAnonymizer` explicitly references an `obj` arg (as well as `**kwargs`)
    - While downstream logic relies on `obj`, we currently have a call that passes in the suite as a kwarg
    - This results in the method blowing up, causing the payload to become malformed.
- This patch resolves an issue that has been present since `0.14.13`

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
