### PR TITLE
[MAINTENANCE] Cast type in `execution_environment.py` to bypass flaky `mypy` warnings

### DIFF
--- a/great_expectations/core/usage_statistics/execution_environment.py
+++ b/great_expectations/core/usage_statistics/execution_environment.py
@@ -13,7 +13,7 @@ access to features of new package versions.
 import enum
 import sys
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, cast
 
 from marshmallow import Schema, fields
 from packaging import version
@@ -129,7 +129,9 @@ class GXExecutionEnvironment:
             installed: bool
             if dependency_name in self._get_all_installed_packages():
                 installed = True
-                package_version = version.parse(metadata.version(dependency_name))  # type: ignore[assignment]
+                package_version = cast(
+                    version.Version, version.parse(metadata.version(dependency_name))
+                )
             else:
                 installed = False
                 package_version = None


### PR DESCRIPTION
Changes proposed in this pull request:
- `cast` let's us bypass this issue that's been plaguing CI


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
