### PR TITLE
[FEATURE] Atomic rendering of meta notes

### DIFF
--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -1103,6 +1103,7 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                         },
                     },
                     "graph": renderer_configuration.graph,
+                    "meta_notes": renderer_configuration.meta_notes,
                     "schema": {"type": "GraphType"},
                 }
             )
@@ -1119,6 +1120,7 @@ class ExpectColumnKlDivergenceToBeLessThan(ColumnExpectation):
                     },
                     "header_row": renderer_configuration.header_row,
                     "table": renderer_configuration.table,
+                    "meta_notes": renderer_configuration.meta_notes,
                     "schema": {"type": "TableType"},
                 }
             )

--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -351,9 +351,6 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> RenderedAtomicContent:
-        """
-        Rendering function that is utilized by GE Cloud Front-end
-        """
         renderer_configuration: RendererConfiguration = RendererConfiguration(
             configuration=configuration,
             result=result,
@@ -373,6 +370,7 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnExpectation):
                 },
                 "header_row": renderer_configuration.header_row,
                 "table": renderer_configuration.table,
+                "meta_notes": renderer_configuration.meta_notes,
                 "schema": {"type": "TableType"},
             }
         )

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -352,7 +352,7 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     # NOTE: This method is a pretty good example of good usage of `params`.
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -352,7 +352,7 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     # NOTE: This method is a pretty good example of good usage of `params`.
     @classmethod

--- a/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
@@ -140,7 +140,7 @@ class ExpectColumnValuesToBeDateutilParseable(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_dateutil_parseable.py
@@ -140,7 +140,7 @@ class ExpectColumnValuesToBeDateutilParseable(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
@@ -176,7 +176,7 @@ class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_decreasing.py
@@ -176,7 +176,7 @@ class ExpectColumnValuesToBeDecreasing(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -238,7 +238,7 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="type_list",
         )
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_in_type_list.py
@@ -238,7 +238,7 @@ class ExpectColumnValuesToBeInTypeList(ColumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="type_list",
         )
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
@@ -175,7 +175,7 @@ class ExpectColumnValuesToBeIncreasing(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_increasing.py
@@ -175,7 +175,7 @@ class ExpectColumnValuesToBeIncreasing(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
@@ -144,7 +144,7 @@ class ExpectColumnValuesToBeJsonParseable(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_json_parseable.py
@@ -144,7 +144,7 @@ class ExpectColumnValuesToBeJsonParseable(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -258,7 +258,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_of_type.py
@@ -258,7 +258,7 @@ class ExpectColumnValuesToBeOfType(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -161,7 +161,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_unique.py
@@ -87,7 +87,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
     args_keys = ("column",)
 
     def validate_configuration(
-        self, configuration: Optional[ExpectationConfiguration]
+        self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
         super().validate_configuration(configuration)
         try:
@@ -161,7 +161,7 @@ class ExpectColumnValuesToBeUnique(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
@@ -165,7 +165,7 @@ class ExpectColumnValuesToMatchJsonSchema(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_json_schema.py
@@ -165,7 +165,7 @@ class ExpectColumnValuesToMatchJsonSchema(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -265,7 +265,7 @@ class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex.py
@@ -265,7 +265,7 @@ class ExpectColumnValuesToMatchRegex(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -220,7 +220,7 @@ class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):
             param_key_with_list="regex_list",
         )
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_regex_list.py
@@ -220,7 +220,7 @@ class ExpectColumnValuesToMatchRegexList(ColumnMapExpectation):
             param_key_with_list="regex_list",
         )
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
@@ -243,7 +243,7 @@ class ExpectColumnValuesToMatchStrftimeFormat(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
+++ b/great_expectations/expectations/core/expect_column_values_to_match_strftime_format.py
@@ -243,7 +243,7 @@ class ExpectColumnValuesToMatchStrftimeFormat(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -157,7 +157,7 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -157,7 +157,7 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -256,7 +256,7 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -256,7 +256,7 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
             template_str = f"{conditional_template_str}, then {template_str}"
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -199,7 +199,7 @@ class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="regex_list",
         )
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex_list.py
@@ -199,7 +199,7 @@ class ExpectColumnValuesToNotMatchRegexList(ColumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="regex_list",
         )
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -174,7 +174,7 @@ class ExpectCompoundColumnsToBeUnique(MulticolumnMapExpectation):
             )
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_compound_columns_to_be_unique.py
@@ -174,7 +174,7 @@ class ExpectCompoundColumnsToBeUnique(MulticolumnMapExpectation):
             )
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
@@ -182,7 +182,7 @@ class ExpectMulticolumnValuesToBeUnique(ColumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="column_list",
         )
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
+++ b/great_expectations/expectations/core/expect_multicolumn_values_to_be_unique.py
@@ -182,7 +182,7 @@ class ExpectMulticolumnValuesToBeUnique(ColumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="column_list",
         )
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -193,7 +193,7 @@ class ExpectSelectColumnValuesToBeUniqueWithinRecord(MulticolumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="column_list",
         )
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -193,7 +193,7 @@ class ExpectSelectColumnValuesToBeUniqueWithinRecord(MulticolumnMapExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="column_list",
         )
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -150,7 +150,7 @@ class ExpectTableColumnCountToBeBetween(TableExpectation):
                 "value": params.get("strict_max"),
             },
         }
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_be_between.py
@@ -150,7 +150,7 @@ class ExpectTableColumnCountToBeBetween(TableExpectation):
                 "value": params.get("strict_max"),
             },
         }
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -122,7 +122,7 @@ class ExpectTableColumnCountToEqual(TableExpectation):
         params_with_json_schema = {
             "value": {"schema": {"type": "number"}, "value": params.get("value")},
         }
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_column_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_column_count_to_equal.py
@@ -122,7 +122,7 @@ class ExpectTableColumnCountToEqual(TableExpectation):
         params_with_json_schema = {
             "value": {"schema": {"type": "number"}, "value": params.get("value")},
         }
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -149,7 +149,7 @@ class ExpectTableColumnsToMatchOrderedList(TableExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="column_list",
         )
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_ordered_list.py
@@ -149,7 +149,7 @@ class ExpectTableColumnsToMatchOrderedList(TableExpectation):
             params_with_json_schema=params_with_json_schema,
             param_key_with_list="column_list",
         )
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -212,7 +212,7 @@ class ExpectTableColumnsToMatchSet(TableExpectation):
                 "value": params.get("exact_match"),
             },
         }
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_columns_to_match_set.py
+++ b/great_expectations/expectations/core/expect_table_columns_to_match_set.py
@@ -212,7 +212,7 @@ class ExpectTableColumnsToMatchSet(TableExpectation):
                 "value": params.get("exact_match"),
             },
         }
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -97,7 +97,7 @@ class ExpectTableRowCountToEqualOtherTable(TableExpectation):
                 "value": params.get("other_table_name"),
             },
         }
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal_other_table.py
@@ -97,7 +97,7 @@ class ExpectTableRowCountToEqualOtherTable(TableExpectation):
                 "value": params.get("other_table_name"),
             },
         }
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type=LegacyRendererType.PRESCRIPTIVE)

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -118,6 +118,7 @@ from great_expectations.validator.validator import ValidationDependencies, Valid
 
 if TYPE_CHECKING:
     from great_expectations.data_context import AbstractDataContext
