### PR TITLE
[BUGFIX] Fix observed value

### DIFF
--- a/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_to_have_n_distinct_values_with_condition.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/expect_queried_column_to_have_n_distinct_values_with_condition.py
@@ -84,7 +84,7 @@ class ExpectQueriedColumnToHaveNDistinctValuesWithCondition(QueryExpectation):
                 "success": False,
                 "result": {
                     "info": f"Expected {expected_num_of_distinct_values} but found {actual_num_of_distinct_values} distinct values",
-                    "observed_value": [list(row) for row in query_result],
+                    "observed_value": query_result,
                 },
             }
 


### PR DESCRIPTION
Hi, 
here is a fix for the observed value - after the change to the metric "query.template_values" by @alexsherstinsky the returned value from the metric is not SQL Alchemy row anymore, so no need to serialize it. 

Thanks!
 