### PR TITLE
[MAINTENANCE] Simplify computational graph assembly from metric configurations

### DIFF
--- a/great_expectations/core/expectation_configuration.py
+++ b/great_expectations/core/expectation_configuration.py
@@ -1388,6 +1388,7 @@ class ExpectationConfiguration(SerializableDictDot):
         runtime_configuration=None,
     ):
         expectation_impl: Expectation = self._get_expectation_impl()
+        # noinspection PyCallingNonCallable
         return expectation_impl(self).validate(
             validator=validator,
             runtime_configuration=runtime_configuration,
@@ -1401,6 +1402,7 @@ class ExpectationConfiguration(SerializableDictDot):
         **kwargs: dict,
     ):
         expectation_impl: Expectation = self._get_expectation_impl()
+        # noinspection PyCallingNonCallable
         return expectation_impl(self).metrics_validate(
             metrics=metrics,
             runtime_configuration=runtime_configuration,

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -370,12 +370,12 @@ class ExpectationValidationGraph:
     ) -> None:
         if configuration is None:
             raise ValueError(
-                f"""Instantiation of "ExpectationValidationGraph" requires valid "ExpectationConfiguration" object."""
+                """Instantiation of "ExpectationValidationGraph" requires valid "ExpectationConfiguration" object."""
             )
 
         if graph is None:
             raise ValueError(
-                f"""Instantiation of "ExpectationValidationGraph" requires valid "ValidationGraph" object."""
+                """Instantiation of "ExpectationValidationGraph" requires valid "ValidationGraph" object."""
             )
 
         self._configuration = configuration

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -365,15 +365,20 @@ class ValidationGraph:
 class ExpectationValidationGraph:
     def __init__(
         self,
-        execution_engine: ExecutionEngine,
         configuration: ExpectationConfiguration,
-        graph: Optional[ValidationGraph] = None,
+        graph: ValidationGraph,
     ) -> None:
-        self._configuration = configuration
+        if configuration is None:
+            raise ValueError(
+                f"""Instantiation of "ExpectationValidationGraph" requires valid "ExpectationConfiguration" object."""
+            )
 
         if graph is None:
-            graph = ValidationGraph(execution_engine=execution_engine)
+            raise ValueError(
+                f"""Instantiation of "ExpectationValidationGraph" requires valid "ValidationGraph" object."""
+            )
 
+        self._configuration = configuration
         self._graph = graph
 
     @property

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -367,9 +367,14 @@ class ExpectationValidationGraph:
         self,
         execution_engine: ExecutionEngine,
         configuration: ExpectationConfiguration,
+        graph: Optional[ValidationGraph] = None,
     ) -> None:
         self._configuration = configuration
