### PR TITLE
[FEATURE] F/great 1400/postgres constr

### DIFF
--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -1,16 +1,9 @@
-from typing import TYPE_CHECKING
-
-from pydantic import constr
+from pydantic import PostgresDsn
 from typing_extensions import Literal
 
 from great_expectations.experimental.datasources.sql_datasource import SQLDatasource
 
-if TYPE_CHECKING:
-    PostgresConnectionString = str
-else:
-    PostgresConnectionString = constr(regex=r"^postgresql")
-
 
 class PostgresDatasource(SQLDatasource):
     type: Literal["postgres"] = "postgres"  # type: ignore[assignment]
-    connection_string: PostgresConnectionString
+    connection_string: PostgresDsn

--- a/great_expectations/experimental/datasources/postgres_datasource.py
+++ b/great_expectations/experimental/datasources/postgres_datasource.py
@@ -1,7 +1,16 @@
+from typing import TYPE_CHECKING
+
+from pydantic import constr
 from typing_extensions import Literal
 
 from great_expectations.experimental.datasources.sql_datasource import SQLDatasource
 
+if TYPE_CHECKING:
+    PostgresConnectionString = str
+else:
+    PostgresConnectionString = constr(regex=r"^postgresql")
+
 
 class PostgresDatasource(SQLDatasource):
     type: Literal["postgres"] = "postgres"  # type: ignore[assignment]
+    connection_string: PostgresConnectionString

--- a/tests/experimental/datasources/great_expectations.yml
+++ b/tests/experimental/datasources/great_expectations.yml
@@ -2,7 +2,7 @@ xdatasources:
   my_pg_ds:
     type: postgres
     name: my_pg_ds
-    connection_string: "postgres://foo.bar"
+    connection_string: "postgresql://foo.bar"
     assets:
       my_table_asset_wo_splitters:
         type: table

--- a/tests/experimental/datasources/great_expectations.yml
+++ b/tests/experimental/datasources/great_expectations.yml
@@ -2,7 +2,7 @@ xdatasources:
   my_pg_ds:
     type: postgres
     name: my_pg_ds
-    connection_string: "postgresql://foo.bar"
+    connection_string: "postgresql://userName:@hostname/dbName"
     assets:
       my_table_asset_wo_splitters:
         type: table

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -32,7 +32,7 @@ PG_CONFIG_YAML_STR = PG_CONFIG_YAML_FILE.read_text()
 PG_COMPLEX_CONFIG_DICT = {
     "xdatasources": {
         "my_pg_ds": {
-            "connection_string": "postgres://foo.bar",
+            "connection_string": "postgresql://foo.bar",
             "name": "my_pg_ds",
             "type": "postgres",
             "assets": {
@@ -233,7 +233,7 @@ def test_catch_bad_asset_configs(
         "my_test_ds": {
             "type": "postgres",
             "name": "my_test_ds",
-            "connection_string": "my_db://",
+            "connection_string": "postgresql://",
             "assets": {bad_asset_config["name"]: bad_asset_config},
         }
     }

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -32,7 +32,7 @@ PG_CONFIG_YAML_STR = PG_CONFIG_YAML_FILE.read_text()
 PG_COMPLEX_CONFIG_DICT = {
     "xdatasources": {
         "my_pg_ds": {
-            "connection_string": "postgresql://foo.bar",
+            "connection_string": "postgresql://userName:@hostname/dbName",
             "name": "my_pg_ds",
             "type": "postgres",
             "assets": {
@@ -233,7 +233,7 @@ def test_catch_bad_asset_configs(
         "my_test_ds": {
             "type": "postgres",
             "name": "my_test_ds",
-            "connection_string": "postgresql://",
+            "connection_string": "postgres://userName:@hostname/dbName",
             "assets": {bad_asset_config["name"]: bad_asset_config},
         }
     }

--- a/tests/experimental/datasources/test_sqlite_datasource.py
+++ b/tests/experimental/datasources/test_sqlite_datasource.py
@@ -7,6 +7,7 @@ from great_expectations.data_context.util import file_relative_path
 from great_expectations.experimental.datasources import SqliteDatasource
 
 
+@pytest.mark.unit
 def test_connection_string_starts_with_sqlite():
     # The actual file doesn't matter only it's existence since SqlAlchemy does a check
     # when it creates the database engine.
@@ -26,6 +27,7 @@ def test_connection_string_starts_with_sqlite():
     assert datasource.connection_string == connection_string
 
 
+@pytest.mark.unit
 def test_connection_string_that_does_not_start_with_sqlite():
     name = "sqlite_datasource"
     connection_string = "stuff+sqlite:///path/to/database/file.db"

--- a/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant_happy_paths.py
+++ b/tests/rule_based_profiler/data_assistant/test_onboarding_data_assistant_happy_paths.py
@@ -358,8 +358,7 @@ def test_sql_happy_path_onboarding_data_assistant_null_column_quantiles_metric_v
         ),
     )
 
-    # This actually works with any SQLAlchemy-compatible backend; the naming will reflect this as part of near-term fix.
-    datasource = context.sources.add_postgres(
+    datasource = context.sources.add_sqlite(
         name="test_datasource",
         connection_string=f"sqlite:///{db_file}",
     )


### PR DESCRIPTION
Update postgres datasource to validate the connection string starts with `postgresql`.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