+    from great_expectations.render.renderer_configuration import MetaNotes
 
 logger = logging.getLogger(__name__)
 
@@ -438,7 +439,7 @@ class Expectation(metaclass=MetaExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> Tuple[str, dict, dict, Optional[dict]]:
+    ) -> Tuple[str, dict, MetaNotes, Optional[dict]]:
         """
         Template function that contains the logic that is shared by AtomicPrescriptiveRendererType.SUMMARY and
         LegacyRendererType.PRESCRIPTIVE.

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -391,6 +391,7 @@ class Expectation(metaclass=MetaExpectation):
             {
                 "template": template_str,
                 "params": renderer_configuration.params.dict(),
+                "meta_notes": renderer_configuration.meta_notes,
                 "schema": {"type": "com.superconductive.rendered.string"},
             }
         )

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -437,7 +437,7 @@ class Expectation(metaclass=MetaExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> Tuple[str, dict, Optional[dict]]:
+    ) -> Tuple[str, dict, dict, Optional[dict]]:
         """
         Template function that contains the logic that is shared by AtomicPrescriptiveRendererType.SUMMARY and
         LegacyRendererType.PRESCRIPTIVE.
@@ -456,6 +456,7 @@ class Expectation(metaclass=MetaExpectation):
         return (
             renderer_configuration.template_str,
             renderer_configuration.params.dict(),
+            renderer_configuration.meta_notes,
             styling,
         )
 
@@ -468,7 +469,12 @@ class Expectation(metaclass=MetaExpectation):
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
     ) -> RenderedAtomicContent:
-        (template_str, params_with_json_schema, _) = cls._atomic_prescriptive_template(
+        (
+            template_str,
+            params_with_json_schema,
+            meta_notes,
+            _,
+        ) = cls._atomic_prescriptive_template(
             configuration=configuration,
             result=result,
             runtime_configuration=runtime_configuration,
@@ -477,6 +483,7 @@ class Expectation(metaclass=MetaExpectation):
             {
                 "template": template_str,
                 "params": params_with_json_schema,
+                "meta_notes": meta_notes,
                 "schema": {"type": "com.superconductive.rendered.string"},
             }
         )

--- a/great_expectations/expectations/regex_based_column_map_expectation.py
+++ b/great_expectations/expectations/regex_based_column_map_expectation.py
@@ -209,7 +209,7 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
             template_str = conditional_template_str + ", then " + template_str
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type="renderer.prescriptive")

