### PR TITLE
[MAINTENANCE] Refactor tests to leverage `get_context` instead of `BaseDataContext`

### DIFF
--- a/tests/actions/conftest.py
+++ b/tests/actions/conftest.py
@@ -6,7 +6,6 @@ import pytest
 from moto import mock_sns
 
 from great_expectations.core import ExpectationSuiteValidationResult, RunIdentifier
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.types.resource_identifiers import (
@@ -15,6 +14,7 @@ from great_expectations.data_context.types.resource_identifiers import (
     GXCloudIdentifier,
     ValidationResultIdentifier,
 )
+from great_expectations.util import get_context
 
 
 @pytest.fixture(scope="module")
@@ -80,7 +80,7 @@ def basic_data_context_config_for_validation_operator():
 def basic_in_memory_data_context_for_validation_operator(
     basic_data_context_config_for_validation_operator,
 ):
-    return BaseDataContext(basic_data_context_config_for_validation_operator)
+    return get_context(basic_data_context_config_for_validation_operator)
 
 
 @pytest.fixture(scope="module")

--- a/tests/actions/test_validation_operators.py
+++ b/tests/actions/test_validation_operators.py
@@ -7,8 +7,8 @@ from freezegun import freeze_time
 
 import great_expectations as gx
 from great_expectations.core.run_identifier import RunIdentifier
-from great_expectations.data_context import BaseDataContext
 from great_expectations.self_check.util import modify_locale
+from great_expectations.util import get_context
 from great_expectations.validation_operators.validation_operators import (
     WarningAndFailureExpectationSuitesValidationOperator,
 )
@@ -57,7 +57,7 @@ def warning_failure_validation_operator_data_context(
     # NOTE: This setup is almost identical to test_DefaultDataContextAwareValidationOperator.
     # Consider converting to a single fixture.
 
-    data_context = BaseDataContext(
+    data_context = get_context(
         basic_data_context_config_for_validation_operator,
         project_path,
     )

--- a/tests/actions/test_validation_operators_in_data_context.py
+++ b/tests/actions/test_validation_operators_in_data_context.py
@@ -5,10 +5,10 @@ import pytest
 from great_expectations import DataContext
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.run_identifier import RunIdentifier
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import DataContextError
 from great_expectations.self_check.util import expectationSuiteSchema
+from great_expectations.util import get_context
 
 
 @pytest.fixture()
@@ -29,7 +29,7 @@ def parameterized_expectation_suite(empty_data_context_stats_enabled):
 def validation_operators_data_context(
     basic_data_context_config_for_validation_operator, filesystem_csv_4
 ):
-    data_context = BaseDataContext(basic_data_context_config_for_validation_operator)
+    data_context = get_context(basic_data_context_config_for_validation_operator)
 
     data_context.add_datasource(
         "my_datasource",

--- a/tests/cli/test_docs.py
+++ b/tests/cli/test_docs.py
@@ -6,7 +6,7 @@ from click.testing import CliRunner
 
 from great_expectations import DataContext
 from great_expectations.cli import cli
-from great_expectations.data_context import BaseDataContext
+from great_expectations.util import get_context
 from tests.cli.utils import (
     VALIDATION_OPERATORS_DEPRECATION_MESSAGE,
     assert_no_logging_messages_or_tracebacks,
@@ -219,7 +219,7 @@ def context_with_two_sites(titanic_data_context_stats_enabled_config_version_3):
         },
         "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
     }
-    temp_context = BaseDataContext(config, context_root_dir=context.root_directory)
+    temp_context = get_context(config, context_root_dir=context.root_directory)
     new_context = DataContext(context.root_directory)
     new_context.set_config(temp_context.get_config_with_variables_substituted())
     new_context._save_project_config()

--- a/tests/core/usage_statistics/test_usage_statistics.py
+++ b/tests/core/usage_statistics/test_usage_statistics.py
@@ -9,9 +9,10 @@ import pytest
 from great_expectations.core.usage_statistics.usage_statistics import (
     run_validation_operator_usage_statistics,
 )
-from great_expectations.data_context import BaseDataContext, DataContext
+from great_expectations.data_context import DataContext
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.data_context.util import file_relative_path
+from great_expectations.util import get_context
 from tests.integration.usage_statistics.test_integration_usage_statistics import (
     USAGE_STATISTICS_QA_URL,
 )
@@ -63,7 +64,7 @@ def test_consistent_name_anonymization(
     monkeypatch.delenv(
         "GE_USAGE_STATS", raising=False
     )  # Undo the project-wide test default
-    context = BaseDataContext(in_memory_data_context_config_usage_stats_enabled)
+    context = get_context(in_memory_data_context_config_usage_stats_enabled)
     assert context.data_context_id == "00000000-0000-0000-0000-000000000001"
     payload = run_validation_operator_usage_statistics(
         context,
@@ -87,7 +88,7 @@ def test_global_override_environment_variable_base_data_context(
         in_memory_data_context_config_usage_stats_enabled.anonymous_usage_statistics.enabled
         is True
     )
-    context = BaseDataContext(in_memory_data_context_config_usage_stats_enabled)
+    context = get_context(in_memory_data_context_config_usage_stats_enabled)
     project_config = context._project_config
     assert project_config.anonymous_usage_statistics.enabled is False
 
@@ -126,7 +127,7 @@ def test_global_override_from_config_file_in_etc(
                 in_memory_data_context_config_usage_stats_enabled.anonymous_usage_statistics.enabled
                 is True
             )
-            context = BaseDataContext(
+            context = get_context(
                 deepcopy(in_memory_data_context_config_usage_stats_enabled)
             )
             project_config = context._project_config
@@ -170,7 +171,7 @@ def test_global_override_from_config_file_in_home_folder(
                 in_memory_data_context_config_usage_stats_enabled.anonymous_usage_statistics.enabled
                 is True
             )
-            context = BaseDataContext(
+            context = get_context(
                 deepcopy(in_memory_data_context_config_usage_stats_enabled)
             )
             project_config = context._project_config

--- a/tests/core/usage_statistics/test_usage_statistics_handler_methods.py
+++ b/tests/core/usage_statistics/test_usage_statistics_handler_methods.py
@@ -12,9 +12,9 @@ from great_expectations.core.usage_statistics.usage_statistics import (
     UsageStatisticsHandler,
     get_profiler_run_usage_statistics,
 )
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import DataContextConfig
 from great_expectations.rule_based_profiler.rule_based_profiler import RuleBasedProfiler
+from great_expectations.util import get_context
 from tests.core.usage_statistics.util import usage_stats_invalid_messages_exist
 from tests.integration.usage_statistics.test_integration_usage_statistics import (
     USAGE_STATISTICS_QA_URL,
@@ -131,9 +131,7 @@ def test_usage_statistics_handler_build_envelope(
 ):
     """This test is for a happy path only but will fail if there is an exception thrown in build_envelope"""
 
-    context: BaseDataContext = BaseDataContext(
-        in_memory_data_context_config_usage_stats_enabled
-    )
+    context = get_context(in_memory_data_context_config_usage_stats_enabled)
 
     usage_statistics_handler = UsageStatisticsHandler(
         data_context=context,
@@ -172,9 +170,7 @@ def test_usage_statistics_handler_validate_message_failure(
         logger="great_expectations.core.usage_statistics.usage_statistics",
     )
 
-    context: BaseDataContext = BaseDataContext(
-        in_memory_data_context_config_usage_stats_enabled
-    )
+    context = get_context(in_memory_data_context_config_usage_stats_enabled)
 
     usage_statistics_handler = UsageStatisticsHandler(
         data_context=context,
@@ -204,9 +200,7 @@ def test_usage_statistics_handler_validate_message_success(
         logger="great_expectations.core.usage_statistics.usage_statistics",
     )
 
-    context: BaseDataContext = BaseDataContext(
-        in_memory_data_context_config_usage_stats_enabled
-    )
+    context = get_context(in_memory_data_context_config_usage_stats_enabled)
 
     usage_statistics_handler = UsageStatisticsHandler(
         data_context=context,

--- a/tests/data_context/cloud_data_context/test_checkpoint_crud.py
+++ b/tests/data_context/cloud_data_context/test_checkpoint_crud.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Callable, Optional, Tuple, Type
+from typing import Callable, Optional, Tuple
 from unittest import mock
 
 import pandas as pd
@@ -7,12 +7,6 @@ import pytest
 
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
-from great_expectations.data_context.data_context.abstract_data_context import (
-    AbstractDataContext,
-)
-from great_expectations.data_context.data_context.base_data_context import (
-    BaseDataContext,
-)
 from great_expectations.data_context.data_context.cloud_data_context import (
     CloudDataContext,
 )
@@ -24,6 +18,7 @@ from great_expectations.data_context.types.base import (
     checkpointConfigSchema,
 )
 from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
+from great_expectations.util import get_context
 from tests.data_context.conftest import MockResponse
 
 
@@ -128,23 +123,8 @@ def mocked_get_response(
 
 @pytest.mark.cloud
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "data_context_fixture_name",
-    [
-        # In order to leverage existing fixtures in parametrization, we provide
-        # their string names and dynamically retrieve them using pytest's built-in
-        # `request` fixture.
-        # Source: https://stackoverflow.com/a/64348247
-        pytest.param(
-            "empty_base_data_context_in_cloud_mode",
-            id="BaseDataContext",
-        ),
-        pytest.param("empty_data_context_in_cloud_mode", id="DataContext"),
-        pytest.param("empty_cloud_data_context", id="CloudDataContext"),
-    ],
-)
 def test_cloud_backed_data_context_add_checkpoint(
-    data_context_fixture_name: str,
+    empty_cloud_data_context: CloudDataContext,
     checkpoint_id: str,
     validation_ids: Tuple[str, str],
     checkpoint_config: dict,
@@ -152,16 +132,12 @@ def test_cloud_backed_data_context_add_checkpoint(
     mocked_get_response: Callable[[], MockResponse],
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request,
 ) -> None:
     """
-    All Cloud-backed contexts (DataContext, BaseDataContext, and CloudDataContext) should save to a Cloud-backed CheckpointStore when calling `add_checkpoint`.
+    A Cloud-backed context should save to a Cloud-backed CheckpointStore when calling `add_checkpoint`.
     When saving, it should use the id from the response to create the checkpoint.
     """
-    context = request.getfixturevalue(data_context_fixture_name)
-
-    # Make sure the fixture has the right configuration
-    assert isinstance(context, CloudDataContext)
+    context = empty_cloud_data_context
 
     validation_id_1, validation_id_2 = validation_ids
 
@@ -209,23 +185,8 @@ def test_cloud_backed_data_context_add_checkpoint(
 
 @pytest.mark.cloud
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "data_context_fixture_name",
-    [
-        # In order to leverage existing fixtures in parametrization, we provide
-        # their string names and dynamically retrieve them using pytest's built-in
-        # `request` fixture.
-        # Source: https://stackoverflow.com/a/64348247
-        pytest.param(
-            "empty_base_data_context_in_cloud_mode",
-            id="BaseDataContext",
-        ),
-        pytest.param("empty_data_context_in_cloud_mode", id="DataContext"),
-        pytest.param("empty_cloud_data_context", id="CloudDataContext"),
-    ],
-)
 def test_add_checkpoint_updates_existing_checkpoint_in_cloud_backend(
-    data_context_fixture_name: str,
+    empty_cloud_data_context: CloudDataContext,
     checkpoint_config: dict,
     checkpoint_id: str,
     mocked_post_response: Callable[[], MockResponse],
@@ -233,12 +194,8 @@ def test_add_checkpoint_updates_existing_checkpoint_in_cloud_backend(
     mocked_get_response: Callable[[], MockResponse],
     ge_cloud_base_url: str,
     ge_cloud_organization_id: str,
-    request,
 ) -> None:
-    context = request.getfixturevalue(data_context_fixture_name)
-
-    # Make sure the fixture has the right configuration
-    assert isinstance(context, CloudDataContext)
+    context = empty_cloud_data_context
 
     with mock.patch(
         "requests.Session.post", autospec=True, side_effect=mocked_post_response
@@ -529,10 +486,12 @@ def test_list_checkpoints(
 ) -> None:
     project_path_name = "foo/bar/baz"
 
-    context = BaseDataContext(
+    context = get_context(
         project_config=empty_ge_cloud_data_context_config,
         context_root_dir=project_path_name,
-        cloud_config=ge_cloud_config,
+        cloud_base_url=ge_cloud_config.base_url,
+        cloud_access_token=ge_cloud_config.access_token,
+        cloud_organization_id=ge_cloud_config.organization_id,
         cloud_mode=True,
     )
 

--- a/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
+++ b/tests/data_context/cloud_data_context/test_expectation_suite_crud.py
@@ -5,12 +5,13 @@ import pytest
 
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
-from great_expectations.data_context.data_context.base_data_context import (
-    BaseDataContext,
+from great_expectations.data_context.data_context.cloud_data_context import (
+    CloudDataContext,
 )
 from great_expectations.data_context.types.base import DataContextConfig, GXCloudConfig
 from great_expectations.data_context.types.resource_identifiers import GXCloudIdentifier
 from great_expectations.exceptions.exceptions import DataContextError
+from great_expectations.util import get_context
 from tests.data_context.conftest import MockResponse
 
 
@@ -207,10 +208,12 @@ def test_list_expectation_suites(
 ) -> None:
     project_path_name = "foo/bar/baz"
 
-    context = BaseDataContext(
+    context = get_context(
         project_config=empty_ge_cloud_data_context_config,
         context_root_dir=project_path_name,
-        cloud_config=ge_cloud_config,
+        cloud_base_url=ge_cloud_config.base_url,
+        cloud_access_token=ge_cloud_config.access_token,
+        cloud_organization_id=ge_cloud_config.organization_id,
         cloud_mode=True,
     )
 
@@ -237,7 +240,7 @@ def test_list_expectation_suites(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_create_expectation_suite_saves_suite_to_cloud(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     mocked_post_response: Callable[[], MockResponse],
     mock_list_expectation_suite_names: mock.MagicMock,
 ) -> None:
@@ -258,7 +261,7 @@ def test_create_expectation_suite_saves_suite_to_cloud(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_create_expectation_suite_overwrites_existing_suite(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     mock_list_expectation_suite_names: mock.MagicMock,
     mock_list_expectation_suites: mock.MagicMock,
     suite_1: SuiteIdentifierTuple,
@@ -290,7 +293,7 @@ def test_create_expectation_suite_overwrites_existing_suite(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_create_expectation_suite_namespace_collision_raises_error(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     mock_list_expectation_suite_names: mock.MagicMock,
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
@@ -308,7 +311,7 @@ def test_create_expectation_suite_namespace_collision_raises_error(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_delete_expectation_suite_deletes_suite_in_cloud(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
     mock_expectations_store_has_key: mock.MagicMock,
 ) -> None:
@@ -334,7 +337,7 @@ def test_delete_expectation_suite_deletes_suite_in_cloud(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_delete_expectation_suite_nonexistent_suite_raises_error(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
     mock_expectations_store_has_key: mock.MagicMock,
 ) -> None:
@@ -354,7 +357,7 @@ def test_delete_expectation_suite_nonexistent_suite_raises_error(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_get_expectation_suite_retrieves_suite_from_cloud(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
     mocked_get_response: Callable[[], MockResponse],
     mock_expectations_store_has_key: mock.MagicMock,
@@ -377,7 +380,7 @@ def test_get_expectation_suite_retrieves_suite_from_cloud(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_get_expectation_suite_nonexistent_suite_raises_error(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     mock_expectations_store_has_key: mock.MagicMock,
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
@@ -397,7 +400,7 @@ def test_get_expectation_suite_nonexistent_suite_raises_error(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_save_expectation_suite_saves_suite_to_cloud(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     mocked_post_response: Callable[[], MockResponse],
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
@@ -419,7 +422,7 @@ def test_save_expectation_suite_saves_suite_to_cloud(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_save_expectation_suite_overwrites_existing_suite(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
 ) -> None:
     context = empty_base_data_context_in_cloud_mode
@@ -453,7 +456,7 @@ def test_save_expectation_suite_overwrites_existing_suite(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_save_expectation_suite_no_overwrite_namespace_collision_raises_error(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     mock_expectations_store_has_key: mock.MagicMock,
     mock_list_expectation_suite_names: mock.MagicMock,
 ) -> None:
@@ -478,7 +481,7 @@ def test_save_expectation_suite_no_overwrite_namespace_collision_raises_error(
 @pytest.mark.unit
 @pytest.mark.cloud
 def test_save_expectation_suite_no_overwrite_id_collision_raises_error(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     suite_1: SuiteIdentifierTuple,
     mock_expectations_store_has_key: mock.MagicMock,
 ) -> None:

--- a/tests/data_context/cloud_data_context/test_profiler_crud.py
+++ b/tests/data_context/cloud_data_context/test_profiler_crud.py
@@ -4,8 +4,8 @@ from unittest import mock
 import pytest
 
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
-from great_expectations.data_context.data_context.base_data_context import (
-    BaseDataContext,
+from great_expectations.data_context.data_context.cloud_data_context import (
+    CloudDataContext,
 )
 from great_expectations.data_context.data_context.data_context import DataContext
 from great_expectations.data_context.types.base import DataContextConfig, GXCloudConfig
@@ -14,6 +14,7 @@ from great_expectations.rule_based_profiler.config.base import (
     ruleBasedProfilerConfigSchema,
 )
 from great_expectations.rule_based_profiler.rule_based_profiler import RuleBasedProfiler
+from great_expectations.util import get_context
 from tests.data_context.conftest import MockResponse
 
 
@@ -98,7 +99,7 @@ def mocked_post_response(
 @pytest.mark.cloud
 @pytest.mark.integration
 def test_profiler_save_with_existing_profiler_retrieves_obj_with_id_from_store(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     profiler_with_id: RuleBasedProfiler,
     mocked_get_response: Callable[[], MockResponse],
     ge_cloud_base_url: str,
@@ -149,7 +150,7 @@ def test_profiler_save_with_existing_profiler_retrieves_obj_with_id_from_store(
 @pytest.mark.cloud
 @pytest.mark.integration
 def test_profiler_save_with_new_profiler_retrieves_obj_with_id_from_store(
-    empty_base_data_context_in_cloud_mode: BaseDataContext,
+    empty_base_data_context_in_cloud_mode: CloudDataContext,
     profiler_without_id: RuleBasedProfiler,
     profiler_id: str,
     mocked_get_response: Callable[[], MockResponse],
@@ -344,10 +345,12 @@ def test_list_profilers(
 ) -> None:
     project_path_name = "foo/bar/baz"
 
-    context = BaseDataContext(
+    context = get_context(
         project_config=empty_ge_cloud_data_context_config,
         context_root_dir=project_path_name,
-        cloud_config=ge_cloud_config,
+        cloud_base_url=ge_cloud_config.base_url,
+        cloud_organization_id=ge_cloud_config.organization_id,
+        cloud_access_token=ge_cloud_config.access_token,
         cloud_mode=True,
     )
 

--- a/tests/data_context/store/test_store_backends.py
+++ b/tests/data_context/store/test_store_backends.py
@@ -14,7 +14,6 @@ from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.run_identifier import RunIdentifier
 from great_expectations.core.yaml_handler import YAMLHandler
 from great_expectations.data_context import DataContext
-from great_expectations.data_context.data_context import BaseDataContext
 from great_expectations.data_context.data_context_variables import (
     DataContextVariableSchema,
 )
@@ -37,7 +36,11 @@ from great_expectations.data_context.types.resource_identifiers import (
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.exceptions import InvalidKeyError, StoreBackendError, StoreError
 from great_expectations.self_check.util import expectationSuiteSchema
-from great_expectations.util import gen_directory_tree_str, is_library_loadable
+from great_expectations.util import (
+    gen_directory_tree_str,
+    get_context,
+    is_library_loadable,
+)
 
 yaml = YAMLHandler()
 
@@ -105,7 +108,7 @@ def basic_data_context_config_for_validation_operator():
 def validation_operators_data_context(
     basic_data_context_config_for_validation_operator, filesystem_csv_4
 ):
-    data_context = BaseDataContext(basic_data_context_config_for_validation_operator)
+    data_context = get_context(basic_data_context_config_for_validation_operator)
 
     data_context.add_datasource(
         "my_datasource",

--- a/tests/data_context/test_concurrency_config.py
+++ b/tests/data_context/test_concurrency_config.py
@@ -1,9 +1,9 @@
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     ConcurrencyConfig,
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 
 def test_concurrency_disabled_by_default():
@@ -22,7 +22,7 @@ def test_concurrency_enabled_with_config():
 
 
 def test_data_context_concurrency_property():
-    data_context = BaseDataContext(
+    data_context = get_context(
         project_config=DataContextConfig(
             concurrency=ConcurrencyConfig(enabled=True),
             store_backend_defaults=InMemoryStoreBackendDefaults(),

--- a/tests/data_context/test_data_context.py
+++ b/tests/data_context/test_data_context.py
@@ -19,7 +19,7 @@ from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.core.config_peer import ConfigOutputModes
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.run_identifier import RunIdentifier
-from great_expectations.data_context import BaseDataContext, DataContext
+from great_expectations.data_context import DataContext
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
 )
@@ -53,6 +53,7 @@ from great_expectations.render.renderer.renderer import renderer
 from great_expectations.util import (
     deep_filter_properties_iterable,
     gen_directory_tree_str,
+    get_context,
     is_library_loadable,
 )
 from tests.test_utils import create_files_in_directory, safe_remove
@@ -866,7 +867,7 @@ def test_ConfigOnlyDataContext__initialization(
     config_path = str(
         tmp_path_factory.mktemp("test_ConfigOnlyDataContext__initialization__dir")
     )
-    context = BaseDataContext(
+    context = get_context(
         basic_data_context_config,
         config_path,
     )
@@ -892,7 +893,7 @@ def test__normalize_absolute_or_relative_path(
     )
     test_dir = full_test_dir.parts[-1]
     config_path = str(full_test_dir)
-    context = BaseDataContext(
+    context = get_context(
         basic_data_context_config,
         config_path,
     )
@@ -1418,11 +1419,11 @@ def test_load_config_variables_property(
     try:
         # We should be able to load different files based on an environment variable
         monkeypatch.setenv("TEST_CONFIG_FILE_ENV", "dev")
-        context = BaseDataContext(basic_data_context_config, context_root_dir=base_path)
+        context = get_context(basic_data_context_config, context_root_dir=base_path)
         config_vars = context.config_variables
         assert config_vars["env"] == "dev"
         monkeypatch.setenv("TEST_CONFIG_FILE_ENV", "prod")
-        context = BaseDataContext(basic_data_context_config, context_root_dir=base_path)
+        context = get_context(basic_data_context_config, context_root_dir=base_path)
         config_vars = context.config_variables
         assert config_vars["env"] == "prod"
     except Exception:

--- a/tests/data_context/test_data_context_config_ui.py
+++ b/tests/data_context/test_data_context_config_ui.py
@@ -4,7 +4,6 @@ from typing import Dict, Optional
 
 import pytest
 
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.data_context.serializable_data_context import (
     SerializableDataContext,
 )
@@ -20,7 +19,7 @@ from great_expectations.data_context.types.base import (
     InMemoryStoreBackendDefaults,
     S3StoreBackendDefaults,
 )
-from great_expectations.util import filter_properties_dict
+from great_expectations.util import filter_properties_dict, get_context
 
 """
 What does this test and why?
@@ -1479,7 +1478,7 @@ def test_DataContextConfig_with_S3StoreBackendDefaults_and_simple_defaults_with_
         DataContextConfig,
     )
 
-    data_context = BaseDataContext(project_config=data_context_config)
+    data_context = get_context(project_config=data_context_config)
     assert (
         data_context.datasources["my_pandas_datasource"]
         .get_batch_kwargs_generator("subdir_reader")

--- a/tests/data_context/test_data_context_data_docs_api.py
+++ b/tests/data_context/test_data_context_data_docs_api.py
@@ -4,11 +4,11 @@ from unittest import mock
 import pytest
 
 from great_expectations import DataContext
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.data_context.file_data_context import (
     FileDataContext,
 )
 from great_expectations.exceptions import DataContextError
+from great_expectations.util import get_context
 
 
 @mock.patch("webbrowser.open", return_value=True, side_effect=None)
@@ -352,7 +352,7 @@ def test_build_data_docs_skipping_index_does_not_build_index(
 
 
 def test_get_site_names_with_no_sites(tmpdir, basic_data_context_config):
-    context = BaseDataContext(basic_data_context_config, context_root_dir=tmpdir)
+    context = get_context(basic_data_context_config, context_root_dir=tmpdir)
     assert context.get_site_names() == []
 
 
@@ -372,5 +372,5 @@ def test_get_site_names_with_three_sites(tmpdir, basic_data_context_config):
             },
             "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
         }
-    context = BaseDataContext(basic_data_context_config, context_root_dir=tmpdir)
+    context = get_context(basic_data_context_config, context_root_dir=tmpdir)
     assert context.get_site_names() == ["site-0", "site-1", "site-2"]

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -3,10 +3,10 @@ from unittest import mock
 
 import pytest
 
-from great_expectations.data_context.data_context.base_data_context import (
-    BaseDataContext,
-)
 from great_expectations.data_context.data_context.data_context import DataContext
+from great_expectations.data_context.data_context.ephemeral_data_context import (
+    EphemeralDataContext,
+)
 from great_expectations.data_context.store.gx_cloud_store_backend import (
     GXCloudStoreBackend,
 )
@@ -60,7 +60,7 @@ def test_data_context_instantiates_ge_cloud_store_backend_with_cloud_config(
     # Clear datasources to improve test performance in DataContext._init_datasources
     data_context_config_with_datasources.datasources = {}
 
-    context = BaseDataContext(
+    context = get_context(
         project_config=data_context_config_with_datasources,
         context_root_dir=str(project_path),
         cloud_mode=True,
@@ -81,7 +81,7 @@ def test_data_context_instantiates_inline_store_backend_with_filesystem_config(
     # Clear datasources to improve test performance in DataContext._init_datasources
     data_context_config_with_datasources.datasources = {}
 
-    context = BaseDataContext(
+    context = get_context(
         project_config=data_context_config_with_datasources,
         context_root_dir=str(project_path),
         cloud_mode=False,
@@ -316,7 +316,7 @@ def test_DataContext_delete_datasource_updates_cache(
 
 @pytest.mark.unit
 def test_BaseDataContext_add_datasource_updates_cache(
-    in_memory_runtime_context: BaseDataContext,
+    in_memory_runtime_context: EphemeralDataContext,
     pandas_enabled_datasource_config: dict,
 ) -> None:
     """
@@ -338,7 +338,7 @@ def test_BaseDataContext_add_datasource_updates_cache(
 
 @pytest.mark.unit
 def test_BaseDataContext_update_datasource_updates_existing_value_in_cache(
-    in_memory_runtime_context: BaseDataContext,
+    in_memory_runtime_context: EphemeralDataContext,
     pandas_enabled_datasource_config: dict,
 ) -> None:
     """
@@ -373,7 +373,7 @@ def test_BaseDataContext_update_datasource_updates_existing_value_in_cache(
 
 @pytest.mark.unit
 def test_BaseDataContext_update_datasource_creates_new_value_in_cache(
-    in_memory_runtime_context: BaseDataContext,
+    in_memory_runtime_context: EphemeralDataContext,
     pandas_enabled_datasource_config: dict,
 ) -> None:
     """
@@ -399,7 +399,7 @@ def test_BaseDataContext_update_datasource_creates_new_value_in_cache(
 
 @pytest.mark.unit
 def test_BaseDataContext_delete_datasource_updates_cache(
-    in_memory_runtime_context: BaseDataContext,
+    in_memory_runtime_context: EphemeralDataContext,
 ) -> None:
     """
     What does this test and why?

--- a/tests/data_context/test_data_context_datasources.py
+++ b/tests/data_context/test_data_context_datasources.py
@@ -19,6 +19,7 @@ from great_expectations.data_context.types.base import (
     GXCloudConfig,
 )
 from great_expectations.datasource import Datasource
+from great_expectations.util import get_context
 
 
 @pytest.fixture
@@ -63,8 +64,10 @@ def test_data_context_instantiates_ge_cloud_store_backend_with_cloud_config(
     context = get_context(
         project_config=data_context_config_with_datasources,
         context_root_dir=str(project_path),
+        cloud_base_url=ge_cloud_config.base_url,
+        cloud_access_token=ge_cloud_config.access_token,
+        cloud_organization_id=ge_cloud_config.organization_id,
         cloud_mode=True,
-        cloud_config=ge_cloud_config,
     )
 
     assert isinstance(context._datasource_store.store_backend, GXCloudStoreBackend)

--- a/tests/data_context/test_data_context_in_code_config.py
+++ b/tests/data_context/test_data_context_in_code_config.py
@@ -4,9 +4,9 @@ import boto3
 import pyparsing as pp
 from moto import mock_s3
 
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.store import StoreBackend, TupleS3StoreBackend
 from great_expectations.data_context.types.base import DataContextConfig
+from great_expectations.util import get_context
 from tests.integration.usage_statistics.test_integration_usage_statistics import (
     USAGE_STATISTICS_QA_URL,
 )
@@ -221,13 +221,13 @@ def test_DataContext_construct_data_context_id_uses_id_of_currently_configured_e
         validations_store_prefix=validations_store_prefix,
         data_docs_store_prefix=data_docs_store_prefix,
     )
-    in_code_data_context = BaseDataContext(
+    in_code_data_context = get_context(
         project_config=in_code_data_context_project_config
     )
-    bucket_contents_after_instantiating_BaseDataContext = list_s3_bucket_contents(
+    bucket_contents_after_instantiating_get_context = list_s3_bucket_contents(
         bucket=bucket, prefix=data_context_prefix
     )
-    assert bucket_contents_after_instantiating_BaseDataContext == {
+    assert bucket_contents_after_instantiating_get_context == {
         f"{expectations_store_prefix}/{store_backend_id_filename}",
         f"{validations_store_prefix}/{store_backend_id_filename}",
     }
@@ -288,7 +288,7 @@ def test_DataContext_construct_data_context_id_uses_id_stored_in_DataContextConf
     in_code_data_context_project_config.anonymous_usage_statistics.data_context_id = (
         manually_created_uuid
     )
-    in_code_data_context = BaseDataContext(
+    in_code_data_context = get_context(
         project_config=in_code_data_context_project_config
     )
 
@@ -336,7 +336,7 @@ def test_DataContext_construct_data_context_id_uses_id_stored_in_env_var_GE_DATA
         validations_store_prefix=validations_store_prefix,
         data_docs_store_prefix=data_docs_store_prefix,
     )
-    in_code_data_context = BaseDataContext(
+    in_code_data_context = get_context(
         project_config=in_code_data_context_project_config
     )
 
@@ -416,7 +416,7 @@ def test_suppress_store_backend_id_is_true_for_inactive_stores():
         data_docs_store_prefix=data_docs_store_prefix,
         stores=stores,
     )
-    in_code_data_context = BaseDataContext(
+    in_code_data_context = get_context(
         project_config=in_code_data_context_project_config
     )
 
@@ -510,7 +510,7 @@ def test_inaccessible_active_bucket_warning_messages(caplog):
         data_docs_store_prefix=data_docs_store_prefix,
         stores=stores,
     )
-    _ = BaseDataContext(project_config=in_code_data_context_project_config)
+    _ = get_context(project_config=in_code_data_context_project_config)
     assert (
         caplog.messages.count(
             "Invalid store configuration: Please check the configuration of your TupleS3StoreBackend named expectations_S3_store"
@@ -592,7 +592,7 @@ def test_inaccessible_inactive_bucket_no_warning_messages(caplog):
         data_docs_store_prefix=data_docs_store_prefix,
         stores=stores,
     )
-    _ = BaseDataContext(project_config=in_code_data_context_project_config)
+    _ = get_context(project_config=in_code_data_context_project_config)
     assert (
         caplog.messages.count(
             "Invalid store configuration: Please check the configuration of your TupleS3StoreBackend named expectations_S3_store"

--- a/tests/data_context/test_data_context_v013.py
+++ b/tests/data_context/test_data_context_v013.py
@@ -9,7 +9,6 @@ from great_expectations import DataContext
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.batch import Batch, RuntimeBatchRequest
 from great_expectations.core.config_peer import ConfigOutputModes
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     dataContextConfigSchema,
@@ -20,6 +19,7 @@ from great_expectations.execution_engine.pandas_batch_data import PandasBatchDat
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
 )
+from great_expectations.util import get_context
 from great_expectations.validator.validator import Validator
 from tests.integration.usage_statistics.test_integration_usage_statistics import (
     USAGE_STATISTICS_QA_URL,
@@ -114,7 +114,7 @@ def test_ConfigOnlyDataContext_v013__initialization(
     config_path = str(
         tmp_path_factory.mktemp("test_ConfigOnlyDataContext__initialization__dir")
     )
-    context = BaseDataContext(
+    context = get_context(
         basic_data_context_v013_config,
         config_path,
     )
@@ -148,7 +148,7 @@ def test__normalize_absolute_or_relative_path(
     )
     test_dir = full_test_path.parts[-1]
     config_path = str(full_test_path)
-    context = BaseDataContext(
+    context = get_context(
         basic_data_context_v013_config,
         config_path,
     )
@@ -184,13 +184,13 @@ def test_load_config_variables_file(
     try:
         # We should be able to load different files based on an environment variable
         monkeypatch.setenv("TEST_CONFIG_FILE_ENV", "dev")
-        context = BaseDataContext(
+        context = get_context(
             basic_data_context_v013_config, context_root_dir=base_path
         )
         config_vars = context.config_variables
         assert config_vars["env"] == "dev"
         monkeypatch.setenv("TEST_CONFIG_FILE_ENV", "prod")
-        context = BaseDataContext(
+        context = get_context(
             basic_data_context_v013_config, context_root_dir=base_path
         )
         config_vars = context.config_variables
@@ -536,7 +536,7 @@ def test_in_memory_data_context_configuration(
     project_config_dict = dataContextConfigSchema.load(project_config_dict)
 
     project_config: DataContextConfig = DataContextConfig(**project_config_dict)
-    data_context = BaseDataContext(
+    data_context = get_context(
         project_config=project_config,
         context_root_dir=titanic_pandas_data_context_with_v013_datasource_with_checkpoints_v1_with_empty_store_stats_enabled.root_directory,
     )

--- a/tests/integration/common_workflows/simple_build_data_docs.py
+++ b/tests/integration/common_workflows/simple_build_data_docs.py
@@ -2,12 +2,12 @@ import os
 import tempfile
 
 import great_expectations as gx
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     DatasourceConfig,
     FilesystemStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 """
 A simple test to verify that `context.build_data_docs()` works as expected.
@@ -41,5 +41,5 @@ data_context_config = DataContextConfig(
         root_directory=tempfile.mkdtemp() + os.sep + "my_greatexp_workdir"
     ),
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 print(f"Great Expectations data_docs url: {context.build_data_docs()}")

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/spark/inferred_and_runtime_python_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/spark/inferred_and_runtime_python_example.py
@@ -4,11 +4,11 @@ from ruamel import yaml
 
 import great_expectations as gx
 from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # NOTE: InMemoryStoreBackendDefaults SHOULD NOT BE USED in normal settings. You
 # may experience data loss as it persists nothing. It is used here for testing.
@@ -18,7 +18,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 datasource_config = {
     "name": "my_gcs_datasource",

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/spark/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/gcs/spark/inferred_and_runtime_yaml_example.py
@@ -5,11 +5,11 @@ from ruamel import yaml
 # <snippet>
 import great_expectations as gx
 from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # </snippet>
 
@@ -21,7 +21,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 # <snippet>
 datasource_yaml = rf"""

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_python_example.py
@@ -4,11 +4,11 @@ from ruamel import yaml
 
 import great_expectations as gx
 from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # NOTE: InMemoryStoreBackendDefaults SHOULD NOT BE USED in normal settings. You
 # may experience data loss as it persists nothing. It is used here for testing.
@@ -18,7 +18,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 datasource_config = {
     "name": "my_s3_datasource",

--- a/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/cloud/s3/spark/inferred_and_runtime_yaml_example.py
@@ -4,11 +4,11 @@ from ruamel import yaml
 
 import great_expectations as gx
 from great_expectations.core.batch import Batch, BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # NOTE: InMemoryStoreBackendDefaults SHOULD NOT BE USED in normal settings. You
 # may experience data loss as it persists nothing. It is used here for testing.
@@ -18,7 +18,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 datasource_yaml = rf"""
 name: my_s3_datasource

--- a/tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_python_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_python_example.py
@@ -2,11 +2,11 @@ from ruamel import yaml
 
 import great_expectations as gx
 from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # NOTE: InMemoryStoreBackendDefaults SHOULD NOT BE USED in normal settings. You
 # may experience data loss as it persists nothing. It is used here for testing.
@@ -16,7 +16,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 datasource_config = {
     "name": "my_filesystem_datasource",

--- a/tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/filesystem/spark_yaml_example.py
@@ -2,11 +2,11 @@ from ruamel import yaml
 
 import great_expectations as gx
 from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # NOTE: InMemoryStoreBackendDefaults SHOULD NOT BE USED in normal settings. You
 # may experience data loss as it persists nothing. It is used here for testing.
@@ -16,7 +16,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 datasource_yaml = rf"""
 name: my_filesystem_datasource

--- a/tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_python_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_python_example.py
@@ -1,12 +1,12 @@
 from ruamel import yaml
 
 import great_expectations as gx
-from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
+from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # Set up a basic spark session
 spark = gx.core.util.get_or_create_spark_application()
@@ -27,7 +27,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 datasource_config = {
     "name": "my_spark_dataframe",

--- a/tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/in_memory/spark_yaml_example.py
@@ -1,12 +1,12 @@
 from ruamel import yaml
 
 import great_expectations as gx
-from great_expectations.core.batch import BatchRequest, RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
+from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # Set up a basic spark session
 spark = gx.core.util.get_or_create_spark_application()
@@ -27,7 +27,7 @@ data_context_config = DataContextConfig(
     store_backend_defaults=store_backend_defaults,
     checkpoint_store_name=store_backend_defaults.checkpoint_store_name,
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 
 datasource_yaml = f"""
 name: my_spark_dataframe

--- a/tests/integration/docusaurus/deployment_patterns/aws_emr_serverless_deployment_patterns.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_emr_serverless_deployment_patterns.py
@@ -4,11 +4,11 @@ from pyspark import SQLContext
 
 import great_expectations as gx
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     S3StoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 if __name__ == "__main__":
     ### critical part to reinitialize spark context
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         ),
     )
 
-    context_gx = BaseDataContext(project_config=config)
+    context_gx = get_context(project_config=config)
 
     expectation_suite_name = suite_name
     suite = context_gx.get_expectation_suite(suite_name)

--- a/tests/integration/docusaurus/deployment_patterns/aws_glue_deployment_patterns.py
+++ b/tests/integration/docusaurus/deployment_patterns/aws_glue_deployment_patterns.py
@@ -6,11 +6,11 @@ from pyspark.context import SparkContext
 import great_expectations as gx
 from great_expectations.checkpoint import SimpleCheckpoint
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     S3StoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 sc = SparkContext.getOrCreate()
 glueContext = GlueContext(sc)
@@ -40,7 +40,7 @@ config = DataContextConfig(
         ]
     ),
 )
-context_gx = BaseDataContext(project_config=config)
+context_gx = get_context(project_config=config)
 
 expectation_suite_name = "suite_name"
 suite = context_gx.create_expectation_suite(expectation_suite_name)

--- a/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_dataframe_python_configs.py
+++ b/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_dataframe_python_configs.py
@@ -6,7 +6,7 @@ import pandas as pd
 from ruamel import yaml
 
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
+from great_expectations.util import get_context
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     FilesystemStoreBackendDefaults,
@@ -39,7 +39,7 @@ data_context_config = DataContextConfig(
         root_directory=root_directory
     ),
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 # CODE ^^^^^ ^^^^^
 
 # ASSERTIONS vvvvv vvvvv

--- a/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_dataframe_yaml_configs.py
+++ b/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_dataframe_yaml_configs.py
@@ -6,7 +6,7 @@ import pandas as pd
 from ruamel import yaml
 
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
+from great_expectations.util import get_context
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     FilesystemStoreBackendDefaults,
@@ -35,7 +35,7 @@ data_context_config = DataContextConfig(
         root_directory=root_directory
     ),
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 # CODE ^^^^^ ^^^^^
 
 # ASSERTIONS vvvvv vvvvv

--- a/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_file_python_configs.py
+++ b/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_file_python_configs.py
@@ -3,11 +3,11 @@ import os
 from ruamel import yaml
 
 from great_expectations.core.batch import BatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     FilesystemStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # 1. Install Great Expectations
 # %pip install great-expectations
@@ -28,7 +28,7 @@ data_context_config = DataContextConfig(
         root_directory=root_directory
     ),
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 # CODE ^^^^^ ^^^^^
 
 # ASSERTIONS vvvvv vvvvv

--- a/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_file_yaml_configs.py
+++ b/tests/integration/docusaurus/deployment_patterns/databricks_deployment_patterns_file_yaml_configs.py
@@ -3,11 +3,11 @@ import os
 from ruamel import yaml
 
 from great_expectations.core.batch import BatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
     FilesystemStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 # 1. Install Great Expectations
 # %pip install great-expectations
@@ -28,7 +28,7 @@ data_context_config = DataContextConfig(
         root_directory=root_directory
     ),
 )
-context = BaseDataContext(project_config=data_context_config)
+context = get_context(project_config=data_context_config)
 # CODE ^^^^^ ^^^^^
 
 # ASSERTIONS vvvvv vvvvv

--- a/tests/integration/usage_statistics/instantiate_context_with_usage_statistics.py
+++ b/tests/integration/usage_statistics/instantiate_context_with_usage_statistics.py
@@ -8,8 +8,8 @@ import uuid
 
 import pandas as pd
 
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import DataContextConfig
+from great_expectations.util import get_context
 
 logging.basicConfig(level=logging.INFO)
 
@@ -65,7 +65,7 @@ def main(
         },
         commented_map=None,
     )
-    context = BaseDataContext(config)
+    context = get_context(config)
     print("Done constructing a DataContext.")
     print("Building a suite and validating.")
     df = pd.DataFrame({"a": [1, 2, 3]})

--- a/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
+++ b/tests/integration/usage_statistics/test_usage_stats_common_messages_are_sent_v3api.py
@@ -7,8 +7,8 @@ import pytest
 from ruamel import yaml
 
 from great_expectations.core.batch import RuntimeBatchRequest
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import DataContextConfig
+from great_expectations.util import get_context
 from tests.core.usage_statistics.util import (
     usage_stats_exceptions_exist,
     usage_stats_invalid_messages_exist,
@@ -86,9 +86,7 @@ def test_common_usage_stats_are_sent_no_mocking(
     )  # Undo the project-wide test default
     assert os.getenv("GE_USAGE_STATS") is None
 
-    context: BaseDataContext = BaseDataContext(
-        in_memory_data_context_config_usage_stats_enabled
-    )
+    context = get_context(in_memory_data_context_config_usage_stats_enabled)
 
     # Note, we lose the `data_context.__init__` event because it was emitted before closing the worker
     context._usage_statistics_handler._close_worker()

--- a/tests/performance/taxi_benchmark_util.py
+++ b/tests/performance/taxi_benchmark_util.py
@@ -10,9 +10,6 @@ from great_expectations import DataContext
 from great_expectations.checkpoint import SimpleCheckpoint
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.data_context import AbstractDataContext
-from great_expectations.data_context.data_context.abstract_data_context import (
-    AbstractDataContext,
-)
 from great_expectations.data_context.types.base import (
     ConcurrencyConfig,
     DataContextConfig,

--- a/tests/performance/taxi_benchmark_util.py
+++ b/tests/performance/taxi_benchmark_util.py
@@ -9,12 +9,16 @@ from typing import List, Optional
 from great_expectations import DataContext
 from great_expectations.checkpoint import SimpleCheckpoint
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
-from great_expectations.data_context import BaseDataContext
+from great_expectations.data_context import AbstractDataContext
+from great_expectations.data_context.data_context.abstract_data_context import (
+    AbstractDataContext,
+)
 from great_expectations.data_context.types.base import (
     ConcurrencyConfig,
     DataContextConfig,
     InMemoryStoreBackendDefaults,
 )
+from great_expectations.util import get_context
 
 
 def create_checkpoint(
@@ -268,7 +272,7 @@ def _create_context(
         concurrency=concurrency_config(),
     )
 
-    context = BaseDataContext(project_config=data_context_config)
+    context = get_context(project_config=data_context_config)
 
     if backend_api == "V3":
         datasource_config = {
@@ -308,7 +312,7 @@ def _create_context(
 
 
 def _add_checkpoint(
-    context: BaseDataContext,
+    context: AbstractDataContext,
     backend_api: str,
     datasource_name: str,
     data_connector_name: str,
@@ -356,7 +360,7 @@ def _add_checkpoint(
         raise ValueError(f"Unsupported backend_api {backend_api}")
 
 
-def _add_expectation_configuration(context: BaseDataContext, suite_name: str):
+def _add_expectation_configuration(context: AbstractDataContext, suite_name: str):
     suite = context.create_expectation_suite(expectation_suite_name=suite_name)
     suite.add_expectation(
         expectation_configuration=ExpectationConfiguration(

--- a/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
+++ b/tests/render/renderer/test_checkpoint_new_notebook_renderer.py
@@ -6,11 +6,11 @@ import pytest
 
 import great_expectations as gx
 from great_expectations import DataContext
-from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.render.renderer.checkpoint_new_notebook_renderer import (
     CheckpointNewNotebookRenderer,
 )
+from great_expectations.util import get_context
 
 
 @pytest.fixture
@@ -110,7 +110,7 @@ def test_find_datasource_with_asset_on_context_with_a_datasource_with_a_dataconn
     config = context.get_config_with_variables_substituted()
     root_directory = context.root_directory
 
-    context = BaseDataContext(project_config=config, context_root_dir=root_directory)
+    context = get_context(project_config=config, context_root_dir=root_directory)
 
     renderer = CheckpointNewNotebookRenderer(context, "foo")
     obs = renderer._find_datasource_with_asset()


### PR DESCRIPTION
Changes proposed in this pull request:
- As `get_context()` is our desired canonical entry point into context instantiation, let's use it in our tests.
- `BaseDataContext` is not formally deprecated but we want to emphasize the usage of our new, more lightweight method.


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
