### PR TITLE
[MAINTENANCE] Make only column y data_alt different in col_pair_in_set tests

### DIFF
--- a/tests/test_definitions/column_pair_map_expectations/expect_column_pair_values_to_be_in_set.json
+++ b/tests/test_definitions/column_pair_map_expectations/expect_column_pair_values_to_be_in_set.json
@@ -10,12 +10,12 @@
       "b" : [1, 2, 1, 2, 1, 2, 1, 2, 1, null]
     },
     "data_alt" : {
-      "w" : [2, 3, 4, 5, 6, 7, 8, 9, 10],
-      "x" : [1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "y" : [1, 2, 3, 4, 5, 6, 7, 8, 9],
-      "z" : [1, 2, 3, 4, 5, null, null, null, null],
-      "a" : [1, 1, 1, 1, 1, 2, 2, 2, 2],
-      "b" : [1, 2, 1, 2, 1, 2, 1, 2, 1]
+      "w" : [2, 3, 4, 5, 6, 7, 8, 9, 10, null],
+      "x" : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      "y" : [1, 2, 3, 4, 5, 6, 7, 8, 9, null],
+      "z" : [1, 2, 3, 4, 5, null, null, null, null, null],
+      "a" : [1, 1, 1, 1, 1, 2, 2, 2, 2, null],
+      "b" : [1, 2, 1, 2, 1, 2, 1, 2, 1, null]
     },
     "schemas": {
       "spark": {
@@ -69,7 +69,7 @@
       "title": "negative_test_with_nulls",
       "include_in_gallery": true,
       "exact_match_out" : false,
-      "suppress_test_for": ["trino", "mssql_v2_api"],
+      "suppress_test_for": ["mssql_v2_api"],
       "in": {
         "column_A": "x",
         "column_B": "z",


### PR DESCRIPTION
Both Trino and Snowflake don't allow strings in numeric columns (the "abc" in final row of column y) and both raise errors when trying to insert original data to a table.