### PR TITLE
[MAINTENANCE] Clean up public_api excludes

### DIFF
--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -994,6 +994,11 @@ class CodeReferenceFilter:
         IncludeExcludeDefinition(
             reason="self_check is mentioned but in the docs we currently recommend using test_yaml_config which uses self_check under the hood. E.g. https://docs.greatexpectations.io/docs/guides/setup/configuring_data_contexts/how_to_configure_datacontext_components_using_test_yaml_config/#steps",
             name="self_check",
+            filepath=pathlib.Path("great_expectations/checkpoint/checkpoint.py"),
+        ),
+        IncludeExcludeDefinition(
+            reason="self_check is mentioned but in the docs we currently recommend using test_yaml_config which uses self_check under the hood. E.g. https://docs.greatexpectations.io/docs/guides/setup/configuring_data_contexts/how_to_configure_datacontext_components_using_test_yaml_config/#steps",
+            name="self_check",
             filepath=pathlib.Path(
                 "great_expectations/datasource/data_connector/data_connector.py"
             ),


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove checkpoint self_check from public API to be consistent with other excludes

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.