### PR TITLE
[MAINTENANCE] Fix develop static type-check stage

### DIFF
--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -4,7 +4,7 @@ invoke>=1.7.1
 isort==5.10.1
 mypy==0.991
 pre-commit>=2.6.0
-pydantic>=1.0,<2.0 # needed for mypy plugin support
+pydantic>=1.0,<2.0
 pytest-cov>=2.8.1
 pytest-order>=0.9.5
 pytest-random-order>=1.0.4


### PR DESCRIPTION
Develop is still broken due to the static type-checking step not getting the needed dependencies installed.

This should be the final PR.

Rather than make grep deal with the ` # comment` I've removed the comment.

Followup to
https://github.com/great-expectations/great_expectations/pull/6621
https://github.com/great-expectations/great_expectations/pull/6624
https://github.com/great-expectations/great_expectations/pull/6609