### PR TITLE
[BUGFIX] Remove unused "type: ignore" comment

### DIFF
--- a/great_expectations/core/usage_statistics/execution_environment.py
+++ b/great_expectations/core/usage_statistics/execution_environment.py
@@ -129,7 +129,7 @@ class GXExecutionEnvironment:
             installed: bool
             if dependency_name in self._get_all_installed_packages():
                 installed = True
-                package_version = version.parse(metadata.version(dependency_name))  # type: ignore[assignment]
+                package_version = version.parse(metadata.version(dependency_name))
             else:
                 installed = False
                 package_version = None

--- a/great_expectations/core/usage_statistics/execution_environment.py
+++ b/great_expectations/core/usage_statistics/execution_environment.py
@@ -13,7 +13,7 @@ access to features of new package versions.
 import enum
 import sys
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Union
 
 from marshmallow import Schema, fields
 from packaging import version
@@ -39,7 +39,7 @@ class PackageInfo:
     package_name: str
     installed: bool
     install_environment: InstallEnvironment
-    version: Optional[version.Version]
+    version: Optional[Union[version.Version, version.LegacyVersion]]
 
 
 class PackageInfoSchema(Schema):
@@ -125,7 +125,7 @@ class GXExecutionEnvironment:
         dependencies: List[PackageInfo] = []
         for dependency_name in dependency_names:
 
-            package_version: Optional[version.Version]
+            package_version: Optional[Union[version.Version, version.LegacyVersion]]
             installed: bool
             if dependency_name in self._get_all_installed_packages():
                 installed = True


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove an unused "type: ignore" comment that was causing issues in PR https://github.com/great-expectations/great_expectations/pull/6557
### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.