### PR TITLE
[MAINTENANCE] Consistent use of Metric Name Enum values

### DIFF
--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/profile_numeric_columns_diff_expectation.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/profile_numeric_columns_diff_expectation.py
@@ -5,6 +5,7 @@ from great_expectations.execution_engine.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import TableExpectation
 from great_expectations.expectations.registry import get_metric_kwargs
 from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.validator import ValidationDependencies
 
 
 class ProfileNumericColumnsDiffExpectation(TableExpectation):
@@ -19,8 +20,8 @@ class ProfileNumericColumnsDiffExpectation(TableExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ):
-        dependencies = super().get_validation_dependencies(
+    ) -> ValidationDependencies:
+        dependencies: ValidationDependencies = super().get_validation_dependencies(
             configuration, execution_engine, runtime_configuration
         )
         assert isinstance(

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
@@ -8,7 +8,10 @@ from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
 from great_expectations.core.metric_domain_types import MetricDomainTypes
-from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypes,
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.exceptions.exceptions import InvalidExpectationKwargsError
 from great_expectations.execution_engine import (
     ExecutionEngine,
@@ -24,6 +27,7 @@ from great_expectations.expectations.metrics.import_manager import F, Window, sp
 from great_expectations.expectations.metrics.metric_provider import metric_partial
 from great_expectations.expectations.registry import get_metric_kwargs
 from great_expectations.validator.metric_configuration import MetricConfiguration
+from great_expectations.validator.validator import ValidationDependencies
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +226,7 @@ class ExpectColumnValuesToBeStringIntegersIncreasing(ColumnExpectation):
         configuration: Optional[ExpectationConfiguration] = None,
         execution_engine: Optional[ExecutionEngine] = None,
         runtime_configuration: Optional[dict] = None,
-    ) -> dict:
+    ) -> ValidationDependencies:
 
         dependencies = super().get_validation_dependencies(
             configuration=configuration,
@@ -230,15 +234,15 @@ class ExpectColumnValuesToBeStringIntegersIncreasing(ColumnExpectation):
             runtime_configuration=runtime_configuration,
         )
         metric_kwargs = get_metric_kwargs(
-            metric_name="column_values.string_integers.increasing.map",
+            metric_name=f"column_values.string_integers.increasing.{MetricPartialFunctionTypeSuffixes.MAP.value}",
             configuration=configuration,
             runtime_configuration=runtime_configuration,
         )
 
         dependencies.set_metric_configuration(
-            metric_name="column_values.string_integers.increasing.map",
+            metric_name=f"column_values.string_integers.increasing.{MetricPartialFunctionTypeSuffixes.MAP.value}",
             metric_configuration=MetricConfiguration(
-                metric_name="column_values.string_integers.increasing.map",
+                metric_name=f"column_values.string_integers.increasing.{MetricPartialFunctionTypeSuffixes.MAP.value}",
                 metric_domain_kwargs=metric_kwargs["metric_domain_kwargs"],
                 metric_value_kwargs=metric_kwargs["metric_value_kwargs"],
             ),
@@ -252,10 +256,10 @@ class ExpectColumnValuesToBeStringIntegersIncreasing(ColumnExpectation):
         metrics: Dict,
         runtime_configuration: dict = None,
         execution_engine: ExecutionEngine = None,
-    ) -> Dict:
+    ) -> ExpectationValidationResult:
 
         string_integers_increasing = metrics.get(
-            "column_values.string_integers.increasing.map"
+            f"column_values.string_integers.increasing.{MetricPartialFunctionTypeSuffixes.MAP.value}"
         )
 
         success = all(string_integers_increasing[0])

--- a/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_column_values_to_be_string_integers_increasing.py
@@ -228,7 +228,7 @@ class ExpectColumnValuesToBeStringIntegersIncreasing(ColumnExpectation):
         runtime_configuration: Optional[dict] = None,
     ) -> ValidationDependencies:
 
