### PR TITLE
[MAINTENANCE] Change public_api task name to avoid confusion

### DIFF
--- a/docs/sphinx_api_docs_source/tasks.py
+++ b/docs/sphinx_api_docs_source/tasks.py
@@ -27,14 +27,14 @@ def docs(ctx):
     doc_builder.build_docs()
 
 
-@invoke.task
-def public_api(ctx):
+@invoke.task(name="public-api")
+def public_api_task(ctx):
     """Generate a report to determine the state of our Public API. Lists classes, methods and functions that are used in examples in our documentation, and any manual includes or excludes (see public_api_report.py). Items listed when generating this report need the @public_api decorator (and a good docstring) or to be excluded from consideration if they are not applicable to our Public API."""
 
     sphinx_api_docs_source_dir = pathlib.Path(__file__).parent
 
     _exit_with_error_if_not_run_from_correct_dir(
-        task_name="public_api", correct_dir=sphinx_api_docs_source_dir
+        task_name="public-api", correct_dir=sphinx_api_docs_source_dir
     )
 
     public_api_report.main()


### PR DESCRIPTION
Changes proposed in this pull request:
- The public_api decorator should not be imported from tasks.py - this PR makes the task a different name to avoid confusion.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.