### PR TITLE
[MAINTENANCE] Add the fragment back to internal references

### DIFF
--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -178,10 +178,23 @@ class SphinxInvokeDocsBuilder:
                 internal_refs = doc.find_all(class_="reference internal")
                 for internal_ref in internal_refs:
                     href = internal_ref["href"]
+
+                    split_href = href.split("#")
+
                     shortened_path_version = self._get_mdx_file_path(
-                        pathlib.Path(href.split("#")[0])
+                        pathlib.Path(split_href[0])
                     ).with_suffix(".html")
-                    absolute_href = self._get_base_url() + str(shortened_path_version)
+
+                    fragment = ""
+                    if len(split_href) > 1:
+                        fragment = split_href[1]
+
+                    absolute_href = (
+                        self._get_base_url()
+                        + str(shortened_path_version)
+                        + "#"
+                        + fragment
+                    )
                     internal_ref["href"] = absolute_href
 
                 doc_str = str(doc)


### PR DESCRIPTION
Changes proposed in this pull request:
- Add the fragment back in to internal references that was accidentally removed in https://github.com/great-expectations/great_expectations/pull/6842

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.