### PR TITLE
[MAINTENANCE] Fix scripts not found error in invoke

### DIFF
--- a/docs/sphinx_api_docs_source/tasks.py
+++ b/docs/sphinx_api_docs_source/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pathlib
+import sys
 from typing import Union
 
 import invoke
@@ -11,6 +12,10 @@ from scripts import public_api_report
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
+
+
+scripts_path = pathlib.Path.cwd().parent.parent / "scripts"
+sys.path.append(str(scripts_path))
 
 
 @invoke.task

--- a/docs/sphinx_api_docs_source/tasks.py
+++ b/docs/sphinx_api_docs_source/tasks.py
@@ -14,13 +14,12 @@ logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
 
-scripts_path = pathlib.Path.cwd().parent.parent / "scripts"
-sys.path.append(str(scripts_path))
-
-
 @invoke.task
 def docs(ctx):
     """Build documentation. Note: Currently only builds the sphinx based api docs, please build docusaurus docs separately."""
+    scripts_path = pathlib.Path.cwd().parent.parent / "scripts"
+    sys.path.append(str(scripts_path))
+
     sphinx_api_docs_source_dir = pathlib.Path(__file__).parent
 
     _exit_with_error_if_not_run_from_correct_dir(
@@ -35,6 +34,9 @@ def docs(ctx):
 @invoke.task(name="public-api")
 def public_api_task(ctx):
     """Generate a report to determine the state of our Public API. Lists classes, methods and functions that are used in examples in our documentation, and any manual includes or excludes (see public_api_report.py). Items listed when generating this report need the @public_api decorator (and a good docstring) or to be excluded from consideration if they are not applicable to our Public API."""
+
+    scripts_path = pathlib.Path.cwd().parent.parent / "scripts"
+    sys.path.append(str(scripts_path))
 
     sphinx_api_docs_source_dir = pathlib.Path(__file__).parent
 

--- a/tasks.py
+++ b/tasks.py
@@ -15,6 +15,7 @@ import json
 import os
 import pathlib
 import shutil
+import sys
 from typing import TYPE_CHECKING
 
 import invoke
@@ -133,6 +134,8 @@ def hooks(
 @invoke.task(aliases=["docstring"])
 def docstrings(ctx: Context):
     """Check public API docstrings."""
+    scripts_path = pathlib.Path.cwd().parent.parent / "scripts"
+    sys.path.append(str(scripts_path))
     try:
         check_public_api_docstrings.main()
     except AssertionError as err:


### PR DESCRIPTION
Changes proposed in this pull request:
- Add scripts to sys path in tasks that need it

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code