--- a/great_expectations/expectations/regex_based_column_map_expectation.py
+++ b/great_expectations/expectations/regex_based_column_map_expectation.py
@@ -209,7 +209,7 @@ class RegexBasedColumnMapExpectation(ColumnMapExpectation, ABC):
             template_str = conditional_template_str + ", then " + template_str
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type="renderer.prescriptive")

--- a/great_expectations/expectations/set_based_column_map_expectation.py
+++ b/great_expectations/expectations/set_based_column_map_expectation.py
@@ -216,7 +216,7 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
             template_str = conditional_template_str + ", then " + template_str
             params_with_json_schema.update(conditional_params)
 
-        return template_str, params_with_json_schema, {}, styling
+        return template_str, params_with_json_schema, None, styling
 
     @classmethod
     @renderer(renderer_type="renderer.prescriptive")

--- a/great_expectations/expectations/set_based_column_map_expectation.py
+++ b/great_expectations/expectations/set_based_column_map_expectation.py
@@ -216,7 +216,7 @@ class SetBasedColumnMapExpectation(ColumnMapExpectation, ABC):
             template_str = conditional_template_str + ", then " + template_str
             params_with_json_schema.update(conditional_params)
 
-        return (template_str, params_with_json_schema, styling)
+        return template_str, params_with_json_schema, {}, styling
 
     @classmethod
     @renderer(renderer_type="renderer.prescriptive")

--- a/great_expectations/profile/base.py
+++ b/great_expectations/profile/base.py
@@ -15,6 +15,7 @@ from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.data_asset import DataAsset
 from great_expectations.dataset import Dataset
 from great_expectations.exceptions import GreatExpectationsError
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.validator.validator import Validator
 
 logger = logging.getLogger(__name__)
