### PR TITLE
[MAINTENANCE] create cache as part of `--ci` type-checking step

### DIFF
--- a/azure-pipelines-dev.yml
+++ b/azure-pipelines-dev.yml
@@ -115,7 +115,7 @@ stages:
       steps:
       - script: |
           pip install --requirement reqs/requirements-dev-contrib.txt
-          invoke type-check --install-types --warn-unused-ignores --pretty
+          invoke type-check --ci --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
       steps:
       - script: |
           pip install $(grep -E '^(invoke|mypy)' reqs/requirements-dev-contrib.txt)
-          invoke type-check --install-types --warn-unused-ignores --pretty
+          invoke type-check --ci --pretty
         name: StaticTypeCheck
 
     - job: docstring_checker

--- a/tasks.py
+++ b/tasks.py
@@ -143,10 +143,27 @@ def type_check(
     daemon=False,
     clear_cache=False,
     report=False,
+    ci=False,
 ):
     """Run mypy static type-checking on select packages."""
+    mypy_cache = pathlib.Path(".mypy_cache")
+
+    if ci:
+        mypy_cache.mkdir(exist_ok=True)
+
+        type_check(
+            ctx,
+            packages,
+            install_types=True,
+            pretty=pretty,
+            warn_unused_ignores=True,
+            daemon=daemon,
+            clear_cache=clear_cache,
+            report=True,
+            ci=False,
+        )
+
     if clear_cache:
-        mypy_cache = pathlib.Path(".mypy_cache")
         print(f"  Clearing {mypy_cache} ... ", end="")
         try:
             shutil.rmtree(mypy_cache)

--- a/tasks.py
+++ b/tasks.py
@@ -150,6 +150,7 @@ def type_check(
 
     if ci:
         mypy_cache.mkdir(exist_ok=True)
+        ctx.run("pip list", echo=True, pty=True)
 
         type_check(
             ctx,

--- a/tasks.py
+++ b/tasks.py
@@ -160,7 +160,7 @@ def type_check(
             warn_unused_ignores=True,
             daemon=daemon,
             clear_cache=clear_cache,
-            report=True,
+            report=report,
             ci=False,
         )
 

--- a/tasks.py
+++ b/tasks.py
@@ -163,6 +163,7 @@ def type_check(
             report=report,
             ci=False,
         )
+        return  # don't run twice
 
     if clear_cache:
         print(f"  Clearing {mypy_cache} ... ", end="")

--- a/tasks.py
+++ b/tasks.py
@@ -150,7 +150,7 @@ def type_check(
 
     if ci:
         mypy_cache.mkdir(exist_ok=True)
-        ctx.run("pip list", echo=True, pty=True)
+        print(f"  mypy cache {mypy_cache.absolute()}")
 
         type_check(
             ctx,


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix static type checking step
  - always create the `mypy` cache directory if it does not exist when running in CI
- add a `--ci` flag to `invoke type-check` and use it in pipelines

Not sure how, but this seems to have started after https://github.com/great-expectations/great_expectations/pull/6609
