### PR TITLE
[MAINTENANCE] M/great 1225/async builds branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,11 +132,22 @@ stages:
       - job: make_suffix
         steps:
           - bash: |
+              # Create a docker allowed image name from the branch name
+              eval `python - <<EOF
+              import os
+              import re
+              branch_name = os.environ["BRANCH_NAME"]
+              new_name = re.sub('[^a-zA-Z0-9_\-\.]', '-', branch_name)
+              print(f'export "IMAGE_BRANCH"="{new_name}"')
+              EOF`
+
               EPOCH=`date +%s`
-              SUFFIX="develop_${EPOCH}_${RANDOM}"
+              SUFFIX="${IMAGE_BRANCH}_${EPOCH}_${RANDOM}"
               echo "Generated image suffix: ${SUFFIX}"
               echo "##vso[task.setvariable variable=IMAGE_SUFFIX;isOutput=true]${SUFFIX}"
             name: suffix
+            env:
+              BRANCH_NAME: $(Build.SourceBranchName)
 
       - job: build_push
         dependsOn: make_suffix
@@ -160,10 +171,12 @@ stages:
               CMD="docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:${DOCKER_TAG} "
               CMD+="--target test --build-arg PYTHON_VERSION=$(python.version) "
               CMD+="--build-arg GE_USAGE_STATISTICS_URL=\"$(GE_USAGE_STATISTICS_URL)\" "
-              CMD+="--build-arg SOURCE=github --build-arg BRANCH=develop ."
+              CMD+="--build-arg SOURCE=github --build-arg BRANCH=\"${BRANCH_NAME}\" ."
               echo ${CMD}
               eval ${CMD}
             displayName: 'Build python $(python.version) image'
+            env:
+              BRANCH_NAME: $(Build.SourceBranchName)
 
           - bash: |
               docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ stages:
               eval ${CMD}
             displayName: 'Build python $(python.version) image'
             env:
-              BRANCH_NAME: $(Build.SourceBranchName)
+              BRANCH_NAME: $(Build.SourceBranch)
 
           - bash: |
               docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,6 +166,7 @@ stages:
         steps:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
+              BRANCH_NAME="${FULL_BRANCH_NAME/#refs\/heads\/}"
               # We repull the develop branch. We could build the local branch that is already present but we should
               # prune it's depth since we don't need the git history.
               CMD="docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:${DOCKER_TAG} "
@@ -176,7 +177,7 @@ stages:
               eval ${CMD}
             displayName: 'Build python $(python.version) image'
             env:
-              BRANCH_NAME: $(Build.SourceBranch)
+              FULL_BRANCH_NAME: $(Build.SourceBranch)
 
           - bash: |
               docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}


### PR DESCRIPTION
Currently our async pipeline always builds develop. However, sometime we need to debug a branch. Currently, we can only do that by making temporary changes to the async pipeline. If you forget to do that you waste time since it build develop. You also must remember to revert the change. This PR makes the async pipeline run the current branch so we no longer need to edit the async pipeline to make it run on the branch we want.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

