### PR TITLE
[BUGFIX] Contrib Expectation tracebacks

### DIFF
--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/profile_numeric_columns_diff_expectation.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/profile_numeric_columns_diff_expectation.py
@@ -31,18 +31,19 @@ class ProfileNumericColumnsDiffExpectation(TableExpectation):
         ), "ProfileNumericColumnsDiffExpectation must be configured using profile_metric, and cannot have metric_dependencies declared."
         # convenient name for updates
 
-        metric_dependencies = dependencies["metrics"]
-
         metric_kwargs = get_metric_kwargs(
             metric_name=f"{self.profile_metric}",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
 
-        metric_dependencies[f"{self.profile_metric}"] = MetricConfiguration(
-            f"{self.profile_metric}",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+        dependencies.set_metric_configuration(
+            metric_name=f"{self.profile_metric}",
+            metric_configuration=MetricConfiguration(
+                metric_name=f"{self.profile_metric}",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         return dependencies

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_in_set_spark_optimized.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_in_set_spark_optimized.py
@@ -8,10 +8,7 @@ from great_expectations.exceptions import InvalidExpectationConfigurationError
 from great_expectations.exceptions.exceptions import MetricResolutionError
 from great_expectations.execution_engine import ExecutionEngine, SparkDFExecutionEngine
 from great_expectations.expectations.expectation import ColumnExpectation
-from great_expectations.expectations.metrics import (
-    ColumnAggregateMetricProvider,
-    metric_value,
-)
+from great_expectations.expectations.metrics import ColumnAggregateMetricProvider
 from great_expectations.expectations.metrics.import_manager import F, sparktypes
 from great_expectations.expectations.metrics.map_metric_provider import (
     ColumnMapMetricProvider,
@@ -20,6 +17,7 @@ from great_expectations.expectations.metrics.map_metric_provider import (
     column_condition_partial,
     metric_partial,
 )
+from great_expectations.expectations.metrics.metric_provider import metric_value
 
 
 # This class defines a Metric to support your Expectation.

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
@@ -242,12 +242,13 @@ class ExpectColumnValuesToBeStringIntegersIncreasing(ColumnExpectation):
             runtime_configuration=runtime_configuration,
         )
 
-        dependencies["metrics"][
-            "column_values.string_integers.increasing.map"
-        ] = MetricConfiguration(
+        dependencies.set_metric_configuration(
             metric_name="column_values.string_integers.increasing.map",
-            metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
-            metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            metric_configuration=MetricConfiguration(
+                metric_name="column_values.string_integers.increasing.map",
+                metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
+                metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
+            ),
         )
 
         return dependencies

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
@@ -22,9 +22,9 @@ from great_expectations.expectations.expectation import ColumnExpectation
 from great_expectations.expectations.metrics import (
     ColumnMapMetricProvider,
     column_function_partial,
-    metric_partial,
 )
 from great_expectations.expectations.metrics.import_manager import F, Window, sparktypes
+from great_expectations.expectations.metrics.metric_provider import metric_partial
 from great_expectations.expectations.registry import get_metric_kwargs
 from great_expectations.validator.metric_configuration import MetricConfiguration
 

--- a/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_binary_label_model_bias.py
+++ b/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_binary_label_model_bias.py
@@ -15,8 +15,11 @@ from great_expectations.expectations.expectation import (
     ExpectationConfiguration,
     TableExpectation,
 )
-from great_expectations.expectations.metrics import MetricDomainTypes, metric_value
-from great_expectations.expectations.metrics.metric_provider import MetricConfiguration
+from great_expectations.expectations.metrics.metric_provider import (
+    MetricConfiguration,
+    MetricDomainTypes,
+    metric_value,
+)
 from great_expectations.expectations.metrics.table_metric_provider import (
     TableMetricProvider,
 )

--- a/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
+++ b/contrib/great_expectations_ethical_ai_expectations/great_expectations_ethical_ai_expectations/expectations/expect_table_linear_feature_importances_to_be.py
@@ -16,8 +16,11 @@ from great_expectations.expectations.expectation import (
     ExpectationConfiguration,
     TableExpectation,
 )
-from great_expectations.expectations.metrics import MetricDomainTypes, metric_value
-from great_expectations.expectations.metrics.metric_provider import MetricConfiguration
+from great_expectations.expectations.metrics.metric_provider import (
+    MetricConfiguration,
+    MetricDomainTypes,
+    metric_value,
+)
 from great_expectations.expectations.metrics.table_metric_provider import (
     TableMetricProvider,
 )

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_mic.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_mic.py
@@ -33,7 +33,7 @@ def is_valid_mic(mic_code: str, df) -> bool:
 class ColumnValuesToBeValidMic(ColumnMapMetricProvider):
 
     url = "https://www.iso20022.org/sites/default/files/ISO10383_MIC/ISO10383_MIC.csv"
-    df = pd.read_csv(url)
+    df = pd.read_csv(url, encoding="cp1250")
 
     # This is the id string that will be used to reference your metric.
     condition_metric_name = "column_values.valid_mic"

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_mic_match_country_code.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_mic_match_country_code.py
@@ -41,7 +41,7 @@ class ColumnValuesToBeValidMicMatchCountryCode(ColumnMapMetricProvider):
     condition_value_keys = ("country_code",)
 
     url = "https://www.iso20022.org/sites/default/files/ISO10383_MIC/ISO10383_MIC.csv"
-    df = pd.read_csv(url)
+    df = pd.read_csv(url, encoding="cp1250")
 
     # This method implements the core logic for the PandasExecutionEngine
     @column_condition_partial(engine=PandasExecutionEngine)


### PR DESCRIPTION
The build_galllery pipeline has not successfully run since some contrib Expectations starting throwing tracebacks during the build process. This fixes them.

Changes proposed in this pull request:
- Specify the file encoding for the MIC csv file for pd.read_csv
- Fix TypeError: 'ValidationDependencies' object is not subscriptable
- Fix ImportError: cannot import name '...' from 'great_expectations.expectations.metrics'