### PR TITLE
[DOCS] DOC-400 remove an outdated video link

### DIFF
--- a/docs/guides/setup/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file.md
+++ b/docs/guides/setup/configuring_data_contexts/how_to_instantiate_a_data_context_without_a_yml_file.md
@@ -10,10 +10,6 @@ This guide will help you instantiate a <TechnicalTag tag="data_context" text="Da
 
 </Prerequisites>
 
-:::note
-- See also our companion video for this guide: [Data Contexts In Code](https://youtu.be/4VMOYpjHNhM).
-:::
-
 ## Steps
 
 ### 1. **Create a DataContextConfig**


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove an admonition box containing link to video with v2 content

### Definition of Done
- [X] I have made corresponding changes to the documentation
