### PR TITLE
[MAINTENANCE] Utilize a `StrEnum` for `ConfigPeer` modes

### DIFF
--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -49,18 +49,18 @@ class ConfigPeer(ABC):
 
         config: BaseYamlConfig = self.config
 
-        if mode is ConfigOutputModes.TYPED:
+        if mode == ConfigOutputModes.TYPED:
             return config
 
-        if mode is ConfigOutputModes.COMMENTED_MAP:
+        if mode == ConfigOutputModes.COMMENTED_MAP:
             return config.commented_map
 
-        if mode is ConfigOutputModes.YAML:
+        if mode == ConfigOutputModes.YAML:
             return config.to_yaml_str()
 
-        if mode is ConfigOutputModes.DICT:
+        if mode == ConfigOutputModes.DICT:
             config_kwargs: dict = config.to_dict()
-        elif mode is ConfigOutputModes.JSON_DICT:
+        elif mode == ConfigOutputModes.JSON_DICT:
             config_kwargs: dict = config.to_json_dict()  # type: ignore[no-redef]
         else:
             raise ValueError(f'Unknown mode {mode} in "BaseCheckpoint.get_config()".')

--- a/great_expectations/core/config_peer.py
+++ b/great_expectations/core/config_peer.py
@@ -9,15 +9,12 @@ from great_expectations.util import filter_properties_dict
 logger = logging.getLogger(__name__)
 
 
-class ConfigOutputModes(Enum):
+class ConfigOutputModes(str, Enum):
     TYPED = "typed"
     COMMENTED_MAP = "commented_map"
     YAML = "yaml"
     DICT = "dict"
     JSON_DICT = "json_dict"
-
-
-ConfigOutputModeType = Union[ConfigOutputModes, str]
 
 
 class ConfigPeer(ABC):
@@ -44,7 +41,7 @@ class ConfigPeer(ABC):
 
     def get_config(
         self,
-        mode: ConfigOutputModeType = ConfigOutputModes.TYPED,
+        mode: ConfigOutputModes = ConfigOutputModes.TYPED,
         **kwargs,
     ) -> Union[BaseYamlConfig, dict, str]:
         if isinstance(mode, str):
@@ -52,18 +49,18 @@ class ConfigPeer(ABC):
 
         config: BaseYamlConfig = self.config
 
-        if mode == ConfigOutputModes.TYPED:
+        if mode is ConfigOutputModes.TYPED:
             return config
 
-        if mode == ConfigOutputModes.COMMENTED_MAP:
+        if mode is ConfigOutputModes.COMMENTED_MAP:
             return config.commented_map
 
-        if mode == ConfigOutputModes.YAML:
+        if mode is ConfigOutputModes.YAML:
             return config.to_yaml_str()
 
-        if mode == ConfigOutputModes.DICT:
+        if mode is ConfigOutputModes.DICT:
             config_kwargs: dict = config.to_dict()
-        elif mode == ConfigOutputModes.JSON_DICT:
+        elif mode is ConfigOutputModes.JSON_DICT:
             config_kwargs: dict = config.to_json_dict()  # type: ignore[no-redef]
         else:
             raise ValueError(f'Unknown mode {mode} in "BaseCheckpoint.get_config()".')

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -123,7 +123,7 @@ class DataAssistantRunner:
                 DataAssistantResult: The result object for the DataAssistant
             """
             if batch_request is None:
-                data_assistant_name: str = self._data_assistant_cls.data_assistant_type  # type: ignore[attr-defined] # Dynamic attr assigned in __new__
+                data_assistant_name: str = self._data_assistant_cls.data_assistant_type  # type: ignore[attr-defined] # dynamic attr assigned in __new__
                 raise ge_exceptions.DataAssistantExecutionError(
                     message=f"""Utilizing "{data_assistant_name}.run()" requires valid "batch_request" to be specified \
 (empty or missing "batch_request" detected)."""
@@ -219,7 +219,7 @@ class DataAssistantRunner:
         Returns:
             DataAssistant: The "DataAssistant" object, corresponding to this instance's specified "DataAssistant" type.
         """
-        data_assistant_name: str = self._data_assistant_cls.data_assistant_type  # type: ignore[attr-defined] # Dynamic attr assigned in __new__
+        data_assistant_name: str = self._data_assistant_cls.data_assistant_type  # type: ignore[attr-defined] # dynamic attr assigned in __new__
 
         data_assistant: DataAssistant
 
@@ -351,7 +351,7 @@ class DataAssistantRunner:
 
         attribute_names: List[str] = list(
             filter(
-                lambda element: element not in exclude_field_names,  # type: ignore[arg-type] # filter type check is strict: https://github.com/python/mypy/issues/12682
+                lambda element: element not in exclude_field_names,
                 list(parameters.keys())[1:],
             )
         )

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py
@@ -8,7 +8,7 @@ from makefun import create_function
 
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.core.batch import BatchRequestBase
-from great_expectations.core.config_peer import ConfigOutputModes, ConfigOutputModeType
+from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.data_context.types.base import BaseYamlConfig
 from great_expectations.rule_based_profiler import BaseRuleBasedProfiler
 from great_expectations.rule_based_profiler.data_assistant import DataAssistant
@@ -78,7 +78,7 @@ class DataAssistantRunner:
 
     def get_profiler_config(
         self,
-        mode: ConfigOutputModeType = ConfigOutputModes.JSON_DICT,
+        mode: ConfigOutputModes = ConfigOutputModes.JSON_DICT,
     ) -> Union[BaseYamlConfig, dict, str]:
         """
         This method returns configuration of effective "BaseRuleBasedProfiler", corresponding to this instance's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ exclude = [
     'rule_based_profiler/data_assistant_result/onboarding_data_assistant_result\.py', # 1
     'rule_based_profiler/data_assistant_result/plot_components\.py', # 12
     'rule_based_profiler/data_assistant/data_assistant_dispatcher\.py',  # 3
+    'rule_based_profiler/data_assistant/data_assistant_runner\.py',  # 10
     'rule_based_profiler/data_assistant/data_assistant\.py',  # 15
     'rule_based_profiler/domain_builder/categorical_column_domain_builder\.py',  # 18
     'rule_based_profiler/domain_builder/column_domain_builder\.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ exclude = [
     'rule_based_profiler/data_assistant_result/onboarding_data_assistant_result\.py', # 1
     'rule_based_profiler/data_assistant_result/plot_components\.py', # 12
     'rule_based_profiler/data_assistant/data_assistant_dispatcher\.py',  # 3
-    'rule_based_profiler/data_assistant/data_assistant_runner\.py',  # 10
     'rule_based_profiler/data_assistant/data_assistant\.py',  # 15
     'rule_based_profiler/domain_builder/categorical_column_domain_builder\.py',  # 18
     'rule_based_profiler/domain_builder/column_domain_builder\.py',


### PR DESCRIPTION
Changes proposed in this pull request:
- Utilize a string enum for `ConfigPeer` logic


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
