### PR TITLE
[BUGFIX] Format current branch name properly for tag branches in docker tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
               echo "##vso[task.setvariable variable=IMAGE_SUFFIX;isOutput=true]${SUFFIX}"
             name: suffix
             env:
-              BRANCH_NAME: $(Build.SourceBranchName)
+              BRANCH_NAME: $(Build.SourceBranch)
 
       - job: build_push
         dependsOn: make_suffix

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,7 +170,9 @@ stages:
         steps:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
+              # Remove /refs/heads or /refs/tags from the FULL_BRANCH_NAME
               BRANCH_NAME="${FULL_BRANCH_NAME/#refs\/heads\/}"
+              BRANCH_NAME="${BRANCH_NAME/#refs\/tags\/}"
               # Use the local branch that is already present, but prune it's depth since we don't need the git history.
               CMD="docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:${DOCKER_TAG} "
               CMD+="--target test --build-arg PYTHON_VERSION=$(python.version) "
@@ -180,9 +182,7 @@ stages:
               eval ${CMD}
             displayName: 'Build python $(python.version) image'
             env:
-              FULL_BRANCH_NAME:
-                ${{ if eq(variables.isRelease, false) }}: $(Build.SourceBranch)
-                ${{ if eq(variables.isRelease, true) }}: $(Build.SourceBranch) -replace "refs/tags/", ""
+              FULL_BRANCH_NAME: $(Build.SourceBranch)
 
           - bash: |
               docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,8 +171,7 @@ stages:
           - bash: |
               DOCKER_TAG="$(python.version)_$(IMAGE_SUFFIX)"
               BRANCH_NAME="${FULL_BRANCH_NAME/#refs\/heads\/}"
-              # We repull the develop branch. We could build the local branch that is already present but we should
-              # prune it's depth since we don't need the git history.
+              # Use the local branch that is already present, but prune it's depth since we don't need the git history.
               CMD="docker buildx build -f docker/Dockerfile.tests --tag greatexpectations/test:${DOCKER_TAG} "
               CMD+="--target test --build-arg PYTHON_VERSION=$(python.version) "
               CMD+="--build-arg GE_USAGE_STATISTICS_URL=\"$(GE_USAGE_STATISTICS_URL)\" "
@@ -181,7 +180,9 @@ stages:
               eval ${CMD}
             displayName: 'Build python $(python.version) image'
             env:
-              FULL_BRANCH_NAME: $(Build.SourceBranchName)
+              FULL_BRANCH_NAME:
+                ${{ if eq(variables.isRelease, false) }}: $(Build.SourceBranch)
+                ${{ if eq(variables.isRelease, true) }}: $(Build.SourceBranch) -replace "refs/tags/", ""
 
           - bash: |
               docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
               echo "##vso[task.setvariable variable=IMAGE_SUFFIX;isOutput=true]${SUFFIX}"
             name: suffix
             env:
-              BRANCH_NAME: $(Build.SourceBranch)
+              BRANCH_NAME: $(Build.SourceBranchName)
 
       - job: build_push
         dependsOn: make_suffix
@@ -181,7 +181,7 @@ stages:
               eval ${CMD}
             displayName: 'Build python $(python.version) image'
             env:
-              FULL_BRANCH_NAME: $(Build.SourceBranch)
+              FULL_BRANCH_NAME: $(Build.SourceBranchName)
 
           - bash: |
               docker login -u ${DOCKER_USER} -p ${DOCKER_TOKEN}


### PR DESCRIPTION
Changes proposed in this pull request:
- Use release-aware environment variable

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
