### PR TITLE
[MAINTENANCE] Make only column y data_alt different in col_pair_equal tests

### DIFF
--- a/tests/test_definitions/column_pair_map_expectations/expect_column_pair_values_to_be_equal.json
+++ b/tests/test_definitions/column_pair_map_expectations/expect_column_pair_values_to_be_equal.json
@@ -10,12 +10,12 @@
       "b" : [1, 2, 3, 4, 5, null, null, null, null, null]
     },
     "data_alt" : {
-      "w" : [1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "x" : [1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "y" : [1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "z" : [1, 2, 3, 4, 5, null, null, null, null],
-      "a" : [1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "b" : [1, 2, 3, 4, 5, null, null, null, null]
+      "w" : [1, 2, 3, 4, 5, 6, 7, 8, 9, null],
+      "x" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      "y" : [1, 2, 3, 4, 5, 6, 7, 8, 9, null],
+      "z" : [1, 2, 3, 4, 5, null, null, null, null, null],
+      "a" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 11],
+      "b" : [1, 2, 3, 4, 5, null, null, null, null, null]
     },
     "schemas": {
       "spark": {
@@ -57,7 +57,6 @@
       "title" : "basic_negative_example_compare_numbers",
       "include_in_gallery": true,
       "exact_match_out" : false,
-      "suppress_test_for": ["trino"],
       "in": {
         "column_A": "a",
         "column_B": "x"
@@ -87,7 +86,6 @@
     },{
       "title" : "positive_example_with_mostly_compare_numbers",
       "exact_match_out" : false,
-      "suppress_test_for": ["trino"],
       "in": {
         "column_A": "a",
         "column_B": "x",


### PR DESCRIPTION
Both Trino and Snowflake don't allow strings in numeric columns (the "abc" in final row of column y) and both raise errors when trying to insert original data to a table.

Note that column y is only used in pandas tests anyway.