### PR TITLE
[MAINTENANCE] Pull functionality up from sql_datasource.py to interfaces.py

### DIFF
--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -156,7 +156,7 @@ class DataAsset(ExperimentalBaseModel):
         self._sort_batches(batch_list)
         return batch_list
 
-    def _batch_from_fully_specified_batch_request(self, request: BatchRequest):
+    def _batch_from_fully_specified_batch_request(self, request: BatchRequest) -> Batch:
         """Returns a Batch object from a fully specified batch request
 
         Args:

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import dataclasses
+import itertools
 import logging
+from datetime import datetime
 from pprint import pformat as pf
 from typing import (
     TYPE_CHECKING,
@@ -10,13 +12,19 @@ from typing import (
     Generic,
     List,
     Mapping,
+    NamedTuple,
     Optional,
+    Sequence,
     Set,
     Type,
     TypeVar,
+    Union,
+    cast,
 )
 
 import pydantic
+from pydantic import Field
+from pydantic import dataclasses as pydantic_dc
 from typing_extensions import ClassVar, TypeAlias
 
 from great_expectations.experimental.datasources.experimental_base_model import (
@@ -36,6 +44,8 @@ if TYPE_CHECKING:
     )
     from great_expectations.execution_engine import ExecutionEngine
 
+
+# Data Asset Interface
 # BatchRequestOptions is a dict that is composed into a BatchRequest that specifies the
 # Batches one wants returned. The keys represent dimensions one can slice the data along
 # and the values are the realized. If a value is None or unspecified, the batch_request
@@ -43,6 +53,10 @@ if TYPE_CHECKING:
 # splitter and we want to query all months in the year 2020, the batch request options
 # would look like:
 #   options = { "year": 2020 }
+class BatchRequestError(Exception):
+    pass
+
+
 BatchRequestOptions: TypeAlias = Dict[str, Any]
 
 
@@ -53,13 +67,19 @@ class BatchRequest:
     options: BatchRequestOptions
 
 
+DataAssetSelf = TypeVar("DataAssetSelf", bound="DataAsset")
+
+
 class DataAsset(ExperimentalBaseModel):
     name: str
     type: str
+    column_splitter: Optional[ColumnSplitter] = None
+    order_by: List[BatchSorter] = Field(default_factory=list)
 
     # non-field private attrs
     _datasource: Datasource = pydantic.PrivateAttr()
 
+    # Properties
     @property
     def datasource(self) -> Datasource:
         return self._datasource
@@ -70,13 +90,203 @@ class DataAsset(ExperimentalBaseModel):
         assert isinstance(ds, Datasource)
         self._datasource = ds
 
-    def get_batch_request(self, options: Optional[BatchRequestOptions]) -> BatchRequest:
+    def batch_request_options_template(
+        self,
+    ) -> BatchRequestOptions:
+        """A BatchRequestOptions template for get_batch_request.
+
+        Returns:
+            A BatchRequestOptions dictionary with the correct shape that get_batch_request
+            will understand. All the option values are defaulted to None.
+        """
+        template: BatchRequestOptions = {}
+        if not self.column_splitter:
+            return template
+        return {p: None for p in self.column_splitter.param_names}
+
+    def get_batch_request(
+        self, options: Optional[BatchRequestOptions] = None
+    ) -> BatchRequest:
+        """A batch request that can be used to obtain batches for this DataAsset.
+
+        Args:
+            options: A dict that can be used to limit the number of batches returned from the asset.
+                The dict structure depends on the asset type. A template of the dict can be obtained by
+                calling batch_request_options_template.
+
+        Returns:
+            A BatchRequest object that can be used to obtain a batch list from a Datasource by calling the
+            get_batch_list_from_batch_request method.
+        """
+        if options is not None and not self._valid_batch_request_options(options):
+            raise BatchRequestError(
+                "Batch request options should have a subset of keys:\n"
+                f"{list(self.batch_request_options_template().keys())}\n"
+                f"but actually has the form:\n{pf(options)}\n"
+            )
+        return BatchRequest(
+            datasource_name=self.datasource.name,
+            data_asset_name=self.name,
+            options=options or {},
+        )
+
+    def _valid_batch_request_options(self, options: BatchRequestOptions) -> bool:
+        return set(options.keys()).issubset(
+            set(self.batch_request_options_template().keys())
+        )
+
+    def get_batch_list_from_batch_request(
+        self, batch_request: BatchRequest
+    ) -> List[Batch]:
+        """A list of batches that match the BatchRequest.
+
+        Args:
+            batch_request: A batch request for this asset. Usually obtained by calling
+                get_batch_request on the asset.
+
+        Returns:
+            A list of batches that match the options specified in the batch request.
+        """
+        # We translate the batch_request into a BatchSpec to hook into GX core.
+        self._validate_batch_request(batch_request)
+
+        batch_list: List[Batch] = []
+        for request in self._fully_specified_batch_requests(batch_request):
+            batch_list.append(self._batch_from_fully_specified_batch_request(request))
+        self._sort_batches(batch_list)
+        return batch_list
+
+    def _batch_from_fully_specified_batch_request(self, request: BatchRequest):
+        """Returns a Batch object from a fully specified batch request
+
+        Args:
+            request: A fully specified batch request. A fully specified batch request is
+              one where all the arguments are explicitly set so corresponds to exactly 1 batch.
+
+        Returns:
+            A single Batch object specified by the batch request
+        """
         raise NotImplementedError
+
+    def _validate_batch_request(self, batch_request: BatchRequest) -> None:
+        """Validates the batch_request has the correct form.
+
+        Args:
+            batch_request: A batch request object to be validated.
+        """
+        if not (
+            batch_request.datasource_name == self.datasource.name
+            and batch_request.data_asset_name == self.name
+            and self._valid_batch_request_options(batch_request.options)
+        ):
+            expect_batch_request_form = BatchRequest(
+                datasource_name=self.datasource.name,
+                data_asset_name=self.name,
+                options=self.batch_request_options_template(),
+            )
+            raise BatchRequestError(
+                "BatchRequest should have form:\n"
+                f"{pf(dataclasses.asdict(expect_batch_request_form))}\n"
+                f"but actually has form:\n{pf(dataclasses.asdict(batch_request))}\n"
+            )
+
+    def _fully_specified_batch_requests(self, batch_request) -> List[BatchRequest]:
+        """Populates a batch requests unspecified params producing a list of batch requests."""
+        if self.column_splitter is None:
+            # Currently batch_request.options is complete determined by the presence of a
+            # column splitter. If column_splitter is None, then there are no specifiable options
+            # so we return early.
+            # In the future, if there are options that are not determined by the column splitter
+            # this check will have to be generalized.
+            return [batch_request]
+
+        # Make a list of the specified and unspecified params in batch_request
+        specified_options = []
+        unspecified_options = []
+        options_template = self.batch_request_options_template()
+        for option_name in options_template.keys():
+            if (
+                option_name in batch_request.options
+                and batch_request.options[option_name] is not None
+            ):
+                specified_options.append(option_name)
+            else:
+                unspecified_options.append(option_name)
+
+        # Make a list of the all possible batch_request.options by expanding out the unspecified
+        # options
+        batch_requests: List[BatchRequest] = []
+
+        if not unspecified_options:
+            batch_requests.append(batch_request)
+        else:
+            # All options are defined by the splitter, so we look at its default values to fill
+            # in the option values.
+            default_option_values = []
+            for option in unspecified_options:
+                default_option_values.append(
+                    self.column_splitter.param_defaults(self)[option]
+                )
+            for option_values in itertools.product(*default_option_values):
+                # Add options from specified options
+                options = {
+                    name: batch_request.options[name] for name in specified_options
+                }
+                # Add options from unspecified options
+                for i, option_value in enumerate(option_values):
+                    options[unspecified_options[i]] = option_value
+                batch_requests.append(
+                    BatchRequest(
+                        datasource_name=batch_request.datasource_name,
+                        data_asset_name=batch_request.data_asset_name,
+                        options=options,
+                    )
+                )
+        return batch_requests
+
+    def _sort_batches(self, batch_list: List[Batch]) -> None:
+        """Sorts batch_list in place.
+
+        Args:
+            batch_list: The list of batches to sort in place.
+        """
+        for sorter in reversed(self.order_by):
+            try:
+                batch_list.sort(
+                    key=lambda b: b.metadata[sorter.metadata_key],
+                    reverse=sorter.reverse,
+                )
+            except KeyError as e:
+                raise KeyError(
+                    f"Trying to sort {self.name} table asset batches on key {sorter.metadata_key} "
+                    "which isn't available on all batches."
+                ) from e
+
+    def add_sorters(
+        self: DataAssetSelf, sorters: BatchSortersDefinition
+    ) -> DataAssetSelf:
+        # NOTE: (kilo59) we could use pydantic `validate_assignment` for this
+        # https://docs.pydantic.dev/usage/model_config/#options
+        self.order_by = _batch_sorter_from_list(sorters)
+        return self
+
+    # Private helper methods
+    @pydantic.validator("order_by", pre=True, each_item=True)
+    @classmethod
+    def _parse_order_by_sorter(
+        cls, v: Union[str, BatchSorter]
+    ) -> Union[BatchSorter, dict]:
+        if isinstance(v, str):
+            if not v:
+                raise ValueError("empty string")
+            return _batch_sorter_from_str(v)
+        return v
 
 
 DataAssetType = TypeVar("DataAssetType", bound=DataAsset)
 
 
+# Datasource Interface
 class Datasource(
     ExperimentalBaseModel, Generic[DataAssetType], metaclass=MetaDatasource
 ):
@@ -146,17 +356,18 @@ class Datasource(
     def get_batch_list_from_batch_request(
         self, batch_request: BatchRequest
     ) -> List[Batch]:
-        """Processes a batch request and returns a list of batches.
+        """A list of batches that match the BatchRequest.
 
         Args:
-            batch_request: contains parameters necessary to retrieve batches.
+            batch_request: A batch request for this asset. Usually obtained by calling
+                get_batch_request on the asset.
 
         Returns:
-            A list of batches. The list may be empty.
+            A list of batches that match the options specified in the batch request.
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} must implement `.get_batch_list_from_batch_request()`"
-        )
+        # We translate the batch_request into a BatchSpec to hook into GX core.
+        data_asset = self.get_asset(batch_request.data_asset_name)
+        return data_asset.get_batch_list_from_batch_request(batch_request)
 
     def get_asset(self, asset_name: str) -> DataAssetType:
         """Returns the DataAsset referred to by name"""
@@ -260,3 +471,74 @@ class Batch:
     @property
     def batch_definition(self) -> BatchDefinition:
         return self._legacy_batch_definition
+
+
+# Splitter Interface
+@pydantic_dc.dataclass(frozen=True)
+class ColumnSplitter(Generic[DataAssetType]):
+    column_name: str
+    method_name: str
+    param_names: Sequence[str]
+
+    def param_defaults(self, table_asset: DataAssetType) -> Dict[str, List]:
+        raise NotImplementedError
+
+    @pydantic.validator("method_name")
+    def _splitter_method_exists(cls, v: str):
+        """Fail early if the `method_name` does not exist and would fail at runtime."""
+        # NOTE (kilo59): this could be achieved by simply annotating the method_name field
+        # as a `SplitterMethod` enum but we get cyclic imports.
+        # This also adds the enums to the generated json schema.
+        # https://docs.pydantic.dev/usage/types/#enums-and-choices
+        # We could use `update_forward_refs()` but would have to change this to a BaseModel
+        # https://docs.pydantic.dev/usage/postponed_annotations/
+        from great_expectations.execution_engine.split_and_sample.data_splitter import (
+            SplitterMethod,
+        )
+
+        method_members = set(SplitterMethod)
+        if v not in method_members:
+            permitted_values_str = "', '".join([m.value for m in method_members])
+            raise ValueError(f"unexpected value; permitted: '{permitted_values_str}'")
+        return v
+
+
+# Type supporting datetime splitters
+class DatetimeRange(NamedTuple):
+    min: datetime
+    max: datetime
+
+
+# Sorter Interface
+@pydantic_dc.dataclass(frozen=True)
+class BatchSorter:
+    metadata_key: str
+    reverse: bool = False
+
+
+BatchSortersDefinition: TypeAlias = Union[List[BatchSorter], List[str]]
+
+
+def _batch_sorter_from_list(sorters: BatchSortersDefinition) -> List[BatchSorter]:
+    if len(sorters) == 0 or isinstance(sorters[0], BatchSorter):
+        # mypy gets confused here. Since BatchSortersDefinition has all elements of the
+        # same type in the list so if the first on is BatchSorter so are the others.
+        return cast(List[BatchSorter], sorters)
+    # Likewise, sorters must be List[str] here.
+    return [_batch_sorter_from_str(sorter) for sorter in cast(List[str], sorters)]
+
+
+def _batch_sorter_from_str(sort_key: str) -> BatchSorter:
+    """Convert a list of strings to BatchSorters
+
+    Args:
+        sort_key: A batch metadata key which will be used to sort batches on a data asset.
+                  This can be prefixed with a + or - to indicate increasing or decreasing
+                  sorting. If not specified, defaults to increasing order.
+    """
+    if sort_key[0] == "-":
+        return BatchSorter(metadata_key=sort_key[1:], reverse=True)
+    elif sort_key[0] == "+":
+        return BatchSorter(metadata_key=sort_key[1:], reverse=False)
+    else:
+        return BatchSorter(metadata_key=sort_key, reverse=False)

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -21,15 +21,18 @@ from typing import (
 import pydantic
 from pydantic import Field
 from pydantic import dataclasses as pydantic_dc
-from typing_extensions import ClassVar, Literal, TypeAlias
+from typing_extensions import ClassVar, Literal
 
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.experimental.datasources.interfaces import (
     Batch,
     BatchRequest,
-    BatchRequestOptions,
+    BatchSorter,
+    BatchSortersDefinition,
+    ColumnSplitter,
     DataAsset,
     Datasource,
+    DatetimeRange,
 )
 
 if TYPE_CHECKING:
@@ -40,44 +43,6 @@ if TYPE_CHECKING:
 
 class SQLDatasourceError(Exception):
     pass
-
-
-class BatchRequestError(Exception):
-    pass
-
-
-@pydantic_dc.dataclass(frozen=True)
-class ColumnSplitter:
-    column_name: str
-    method_name: str
-    param_names: Sequence[str]
-
-    def param_defaults(self, table_asset: TableAsset) -> Dict[str, List]:
-        raise NotImplementedError
-
-    @pydantic.validator("method_name")
-    def _splitter_method_exists(cls, v: str):
-        """Fail early if the `method_name` does not exist and would fail at runtime."""
-        # NOTE (kilo59): this could be achieved by simply annotating the method_name field
-        # as a `SplitterMethod` enum but we get cyclic imports.
-        # This also adds the enums to the generated json schema.
-        # https://docs.pydantic.dev/usage/types/#enums-and-choices
-        # We could use `update_forward_refs()` but would have to change this to a BaseModel
-        # https://docs.pydantic.dev/usage/postponed_annotations/
-        from great_expectations.execution_engine.split_and_sample.data_splitter import (
-            SplitterMethod,
-        )
-
-        method_members = set(SplitterMethod)
-        if v not in method_members:
-            permitted_values_str = "', '".join([m.value for m in method_members])
-            raise ValueError(f"unexpected value; permitted: '{permitted_values_str}'")
-        return v
-
-
-class DatetimeRange(NamedTuple):
-    min: datetime
-    max: datetime
 
 
 @pydantic_dc.dataclass(frozen=True)
@@ -136,133 +101,13 @@ def _get_sql_datetime_range(
     return DatetimeRange(min=min_max_dt[0], max=min_max_dt[1])
 
 
-@pydantic_dc.dataclass(frozen=True)
-class BatchSorter:
-    metadata_key: str
-    reverse: bool = False
-
-
-BatchSortersDefinition: TypeAlias = Union[List[BatchSorter], List[str]]
-
-
-def _batch_sorter_from_list(sorters: BatchSortersDefinition) -> List[BatchSorter]:
-    if len(sorters) == 0 or isinstance(sorters[0], BatchSorter):
-        # mypy gets confused here. Since BatchSortersDefinition has all elements of the
-        # same type in the list so if the first on is BatchSorter so are the others.
-        return cast(List[BatchSorter], sorters)
-    # Likewise, sorters must be List[str] here.
-    return [_batch_sorter_from_str(sorter) for sorter in cast(List[str], sorters)]
-
-
-def _batch_sorter_from_str(sort_key: str) -> BatchSorter:
-    """Convert a list of strings to BatchSorters
-
-    Args:
-        sort_key: A batch metadata key which will be used to sort batches on a data asset.
-                  This can be prefixed with a + or - to indicate increasing or decreasing
-                  sorting. If not specified, defaults to increasing order.
-    """
-    if sort_key[0] == "-":
-        return BatchSorter(metadata_key=sort_key[1:], reverse=True)
-    elif sort_key[0] == "+":
-        return BatchSorter(metadata_key=sort_key[1:], reverse=False)
-    else:
-        return BatchSorter(metadata_key=sort_key, reverse=False)
-
-
 class TableAsset(DataAsset):
-    # Instance fields
+    # Overridden inherited instance fields
     type: Literal["table"] = "table"
-    table_name: str
     column_splitter: Optional[SqlYearMonthSplitter] = None
-    name: str
-    order_by: List[BatchSorter] = Field(default_factory=list)
+    # Instance fields
+    table_name: str
 
-    @pydantic.validator("order_by", pre=True, each_item=True)
-    @classmethod
-    def _parse_order_by_sorter(
-        cls, v: Union[str, BatchSorter]
-    ) -> Union[BatchSorter, dict]:
-        if isinstance(v, str):
-            if not v:
-                raise ValueError("empty string")
-            return _batch_sorter_from_str(v)
-        return v
-
-    def get_batch_request(
-        self, options: Optional[BatchRequestOptions] = None
-    ) -> BatchRequest:
-        """A batch request that can be used to obtain batches for this DataAsset.
-
-        Args:
-            options: A dict that can be used to limit the number of batches returned from the asset.
-                The dict structure depends on the asset type. A template of the dict can be obtained by
-                calling batch_request_options_template.
-
-        Returns:
-            A BatchRequest object that can be used to obtain a batch list from a Datasource by calling the
-            get_batch_list_from_batch_request method.
-        """
-        if options is not None and not self._valid_batch_request_options(options):
-            raise BatchRequestError(
-                "Batch request options should have a subset of keys:\n"
-                f"{list(self.batch_request_options_template().keys())}\n"
-                f"but actually has the form:\n{pf(options)}\n"
-            )
-        return BatchRequest(
-            datasource_name=self._datasource.name,
-            data_asset_name=self.name,
-            options=options or {},
-        )
-
-    def _valid_batch_request_options(self, options: BatchRequestOptions) -> bool:
-        return set(options.keys()).issubset(
-            set(self.batch_request_options_template().keys())
-        )
-
-    def _validate_batch_request(self, batch_request: BatchRequest) -> None:
-        """Validates the batch_request has the correct form.
-
-        Args:
-            batch_request: A batch request object to be validated.
-        """
-        if not (
-            batch_request.datasource_name == self.datasource.name
-            and batch_request.data_asset_name == self.name
-            and self._valid_batch_request_options(batch_request.options)
-        ):
-            expect_batch_request_form = BatchRequest(
-                datasource_name=self.datasource.name,
-                data_asset_name=self.name,
-                options=self.batch_request_options_template(),
-            )
-            raise BatchRequestError(
-                "BatchRequest should have form:\n"
-                f"{pf(dataclasses.asdict(expect_batch_request_form))}\n"
-                f"but actually has form:\n{pf(dataclasses.asdict(batch_request))}\n"
-            )
-
-    def batch_request_options_template(
-        self,
-    ) -> BatchRequestOptions:
-        """A BatchRequestOptions template for get_batch_request.
-
-        Returns:
-            A BatchRequestOptions dictionary with the correct shape that get_batch_request
-            will understand. All the option values are defaulted to None.
-        """
-        template: BatchRequestOptions = {}
-        if not self.column_splitter:
-            return template
-        return {p: None for p in self.column_splitter.param_names}
-
-    def add_sorters(self, sorters: BatchSortersDefinition) -> TableAsset:
-        # NOTE: (kilo59) we could use pydantic `validate_assignment` for this
-        # https://docs.pydantic.dev/usage/model_config/#options
-        self.order_by = _batch_sorter_from_list(sorters)
-        return self
-
-    # This asset type will support a variety of splitters
     def add_year_and_month_splitter(
         self,
         column_name: str,
@@ -280,146 +125,63 @@ class TableAsset(DataAsset):
         )
         return self
 
-    def _fully_specified_batch_requests(self, batch_request) -> List[BatchRequest]:
-        """Populates a batch requests unspecified params producing a list of batch requests."""
-        if self.column_splitter is None:
-            # Currently batch_request.options is complete determined by the presence of a
-            # column splitter. If column_splitter is None, then there are no specifiable options
-            # so we return early.
-            # In the future, if there are options that are not determined by the column splitter
-            # this check will have to be generalized.
-            return [batch_request]
-
-        # Make a list of the specified and unspecified params in batch_request
-        specified_options = []
-        unspecified_options = []
-        options_template = self.batch_request_options_template()
-        for option_name in options_template.keys():
-            if (
-                option_name in batch_request.options
-                and batch_request.options[option_name] is not None
-            ):
-                specified_options.append(option_name)
-            else:
-                unspecified_options.append(option_name)
-
-        # Make a list of the all possible batch_request.options by expanding out the unspecified
-        # options
-        batch_requests: List[BatchRequest] = []
-
-        if not unspecified_options:
-            batch_requests.append(batch_request)
-        else:
-            # All options are defined by the splitter, so we look at its default values to fill
-            # in the option values.
-            default_option_values = []
-            for option in unspecified_options:
-                default_option_values.append(
-                    self.column_splitter.param_defaults(self)[option]
-                )
-            for option_values in itertools.product(*default_option_values):
-                # Add options from specified options
-                options = {
-                    name: batch_request.options[name] for name in specified_options
-                }
-                # Add options from unspecified options
-                for i, option_value in enumerate(option_values):
-                    options[unspecified_options[i]] = option_value
-                batch_requests.append(
-                    BatchRequest(
-                        datasource_name=batch_request.datasource_name,
-                        data_asset_name=batch_request.data_asset_name,
-                        options=options,
-                    )
-                )
-        return batch_requests
-
-    def _sort_batches(self, batch_list: List[Batch]) -> None:
-        """Sorts batch_list in place.
+    def _batch_from_fully_specified_batch_request(self, request: BatchRequest):
+        """Returns a Batch object from a fully specified batch request
 
         Args:
-            batch_list: The list of batches to sort in place.
-        """
-        for sorter in reversed(self.order_by):
-            try:
-                batch_list.sort(
-                    key=lambda b: b.metadata[sorter.metadata_key],
-                    reverse=sorter.reverse,
-                )
-            except KeyError as e:
-                raise KeyError(
-                    f"Trying to sort {self.name} table asset batches on key {sorter.metadata_key} "
-                    "which isn't available on all batches."
-                ) from e
-
-    def get_batch_list_from_batch_request(
-        self, batch_request: BatchRequest
-    ) -> List[Batch]:
-        """A list of batches that match the BatchRequest.
-
-        Args:
-            batch_request: A batch request for this asset. Usually obtained by calling
-                get_batch_request on the asset.
+            request: A fully specified batch request. A fully specified batch request is
+              one where all the arguments are explicitly set so corresponds to exactly 1 batch.
 
         Returns:
-            A list of batches that match the options specified in the batch request.
+            A single Batch object specified by the batch request
         """
