### PR TITLE
[BUGFIX] Stop overwriting query with static string in RuntimeBatchRequests for SQL

### DIFF
--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -1225,7 +1225,6 @@ class SqlAlchemyExecutionEngine(ExecutionEngine):
             # query != None is already checked when RuntimeQueryBatchSpec is instantiated
             query: str = batch_spec.query
 
-            batch_spec.query = "SQLQuery"
             batch_data = SqlAlchemyBatchData(
                 execution_engine=self,
                 query=query,

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -905,8 +905,8 @@ def test_get_batch_data_and_markers_using_query(sqlite_view_engine, test_df):
 
     query: str = "SELECT * FROM test_table_0"
     batch_spec = RuntimeQueryBatchSpec(
-            query=query,
-        )
+        query=query,
+    )
     batch_data, batch_markers = my_execution_engine.get_batch_data_and_markers(
         batch_spec=batch_spec
     )

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -904,12 +904,14 @@ def test_get_batch_data_and_markers_using_query(sqlite_view_engine, test_df):
     test_df.to_sql("test_table_0", con=my_execution_engine.engine)
 
     query: str = "SELECT * FROM test_table_0"
-    batch_data, batch_markers = my_execution_engine.get_batch_data_and_markers(
-        batch_spec=RuntimeQueryBatchSpec(
+    batch_spec = RuntimeQueryBatchSpec(
             query=query,
         )
+    batch_data, batch_markers = my_execution_engine.get_batch_data_and_markers(
+        batch_spec=batch_spec
     )
 
+    assert batch_spec.query == query
     assert len(get_sqlite_temp_table_names(sqlite_view_engine)) == 2
     assert batch_markers.get("ge_load_time") is not None
 


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- Previously, we were overwriting the original query in the BatchSpec with a hard-coded string in the case of a RuntimeBatchRequest. This meant that there was no record of the original query in the validation results nor in Data Docs. 
- This removes that overwrite
- Closes #4970


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
