### PR TITLE
[MAINTENANCE] fix remaining core/utils.py typing issues

### DIFF
--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -198,7 +198,7 @@ ToStr: TypeAlias = Union[
 
 ToList: TypeAlias = Union[list, set, tuple, "npt.NDArray", pd.Index, pd.Series]
 ToDict: TypeAlias = Union[
-    dict, CommentedMap, pd.DataFrame, SerializableDictDot, SerializableDotDict
+    dict, "CommentedMap", pd.DataFrame, SerializableDictDot, SerializableDotDict
 ]
 
 JSONConvertable: TypeAlias = Union[

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -402,9 +402,11 @@ def convert_to_json_serializable(  # noqa: C901 - complexity 28
         if isinstance(data, StructType):
             return dict(data.jsonValue())
 
-    raise TypeError(
-        f"{str(data)} is of type {type(data).__name__} which cannot be serialized."
-    )
+    else:
+        raise TypeError(
+            f"{str(data)} is of type {type(data).__name__} which cannot be serialized."
+        )
+    return None
 
 
 def ensure_json_serializable(data):  # noqa: C901 - complexity 21

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -342,11 +342,11 @@ def convert_to_json_serializable(  # noqa: C901 - complexity 28
         return bool(data)
 
     if np.issubdtype(type(data), np.integer) or np.issubdtype(type(data), np.uint):
-        return int(data)
+        return int(data)  # type: ignore[arg-type] # could be None
 
     if np.issubdtype(type(data), np.floating):
         # Note: Use np.floating to avoid FutureWarning from numpy
-        return float(round(data, sys.float_info.dig))
+        return float(round(data, sys.float_info.dig))  # type: ignore[arg-type] # could be None
 
     # Note: This clause has to come after checking for np.ndarray or we get:
     #      `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -19,6 +19,7 @@ from typing import (
     MutableMapping,
     Optional,
     Tuple,
+    TypeVar,
     Union,
     overload,
 )
@@ -104,13 +105,15 @@ if TYPE_CHECKING:
 
 _SUFFIX_TO_PD_KWARG = {"gz": "gzip", "zip": "zip", "bz2": "bz2", "xz": "xz"}
 
+M = TypeVar("M", bound=MutableMapping)
+
 
 def nested_update(
-    d: MutableMapping,
+    d: M,
     u: Mapping,
     dedup: bool = False,
     concat_lists: bool = True,
-) -> MutableMapping:
+) -> M:
     """
     Update d with items from u, recursively and joining elements. By default, list values are
     concatenated without de-duplication. If concat_lists is set to False, lists in u (new dict)

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -190,8 +190,8 @@ def determine_progress_bar_method_by_environment() -> Callable:
 JSONValues: TypeAlias = Union[dict, list, str, int, float, bool, None]
 
 ToBool: TypeAlias = bool
-ToFloat: TypeAlias = Union[float, np.float32, np.float64]
-ToInt: TypeAlias = Union[int, np.integer, np.uint8, np.int32, np.int64]
+ToFloat: TypeAlias = Union[float, np.floating]
+ToInt: TypeAlias = Union[int, np.integer]
 ToStr: TypeAlias = Union[
     str, bytes, uuid.UUID, datetime.date, datetime.datetime, np.datetime64
 ]

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -9,8 +9,7 @@ import re
 import sys
 import uuid
 from collections import OrderedDict
-from types import NoneType
-from typing import (  # TypeVar,
+from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
@@ -100,6 +99,7 @@ except ImportError:
 if TYPE_CHECKING:
     import numpy.typing as npt
     from pyspark.sql import SparkSession  # noqa: F401
+    from ruamel.yaml.comments import CommentedMap
 
 
 _SUFFIX_TO_PD_KWARG = {"gz": "gzip", "zip": "zip", "bz2": "bz2", "xz": "xz"}
@@ -184,7 +184,7 @@ def determine_progress_bar_method_by_environment() -> Callable:
     return tqdm
 
 
-JSONValues: TypeAlias = Union[dict, list, str, int, float, bool, NoneType]
+JSONValues: TypeAlias = Union[dict, list, str, int, float, bool, None]
 
 ToBool: TypeAlias = bool
 ToFloat: TypeAlias = Union[float, np.float32, np.float64]
@@ -194,10 +194,12 @@ ToStr: TypeAlias = Union[
 ]
 
 ToList: TypeAlias = Union[list, set, tuple, npt.NDArray, pd.Index]
-ToDict: TypeAlias = Union[dict, pd.DataFrame, SerializableDictDot, SerializableDotDict]
+ToDict: TypeAlias = Union[
+    dict, CommentedMap, pd.DataFrame, SerializableDictDot, SerializableDotDict
+]
 
 JSONConvertable: TypeAlias = Union[
-    ToDict, ToList, ToStr, ToInt, ToFloat, ToBool, ToBool
+    ToDict, ToList, ToStr, ToInt, ToFloat, ToBool, ToBool, None
 ]
 
 
@@ -250,16 +252,16 @@ def convert_to_json_serializable(
     ...
 
 
-# @overload
-# def convert_to_json_serializable(
-#     data: NoneType,
-# ) -> NoneType:
-#     ...
+@overload
+def convert_to_json_serializable(
+    data: None,
+) -> None:
+    ...
 
 
 def convert_to_json_serializable(  # noqa: C901 - complexity 28
     data: JSONConvertable,
-) -> Union[dict, list, str, int, float, bool]:
+) -> JSONValues:
     """
     Helper function to convert an object to one that is json serializable
 

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -196,7 +196,7 @@ ToStr: TypeAlias = Union[
     str, bytes, uuid.UUID, datetime.date, datetime.datetime, np.datetime64
 ]
 
-ToList: TypeAlias = Union[list, set, tuple, npt.NDArray, pd.Index]
+ToList: TypeAlias = Union[list, set, tuple, "npt.NDArray", pd.Index]
 ToDict: TypeAlias = Union[
     dict, CommentedMap, pd.DataFrame, SerializableDictDot, SerializableDotDict
 ]

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -196,7 +196,7 @@ ToStr: TypeAlias = Union[
     str, bytes, uuid.UUID, datetime.date, datetime.datetime, np.datetime64
 ]
 
-ToList: TypeAlias = Union[list, set, tuple, "npt.NDArray", pd.Index]
+ToList: TypeAlias = Union[list, set, tuple, "npt.NDArray", pd.Index, pd.Series]
 ToDict: TypeAlias = Union[
     dict, CommentedMap, pd.DataFrame, SerializableDictDot, SerializableDotDict
 ]
@@ -208,15 +208,15 @@ JSONConvertable: TypeAlias = Union[
 
 @overload
 def convert_to_json_serializable(  # type: ignore[misc]
-    data: ToList,
-) -> list:
+    data: ToDict,
+) -> dict:
     ...
 
 
 @overload
 def convert_to_json_serializable(  # type: ignore[misc]
-    data: ToDict,
-) -> dict:
+    data: ToList,
+) -> list:
     ...
 
 

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -207,14 +207,14 @@ JSONConvertable: TypeAlias = Union[
 
 
 @overload
-def convert_to_json_serializable(  # type: ignore[misc]
+def convert_to_json_serializable(  # type: ignore[misc] # overlap with `ToList`?
     data: ToDict,
 ) -> dict:
     ...
 
 
 @overload
-def convert_to_json_serializable(  # type: ignore[misc]
+def convert_to_json_serializable(  # type: ignore[misc] # overlap with `ToDict`?
     data: ToList,
 ) -> list:
     ...

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -206,22 +206,15 @@ JSONConvertable: TypeAlias = Union[
 ]
 
 
-# @overload
-# def convert_to_json_serializable(
-#     data: JT,
-# ) -> JT:
-#     ...
-
-
 @overload
-def convert_to_json_serializable(
+def convert_to_json_serializable(  # type: ignore[misc]
     data: ToList,
 ) -> list:
     ...
 
 
 @overload
-def convert_to_json_serializable(
+def convert_to_json_serializable(  # type: ignore[misc]
     data: ToDict,
 ) -> dict:
     ...

--- a/great_expectations/core/util.py
+++ b/great_expectations/core/util.py
@@ -42,7 +42,7 @@ from great_expectations.util import convert_decimal_to_float
 try:
     from pyspark.sql.types import StructType
 except ImportError:
-    StructType = None  # type: ignore[assignment, misc]
+    StructType = None
 
 logger = logging.getLogger(__name__)
 
@@ -88,8 +88,8 @@ try:
     from pyspark.sql import SparkSession
 
 except ImportError:
-    pyspark = None  # type: ignore[assignment]
-    SparkSession = None  # type: ignore[assignment, misc]
+    pyspark = None
+    SparkSession = None
     logger.debug(
         "Unable to load pyspark; install optional spark dependency if you will be working with Spark dataframes"
     )


### PR DESCRIPTION
This should fix the union type errors for code that calls into the json converter function.
We now use `overloads` to indicate the specific JSON-compatible primitive that will be returned.
https://mypy.readthedocs.io/en/stable/more_types.html#function-overloading

Merging into https://github.com/great-expectations/great_expectations/pull/6617
