### PR TITLE
[BUGFIX] Support slack channel name with webhook also

### DIFF
--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -35,7 +35,7 @@ def send_slack_notification(
     url = slack_webhook
     query = query
     headers = None
-    
+
     # Slack doc about overwritting the channel when using the legacy Incoming Webhooks
     # https://api.slack.com/legacy/custom-integrations/messaging/webhooks
     # ** Since it is legacy, it could be deprecated or removed in the future **

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -35,7 +35,10 @@ def send_slack_notification(
     url = slack_webhook
     query = query
     headers = None
-
+    
+    # Slack doc about overwritting the channel when using the legacy Incoming Webhooks
+    # https://api.slack.com/legacy/custom-integrations/messaging/webhooks
+    # ** Since it is legacy, it could be deprecated or removed in the future **
     if slack_channel:
         query["channel"] = slack_channel
 

--- a/great_expectations/checkpoint/util.py
+++ b/great_expectations/checkpoint/util.py
@@ -36,10 +36,12 @@ def send_slack_notification(
     query = query
     headers = None
 
+    if slack_channel:
+        query["channel"] = slack_channel
+
     if not slack_webhook:
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {slack_token}"}
-        query["channel"] = slack_channel
 
     try:
         response = session.post(url=url, headers=headers, json=query)


### PR DESCRIPTION
I my use case, I tried using the webhook url and passing the slack_channel in my checkpoint file but I saw that it sent a slack message to the webhook's default channel.

Changes proposed in this pull request:
- Support slack channel name with webhook also

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
