### PR TITLE
[DOCS] Fix line numbers in snippets

### DIFF
--- a/docs/terms/checkpoint.md
+++ b/docs/terms/checkpoint.md
@@ -274,7 +274,7 @@ Below is an example of a `CheckpointResult` object which itself contains `Valida
 
 #### Example CheckpointResult
 
-```python file=../../tests/integration/docusaurus/reference/core_concepts/checkpoints_and_actions.py#L101-L115
+```python file=../../tests/integration/docusaurus/reference/core_concepts/checkpoints_and_actions.py#L104-L118
 ```
 
 ### Example script

--- a/docs/tutorials/getting_started/tutorial_create_expectations.md
+++ b/docs/tutorials/getting_started/tutorial_create_expectations.md
@@ -97,7 +97,7 @@ Since notebooks are often less permanent, creating Expectations in a notebook al
 
 2. The second cell allows you to specify which columns you want to **ignore** when creating Expectations. For our tutorial, we're going to ensure that the number of passengers recorded in our data is reasonable.  To do this, we'll want our Data Assistant to examine the `passenger_count` column and determine just what a reasonable range _is_ based on our January data. **Let’s comment just this one line to include it**:
 
-```python file=../../../tests/integration/docusaurus/tutorials/getting-started/getting_started.py#L86-L105
+```python file=../../../tests/integration/docusaurus/tutorials/getting-started/getting_started.py#L89-L108
 ```
 
 **Cell 3**

--- a/docs/tutorials/getting_started/tutorial_validate_data.md
+++ b/docs/tutorials/getting_started/tutorial_validate_data.md
@@ -30,7 +30,7 @@ This will **open a Jupyter Notebook** that will allow you to complete the config
 
 The Jupyter Notebook contains some boilerplate code that allows you to configure a new Checkpoint. The second code cell is pre-populated with an arbitrarily chosen Batch Request and Expectation Suite to get you started. Edit the `data_asset_name` to reference the data we want to validate (the February data), as follows:
 
-```python file=../../../tests/integration/docusaurus/tutorials/getting-started/getting_started.py#L164-L177
+```python file=../../../tests/integration/docusaurus/tutorials/getting-started/getting_started.py#L168-L181
 ```
 
 You can then execute all cells in the notebook in order to store the Checkpoint to your Data Context.


### PR DESCRIPTION
Changes proposed in this pull request:
- A few of the snippets got out of sync with their underlying files. This PR is a quick fix. Will need to separately address our alerting for this issue.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code