### PR TITLE
[BUGFIX] fix comment stripping when saving a zep configuration

### DIFF
--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -33,7 +33,7 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 yaml.default_flow_style = False
 
 if TYPE_CHECKING:
-    from great_expectations.alias_types import PathStr
+    from great_expectations.alias_types import JSONValues, PathStr
 
 
 class SerializableDataContext(AbstractDataContext):
@@ -93,15 +93,12 @@ class SerializableDataContext(AbstractDataContext):
                     logger.info(
                         f"Saving {len(self.zep_config.datasources)} ZEP Datasources to {config_filepath}"
                     )
-                    yaml.dump(
-                        {
-                            **self.config.commented_map,
-                            **self.zep_config._json_dict(),
-                        },
-                        outfile,
-                    )
-                else:
-                    self.config.to_yaml(outfile)
+                    zep_json_dict: dict[str, JSONValues] = self.zep_config._json_dict()
+                    self.config.commented_map["xdatasources"] = zep_json_dict[
+                        "xdatasources"
+                    ]
+
+                self.config.to_yaml(outfile)
         except PermissionError as e:
             logger.warning(f"Could not save project config to disk: {e}")
 

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -94,9 +94,7 @@ class SerializableDataContext(AbstractDataContext):
                         f"Saving {len(self.zep_config.datasources)} ZEP Datasources to {config_filepath}"
                     )
                     zep_json_dict: dict[str, JSONValues] = self.zep_config._json_dict()
-                    self.config.commented_map["xdatasources"] = zep_json_dict[
-                        "xdatasources"
-                    ]
+                    self.config._commented_map.update(zep_json_dict)
 
                 self.config.to_yaml(outfile)
         except PermissionError as e:

--- a/tests/experimental/datasources/test_viral_snippets.py
+++ b/tests/experimental/datasources/test_viral_snippets.py
@@ -219,6 +219,8 @@ def test_add_and_save_zep_datasource(
 
     assert datasource_name == ds.name
     assert datasource_name in final_yaml
+    # ensure comments preserved
+    assert "# Welcome to Great Expectations!" in final_yaml
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes proposed in this pull request:
- use the `CommentMap` when saving `zep_config` experimental datasources
- [x] add a test verifying comments are preserved

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
