### PR TITLE
[MAINTENANCE] Use `is` instead of `==` for boolean and enum checks

### DIFF
--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_bitcoin_address_positive_balance.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_bitcoin_address_positive_balance.py
@@ -22,7 +22,7 @@ from great_expectations.expectations.metrics import (
 def has_btc_address_positive_balance(addr: str) -> bool:
     try:
         res = coinaddrvalidator.validate("btc", addr).valid
-        if res == True:
+        if res is True:
             balance = blockcypher.get_total_balance(addr)
             if balance > 0:
                 return True

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_eth_address_positive_balance.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_eth_address_positive_balance.py
@@ -22,7 +22,7 @@ from great_expectations.expectations.metrics import (
 def has_eth_address_positive_balance(addr: str) -> bool:
     try:
         res = coinaddrvalidator.validate("eth", addr).valid
-        if res == True:
+        if res is True:
             balance = blockcypher.get_total_balance(addr, "eth")
             if balance > 0:
                 return True

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_formatted_vat.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_formatted_vat.py
@@ -21,7 +21,7 @@ from great_expectations.expectations.metrics import (
 def is_valid_formatted_vat(vat_num: str) -> bool:
     try:
         res = pyvat.is_vat_number_format_valid(vat_num, None)
-        if res == True:
+        if res is True:
             return True
         else:
             return False

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state.py
@@ -15,7 +15,7 @@ from great_expectations.expectations.metrics import (
 
 def is_valid_state(state: str, dc_statehood: bool):
     list_of_states = [str(x) for x in us.states.STATES]
-    if dc_statehood == True:
+    if dc_statehood is True:
         list_of_states.append("District Of Columbia")
     else:
         pass

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state_abbreviation.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state_abbreviation.py
@@ -14,7 +14,7 @@ from great_expectations.expectations.metrics import (
 
 def is_valid_state_abbreviation(state: str, dc_statehood: bool):
     list_of_state_abbrs = [x.abbr for x in us.states.STATES]
-    if dc_statehood == True:
+    if dc_statehood is True:
         list_of_state_abbrs.append("DC")
     else:
         pass

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state_or_territory.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state_or_territory.py
@@ -15,7 +15,7 @@ from great_expectations.expectations.metrics import (
 
 def is_valid_state_or_territory(state: str, dc_statehood: bool):
     list_of_states_and_territories = [str(x) for x in us.states.STATES_AND_TERRITORIES]
-    if dc_statehood == True:
+    if dc_statehood is True:
         list_of_states_and_territories.append("District Of Columbia")
     else:
         pass

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state_or_territory_abbreviation.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_us_state_or_territory_abbreviation.py
@@ -17,7 +17,7 @@ def is_valid_state_or_territory_abbreviation(state: str, dc_statehood: bool):
     list_of_state_and_territory_abbrs = [
         x.abbr for x in us.states.STATES_AND_TERRITORIES
     ]
-    if dc_statehood == True:
+    if dc_statehood is True:
         list_of_state_and_territory_abbrs.append("DC")
     else:
         pass

--- a/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_vies_vat.py
+++ b/contrib/great_expectations_semantic_types_expectations/great_expectations_semantic_types_expectations/expectations/expect_column_values_to_be_valid_vies_vat.py
@@ -21,7 +21,7 @@ from great_expectations.expectations.metrics import (
 def is_valid_vies_vat(vat_num: str) -> bool:
     try:
         res = pyvat.check_vat_number(vat_num, None).is_valid
-        if res == True:
+        if res is True:
             return True
         else:
             return False

--- a/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations_for_pandas.rst
+++ b/docs_rtd/guides/how_to_guides/creating_and_editing_expectations/how_to_create_custom_expectations_for_pandas.rst
@@ -329,12 +329,12 @@ Here's a single code block containing all the notebook code in this article:
     gx.from_pandas(my_other_df, dataset_class=MyCustomPandasDataset)
 
     # Run Expectations in assertions so that they can be used as tests for this guide
-    assert my_df.expect_column_values_to_be_in_set("Sex", value_set=["Male", "Female"]).success == False
-    assert my_df.expect_column_values_to_be_even("Survived").success == False
-    assert my_df.expect_column_values_to_be_even("Survived", mostly=.6).success == True
-    assert my_df.expect_column_value_word_counts_to_be_between("Name", 3, 5).success == False
-    assert my_df.expect_column_value_word_counts_to_be_between("Name", 3, 5, mostly=.9).success == True
-    assert my_df.expect_column_values_to_be_valid_timezones("Name", mostly=.9).success == False
+    assert my_df.expect_column_values_to_be_in_set("Sex", value_set=["Male", "Female"]).success is False
+    assert my_df.expect_column_values_to_be_even("Survived").success is False
+    assert my_df.expect_column_values_to_be_even("Survived", mostly=.6).success is True
+    assert my_df.expect_column_value_word_counts_to_be_between("Name", 3, 5).success is False
+    assert my_df.expect_column_value_word_counts_to_be_between("Name", 3, 5, mostly=.9).success is True
+    assert my_df.expect_column_values_to_be_valid_timezones("Name", mostly=.9).success is False
 
 Comments
 --------

--- a/examples/notebooks/Crop_Expectations_With_Reshape.ipynb
+++ b/examples/notebooks/Crop_Expectations_With_Reshape.ipynb
@@ -1130,7 +1130,7 @@
     "for column in df.columns:\n",
     "    #print('Column: ' + column + \"\\nResult: \" + str(df.expect_column_mean_to_be_between(column, 15000, 25000)))\n",
     "    result = df.expect_column_mean_to_be_between(column, 15000, 25000)\n",
-    "    if (result['success'] == False):\n",
+    "    if (result['success'] is False):\n",
     "        print(column)\n",
     "        print(result)"
    ]

--- a/examples/notebooks/Distributional_Expectations_Demo_Prep.ipynb
+++ b/examples/notebooks/Distributional_Expectations_Demo_Prep.ipynb
@@ -66,16 +66,16 @@
    },
    "outputs": [],
    "source": [
-    "df_train = df[splitter == False]\n",
-    "df_test = df[splitter == True]\n",
-    "df_b_1 = df[biased_splitter == True]\n",
+    "df_train = df[splitter is False]\n",
+    "df_test = df[splitter is True]\n",
+    "df_b_1 = df[biased_splitter is True]\n",
     "b_1_splitter = np.random.binomial(1, 0.2, size=len(df_b_1))\n",
-    "df_b_1_train = df_b_1[b_1_splitter == False]\n",
-    "df_b_1_test = df_b_1[b_1_splitter == True]\n",
-    "df_b_2 = df[biased_splitter == False]\n",
+    "df_b_1_train = df_b_1[b_1_splitter is False]\n",
+    "df_b_1_test = df_b_1[b_1_splitter is True]\n",
+    "df_b_2 = df[biased_splitter is False]\n",
     "b_2_splitter = np.random.binomial(1, 0.2, size=len(df_b_2))\n",
-    "df_b_2_train = df_b_2[b_2_splitter == False]\n",
-    "df_b_2_test = df_b_2[b_2_splitter == True]"
+    "df_b_2_train = df_b_2[b_2_splitter is False]\n",
+    "df_b_2_test = df_b_2[b_2_splitter is True]"
    ]
   },
   {

--- a/great_expectations/core/expectation_diagnostics/expectation_diagnostics.py
+++ b/great_expectations/core/expectation_diagnostics/expectation_diagnostics.py
@@ -300,7 +300,7 @@ class ExpectationDiagnostics(SerializableDictDot):
     def _count_positive_and_negative_example_cases(
         examples: List[ExpectationTestDataCases],
     ) -> Tuple[int, int]:
-        """Scans examples and returns a 2-ple with the numbers of cases with success == True and success == False"""
+        """Scans examples and returns a 2-ple with the numbers of cases with success is True and success is False"""
 
         positive_cases: int = 0
         negative_cases: int = 0

--- a/great_expectations/data_asset/file_data_asset.py
+++ b/great_expectations/data_asset/file_data_asset.py
@@ -102,7 +102,7 @@ class MetaFileDataAsset(DataAsset):
                         compress(lines, np.invert(boolean_mapped_null_lines))
                     )
                     nonnull_count = int(
-                        (boolean_mapped_null_lines == False).sum()  # noqa: E712
+                        (boolean_mapped_null_lines is False).sum()  # noqa: E712
                     )
                     boolean_mapped_success_lines = np.array(
                         func(self, _lines=nonnull_lines, *args, **kwargs)

--- a/great_expectations/dataset/pandas_dataset.py
+++ b/great_expectations/dataset/pandas_dataset.py
@@ -106,17 +106,17 @@ class MetaPandasDataset(Dataset):
             element_count = int(len(series))
 
             # FIXME rename nonnull to non_ignored?
-            nonnull_values = series[boolean_mapped_null_values == False]
-            nonnull_count = int((boolean_mapped_null_values == False).sum())
+            nonnull_values = series[boolean_mapped_null_values is False]
+            nonnull_count = int((boolean_mapped_null_values is False).sum())
 
             boolean_mapped_success_values = func(self, nonnull_values, *args, **kwargs)
             success_count = np.count_nonzero(boolean_mapped_success_values)
 
             unexpected_list = list(
-                nonnull_values[boolean_mapped_success_values == False]
+                nonnull_values[boolean_mapped_success_values is False]
             )
             unexpected_index_list = list(
-                nonnull_values[boolean_mapped_success_values == False].index
+                nonnull_values[boolean_mapped_success_values is False].index
             )
 
             if "output_strftime_format" in kwargs:
@@ -222,10 +222,10 @@ class MetaPandasDataset(Dataset):
 
             # This next bit only works if series_A and _B are the same length
             element_count = int(len(series_A))
-            nonnull_count = (boolean_mapped_null_values == False).sum()
+            nonnull_count = (boolean_mapped_null_values is False).sum()
 
-            nonnull_values_A = series_A[boolean_mapped_null_values == False]
-            nonnull_values_B = series_B[boolean_mapped_null_values == False]
+            nonnull_values_A = series_A[boolean_mapped_null_values is False]
+            nonnull_values_B = series_B[boolean_mapped_null_values is False]
             nonnull_values = [
                 value_pair
                 for value_pair in zip(list(nonnull_values_A), list(nonnull_values_B))
@@ -241,22 +241,22 @@ class MetaPandasDataset(Dataset):
                 for value_pair in zip(
                     list(
                         series_A[
-                            (boolean_mapped_success_values == False)
-                            & (boolean_mapped_null_values == False)
+                            (boolean_mapped_success_values is False)
+                            & (boolean_mapped_null_values is False)
                         ]
                     ),
                     list(
                         series_B[
-                            (boolean_mapped_success_values == False)
-                            & (boolean_mapped_null_values == False)
+                            (boolean_mapped_success_values is False)
+                            & (boolean_mapped_null_values is False)
                         ]
                     ),
                 )
             ]
             unexpected_index_list = list(
                 series_A[
-                    (boolean_mapped_success_values == False)
-                    & (boolean_mapped_null_values == False)
+                    (boolean_mapped_success_values is False)
+                    & (boolean_mapped_null_values is False)
                 ].index
             )
 
@@ -322,15 +322,15 @@ class MetaPandasDataset(Dataset):
             validate_mostly(mostly)
 
             boolean_mapped_success_values = func(
-                self, test_df[boolean_mapped_skip_values == False], *args, **kwargs
+                self, test_df[boolean_mapped_skip_values is False], *args, **kwargs
             )
             success_count = boolean_mapped_success_values.sum()
             nonnull_count = (~boolean_mapped_skip_values).sum()
             element_count = len(test_df)
 
             unexpected_list = test_df[
-                (boolean_mapped_skip_values == False)
-                & (boolean_mapped_success_values == False)
+                (boolean_mapped_skip_values is False)
+                & (boolean_mapped_success_values is False)
             ]
             unexpected_index_list = list(unexpected_list.index)
 
@@ -476,7 +476,7 @@ Notes:
     def get_column_nonnull_count(self, column):
         series = self[column]
         null_indexes = series.isnull()
-        nonnull_values = series[null_indexes == False]
+        nonnull_values = series[null_indexes is False]
         return len(nonnull_values)
 
     def get_column_value_counts(self, column, sort="value", collate=None):
@@ -1769,7 +1769,7 @@ Notes:
         meta=None,
     ):
         # FIXME
-        if allow_cross_type_comparisons == True:
+        if allow_cross_type_comparisons is True:
             raise NotImplementedError
 
         if parse_strings_as_datetimes:
@@ -1780,7 +1780,7 @@ Notes:
             temp_column_A = column_A
             temp_column_B = column_B
 
-        if or_equal == True:
+        if or_equal is True:
             return temp_column_A >= temp_column_B
         else:
             return temp_column_A > temp_column_B

--- a/great_expectations/dataset/util.py
+++ b/great_expectations/dataset/util.py
@@ -102,7 +102,7 @@ def categorical_partition_data(data):
 
     # Compute weights using denominator only of nonnull values
     null_indexes = series.isnull()
-    nonnull_count = (null_indexes == False).sum()
+    nonnull_count = (null_indexes is False).sum()
 
     weights = value_counts.values / nonnull_count
     return {"values": value_counts.index.tolist(), "weights": weights}

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1375,8 +1375,8 @@ class Expectation(metaclass=MetaExpectation):
             top_level_suppress_test_for = example.get("suppress_test_for")
             for test in example["tests"]:
                 if (
-                    test.get("include_in_gallery") == True
-                    or return_only_gallery_examples == False
+                    test.get("include_in_gallery") is True
+                    or return_only_gallery_examples is False
                 ):
                     copied_test = deepcopy(test)
                     if top_level_only_for:

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -1465,7 +1465,7 @@ def _pandas_column_map_condition_values(
 
     domain_values = df[column_name]
 
-    domain_values = domain_values[boolean_mapped_unexpected_values == True]
+    domain_values = domain_values[boolean_mapped_unexpected_values is True]
 
     result_format = metric_value_kwargs["result_format"]
 
@@ -1521,7 +1521,7 @@ def _pandas_column_pair_map_condition_values(
 
     domain_values = df[column_names]
 
-    domain_values = domain_values[boolean_mapped_unexpected_values == True]
+    domain_values = domain_values[boolean_mapped_unexpected_values is True]
 
     result_format = metric_value_kwargs["result_format"]
 
@@ -1612,7 +1612,7 @@ def _pandas_multicolumn_map_condition_values(
 
     domain_values = df[column_list]
 
-    domain_values = domain_values[boolean_mapped_unexpected_values == True]
+    domain_values = domain_values[boolean_mapped_unexpected_values is True]
 
     result_format = metric_value_kwargs["result_format"]
 
@@ -1710,8 +1710,8 @@ def _pandas_column_map_series_and_domain_values(
 
     domain_values = df[column_name]
 
-    domain_values = domain_values[boolean_mapped_unexpected_values == True]
-    map_series = map_series[boolean_mapped_unexpected_values == True]
+    domain_values = domain_values[boolean_mapped_unexpected_values is True]
+    map_series = map_series[boolean_mapped_unexpected_values is True]
 
     result_format = metric_value_kwargs["result_format"]
 
@@ -2547,7 +2547,7 @@ def _spark_map_condition_unexpected_count_value(
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
-    filtered = data.filter(F.col("__unexpected") == True).drop(F.col("__unexpected"))
+    filtered = data.filter(F.col("__unexpected") is True).drop(F.col("__unexpected"))
 
     return filtered.count()
 
@@ -2583,7 +2583,7 @@ def _spark_column_map_condition_values(
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
-    filtered = data.filter(F.col("__unexpected") == True).drop(F.col("__unexpected"))
+    filtered = data.filter(F.col("__unexpected") is True).drop(F.col("__unexpected"))
 
     result_format = metric_value_kwargs["result_format"]
     if result_format["result_format"] == "COMPLETE":
@@ -2631,7 +2631,7 @@ def _spark_column_map_condition_value_counts(
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
-    filtered = data.filter(F.col("__unexpected") == True).drop(F.col("__unexpected"))
+    filtered = data.filter(F.col("__unexpected") is True).drop(F.col("__unexpected"))
 
     result_format = metric_value_kwargs["result_format"]
 
@@ -2663,7 +2663,7 @@ def _spark_map_condition_rows(
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
-    filtered = data.filter(F.col("__unexpected") == True).drop(F.col("__unexpected"))
+    filtered = data.filter(F.col("__unexpected") is True).drop(F.col("__unexpected"))
 
     result_format = metric_value_kwargs["result_format"]
 
@@ -2712,7 +2712,7 @@ def _spark_column_pair_map_condition_values(
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
-    filtered = data.filter(F.col("__unexpected") == True).drop(F.col("__unexpected"))
+    filtered = data.filter(F.col("__unexpected") is True).drop(F.col("__unexpected"))
 
     result_format = metric_value_kwargs["result_format"]
     if result_format["result_format"] == "COMPLETE":
@@ -2806,7 +2806,7 @@ def _spark_multicolumn_map_condition_values(
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)
-    filtered = data.filter(F.col("__unexpected") == True).drop(F.col("__unexpected"))
+    filtered = data.filter(F.col("__unexpected") is True).drop(F.col("__unexpected"))
 
     column_selector = [
         F.col(column_name).alias(column_name) for column_name in column_list

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -1049,7 +1049,7 @@ def empty_context(tmp_path_factory):
 
 def test_data_context_does_ge_yml_exist_returns_true_when_it_does_exist(empty_context):
     ge_dir = empty_context.root_directory
-    assert DataContext.does_config_exist_on_disk(ge_dir) == True
+    assert DataContext.does_config_exist_on_disk(ge_dir) is True
 
 
 def test_data_context_does_ge_yml_exist_returns_false_when_it_does_not_exist(
@@ -1058,7 +1058,7 @@ def test_data_context_does_ge_yml_exist_returns_false_when_it_does_not_exist(
     ge_dir = empty_context.root_directory
     # mangle project
     safe_remove(os.path.join(ge_dir, empty_context.GX_YML))
-    assert DataContext.does_config_exist_on_disk(ge_dir) == False
+    assert DataContext.does_config_exist_on_disk(ge_dir) is False
 
 
 def test_data_context_does_project_have_a_datasource_in_config_file_returns_true_when_it_has_a_datasource_configured_in_yml_file_on_disk(
@@ -1066,14 +1066,14 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_true
 ):
     ge_dir = empty_context.root_directory
     empty_context.add_datasource("arthur", **{"class_name": "PandasDatasource"})
-    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) == True
+    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) is True
 
 
 def test_data_context_does_project_have_a_datasource_in_config_file_returns_false_when_it_does_not_have_a_datasource_configured_in_yml_file_on_disk(
     empty_context,
 ):
     ge_dir = empty_context.root_directory
-    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) == False
+    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) is False
 
 
 def test_data_context_does_project_have_a_datasource_in_config_file_returns_false_when_it_does_not_have_a_ge_yml_file(
@@ -1081,7 +1081,7 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_fals
 ):
     ge_dir = empty_context.root_directory
     safe_remove(os.path.join(ge_dir, empty_context.GX_YML))
-    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) == False
+    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) is False
 
 
 def test_data_context_does_project_have_a_datasource_in_config_file_returns_false_when_it_does_not_have_a_ge_dir(
@@ -1089,7 +1089,7 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_fals
 ):
     ge_dir = empty_context.root_directory
     safe_remove(os.path.join(ge_dir))
-    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) == False
+    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) is False
 
 
 def test_data_context_does_project_have_a_datasource_in_config_file_returns_false_when_the_project_has_an_invalid_config_file(
@@ -1098,7 +1098,7 @@ def test_data_context_does_project_have_a_datasource_in_config_file_returns_fals
     ge_dir = empty_context.root_directory
     with open(os.path.join(ge_dir, DataContext.GX_YML), "w") as yml:
         yml.write("this file: is not a valid ge config")
-    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) == False
+    assert DataContext.does_project_have_a_datasource_in_config_file(ge_dir) is False
 
 
 def test_data_context_is_project_initialized_returns_true_when_its_valid_context_has_one_datasource_and_one_suite(
@@ -1110,7 +1110,7 @@ def test_data_context_is_project_initialized_returns_true_when_its_valid_context
     context.create_expectation_suite("dent")
     assert len(context.list_expectation_suites()) == 1
 
-    assert DataContext.is_project_initialized(ge_dir) == True
+    assert DataContext.is_project_initialized(ge_dir) is True
 
 
 def test_data_context_is_project_initialized_returns_true_when_its_valid_context_has_one_datasource_and_no_suites(
@@ -1121,14 +1121,14 @@ def test_data_context_is_project_initialized_returns_true_when_its_valid_context
     context.add_datasource("arthur", class_name="PandasDatasource")
     assert len(context.list_expectation_suites()) == 0
 
-    assert DataContext.is_project_initialized(ge_dir) == False
+    assert DataContext.is_project_initialized(ge_dir) is False
 
 
 def test_data_context_is_project_initialized_returns_false_when_its_valid_context_has_no_datasource(
     empty_context,
 ):
     ge_dir = empty_context.root_directory
-    assert DataContext.is_project_initialized(ge_dir) == False
+    assert DataContext.is_project_initialized(ge_dir) is False
 
 
 def test_data_context_is_project_initialized_returns_false_when_config_yml_is_missing(
@@ -1138,7 +1138,7 @@ def test_data_context_is_project_initialized_returns_false_when_config_yml_is_mi
     # mangle project
     safe_remove(os.path.join(ge_dir, empty_context.GX_YML))
 
-    assert DataContext.is_project_initialized(ge_dir) == False
+    assert DataContext.is_project_initialized(ge_dir) is False
 
 
 def test_data_context_is_project_initialized_returns_false_when_uncommitted_dir_is_missing(
@@ -1148,7 +1148,7 @@ def test_data_context_is_project_initialized_returns_false_when_uncommitted_dir_
     # mangle project
     shutil.rmtree(os.path.join(ge_dir, empty_context.GX_UNCOMMITTED_DIR))
 
-    assert DataContext.is_project_initialized(ge_dir) == False
+    assert DataContext.is_project_initialized(ge_dir) is False
 
 
 def test_data_context_is_project_initialized_returns_false_when_uncommitted_data_docs_dir_is_missing(
@@ -1158,7 +1158,7 @@ def test_data_context_is_project_initialized_returns_false_when_uncommitted_data
     # mangle project
     shutil.rmtree(os.path.join(ge_dir, empty_context.GX_UNCOMMITTED_DIR, "data_docs"))
 
-    assert DataContext.is_project_initialized(ge_dir) == False
+    assert DataContext.is_project_initialized(ge_dir) is False
 
 
 def test_data_context_is_project_initialized_returns_false_when_uncommitted_validations_dir_is_missing(
@@ -1168,7 +1168,7 @@ def test_data_context_is_project_initialized_returns_false_when_uncommitted_vali
     # mangle project
     shutil.rmtree(os.path.join(ge_dir, empty_context.GX_UNCOMMITTED_DIR, "validations"))
 
-    assert DataContext.is_project_initialized(ge_dir) == False
+    assert DataContext.is_project_initialized(ge_dir) is False
 
 
 def test_data_context_is_project_initialized_returns_false_when_config_variable_yml_is_missing(
@@ -1180,7 +1180,7 @@ def test_data_context_is_project_initialized_returns_false_when_config_variable_
         os.path.join(ge_dir, empty_context.GX_UNCOMMITTED_DIR, "config_variables.yml")
     )
 
-    assert DataContext.is_project_initialized(ge_dir) == False
+    assert DataContext.is_project_initialized(ge_dir) is False
 
 
 def test_data_context_create_raises_warning_and_leaves_existing_yml_untouched(

--- a/tests/data_context/test_data_context_in_code_config.py
+++ b/tests/data_context/test_data_context_in_code_config.py
@@ -420,7 +420,7 @@ def test_suppress_store_backend_id_is_true_for_inactive_stores():
         project_config=in_code_data_context_project_config
     )
 
-    # Check here that suppress_store_backend_id == True for inactive stores
+    # Check here that suppress_store_backend_id is True for inactive stores
     # and False for active stores
     assert (
         in_code_data_context.stores.get(

--- a/tests/dataset/test_pandas_dataset.py
+++ b/tests/dataset/test_pandas_dataset.py
@@ -871,7 +871,7 @@ def test_pandas_deepcopy():
     df["a"] = [2, 3, 4]
 
     # Our copied dataframe should not be affected
-    assert df2.expect_column_to_exist("a").success == True
+    assert df2.expect_column_to_exist("a").success is True
     assert list(df["a"]) == [2, 3, 4]
     assert list(df2["a"]) == [1, 2, 3]
 

--- a/tests/datasource/test_sparkdf_datasource.py
+++ b/tests/datasource/test_sparkdf_datasource.py
@@ -194,7 +194,7 @@ def test_spark_kwargs_are_passed_through(
         dataset_name
     ).config
     assert datasource_config["spark_config"] == {}
-    assert datasource_config["force_reuse_spark_context"] == True
+    assert datasource_config["force_reuse_spark_context"] is True
 
 
 def test_create_sparkdf_datasource(

--- a/tests/expectations/core/test_expect_queried_column_value_frequency_to_meet_threshold.py
+++ b/tests/expectations/core/test_expect_queried_column_value_frequency_to_meet_threshold.py
@@ -313,7 +313,7 @@ def test_expect_queried_column_value_frequency_to_meet_threshold_sqlite_multi_va
             )
         )
 
-    assert result["success"] == True and result["result"]["observed_value"] == [
+    assert result["success"] is True and result["result"]["observed_value"] == [
         0.6393939393939394,
         0.3606060606060606,
     ]

--- a/tests/expectations/test_dataclass_serializable_dot_dict_pattern.py
+++ b/tests/expectations/test_dataclass_serializable_dot_dict_pattern.py
@@ -375,7 +375,7 @@ def test_to_raw_dict_works_recursively():
 
     # Make sure it's a dictionary, not a DictDot
     assert type(C_dict) == dict
-    assert isinstance(C_dict, DictDot) == False
+    assert isinstance(C_dict, DictDot) is False
     # Dictionaries don't support dot notation.
     with raises(AttributeError):
         C_dict.A_list

--- a/tests/expectations/test_run_diagnostics_supporting_methods.py
+++ b/tests/expectations/test_run_diagnostics_supporting_methods.py
@@ -219,6 +219,6 @@ def test__get_test_results():
     for result in test_results:
         # Abe: 1/1/2022: I'm not sure this is the behavior we want long term. How does backend relate to ExecutionEngine?
         if result.backend == "pandas":
-            assert result.test_passed == True
+            assert result.test_passed is True
         elif result.backend == "sqlite":
-            assert result.test_passed == False
+            assert result.test_passed is False

--- a/tests/expectations/test_util.py
+++ b/tests/expectations/test_util.py
@@ -661,7 +661,7 @@ def test__should_we_generate_this_test__obvious():
     )
     backend = "spark"
 
-    assert should_we_generate_this_test(backend, test_case) == True
+    assert should_we_generate_this_test(backend, test_case) is True
 
     test_case2 = ExpectationTestCase(
         title="",
@@ -674,7 +674,7 @@ def test__should_we_generate_this_test__obvious():
     )
     backend2 = "sqlite"
 
-    assert should_we_generate_this_test(backend2, test_case2) == False
+    assert should_we_generate_this_test(backend2, test_case2) is False
 
     test_case3 = ExpectationTestCase(
         title="",
@@ -687,7 +687,7 @@ def test__should_we_generate_this_test__obvious():
     )
     backend3 = "sqlite"
 
-    assert should_we_generate_this_test(backend3, test_case3) == True
+    assert should_we_generate_this_test(backend3, test_case3) is True
 
     test_case4 = ExpectationTestCase(
         title="",
@@ -700,7 +700,7 @@ def test__should_we_generate_this_test__obvious():
     )
     backend4 = "sqlite"
 
-    assert should_we_generate_this_test(backend4, test_case4) == False
+    assert should_we_generate_this_test(backend4, test_case4) is False
 
     test_case5 = ExpectationTestCase(
         title="",
@@ -713,7 +713,7 @@ def test__should_we_generate_this_test__obvious():
     )
     backend5 = "pandas"
 
-    assert should_we_generate_this_test(backend5, test_case5) == True
+    assert should_we_generate_this_test(backend5, test_case5) is True
 
 
 def test__should_we_generate_this_test__sqlalchemy():
@@ -728,7 +728,7 @@ def test__should_we_generate_this_test__sqlalchemy():
     )
     backend = "mysql"
 
-    assert should_we_generate_this_test(backend, test_case) == True
+    assert should_we_generate_this_test(backend, test_case) is True
 
     test_case2 = ExpectationTestCase(
         title="",
@@ -741,7 +741,7 @@ def test__should_we_generate_this_test__sqlalchemy():
     )
     backend2 = "postgresql"
 
-    assert should_we_generate_this_test(backend2, test_case2) == True
+    assert should_we_generate_this_test(backend2, test_case2) is True
 
     test_case3 = ExpectationTestCase(
         title="",
@@ -754,7 +754,7 @@ def test__should_we_generate_this_test__sqlalchemy():
     )
     backend3 = "mysql"
 
-    assert should_we_generate_this_test(backend3, test_case3) == False
+    assert should_we_generate_this_test(backend3, test_case3) is False
 
     test_case4 = ExpectationTestCase(
         title="",
@@ -767,7 +767,7 @@ def test__should_we_generate_this_test__sqlalchemy():
     )
     backend4 = "sqlite"
 
-    assert should_we_generate_this_test(backend4, test_case4) == False
+    assert should_we_generate_this_test(backend4, test_case4) is False
 
     test_case5 = ExpectationTestCase(
         title="",
@@ -780,7 +780,7 @@ def test__should_we_generate_this_test__sqlalchemy():
     )
     backend5 = "spark"
 
-    assert should_we_generate_this_test(backend5, test_case5) == True
+    assert should_we_generate_this_test(backend5, test_case5) is True
 
 
 def test__should_we_generate_this_test__pandas():
@@ -802,7 +802,7 @@ def test__should_we_generate_this_test__pandas():
     )
     backend = "pandas"
 
-    assert should_we_generate_this_test(backend, test_case) == True
+    assert should_we_generate_this_test(backend, test_case) is True
 
     test_case2 = ExpectationTestCase(
         title="",
@@ -815,7 +815,7 @@ def test__should_we_generate_this_test__pandas():
     )
     backend2 = "pandas"
 
-    assert should_we_generate_this_test(backend2, test_case2) == True
+    assert should_we_generate_this_test(backend2, test_case2) is True
 
     test_case3 = ExpectationTestCase(
         title="",
@@ -862,4 +862,4 @@ def test__should_we_generate_this_test__pandas():
     )
     backend5 = "pandas"
 
-    assert should_we_generate_this_test(backend5, test_case5) == False
+    assert should_we_generate_this_test(backend5, test_case5) is False

--- a/tests/integration/docusaurus/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py
+++ b/tests/integration/docusaurus/setup/configuring_metadata_stores/how_to_configure_a_validation_result_store_in_gcs.py
@@ -258,7 +258,7 @@ assert (
 # get the updated context and run a checkpoint to ensure validation store is updated
 context = gx.get_context()
 validation_result = context.run_checkpoint(checkpoint_name=checkpoint_name)
-assert validation_result["success"] == True
+assert validation_result["success"] is True
 list_validation_store_files = (
     f"gsutil ls gs://{configured_validations_store['stores']['validations_GCS_store']['store_backend']['bucket']}"
     + f"/{configured_validations_store['stores']['validations_GCS_store']['store_backend']['prefix']}"

--- a/tests/integration/docusaurus/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py
+++ b/tests/integration/docusaurus/validation/checkpoints/how_to_pass_an_in_memory_dataframe_to_a_checkpoint.py
@@ -127,7 +127,7 @@ results = context.run_checkpoint(
 # </snippet>
 
 # NOTE: The following code is only for testing and can be ignored by users.
-assert results["success"] == True
+assert results["success"] is True
 
 # YAML <snippet>
 checkpoint_yaml = """
@@ -192,4 +192,4 @@ results = context.run_checkpoint(
 # </snippet>
 
 # NOTE: The following code is only for testing and can be ignored by users.
-assert results["success"] == True
+assert results["success"] is True

--- a/tests/performance/test_bigquery_benchmarks.py
+++ b/tests/performance/test_bigquery_benchmarks.py
@@ -148,7 +148,7 @@ def _recursively_assert_actual_result_matches_expected_result_keys(
 
             >           assert expected == actual, description_for_error_reporting
             E           AssertionError: expect_table_columns_to_match_set result["exception_info"]["raised_exception"]
-            E           assert True == False
+            E           assert True is False
             E             +True
             E             -False
     """

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -19,7 +19,7 @@ def test_base_class_not_instantiable_due_to_abstract_methods():
 def test_DataSetProfiler_methods():
     toy_dataset = PandasDataset({"x": [1, 2, 3]})
 
-    assert DatasetProfiler.validate(1) == False
+    assert DatasetProfiler.validate(1) is False
     assert DatasetProfiler.validate(toy_dataset)
 
     with pytest.raises(NotImplementedError):
@@ -323,7 +323,7 @@ def test_context_profiler_with_data_asset_name(filesystem_csv_data_context):
         "rad_datasource", data_assets=["f1"], profiler=BasicDatasetProfiler
     )
 
-    assert profiling_result["success"] == True
+    assert profiling_result["success"] is True
     assert len(profiling_result["results"]) == 1
     assert (
         profiling_result["results"][0][0].expectation_suite_name

--- a/tests/test_fixtures/fixed_distribution_data.py
+++ b/tests/test_fixtures/fixed_distribution_data.py
@@ -2,7 +2,7 @@
 Use this code to create the reproducible data in ./tests/test_sets/fixed_distributional_test_data.csv
 
 The data should pass a kstest with the cdf parameter=distribution and a=0.05,
-e.g. kstest(data_column, "distribution name", p-value=0.05) == True
+e.g. kstest(data_column, "distribution name", p-value=0.05) is True
 
 """
 import numpy as np

--- a/tests/test_great_expectations.py
+++ b/tests/test_great_expectations.py
@@ -72,7 +72,7 @@ class CustomPandasDataset(PandasDataset):
         not_null = self[column].notnull()
 
         result = self[column][not_null] == 1
-        unexpected_values = list(self[column][not_null][result == False])
+        unexpected_values = list(self[column][not_null][result is False])
 
         if mostly:
             # Prevent division-by-zero errors
@@ -90,7 +90,7 @@ class CustomPandasDataset(PandasDataset):
                 "success": percent_equaling_1 >= mostly,
                 "result": {
                     "unexpected_list": unexpected_values[:20],
-                    "unexpected_index_list": list(self.index[result == False])[:20],
+                    "unexpected_index_list": list(self.index[result is False])[:20],
                 },
             }
         else:
@@ -98,7 +98,7 @@ class CustomPandasDataset(PandasDataset):
                 "success": len(unexpected_values) == 0,
                 "result": {
                     "unexpected_list": unexpected_values[:20],
-                    "unexpected_index_list": list(self.index[result == False])[:20],
+                    "unexpected_index_list": list(self.index[result is False])[:20],
                 },
             }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- PEP8 states to use `is` here


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
