### PR TITLE
[MAINTENANCE] Add docstring check to pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
+  - repo: local
+    hooks:
+      - id: check-docstrings
+        name: check-docstrings
+        entry: scripts/check_docstrings
+        language: script
 # https://pre-commit.ci/
 ci:
     autofix_commit_msg: |

--- a/scripts/check_docstrings
+++ b/scripts/check_docstrings
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+invoke docstrings


### PR DESCRIPTION
Changes proposed in this pull request:
- Add our docstring check for methods and classes marked public api to pre-commit hooks.
- Note: this adds some time to each commit (~30 sec) since the check takes time. We may wish to not merge this PR.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code