### PR TITLE
[DOCS] Doc Strings for ExpectationSuite Display Methods

### DIFF
--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -744,14 +744,6 @@ class ExpectationSuite(SerializableDictDot):
         """Displays "ExpectationConfiguration" list, grouped by "domain_type", in predetermined designated order.
 
         The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
-
-        Args: N/A
-
-        Returns:
-            N/A
-
-        Raises:
-            N/A
         """
         expectation_configurations_by_domain: Dict[
             str, List[ExpectationConfiguration]
@@ -775,14 +767,6 @@ class ExpectationSuite(SerializableDictDot):
         """Displays "ExpectationConfiguration" list, grouped by "expectation_type", in predetermined designated order.
 
         The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
-
-        Args: N/A
-
-        Returns:
-            N/A
-
-        Raises:
-            N/A
         """
         if expectation_configurations is None:
             expectation_configurations = (

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -739,9 +739,18 @@ class ExpectationSuite(SerializableDictDot):
             overwrite_existing=overwrite_existing,
         )
 
+    @public_api
     def show_expectations_by_domain_type(self) -> None:
-        """
-        Displays "ExpectationConfiguration" list, grouped by "domain_type", in predetermined designated order.
+        """Displays "ExpectationConfiguration" list, grouped by "domain_type", in predetermined designated order.
+            The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
+
+        Args: N/A
+
+        Returns:
+            N/A
+
+        Raises:
+            N/A
         """
         expectation_configurations_by_domain: Dict[
             str, List[ExpectationConfiguration]

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -742,7 +742,8 @@ class ExpectationSuite(SerializableDictDot):
     @public_api
     def show_expectations_by_domain_type(self) -> None:
         """Displays "ExpectationConfiguration" list, grouped by "domain_type", in predetermined designated order.
-            The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
+
+        The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
 
         Args: N/A
 
@@ -772,7 +773,8 @@ class ExpectationSuite(SerializableDictDot):
         expectation_configurations: Optional[List[ExpectationConfiguration]] = None,
     ) -> None:
         """Displays "ExpectationConfiguration" list, grouped by "expectation_type", in predetermined designated order.
-            The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
+
+        The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
 
         Args: N/A
 

--- a/great_expectations/core/expectation_suite.py
+++ b/great_expectations/core/expectation_suite.py
@@ -771,8 +771,16 @@ class ExpectationSuite(SerializableDictDot):
         self,
         expectation_configurations: Optional[List[ExpectationConfiguration]] = None,
     ) -> None:
-        """
-        Displays "ExpectationConfiguration" list, grouped by "expectation_type", in predetermined designated order.
+        """Displays "ExpectationConfiguration" list, grouped by "expectation_type", in predetermined designated order.
+            The means of displaying is through the use of the "Pretty Print" library method "pprint.pprint()".
+
+        Args: N/A
+
+        Returns:
+            N/A
+
+        Raises:
+            N/A
         """
         if expectation_configurations is None:
             expectation_configurations = (


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: dx-237
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!