### PR TITLE
[MAINTENANCE] Update `Domain` computation in MetricConfiguration

### DIFF
--- a/great_expectations/rule_based_profiler/parameter_container.py
+++ b/great_expectations/rule_based_profiler/parameter_container.py
@@ -230,13 +230,13 @@ class ParameterContainer(SerializableDictDot):
 def deep_convert_properties_iterable_to_parameter_node(
     source: Union[T, dict]
 ) -> Union[T, ParameterNode]:
-    if type(source) == dict:
+    if isinstance(source, dict):
         return _deep_convert_properties_iterable_to_parameter_node(
             source=ParameterNode(source)
         )
 
     # Must allow for non-dictionary source types, since their internal nested structures may contain dictionaries.
-    if type(source) in (list, set, tuple):
+    if isinstance(source, (list, set, tuple)):
         data_type: type = type(source)
 
         element: Any
@@ -254,11 +254,11 @@ def _deep_convert_properties_iterable_to_parameter_node(source: dict) -> Paramet
     key: str
     value: Any
     for key, value in source.items():
-        if type(value) == dict:
+        if isinstance(value, dict):
             source[key] = _deep_convert_properties_iterable_to_parameter_node(
                 source=value
             )
-        elif type(value) in (list, set, tuple):
+        elif isinstance(value, (list, set, tuple)):
             data_type: type = type(value)
 
             element: Any

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from great_expectations.core.domain import Domain
 from great_expectations.core.id_dict import IDDict
@@ -69,10 +69,40 @@ class MetricConfiguration:
 
     def get_domain(self) -> Domain:
         """Return "Domain" object, constructed from this "MetricConfiguration" object."""
-        return Domain(
-            domain_type=self.get_domain_type(),
-            domain_kwargs=self._metric_domain_kwargs,
-        )
+        domain_type: MetricDomainTypes = self.get_domain_type()
+
+        if domain_type == MetricDomainTypes.TABLE:
+            return Domain(
+                domain_type=domain_type,
+                domain_kwargs={},
+            )
+
+        if domain_type == MetricDomainTypes.COLUMN:
+            return Domain(
+                domain_type=domain_type,
+                domain_kwargs={
+                    "column": self._metric_domain_kwargs["column"],
+                },
+            )
+
+        if domain_type == MetricDomainTypes.COLUMN_PAIR:
+            return Domain(
+                domain_type=domain_type,
+                domain_kwargs={
+                    "column_A": self._metric_domain_kwargs["column_A"],
+                    "column_B": self._metric_domain_kwargs["column_B"],
+                },
+            )
+
+        if domain_type == MetricDomainTypes.MULTICOLUMN:
+            return Domain(
+                domain_type=domain_type,
+                domain_kwargs={
+                    "column_list": self._metric_domain_kwargs["column_list"],
+                },
+            )
+
+        raise ValueError(f"""Domain type "{domain_type}" is not recognized.""")
 
     def get_domain_type(self) -> MetricDomainTypes:
         """Return "domain_type" of this "MetricConfiguration" object."""

--- a/great_expectations/validator/metric_configuration.py
+++ b/great_expectations/validator/metric_configuration.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 from great_expectations.core.domain import Domain
 from great_expectations.core.id_dict import IDDict

--- a/tests/validator/test_metric_configuration.py
+++ b/tests/validator/test_metric_configuration.py
@@ -55,14 +55,11 @@ def test_metric_configuration_get_domain(
 ) -> None:
     assert table_head_metric_config.get_domain() == Domain(
         domain_type=MetricDomainTypes.TABLE,
-        domain_kwargs={
-            "batch_id": "abc123",
-        },
+        domain_kwargs={},
     )
     assert column_histogram_metric_config.get_domain() == Domain(
         domain_type=MetricDomainTypes.COLUMN,
         domain_kwargs={
             "column": "my_column",
-            "batch_id": "def456",
         },
     )


### PR DESCRIPTION
### Scope
* We insure that only relevant `Domain` arguments are present (i.e., column names).
* Revert `ParameterNode` conversion to using `isinstance()` for type comparisons.
* Update unit tests.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1347/GREAT-181/GREAT-1432
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
