### PR TITLE
[MAINTENANCE] Use shortened dotted paths in api docs

### DIFF
--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -279,7 +279,9 @@ class SphinxInvokeDocsBuilder:
     def _create_class_md_stub(self, definition: Definition) -> str:
         """Create the markdown stub content for a class."""
         class_name = self._get_entity_name(definition=definition)
-        dotted_import = get_shortest_dotted_path(definition=definition)
+        dotted_import = get_shortest_dotted_path(
+            definition=definition, repo_root_path=self.repo_root
+        )
         return f"""# {class_name}
 
 ```{{eval-rst}}

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -374,6 +374,67 @@ class CodeParser:
         return function_definitions
 
 
+def get_shortest_dotted_path(definition: Definition) -> str:
+    """Get the shortest dotted path to a class definition.
+
+    e.g. if a class is imported in a parent __init__.py file use that
+    instead of the file with the class definition.
+
+    Args:
+        definition: Class definition.
+
+    Returns:
+        Dotted representation of shortest import path
+            e.g. great_expectations.core.ExpectationSuite
+    """
+
+    # Traverse parent folders from definition.filepath
+    shortest_path_prefix = str(".".join(definition.filepath.parts)).replace(".py", "")
+    shortest_path = f"{shortest_path_prefix}.{definition.name}"
+
+    path_parts = list(definition.filepath.parts)
+    while path_parts:
+        # Keep traversing, shortening path if shorter path is found.
+        path_parts.pop()
+        # if __init__.py is found, ast parse and check for import of the class
+        init_path = pathlib.Path(*path_parts, "__init__.py")
+        if init_path.is_file():
+
+            import_names = []
+            with open(init_path) as f:
+                file_contents: str = f.read()
+
+            import_names.extend(_get_import_names(file_contents))
+
+            # If name is found in imports, shorten path to where __init__.py is found
+            if definition.name in import_names:
+                shortest_path_prefix = str(".".join(path_parts))
+                shortest_path = f"{shortest_path_prefix}.{definition.name}"
+
+    return shortest_path
+
+
+def _get_import_names(code: str) -> List[str]:
+    """Get import names from import statements.
+
+    Args:
+        code: Code with imports to parse.
+
+    Returns:
+        Flattened list of names from imports.
+    """
+
+    tree = ast.parse(code)
+
+    import_names = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                import_names.append(alias.name)
+
+    return import_names
+
+
 class PublicAPIChecker:
     """Check if functions, methods and classes are marked part of the PublicAPI."""
 

--- a/tests/scripts/test_public_api_report.py
+++ b/tests/scripts/test_public_api_report.py
@@ -288,12 +288,12 @@ def test_get_shortest_dotted_path(monkeypatch):
 
     # This is the actual path
     assert (
-        get_shortest_dotted_path(definition)
+        get_shortest_dotted_path(definition=definition, repo_root_path=repo_root)
         != "great_expectations.core.expectation_suite.ExpectationSuite"
     )
     # This is the shortest path
     assert (
-        get_shortest_dotted_path(definition)
+        get_shortest_dotted_path(definition=definition, repo_root_path=repo_root)
         == "great_expectations.core.ExpectationSuite"
     )
 

--- a/tests/scripts/test_public_api_report.py
+++ b/tests/scripts/test_public_api_report.py
@@ -14,7 +14,6 @@ from scripts.public_api_report import (
     PublicAPIChecker,
     PublicAPIReport,
     _get_import_names,
-    _parse_file_to_ast_tree,
     get_shortest_dotted_path,
 )
 

--- a/tests/scripts/test_public_api_report.py
+++ b/tests/scripts/test_public_api_report.py
@@ -13,6 +13,9 @@ from scripts.public_api_report import (
     IncludeExcludeDefinition,
     PublicAPIChecker,
     PublicAPIReport,
+    _get_import_names,
+    _parse_file_to_ast_tree,
+    get_shortest_dotted_path,
 )
 
 
@@ -266,6 +269,67 @@ class TestCodeParser:
                 "great_expectations/sample_with_definitions_python_file_string.py"
             )
         }
+
+
+def test_get_shortest_dotted_path(monkeypatch):
+    """Test path traversal using an example file.
+
+    The example is just any class that is imported in a __init__.py file in a
+    parent folder. This test can be modified to use any such import e.g. if the
+    example file changes, or a fixture created so the example isn't coming
+    from the repo.
+    """
+    repo_root = pathlib.Path(__file__).parent.parent.parent
+    monkeypatch.chdir(repo_root)
+    filepath = pathlib.Path("great_expectations/core/expectation_suite.py")
+    definition = Definition(
+        name="ExpectationSuite", filepath=filepath, ast_definition=ast.ClassDef()
+    )
+
+    # This is the actual path
+    assert (
+        get_shortest_dotted_path(definition)
+        != "great_expectations.core.expectation_suite.ExpectationSuite"
+    )
+    # This is the shortest path
+    assert (
+        get_shortest_dotted_path(definition)
+        == "great_expectations.core.ExpectationSuite"
+    )
+
+
+@pytest.fixture
+def various_imports() -> str:
+    return """import some_module
+import SomeClass
+from some_module import ClassFromSomeModule
+from some_other_module import ClassFromSomeOtherModule
+import AliasClass as ac
+import alias_module as am
+from alias_module import AliasClassFromAliasModule as acfam
+from a.b.c import some_method as sm
+"""
+
+
+def test__get_import_names(various_imports: str):
+    """Make sure the actual class and module names are returned."""
+    tree = ast.parse(various_imports)
+    import_names = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            import_names.extend(_get_import_names(node))
+
+    assert import_names == [
+        "some_module",
+        "SomeClass",
+        "ClassFromSomeModule",
+        "ClassFromSomeOtherModule",
+        "AliasClass",
+        "alias_module",
+        "AliasClassFromAliasModule",
+        "some_method",
+    ]
 
 
 @pytest.fixture


### PR DESCRIPTION
Changes proposed in this pull request:
- Use shortened paths in API docs. E.g. if a class is imported in a parent `__init__.py` file use that instead of the file with the class definition. For example, `great_expectations.core.ExpectationSuite` instead of `great_expectations.core.expectation_suite.ExpectationSuite`. This appears in API docs in the class definitions.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.