### PR TITLE
[FEATURE] Ensure Pandas ID/PK can use named indices

### DIFF
--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -1783,7 +1783,7 @@ def _pandas_map_condition_index(
 
     column_name: Union[str, quoted_name]
 
-    expectation_domain_column_name: str = domain_kwargs["column"]
+    expectation_domain_column_name: str = domain_kwargs.get("column")
 
     # one named index
     if df.index.name is not None:

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -36,6 +36,8 @@ from great_expectations.expectations.metrics.util import (
     Select,
     get_dbms_compatible_column_names,
     get_sqlalchemy_source_table_and_schema,
+    get_unexpected_indices_for_multiple_pandas_named_indices,
+    get_unexpected_indices_for_single_pandas_named_index,
     sql_statement_with_post_compile_to_string,
     verify_column_names_exist,
 )
@@ -1781,41 +1783,81 @@ def _pandas_map_condition_index(
 
     column_name: Union[str, quoted_name]
 
+    unexpected_index_list: Optional[List[Dict[str, Any]]] = []
+    expectation_domain_column_name: str = domain_kwargs["column"]
+
+    # if we have defined unexpected_index_column_names
     if "unexpected_index_column_names" in result_format:
-        unexpected_index_list: Optional[List[Dict[str, Any]]] = []
         unexpected_index_column_names: List[str] = result_format[
             "unexpected_index_column_names"
         ]
-        # column the expectation is being run on
-        expectation_domain_column_name: str = domain_kwargs["column"]
-
-        unexpected_indices: List[int] = list(df.index)
-        for index in unexpected_indices:
-            primary_key_dict: Dict[str, Any] = {}
-            primary_key_dict[expectation_domain_column_name] = df.at[
-                index, expectation_domain_column_name
-            ]
-            for column_name in unexpected_index_column_names:
-                column_name = get_dbms_compatible_column_names(
-                    column_names=column_name,
-                    batch_columns_list=metrics["table.columns"],
-                    execution_engine=execution_engine,
-                    error_message_template='Error: The unexpected_index_column "{column_name:s}" does not exist in Dataframe. Please check your configuration and try again.',
+        if df.index.name is not None:
+            unexpected_index_list = (
+                get_unexpected_indices_for_single_pandas_named_index(
+                    df,
+                    unexpected_index_list,
+                    expectation_domain_column_name,
+                    unexpected_index_column_names,
                 )
-                # add the actual unexpected value
-                primary_key_dict[column_name] = df.at[index, column_name]
-
-            unexpected_index_list.append(primary_key_dict)
-
-        if result_format["result_format"] == "COMPLETE":
-            return unexpected_index_list
-
-        return unexpected_index_list[: result_format["partial_unexpected_count"]]
+            )
+        elif df.index.names[0] is not None:
+            unexpected_index_list = (
+                get_unexpected_indices_for_multiple_pandas_named_indices(
+                    df,
+                    unexpected_index_list,
+                    expectation_domain_column_name,
+                    unexpected_index_column_names,
+                )
+            )
+        else:
+            unexpected_indices: List[Union[int, str]] = list(df.index)
+            for index in unexpected_indices:
+                primary_key_dict: Dict[str, Any] = dict()
+                primary_key_dict[expectation_domain_column_name] = df.at[
+                    index, expectation_domain_column_name
+                ]
+                for column_name in unexpected_index_column_names:
+                    column_name = get_dbms_compatible_column_names(
+                        column_names=column_name,
+                        batch_columns_list=metrics["table.columns"],
+                        execution_engine=execution_engine,
+                        error_message_template='Error: The unexpected_index_column "{column_name:s}" does not exist in Dataframe. Please check your configuration and try again.',
+                    )
+                    # add the actual unexpected value
+                    primary_key_dict[column_name] = df.at[index, column_name]
+                unexpected_index_list.append(primary_key_dict)
     else:
-        if result_format["result_format"] == "COMPLETE":
-            return list(df.index)
+        if df.index.name:
+            unexpected_index_column_names: List[str] = [df.index.name]
+            unexpected_index_list = (
+                get_unexpected_indices_for_single_pandas_named_index(
+                    df,
+                    unexpected_index_list,
+                    expectation_domain_column_name,
+                    unexpected_index_column_names,
+                )
+            )
+        elif hasattr(df.index, "names"):
+            unexpected_index_column_names: List[str] = list(df.index.names)
+            unexpected_index_list = (
+                get_unexpected_indices_for_multiple_pandas_named_indices(
+                    df,
+                    unexpected_index_list,
+                    expectation_domain_column_name,
+                    unexpected_index_column_names,
+                )
+            )
 
-        return list(df.index[: result_format["partial_unexpected_count"]])
+        else:
+            unexpected_index_list = list(df.index)
+
+    # do the formatting
+    if result_format["result_format"] == "COMPLETE":
+        # how does this affect named indices when it comes to printing them out?
+        # i could technically build it out here
+        # TODO: see if i can take care of the rendering here
+        return unexpected_index_list
+    return unexpected_index_list[: result_format["partial_unexpected_count"]]
 
 
 def _pandas_column_map_condition_value_counts(

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -1132,5 +1132,10 @@ def get_unexpected_indices_for_single_pandas_named_index(
         for column_name in unexpected_index_column_names:
             if column_name == df.index.name:
                 primary_key_dict[column_name] = index
+            else:
+                raise ge_exceptions.MetricResolutionError(
+                    message=f"Error: The column {column_name} does not exist in the named indices. Please check your configuration",
+                    failed_metrics=["unexpected_index_list"],
+                )
         unexpected_index_list.append(primary_key_dict)
     return unexpected_index_list

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -1077,6 +1077,11 @@ def get_unexpected_indices_for_multiple_pandas_named_indices(
     Returns:
         List of Dicts that contain ID/PK values
     """
+    if not expectation_domain_column_name:
+        raise ge_exceptions.MetricResolutionError(
+            message=f"Error: The domain column is currently set to None. Please check your configuration.",
+            failed_metrics=["unexpected_index_list"],
+        )
     index_names: List[str] = df.index.names
     unexpected_index_list: List[Dict[str, Any]] = list()
     unexpected_indices: List[Union[int, str]] = list(df.index)
@@ -1089,7 +1094,7 @@ def get_unexpected_indices_for_multiple_pandas_named_indices(
         for column_name in unexpected_index_column_names:
             if column_name not in index_names:
                 raise ge_exceptions.MetricResolutionError(
-                    message=f"Error: The column {column_name} does not exist in the named indices.",
+                    message=f"Error: The column {column_name} does not exist in the named indices. Please check your configuration",
                     failed_metrics=["unexpected_index_list"],
                 )
             tuple_index = index_names.index(column_name, 0)

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -11,6 +11,7 @@ from packaging import version
 import great_expectations.exceptions as ge_exceptions
 from great_expectations.execution_engine import (
     ExecutionEngine,
+    PandasExecutionEngine,
     SqlAlchemyExecutionEngine,
 )
 from great_expectations.execution_engine.sqlalchemy_dialect import GXSqlDialect
@@ -1062,57 +1063,62 @@ def get_sqlalchemy_source_table_and_schema(
 
 
 def get_unexpected_indices_for_multiple_pandas_named_indices(
-    df: pd.DataFrame,
-    expectation_domain_column_name: str,
+    domain_records_df: pd.DataFrame,
     unexpected_index_column_names: List[str],
+    expectation_domain_column_name: Union[str, None] = None,
 ) -> List[Dict[str, Any]]:
     """
     Builds unexpected_index list for Pandas Dataframe in situation where the named
     columns is also a named index. This method handles the case when there are multiple named indices.
     Args:
-        df: reference to Pandas dataframe
+        domain_records_df: reference to Pandas dataframe
         expectation_domain_column_name: column that Expectation is being run for
         unexpected_index_column_names: column_names for indices, either named index or unexpected_index_columns
 
     Returns:
         List of Dicts that contain ID/PK values
     """
-    if not expectation_domain_column_name:
+    if expectation_domain_column_name is None:
         raise ge_exceptions.MetricResolutionError(
             message=f"Error: The domain column is currently set to None. Please check your configuration.",
             failed_metrics=["unexpected_index_list"],
         )
-    index_names: List[str] = df.index.names
+
+    domain_records_df_index_names: List[str] = domain_records_df.index.names
+    unexpected_indices: List[Union[int, str]] = list(domain_records_df.index)
+
+    for column_name in unexpected_index_column_names:
+        if column_name not in domain_records_df_index_names:
+            raise ge_exceptions.MetricResolutionError(
+                message=f"Error: The column {column_name} does not exist in the named indices. Please check your configuration",
+                failed_metrics=["unexpected_index_list"],
+            )
+
     unexpected_index_list: List[Dict[str, Any]] = list()
-    unexpected_indices: List[Union[int, str]] = list(df.index)
+
     for index in unexpected_indices:
         primary_key_dict: Dict[str, Any] = dict()
         # domain column first
-        primary_key_dict[expectation_domain_column_name] = df.at[
+        primary_key_dict[expectation_domain_column_name] = domain_records_df.at[
             index, expectation_domain_column_name
         ]
         for column_name in unexpected_index_column_names:
-            if column_name not in index_names:
-                raise ge_exceptions.MetricResolutionError(
-                    message=f"Error: The column {column_name} does not exist in the named indices. Please check your configuration",
-                    failed_metrics=["unexpected_index_list"],
-                )
-            tuple_index = index_names.index(column_name, 0)
+            tuple_index = domain_records_df_index_names.index(column_name, 0)
             primary_key_dict[column_name] = index[tuple_index]
         unexpected_index_list.append(primary_key_dict)
     return unexpected_index_list
 
 
 def get_unexpected_indices_for_single_pandas_named_index(
-    df: pd.DataFrame,
-    expectation_domain_column_name: str,
+    domain_records_df: pd.DataFrame,
     unexpected_index_column_names: List[str],
+    expectation_domain_column_name: Union[str, None] = None,
 ) -> List[Dict[str, Any]]:
     """
     Builds unexpected_index list for Pandas Dataframe in situation where the named
     columns is also a named index. This method handles the case when there is a single named index.
     Args:
-        df: reference to Pandas dataframe
+        domain_records_df: reference to Pandas dataframe
         expectation_domain_column_name: column that Expectation is being run on.
         unexpected_index_column_names: column_names for indices, either named index or unexpected_index_columns
 
@@ -1120,22 +1126,99 @@ def get_unexpected_indices_for_single_pandas_named_index(
         List of Dicts that contain ID/PK values
 
     """
-    unexpected_index_values_by_named_index: List[Union[int, str]] = list(df.index)
+    unexpected_index_values_by_named_index: List[Union[int, str]] = list(
+        domain_records_df.index
+    )
     unexpected_index_list: List[Dict[str, Any]] = list()
+
+    if not (
+        len(unexpected_index_column_names) == 1
+        and unexpected_index_column_names[0] == domain_records_df.index.name
+    ):
+        raise ge_exceptions.MetricResolutionError(
+            message=f"Error: The column {unexpected_index_column_names[0]} does not exist in the named indices. Please check your configuration",
+            failed_metrics=["unexpected_index_list"],
+        )
 
     for index in unexpected_index_values_by_named_index:
         primary_key_dict: Dict[str, Any] = dict()
         # domain column first
-        primary_key_dict[expectation_domain_column_name] = df.at[
+        primary_key_dict[expectation_domain_column_name] = domain_records_df.at[
             index, expectation_domain_column_name
         ]
-        for column_name in unexpected_index_column_names:
-            if column_name == df.index.name:
-                primary_key_dict[column_name] = index
-            else:
-                raise ge_exceptions.MetricResolutionError(
-                    message=f"Error: The column {column_name} does not exist in the named indices. Please check your configuration",
-                    failed_metrics=["unexpected_index_list"],
-                )
+        column_name: str = unexpected_index_column_names[0]
+        primary_key_dict[column_name] = index
         unexpected_index_list.append(primary_key_dict)
+    return unexpected_index_list
+
+
+def compute_unexpected_pandas_indices(
+    domain_records_df: pd.DataFrame,
+    result_format: Dict[str, Any],
+    execution_engine: PandasExecutionEngine,
+    metrics: Dict[str, Any],
+    expectation_domain_column_name: Union[str, None] = None,
+) -> Union[List[int], List[Dict[str, Any]]]:
+    """
+    Helper method to compute unexpected_index_list for PandasExecutionEngine. Handles logic needed for named indices.
+
+    Args:
+        domain_records_df: DataFrame of data we are currently running Expectation on.
+        result_format: configuration that contains `unexpected_index_column_names`
+        expectation_domain_column_name: column that we are running Expectation on.
+        execution_engine: PandasExecutionEngine
+        metrics: dict of currently available metrics
+
+    Returns:
+        list of unexpected_index_list values. It can either be a list of dicts or a list of numbers (if using default index).
+
+    """
+    if domain_records_df.index.name is not None:
+        unexpected_index_column_names: List[str] = result_format.get(
+            "unexpected_index_column_names", [domain_records_df.index.name]
+        )
+        unexpected_index_list: Optional[
+            List[Dict[str, Any]]
+        ] = get_unexpected_indices_for_single_pandas_named_index(
+            domain_records_df=domain_records_df,
+            unexpected_index_column_names=unexpected_index_column_names,
+            expectation_domain_column_name=expectation_domain_column_name,
+        )
+    # multiple named indices
+    elif domain_records_df.index.names[0] is not None:
+        unexpected_index_column_names: Union[List[str], None] = result_format.get(
+            "unexpected_index_column_names", list(domain_records_df.index.names)
+        )
+        unexpected_index_list: Optional[
+            List[Dict[str, Any]]
+        ] = get_unexpected_indices_for_multiple_pandas_named_indices(
+            domain_records_df=domain_records_df,
+            unexpected_index_column_names=unexpected_index_column_names,
+            expectation_domain_column_name=expectation_domain_column_name,
+        )
+    # named columns
+    elif result_format.get("unexpected_index_column_names"):
+        unexpected_index_column_names: List[str] = result_format.get(
+            "unexpected_index_column_names"
+        )
+        unexpected_index_list: Optional[List[Dict[str, Any]]] = []
+        unexpected_indices: List[Union[int, str]] = list(domain_records_df.index)
+        for index in unexpected_indices:
+            primary_key_dict: Dict[str, Any] = dict()
+            primary_key_dict[expectation_domain_column_name] = domain_records_df.at[
+                index, expectation_domain_column_name
+            ]
+            for column_name in unexpected_index_column_names:
+                column_name = get_dbms_compatible_column_names(
+                    column_names=column_name,
+                    batch_columns_list=metrics["table.columns"],
+                    execution_engine=execution_engine,
+                    error_message_template='Error: The unexpected_index_column "{column_name:s}" does not exist in Dataframe. Please check your configuration and try again.',
+                )
+                primary_key_dict[column_name] = domain_records_df.at[index, column_name]
+            unexpected_index_list.append(primary_key_dict)
+    # or just the default indices
+    else:
+        unexpected_index_list = list(domain_records_df.index)
+
     return unexpected_index_list

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -1087,11 +1087,16 @@ def get_unexpected_indices_for_multiple_pandas_named_indices(
     domain_records_df_index_names: List[str] = domain_records_df.index.names
     unexpected_indices: List[Union[int, str]] = list(domain_records_df.index)
 
+    tuple_index: Dict[str, int] = dict()
     for column_name in unexpected_index_column_names:
         if column_name not in domain_records_df_index_names:
             raise ge_exceptions.MetricResolutionError(
                 message=f"Error: The column {column_name} does not exist in the named indices. Please check your configuration",
                 failed_metrics=["unexpected_index_list"],
+            )
+        else:
+            tuple_index[column_name] = domain_records_df_index_names.index(
+                column_name, 0
             )
 
     unexpected_index_list: List[Dict[str, Any]] = list()
@@ -1103,8 +1108,7 @@ def get_unexpected_indices_for_multiple_pandas_named_indices(
             index, expectation_domain_column_name
         ]
         for column_name in unexpected_index_column_names:
-            tuple_index = domain_records_df_index_names.index(column_name, 0)
-            primary_key_dict[column_name] = index[tuple_index]
+            primary_key_dict[column_name] = index[tuple_index[column_name]]
         unexpected_index_list.append(primary_key_dict)
     return unexpected_index_list
 
@@ -1130,13 +1134,12 @@ def get_unexpected_indices_for_single_pandas_named_index(
         domain_records_df.index
     )
     unexpected_index_list: List[Dict[str, Any]] = list()
-
     if not (
         len(unexpected_index_column_names) == 1
         and unexpected_index_column_names[0] == domain_records_df.index.name
     ):
         raise ge_exceptions.MetricResolutionError(
-            message=f"Error: The column {unexpected_index_column_names[0]} does not exist in the named indices. Please check your configuration",
+            message=f"Error: The column {unexpected_index_column_names[0] if unexpected_index_column_names else '<no column specified>'} does not exist in the named indices. Please check your configuration",
             failed_metrics=["unexpected_index_list"],
         )
 

--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -1063,33 +1063,35 @@ def get_sqlalchemy_source_table_and_schema(
 
 def get_unexpected_indices_for_multiple_pandas_named_indices(
     df: pd.DataFrame,
-    unexpected_index_list: [List[Dict[str, Any]]],
     expectation_domain_column_name: str,
     unexpected_index_column_names: List[str],
-):
+) -> List[Dict[str, Any]]:
     """
     Builds unexpected_index list for Pandas Dataframe in situation where the named
     columns is also a named index. This method handles the case when there are multiple named indices.
     Args:
-        df ():
-        unexpected_index_list ():
-        expectation_domain_column_name ():
-        unexpected_index_column_names ():
+        df: reference to Pandas dataframe
+        expectation_domain_column_name: column that Expectation is being run for
+        unexpected_index_column_names: column_names for indices, either named index or unexpected_index_columns
 
     Returns:
-
+        List of Dicts that contain ID/PK values
     """
     index_names: List[str] = df.index.names
-    unexpected_indices: Tuple[Union[int, str]] = list(df.index)
+    unexpected_index_list: List[Dict[str, Any]] = list()
+    unexpected_indices: List[Union[int, str]] = list(df.index)
     for index in unexpected_indices:
-        primary_key_dict: Dict[str, Any] = {}
+        primary_key_dict: Dict[str, Any] = dict()
+        # domain column first
         primary_key_dict[expectation_domain_column_name] = df.at[
             index, expectation_domain_column_name
         ]
         for column_name in unexpected_index_column_names:
             if column_name not in index_names:
-                raise ge_exceptions.MetricResolutionError("Hi will this is not good")
-            # tumple index
+                raise ge_exceptions.MetricResolutionError(
+                    message=f"Error: The column {column_name} does not exist in the named indices.",
+                    failed_metrics=["unexpected_index_list"],
+                )
             tuple_index = index_names.index(column_name, 0)
             primary_key_dict[column_name] = index[tuple_index]
         unexpected_index_list.append(primary_key_dict)
@@ -1098,7 +1100,6 @@ def get_unexpected_indices_for_multiple_pandas_named_indices(
 
 def get_unexpected_indices_for_single_pandas_named_index(
     df: pd.DataFrame,
-    unexpected_index_list: [List[Dict[str, Any]]],
     expectation_domain_column_name: str,
     unexpected_index_column_names: List[str],
 ) -> List[Dict[str, Any]]:
@@ -1106,15 +1107,17 @@ def get_unexpected_indices_for_single_pandas_named_index(
     Builds unexpected_index list for Pandas Dataframe in situation where the named
     columns is also a named index. This method handles the case when there is a single named index.
     Args:
-        df (DataFrame with indices):
-        unexpected_index_list (): value to return
-        expectation_domain_column_name ():
-        unexpected_index_column_names ():
+        df: reference to Pandas dataframe
+        expectation_domain_column_name: column that Expectation is being run on.
+        unexpected_index_column_names: column_names for indices, either named index or unexpected_index_columns
 
     Returns:
+        List of Dicts that contain ID/PK values
 
     """
     unexpected_index_values_by_named_index: List[Union[int, str]] = list(df.index)
+    unexpected_index_list: List[Dict[str, Any]] = list()
+
     for index in unexpected_index_values_by_named_index:
         primary_key_dict: Dict[str, Any] = dict()
         # domain column first

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -785,3 +785,139 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_summary_o
         "result"
     ].get("partial_unexpected_index_list")
     assert first_result_partial_list == expected_unexpected_indices_output
+
+
+@pytest.mark.integration
+def test_pandas_result_format_in_checkpoint_named_index_one_index_column(
+    in_memory_runtime_context,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_unexpected_indices_output,
+):
+    """
+    What does this test?
+        - DataFrame being passed into Checkpoint has named index 'pk_1', which correspond to unexpected_index_column_names
+        - MapMatric calculation happens the same as if `pk_1` was a non-index column
+    """
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk_1"],
+        }
+    }
+    # build our own BatchRequest
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    # setting named index
+    dataframe.set_index("pk_1")
+
+    batch_request: dict = {
+        "datasource_name": "pandas_datasource",
+        "data_connector_name": "runtime_data_connector",
+        "data_asset_name": "IN_MEMORY_DATA_ASSET",
+        "runtime_parameters": {
+            "batch_data": dataframe,
+        },
+        "batch_identifiers": {
+            "id_key_0": 1234567890,
+        },
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+
+    index_column_names: List[str] = evrs[0]["results"][0]["result"][
+        "unexpected_index_column_names"
+    ]
+    assert index_column_names == ["pk_1"]
+
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert first_result_full_list == expected_unexpected_indices_output
+    first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0][
+        "result"
+    ].get("partial_unexpected_index_list")
+    assert first_result_partial_list == expected_unexpected_indices_output
+
+
+@pytest.mark.integration
+def test_pandas_result_format_in_checkpoint_named_index_two_index_column(
+    in_memory_runtime_context,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_unexpected_indices_output,
+):
+    """
+    What does this test?
+        - DataFrame being passed into Checkpoint has two named indices, which correspond to unexpected_index_column_names
+        - MapMatric calculation happens the same as if `pk_1` and `pk_2` were non-index columns
+    """
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk_1", "pk_2"],
+        }
+    }
+    # build our own BatchRequest
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    # setting named index
+    dataframe.set_index(["pk_1", "pk_2"])
+
+    batch_request: dict = {
+        "datasource_name": "pandas_datasource",
+        "data_connector_name": "runtime_data_connector",
+        "data_asset_name": "IN_MEMORY_DATA_ASSET",
+        "runtime_parameters": {
+            "batch_data": dataframe,
+        },
+        "batch_identifiers": {
+            "id_key_0": 1234567890,
+        },
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+
+    index_column_names: List[str] = evrs[0]["results"][0]["result"][
+        "unexpected_index_column_names"
+    ]
+    assert index_column_names == ["pk_1", "pk_2"]
+
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert first_result_full_list == [
+        {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
+        {"animals": "lion", "pk_1": 4, "pk_2": "four"},
+        {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
+    ]
+    first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0][
+        "result"
+    ].get("partial_unexpected_index_list")
+    assert first_result_partial_list == [
+        {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
+        {"animals": "lion", "pk_1": 4, "pk_2": "four"},
+        {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
+    ]

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -803,20 +803,20 @@ def test_pandas_result_format_in_checkpoint_named_index_one_index_column(
     dict_to_update_checkpoint: dict = {
         "result_format": {
             "result_format": "COMPLETE",
-            "unexpected_index_column_names": ["pk_1"],
+            "unexpected_index_column_names": ["pk_2"],
         }
     }
     # build our own BatchRequest
     dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
     # setting named index
-    dataframe.set_index("pk_1")
+    updated_dataframe: pd.DataFrame = dataframe.set_index("pk_2")
 
     batch_request: dict = {
         "datasource_name": "pandas_datasource",
         "data_connector_name": "runtime_data_connector",
         "data_asset_name": "IN_MEMORY_DATA_ASSET",
         "runtime_parameters": {
-            "batch_data": dataframe,
+            "batch_data": updated_dataframe,
         },
         "batch_identifiers": {
             "id_key_0": 1234567890,
@@ -839,16 +839,25 @@ def test_pandas_result_format_in_checkpoint_named_index_one_index_column(
     index_column_names: List[str] = evrs[0]["results"][0]["result"][
         "unexpected_index_column_names"
     ]
-    assert index_column_names == ["pk_1"]
+    assert index_column_names == ["pk_2"]
 
     first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
         "unexpected_index_list"
     )
-    assert first_result_full_list == expected_unexpected_indices_output
+    assert first_result_full_list == [
+        {"animals": "giraffe", "pk_2": "three"},
+        {"animals": "lion", "pk_2": "four"},
+        {"animals": "zebra", "pk_2": "five"},
+    ]
     first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0][
         "result"
     ].get("partial_unexpected_index_list")
-    assert first_result_partial_list == expected_unexpected_indices_output
+    assert first_result_partial_list == [
+        {"animals": "giraffe", "pk_2": "three"},
+        {"animals": "lion", "pk_2": "four"},
+        {"animals": "zebra", "pk_2": "five"},
+    ]
+    # what happens to query
 
 
 @pytest.mark.integration
@@ -873,14 +882,14 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column(
     # build our own BatchRequest
     dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
     # setting named index
-    dataframe.set_index(["pk_1", "pk_2"])
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
 
     batch_request: dict = {
         "datasource_name": "pandas_datasource",
         "data_connector_name": "runtime_data_connector",
         "data_asset_name": "IN_MEMORY_DATA_ASSET",
         "runtime_parameters": {
-            "batch_data": dataframe,
+            "batch_data": updated_dataframe,
         },
         "batch_identifiers": {
             "id_key_0": 1234567890,
@@ -921,3 +930,140 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column(
         {"animals": "lion", "pk_1": 4, "pk_2": "four"},
         {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
     ]
+
+
+@pytest.mark.integration
+def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set(
+    in_memory_runtime_context,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_unexpected_indices_output,
+):
+    """
+    What does this test?
+        - DataFrame being passed into Checkpoint has two named indices, which correspond to unexpected_index_column_names
+        - MapMatric calculation happens the same as if `pk_1` and `pk_2` were non-index columns
+    """
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "COMPLETE",
+        }
+    }
+    # build our own BatchRequest
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    # setting named index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_2"])
+
+    batch_request: dict = {
+        "datasource_name": "pandas_datasource",
+        "data_connector_name": "runtime_data_connector",
+        "data_asset_name": "IN_MEMORY_DATA_ASSET",
+        "runtime_parameters": {
+            "batch_data": updated_dataframe,
+        },
+        "batch_identifiers": {
+            "id_key_0": 1234567890,
+        },
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+
+    index_column_names: List[str] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_column_names"
+    )
+    assert not index_column_names
+
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert first_result_full_list == [("three"), ("four"), ("five")]
+    first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0][
+        "result"
+    ].get("partial_unexpected_index_list")
+    assert first_result_partial_list == [("three"), ("four"), ("five")]
+
+
+@pytest.mark.integration
+def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set(
+    in_memory_runtime_context,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_unexpected_indices_output,
+):
+    """
+    What does this test?
+        - DataFrame being passed into Checkpoint has two named indices, which correspond to unexpected_index_column_names
+        - MapMatric calculation happens the same as if `pk_1` and `pk_2` were non-index columns
+    """
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "COMPLETE",
+        }
+    }
+    # build our own BatchRequest
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    # setting named index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+
+    batch_request: dict = {
+        "datasource_name": "pandas_datasource",
+        "data_connector_name": "runtime_data_connector",
+        "data_asset_name": "IN_MEMORY_DATA_ASSET",
+        "runtime_parameters": {
+            "batch_data": updated_dataframe,
+        },
+        "batch_identifiers": {
+            "id_key_0": 1234567890,
+        },
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+
+    index_column_names: List[str] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_column_names"
+    )
+    assert not index_column_names
+
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert first_result_full_list == [
+        {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
+        {"animals": "lion", "pk_1": 4, "pk_2": "four"},
+        {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
+    ]
+    first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0][
+        "result"
+    ].get("partial_unexpected_index_list")
+    assert first_result_partial_list == [
+        {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
+        {"animals": "lion", "pk_1": 4, "pk_2": "four"},
+        {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
+    ]
+
+
+# one index and one non

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -1015,7 +1015,6 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set
     }
     # build our own BatchRequest
     dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
-    # setting named index
     updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
 
     batch_request: dict = {
@@ -1066,4 +1065,138 @@ def test_pandas_result_format_in_checkpoint_named_index_two_index_column_not_set
     ]
 
 
-# one index and one non
+@pytest.mark.integration
+def test_pandas_result_format_in_checkpoint_named_index_two_index_column_set(
+    in_memory_runtime_context,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_unexpected_indices_output,
+):
+    """
+    What does this test?
+        - DataFrame being passed into Checkpoint has two named indices, which correspond to unexpected_index_column_names
+        - MapMetric calculation happens the same as if `pk_1` and `pk_2` were non-index columns
+        - we also pass in `pk_1`  as unexpected_index_column_names
+    """
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk_1"],
+        }
+    }
+    # build our own BatchRequest
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    # setting named index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_2"])
+
+    batch_request: dict = {
+        "datasource_name": "pandas_datasource",
+        "data_connector_name": "runtime_data_connector",
+        "data_asset_name": "IN_MEMORY_DATA_ASSET",
+        "runtime_parameters": {
+            "batch_data": updated_dataframe,
+        },
+        "batch_identifiers": {
+            "id_key_0": 1234567890,
+        },
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+
+    index_column_names: List[str] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_column_names"
+    )
+    assert not index_column_names
+
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert first_result_full_list == [("three"), ("four"), ("five")]
+    first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0][
+        "result"
+    ].get("partial_unexpected_index_list")
+    assert first_result_partial_list == [("three"), ("four"), ("five")]
+
+
+@pytest.mark.integration
+def test_pandas_result_format_in_checkpoint_named_index_two_index_column_set(
+    in_memory_runtime_context,
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_unexpected_indices_output,
+):
+    """
+    What does this test?
+        - DataFrame being passed into Checkpoint has two named indices, which correspond to unexpected_index_column_names
+        - MapMetric calculation happens the same as if `pk_1` and `pk_2` were non-index columns
+        - we also pass in `pk_1` and `pk_2`  as unexpected_index_column_names
+
+    """
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk_1", "pk_2"],
+        }
+    }
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+
+    batch_request: dict = {
+        "datasource_name": "pandas_datasource",
+        "data_connector_name": "runtime_data_connector",
+        "data_asset_name": "IN_MEMORY_DATA_ASSET",
+        "runtime_parameters": {
+            "batch_data": updated_dataframe,
+        },
+        "batch_identifiers": {
+            "id_key_0": 1234567890,
+        },
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+
+    index_column_names: List[str] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_column_names"
+    )
+    assert index_column_names == ["pk_1", "pk_2"]
+
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert first_result_full_list == [
+        {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
+        {"animals": "lion", "pk_1": 4, "pk_2": "four"},
+        {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
+    ]
+    first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0][
+        "result"
+    ].get("partial_unexpected_index_list")
+    assert first_result_partial_list == [
+        {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
+        {"animals": "lion", "pk_1": 4, "pk_2": "four"},
+        {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
+    ]

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -904,11 +904,12 @@ def test_pandas_result_format_in_checkpoint_named_index_one_index_column_wrong_c
             checkpoint_name="my_checkpoint",
             expectation_suite_name="animal_names_exp",
             batch_request=batch_request,
+            runtime_configuration={"catch_exceptions": False},
         )
     assert e.value.message == (
         "Exception occurred while running validation[0] of Checkpoint "
-        "'my_checkpoint': Error: The unexpected_index_column: \"i_dont_exist\" in "
-        "does not exist in SQL Table. Please check your configuration and try again.."
+        "'my_checkpoint': Error: The column pk_2 does not exist in the named indices. "
+        "Please check your configuration."
     )
 
 

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -194,6 +194,24 @@ def test_get_unexpected_indices_for_single_pandas_named_index(
 
 
 @pytest.mark.unit
+def test_get_unexpected_indices_for_multiple_pandas_named_indices(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    unexpected_index_list_two_index_columns,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+    expectation_domain_column_name = "animals"
+    unexpected_index_column_names = list(updated_dataframe.index.names)
+
+    unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
+        df=updated_dataframe,
+        expectation_domain_column_name=expectation_domain_column_name,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert unexpected_index_list == unexpected_index_list_two_index_columns
+
+
+@pytest.mark.unit
 def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpected_index_columns(
     pandas_animals_dataframe_for_unexpected_rows_and_index,
     unexpected_index_list_two_index_columns,
@@ -267,21 +285,3 @@ def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpect
         "Error: The domain column is currently set to None. Please check your "
         "configuration."
     )
-
-
-@pytest.mark.unit
-def test_get_unexpected_indices_for_multiple_pandas_named_indices(
-    pandas_animals_dataframe_for_unexpected_rows_and_index,
-    unexpected_index_list_two_index_columns,
-):
-    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
-    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
-    expectation_domain_column_name = "animals"
-    unexpected_index_column_names = list(updated_dataframe.index.names)
-
-    unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
-        df=updated_dataframe,
-        expectation_domain_column_name=expectation_domain_column_name,
-        unexpected_index_column_names=unexpected_index_column_names,
-    )
-    assert unexpected_index_list == unexpected_index_list_two_index_columns

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -168,7 +168,7 @@ def test_get_unexpected_indices_for_single_pandas_named_index_named_unexpected_i
     unexpected_index_column_names: List[str] = ["pk_1"]
 
     unexpected_index_list = get_unexpected_indices_for_single_pandas_named_index(
-        df=updated_dataframe,
+        domain_records_df=updated_dataframe,
         expectation_domain_column_name=expectation_domain_column_name,
         unexpected_index_column_names=unexpected_index_column_names,
     )
@@ -186,7 +186,7 @@ def test_get_unexpected_indices_for_single_pandas_named_index(
     unexpected_index_column_names = [updated_dataframe.index.name]
 
     unexpected_index_list = get_unexpected_indices_for_single_pandas_named_index(
-        df=updated_dataframe,
+        domain_records_df=updated_dataframe,
         expectation_domain_column_name=expectation_domain_column_name,
         unexpected_index_column_names=unexpected_index_column_names,
     )
@@ -204,7 +204,7 @@ def test_get_unexpected_indices_for_multiple_pandas_named_indices(
     unexpected_index_column_names = list(updated_dataframe.index.names)
 
     unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
-        df=updated_dataframe,
+        domain_records_df=updated_dataframe,
         expectation_domain_column_name=expectation_domain_column_name,
         unexpected_index_column_names=unexpected_index_column_names,
     )
@@ -222,7 +222,7 @@ def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpect
     unexpected_index_column_names = ["pk_1", "pk_2"]
 
     unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
-        df=updated_dataframe,
+        domain_records_df=updated_dataframe,
         expectation_domain_column_name=expectation_domain_column_name,
         unexpected_index_column_names=unexpected_index_column_names,
     )
@@ -240,7 +240,7 @@ def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpect
     unexpected_index_column_names = ["pk_1"]
 
     unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
-        df=updated_dataframe,
+        domain_records_df=updated_dataframe,
         expectation_domain_column_name=expectation_domain_column_name,
         unexpected_index_column_names=unexpected_index_column_names,
     )
@@ -257,7 +257,7 @@ def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpect
     unexpected_index_column_names = ["i_dont_exist"]
     with pytest.raises(MetricResolutionError) as e:
         get_unexpected_indices_for_multiple_pandas_named_indices(
-            df=updated_dataframe,
+            domain_records_df=updated_dataframe,
             expectation_domain_column_name=expectation_domain_column_name,
             unexpected_index_column_names=unexpected_index_column_names,
         )
@@ -277,7 +277,7 @@ def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpect
     unexpected_index_column_names = ["pk_1"]
     with pytest.raises(MetricResolutionError) as e:
         get_unexpected_indices_for_multiple_pandas_named_indices(
-            df=updated_dataframe,
+            domain_records_df=updated_dataframe,
             expectation_domain_column_name=expectation_domain_column_name,
             unexpected_index_column_names=unexpected_index_column_names,
         )

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -237,12 +237,36 @@ def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpect
     updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
     expectation_domain_column_name = "animals"
     unexpected_index_column_names = ["i_dont_exist"]
-    with pytest.raises(MetricResolutionError):
+    with pytest.raises(MetricResolutionError) as e:
         get_unexpected_indices_for_multiple_pandas_named_indices(
             df=updated_dataframe,
             expectation_domain_column_name=expectation_domain_column_name,
             unexpected_index_column_names=unexpected_index_column_names,
         )
+    assert e.value.message == (
+        "Error: The column i_dont_exist does not exist in the named indices. Please "
+        "check your configuration"
+    )
+
+
+@pytest.mark.unit
+def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpected_index_wrong_domain(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+    expectation_domain_column_name = None
+    unexpected_index_column_names = ["pk_1"]
+    with pytest.raises(MetricResolutionError) as e:
+        get_unexpected_indices_for_multiple_pandas_named_indices(
+            df=updated_dataframe,
+            expectation_domain_column_name=expectation_domain_column_name,
+            unexpected_index_column_names=unexpected_index_column_names,
+        )
+    assert e.value.message == (
+        "Error: The domain column is currently set to None. Please check your "
+        "configuration."
+    )
 
 
 @pytest.mark.unit

--- a/tests/expectations/metrics/test_metrics_util.py
+++ b/tests/expectations/metrics/test_metrics_util.py
@@ -1,9 +1,11 @@
-from typing import List
+from typing import Any, Dict, List
 
+import pandas as pd
 import pytest
 from _pytest import monkeypatch
 
 from great_expectations.data_context.util import file_relative_path
+from great_expectations.exceptions import MetricResolutionError
 
 try:
     import sqlalchemy as sa
@@ -20,6 +22,8 @@ except ImportError:
 
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 from great_expectations.expectations.metrics.util import (
+    get_unexpected_indices_for_multiple_pandas_named_indices,
+    get_unexpected_indices_for_single_pandas_named_index,
     sql_statement_with_post_compile_to_string,
 )
 from tests.test_utils import (
@@ -63,6 +67,30 @@ def _compare_select_statement_with_converted_string(engine) -> None:
     assert returned_string == (
         "SELECT a.id, a.data \n" "FROM a \n" "WHERE a.data = '00000000'"
     )
+
+
+@pytest.fixture
+def unexpected_index_list_one_index_column():
+    return [
+        {"animals": "cat", "pk_1": 0},
+        {"animals": "fish", "pk_1": 1},
+        {"animals": "dog", "pk_1": 2},
+        {"animals": "giraffe", "pk_1": 3},
+        {"animals": "lion", "pk_1": 4},
+        {"animals": "zebra", "pk_1": 5},
+    ]
+
+
+@pytest.fixture
+def unexpected_index_list_two_index_columns():
+    return [
+        {"animals": "cat", "pk_1": 0, "pk_2": "zero"},
+        {"animals": "fish", "pk_1": 1, "pk_2": "one"},
+        {"animals": "dog", "pk_1": 2, "pk_2": "two"},
+        {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
+        {"animals": "lion", "pk_1": 4, "pk_2": "four"},
+        {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
+    ]
 
 
 @pytest.mark.unit
@@ -127,3 +155,109 @@ def test_sql_statement_conversion_to_string_bigquery(test_backends):
         )
     else:
         pytest.skip(f"skipping sql statement conversion test for : bigquery")
+
+
+@pytest.mark.unit
+def test_get_unexpected_indices_for_single_pandas_named_index_named_unexpected_index_columns(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    unexpected_index_list_one_index_column,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1"])
+    expectation_domain_column_name: str = "animals"
+    unexpected_index_column_names: List[str] = ["pk_1"]
+
+    unexpected_index_list = get_unexpected_indices_for_single_pandas_named_index(
+        df=updated_dataframe,
+        expectation_domain_column_name=expectation_domain_column_name,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert unexpected_index_list == unexpected_index_list_one_index_column
+
+
+@pytest.mark.unit
+def test_get_unexpected_indices_for_single_pandas_named_index(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    unexpected_index_list_one_index_column,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1"])
+    expectation_domain_column_name = "animals"
+    unexpected_index_column_names = [updated_dataframe.index.name]
+
+    unexpected_index_list = get_unexpected_indices_for_single_pandas_named_index(
+        df=updated_dataframe,
+        expectation_domain_column_name=expectation_domain_column_name,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert unexpected_index_list == unexpected_index_list_one_index_column
+
+
+@pytest.mark.unit
+def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpected_index_columns(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    unexpected_index_list_two_index_columns,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+    expectation_domain_column_name = "animals"
+    unexpected_index_column_names = ["pk_1", "pk_2"]
+
+    unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
+        df=updated_dataframe,
+        expectation_domain_column_name=expectation_domain_column_name,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert unexpected_index_list == unexpected_index_list_two_index_columns
+
+
+@pytest.mark.unit
+def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpected_index_columns_one_column(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    unexpected_index_list_one_index_column,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+    expectation_domain_column_name = "animals"
+    unexpected_index_column_names = ["pk_1"]
+
+    unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
+        df=updated_dataframe,
+        expectation_domain_column_name=expectation_domain_column_name,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert unexpected_index_list == unexpected_index_list_one_index_column
+
+
+@pytest.mark.unit
+def test_get_unexpected_indices_for_multiple_pandas_named_indices_named_unexpected_index_columns_wrong_column(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+    expectation_domain_column_name = "animals"
+    unexpected_index_column_names = ["i_dont_exist"]
+    with pytest.raises(MetricResolutionError):
+        get_unexpected_indices_for_multiple_pandas_named_indices(
+            df=updated_dataframe,
+            expectation_domain_column_name=expectation_domain_column_name,
+            unexpected_index_column_names=unexpected_index_column_names,
+        )
+
+
+@pytest.mark.unit
+def test_get_unexpected_indices_for_multiple_pandas_named_indices(
+    pandas_animals_dataframe_for_unexpected_rows_and_index,
+    unexpected_index_list_two_index_columns,
+):
+    dataframe: pd.DataFrame = pandas_animals_dataframe_for_unexpected_rows_and_index
+    updated_dataframe: pd.DataFrame = dataframe.set_index(["pk_1", "pk_2"])
+    expectation_domain_column_name = "animals"
+    unexpected_index_column_names = list(updated_dataframe.index.names)
+
+    unexpected_index_list = get_unexpected_indices_for_multiple_pandas_named_indices(
+        df=updated_dataframe,
+        expectation_domain_column_name=expectation_domain_column_name,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert unexpected_index_list == unexpected_index_list_two_index_columns


### PR DESCRIPTION
Changes proposed in this pull request:
- Allows `named_indices` to be used for Pandas ID/PK.
- Refactored `_pandas_map_condition_index()` method to allow for
    1. single named index in Pandas DF
    2. multiple named indices Pandas DF.
    4. no named indices but `unexpected_index_column_names` are defined. 
    5. no named indices and no `unexpected_index_column_names` (just return default indices as before)
- Note: In cases where both named indices exist and `unexpected_index_column_names` are defined, we will default to outputting columns that are defined in `unexpected_index_column_names`. If there is a conflict (ie. we define a column that doesn't exist as a named index), then we will raise a `MetricsResolution` error. 
- Tests have been added at the `tests/checkpoint/test_checkpoint_result_format.py`-level. 
- Tests have been added at the `test_metrics_util.py`-level for the helper methods. 

#### What are named indices?
* [Here is a great resource. The method `set_index()` was used in tests that exercise named indices behavior](https://www.w3resource.com/pandas/dataframe/dataframe-set_index.php)
### Examples
#### DataFrame with default index
![Screen Shot 2022-12-28 at 9 40 23 PM](https://user-images.githubusercontent.com/25670697/209908087-7835f6e8-1b26-4ced-add4-88b02f519bc8.png)

* If `unexpected_index_column_names` are passed in 
```python
{
"result_format": {
   "result_format": "COMPLETE",
    "unexpected_index_column_names": ["pk_2"],
   }
}
# we will return 
[
   {"animals": "giraffe", "pk_2": "three"},
   {"animals": "lion", "pk_2": "four"},
   {"animals": "zebra", "pk_2": "five"},
]
```
* If `unexpected_index_column_names` are **not** passed in 
```python
{
"result_format": {
   "result_format": "COMPLETE",
   }
}
# we will return the default indices 
[ 3, 4, 5] 
```

####  DataFrame with named index `pk_1`
![Screen Shot 2022-12-28 at 9 40 55 PM](https://user-images.githubusercontent.com/25670697/209908127-02b83997-fc7c-4081-b3c7-6cb6eb2ec985.png)
* If `unexpected_index_column_names` are passed in 

```python 
{
"result_format": {
   "result_format": "COMPLETE",
    "unexpected_index_column_names": ["pk_1"],
   }
}
# we will return 
[
   {"animals": "giraffe", "pk_1": 3},
   {"animals": "lion", "pk_1": 4},
   {"animals": "zebra", "pk_1": 5},
]
```
* If non existent `unexpected_index_column_names` is passed in 
```python
{
"result_format": {
   "result_format": "COMPLETE",
    "unexpected_index_column_names": ["i_dont_exist"],
   }
}

# this will give an ERROR
```

#### DataFrame with named index `pk_1` and `pk_2`
![Screen Shot 2022-12-28 at 9 41 05 PM](https://user-images.githubusercontent.com/25670697/209908140-68251873-73d5-475e-ad9a-a807e1077314.png)

* If 1 `unexpected_index_column_names` is passed in 

```python 
{
"result_format": {
   "result_format": "COMPLETE",
    "unexpected_index_column_names": ["pk_1"],
   }
}
# we will return 
[
   {"animals": "giraffe", "pk_1": 3},
   {"animals": "lion", "pk_1": 4},
   {"animals": "zebra", "pk_1": 5},
]
```
* If 2 `unexpected_index_column_names` are passed in 
```python 
{
"result_format": {
   "result_format": "COMPLETE",
    "unexpected_index_column_names": ["pk_1", "pk_2"],
   }
}
# we will return 
[
   {"animals": "giraffe", "pk_1": 3, "pk_2": "three"},
   {"animals": "lion", "pk_1": 4, "pk_2": "four"},
   {"animals": "zebra", "pk_1": 5, "pk_2": "five"},
]
```
* If non existent `unexpected_index_column_names` is passed in 
```python
{
"result_format": {
   "result_format": "COMPLETE",
    "unexpected_index_column_names": ["i_dont_exist"],
   }
}

# this will give an ERROR
```



### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.