### PR TITLE
[BUGFIX] Validator uses proper arguments to show progress bar at Metrics resolution-level

### DIFF
--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1028,6 +1028,7 @@ class Validator:
                 expectation_validation_graphs=expectation_validation_graphs,
                 evrs=evrs,
                 processed_configurations=processed_configurations,
+                show_progress_bars=self._determine_progress_bars()
             )
         except Exception as err:
             # If a general Exception occurs during the execution of "ValidationGraph.resolve()", then
@@ -1172,6 +1173,7 @@ class Validator:
         expectation_validation_graphs: List[ExpectationValidationGraph],
         evrs: List[ExpectationValidationResult],
         processed_configurations: List[ExpectationConfiguration],
+        show_progress_bars: bool
     ) -> Tuple[
         Dict[Tuple[str, str, str], MetricValue],
         List[ExpectationValidationResult],
@@ -1186,7 +1188,7 @@ class Validator:
         resolved_metrics, aborted_metrics_info = graph.resolve(
             runtime_configuration=runtime_configuration,
             min_graph_edges_pbar_enable=0,
-            show_progress_bars=True,
+            show_progress_bars=show_progress_bars
         )
 
         # Trace MetricResolutionError occurrences to expectations relying on corresponding malfunctioning metrics.

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1028,7 +1028,7 @@ class Validator:
                 expectation_validation_graphs=expectation_validation_graphs,
                 evrs=evrs,
                 processed_configurations=processed_configurations,
-                show_progress_bars=self._determine_progress_bars()
+                show_progress_bars=self._determine_progress_bars(),
             )
         except Exception as err:
             # If a general Exception occurs during the execution of "ValidationGraph.resolve()", then
@@ -1173,7 +1173,7 @@ class Validator:
         expectation_validation_graphs: List[ExpectationValidationGraph],
         evrs: List[ExpectationValidationResult],
         processed_configurations: List[ExpectationConfiguration],
-        show_progress_bars: bool
+        show_progress_bars: bool,
     ) -> Tuple[
         Dict[Tuple[str, str, str], MetricValue],
         List[ExpectationValidationResult],
@@ -1188,7 +1188,7 @@ class Validator:
         resolved_metrics, aborted_metrics_info = graph.resolve(
             runtime_configuration=runtime_configuration,
             min_graph_edges_pbar_enable=0,
-            show_progress_bars=show_progress_bars
+            show_progress_bars=show_progress_bars,
         )
 
         # Trace MetricResolutionError occurrences to expectations relying on corresponding malfunctioning metrics.


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
-
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
