### PR TITLE
[BUGFIX] Add missing `raise` statement in `RuntimeDataConnector` logic

### DIFF
--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -244,7 +244,7 @@ class RuntimeDataConnector(DataConnector):
             batch_identifiers = batch_request.batch_identifiers
 
         if not batch_identifiers:
-            ge_exceptions.DataConnectorError(
+            raise ge_exceptions.DataConnectorError(
                 "Passed in a RuntimeBatchRequest with no batch_identifiers"
             )
 

--- a/great_expectations/datasource/data_connector/runtime_data_connector.py
+++ b/great_expectations/datasource/data_connector/runtime_data_connector.py
@@ -253,14 +253,14 @@ class RuntimeDataConnector(DataConnector):
             datasource_name=self.datasource_name,
             data_connector_name=self.name,
             data_asset_name=batch_request.data_asset_name,
-            batch_identifiers=IDDict(batch_identifiers),  # type: ignore[arg-type]
+            batch_identifiers=IDDict(batch_identifiers),
             batch_spec_passthrough=batch_request.batch_spec_passthrough,
         )
         batch_definition_list = [batch_definition]
         self._update_data_references_cache(
             batch_request.data_asset_name,
             batch_definition_list,
-            IDDict(batch_identifiers),  # type: ignore[arg-type]
+            IDDict(batch_identifiers),
         )
         return batch_definition_list
 


### PR DESCRIPTION
Changes proposed in this pull request:
- We define an exception but never use it


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
