### PR TITLE
[MAINTENANCE] Use shortened_dotted_paths in API docs

### DIFF
--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -211,7 +211,7 @@ class SphinxInvokeDocsBuilder:
         directories inside of /docs/reference/api/
         """
         # URL is an environment variable provided by Netlify
-        base_url = os.getenv("URL", "https://localhost:3000")
+        base_url = os.getenv("URL", "http://localhost:3000")
         return f"{base_url}/docs/reference/api/"
 
     def _remove_temp_html(self) -> None:
@@ -279,6 +279,16 @@ class SphinxInvokeDocsBuilder:
 
         class_name = self._get_entity_name(definition=definition)
         dotted_path = f"{dotted_path_prefix}.{class_name}"
+
+        # Note: shortened_dotted_paths is temporary,
+        # to be replaced with automated method using AST parsing:
+        shortened_dotted_paths = {
+            "great_expectations.data_context.data_context.abstract_data_context.AbstractDataContext": "great_expectations.data_context.AbstractDataContext",
+            "great_expectations.core.expectation_suite.ExpectationSuite": "great_expectations.core.ExpectationSuite",
+        }
+
+        if dotted_path in shortened_dotted_paths:
+            return shortened_dotted_paths[dotted_path]
 
         return dotted_path
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Reference the shortened path that is typically used, rather than the full path as shown in the API docs. For example via importing in `__init__.py` we can reference `AbstractDataContext` via `great_expectations.data_context.AbstractDataContext` instead of `great_expectations.data_context.data_context.abstract_data_context.AbstractDataContext`
- Follow up PR via DX-218 coming to use AST parsing to determine this in an automated way, this PR is to fix existing docs using a manual approach.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.