### PR TITLE
[BUGFIX] Revert refactor to `Datasource` instantiation logic in `DataContext`

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -3063,17 +3063,22 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         Raises:
             DatasourceInitializationError
         """
+        if save_changes:
+            config = self._datasource_store.set(key=None, value=config)  # type: ignore[attr-defined]
+
         substituted_config = self._perform_substitutions_on_datasource_config(config)
 
         datasource: Optional[Datasource] = None
         if initialize:
-            datasource = self._instantiate_datasource_from_config(
-                raw_config=config, substituted_config=substituted_config
-            )
-            self._cached_datasources[config.name] = datasource
-
-        if save_changes:
-            config = self._datasource_store.set(key=None, value=config)  # type: ignore[attr-defined]
+            try:
+                datasource = self._instantiate_datasource_from_config(
+                    raw_config=config, substituted_config=substituted_config
+                )
+                self._cached_datasources[config.name] = datasource
+            except ge_exceptions.DatasourceInitializationError as e:
+                if save_changes:
+                    self._datasource_store.delete(config)
+                raise e
 
         self.config.datasources[config.name] = config  # type: ignore[index,assignment]
 

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -3080,7 +3080,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
                 self._cached_datasources[config.name] = datasource
             except ge_exceptions.DatasourceInitializationError as e:
                 if save_changes:
-                    self._datasource_store.delete(config)
+                    self._datasource_store.delete(config)  # type: ignore[attr-defined]
                 raise e
 
         self.config.datasources[config.name] = config  # type: ignore[index,assignment]

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -3063,14 +3063,17 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         Raises:
             DatasourceInitializationError
         """
+        # Note that the call to `DatasourcStore.set` may alter the config object's state
+        # As such, we invoke it at the top of our function so any changes are reflected downstream
         if save_changes:
             config = self._datasource_store.set(key=None, value=config)  # type: ignore[attr-defined]
-
-        substituted_config = self._perform_substitutions_on_datasource_config(config)
 
         datasource: Optional[Datasource] = None
         if initialize:
             try:
+                substituted_config = self._perform_substitutions_on_datasource_config(
+                    config
+                )
                 datasource = self._instantiate_datasource_from_config(
                     raw_config=config, substituted_config=substituted_config
                 )


### PR DESCRIPTION
Changes proposed in this pull request:
- Faulty refactor in prior PR: https://github.com/great-expectations/great_expectations/pull/6517


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
