### PR TITLE
[FEATURE] ID/PK flag `return_unexpected_index_query` that allows `QUERY` output to be suppressed

### DIFF
--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -2412,7 +2412,7 @@ def _sqlalchemy_map_condition_query(
     result_format: dict = metric_value_kwargs["result_format"]
 
     # We will not return map_condition_query if return_unexpected_index_query = False
-    return_unexpected_index_query: Union[bool, None] = result_format.get(
+    return_unexpected_index_query: bool = result_format.get(
         "return_unexpected_index_query"
     )
     if return_unexpected_index_query is False:

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -2411,6 +2411,13 @@ def _sqlalchemy_map_condition_query(
     domain_kwargs: dict = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
     result_format: dict = metric_value_kwargs["result_format"]
 
+    # check flag - we will only return query if we set return_unexpected_index_query = True
+    return_unexpected_index_query: Union[bool, None] = result_format.get(
+        "return_unexpected_index_query"
+    )
+    if not return_unexpected_index_query:
+        return
+
     column_selector: List[sa.Column] = [sa.column(domain_kwargs["column"])]
     all_table_columns: List[str] = metrics.get("table.columns")
     unexpected_index_column_names: List[str] = result_format.get(

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -2411,11 +2411,11 @@ def _sqlalchemy_map_condition_query(
     domain_kwargs: dict = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
     result_format: dict = metric_value_kwargs["result_format"]
 
-    # check flag - we will only return query if we set return_unexpected_index_query = True
+    # We will not return if return_unexpected_index_query = False
     return_unexpected_index_query: Union[bool, None] = result_format.get(
         "return_unexpected_index_query"
     )
-    if not return_unexpected_index_query:
+    if return_unexpected_index_query is False:
         return
 
     column_selector: List[sa.Column] = [sa.column(domain_kwargs["column"])]

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -2411,7 +2411,7 @@ def _sqlalchemy_map_condition_query(
     domain_kwargs: dict = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
     result_format: dict = metric_value_kwargs["result_format"]
 
-    # We will not return if return_unexpected_index_query = False
+    # We will not return map_condition_query if return_unexpected_index_query = False
     return_unexpected_index_query: Union[bool, None] = result_format.get(
         "return_unexpected_index_query"
     )

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -228,7 +228,10 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
     ]
     assert first_result_partial_list == expected_unexpected_indices_output
 
-    assert evrs[0]["results"][0]["result"].get("unexpected_index_query") is None
+    unexpected_index_query: str = evrs[0]["results"][0]["result"][
+        "unexpected_index_query"
+    ]
+    assert unexpected_index_query == unexpected_index_query_output
 
 
 @pytest.mark.integration
@@ -345,6 +348,7 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
     reference_sql_checkpoint_config_for_unexpected_column_names,
     expectation_config_expect_column_values_to_be_in_set,
     expected_unexpected_indices_output,
+    unexpected_index_query_output,
 ):
     """
     What does this test?
@@ -382,6 +386,10 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
         "partial_unexpected_index_list"
     ]
     assert first_result_partial_list == expected_unexpected_indices_output
+    unexpected_index_query: str = evrs[0]["results"][0]["result"][
+        "unexpected_index_query"
+    ]
+    assert unexpected_index_query == unexpected_index_query_output
 
 
 @pytest.mark.integration
@@ -389,6 +397,7 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
     data_context_with_connection_to_animal_names_db,
     reference_sql_checkpoint_config_for_unexpected_column_names,
     expectation_config_expect_column_values_to_be_in_set,
+    unexpected_index_query_output,
 ):
     """
     What does this test?
@@ -402,7 +411,7 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
         expectations_list=[expectation_config_expect_column_values_to_be_in_set],
     )
     result_format: dict = {
-        "result_format": "SUMMARY",
+        "result_format": "COMPLETE",
         "partial_unexpected_count": 1,
         "unexpected_index_column_names": ["pk_1"],
     }
@@ -415,11 +424,18 @@ def test_sql_result_format_not_in_checkpoint_passed_into_run_checkpoint_one_expe
         "unexpected_index_column_names"
     ]
     assert index_column_names == ["pk_1"]
-
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"][
+        "unexpected_index_list"
+    ]
+    assert first_result_full_list == [{"animals": "giraffe", "pk_1": 3}]
     first_result_partial_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"][
         "partial_unexpected_index_list"
     ]
     assert first_result_partial_list == [{"animals": "giraffe", "pk_1": 3}]
