### PR TITLE
[MAINTENANCE] Remove printing of entire snippet map in `remark-named-snippet` hook

### DIFF
--- a/docs/scripts/remark-named-snippets/index.js
+++ b/docs/scripts/remark-named-snippets/index.js
@@ -27,7 +27,6 @@ const constructSnippetMap = require('./snippet')
 function codeImport () {
   // Instantiated within the import so it can be hot-reloaded
   const snippetMap = constructSnippetMap('.')
-  console.log(snippetMap)
 
   return function transformer (tree, file) {
     const codes = []


### PR DESCRIPTION
Changes proposed in this pull request:
- Reduce verbosity of terminal output during docs compilation


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
