### PR TITLE
Increase timeout to 15 minutes for the 2 jobs in manual-staging-json-to-prod pipeline

### DIFF
--- a/azure-pipelines-manual-staging-json-to-prod.yml
+++ b/azure-pipelines-manual-staging-json-to-prod.yml
@@ -16,7 +16,7 @@ stages:
     jobs:
       - job: copy_staging_to_prod
         condition: eq(variables.isManual, true)
-        timeoutInMinutes: 5
+        timeoutInMinutes: 15
         variables:
           python.version: '3.8'
 
@@ -74,7 +74,7 @@ stages:
     jobs:
       - job: copy_old_prod_to_prod
         condition: eq(variables.isManual, true)
-        timeoutInMinutes: 5
+        timeoutInMinutes: 15
         variables:
           python.version: '3.8'
 


### PR DESCRIPTION

Changes proposed in this pull request:
- Increase timeout to 15 minutes for the 2 jobs in manual-staging-json-to-prod pipeline
