### PR TITLE
[BUGFIX] Add connect args to execution engine schema

### DIFF
--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -1004,6 +1004,9 @@ class ExecutionEngineConfigSchema(Schema):
     boto3_options = fields.Dict(
         keys=fields.Str(), values=fields.Str(), required=False, allow_none=True
     )
+    connect_args = fields.Dict(
+        keys=fields.Str(), values=fields.Dict(), required=False, allow_none=True
+    )
     azure_options = fields.Dict(
         keys=fields.Str(), values=fields.Str(), required=False, allow_none=True
     )

--- a/great_expectations/data_context/types/base.py
+++ b/great_expectations/data_context/types/base.py
@@ -947,6 +947,7 @@ class ExecutionEngineConfig(DictDot):
         azure_options=None,
         gcs_options=None,
         credentials_info=None,
+        connect_args=None,
         **kwargs,
     ) -> None:
         self._class_name = class_name
@@ -969,6 +970,8 @@ class ExecutionEngineConfig(DictDot):
             self.gcs_options = gcs_options
         if credentials_info is not None:
             self.credentials_info = credentials_info
+        if connect_args is not None:
+            self.connect_args = connect_args
         for k, v in kwargs.items():
             setattr(self, k, v)
 


### PR DESCRIPTION
This PR is to solve [this issue](https://github.com/great-expectations/great_expectations/issues/6226).

There is an issue that when creating SQLAlchemy execution engine, if the user send "connect_args" in the execution engine config, it is not passed to the "create_engine" method. 
This is because this attribute is dropped when creating the ExecutionEngineConfigSchema.

I checked it locally and this PR solve the issue

Changes proposed in this pull request:
- Add connect_args to the ExecutionEngineConfigSchema
