### PR TITLE
[BUGFIX] Remove rendered header from Cloud-rendering tests

### DIFF
--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -98,7 +98,6 @@ def test_cloud_backed_data_context_save_expectation_suite_include_rendered_conte
                                         }
                                     },
                                     "template": "Must have exactly $value rows.",
-                                    "header": None,
                                 },
                                 "name": "atomic.prescriptive.summary",
                                 "value_type": "StringValueType",


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1373
- Update one line missed in test

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