+    unexpected_index_query: str = evrs[0]["results"][0]["result"][
+        "unexpected_index_query"
+    ]
+    assert unexpected_index_query == unexpected_index_query_output
 
 
 @pytest.mark.integration
@@ -464,6 +480,7 @@ def test_sql_result_format_in_checkpoint_pk_defined_two_expectation_complete_out
     expectation_config_expect_column_values_to_be_in_set,
     expectation_config_expect_column_values_to_not_be_in_set,
     expected_unexpected_indices_output,
+    unexpected_index_query_output,
 ):
     """
     What does this test?
@@ -513,6 +530,10 @@ def test_sql_result_format_in_checkpoint_pk_defined_two_expectation_complete_out
         "partial_unexpected_index_list"
     ]
     assert second_result_partial_list == expected_unexpected_indices_output
+    unexpected_index_query: str = evrs[0]["results"][0]["result"][
+        "unexpected_index_query"
+    ]
+    assert unexpected_index_query == unexpected_index_query_output
 
 
 @pytest.mark.integration
@@ -566,6 +587,7 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_basic_output
     data_context_with_connection_to_animal_names_db,
     reference_sql_checkpoint_config_for_unexpected_column_names,
     expectation_config_expect_column_values_to_be_in_set,
+    unexpected_index_query_output,
 ):
     """
     What does this test?
@@ -604,6 +626,8 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_basic_output
         "partial_unexpected_index_list"
     )
     assert not first_result_partial_list
+
+    assert evrs[0]["results"][0]["result"].get("unexpected_index_query") is None
 
 
 # pandas
@@ -822,6 +846,7 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_summary_outp
     reference_sql_checkpoint_config_for_unexpected_column_names,
     expectation_config_expect_column_values_to_be_in_set,
     expected_unexpected_indices_output,
+    unexpected_index_query_output,
 ):
     """
     What does this test?
@@ -862,6 +887,7 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_summary_outp
         "partial_unexpected_index_list"
     ]
     assert first_result_partial_list == expected_unexpected_indices_output
+    assert evrs[0]["results"][0]["result"].get("unexpected_index_query") is None
 
 
 @pytest.mark.integration

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -247,6 +247,7 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
         - unexpected_index_column defined in Checkpoint only.
         - COMPLETE output, which means we have `unexpected_index_list` and `partial_unexpected_index_list`
         - 1 Expectations added to suite
+        - return_unexpected_index_query flag set to True
     """
 
     dict_to_update_checkpoint: dict = {
@@ -302,7 +303,7 @@ def test_sql_result_format_in_checkpoint_pk_defined_one_expectation_complete_out
         - unexpected_index_column defined in Checkpoint only.
         - COMPLETE output, which means we have `unexpected_index_list` and `partial_unexpected_index_list`
         - 1 Expectations added to suite
-        - testing unexpected_index_query flag
+        - return_unexpected_index_query flag set to False
     """
 
     dict_to_update_checkpoint: dict = {


### PR DESCRIPTION
- Adds `return_unexpected_index_query` flag to `result_format`. 
- By default, `unexpected_index_query` is returned by `ExecutionEngines` that support it (currently on `SqlAlchemyExecutionEngine`), only when `result_format` is set to `COMPLETE`. 
- setting `return_unexpected_index_query` to `False` will suppress the `unexpected_index_query` even when `result_format` is set to `COMPLETE`
-  Added tests at `tests/checkpoint/test_checkpoint_result_format.py`-level

### Can you give some examples? 
```python 
        "result_format": {
            "result_format": "COMPLETE",
            "unexpected_index_column_names": ["pk_1"],
            "return_unexpected_index_query": True,
        }
```
* **Will** have `unexpected_index_query`, since `return_unexpected_index_query` is explicitly set to `True`

```python 
        "result_format": {
            "result_format": "COMPLETE",
            "unexpected_index_column_names": ["pk_1"],
            "return_unexpected_index_query": False,
        }
```
* **Will not** have `unexpected_index_query`, since `return_unexpected_index_query` is explicitly set to `False`


```python 
        "result_format": {
            "result_format": "COMPLETE",
            "unexpected_index_column_names": ["pk_1"],
        }
```
* **Will** have `unexpected_index_query`, since it is returned by default if result format is set to `COMPLETE`

```python 
        "result_format": {
            "result_format": "SUMMARY",
            "unexpected_index_column_names": ["pk_1"],
        }
```
* **Will not** have `unexpected_index_query`, since result format is set to `SUMMARY`

### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
