### PR TITLE
[BUGFIX] Avoid key collisions between Rule-Based Profiler terminal literals and MetricConfiguration value keys

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -562,7 +562,7 @@ class ExpectationSuite(SerializableDictDot):
         """
         This is a private method for adding expectations that allows for usage_events to be suppressed when
         Expectations are added through internal processing (ie. while building profilers, rendering or validation). It
-        takes in send_usage_event boolean.  If successful, upserts ExpectationConfigurations into this ExpectationSuite.
+        takes in send_usage_event boolean.  If successful, upserts ExpectationConfiguration into this ExpectationSuite.
 
         Args:
             expectation_configuration: The ExpectationConfiguration to add or update
@@ -681,7 +681,7 @@ class ExpectationSuite(SerializableDictDot):
         match_type: str = "domain",
         overwrite_existing: bool = True,
     ) -> ExpectationConfiguration:
-        """Upsert specified ExpectationConfigurations into this ExpectationSuite.
+        """Upsert specified ExpectationConfiguration into this ExpectationSuite.
 
         Args:
             expectation_configuration: The ExpectationConfiguration to add or update

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -562,7 +562,7 @@ class ExpectationSuite(SerializableDictDot):
         """
         This is a private method for adding expectations that allows for usage_events to be suppressed when
         Expectations are added through internal processing (ie. while building profilers, rendering or validation). It
-        takes in send_usage_event boolean.
+        takes in send_usage_event boolean.  If successful, upserts ExpectationConfigurations into this ExpectationSuite.
 
         Args:
             expectation_configuration: The ExpectationConfiguration to add or update
@@ -642,7 +642,8 @@ class ExpectationSuite(SerializableDictDot):
         match_type: str = "domain",
         overwrite_existing: bool = True,
     ) -> List[ExpectationConfiguration]:
-        """
+        """Upsert a list of ExpectationConfigurations into this ExpectationSuite.
+
         Args:
             expectation_configurations: The List of candidate new/modifed "ExpectationConfiguration" objects for Suite.
             send_usage_event: Whether to send a usage_statistics event. When called through ExpectationSuite class'
@@ -680,7 +681,8 @@ class ExpectationSuite(SerializableDictDot):
         match_type: str = "domain",
         overwrite_existing: bool = True,
     ) -> ExpectationConfiguration:
-        """
+        """Upsert specified ExpectationConfigurations into this ExpectationSuite.
+
         Args:
             expectation_configuration: The ExpectationConfiguration to add or update
             send_usage_event: Whether to send a usage_statistics event. When called through ExpectationSuite class'

--- a/great_expectations/rule_based_profiler/parameter_container.py
+++ b/great_expectations/rule_based_profiler/parameter_container.py
@@ -43,14 +43,14 @@ RAW_PARAMETER_KEY: str = (
     f"{PARAMETER_KEY}{RAW_SUFFIX}{FULLY_QUALIFIED_PARAMETER_NAME_SEPARATOR_CHARACTER}"
 )
 
-FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY: str = "value"
 FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY: str = "attributed_value"
 FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY: str = "details"
+FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY: str = "value"
 
 RESERVED_TERMINAL_LITERALS: Set[str] = {
-    FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY,
     FULLY_QUALIFIED_PARAMETER_NAME_ATTRIBUTED_VALUE_KEY,
     FULLY_QUALIFIED_PARAMETER_NAME_METADATA_KEY,
+    FULLY_QUALIFIED_PARAMETER_NAME_VALUE_KEY,
 }
 
 attribute_naming_pattern = Word(alphas, alphanums + "_.") + ZeroOrMore(
@@ -677,9 +677,12 @@ def _get_parameter_name_parts_up_to_including_reserved_literal(
     if not (set(attribute_name_as_list) & RESERVED_TERMINAL_LITERALS):
         return attribute_name_as_list
 
+    # TODO: <Alex>12/29/2022: Lexicographical order avoids collisions between regular keys and reserved literals.</Alex>
+    reserved_terminal_literals: List[str] = list(sorted(RESERVED_TERMINAL_LITERALS))
+
     idx: Optional[int] = None
     key: str
-    for key in RESERVED_TERMINAL_LITERALS:
+    for key in reserved_terminal_literals:
         try:
             idx = attribute_name_as_list.index(key)
             break


### PR DESCRIPTION
### Scope
* A set of reserved keywords are used for Rule-Based Profiler fully-qualified parameter names syntax: "value", “attributed_value”, and “details”.  However, the `metric_value_kwargs` dictionary for at least one metric uses the key "value" as one of its parameters.  Lexicographical ordering of reserved literals in ParameterContainer module skirts the problem for the time being.  Eventually, a more robust fix will need to be devised.
* Also improve docstrings in `ExpectationSuite`.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1358/GREAT-1483
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!