### PR TITLE
[MAINTENANCE] Update `get_context` return type

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -294,6 +294,12 @@ class AbstractDataContext(ConfigPeer, ABC):
         )
 
     @abstractmethod
+    def _init_project_config(
+        self, project_config: Union[DataContextConfig, Mapping]
+    ) -> DataContextConfig:
+        raise NotImplementedError
+
+    @abstractmethod
     def _init_variables(self) -> DataContextVariables:
         raise NotImplementedError
 

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -100,27 +100,29 @@ class CloudDataContext(SerializableDataContext):
             cloud_access_token=cloud_access_token,
             cloud_organization_id=cloud_organization_id,
         )
-
         self._context_root_directory = self.determine_context_root_directory(
             context_root_dir
         )
+        self._project_config = self._init_project_config(project_config)
 
+        super().__init__(
+            context_root_dir=self._context_root_directory,
+            runtime_environment=runtime_environment,
+        )
+
+    def _init_project_config(
+        self, project_config: Optional[Union[DataContextConfig, Mapping]]
+    ) -> DataContextConfig:
         if project_config is None:
             project_config = self.retrieve_data_context_config_from_cloud(
                 cloud_config=self._cloud_config,
             )
 
-        project_data_context_config: DataContextConfig = (
-            self.get_or_create_data_context_config(project_config)
+        project_data_context_config = (
+            CloudDataContext.get_or_create_data_context_config(project_config)
         )
 
-        self._project_config = self._apply_global_config_overrides(
-            config=project_data_context_config
-        )
-        super().__init__(
-            context_root_dir=self._context_root_directory,
-            runtime_environment=runtime_environment,
-        )
+        return self._apply_global_config_overrides(config=project_data_context_config)
 
     @staticmethod
     def _resolve_cloud_args(

--- a/great_expectations/data_context/data_context/ephemeral_data_context.py
+++ b/great_expectations/data_context/data_context/ephemeral_data_context.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Mapping, Optional, Union
 
 from great_expectations.core.serializer import DictConfigSerializer
 from great_expectations.data_context.data_context.abstract_data_context import (
@@ -20,14 +20,11 @@ class EphemeralDataContext(AbstractDataContext):
     """
     Will contain functionality to create DataContext at runtime (ie. passed in config object or from stores). Users will
     be able to use EphemeralDataContext for having a temporary or in-memory DataContext
-
-    TODO: Most of the BaseDataContext code will be migrated to this class, which will continue to exist for backwards
-    compatibility reasons.
     """
 
     def __init__(
         self,
-        project_config: DataContextConfig,
+        project_config: Union[DataContextConfig, Mapping],
         runtime_environment: Optional[dict] = None,
     ) -> None:
         """EphemeralDataContext constructor
@@ -37,10 +34,16 @@ class EphemeralDataContext(AbstractDataContext):
                 override both those set in config_variables.yml and the environment
 
         """
-        self._project_config = self._apply_global_config_overrides(
-            config=project_config
-        )
+        self._project_config = self._init_project_config(project_config)
         super().__init__(runtime_environment=runtime_environment)
+
+    def _init_project_config(
+        self, project_config: Union[DataContextConfig, Mapping]
+    ) -> DataContextConfig:
+        project_config = EphemeralDataContext.get_or_create_data_context_config(
+            project_config
+        )
+        return self._apply_global_config_overrides(project_config)
 
     def _init_variables(self) -> EphemeralDataContextVariables:
         variables = EphemeralDataContextVariables(

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -68,7 +68,7 @@ class FileDataContext(SerializableDataContext):
             context_root_dir = str(context_root_dir)
 
         if not context_root_dir:
-            context_root_dir = FileDataContext.find_context_yml_file()
+            context_root_dir = FileDataContext.find_context_root_dir()
             if not context_root_dir:
                 raise ValueError(
                     "A FileDataContext relies on the presence of a local great_expectations.yml project config"

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Mapping, Optional, Union
 
 from ruamel.yaml import YAML, YAMLError
 from ruamel.yaml.constructor import DuplicateKeyError
@@ -37,15 +37,12 @@ yaml.default_flow_style = False
 class FileDataContext(SerializableDataContext):
     """
     Extends AbstractDataContext, contains only functionality necessary to hydrate state from disk.
-
-    TODO: Most of the functionality in DataContext will be refactored into this class, and the current DataContext
-    class will exist only for backwards-compatibility reasons.
     """
 
     def __init__(
         self,
-        context_root_dir: PathStr,
         project_config: Optional[DataContextConfig] = None,
+        context_root_dir: Optional[PathStr] = None,
         runtime_environment: Optional[dict] = None,
     ) -> None:
         """FileDataContext constructor
@@ -57,20 +54,40 @@ class FileDataContext(SerializableDataContext):
             runtime_environment (Optional[dict]): a dictionary of config variables that override both those set in
                 config_variables.yml and the environment
         """
-        if isinstance(context_root_dir, pathlib.Path):
-            context_root_dir = str(context_root_dir)
-        self._context_root_directory = context_root_dir
-        if not project_config:
-            project_config = FileDataContext._load_file_backed_project_config(
-                context_root_directory=context_root_dir,
-            )
-        self._project_config = self._apply_global_config_overrides(
-            config=project_config
+        self._context_root_directory = self._init_context_root_directory(
+            context_root_dir
         )
+        self._project_config = self._init_project_config(project_config)
         super().__init__(
             context_root_dir=self._context_root_directory,
             runtime_environment=runtime_environment,
         )
+
+    def _init_context_root_directory(self, context_root_dir: Optional[PathStr]) -> str:
+        if isinstance(context_root_dir, pathlib.Path):
+            context_root_dir = str(context_root_dir)
+
+        if not context_root_dir:
+            context_root_dir = FileDataContext.find_context_yml_file()
+            if not context_root_dir:
+                raise ValueError(
+                    "A FileDataContext relies on the presence of a local great_expectations.yml project config"
+                )
+
+        return context_root_dir
+
+    def _init_project_config(
+        self, project_config: Optional[Union[DataContextConfig, Mapping]]
+    ) -> DataContextConfig:
+        if project_config:
+            project_config = FileDataContext.get_or_create_data_context_config(
+                project_config
+            )
+        else:
+            project_config = FileDataContext._load_file_backed_project_config(
+                context_root_directory=self._context_root_directory,
+            )
+        return self._apply_global_config_overrides(config=project_config)
 
     def _init_datasource_store(self) -> None:
         from great_expectations.data_context.store.datasource_store import (

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -448,7 +448,7 @@ class SerializableDataContext(AbstractDataContext):
         cls, ge_dir: PathStr
     ) -> Optional[SerializableDataContext]:
         try:
-            context = cls(ge_dir)
+            context = cls(context_root_dir=ge_dir)
             return context
         except (
             gx_exceptions.DataContextError,

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -53,7 +53,7 @@ import pandas as pd
 from dateutil.parser import parse
 from packaging import version
 from pkg_resources import Distribution
-from typing_extensions import TypeGuard
+from typing_extensions import Literal, TypeGuard
 
 from great_expectations.exceptions import (
     GXCloudConfigurationError,
@@ -1738,6 +1738,15 @@ def get_context(
     project_config: Optional[Union[DataContextConfig, Mapping]] = ...,
     context_root_dir: PathStr = ...,
     runtime_environment: Optional[dict] = ...,
+    cloud_base_url: None = ...,
+    cloud_access_token: None = ...,
+    cloud_organization_id: None = ...,
+    cloud_mode: Optional[Literal[False]] = ...,
+    # <GX_RENAME> Deprecated as of 0.15.37
+    ge_cloud_base_url: None = ...,
+    ge_cloud_access_token: None = ...,
+    ge_cloud_organization_id: None = ...,
+    ge_cloud_mode: Optional[Literal[False]] = ...,
 ) -> FileDataContext:
     ...
 

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1733,7 +1733,7 @@ def convert_ndarray_decimal_to_float_dtype(data: np.ndarray) -> np.ndarray:
 
 
 def get_context(
-    project_config: Optional[Union["DataContextConfig", Mapping]] = None,
+    project_config: Optional[Union[DataContextConfig, Mapping]] = None,
     context_root_dir: Optional[PathStr] = None,
     runtime_environment: Optional[dict] = None,
     cloud_base_url: Optional[str] = None,
@@ -1754,18 +1754,18 @@ def get_context(
         my_context = gx.get_context([parameters])
 
     1. If gx.get_context() is run in a filesystem where `great_expectations init` has been run, then it will return a
-        DataContext
+        FileDataContext.
 
     2. If gx.get_context() is passed in a `context_root_dir` (which contains great_expectations.yml) then it will return
-         a DataContext
+         a FileDataContext.
 
-    3. If gx.get_context() is passed in an in-memory `project_config` then it will return BaseDataContext.
+    3. If gx.get_context() is passed in an in-memory `project_config` then it will return EphemeralDataContext.
         `context_root_dir` can also be passed in, but the configurations from the in-memory config will override the
         configurations in the `great_expectations.yml` file.
 
 
-    4. If GX is being run in the cloud, and the information needed for ge_cloud_config (ie ge_cloud_base_url,
-        ge_cloud_access_token, ge_cloud_organization_id) are passed in as parameters to get_context(), configured as
+    4. If GX is being run in the Cloud, and the information needed for gx_cloud_config (ie gx_cloud_base_url,
+        gx_cloud_access_token, gx_cloud_organization_id) are passed in as parameters to get_context(), configured as
         environment variables, or in a .conf file, then get_context() will return a CloudDataContext.
 
 
@@ -1777,8 +1777,6 @@ def get_context(
     | (cloud_mode=False)    | Local               | Local         |
     +-----------------------+---------------------+---------------+
 
-    TODO: This method will eventually return FileDataContext and EphemeralDataContext, rather than DataContext and Base
-
     Args:
         project_config (dict or DataContextConfig): In-memory configuration for DataContext.
         context_root_dir (str or pathlib.Path): Path to directory that contains great_expectations.yml file
@@ -1787,20 +1785,20 @@ def get_context(
             from environment variables.
 
         The following parameters are relevant when running ge_cloud
-        cloud_base_url (str): url for ge_cloud endpoint.
-        cloud_access_token (str): access_token for ge_cloud account.
-        cloud_organization_id (str): org_id for ge_cloud account.
-        cloud_mode (bool): bool flag to specify whether to run GX in cloud mode (default is None).
+            * cloud_base_url (str): url for GX Cloud endpoint.
+            * cloud_access_token (str): access_token for GX Cloud account.
+            * cloud_organization_id (str): org_id for GX Cloud account.
+            * cloud_mode (bool): bool flag to specify whether to run GX in Cloud mode (default is None).
 
     Returns:
-        DataContext. Either a DataContext, BaseDataContext, or CloudDataContext depending on environment and/or
+        DataContext. Either a FileDataContext, EpehemralDataContext, or CloudDataContext depending on environment and/or
         parameters
 
     """
     from great_expectations.data_context.data_context import (
-        BaseDataContext,
         CloudDataContext,
-        DataContext,
+        EphemeralDataContext,
+        FileDataContext,
     )
 
     # Chetan - 20221208 - not formally deprecating these values until a future date

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -94,6 +94,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from great_expectations.alias_types import PathStr
+    from great_expectations.data_context import FileDataContext
     from great_expectations.data_context.data_context.abstract_data_context import (
         AbstractDataContext,
     )
@@ -1730,6 +1731,33 @@ def convert_ndarray_decimal_to_float_dtype(data: np.ndarray) -> np.ndarray:
         [np.ndarray], np.ndarray
     ] = np.vectorize(pyfunc=convert_decimal_to_float)
     return convert_decimal_to_float_vectorized(data)
+
+
+@overload
+def get_context(
+    project_config: Optional[Union[DataContextConfig, Mapping]] = ...,
+    context_root_dir: PathStr = ...,
+    runtime_environment: Optional[dict] = ...,
+) -> FileDataContext:
+    ...
+
+
+@overload
+def get_context(
+    project_config: Optional[Union[DataContextConfig, Mapping]] = ...,
+    context_root_dir: Optional[PathStr] = ...,
+    runtime_environment: Optional[dict] = ...,
+    cloud_base_url: Optional[str] = ...,
+    cloud_access_token: Optional[str] = ...,
+    cloud_organization_id: Optional[str] = ...,
+    cloud_mode: Optional[bool] = ...,
+    # <GX_RENAME> Deprecated as of 0.15.37
+    ge_cloud_base_url: Optional[str] = ...,
+    ge_cloud_access_token: Optional[str] = ...,
+    ge_cloud_organization_id: Optional[str] = ...,
+    ge_cloud_mode: Optional[bool] = ...,
+) -> AbstractDataContext:
+    ...
 
 
 def get_context(

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1845,13 +1845,12 @@ def get_context(
     # Second, check for which type of local
 
     if project_config is not None:
-        return BaseDataContext(
+        return EphemeralDataContext(
             project_config=project_config,
-            context_root_dir=context_root_dir,
             runtime_environment=runtime_environment,
         )
 
-    return DataContext(
+    return FileDataContext(
         context_root_dir=context_root_dir,
         runtime_environment=runtime_environment,
     )

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1802,11 +1802,14 @@ def get_context(
     )
     from great_expectations.data_context.types.base import DataContextConfig
 
+    # If available and applicable, convert project_config mapping into a rich config type
     if project_config:
         project_config = EphemeralDataContext.get_or_create_data_context_config(
             project_config
         )
-    assert project_config is None or isinstance(project_config, DataContextConfig)
+    assert project_config is None or isinstance(
+        project_config, DataContextConfig
+    ), "project_config must be of type Optional[DataContextConfig]"
 
     # Chetan - 20221208 - not formally deprecating these values until a future date
     (
@@ -1850,20 +1853,14 @@ def get_context(
 
     # Second, check for which type of local
     # Prioritize FileDataContext but default to EphemeralDataContext if no context_root_dir
-    if context_root_dir:
+    if context_root_dir or not project_config:
         return FileDataContext(
             project_config=project_config,
             context_root_dir=context_root_dir,
             runtime_environment=runtime_environment,
         )
-    if project_config is not None:
-        return EphemeralDataContext(
-            project_config=project_config,
-            runtime_environment=runtime_environment,
-        )
-    return FileDataContext(
+    return EphemeralDataContext(
         project_config=project_config,
-        context_root_dir=context_root_dir,
         runtime_environment=runtime_environment,
     )
 

--- a/great_expectations/util.py
+++ b/great_expectations/util.py
@@ -1800,6 +1800,13 @@ def get_context(
         EphemeralDataContext,
         FileDataContext,
     )
+    from great_expectations.data_context.types.base import DataContextConfig
+
+    if project_config:
+        project_config = EphemeralDataContext.get_or_create_data_context_config(
+            project_config
+        )
+    assert project_config is None or isinstance(project_config, DataContextConfig)
 
     # Chetan - 20221208 - not formally deprecating these values until a future date
     (
@@ -1818,8 +1825,7 @@ def get_context(
         ge_cloud_organization_id=ge_cloud_organization_id,
     )
 
-    # First, check for ge_cloud conditions
-
+    # First, check for GX Cloud conditions
     config_available = CloudDataContext.is_cloud_config_available(
         cloud_base_url=cloud_base_url,
         cloud_access_token=cloud_access_token,
@@ -1843,14 +1849,20 @@ def get_context(
         )
 
     # Second, check for which type of local
-
+    # Prioritize FileDataContext but default to EphemeralDataContext if no context_root_dir
+    if context_root_dir:
+        return FileDataContext(
+            project_config=project_config,
+            context_root_dir=context_root_dir,
+            runtime_environment=runtime_environment,
+        )
     if project_config is not None:
         return EphemeralDataContext(
             project_config=project_config,
             runtime_environment=runtime_environment,
         )
-
     return FileDataContext(
+        project_config=project_config,
         context_root_dir=context_root_dir,
         runtime_environment=runtime_environment,
     )

--- a/tests/data_context/abstract_data_context/test_abstract_data_context_datasource_crud.py
+++ b/tests/data_context/abstract_data_context/test_abstract_data_context_datasource_crud.py
@@ -58,6 +58,10 @@ class FakeAbstractDataContext(AbstractDataContext):
         """Abstract method. Only a stub is needed."""
         pass
 
+    def _init_project_config(self, project_config):
+        """Abstract method. Only a stub is needed."""
+        pass
+
 
 @pytest.mark.unit
 def test_save_datasource_empty_store(datasource_config_with_names: DatasourceConfig):


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that `get_context` returns one of `EphemeralDataContext`, `CloudDataContext`, or `FileDataContext`
- Allow all context types to accept `Mapping` instead of rich `DataContextConfig` to allow for parity
- Misc cleanup


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.