### PR TITLE
[BUGFIX] reformatting `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,9 @@ config = {
     "cmdclass": versioneer.get_cmdclass(),
     "install_requires": required,
     "extras_require": get_extras_require(),
-    "packages": find_packages(exclude=["contrib*", "docs*", "tests*", "examples*", "scripts*"]),
+    "packages": find_packages(
+        exclude=["contrib*", "docs*", "tests*", "examples*", "scripts*"]
+    ),
     "entry_points": {
         "console_scripts": ["great_expectations=great_expectations.cli:main"]
     },


### PR DESCRIPTION
* linting `setup.py`, which is currently giving us linting errors