### PR TITLE
[FEATURE] ID/PK flag `return_unexpected_index_list` that allows index value output to be suppressed

### DIFF
--- a/docs/reference/expectations/result_format.md
+++ b/docs/reference/expectations/result_format.md
@@ -11,6 +11,7 @@ The `result_format` parameter may be either a string or a dictionary which speci
     * `return_unexpected_index_query`: When running validations, a query (or a set of indices) will be returned that will
       allow you to retrieve the full set of unexpected results including any columns identified in `unexpected_index_column_names`.  Setting this value to `False` will 
       suppress the output (default is `True`).
+    * `return_unexpected_index_list`:  Setting this value to `False` will suppress `unexpected_index_list` output (default is `True`).
     * `partial_unexpected_count`: Sets the number of results to include in partial_unexpected_count, if applicable. If 
       set to 0, this will suppress the unexpected counts.
     * `include_unexpected_rows`: When running validations, this will return the entire row for each unexpected value in

--- a/great_expectations/expectations/metrics/map_metric_provider.py
+++ b/great_expectations/expectations/metrics/map_metric_provider.py
@@ -1789,7 +1789,7 @@ def _pandas_map_condition_index(
     metric_value_kwargs: dict,
     metrics: Dict[str, Any],
     **kwargs,
-) -> Union[List[int], List[Dict[str, Any]]]:
+) -> Union[List[int], List[Dict[str, Any]], None]:
     (
         boolean_mapped_unexpected_values,
         compute_domain_kwargs,
@@ -1838,6 +1838,13 @@ def _pandas_map_condition_index(
     domain_records_df = domain_records_df[boolean_mapped_unexpected_values]
     expectation_domain_column_name: Union[str, None] = domain_kwargs.get("column")
 
+    # We will not return map_condition_index if return_unexpected_index_list = False
+    return_unexpected_index_list: bool = result_format.get(
+        "return_unexpected_index_list", True
+    )
+    if return_unexpected_index_list is False:
+        return
+
     unexpected_index_list: Union[
         List[int], List[Dict[str, Any]]
     ] = compute_unexpected_pandas_indices(
@@ -1872,7 +1879,7 @@ def _pandas_map_condition_query(
 
     # We will not return map_condition_query if return_unexpected_index_query = False
     return_unexpected_index_query: bool = result_format.get(
-        "return_unexpected_index_query"
+        "return_unexpected_index_query", True
     )
     if return_unexpected_index_query is False:
         return
@@ -2510,7 +2517,7 @@ def _sqlalchemy_map_condition_query(
 
     # We will not return map_condition_query if return_unexpected_index_query = False
     return_unexpected_index_query: bool = result_format.get(
-        "return_unexpected_index_query"
+        "return_unexpected_index_query", True
     )
     if return_unexpected_index_query is False:
         return
@@ -2558,7 +2565,7 @@ def _sqlalchemy_map_condition_index(
     metric_value_kwargs: Dict,
     metrics: Dict[str, Any],
     **kwargs,
-) -> List[Dict[str, Any]]:
+) -> Union[List[Dict[str, Any]], None]:
     """
     Returns indices of the metric values which do not meet an expected Expectation condition for instances
     of ColumnMapExpectation.
@@ -2574,6 +2581,14 @@ def _sqlalchemy_map_condition_index(
 
     domain_kwargs: dict = dict(**compute_domain_kwargs, **accessor_domain_kwargs)
     result_format: dict = metric_value_kwargs["result_format"]
+
+    # We will not return map_condition_index if return_unexpected_index_list = False
+    return_unexpected_index_list: bool = result_format.get(
+        "return_unexpected_index_list", True
+    )
+
+    if return_unexpected_index_list is False:
+        return
 
     column_selector: List[sa.Column] = []
     all_table_columns: List[str] = metrics.get("table.columns")
@@ -2838,6 +2853,14 @@ def _spark_map_condition_index(
         raise gx_exceptions.MetricResolutionError(
             "unexpected_indices cannot be returned without 'unexpected_index_column_names'. Please check your configuration."
         )
+
+    # We will not return map_condition_index if return_unexpected_index_list = False
+    return_unexpected_index_list: bool = result_format.get(
+        "return_unexpected_index_list", True
+    )
+
+    if return_unexpected_index_list is False:
+        return
 
     # withColumn is required to transform window functions returned by some metrics to boolean mask
     data = df.withColumn("__unexpected", unexpected_condition)

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import pandas as pd
 import pytest
@@ -14,6 +14,9 @@ from great_expectations.data_context.data_context.data_context import DataContex
 from great_expectations.data_context.types.base import CheckpointConfig
 from great_expectations.exceptions import CheckpointError
 from great_expectations.util import filter_properties_dict
+
+if TYPE_CHECKING:
+    from great_expectations.data_context import DataContext
 
 yaml = YAMLHandler()
 
@@ -152,6 +155,11 @@ def expected_sql_query_output() -> str:
     return "SELECT animals, pk_1 \n\
 FROM animal_names \n\
 WHERE animals IS NOT NULL AND (animals NOT IN ('cat', 'fish', 'dog'));"
+
+
+@pytest.fixture
+def expected_pandas_query_output() -> List[int]:
+    return [3, 4, 5]
 
 
 @pytest.fixture
@@ -1315,6 +1323,53 @@ def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_basic_out
     assert evrs[0]["results"][0]["result"].get("unexpected_index_query") is None
 
 
+@pytest.mark.integration
+def test_pandas_result_format_in_checkpoint_pk_defined_one_expectation_complete_suppress_index_output(
+    in_memory_runtime_context,
+    batch_request_for_pandas_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_pandas_query_output,
+):
+    """
+    What does this test?
+        - return_unexpected_index_list will suppress unexpected_index_list_output
+        - query will still appear, which for pandas, is the index
+    """
+
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "COMPLETE",
+            "unexpected_index_column_names": ["pk_1"],
+            "return_unexpected_index_list": False,
+        }
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request_for_pandas_unexpected_rows_and_index,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+    first_result_full_list = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert not first_result_full_list
+    first_result_partial_list = evrs[0]["results"][0]["result"].get(
+        "partial_unexpected_index_list"
+    )
+    assert not first_result_partial_list
+
+    query: str = evrs[0]["results"][0]["result"]["unexpected_index_query"]
+    assert query == expected_pandas_query_output
+
+
 # spark
 @pytest.mark.integration
 def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_complete_output(
@@ -1730,6 +1785,58 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_basic_outp
     )
     assert not first_result_partial_list
     assert evrs[0]["results"][0]["result"].get("unexpected_index_query") is None
+
+
+@pytest.mark.integration
+def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_complete_suppress_index_output(
+    in_memory_runtime_context,
+    batch_request_for_spark_unexpected_rows_and_index,
+    reference_checkpoint_config_for_unexpected_column_names,
+    expectation_config_expect_column_values_to_be_in_set,
+    expected_spark_query_output,
+):
+    """
+    What does this test?
+        - return_unexpected_index_list will suppress unexpected_index_list_output
+        - query will still appear
+    """
+
+    dict_to_update_checkpoint: dict = {
+        "result_format": {
+            "result_format": "BASIC",
+            "unexpected_index_column_names": ["pk_1"],
+        }
+    }
+    context: DataContext = _add_expectations_and_checkpoint(
+        data_context=in_memory_runtime_context,
+        checkpoint_config=reference_checkpoint_config_for_unexpected_column_names,
+        expectations_list=[expectation_config_expect_column_values_to_be_in_set],
+        dict_to_update_checkpoint=dict_to_update_checkpoint,
+    )
+
+    result: CheckpointResult = context.run_checkpoint(
+        checkpoint_name="my_checkpoint",
+        expectation_suite_name="animal_names_exp",
+        batch_request=batch_request_for_spark_unexpected_rows_and_index,
+    )
+    evrs: List[ExpectationSuiteValidationResult] = result.list_validation_results()
+
+    index_column_names: List[str] = evrs[0]["results"][0]["result"][
+        "unexpected_index_column_names"
+    ]
+    assert index_column_names == ["pk_1"]
+
+    first_result_full_list: List[Dict[str, Any]] = evrs[0]["results"][0]["result"].get(
+        "unexpected_index_list"
+    )
+    assert not first_result_full_list
+    first_result_partial_list = evrs[0]["results"][0]["result"].get(
+        "partial_unexpected_index_list"
+    )
+    assert not first_result_partial_list
+
+    query: str = evrs[0]["results"][0]["result"]["unexpected_index_query"]
+    assert query == expected_spark_query_output
 
 
 @pytest.mark.integration

--- a/tests/checkpoint/test_checkpoint_result_format.py
+++ b/tests/checkpoint/test_checkpoint_result_format.py
@@ -1803,8 +1803,9 @@ def test_spark_result_format_in_checkpoint_pk_defined_one_expectation_complete_s
 
     dict_to_update_checkpoint: dict = {
         "result_format": {
-            "result_format": "BASIC",
+            "result_format": "COMPLETE",
             "unexpected_index_column_names": ["pk_1"],
+            "return_unexpected_index_list": False,
         }
     }
     context: DataContext = _add_expectations_and_checkpoint(


### PR DESCRIPTION
# What is this PR? 
* It's a small follow-up to the ID/PK work that introduces a `return_unexpected_index_list` that allows `unexpected_indices` output to be suppressed selectively.
* Tests for Pandas, Spark and SQL. 
* Update to documentation. 

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
