### PR TITLE
[BUGFIX] Add additional error checking to `ExpectationAnonymizer`

### DIFF
--- a/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
@@ -16,14 +16,19 @@ class ExpectationSuiteAnonymizer(BaseAnonymizer):
     def anonymize(
         self, obj: Optional["ExpectationSuite"] = None, **kwargs  # noqa: F821
     ) -> dict:
+        # Exit early if null
         expectation_suite = obj
-        if not expectation_suite:
+        if expectation_suite is None:
+            return {}
+
+        # Exit early if no expectations to anonymize
+        expectations = expectation_suite.expectations
+        if expectations is None:
             return {}
 
         anonymized_info_dict = {}
         anonymized_expectation_counts = list()
 
-        expectations = expectation_suite.expectations
         expectation_types = [
             expectation.expectation_type for expectation in expectations
         ]

--- a/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
@@ -18,12 +18,12 @@ class ExpectationSuiteAnonymizer(BaseAnonymizer):
     ) -> dict:
         # Exit early if null
         expectation_suite = obj
-        if expectation_suite is None:
+        if not expectation_suite:
             return {}
 
         # Exit early if no expectations to anonymize
         expectations = expectation_suite.expectations
-        if expectations is None:
+        if not expectations:
             return {}
 
         anonymized_info_dict = {}

--- a/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
+++ b/great_expectations/core/usage_statistics/anonymizers/expectation_anonymizer.py
@@ -17,6 +17,9 @@ class ExpectationSuiteAnonymizer(BaseAnonymizer):
         self, obj: Optional["ExpectationSuite"] = None, **kwargs  # noqa: F821
     ) -> dict:
         expectation_suite = obj
+        if not expectation_suite:
+            return {}
+
         anonymized_info_dict = {}
         anonymized_expectation_counts = list()
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Since the `ExpectationAnonymizer`'s `anonymize` method depends on a non-null object, we should add a check and exit early if faced with a null value.

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