-        self._graph = ValidationGraph(execution_engine=execution_engine)
+
+        if graph is None:
+            graph = ValidationGraph(execution_engine=execution_engine)
+
+        self._graph = graph
 
     @property
     def configuration(self) -> ExpectationConfiguration:

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1111,7 +1111,6 @@ class Validator:
 
             try:
                 expectation_validation_graph: ExpectationValidationGraph = ExpectationValidationGraph(
-                    execution_engine=self._execution_engine,
                     configuration=evaluated_config,
                     graph=self.metrics_calculator.build_metric_dependency_graph(
                         metric_configurations=validation_dependencies.get_metric_configurations(),

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -1110,22 +1110,14 @@ class Validator:
             )
 
             try:
-                expectation_validation_graph: ExpectationValidationGraph = (
-                    ExpectationValidationGraph(
-                        execution_engine=self._execution_engine,
-                        configuration=evaluated_config,
-                    )
-                )
-                for (
-                    metric_configuration
-                ) in validation_dependencies.get_metric_configurations():
-                    graph = ValidationGraph(execution_engine=self._execution_engine)
-                    graph.build_metric_dependency_graph(
-                        metric_configuration=metric_configuration,
+                expectation_validation_graph: ExpectationValidationGraph = ExpectationValidationGraph(
+                    execution_engine=self._execution_engine,
+                    configuration=evaluated_config,
+                    graph=self.metrics_calculator.build_metric_dependency_graph(
+                        metric_configurations=validation_dependencies.get_metric_configurations(),
                         runtime_configuration=runtime_configuration,
-                    )
-                    expectation_validation_graph.update(graph=graph)
-
+                    ),
+                )
                 expectation_validation_graphs.append(expectation_validation_graph)
                 processed_configurations.append(evaluated_config)
             except Exception as err:

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -74,6 +74,7 @@ def expect_column_values_to_be_unique_expectation_validation_graph(
     return ExpectationValidationGraph(
         execution_engine=execution_engine,
         configuration=expect_column_values_to_be_unique_expectation_config,
+        graph=None,
     )
 
 

--- a/tests/validator/test_validation_graph.py
+++ b/tests/validator/test_validation_graph.py
@@ -31,6 +31,16 @@ def metric_edge(
 
 
 @pytest.fixture
+def validation_graph_with_no_edges() -> ValidationGraph:
+    class DummyExecutionEngine:
+        pass
+
+    execution_engine = cast(ExecutionEngine, DummyExecutionEngine)
+
+    return ValidationGraph(execution_engine=execution_engine, edges=None)
+
+
+@pytest.fixture
 def validation_graph_with_single_edge(metric_edge: MetricEdge) -> ValidationGraph:
     class DummyExecutionEngine:
         pass
@@ -65,16 +75,11 @@ def expect_column_value_z_scores_to_be_less_than_expectation_config() -> Expecta
 @pytest.fixture
 def expect_column_values_to_be_unique_expectation_validation_graph(
     expect_column_values_to_be_unique_expectation_config: ExpectationConfiguration,
+    validation_graph_with_no_edges: ValidationGraph,
 ) -> ExpectationValidationGraph:
-    class DummyExecutionEngine:
-        pass
-
-    execution_engine = cast(ExecutionEngine, DummyExecutionEngine)
-
     return ExpectationValidationGraph(
-        execution_engine=execution_engine,
         configuration=expect_column_values_to_be_unique_expectation_config,
-        graph=None,
+        graph=validation_graph_with_no_edges,
     )
 
 
@@ -113,6 +118,7 @@ def expect_column_value_z_scores_to_be_less_than_expectation_validation_graph():
     return graph
 
 
+# noinspection PyPep8Naming
 @pytest.mark.unit
 def test_ValidationGraph_init_no_input_edges() -> None:
     class DummyExecutionEngine:
@@ -160,10 +166,43 @@ def test_ValidationGraph_add(metric_edge: MetricEdge) -> None:
     assert metric_edge.id in graph.edge_ids
 
 
+def test_ExpectationValidationGraph_constructor(
+    expect_column_values_to_be_unique_expectation_config: ExpectationConfiguration,
+    validation_graph_with_no_edges: ValidationGraph,
+):
+    with pytest.raises(ValueError) as ve:
+        # noinspection PyUnusedLocal,PyTypeChecker
+        expectation_validation_graph = ExpectationValidationGraph(
+            configuration=None,
+            graph=None,
+        )
+
+    assert ve.value.args == (
+        'Instantiation of "ExpectationValidationGraph" requires valid "ExpectationConfiguration" object.',
+    )
+
+    with pytest.raises(ValueError) as ve:
+        # noinspection PyUnusedLocal,PyTypeChecker
+        expectation_validation_graph = ExpectationValidationGraph(
+            configuration=expect_column_values_to_be_unique_expectation_config,
+            graph=None,
+        )
+
+    assert ve.value.args == (
+        'Instantiation of "ExpectationValidationGraph" requires valid "ValidationGraph" object.',
+    )
+
+    expectation_validation_graph = ExpectationValidationGraph(
+        configuration=expect_column_values_to_be_unique_expectation_config,
+        graph=validation_graph_with_no_edges,
+    )
+    assert len(expectation_validation_graph.graph.edges) == 0
+
+
 @pytest.mark.unit
 def test_ExpectationValidationGraph_update(
-    expect_column_values_to_be_unique_expectation_validation_graph: ExpectationValidationGraph,
     validation_graph_with_single_edge: ValidationGraph,
+    expect_column_values_to_be_unique_expectation_validation_graph: ExpectationValidationGraph,
 ) -> None:
     assert (
         len(expect_column_values_to_be_unique_expectation_validation_graph.graph.edges)

--- a/tests/validator/test_validator.py
+++ b/tests/validator/test_validator.py
@@ -406,6 +406,7 @@ def test_validator_with_bad_batchrequest(
         data_connector_query={"batch_filter_parameters": {"year": "2019"}},
     )
     with pytest.raises(ge_exceptions.InvalidBatchRequestError):
+        # noinspection PyUnusedLocal
         validator_multi_batch: Validator = context.get_validator(
             batch_request=multi_batch_request, expectation_suite=suite
         )


### PR DESCRIPTION
### Scope
Instead of adding computational graph one `MetricConfiguration` at a time, use `MetricsCalculator.build_metric_dependency_graph()` to incorporate all `MetricConfiguration` objects part of `ValidationDependencies` of `ExpectationConfiguration` at once.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1347/GREAT-181/GREAT-1437
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!