### PR TITLE
[MAINTENANCE] Only include relevant diagnostics info in gallery JSON

### DIFF
--- a/assets/scripts/build_gallery.py
+++ b/assets/scripts/build_gallery.py
@@ -341,6 +341,7 @@ def build_gallery(
             diagnostics = impl().run_diagnostics(
                 ignore_suppress=ignore_suppress,
                 ignore_only_for=ignore_only_for,
+                for_gallery=True,
                 debug_logger=logger,
                 only_consider_these_backends=only_consider_these_backends,
                 context=context,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1229,6 +1229,7 @@ class Expectation(metaclass=MetaExpectation):
         raise_exceptions_for_backends: bool = False,
         ignore_suppress: bool = False,
         ignore_only_for: bool = False,
+        for_gallery: bool = False,
         debug_logger: Optional[logging.Logger] = None,
         only_consider_these_backends: Optional[List[str]] = None,
         context: Optional[AbstractDataContext] = None,
@@ -1379,6 +1380,14 @@ class Expectation(metaclass=MetaExpectation):
             for test_result in test_results
             if test_result.error_diagnostics
         ]
+
+        # If run for the gallery, don't include a bunch of stuff
+        if for_gallery:
+            examples = []
+            gallery_examples = []
+            renderers = []
+            test_results = []
+            errors = []
 
         return ExpectationDiagnostics(
             library_metadata=library_metadata,


### PR DESCRIPTION
Changes proposed in this pull request:
- When run_diagnostics is called by build_gallery, only return relevant useful info