### PR TITLE
Add pretty representations for zep pydantic models

### DIFF
--- a/great_expectations/experimental/datasources/experimental_base_model.py
+++ b/great_expectations/experimental/datasources/experimental_base_model.py
@@ -68,7 +68,7 @@ class ExperimentalBaseModel(pydantic.BaseModel):
     def __str__(self):
         return self.yaml()
 
-    ##### Workaround for https://github.com/pydantic/pydantic/issues/935 ####
+    # Workaround for https://github.com/pydantic/pydantic/issues/935
     #
     # Currently there is no way to output properties using pydantics builtin in json and dict
     # methods. Our current fix does let one use the exclude/include arguments on properties,
@@ -78,22 +78,24 @@ class ExperimentalBaseModel(pydantic.BaseModel):
     # https://github.com/pydantic/pydantic/issues/935#issuecomment-554378904
 
     @classmethod
-    def get_properties(cls) -> List[str]:
+    def _get_properties(cls) -> List[str]:
         return [
             prop for prop in cls.__dict__ if isinstance(cls.__dict__[prop], property)
         ]
 
     def json(self, **kwargs) -> str:
+        """The json representation of the Model."""
         self.__dict__.update(
-            {prop: getattr(self, prop) for prop in self.get_properties()}
+            {prop: getattr(self, prop) for prop in self._get_properties()}
         )
         attribs = super().json(**kwargs)
         return attribs
 
-    def dict(self, **kwargs) -> "DictStrAny":
+    def dict(self, **kwargs) -> DictStrAny:
+        """The dict representation of the Model."""
         self.__dict__.update(
-            {prop: getattr(self, prop) for prop in self.get_properties()}
+            {prop: getattr(self, prop) for prop in self._get_properties()}
         )
         return super().dict(**kwargs)
 
-    ##### End Workaround #####
+    # End Workaround

--- a/great_expectations/experimental/datasources/experimental_base_model.py
+++ b/great_expectations/experimental/datasources/experimental_base_model.py
@@ -5,10 +5,13 @@ import logging
 import pathlib
 from io import StringIO
 from pprint import pformat as pf
-from typing import Type, TypeVar, Union, overload
+from typing import TYPE_CHECKING, List, Type, TypeVar, Union, overload
 
 import pydantic
 from ruamel.yaml import YAML
+
+if TYPE_CHECKING:
+    from pydantic.typing import DictStrAny
 
 LOGGER = logging.getLogger(__name__)
 
@@ -61,3 +64,36 @@ class ExperimentalBaseModel(pydantic.BaseModel):
         if isinstance(stream_or_path, pathlib.Path):
             return stream_or_path
         return stream_or_path.getvalue()
+
+    def __str__(self):
+        return self.yaml()
+
+    ##### Workaround for https://github.com/pydantic/pydantic/issues/935 ####
+    #
+    # Currently there is no way to output properties using pydantics builtin in json and dict
+    # methods. Our current fix does let one use the exclude/include arguments on properties,
+    # we always include them. We could fix this by changing the json and dict signatures
+    # to `def dict(self, *, include, exclude, **kwargs)` and add the implementation.
+    # See this comment for one way to do this:
+    # https://github.com/pydantic/pydantic/issues/935#issuecomment-554378904
+
+    @classmethod
+    def get_properties(cls) -> List[str]:
+        return [
+            prop for prop in cls.__dict__ if isinstance(cls.__dict__[prop], property)
+        ]
+
+    def json(self, **kwargs) -> str:
+        self.__dict__.update(
+            {prop: getattr(self, prop) for prop in self.get_properties()}
+        )
+        attribs = super().json(**kwargs)
+        return attribs
+
+    def dict(self, **kwargs) -> "DictStrAny":
+        self.__dict__.update(
+            {prop: getattr(self, prop) for prop in self.get_properties()}
+        )
+        return super().dict(**kwargs)
+
+    ##### End Workaround #####

--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -35,8 +35,8 @@ class BatchRequestError(Exception):
 
 # For our year splitter we default the range to the last 2 year.
 _CURRENT_YEAR = datetime.now(dateutil.tz.tzutc()).year
-_DEFAULT_YEAR_RANGE = range(_CURRENT_YEAR - 1, _CURRENT_YEAR + 1)
-_DEFAULT_MONTH_RANGE = range(1, 13)
+_DEFAULT_YEAR_RANGE = list(range(_CURRENT_YEAR - 1, _CURRENT_YEAR + 1))
+_DEFAULT_MONTH_RANGE = list(range(1, 13))
 
 
 @pydantic_dc.dataclass(frozen=True)

--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -5,7 +5,7 @@ import dataclasses
 import itertools
 from datetime import datetime
 from pprint import pformat as pf
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union, cast
 
 import dateutil.tz
 import pydantic

--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -45,11 +45,7 @@ class ColumnSplitter:
     column_name: str
     # param_defaults is a Dict where the keys are the parameters of the splitter and the values are the default
     # values are the default values if a batch request using the splitter leaves the parameter unspecified.
