### PR TITLE
[BUGFIX] Increase minimum `numpy` versions for Python 3.8 and 3.9 due to support in latest release of `scipy`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -414,11 +414,11 @@ stages:
               min_pandas: '1.1.0'
             Python38:
               python.version: '3.8'
-              min_numpy: '1.18.5'
+              min_numpy: '1.19.5'
               min_pandas: '1.1.0'
             Python39:
               python.version: '3.9'
-              min_numpy: '1.19.3'
+              min_numpy: '1.19.5'
               min_pandas: '1.1.3'
         variables:
           IMAGE_SUFFIX: $[ dependencies.make_suffix.outputs['suffix.IMAGE_SUFFIX'] ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,11 @@ marshmallow>=3.7.1,<4.0.0
 mistune>=0.8.4
 nbformat>=5.0
 notebook>=6.4.10
-numpy>=1.18.5
+numpy>=1.18.5; python_version <= "3.7"
+numpy>=1.19.5; python_version > "3.7"
 packaging
-pandas>=1.1.0
+pandas>=1.1.0; python_version <= "3.8"
+pandas>=1.1.3; python_version > "3.8"
 pydantic>=1.0,<2.0
 pyparsing>=2.4
 python-dateutil>=2.8.1


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1509
- Increase minimum `numpy` for Python 3.8 to 1.19.5 due to `scipy` 1.10.0 support
- Increase minimum `numpy` for Python 3.9 to 1.19.5 due to `scipy` 1.10.0 support
- Reference: https://docs.scipy.org/doc/scipy/dev/toolchain.html#numpy


### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
