### PR TITLE
[BUGFIX] Patch outdated `ge_cloud_id` attribute call in `ValidationOperator`

### DIFF
--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -391,7 +391,7 @@ class ActionListValidationOperator(ValidationOperator):
                 validation_result = async_batch_validation_result.result()
                 validation_result.meta["validation_id"] = validation_id
                 validation_result.meta["checkpoint_id"] = (
-                    checkpoint_identifier.ge_cloud_id if checkpoint_identifier else None
+                    checkpoint_identifier.cloud_id if checkpoint_identifier else None
                 )
 
                 batch_actions_results = self._run_actions(

--- a/great_expectations/validation_operators/validation_operators.py
+++ b/great_expectations/validation_operators/validation_operators.py
@@ -286,7 +286,7 @@ class ActionListValidationOperator(ValidationOperator):
         run_time=None,
         catch_exceptions=None,
         result_format=None,
-        checkpoint_identifier=None,
+        checkpoint_identifier: Optional[GXCloudIdentifier] = None,
         checkpoint_name: Optional[str] = None,
         validation_id: Optional[str] = None,
     ) -> ValidationOperatorResult:


### PR DESCRIPTION
Changes proposed in this pull request:
- `GXCloudIdentifier` no longer has a `ge_cloud_id` attr


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.