### PR TITLE
Query the database for datetime column splitter defaults

### DIFF
--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -47,6 +47,11 @@ class SqlYearMonthSplitter(ColumnSplitter):
     param_names: List[str] = pydantic.Field(default_factory=lambda: ["year", "month"])
 
     def param_defaults(self, data_asset: DataAsset) -> Dict[str, List]:
+        """Query the database to get the years and months to split over.
+
+        Args:
+            data_asset: A TableAsset over which we want to split the data.
+        """
         # This column splitter is only relevant to SQL data assets so we do some assertions
         # to validate this.
         from great_expectations.execution_engine import SqlAlchemyExecutionEngine

--- a/tests/experimental/datasources/config.yaml
+++ b/tests/experimental/datasources/config.yaml
@@ -16,10 +16,6 @@ datasources:
               method_name: foobar_it
               column_name: my_column
               name: my_splitter
-              param_defaults:
-                alpha:
-                  - fizz
-                  - bizz
-                bravo:
-                  - foo
-                  - bar
+              param_names:
+                - alpha
+                - bravo

--- a/tests/experimental/datasources/conftest.py
+++ b/tests/experimental/datasources/conftest.py
@@ -30,16 +30,23 @@ DEFAULT_MAX_DT = datetime(2022, 12, 31, 0, 0, 0)
 
 class _MockConnection:
     def execute(self, query):
-        # Right now we assume the query is:
-        # "select min(col), max(col) from table"
-        # where col is a datetime column since that's all that's necessary.
-        # We could build something more robust as needed.
+        """Execute a query over a sqlalchemy engine connection.
+
+        Currently this mock assumes the query is always of the form:
+        "select min(col), max(col) from table"
+        where col is a datetime column since that's all that's necessary.
+        This can be generalized if needed.
+
+        Args:
+            query: The SQL query to execute.
+        """
         return [(DEFAULT_MIN_DT, DEFAULT_MAX_DT)]
 
 
 class _MockSaEngine:
     @contextmanager
     def connect(self):
+        """A contextmanager that yields a _MockConnection"""
         yield _MockConnection()
 
 

--- a/tests/experimental/datasources/conftest.py
+++ b/tests/experimental/datasources/conftest.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Callable, Dict, Tuple
 
 import pytest
@@ -12,6 +13,8 @@ from great_expectations.experimental.datasources.metadatasource import MetaDatas
 
 LOGGER = logging.getLogger(__name__)
 
+from contextlib import contextmanager
+
 from great_expectations.core.batch import BatchData
 from great_expectations.core.batch_spec import (
     BatchMarkers,
@@ -19,13 +22,43 @@ from great_expectations.core.batch_spec import (
 )
 from great_expectations.experimental.datasources.sources import _SourceFactories
 
+# This is the default min/max time that we are using in our mocks.
+# They are made global so our tests can reference them directly.
+DEFAULT_MIN_DT = datetime(2021, 1, 1, 0, 0, 0)
+DEFAULT_MAX_DT = datetime(2022, 12, 31, 0, 0, 0)
+
+
+class _MockConnection:
+    def execute(self, query):
+        # Right now we assume the query is:
+        # "select min(col), max(col) from table"
+        # where col is a datetime column since that's all that's necessary.
+        # We could build something more robust as needed.
+        return [(DEFAULT_MIN_DT, DEFAULT_MAX_DT)]
+
+
+class _MockSaEngine:
+    @contextmanager
+    def connect(self):
+        yield _MockConnection()
+
 
 def sqlachemy_execution_engine_mock_cls(
     validate_batch_spec: Callable[[SqlAlchemyDatasourceBatchSpec], None]
 ):
+    """Creates a mock gx sql alchemy engine class
+
+    Args:
+        validate_batch_spec: A hook that can be used to validate the generated the batch spec
+            passed into get_batch_data_and_markers
+    """
+
     class MockSqlAlchemyExecutionEngine(SqlAlchemyExecutionEngine):
         def __init__(self, *args, **kwargs):
-            pass
+            # We should likely let the user pass in an engine. In a SqlAlchemyExecutionEngine used in
+            # non-mocked code the engine property is of the type:
+            # from sqlalchemy.engine import Engine as SaEngine
+            self.engine = _MockSaEngine()
 
         def get_batch_data_and_markers(  # type: ignore[override]
             self, batch_spec: SqlAlchemyDatasourceBatchSpec

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -40,10 +40,7 @@ PG_COMPLEX_CONFIG_DICT = {
                         "column_name": "my_column",
                         "method_name": "foobar_it",
                         "name": "my_splitter",
-                        "param_defaults": {
-                            "alpha": ["fizz", "bizz"],
-                            "bravo": ["foo", "bar"],
-                        },
+                        "param_names": ["alpha", "bravo"],
                     },
                     "name": "with_splitters",
                     "table_name": "another_table",


### PR DESCRIPTION
We introduce a new splitter `SqlYearMonthSplitter` which is able to query the database to get the time range for the underlying data (instead of using a hardcoded range). This allows us to validate the data appears in the time range we expect and gives more sensible default batches when querying historic data.

This probably could be generalized to generic datetime splitters instead of just a year and month but we avoided this for now because we'd like to get a demo-able version out asap. We can file a followup ticket for generalizing the splitters.