### PR TITLE
[MAINTENANCE] Fix missing exclamation marks in API docs admonitions

### DIFF
--- a/src/css/api_docs/pydata-sphinx-theme-modified.scss
+++ b/src/css/api_docs/pydata-sphinx-theme-modified.scss
@@ -8913,7 +8913,7 @@ a.text-dark:focus, a.text-dark:hover {
   --pst-icon-check-circle: "\f058";
   --pst-icon-info-circle: "\f05a";
   --pst-icon-exclamation-triangle: "\f071";
-  --pst-icon-exclamation-circle: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3C!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. --%3E%3Cpath d='M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zm32 224c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z'/%3E%3C/svg%3E");
+  --pst-icon-exclamation-circle: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16px' height='16px' viewBox='0 0 512 512'%3E%3C!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. --%3E%3Cpath d='M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zm32 224c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z'/%3E%3C/svg%3E");
   --pst-icon-times-circle: "\f057";
   --pst-icon-lightbulb: "\f0eb";
   --pst-icon-download: "\f019";

--- a/src/css/api_docs/pydata-sphinx-theme-modified.scss
+++ b/src/css/api_docs/pydata-sphinx-theme-modified.scss
@@ -8913,7 +8913,7 @@ a.text-dark:focus, a.text-dark:hover {
   --pst-icon-check-circle: "\f058";
   --pst-icon-info-circle: "\f05a";
   --pst-icon-exclamation-triangle: "\f071";
-  --pst-icon-exclamation-circle: "";  // Removed since we are not currently using fontawesome
+  --pst-icon-exclamation-circle: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3C!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. --%3E%3Cpath d='M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zm32 224c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z'/%3E%3C/svg%3E");
   --pst-icon-times-circle: "\f057";
   --pst-icon-lightbulb: "\f0eb";
   --pst-icon-download: "\f019";
@@ -10358,7 +10358,8 @@ span.versionmodified:before {
 
 span.versionmodified.added:before {
   color: var(--pst-color-success);
-  content: var(--pst-icon-versionmodified-added)
+  // Note: Color is currently hardcoded into the svg below:
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16px' height='16px' viewBox='0 0 512 512'%3E%3C!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. --%3E%3Cpath fill='%2328a745' d='M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zm32 224c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z'/%3E%3C/svg%3E");
 }
 
 span.versionmodified.changed:before {
@@ -10368,7 +10369,8 @@ span.versionmodified.changed:before {
 
 span.versionmodified.deprecated:before {
   color: var(--pst-color-danger);
-  content: var(--pst-icon-versionmodified-deprecated)
+  // Note: Color is currently hardcoded into the svg below:
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16px' height='16px' viewBox='0 0 512 512'%3E%3C!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. --%3E%3Cpath fill='%23dc3545' d='M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zm0-384c13.3 0 24 10.7 24 24V264c0 13.3-10.7 24-24 24s-24-10.7-24-24V152c0-13.3 10.7-24 24-24zm32 224c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z'/%3E%3C/svg%3E");
 }
 
 .sidebar-indices-items {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add svgs of missing exclamation marks in API docs admonitions. See example image below:

![image](https://user-images.githubusercontent.com/9903066/211052156-1c397317-7388-43c3-be22-631c4a08fae7.png)

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas