### PR TITLE
add validate_configuration docstring

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -123,10 +123,14 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
         """
-        "Validates the configuration of an Expectation.
+        Validates the configuration of an Expectation.
+
+        The configuration will also be validated using each of the `validate_configuration` methods in its Expectation
+        superclass hierarchy.
 
         Args:
-            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided it will be pulled from the configuration attribute of the Expectation instance.
+            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
+                                  from the configuration attribute of the Expectation instance.
 
         Raises:
             `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the Expectation."

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -122,7 +122,15 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
-        """Validates that a value_set has been provided."""
+        """
+        "Validates the configuration of an Expectation.
+
+        Args:
+            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided it will be pulled from the configuration attribute of the Expectation instance.
+
+        Raises:
+            `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the Expectation."
+        """
         super().validate_configuration(configuration)
         configuration = configuration or self.configuration
         try:

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -133,7 +133,8 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
                                   from the configuration attribute of the Expectation instance.
 
         Raises:
-            `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the Expectation."
+            `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the
+            Expectation.
         """
         super().validate_configuration(configuration)
         configuration = configuration or self.configuration


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- add expect_column_values_to_not_be_in_set.py:validate_configuration docstring



After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