@@ -200,7 +201,7 @@ class DatasetProfiler(DataAssetProfiler):
 
         if "notes" not in expectation_suite.meta:
             expectation_suite.meta["notes"] = {
-                "format": "markdown",
+                "format": MetaNotesFormat.MARKDOWN,
                 "content": [
                     "_To add additional notes, edit the <code>meta.notes.content</code> field in the appropriate Expectation json file._"
                     # TODO: be more helpful to the user by piping in the filename.

--- a/great_expectations/profile/basic_suite_builder_profiler.py
+++ b/great_expectations/profile/basic_suite_builder_profiler.py
@@ -11,6 +11,7 @@ from great_expectations.profile.basic_dataset_profiler import (
     BasicDatasetProfilerBase,
     logger,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.util import is_nan
 
 
@@ -732,7 +733,7 @@ class BasicSuiteBuilderProfiler(BasicDatasetProfilerBase):
         expectation_suite = cls._build_column_description_metadata(dataset)
 
         expectation_suite.meta["notes"] = {
-            "format": "markdown",
+            "format": MetaNotesFormat.MARKDOWN,
             "content": [
                 """#### This is an _example_ suite
 

--- a/great_expectations/profile/json_schema_profiler.py
+++ b/great_expectations/profile/json_schema_profiler.py
@@ -8,6 +8,7 @@ from great_expectations.core.expectation_configuration import ExpectationConfigu
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.profiler_types_mapping import ProfilerTypeMapping
 from great_expectations.profile.base import Profiler
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +111,7 @@ class JsonSchemaProfiler(Profiler):
         if description:
             meta = {
                 "notes": {
-                    "format": "markdown",
+                    "format": MetaNotesFormat.MARKDOWN,
                     "content": [f"### Description:\n{description}"],
                 }
             }
@@ -173,7 +174,7 @@ class JsonSchemaProfiler(Profiler):
         if description:
             meta = {
                 "notes": {
-                    "format": "markdown",
+                    "format": MetaNotesFormat.MARKDOWN,
                     "content": [f"### Description:\n{description}"],
                 }
             }

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -4,7 +4,7 @@ import json
 from copy import deepcopy
 from enum import Enum
 from string import Template as pTemplate
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from marshmallow import INCLUDE, Schema, fields, post_dump, post_load
 
@@ -627,6 +627,7 @@ class RenderedAtomicValue(DictDot):
         header_row: Optional[List[RenderedAtomicValue]] = None,
         table: Optional[List[List[RenderedAtomicValue]]] = None,
         graph: Optional[dict] = None,
+        meta_notes: Optional[Dict[str, Union[str, List[str]]]] = None,
     ) -> None:
         self.schema: Optional[dict] = schema
         self.header: Optional[RenderedAtomicValue] = header
@@ -641,6 +642,8 @@ class RenderedAtomicValue(DictDot):
 
         # GraphType
         self.graph = RenderedAtomicValueGraph(graph=graph)
+
+        self.meta_notes: Optional[Dict[str, Union[str, List[str]]]] = meta_notes
 
     def __repr__(self) -> str:
         return json.dumps(self.to_json_dict(), indent=2)
@@ -696,6 +699,8 @@ class RenderedAtomicValueSchema(Schema):
     # for GraphType
     graph = fields.Dict(required=False, allow_none=True)
 
+    meta_notes = fields.Dict(required=False, allow_none=True)
+
     @post_load
     def create_value_obj(self, data, **kwargs):
         return RenderedAtomicValue(**data)
@@ -708,6 +713,7 @@ class RenderedAtomicValueSchema(Schema):
         "header_row",
         "table",
         "graph",
+        "meta_notes",
     ]
 
     @post_dump

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -4,12 +4,15 @@ import json
 from copy import deepcopy
 from enum import Enum
 from string import Template as pTemplate
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from marshmallow import INCLUDE, Schema, fields, post_dump, post_load
 
 from great_expectations.render.exceptions import InvalidRenderedContentError
 from great_expectations.types import DictDot
+
+if TYPE_CHECKING:
+    from great_expectations.render.renderer_configuration import MetaNotes
 
 
 class RendererPrefix(str, Enum):
@@ -627,7 +630,7 @@ class RenderedAtomicValue(DictDot):
         header_row: Optional[List[RenderedAtomicValue]] = None,
         table: Optional[List[List[RenderedAtomicValue]]] = None,
         graph: Optional[dict] = None,
-        meta_notes: Optional[Dict[str, Union[str, List[str]]]] = None,
+        meta_notes: Optional[MetaNotes] = None,
     ) -> None:
         self.schema: Optional[dict] = schema
         self.header: Optional[RenderedAtomicValue] = header
@@ -643,7 +646,7 @@ class RenderedAtomicValue(DictDot):
         # GraphType
         self.graph = RenderedAtomicValueGraph(graph=graph)
 
-        self.meta_notes: Optional[Dict[str, Union[str, List[str]]]] = meta_notes
+        self.meta_notes: Optional[MetaNotes] = meta_notes
 
     def __repr__(self) -> str:
         return json.dumps(self.to_json_dict(), indent=2)

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -105,7 +105,7 @@ class MetaNotesFormat(str, Enum):
 
 
 class MetaNotes(TypedDict):
-    format: str
+    format: MetaNotesFormat
     content: List[str]
 
 

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -115,7 +115,9 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
     expectation_type: str = Field("", allow_mutation=False)
     kwargs: dict = Field({}, allow_mutation=False)
     include_column_name: bool = Field(True, allow_mutation=False)
-    meta_notes: MetaNotes = Field({}, allow_mutation=False)
+    meta_notes: MetaNotes = Field(
+        MetaNotes(format="", content=[]), allow_mutation=False
+    )
     template_str: str = Field("", allow_mutation=True)
     header_row: List[Dict[str, Optional[Any]]] = Field([], allow_mutation=True)
     table: List[List[Dict[str, Optional[Any]]]] = Field([], allow_mutation=True)

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -30,6 +30,7 @@ from pydantic import (
     validator,
 )
 from pydantic.generics import GenericModel
+from typing_extensions import TypedDict
 
 from great_expectations.core import (
     ExpectationConfiguration,
@@ -98,6 +99,11 @@ class _RendererParamsBase(BaseModel):
 RendererParams = TypeVar("RendererParams", bound=_RendererParamsBase)
 
 
+class MetaNotes(TypedDict):
+    format: str
+    content: List[str]
+
+
 class RendererConfiguration(GenericModel, Generic[RendererParams]):
     """Configuration object built for each renderer."""
 
@@ -109,7 +115,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
     expectation_type: str = Field("", allow_mutation=False)
     kwargs: dict = Field({}, allow_mutation=False)
     include_column_name: bool = Field(True, allow_mutation=False)
-    meta_notes: Dict[str, List[str]] = Field({}, allow_mutation=False)
+    meta_notes: MetaNotes = Field({}, allow_mutation=False)
     template_str: str = Field("", allow_mutation=True)
     header_row: List[Dict[str, Optional[Any]]] = Field([], allow_mutation=True)
     table: List[List[Dict[str, Optional[Any]]]] = Field([], allow_mutation=True)
@@ -317,7 +323,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
 
     @root_validator()
     def _validate_for_meta_notes(cls, values: dict) -> dict:
-        meta_notes: Optional[Dict[str, Union[str, List[str]]]]
+        meta_notes: Optional[MetaNotes]
         if (
             "result" in values
             and values["result"] is not None

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -99,6 +99,11 @@ class _RendererParamsBase(BaseModel):
 RendererParams = TypeVar("RendererParams", bound=_RendererParamsBase)
 
 
+class MetaNotesFormat(str, Enum):
+    STRING = "string"
+    MARKDOWN = "markdown"
+
+
 class MetaNotes(TypedDict):
     format: str
     content: List[str]

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -317,17 +317,15 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
 
     @root_validator()
     def _validate_for_meta_notes(cls, values: dict) -> dict:
-        meta_notes: Dict[str, Union[str, List[str]]]
+        meta_notes: Optional[Dict[str, Union[str, List[str]]]]
         if (
             "result" in values
             and values["result"] is not None
             and values["result"].expectation_config is not None
         ):
-            values["meta_notes"] = values["result"].expectation_config.meta.get(
-                "notes", {}
-            )
+            values["meta_notes"] = values["result"].expectation_config.meta.get("notes")
         else:
-            values["meta_notes"] = values["configuration"].meta.get("notes", {})
+            values["meta_notes"] = values["configuration"].meta.get("notes")
         return values
 
     @root_validator()

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -267,7 +267,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
         return values
 
     @staticmethod
-    def _get_condition_params(
+    def _get_row_condition_params(
         row_condition_str: str,
     ) -> Dict[str, Dict[str, Collection[str]]]:
         row_condition_str = RendererConfiguration._parse_row_condition_str(
@@ -304,7 +304,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
         if values["_row_condition"]:
             renderer_params_args: Dict[
                 str, Dict[str, Collection[str]]
-            ] = RendererConfiguration._get_condition_params(
+            ] = RendererConfiguration._get_row_condition_params(
                 row_condition_str=values["_row_condition"],
             )
             values["_params"] = (

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -109,6 +109,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
     expectation_type: str = Field("", allow_mutation=False)
     kwargs: dict = Field({}, allow_mutation=False)
     include_column_name: bool = Field(True, allow_mutation=False)
+    meta_notes: Dict[str, List[str]] = Field({}, allow_mutation=False)
     template_str: str = Field("", allow_mutation=True)
     header_row: List[Dict[str, Optional[Any]]] = Field([], allow_mutation=True)
     table: List[List[Dict[str, Optional[Any]]]] = Field([], allow_mutation=True)
@@ -230,8 +231,8 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
             expectation_configuration: ExpectationConfiguration = values[
                 "result"
             ].expectation_config
-            values["expectation_type"] = expectation_configuration.expectation_type
-            values["kwargs"] = expectation_configuration.kwargs
+            values["expectation_type"]: str = expectation_configuration.expectation_type
+            values["kwargs"]: dict = expectation_configuration.kwargs
             raw_configuration: ExpectationConfiguration = (
                 expectation_configuration.get_raw_configuration()
             )
@@ -252,8 +253,8 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
                     else renderer_params_args
                 )
         else:
-            values["expectation_type"] = values["configuration"].expectation_type
-            values["kwargs"] = values["configuration"].kwargs
+            values["expectation_type"]: str = values["configuration"].expectation_type
+            values["kwargs"]: dict = values["configuration"].kwargs
         return values
 
     @root_validator()
@@ -312,6 +313,21 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
                 if "_params" in values and values["_params"]
                 else renderer_params_args
             )
+        return values
+
+    @root_validator()
+    def _validate_for_meta_notes(cls, values: dict) -> dict:
+        meta_notes: Dict[str, Union[str, List[str]]]
+        if (
+            "result" in values
+            and values["result"] is not None
+            and values["result"].expectation_config is not None
+        ):
+            values["meta_notes"] = values["result"].expectation_config.meta.get(
+                "notes", {}
+            )
+        else:
+            values["meta_notes"] = values["configuration"].meta.get("notes", {})
         return values
 
     @root_validator()

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -231,8 +231,8 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
             expectation_configuration: ExpectationConfiguration = values[
                 "result"
             ].expectation_config
-            values["expectation_type"]: str = expectation_configuration.expectation_type
-            values["kwargs"]: dict = expectation_configuration.kwargs
+            values["expectation_type"] = expectation_configuration.expectation_type
+            values["kwargs"] = expectation_configuration.kwargs
             raw_configuration: ExpectationConfiguration = (
                 expectation_configuration.get_raw_configuration()
             )
@@ -253,8 +253,8 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
                     else renderer_params_args
                 )
         else:
-            values["expectation_type"]: str = values["configuration"].expectation_type
-            values["kwargs"]: dict = values["configuration"].kwargs
+            values["expectation_type"] = values["configuration"].expectation_type
+            values["kwargs"] = values["configuration"].kwargs
         return values
 
     @root_validator()

--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -121,7 +121,7 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
     kwargs: dict = Field({}, allow_mutation=False)
     include_column_name: bool = Field(True, allow_mutation=False)
     meta_notes: MetaNotes = Field(
-        MetaNotes(format="", content=[]), allow_mutation=False
+        MetaNotes(format=MetaNotesFormat.STRING, content=[]), allow_mutation=False
     )
     template_str: str = Field("", allow_mutation=True)
     header_row: List[Dict[str, Optional[Any]]] = Field([], allow_mutation=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ from great_expectations.datasource.new_datasource import BaseDatasource, Datasou
 from great_expectations.execution_engine.execution_engine import (
     MetricPartialFunctionTypes,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.rule_based_profiler.config import RuleBasedProfilerConfig
 from great_expectations.rule_based_profiler.config.base import (
     ruleBasedProfilerConfigSchema,
@@ -3049,7 +3050,7 @@ def alice_columnar_table_single_batch(empty_data_context):
                     },
                     meta={
                         "notes": {
-                            "format": "markdown",
+                            "format": MetaNotesFormat.MARKDOWN,
                             "content": [
                                 "### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**"
                             ],
@@ -3067,7 +3068,7 @@ def alice_columnar_table_single_batch(empty_data_context):
                     },
                     meta={
                         "notes": {
-                            "format": "markdown",
+                            "format": MetaNotesFormat.MARKDOWN,
                             "content": [
                                 "### This expectation confirms that the event_ts contains the latest timestamp of all domains"
                             ],
@@ -3088,7 +3089,7 @@ def alice_columnar_table_single_batch(empty_data_context):
                             "candidate_strings": expected_candidate_strings_dict,
                         },
                         "notes": {
-                            "format": "markdown",
+                            "format": MetaNotesFormat.MARKDOWN,
                             "content": [
                                 "### This expectation confirms that fields ending in _ts are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                             ],
@@ -3387,7 +3388,7 @@ def alice_columnar_table_single_batch(empty_data_context):
                         "column": "$domain.domain_kwargs.column",
                         "meta": {
                             "notes": {
-                                "format": "markdown",
+                                "format": MetaNotesFormat.MARKDOWN,
                                 "content": [
                                     "### This expectation confirms no events occur before tracking started **2004-10-19 10:23:54**"
                                 ],
@@ -3405,7 +3406,7 @@ def alice_columnar_table_single_batch(empty_data_context):
                         "column": "$domain.domain_kwargs.column",
                         "meta": {
                             "notes": {
-                                "format": "markdown",
+                                "format": MetaNotesFormat.MARKDOWN,
                                 "content": [
                                     "### This expectation confirms that the event_ts contains the latest timestamp of all domains"
                                 ],
@@ -3424,7 +3425,7 @@ def alice_columnar_table_single_batch(empty_data_context):
                         "meta": {
                             "profiler_details": "$parameter.my_date_format.details",
                             "notes": {
-                                "format": "markdown",
+                                "format": MetaNotesFormat.MARKDOWN,
                                 "content": [
                                     "### This expectation confirms that fields ending in _ts are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                                 ],
@@ -4296,7 +4297,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         },
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in _datetime are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                         ],
@@ -4320,7 +4321,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         },
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in _datetime are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                         ],
@@ -4349,7 +4350,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         },
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in _datetime are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                         ],
@@ -4373,7 +4374,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         },
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in _datetime are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                         ],
@@ -4399,7 +4400,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         "success_ratio": 1.0,
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in ID are of the format detected by parameter builder RegexPatternStringParameterBuilder"
                         ],
@@ -4420,7 +4421,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         "success_ratio": 1.0,
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in ID are of the format detected by parameter builder RegexPatternStringParameterBuilder"
                         ],
@@ -4441,7 +4442,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         "success_ratio": 1.0,
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in ID are of the format detected by parameter builder RegexPatternStringParameterBuilder"
                         ],
@@ -4462,7 +4463,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         "success_ratio": 1.0,
                     },
                     "notes": {
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                         "content": [
                             "### This expectation confirms that fields ending in ID are of the format detected by parameter builder RegexPatternStringParameterBuilder"
                         ],
@@ -4703,7 +4704,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         "meta": {
                             "profiler_details": "$parameter.my_date_format.details",
                             "notes": {
-                                "format": "markdown",
+                                "format": MetaNotesFormat.MARKDOWN,
                                 "content": [
                                     "### This expectation confirms that fields ending in _datetime are of the format detected by parameter builder SimpleDateFormatStringParameterBuilder"
                                 ],
@@ -4750,7 +4751,7 @@ def bobby_columnar_table_multi_batch(empty_data_context):
                         "meta": {
                             "profiler_details": "$parameter.my_regex.details",
                             "notes": {
-                                "format": "markdown",
+                                "format": MetaNotesFormat.MARKDOWN,
                                 "content": [
                                     "### This expectation confirms that fields ending in ID are of the format detected by parameter builder RegexPatternStringParameterBuilder"
                                 ],

--- a/tests/profile/test_basic_suite_builder_profiler.py
+++ b/tests/profile/test_basic_suite_builder_profiler.py
@@ -15,6 +15,7 @@ from great_expectations.exceptions import ProfilerError
 from great_expectations.profile.basic_suite_builder_profiler import (
     BasicSuiteBuilderProfiler,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.self_check.util import (
     expectationSuiteValidationResultSchema,
     get_dataset,
@@ -429,7 +430,7 @@ def test_BasicSuiteBuilderProfiler_with_context(filesystem_csv_data_context):
     }
 
     assert expectation_suite.meta["notes"] == {
-        "format": "markdown",
+        "format": MetaNotesFormat.MARKDOWN,
         "content": [
             """#### This is an _example_ suite
 
@@ -491,7 +492,7 @@ def test_context_profiler(filesystem_csv_data_context):
     assert "batch_kwargs" in expectation_suite.meta["BasicSuiteBuilderProfiler"]
 
     assert expectation_suite.meta["notes"] == {
-        "format": "markdown",
+        "format": MetaNotesFormat.MARKDOWN,
         "content": [
             """#### This is an _example_ suite
 

--- a/tests/profile/test_jsonschema_profiler.py
+++ b/tests/profile/test_jsonschema_profiler.py
@@ -3,6 +3,7 @@ import pytest
 
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.profile.json_schema_profiler import JsonSchemaProfiler
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 
 
 @pytest.fixture
@@ -1691,7 +1692,7 @@ def test_has_profile_create_expectations_from_complex_schema(
     assert isinstance(obs, ExpectationSuite)
     assert obs.expectation_suite_name == "complex"
     assert obs.meta["notes"] == {
-        "format": "markdown",
+        "format": MetaNotesFormat.MARKDOWN,
         "content": ["### Description:\nAn address"],
     }
 
@@ -1764,7 +1765,7 @@ def test_has_profile_create_expectations_from_complex_schema(
         {
             "meta": {
                 "notes": {
-                    "format": "markdown",
+                    "format": MetaNotesFormat.MARKDOWN,
                     "content": ["### Description:\nOnly the address number."],
                 }
             },

--- a/tests/render/renderer/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/test_suite_edit_notebook_renderer.py
@@ -22,6 +22,7 @@ from great_expectations.exceptions import (
 from great_expectations.render.renderer.suite_edit_notebook_renderer import (
     SuiteEditNotebookRenderer,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 
 
 @pytest.fixture
@@ -148,7 +149,7 @@ def critical_suite_with_citations(empty_data_context) -> ExpectationSuite:
                 }
             ],
             "notes": {
-                "format": "markdown",
+                "format": MetaNotesFormat.MARKDOWN,
                 "content": [
                     "#### This is an _example_ suite\n\n- This suite was made by quickly glancing at 1000 rows of your data.\n- This is **not a production suite**. It is meant to show examples of expectations.\n- Because this suite was auto-generated using a very basic profiler that does not know your data like you do, many of the expectations may not be meaningful.\n"
                 ],

--- a/tests/render/renderer/v3/test_suite_edit_notebook_renderer.py
+++ b/tests/render/renderer/v3/test_suite_edit_notebook_renderer.py
@@ -27,6 +27,7 @@ from great_expectations.exceptions import (
 from great_expectations.render.renderer.v3.suite_edit_notebook_renderer import (
     SuiteEditNotebookRenderer,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.validator.validator import Validator
 from tests.render.test_util import run_notebook
 
@@ -142,7 +143,7 @@ def critical_suite_with_citations(empty_data_context) -> ExpectationSuite:
                 }
             ],
             "notes": {
-                "format": "markdown",
+                "format": MetaNotesFormat.MARKDOWN,
                 "content": [
                     "#### This is an _example_ suite\n\n- This suite was made by quickly glancing at 1000 rows of your data.\n- This is **not a production suite**. It is meant to show examples of expectations.\n- Because this suite was auto-generated using a very basic profiler that does not know your data like you do, many of the expectations may not be meaningful.\n"
                 ],

--- a/tests/render/test_column_section_renderer.py
+++ b/tests/render/test_column_section_renderer.py
@@ -20,6 +20,7 @@ from great_expectations.render.renderer.content_block import (
     ProfilingColumnPropertiesTableContentBlockRenderer,
     ValidationResultsTableContentBlockRenderer,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.self_check.util import (
     expectationSuiteSchema,
     expectationSuiteValidationResultSchema,
@@ -413,7 +414,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_markdown_meta_no
         meta={
             "BasicDatasetProfiler": {"confidence": "very low"},
             "notes": {
-                "format": "markdown",
+                "format": MetaNotesFormat.MARKDOWN,
                 "content": [
                     "#### These are expectation notes \n - you can use markdown \n - or just strings"
                 ],
@@ -575,7 +576,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_string_list_meta
         meta={
             "BasicDatasetProfiler": {"confidence": "very low"},
             "notes": {
-                "format": "string",
+                "format": MetaNotesFormat.STRING,
                 "content": [
                     "This is a",
                     "string list,",
@@ -740,7 +741,7 @@ def test_ExpectationSuiteColumnSectionRenderer_expectation_with_single_string_me
         meta={
             "BasicDatasetProfiler": {"confidence": "very low"},
             "notes": {
-                "format": "string",
+                "format": MetaNotesFormat.STRING,
                 "content": "This is just a single string, assigned to the 'content' key of a notes dict.",
             },
         },

--- a/tests/render/test_default_markdown_view.py
+++ b/tests/render/test_default_markdown_view.py
@@ -20,6 +20,7 @@ from great_expectations.render.renderer import (
     ExpectationSuitePageRenderer,
     ValidationResultsPageRenderer,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 from great_expectations.render.view import DefaultMarkdownPageView
 from great_expectations.validation_operators.types.validation_operator_result import (
     ValidationOperatorResult,
@@ -74,7 +75,7 @@ def expectation_suite_to_render_with_notes(empty_data_context):
                             "Example notes about this expectation. **Markdown** `Supported`.",
                             "Second example note **with** *Markdown*",
                         ],
-                        "format": "markdown",
+                        "format": MetaNotesFormat.MARKDOWN,
                     }
                 },
             ),

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -609,6 +609,36 @@ def test_inline_renderer_expectation_validation_result_serialization(
             ],
             id="graph",
         ),
+        pytest.param(
+            ExpectationConfiguration(
+                expectation_type="expect_table_row_count_to_equal",
+                kwargs={"value": 3},
+                meta={
+                    "notes": {
+                        "format": "string",
+                        "content": ["This is the most important Expectation!!"],
+                    }
+                },
+            ),
+            [
+                {
+                    "value_type": "StringValueType",
+                    "name": AtomicPrescriptiveRendererType.SUMMARY,
+                    "value": {
+                        "template": "Must have exactly $value rows.",
+                        "schema": {"type": "com.superconductive.rendered.string"},
+                        "params": {
+                            "value": {"schema": {"type": "number"}, "value": 3},
+                        },
+                        "meta_notes": {
+                            "content": ["This is the most important Expectation!!"],
+                            "format": "string",
+                        },
+                    },
+                }
+            ],
+            id="meta_notes",
+        ),
     ],
 )
 def test_inline_renderer_expectation_configuration_serialization(

--- a/tests/render/test_inline_renderer.py
+++ b/tests/render/test_inline_renderer.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List
 
 import pytest
@@ -15,6 +14,7 @@ from great_expectations.render import (
 )
 from great_expectations.render.exceptions import InlineRendererError
 from great_expectations.render.renderer.inline_renderer import InlineRenderer
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 
 
 def clean_serialized_rendered_atomic_content_graphs(
@@ -615,7 +615,7 @@ def test_inline_renderer_expectation_validation_result_serialization(
                 kwargs={"value": 3},
                 meta={
                     "notes": {
-                        "format": "string",
+                        "format": MetaNotesFormat.STRING,
                         "content": ["This is the most important Expectation!!"],
                     }
                 },
@@ -632,7 +632,7 @@ def test_inline_renderer_expectation_validation_result_serialization(
                         },
                         "meta_notes": {
                             "content": ["This is the most important Expectation!!"],
-                            "format": "string",
+                            "format": MetaNotesFormat.STRING,
                         },
                     },
                 }

--- a/tests/render/test_page_renderer.py
+++ b/tests/render/test_page_renderer.py
@@ -14,6 +14,7 @@ from great_expectations.render.renderer import (
     ProfilingResultsPageRenderer,
     ValidationResultsPageRenderer,
 )
+from great_expectations.render.renderer_configuration import MetaNotesFormat
 
 
 def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
@@ -51,7 +52,7 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
             expectation_suite_name="test",
             meta={
                 "notes": {
-                    "format": "string",
+                    "format": MetaNotesFormat.STRING,
                     "content": ["*alpha*", "_bravo_", "charlie"],
                 }
             },
@@ -69,7 +70,7 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
             expectation_suite_name="test",
-            meta={"notes": {"format": "markdown", "content": "*alpha*"}},
+            meta={"notes": {"format": MetaNotesFormat.MARKDOWN, "content": "*alpha*"}},
             data_context=context,
         )
     )
@@ -96,7 +97,7 @@ def test_ExpectationSuitePageRenderer_render_expectation_suite_notes(
             expectation_suite_name="test",
             meta={
                 "notes": {
-                    "format": "markdown",
+                    "format": MetaNotesFormat.MARKDOWN,
                     "content": ["*alpha*", "_bravo_", "charlie"],
                 }
             },
@@ -154,7 +155,7 @@ def test_expectation_summary_in_ExpectationSuitePageRenderer_render_expectation_
     result = ExpectationSuitePageRenderer._render_expectation_suite_notes(
         ExpectationSuite(
             expectation_suite_name="test",
-            meta={"notes": {"format": "markdown", "content": ["hi"]}},
+            meta={"notes": {"format": MetaNotesFormat.MARKDOWN, "content": ["hi"]}},
             data_context=context,
         )
     )


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1295
- Add meta notes to `RendererConfiguration` and `RenderedAtomicContent`

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.