### PR TITLE
[MAINTENANCE] Fix the error message for invalid batch request options

### DIFF
--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -173,10 +173,12 @@ class DataAsset(ExperimentalBaseModel):
             get_batch_list_from_batch_request method.
         """
         if options is not None and not self._valid_batch_request_options(options):
+            allowed_keys = set(self.batch_request_options_template().keys())
+            actual_keys = set(options.keys())
             raise BatchRequestError(
-                "Batch request options should only contain keys from the following list:\n"
-                f"{list(self.batch_request_options_template().keys())}\n"
-                f"but your specified keys contain\n{pf(options)}\nwhich is not valid.\n"
+                "Batch request options should only contain keys from the following set:\n"
+                f"{allowed_keys}\nbut your specified keys contain\n"
+                f"{actual_keys.difference(allowed_keys)}\nwhich is not valid.\n"
             )
         return BatchRequest(
             datasource_name=self._datasource.name,


### PR DESCRIPTION
Here is a screenshot of the new error message in my terminal:
<img width="878" alt="Screen Shot 2023-01-19 at 4 10 52 PM" src="https://user-images.githubusercontent.com/12725591/213590128-592d0077-f72e-49dd-bc78-e5805c0fd70f.png">



### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
