### PR TITLE
Skip postgres tests in spark.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,8 +268,6 @@ stages:
               python.version: '3.8'
             Python39:
               python.version: '3.9'
-        services:
-          postgres: postgres
         variables:
           IMAGE_SUFFIX: $[ dependencies.make_suffix.outputs['suffix.IMAGE_SUFFIX'] ]
         steps:

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant_happy_paths.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant_happy_paths.py
@@ -391,14 +391,17 @@ def test_sql_happy_path_onboarding_data_assistant_null_column_quantiles_metric_v
 @pytest.mark.integration
 @pytest.mark.slow  # 26.57 seconds
 def test_sql_happy_path_onboarding_data_assistant_mixed_decimal_float_and_boolean_column_unique_proportion_metric_values(
-    sa,
     empty_data_context,
+    test_backends,
+    sa,
 ) -> None:
-    context: DataContext = empty_data_context
+    if "postgresql" not in test_backends:
+        pytest.skip("testing data assistant in sql requires postgres backend")
 
-    postgresql_engine: sa.engine.base.Engine = sa.create_engine(CONNECTION_STRING)
+    context: DataContext = empty_data_context
+    postgresql_engine: sa.engine.Engine = sa.create_engine(CONNECTION_STRING)
     # noinspection PyUnusedLocal
-    conn: sa.engine.base.Connection = postgresql_engine.connect()
+    conn: sa.engine.Connection = postgresql_engine.connect()
 
     table_name = "sampled_yellow_tripdata_test"
 


### PR DESCRIPTION
This PR fixes the spark tests by skipping the postgres test when we run using the spark. These tests have nothing to do with the spark backend so shouldn't run in this stage. I have verified that the test runs in the `test_majority` test target.


- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