-    # template_params: List[str]
-    # Union of List/Iterable for serialization
-    param_defaults: Dict[str, Union[List, Iterable]] = pydantic.Field(
-        default_factory=dict
-    )
+    param_defaults: Dict[str, List] = pydantic.Field(default_factory=dict)
 
     @property
     def param_names(self) -> List[str]:
@@ -185,8 +181,8 @@ class TableAsset(DataAsset):
     def add_year_and_month_splitter(
         self,
         column_name: str,
-        default_year_range: Iterable[int] = _DEFAULT_YEAR_RANGE,
-        default_month_range: Iterable[int] = _DEFAULT_MONTH_RANGE,
+        default_year_range: List[int] = _DEFAULT_YEAR_RANGE,
+        default_month_range: List[int] = _DEFAULT_MONTH_RANGE,
     ) -> TableAsset:
         """Associates a year month splitter with this DataAsset
 

--- a/tests/experimental/datasources/test_postgres_datasource.py
+++ b/tests/experimental/datasources/test_postgres_datasource.py
@@ -136,7 +136,7 @@ def test_construct_table_asset_directly_with_splitter(create_source):
         splitter = ColumnSplitter(
             method_name="splitter_method",
             column_name="col",
-            param_defaults={"a": [1, 2, 3], "b": range(1, 13)},
+            param_defaults={"a": [1, 2, 3], "b": list(range(1, 13))},
         )
         asset = TableAsset(
             name="my_asset",
@@ -406,25 +406,49 @@ def test_get_bad_batch_request(create_source):
         (["+year", "+month"], [_DEFAULT_YEAR_RANGE, _DEFAULT_MONTH_RANGE]),
         (["+year", "month"], [_DEFAULT_YEAR_RANGE, _DEFAULT_MONTH_RANGE]),
         (["year", "+month"], [_DEFAULT_YEAR_RANGE, _DEFAULT_MONTH_RANGE]),
-        (["+year", "-month"], [_DEFAULT_YEAR_RANGE, reversed(_DEFAULT_MONTH_RANGE)]),
-        (["year", "-month"], [_DEFAULT_YEAR_RANGE, reversed(_DEFAULT_MONTH_RANGE)]),
-        (["-year", "month"], [reversed(_DEFAULT_YEAR_RANGE), _DEFAULT_MONTH_RANGE]),
-        (["-year", "+month"], [reversed(_DEFAULT_YEAR_RANGE), _DEFAULT_MONTH_RANGE]),
+        (
+            ["+year", "-month"],
+            [_DEFAULT_YEAR_RANGE, list(reversed(_DEFAULT_MONTH_RANGE))],
+        ),
+        (
+            ["year", "-month"],
+            [_DEFAULT_YEAR_RANGE, list(reversed(_DEFAULT_MONTH_RANGE))],
+        ),
+        (
+            ["-year", "month"],
+            [list(reversed(_DEFAULT_YEAR_RANGE)), _DEFAULT_MONTH_RANGE],
+        ),
+        (
+            ["-year", "+month"],
+            [list(reversed(_DEFAULT_YEAR_RANGE)), _DEFAULT_MONTH_RANGE],
+        ),
         (
             ["-year", "-month"],
-            [reversed(_DEFAULT_YEAR_RANGE), reversed(_DEFAULT_MONTH_RANGE)],
+            [list(reversed(_DEFAULT_YEAR_RANGE)), list(reversed(_DEFAULT_MONTH_RANGE))],
         ),
         (["month", "year"], [_DEFAULT_MONTH_RANGE, _DEFAULT_YEAR_RANGE]),
         (["+month", "+year"], [_DEFAULT_MONTH_RANGE, _DEFAULT_YEAR_RANGE]),
         (["month", "+year"], [_DEFAULT_MONTH_RANGE, _DEFAULT_YEAR_RANGE]),
         (["+month", "year"], [_DEFAULT_MONTH_RANGE, _DEFAULT_YEAR_RANGE]),
-        (["-month", "+year"], [reversed(_DEFAULT_MONTH_RANGE), _DEFAULT_YEAR_RANGE]),
-        (["-month", "year"], [reversed(_DEFAULT_MONTH_RANGE), _DEFAULT_YEAR_RANGE]),
-        (["month", "-year"], [_DEFAULT_MONTH_RANGE, reversed(_DEFAULT_YEAR_RANGE)]),
-        (["+month", "-year"], [_DEFAULT_MONTH_RANGE, reversed(_DEFAULT_YEAR_RANGE)]),
+        (
+            ["-month", "+year"],
+            [list(reversed(_DEFAULT_MONTH_RANGE)), _DEFAULT_YEAR_RANGE],
+        ),
+        (
+            ["-month", "year"],
+            [list(reversed(_DEFAULT_MONTH_RANGE)), _DEFAULT_YEAR_RANGE],
+        ),
+        (
+            ["month", "-year"],
+            [_DEFAULT_MONTH_RANGE, list(reversed(_DEFAULT_YEAR_RANGE))],
+        ),
+        (
+            ["+month", "-year"],
+            [_DEFAULT_MONTH_RANGE, list(reversed(_DEFAULT_YEAR_RANGE))],
+        ),
         (
             ["-month", "-year"],
-            [reversed(_DEFAULT_MONTH_RANGE), reversed(_DEFAULT_YEAR_RANGE)],
+            [list(reversed(_DEFAULT_MONTH_RANGE)), list(reversed(_DEFAULT_YEAR_RANGE))],
         ),
     ],
 )
@@ -444,9 +468,7 @@ def test_sort_batch_list_by_metadata(sort_info, create_source):
         key0 = sort_keys[0].lstrip("+-")
         key1 = sort_keys[1].lstrip("+-")
         for value0 in sort_values[0]:
-            for value1 in copy(sort_values[1]):
-                # We copy(sort_values[1]) because otherwise we'd exhaust this
-                # inner iterator on the first pass of the outer loop.
+            for value1 in sort_values[1]:
                 expected_order.append({key0: value0, key1: value1})
         assert len(batches) == len(expected_order)
         for i, batch in enumerate(batches):
@@ -454,6 +476,7 @@ def test_sort_batch_list_by_metadata(sort_info, create_source):
             assert batch.metadata["month"] == expected_order[i]["month"]
 
 
+@pytest.mark.unit
 def test_sort_batch_list_by_unknown_key(create_source):
     with create_source(lambda _: None) as source:
         asset = source.add_table_asset(name="my_asset", table_name="my_table")
@@ -469,6 +492,7 @@ def test_sort_batch_list_by_unknown_key(create_source):
             source.get_batch_list_from_batch_request(batch_request)
 
 
+@pytest.mark.unit
 def test_data_source_json_has_properties(create_source):
     with create_source(lambda _: None) as source:
         assert (
@@ -484,6 +508,7 @@ def test_data_source_json_has_properties(create_source):
         assert '"order_by": ' in source_json
 
 
+@pytest.mark.unit
 def test_data_source_str_has_properties(create_source):
     with create_source(lambda _: None) as source:
         assert (
@@ -499,6 +524,7 @@ def test_data_source_str_has_properties(create_source):
         assert "order_by:" in source_str
 
 
+@pytest.mark.unit
 def test_datasource_dict_has_properties(create_source):
     with create_source(lambda _: None) as source:
         assert (

--- a/tests/experimental/datasources/test_postgres_datasource.py
+++ b/tests/experimental/datasources/test_postgres_datasource.py
@@ -467,3 +467,48 @@ def test_sort_batch_list_by_unknown_key(create_source):
         )
         with pytest.raises(KeyError):
             source.get_batch_list_from_batch_request(batch_request)
+
+
+def test_data_source_json_has_properties(create_source):
+    with create_source(lambda _: None) as source:
+        assert (
+            type(TableAsset.order_by) == property,
+            "This test assumes TableAsset.order_by is a property. If it is not we "
+            "should update this test",
+        )
+        asset = source.add_table_asset(name="my_asset", table_name="my_table")
+        asset.add_year_and_month_splitter(column_name="my_col").add_sorters(
+            ["year", "month"]
+        )
+        source_json = source.json()
+        assert '"order_by": ' in source_json
+
+
+def test_data_source_str_has_properties(create_source):
+    with create_source(lambda _: None) as source:
+        assert (
+            type(TableAsset.order_by) == property,
+            "This test assumes TableAsset.order_by is a property. If it is not we "
+            "should update this test",
+        )
+        asset = source.add_table_asset(name="my_asset", table_name="my_table")
+        asset.add_year_and_month_splitter(column_name="my_col").add_sorters(
+            ["year", "month"]
+        )
+        source_str = source.__str__()
+        assert "order_by:" in source_str
+
+
+def test_datasource_dict_has_properties(create_source):
+    with create_source(lambda _: None) as source:
+        assert (
+            type(TableAsset.order_by) == property,
+            "This test assumes TableAsset.order_by is a property. If it is not we "
+            "should update this test",
+        )
+        asset = source.add_table_asset(name="my_asset", table_name="my_table")
+        asset.add_year_and_month_splitter(column_name="my_col").add_sorters(
+            ["year", "month"]
+        )
+        source_dict = source.dict()
+        assert type(source_dict["assets"]["my_asset"]["order_by"]) == list


### PR DESCRIPTION
This allows one to do `datasource.yaml` to get a yaml string, `datasource.json` to get a json string, `print(datasource)` to get the yaml string, and `datasource.dict()` to get a dictionary representation.

Since some attributes are private and made available via properties, I hit this [pydantic issue](https://github.com/pydantic/pydantic/issues/935). I use a workaround found in that ticket.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
