### PR TITLE
[MAINTENANCE] Change execution_engine_type from method to property.

### DIFF
--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -227,7 +227,7 @@ class Datasource(
 
     def _execution_engine_type(self) -> Type[ExecutionEngine]:
         """Returns the execution engine to be used"""
-        return self.execution_engine_override or self.execution_engine_type()
+        return self.execution_engine_override or self.execution_engine_type
 
     def get_batch_list_from_batch_request(
         self, batch_request: BatchRequest
@@ -267,6 +267,7 @@ class Datasource(
         return asset
 
     # Abstract Methods
+    @property
     def execution_engine_type(self) -> Type[ExecutionEngine]:
         """Return the ExecutionEngine type use for this Datasource"""
         raise NotImplementedError(

--- a/great_expectations/experimental/datasources/pandas_datasource.py
+++ b/great_expectations/experimental/datasources/pandas_datasource.py
@@ -178,6 +178,7 @@ class PandasDatasource(Datasource):
     name: str
     assets: Dict[str, CSVAsset] = {}
 
+    @property
     def execution_engine_type(self) -> Type[ExecutionEngine]:
         """Return the PandasExecutionEngine unless the override is set"""
         from great_expectations.execution_engine.pandas_execution_engine import (

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -383,6 +383,7 @@ class SQLDatasource(Datasource):
     connection_string: str
     assets: Dict[str, TableAsset] = {}
 
+    @property
     def execution_engine_type(self) -> Type[ExecutionEngine]:
         """Returns the default execution engine type."""
         from great_expectations.execution_engine import SqlAlchemyExecutionEngine

--- a/tests/experimental/datasources/test_metadatasource.py
+++ b/tests/experimental/datasources/test_metadatasource.py
@@ -73,6 +73,7 @@ class TestMetaDatasource:
             asset_types: ClassVar[List[Type[DataAsset]]] = []
             type: str = "my_test"
 
+            @property
             def execution_engine_type(self) -> Type[ExecutionEngine]:
                 return DummyExecutionEngine
 
@@ -95,6 +96,7 @@ class TestMetaDatasource:
             asset_types: ClassVar[List[Type[DataAsset]]] = []
             type: str = "my_test"
 
+            @property
             def execution_engine_type(self) -> Type[ExecutionEngine]:
                 return DummyExecutionEngine
 
@@ -121,6 +123,7 @@ class TestMetaDatasource:
             asset_types: ClassVar = [FooAsset, BarAsset]
             type: str = "foo_bar"
 
+            @property
             def execution_engine_type(self) -> Type[ExecutionEngine]:
                 return DummyExecutionEngine
 
@@ -146,6 +149,7 @@ class TestMisconfiguredMetaDatasource:
         ):
 
             class MissingTypeDatasource(Datasource):
+                @property
                 def execution_engine_type(self) -> Type[ExecutionEngine]:
                     return DummyExecutionEngine
 
@@ -175,6 +179,7 @@ class TestMisconfiguredMetaDatasource:
                 type: str = "valid"
                 asset_types: ClassVar = [MissingTypeAsset]
 
+                @property
                 def execution_engine_type(self) -> Type[ExecutionEngine]:
                     return DummyExecutionEngine
 
@@ -195,6 +200,7 @@ def test_minimal_ds_to_asset_flow(context_sources_cleanup):
         asset_types = [RedAsset, BlueAsset]
         type: str = "purple"
 
+        @property
         def execution_engine_type(self) -> Type[ExecutionEngine]:
             return DummyExecutionEngine
 


### PR DESCRIPTION
From @NathanFarmer's feedback on a previous PR I've updated `Datasource.execution_engine_type` from a method to a property.

 
### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