-        dependencies = super().get_validation_dependencies(
+        dependencies: ValidationDependencies = super().get_validation_dependencies(
             configuration=configuration,
             execution_engine=execution_engine,
             runtime_configuration=runtime_configuration,

--- a/great_expectations/core/metric_function_types.py
+++ b/great_expectations/core/metric_function_types.py
@@ -11,28 +11,34 @@ class MetricFunctionTypes(enum.Enum):
     AGGREGATE_VALUE = "value"  # "aggregate_value"
 
 
+class MetricPartialFunctionTypeSuffixes(enum.Enum):
+    MAP = "map"
+    CONDITION = "condition"
+    AGGREGATE_FUNCTION = "aggregate_fn"
+
+
 class MetricPartialFunctionTypes(enum.Enum):
     MAP_FN = "map_fn"
     MAP_SERIES = "map_series"
+    WINDOW_FN = "window_fn"
     MAP_CONDITION_FN = "map_condition_fn"
     MAP_CONDITION_SERIES = "map_condition_series"
-    WINDOW_FN = "window_fn"
     WINDOW_CONDITION_FN = "window_condition_fn"
     AGGREGATE_FN = "aggregate_fn"
 
     @property
     def metric_suffix(self) -> str:
         if self.name in ["MAP_FN", "MAP_SERIES", "WINDOW_FN"]:
-            return "map"
+            return MetricPartialFunctionTypeSuffixes.MAP.value
 
         if self.name in [
             "MAP_CONDITION_FN",
             "MAP_CONDITION_SERIES",
             "WINDOW_CONDITION_FN",
         ]:
-            return "condition"
+            return MetricPartialFunctionTypeSuffixes.CONDITION.value
 
         if self.name in ["AGGREGATE_FN"]:
-            return "aggregate_fn"
+            return MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value
 
         return ""

--- a/great_expectations/execution_engine/execution_engine.py
+++ b/great_expectations/execution_engine/execution_engine.py
@@ -4,7 +4,6 @@ import copy
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -21,6 +20,10 @@ from typing import (
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch_manager import BatchManager
 from great_expectations.core.metric_domain_types import MetricDomainTypes
+from great_expectations.core.metric_function_types import (
+    MetricFunctionTypes,
+    MetricPartialFunctionTypes,
+)
 from great_expectations.core.util import (
     AzureUrl,
     DBFSPath,
@@ -70,40 +73,6 @@ class NoOpDict:
     # noinspection PyMethodMayBeStatic,PyUnusedLocal
     def update(self, value):
         return None
-
-
-class MetricFunctionTypes(Enum):
-    VALUE = "value"
-    MAP_VALUES = "value"  # "map_values"
-    WINDOW_VALUES = "value"  # "window_values"
-    AGGREGATE_VALUE = "value"  # "aggregate_value"
-
-
-class MetricPartialFunctionTypes(Enum):
-    MAP_FN = "map_fn"
-    MAP_SERIES = "map_series"
-    MAP_CONDITION_FN = "map_condition_fn"
-    MAP_CONDITION_SERIES = "map_condition_series"
-    WINDOW_FN = "window_fn"
-    WINDOW_CONDITION_FN = "window_condition_fn"
-    AGGREGATE_FN = "aggregate_fn"
-
-    @property
-    def metric_suffix(self) -> str:
-        if self.name in ["MAP_FN", "MAP_SERIES", "WINDOW_FN"]:
-            return "map"
-
-        if self.name in [
-            "MAP_CONDITION_FN",
-            "MAP_CONDITION_SERIES",
-            "WINDOW_CONDITION_FN",
-        ]:
-            return "condition"
-
-        if self.name in ["AGGREGATE_FN"]:
-            return "aggregate_fn"
-
-        return ""
 
 
 @dataclass(frozen=True)

--- a/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
 from great_expectations.core import ExpectationConfiguration
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.execution_engine import (
     ExecutionEngine,
     PandasExecutionEngine,
@@ -23,17 +26,23 @@ class ColumnValuesValueLengthEquals(ColumnMapMetricProvider):
 
     @column_condition_partial(engine=PandasExecutionEngine)
     def _pandas(cls, column, value, _metrics, **kwargs):
-        column_lengths, _, _ = _metrics.get("column_values.value_length.map")
+        column_lengths, _, _ = _metrics.get(
+            f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        )
         return column_lengths == value
 
     @column_condition_partial(engine=SqlAlchemyExecutionEngine)
     def _sqlalchemy(cls, column, value, _metrics, **kwargs):
-        column_lengths, _, _ = _metrics.get("column_values.value_length.map")
+        column_lengths, _, _ = _metrics.get(
+            f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        )
         return column_lengths == value
 
     @column_condition_partial(engine=SparkDFExecutionEngine)
     def _spark(cls, column, value, _metrics, **kwargs):
-        column_lengths, _, _ = _metrics.get("column_values.value_length.map")
+        column_lengths, _, _ = _metrics.get(
+            f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        )
         return column_lengths == value
 
     @classmethod
@@ -51,9 +60,14 @@ class ColumnValuesValueLengthEquals(ColumnMapMetricProvider):
             runtime_configuration=runtime_configuration,
         )
 
-        if metric.metric_name == "column_values.value_length.equals.condition":
-            dependencies["column_values.value_length.map"] = MetricConfiguration(
-                metric_name="column_values.value_length.map",
+        if (
+            metric.metric_name
+            == f"column_values.value_length.equals.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+        ):
+            dependencies[
+                f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+            ] = MetricConfiguration(
+                metric_name=f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}",
                 metric_domain_kwargs=metric.metric_domain_kwargs,
             )
 
@@ -92,9 +106,11 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
         max_value=None,
         strict_min=None,
         strict_max=None,
-        **kwargs
+        **kwargs,
     ):
-        column_lengths, _, _ = _metrics.get("column_values.value_length.map")
+        column_lengths, _, _ = _metrics.get(
+            f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        )
 
         metric_series = None
         if min_value is not None and max_value is not None:
@@ -139,9 +155,11 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
         max_value=None,
         strict_min=None,
         strict_max=None,
-        **kwargs
+        **kwargs,
     ):
-        column_lengths, _, _ = _metrics.get("column_values.value_length.map")
+        column_lengths, _, _ = _metrics.get(
+            f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        )
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
@@ -178,9 +196,11 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
         max_value=None,
         strict_min=None,
         strict_max=None,
-        **kwargs
+        **kwargs,
     ):
-        column_lengths, _, _ = _metrics.get("column_values.value_length.map")
+        column_lengths, _, _ = _metrics.get(
+            f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        )
 
         if min_value is None and max_value is None:
             raise ValueError("min_value and max_value cannot both be None")
@@ -220,9 +240,14 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
             runtime_configuration=runtime_configuration,
         )
 
-        if metric.metric_name == "column_values.value_length.between.condition":
-            dependencies["column_values.value_length.map"] = MetricConfiguration(
-                metric_name="column_values.value_length.map",
+        if (
+            metric.metric_name
+            == f"column_values.value_length.between.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+        ):
+            dependencies[
+                f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+            ] = MetricConfiguration(
+                metric_name=f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}",
                 metric_domain_kwargs=metric.metric_domain_kwargs,
             )
 

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_z_score.py
@@ -3,6 +3,9 @@ from typing import Optional
 import pandas as pd
 
 from great_expectations.core import ExpectationConfiguration
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.execution_engine import (
     ExecutionEngine,
     PandasExecutionEngine,
@@ -47,7 +50,10 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
     def _pandas_condition(
         cls, column, _metrics, threshold, double_sided, **kwargs
     ) -> pd.Series:
-        z_score, _, _ = _metrics["column_values.z_score.map"]
+        z_score: pd.Series
+        z_score, _, _ = _metrics[
+            f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        ]
         try:
             if double_sided:
                 under_threshold = z_score.abs() < abs(threshold)
@@ -67,8 +73,9 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
 
     @column_condition_partial(engine=SqlAlchemyExecutionEngine)
     def _sqlalchemy_condition(cls, column, _metrics, threshold, double_sided, **kwargs):
-
-        z_score, _, _ = _metrics["column_values.z_score.map"]
+        z_score, _, _ = _metrics[
+            f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        ]
         if double_sided:
             under_threshold = sa.func.abs(z_score) < abs(threshold)
         else:
@@ -85,7 +92,9 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
 
     @column_condition_partial(engine=SparkDFExecutionEngine)
     def _spark_condition(cls, column, _metrics, threshold, double_sided, **kwargs):
-        z_score, _, _ = _metrics["column_values.z_score.map"]
+        z_score, _, _ = _metrics[
+            f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        ]
 
         if double_sided:
             threshold = abs(threshold)
@@ -110,13 +119,21 @@ class ColumnValuesZScore(ColumnMapMetricProvider):
             runtime_configuration=runtime_configuration,
         )
 
-        if metric.metric_name == "column_values.z_score.under_threshold.condition":
-            dependencies["column_values.z_score.map"] = MetricConfiguration(
-                metric_name="column_values.z_score.map",
+        if (
+            metric.metric_name
+            == f"column_values.z_score.under_threshold.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+        ):
+            dependencies[
+                f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+            ] = MetricConfiguration(
+                metric_name=f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}",
                 metric_domain_kwargs=metric.metric_domain_kwargs,
             )
 
-        if metric.metric_name == "column_values.z_score.map":
+        if (
+            metric.metric_name
+            == f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        ):
             dependencies["column.mean"] = MetricConfiguration(
                 metric_name="column.mean",
                 metric_domain_kwargs=metric.metric_domain_kwargs,

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -12,6 +12,7 @@ from great_expectations.core.metric_domain_types import MetricDomainTypes
 from great_expectations.core.metric_function_types import (
     MetricFunctionTypes,
     MetricPartialFunctionTypes,
+    MetricPartialFunctionTypeSuffixes,
 )
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.execution_engine import (
@@ -3107,7 +3108,7 @@ class MapMetricProvider(MetricProvider):
                 )
                 if issubclass(engine, PandasExecutionEngine):
                     register_metric(
-                        metric_name=f"{metric_name}.condition",
+                        metric_name=f"{metric_name}.{metric_fn_type.metric_suffix}",
                         metric_domain_keys=metric_domain_keys,
                         metric_value_keys=metric_value_keys,
                         execution_engine=engine,
@@ -3210,7 +3211,7 @@ class MapMetricProvider(MetricProvider):
                         )
                 elif issubclass(engine, SqlAlchemyExecutionEngine):
                     register_metric(
-                        metric_name=f"{metric_name}.condition",
+                        metric_name=f"{metric_name}.{metric_fn_type.metric_suffix}",
                         metric_domain_keys=metric_domain_keys,
                         metric_value_keys=metric_value_keys,
                         execution_engine=engine,
@@ -3249,7 +3250,7 @@ class MapMetricProvider(MetricProvider):
                         if domain_type == MetricDomainTypes.COLUMN:
                             register_metric(
                                 metric_name=metric_name
-                                + f".unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+                                + f".unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.metric_suffix}",
                                 metric_domain_keys=metric_domain_keys,
                                 metric_value_keys=metric_value_keys,
                                 execution_engine=engine,
@@ -3347,7 +3348,7 @@ class MapMetricProvider(MetricProvider):
                         )
                 elif issubclass(engine, SparkDFExecutionEngine):
                     register_metric(
-                        metric_name=f"{metric_name}.condition",
+                        metric_name=f"{metric_name}.{metric_fn_type.metric_suffix}",
                         metric_domain_keys=metric_domain_keys,
                         metric_value_keys=metric_value_keys,
                         execution_engine=engine,
@@ -3386,7 +3387,7 @@ class MapMetricProvider(MetricProvider):
                         if domain_type == MetricDomainTypes.COLUMN:
                             register_metric(
                                 metric_name=metric_name
-                                + f".unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+                                + f".unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.metric_suffix}",
                                 metric_domain_keys=metric_domain_keys,
                                 metric_value_keys=metric_value_keys,
                                 execution_engine=engine,
@@ -3497,7 +3498,7 @@ class MapMetricProvider(MetricProvider):
                 metric_domain_keys = cls.function_domain_keys
                 metric_value_keys = cls.function_value_keys
                 register_metric(
-                    metric_name=f"{metric_name}.map",
+                    metric_name=f"{metric_name}.{metric_fn_type.metric_suffix}",
                     metric_domain_keys=metric_domain_keys,
                     metric_value_keys=metric_value_keys,
                     execution_engine=engine,
@@ -3524,7 +3525,7 @@ class MapMetricProvider(MetricProvider):
         if metric_name.endswith(metric_suffix):
             try:
                 _ = get_metric_provider(
-                    f"{metric_name}.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+                    f"{metric_name}.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
                     execution_engine,
                 )
                 has_aggregate_fn = True
@@ -3532,20 +3533,20 @@ class MapMetricProvider(MetricProvider):
                 has_aggregate_fn = False
             if has_aggregate_fn:
                 dependencies["metric_partial_fn"] = MetricConfiguration(
-                    metric_name=f"{metric_name}.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+                    metric_name=f"{metric_name}.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
                     metric_domain_kwargs=metric.metric_domain_kwargs,
                     metric_value_kwargs=base_metric_value_kwargs,
                 )
             else:
                 dependencies["unexpected_condition"] = MetricConfiguration(
-                    metric_name=f"{metric_name[:-len(metric_suffix)]}.condition",
+                    metric_name=f"{metric_name[:-len(metric_suffix)]}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
                     metric_domain_kwargs=metric.metric_domain_kwargs,
                     metric_value_kwargs=base_metric_value_kwargs,
                 )
 
         # MapMetric uses "condition" metric to build "unexpected_count.aggregate_fn" and other listed metrics as well.
         for metric_suffix in [
-            f".unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+            f".unexpected_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
             ".unexpected_value_counts",
             ".unexpected_index_query",
             ".unexpected_index_list",
@@ -3555,7 +3556,7 @@ class MapMetricProvider(MetricProvider):
         ]:
             if metric_name.endswith(metric_suffix):
                 dependencies["unexpected_condition"] = MetricConfiguration(
-                    metric_name=f"{metric_name[:-len(metric_suffix)]}.condition",
+                    metric_name=f"{metric_name[:-len(metric_suffix)]}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
                     metric_domain_kwargs=metric.metric_domain_kwargs,
                     metric_value_kwargs=base_metric_value_kwargs,
                 )

--- a/great_expectations/expectations/metrics/multicolumn_map_metrics/compound_columns_unique.py
+++ b/great_expectations/expectations/metrics/multicolumn_map_metrics/compound_columns_unique.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
 from great_expectations.core import ExpectationConfiguration
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.execution_engine import (
     ExecutionEngine,
     PandasExecutionEngine,
@@ -139,7 +142,9 @@ class CompoundColumnsUnique(MulticolumnMapMetricProvider):
         """
 
         metrics = kwargs.get("_metrics")
-        compound_columns_count_query, _, _ = metrics["compound_columns.count.map"]
+        compound_columns_count_query, _, _ = metrics[
+            f"compound_columns.count.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+        ]
 
         # noinspection PyProtectedMember
         row_wise_cond = compound_columns_count_query.c._num_rows < 2
@@ -175,9 +180,14 @@ class CompoundColumnsUnique(MulticolumnMapMetricProvider):
         )
 
         if isinstance(execution_engine, SqlAlchemyExecutionEngine):
-            if metric.metric_name == "compound_columns.unique.condition":
-                dependencies["compound_columns.count.map"] = MetricConfiguration(
-                    metric_name="compound_columns.count.map",
+            if (
+                metric.metric_name
+                == f"compound_columns.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+            ):
+                dependencies[
+                    f"compound_columns.count.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+                ] = MetricConfiguration(
+                    metric_name=f"compound_columns.count.{MetricPartialFunctionTypeSuffixes.MAP.value}",
                     metric_domain_kwargs=metric.metric_domain_kwargs,
                     metric_value_kwargs=None,
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,9 @@ from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
 )
 from great_expectations.core.metric_domain_types import MetricDomainTypes
-from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.core.usage_statistics.usage_statistics import (
     UsageStatisticsHandler,
 )
@@ -7118,7 +7120,7 @@ def table_row_count_metric_config() -> MetricConfiguration:
 @pytest.fixture
 def table_row_count_aggregate_fn_metric_config() -> MetricConfiguration:
     return MetricConfiguration(
-        metric_name=f"table.row_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"table.row_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )

--- a/tests/execution_engine/test_execution_engine.py
+++ b/tests/execution_engine/test_execution_engine.py
@@ -5,6 +5,9 @@ import pytest
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch import BatchData, BatchMarkers
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.execution_engine import ExecutionEngine, PandasExecutionEngine
 from great_expectations.expectations.row_conditions import (
     RowCondition,
@@ -207,7 +210,7 @@ def test_resolve_metrics_with_aggregates_and_column_map():
     metrics.update(results)
 
     desired_map_metric = MetricConfiguration(
-        metric_name="column_values.z_score.map",
+        metric_name=f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -222,12 +225,12 @@ def test_resolve_metrics_with_aggregates_and_column_map():
     metrics.update(results)
 
     desired_threshold_condition_metric = MetricConfiguration(
-        metric_name="column_values.z_score.under_threshold.condition",
+        metric_name=f"column_values.z_score.under_threshold.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"double_sided": True, "threshold": 2},
     )
     desired_threshold_condition_metric.metric_dependencies = {
-        "column_values.z_score.map": desired_map_metric,
+        f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}": desired_map_metric,
         "table.columns": table_columns_metric,
     }
     results = engine.resolve_metrics(
@@ -315,7 +318,7 @@ def test_resolve_metrics_with_incomplete_metric_input():
     )
 
     desired_metric = MetricConfiguration(
-        metric_name="column_values.z_score.map",
+        metric_name=f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )

--- a/tests/execution_engine/test_sparkdf_execution_engine.py
+++ b/tests/execution_engine/test_sparkdf_execution_engine.py
@@ -9,7 +9,9 @@ import pytest
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch_spec import PathBatchSpec, RuntimeDataBatchSpec
 from great_expectations.core.metric_domain_types import MetricDomainTypes
-from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.execution_engine import SparkDFExecutionEngine
 from great_expectations.expectations.row_conditions import (
     RowCondition,
@@ -734,7 +736,7 @@ def test_sparkdf_batch_aggregate_metrics(caplog, spark_session):
     metrics.update(results)
 
     desired_aggregate_fn_metric_1 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -742,7 +744,7 @@ def test_sparkdf_batch_aggregate_metrics(caplog, spark_session):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_2 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -750,7 +752,7 @@ def test_sparkdf_batch_aggregate_metrics(caplog, spark_session):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_3 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -758,7 +760,7 @@ def test_sparkdf_batch_aggregate_metrics(caplog, spark_session):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_4 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -1169,7 +1171,7 @@ def test_resolve_metric_bundle_with_compute_domain_kwargs_json_serialization(
     metrics.update(results)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column_values.length.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.length.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={
             "column": "names",
             "batch_id": "my_id",

--- a/tests/execution_engine/test_sqlalchemy_execution_engine.py
+++ b/tests/execution_engine/test_sqlalchemy_execution_engine.py
@@ -11,7 +11,9 @@ from great_expectations.core.batch_spec import (
     SqlAlchemyDatasourceBatchSpec,
 )
 from great_expectations.core.metric_domain_types import MetricDomainTypes
-from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.data_context.util import file_relative_path
 from great_expectations.execution_engine.sqlalchemy_batch_data import (
     SqlAlchemyBatchData,
@@ -170,7 +172,7 @@ def test_sa_batch_aggregate_metrics(caplog, sa):
     metrics.update(results)
 
     aggregate_fn_metric_1 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -178,7 +180,7 @@ def test_sa_batch_aggregate_metrics(caplog, sa):
         "table.columns": table_columns_metric,
     }
     aggregate_fn_metric_2 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -186,7 +188,7 @@ def test_sa_batch_aggregate_metrics(caplog, sa):
         "table.columns": table_columns_metric,
     }
     aggregate_fn_metric_3 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -194,7 +196,7 @@ def test_sa_batch_aggregate_metrics(caplog, sa):
         "table.columns": table_columns_metric,
     }
     aggregate_fn_metric_4 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -859,7 +861,7 @@ def test_resolve_metric_bundle_with_compute_domain_kwargs_json_serialization(sa)
     metrics.update(results)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column_values.length.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.length.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={
             "column": "names",
             "batch_id": "1234",
@@ -944,7 +946,7 @@ def test_sa_batch_unexpected_condition_temp_table(caplog, sa):
     validate_tmp_tables()
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )

--- a/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
+++ b/tests/expectations/metrics/column_map_metrics/test_unexpected_indices_and_query.py
@@ -3,6 +3,9 @@ from typing import Dict, Tuple
 import pandas as pd
 import pytest
 
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.exceptions import MetricResolutionError
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
@@ -86,7 +89,7 @@ def _build_table_columns_and_unexpected(
 
     # unexpected_condition metric
     unexpected_condition_metric: MetricConfiguration = MetricConfiguration(
-        metric_name="column_values.in_set.condition",
+        metric_name=f"column_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "animals"},
         metric_value_kwargs=metric_value_kwargs,
     )

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -9,7 +9,10 @@ import pytest
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch import Batch
-from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypes,
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
     SparkDFExecutionEngine,
@@ -279,7 +282,7 @@ def test_column_value_lengths_min_metric_sa(sa):
     metrics.update(results)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column_values.length.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.length.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={
             "column": "names",
         },
@@ -334,7 +337,7 @@ def test_column_value_lengths_min_metric_spark(spark_session):
     metrics.update(results)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column_values.length.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.length.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={
             "column": "names",
         },
@@ -429,7 +432,7 @@ def test_column_value_lengths_max_metric_sa(sa):
     metrics.update(results)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column_values.length.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.length.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={
             "column": "names",
         },
@@ -484,7 +487,7 @@ def test_column_value_lengths_max_metric_spark(spark_session):
     metrics.update(results)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column_values.length.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.length.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={
             "column": "names",
         },
@@ -551,7 +554,7 @@ def test_quantiles_metric_sa(sa):
     metrics.update(results)
 
     partial_metric = MetricConfiguration(
-        metric_name=f"table.row_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"table.row_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
@@ -1029,7 +1032,7 @@ def test_column_partition_metric_sa(sa):
     metrics.update(results)
 
     partial_column_min_metric = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -1037,7 +1040,7 @@ def test_column_partition_metric_sa(sa):
         "table.columns": table_columns_metric,
     }
     partial_column_max_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -1116,7 +1119,7 @@ def test_column_partition_metric_sa(sa):
     metrics.update(results)
 
     partial_column_min_metric = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -1124,7 +1127,7 @@ def test_column_partition_metric_sa(sa):
         "table.columns": table_columns_metric,
     }
     partial_column_max_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -1272,7 +1275,7 @@ def test_column_partition_metric_spark(spark_session):
     metrics.update(results)
 
     partial_column_min_metric = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -1280,7 +1283,7 @@ def test_column_partition_metric_spark(spark_session):
         "table.columns": table_columns_metric,
     }
     partial_column_max_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -1359,7 +1362,7 @@ def test_column_partition_metric_spark(spark_session):
     metrics.update(results)
 
     partial_column_min_metric = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -1367,7 +1370,7 @@ def test_column_partition_metric_spark(spark_session):
         "table.columns": table_columns_metric,
     }
     partial_column_max_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -1519,7 +1522,7 @@ def test_max_metric_column_exists_sa(sa):
     metrics.update(results)
 
     partial_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -1561,7 +1564,7 @@ def test_max_metric_column_does_not_exist_sa(sa):
     metrics.update(results)
 
     partial_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "non_existent_column"},
         metric_value_kwargs=None,
     )
@@ -1597,7 +1600,7 @@ def test_max_metric_column_exists_spark(spark_session):
     metrics.update(results)
 
     partial_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -1643,7 +1646,7 @@ def test_max_metric_column_does_not_exist_spark(spark_session):
     metrics.update(results)
 
     partial_metric = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "non_existent_column"},
         metric_value_kwargs=None,
     )
@@ -1675,7 +1678,7 @@ def test_map_value_set_sa(sa):
     metrics.update(results)
 
     desired_metric = MetricConfiguration(
-        metric_name="column_values.in_set.condition",
+        metric_name=f"column_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"value_set": [1, 2, 3]},
     )
@@ -1688,7 +1691,7 @@ def test_map_value_set_sa(sa):
 
     # Note: metric_dependencies is optional here in the config when called from a validator.
     aggregate_partial = MetricConfiguration(
-        metric_name=f"column_values.in_set.unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.in_set.unexpected_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"value_set": [1, 2, 3]},
     )
@@ -1754,7 +1757,7 @@ def test_map_value_set_spark(spark_session, basic_spark_df_execution_engine):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.in_set.condition",
+        metric_name=f"column_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column": "a",
         },
@@ -1772,7 +1775,7 @@ def test_map_value_set_spark(spark_session, basic_spark_df_execution_engine):
 
     # Note: metric_dependencies is optional here in the config when called from a validator.
     aggregate_partial = MetricConfiguration(
-        metric_name=f"column_values.in_set.unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.in_set.unexpected_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={
             "column": "a",
         },
@@ -1814,7 +1817,7 @@ def test_map_value_set_spark(spark_session, basic_spark_df_execution_engine):
     engine.load_batch_data(batch_id="my_id", batch_data=df)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.in_set.condition",
+        metric_name=f"column_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"value_set": [1, 2, 3]},
     )
@@ -1828,7 +1831,7 @@ def test_map_value_set_spark(spark_session, basic_spark_df_execution_engine):
 
     # Note: metric_dependencies is optional here in the config when called from a validator.
     aggregate_partial = MetricConfiguration(
-        metric_name=f"column_values.in_set.unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.in_set.unexpected_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"value_set": [1, 2, 3]},
     )
@@ -1869,7 +1872,7 @@ def test_map_column_value_lengths_between_pd():
     metrics.update(results)
 
     desired_metric = MetricConfiguration(
-        metric_name="column_values.value_length.map",
+        metric_name=f"column_values.value_length.{MetricPartialFunctionTypeSuffixes.MAP.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -1916,7 +1919,7 @@ def test_map_column_values_increasing_pd():
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.increasing.condition",
+        metric_name=f"column_values.increasing.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
             "strictly": True,
@@ -2017,7 +2020,7 @@ def test_map_column_values_increasing_spark(spark_session):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.increasing.condition",
+        metric_name=f"column_values.increasing.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
             "strictly": True,
@@ -2105,7 +2108,7 @@ def test_map_column_values_decreasing_pd():
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.decreasing.condition",
+        metric_name=f"column_values.decreasing.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
             "strictly": True,
@@ -2206,7 +2209,7 @@ def test_map_column_values_decreasing_spark(spark_session):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.decreasing.condition",
+        metric_name=f"column_values.decreasing.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={
             "strictly": True,
@@ -2275,7 +2278,7 @@ def test_map_unique_column_exists_pd():
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2337,7 +2340,7 @@ def test_map_unique_column_does_not_exist_pd():
     metrics.update(results)
 
     desired_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "non_existent_column"},
         metric_value_kwargs=None,
     )
@@ -2373,7 +2376,7 @@ def test_map_unique_column_exists_sa(sa):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2469,7 +2472,7 @@ def test_map_unique_column_does_not_exist_sa(sa):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "non_existent_column"},
         metric_value_kwargs=None,
     )
@@ -2499,7 +2502,7 @@ def test_map_unique_empty_query_sa(sa):
     table_columns_metric, metrics = get_table_columns_metric(engine=engine)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2548,7 +2551,7 @@ def test_map_unique_column_exists_spark(spark_session):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2650,7 +2653,7 @@ def test_map_unique_column_does_not_exist_spark(spark_session):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_values.unique.condition",
+        metric_name=f"column_values.unique.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "non_existent_column"},
         metric_value_kwargs=None,
     )
@@ -2704,7 +2707,7 @@ def test_z_score_under_threshold_pd():
     metrics.update(results)
 
     column_values_z_score_map_metric = MetricConfiguration(
-        metric_name="column_values.z_score.map",
+        metric_name=f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2718,12 +2721,12 @@ def test_z_score_under_threshold_pd():
     )
     metrics.update(results)
     column_values_z_score_under_threshold_condition_metric = MetricConfiguration(
-        metric_name="column_values.z_score.under_threshold.condition",
+        metric_name=f"column_values.z_score.under_threshold.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"double_sided": True, "threshold": 2},
     )
     column_values_z_score_under_threshold_condition_metric.metric_dependencies = {
-        "column_values.z_score.map": column_values_z_score_map_metric,
+        f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}": column_values_z_score_map_metric,
         "table.columns": table_columns_metric,
     }
     results = engine.resolve_metrics(
@@ -2766,7 +2769,7 @@ def test_z_score_under_threshold_spark(spark_session):
     metrics.update(results)
 
     column_mean_aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column.mean.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.mean.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2774,7 +2777,7 @@ def test_z_score_under_threshold_spark(spark_session):
         "table.columns": table_columns_metric,
     }
     column_standard_deviation_aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column.standard_deviation.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.standard_deviation.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2814,7 +2817,7 @@ def test_z_score_under_threshold_spark(spark_session):
     metrics.update(results)
 
     column_values_z_score_map_metric = MetricConfiguration(
-        metric_name="column_values.z_score.map",
+        metric_name=f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -2828,12 +2831,12 @@ def test_z_score_under_threshold_spark(spark_session):
     )
     metrics.update(results)
     condition_metric = MetricConfiguration(
-        metric_name="column_values.z_score.under_threshold.condition",
+        metric_name=f"column_values.z_score.under_threshold.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"double_sided": True, "threshold": 2},
     )
     condition_metric.metric_dependencies = {
-        "column_values.z_score.map": column_values_z_score_map_metric,
+        f"column_values.z_score.{MetricPartialFunctionTypeSuffixes.MAP.value}": column_values_z_score_map_metric,
         "table.columns": table_columns_metric,
     }
     results = engine.resolve_metrics(
@@ -2842,7 +2845,7 @@ def test_z_score_under_threshold_spark(spark_session):
     metrics.update(results)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"column_values.z_score.under_threshold.unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.z_score.under_threshold.unexpected_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs={"double_sided": True, "threshold": 2},
     )
@@ -2914,7 +2917,9 @@ def test_map_column_pairs_equal_metric_pd():
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "column_pair_values.equal"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -3103,7 +3108,7 @@ def test_table_metric_sa(sa):
     engine = build_sa_engine(pd.DataFrame({"a": [1, 2, 1, 2, 3, 3]}), sa)
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"table.row_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"table.row_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
@@ -3155,7 +3160,9 @@ def test_map_column_pairs_equal_metric_sa(sa):
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "column_pair_values.equal"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -3362,7 +3369,9 @@ def test_map_column_pairs_equal_metric_spark(spark_session):
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "column_pair_values.equal"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -3552,7 +3561,7 @@ def test_map_column_pairs_greater_metric_pd():
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.a_greater_than_b.condition",
+        metric_name=f"column_pair_values.a_greater_than_b.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -3629,7 +3638,7 @@ def test_map_column_pairs_greater_metric_sa(sa):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.a_greater_than_b.condition",
+        metric_name=f"column_pair_values.a_greater_than_b.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -3701,7 +3710,7 @@ def test_map_column_pairs_greater_metric_spark(spark_session):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.a_greater_than_b.condition",
+        metric_name=f"column_pair_values.a_greater_than_b.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -3765,7 +3774,7 @@ def test_map_column_pairs_in_set_metric_pd():
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.in_set.condition",
+        metric_name=f"column_pair_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -3808,7 +3817,7 @@ def test_map_column_pairs_in_set_metric_sa(sa):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.in_set.condition",
+        metric_name=f"column_pair_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -3859,7 +3868,7 @@ def test_map_column_pairs_in_set_metric_sa(sa):
     assert results[unexpected_values_metric.id] == [(10, 1), (9, 4)]
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.in_set.condition",
+        metric_name=f"column_pair_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -3932,7 +3941,7 @@ def test_map_column_pairs_in_set_metric_spark(spark_session):
     metrics.update(results)
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.in_set.condition",
+        metric_name=f"column_pair_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -3983,7 +3992,7 @@ def test_map_column_pairs_in_set_metric_spark(spark_session):
     assert results[unexpected_values_metric.id] == [(10, 1), (9, 4)]
 
     condition_metric = MetricConfiguration(
-        metric_name="column_pair_values.in_set.condition",
+        metric_name=f"column_pair_values.in_set.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={
             "column_A": "a",
             "column_B": "b",
@@ -4048,7 +4057,7 @@ def test_table_metric_spark(spark_session):
     )
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"table.row_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"table.row_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
@@ -4127,7 +4136,7 @@ def test_column_median_metric_sa(sa, dataframe: pd.DataFrame, median: int):
     metrics.update(results)
 
     partial_metric = MetricConfiguration(
-        metric_name=f"table.row_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"table.row_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
@@ -4151,7 +4160,7 @@ def test_column_median_metric_sa(sa, dataframe: pd.DataFrame, median: int):
     metrics.update(results)
 
     column_values_null_condition_metric = MetricConfiguration(
-        metric_name="column_values.null.condition",
+        metric_name=f"column_values.null.{MetricPartialFunctionTypeSuffixes.CONDITION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4205,7 +4214,7 @@ def test_column_median_metric_spark(spark_session):
     )
 
     aggregate_fn_metric = MetricConfiguration(
-        metric_name=f"table.row_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"table.row_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4378,7 +4387,7 @@ def test_distinct_metric_spark(
     assert metrics[column_distinct_values_metric.id] == {1, 2, 3}
 
     column_distinct_values_count_metric_partial_fn = MetricConfiguration(
-        metric_name=f"column.distinct_values.count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.distinct_values.count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4466,7 +4475,7 @@ def test_distinct_metric_sa(
     assert metrics[column_distinct_values_metric.id] == {1, 2, 3}
 
     column_distinct_values_count_metric_partial_fn = MetricConfiguration(
-        metric_name=f"column.distinct_values.count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.distinct_values.count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4695,7 +4704,7 @@ def test_batch_aggregate_metrics_sa(caplog, sa):
     metrics.update(results)
 
     desired_aggregate_fn_metric_1 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4703,7 +4712,7 @@ def test_batch_aggregate_metrics_sa(caplog, sa):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_2 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4711,7 +4720,7 @@ def test_batch_aggregate_metrics_sa(caplog, sa):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_3 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -4719,7 +4728,7 @@ def test_batch_aggregate_metrics_sa(caplog, sa):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_4 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -4825,7 +4834,7 @@ def test_batch_aggregate_metrics_spark(caplog, spark_session):
     metrics.update(results)
 
     desired_aggregate_fn_metric_1 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4833,7 +4842,7 @@ def test_batch_aggregate_metrics_spark(caplog, spark_session):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_2 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "a"},
         metric_value_kwargs=None,
     )
@@ -4841,7 +4850,7 @@ def test_batch_aggregate_metrics_spark(caplog, spark_session):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_3 = MetricConfiguration(
-        metric_name=f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -4849,7 +4858,7 @@ def test_batch_aggregate_metrics_spark(caplog, spark_session):
         "table.columns": table_columns_metric,
     }
     desired_aggregate_fn_metric_4 = MetricConfiguration(
-        metric_name=f"column.min.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column.min.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={"column": "b"},
         metric_value_kwargs=None,
     )
@@ -4955,7 +4964,9 @@ def test_map_multicolumn_sum_equal_pd():
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "multicolumn_sum.equal"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -5159,7 +5170,9 @@ def test_map_multicolumn_sum_equal_sa(sa):
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "multicolumn_sum.equal"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -5353,7 +5366,9 @@ def test_map_multicolumn_sum_equal_spark(spark_session):
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "multicolumn_sum.equal"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -5545,7 +5560,9 @@ def test_map_compound_columns_unique_pd():
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "compound_columns.unique"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -5742,7 +5759,9 @@ def test_map_compound_columns_unique_sa(sa):
     # Save original metrics for testing unexpected results.
     metrics_save: dict = copy.deepcopy(metrics)
 
-    prerequisite_function_metric_name: str = "compound_columns.count.map"
+    prerequisite_function_metric_name: str = (
+        f"compound_columns.count.{MetricPartialFunctionTypeSuffixes.MAP.value}"
+    )
 
     prerequisite_function_metric = MetricConfiguration(
         metric_name=prerequisite_function_metric_name,
@@ -5761,7 +5780,9 @@ def test_map_compound_columns_unique_sa(sa):
     metrics.update(results)
 
     metric_name: str = "compound_columns.unique"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -5776,7 +5797,7 @@ def test_map_compound_columns_unique_sa(sa):
         metric_value_kwargs=None,
     )
     condition_metric.metric_dependencies = {
-        "compound_columns.count.map": prerequisite_function_metric,
+        f"compound_columns.count.{MetricPartialFunctionTypeSuffixes.MAP.value}": prerequisite_function_metric,
         "table.columns": table_columns_metric,
     }
     results = engine.resolve_metrics(
@@ -5873,7 +5894,7 @@ def test_map_compound_columns_unique_sa(sa):
         metric_value_kwargs=None,
     )
     condition_metric.metric_dependencies = {
-        "compound_columns.count.map": prerequisite_function_metric,
+        f"compound_columns.count.{MetricPartialFunctionTypeSuffixes.MAP.value}": prerequisite_function_metric,
         "table.columns": table_columns_metric,
     }
     results = engine.resolve_metrics(
@@ -5968,7 +5989,9 @@ def test_map_compound_columns_unique_spark(spark_session):
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "compound_columns.unique"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -6156,7 +6179,9 @@ def test_map_select_column_values_unique_within_record_pd():
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "select_column_values.unique.within_record"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -6399,7 +6424,9 @@ def test_map_select_column_values_unique_within_record_sa(sa):
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "select_column_values.unique.within_record"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"
@@ -6605,7 +6632,9 @@ def test_map_select_column_values_unique_within_record_spark(spark_session):
     metrics_save: dict = copy.deepcopy(metrics)
 
     metric_name: str = "select_column_values.unique.within_record"
-    condition_metric_name: str = f"{metric_name}.condition"
+    condition_metric_name: str = (
+        f"{metric_name}.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
     unexpected_count_metric_name: str = f"{metric_name}.unexpected_count"
     unexpected_rows_metric_name: str = f"{metric_name}.unexpected_rows"
     unexpected_values_metric_name: str = f"{metric_name}.unexpected_values"

--- a/tests/expectations/metrics/test_map_metric.py
+++ b/tests/expectations/metrics/test_map_metric.py
@@ -8,7 +8,9 @@ from great_expectations.core import (
 )
 from great_expectations.core.batch import Batch, BatchDefinition, BatchRequest
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
-from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
+from great_expectations.core.metric_function_types import (
+    MetricPartialFunctionTypeSuffixes,
+)
 from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.data_context.util import file_relative_path
@@ -241,7 +243,7 @@ def test_get_table_metric_provider_metric_dependencies(empty_sqlite_db):
     )
     assert (
         dependencies["metric_partial_fn"].id[0]
-        == f"column.max.{MetricPartialFunctionTypes.AGGREGATE_FN.value}"
+        == f"column.max.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}"
     )
 
     mp = ColumnMax()
@@ -278,7 +280,8 @@ def test_get_aggregate_count_aware_metric_dependencies(basic_spark_df_execution_
         metric, execution_engine=PandasExecutionEngine()
     )
     assert (
-        dependencies["unexpected_condition"].id[0] == "column_values.nonnull.condition"
+        dependencies["unexpected_condition"].id[0]
+        == f"column_values.nonnull.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
     )
 
     metric = MetricConfiguration(
@@ -291,17 +294,18 @@ def test_get_aggregate_count_aware_metric_dependencies(basic_spark_df_execution_
     )
     assert (
         dependencies["metric_partial_fn"].id[0]
-        == f"column_values.nonnull.unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}"
+        == f"column_values.nonnull.unexpected_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}"
     )
 
     metric = MetricConfiguration(
-        metric_name=f"column_values.nonnull.unexpected_count.{MetricPartialFunctionTypes.AGGREGATE_FN.value}",
+        metric_name=f"column_values.nonnull.unexpected_count.{MetricPartialFunctionTypeSuffixes.AGGREGATE_FUNCTION.value}",
         metric_domain_kwargs={},
         metric_value_kwargs=None,
     )
     dependencies = mp.get_evaluation_dependencies(metric)
     assert (
-        dependencies["unexpected_condition"].id[0] == "column_values.nonnull.condition"
+        dependencies["unexpected_condition"].id[0]
+        == f"column_values.nonnull.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
     )
 
 
@@ -313,7 +317,10 @@ def test_get_map_metric_dependencies():
         metric_value_kwargs=None,
     )
     dependencies = mp.get_evaluation_dependencies(metric)
-    assert dependencies["unexpected_condition"].id[0] == "foo.condition"
+    assert (
+        dependencies["unexpected_condition"].id[0]
+        == f"foo.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
 
     metric = MetricConfiguration(
         metric_name="foo.unexpected_rows",
@@ -321,7 +328,10 @@ def test_get_map_metric_dependencies():
         metric_value_kwargs=None,
     )
     dependencies = mp.get_evaluation_dependencies(metric)
-    assert dependencies["unexpected_condition"].id[0] == "foo.condition"
+    assert (
+        dependencies["unexpected_condition"].id[0]
+        == f"foo.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
 
     metric = MetricConfiguration(
         metric_name="foo.unexpected_values",
@@ -329,7 +339,10 @@ def test_get_map_metric_dependencies():
         metric_value_kwargs=None,
     )
     dependencies = mp.get_evaluation_dependencies(metric)
-    assert dependencies["unexpected_condition"].id[0] == "foo.condition"
+    assert (
+        dependencies["unexpected_condition"].id[0]
+        == f"foo.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
 
     metric = MetricConfiguration(
         metric_name="foo.unexpected_value_counts",
@@ -337,7 +350,10 @@ def test_get_map_metric_dependencies():
         metric_value_kwargs=None,
     )
     dependencies = mp.get_evaluation_dependencies(metric)
-    assert dependencies["unexpected_condition"].id[0] == "foo.condition"
+    assert (
+        dependencies["unexpected_condition"].id[0]
+        == f"foo.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
 
     metric = MetricConfiguration(
         metric_name="foo.unexpected_index_list",
@@ -345,7 +361,10 @@ def test_get_map_metric_dependencies():
         metric_value_kwargs=None,
     )
     dependencies = mp.get_evaluation_dependencies(metric)
-    assert dependencies["unexpected_condition"].id[0] == "foo.condition"
+    assert (
+        dependencies["unexpected_condition"].id[0]
+        == f"foo.{MetricPartialFunctionTypeSuffixes.CONDITION.value}"
+    )
 
 
 def test_is_sqlalchemy_metric_selectable():


### PR DESCRIPTION
### Scope
Right now, metric names are defined as `Enum` members, but used as `string` values.  This is extremely inconsistent and brittle as well as being error prone when logic needs to be constructed based on metric types.  The present work fixes this.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1358/GREAT-1527
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!