### PR TITLE
[BUGFIX] Patch additional deprecated call to `GXCloudIdentifier.ge_cloud_id` attr

### DIFF
--- a/great_expectations/checkpoint/actions.py
+++ b/great_expectations/checkpoint/actions.py
@@ -803,7 +803,7 @@ class StoreValidationResultAction(ValidationAction):
         data_asset,
         payload=None,
         expectation_suite_identifier=None,
-        checkpoint_identifier=None,
+        checkpoint_identifier: Optional[GXCloudIdentifier] = None,
     ):
         logger.debug("StoreValidationResultAction.run")
 
@@ -825,7 +825,7 @@ class StoreValidationResultAction(ValidationAction):
 
         checkpoint_ge_cloud_id = None
         if self.data_context.cloud_mode and checkpoint_identifier:
-            checkpoint_ge_cloud_id = checkpoint_identifier.ge_cloud_id
+            checkpoint_ge_cloud_id = checkpoint_identifier.cloud_id
 
         expectation_suite_ge_cloud_id = None
         if self.data_context.cloud_mode and expectation_suite_identifier:

--- a/great_expectations/data_context/types/resource_identifiers.py
+++ b/great_expectations/data_context/types/resource_identifiers.py
@@ -230,6 +230,16 @@ class GXCloudIdentifier(DataContextKey):
         self._cloud_id = value
 
     @property
+    def ge_cloud_id(self):
+        # Deprecated 0.15.40
+        return self.cloud_id
+
+    @ge_cloud_id.setter
+    def ge_cloud_id(self, value) -> None:
+        # Deprecated 0.15.40
+        self.cloud_id = value
+
+    @property
     def resource_name(self) -> str:
         return self._resource_name
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Patch existing call to `ge_cloud_id`
- Add deprecated property/setter to protect against future issues

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