-        # We translate the batch_request into a BatchSpec to hook into GX core.
-        self._validate_batch_request(batch_request)
-
-        batch_list: List[Batch] = []
+        batch_metadata = copy.deepcopy(request.options)
         column_splitter = self.column_splitter
-        for request in self._fully_specified_batch_requests(batch_request):
-            batch_metadata = copy.deepcopy(request.options)
-            batch_spec_kwargs = {
-                "type": "table",
-                "data_asset_name": self.name,
-                "table_name": self.table_name,
-                "batch_identifiers": {},
+        batch_spec_kwargs = {
+            "type": "table",
+            "data_asset_name": self.name,
+            "table_name": self.table_name,
+            "batch_identifiers": {},
+        }
+        if column_splitter:
+            batch_spec_kwargs["splitter_method"] = column_splitter.method_name
+            batch_spec_kwargs["splitter_kwargs"] = {
+                "column_name": column_splitter.column_name
             }
-            if column_splitter:
-                batch_spec_kwargs["splitter_method"] = column_splitter.method_name
-                batch_spec_kwargs["splitter_kwargs"] = {
-                    "column_name": column_splitter.column_name
-                }
-                # mypy infers that batch_spec_kwargs["batch_identifiers"] is a collection, but
-                # it is hardcoded to a dict above, so we cast it here.
-                cast(Dict, batch_spec_kwargs["batch_identifiers"]).update(
-                    {column_splitter.column_name: request.options}
-                )
-            batch_spec = SqlAlchemyDatasourceBatchSpec(**batch_spec_kwargs)
-            data, markers = self.datasource.execution_engine.get_batch_data_and_markers(
-                batch_spec=batch_spec
+            # mypy infers that batch_spec_kwargs["batch_identifiers"] is a collection, but
+            # it is hardcoded to a dict above, so we cast it here.
+            cast(Dict, batch_spec_kwargs["batch_identifiers"]).update(
+                {column_splitter.column_name: request.options}
             )
+        batch_spec = SqlAlchemyDatasourceBatchSpec(**batch_spec_kwargs)
+        data, markers = self.datasource.execution_engine.get_batch_data_and_markers(
+            batch_spec=batch_spec
+        )
 
-            # batch_definition (along with batch_spec and markers) is only here to satisfy a
-            # legacy constraint when computing usage statistics in a validator. We hope to remove
-            # it in the future.
-            # imports are done inline to prevent a circular dependency with core/batch.py
-            from great_expectations.core import IDDict
-            from great_expectations.core.batch import BatchDefinition
+        # batch_definition (along with batch_spec and markers) is only here to satisfy a
+        # legacy constraint when computing usage statistics in a validator. We hope to remove
+        # it in the future.
+        # imports are done inline to prevent a circular dependency with core/batch.py
+        from great_expectations.core import IDDict
+        from great_expectations.core.batch import BatchDefinition
 
-            batch_definition = BatchDefinition(
-                datasource_name=self.datasource.name,
-                data_connector_name="experimental",
-                data_asset_name=self.name,
-                batch_identifiers=IDDict(batch_spec["batch_identifiers"]),
-                batch_spec_passthrough=None,
-            )
-            batch_list.append(
-                Batch(
-                    datasource=self.datasource,
-                    data_asset=self,
-                    batch_request=request,
-                    data=data,
-                    metadata=batch_metadata,
-                    legacy_batch_markers=markers,
-                    legacy_batch_spec=batch_spec,
-                    legacy_batch_definition=batch_definition,
-                )
-            )
-        self._sort_batches(batch_list)
-        return batch_list
+        batch_definition = BatchDefinition(
+            datasource_name=self.datasource.name,
+            data_connector_name="experimental",
+            data_asset_name=self.name,
+            batch_identifiers=IDDict(batch_spec["batch_identifiers"]),
+            batch_spec_passthrough=None,
+        )
+        return Batch(
+            datasource=self.datasource,
+            data_asset=self,
+            batch_request=request,
+            data=data,
+            metadata=batch_metadata,
+            legacy_batch_markers=markers,
+            legacy_batch_spec=batch_spec,
+            legacy_batch_definition=batch_definition,
+        )
 
 
 class SQLDatasource(Datasource):
@@ -468,17 +230,13 @@ class SQLDatasource(Datasource):
             name=name,
             table_name=table_name,
             order_by=order_by or [],  # type: ignore[arg-type]  # coerce list[str]
-            # see TableAsset._parse_order_by_sorter()
+            # see DataAsset._parse_order_by_sorter()
         )
         # TODO (kilo59): custom init for `DataAsset` to accept datasource in constructor?
         # Will most DataAssets require a `Datasource` attribute?
         asset._datasource = self
         self.assets[name] = asset
         return asset
-
-    def get_asset(self, asset_name: str) -> TableAsset:
-        """Returns the TableAsset referred to by name"""
-        return super().get_asset(asset_name)
 
     def get_batch_list_from_batch_request(
         self, batch_request: BatchRequest

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -90,7 +90,6 @@ class TableAsset(DataAsset):
     # Overridden inherited instance fields
     type: Literal["table"] = "table"
     column_splitter: Optional[SqlYearMonthSplitter] = None
-    order_by: List[BatchSorter] = Field(default_factory=list)
     # Instance fields
     table_name: str
 

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -4,12 +4,14 @@ import copy
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Type, cast
 
 import pydantic
-from pydantic import Field
 from pydantic import dataclasses as pydantic_dc
 from typing_extensions import ClassVar, Literal
 
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
-from great_expectations.experimental.datasources.interfaces import (
+
+# The noqa: F401 is to import BatchSorter. This is necessary for pydantic because
+# TableAsset inherits but doesn't override the `order_by` field.
+from great_expectations.experimental.datasources.interfaces import (  # noqa: F401
     Batch,
     BatchRequest,
     BatchSorter,

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -1,25 +1,9 @@
 from __future__ import annotations
 
 import copy
-import dataclasses
-import itertools
-from datetime import datetime
-from pprint import pformat as pf
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Type,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Type, cast
 
 import pydantic
-from pydantic import Field
 from pydantic import dataclasses as pydantic_dc
 from typing_extensions import ClassVar, Literal
 
@@ -27,7 +11,6 @@ from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.experimental.datasources.interfaces import (
     Batch,
     BatchRequest,
-    BatchSorter,
     BatchSortersDefinition,
     ColumnSplitter,
     DataAsset,

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -4,6 +4,7 @@ import copy
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Type, cast
 
 import pydantic
+from pydantic import Field
 from pydantic import dataclasses as pydantic_dc
 from typing_extensions import ClassVar, Literal
 
@@ -11,6 +12,7 @@ from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.experimental.datasources.interfaces import (
     Batch,
     BatchRequest,
+    BatchSorter,
     BatchSortersDefinition,
     ColumnSplitter,
     DataAsset,
@@ -88,6 +90,7 @@ class TableAsset(DataAsset):
     # Overridden inherited instance fields
     type: Literal["table"] = "table"
     column_splitter: Optional[SqlYearMonthSplitter] = None
+    order_by: List[BatchSorter] = Field(default_factory=list)
     # Instance fields
     table_name: str
 
@@ -108,7 +111,7 @@ class TableAsset(DataAsset):
         )
         return self
 
-    def _batch_from_fully_specified_batch_request(self, request: BatchRequest):
+    def _batch_from_fully_specified_batch_request(self, request: BatchRequest) -> Batch:
         """Returns a Batch object from a fully specified batch request
 
         Args:

--- a/tests/experimental/datasources/test_postgres_datasource.py
+++ b/tests/experimental/datasources/test_postgres_datasource.py
@@ -9,13 +9,13 @@ from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
 from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 from great_expectations.experimental.datasources.interfaces import (
     BatchRequest,
+    BatchRequestError,
     BatchRequestOptions,
 )
 from great_expectations.experimental.datasources.postgres_datasource import (
     PostgresDatasource,
 )
 from great_expectations.experimental.datasources.sql_datasource import (
-    BatchRequestError,
     BatchSorter,
     SqlYearMonthSplitter,
     TableAsset,

--- a/tests/experimental/datasources/test_postgres_datasource.py
+++ b/tests/experimental/datasources/test_postgres_datasource.py
@@ -11,12 +11,12 @@ from great_expectations.experimental.datasources.interfaces import (
     BatchRequest,
     BatchRequestError,
     BatchRequestOptions,
+    BatchSorter,
 )
 from great_expectations.experimental.datasources.postgres_datasource import (
     PostgresDatasource,
 )
 from great_expectations.experimental.datasources.sql_datasource import (
-    BatchSorter,
     SqlYearMonthSplitter,
     TableAsset,
 )


### PR DESCRIPTION
This PR is refactor of sql_datasource.py. We pull up splitters and sorters into interfaces.py since they are more general than sql datasources. Also, a lot of the functionality in `TableAsset` should be applicable to `DataAsset`s in general so I pulled that up. I will highlight any changes that weren't moving things around.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
