### PR TITLE
[MAINTENANCE] Adjust gallery schedule and timeout

### DIFF
--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -83,7 +83,7 @@ stages:
 
     jobs:
       - job: build_gallery
-        timeoutInMinutes: 300
+        timeoutInMinutes: 420
         variables:
           python.version: '3.8'
           GE_pytest_opts: ''

--- a/azure-pipelines-expectation-gallery.yml
+++ b/azure-pipelines-expectation-gallery.yml
@@ -8,7 +8,7 @@
 # to ensure that the gallery is kept to-up-date with change.
 
 schedules:
-- cron: 0 */2 * * *
+- cron: 0 */6 * * *
   displayName: Scheduled Runs
   branches:
     include:


### PR DESCRIPTION
Now that even more contrib Expectations are working with more backends, the build_gallery job ran close to 5hrs! 

Changes proposed in this pull request:
- Scheduled runs every 6 hours instead of every 2 hours
- Timeout bumped from 5hrs to 7hrs