### PR TITLE
updated docstring on validate configuration

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -93,18 +93,14 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
         """
-        "Validates the configuration of an Expectation.
-
-        The configuration will also be validated using each of the `validate_configuration` methods in its Expectation
-        superclass hierarchy.
+        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
+        necessary configuration arguments have been provided for the validation of the expectation.
 
         Args:
-            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
-                                  from the configuration attribute of the Expectation instance.
-
-        Raises:
-            `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the
-                                                                           Expectation."
+            configuration (OPTIONAL[ExpectationConfiguration]): \
+                An optional Expectation Configuration entry that will be used to configure the expectation
+        Returns:
+            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
         """
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)

--- a/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_null.py
@@ -93,14 +93,18 @@ class ExpectColumnValuesToNotBeNull(ColumnMapExpectation):
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
         """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
+        "Validates the configuration of an Expectation.
+
+        The configuration will also be validated using each of the `validate_configuration` methods in its Expectation
+        superclass hierarchy.
 
         Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
+            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
+                                  from the configuration attribute of the Expectation instance.
+
+        Raises:
+            `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the
+                                                                           Expectation."
         """
         super().validate_configuration(configuration)
         self.validate_metric_value_between_configuration(configuration=configuration)

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -177,7 +177,7 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
         """
-        "Validates the configuration of an Expectation.
+        Validates the configuration of an Expectation.
 
         For `expect_column_values_to_not_match_like_pattern` it is required that:
             - 'regex' kwarg is of type str or dict

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -179,7 +179,7 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
         """
         Validates the configuration of an Expectation.
 
-        For `expect_column_values_to_not_match_like_pattern` it is required that:
+        For `expect_column_values_to_not_match_regex` it is required that:
             - 'regex' kwarg is of type str or dict
             - if dict, assert a key "$PARAMETER" is present
 

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -176,13 +176,28 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
+        """
+        "Validates the configuration of an Expectation.
+
+        For `expect_column_values_to_not_match_like_pattern` it is required that:
+            - 'regex' kwarg is of type str or dict
+            - if dict, assert a key "$PARAMETER" is present
+
+        Args:
+            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
+                                  from the configuration attribute of the Expectation instance.
+
+        Raises:
+            `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the
+                                                                           Expectation."
+        """
         super().validate_configuration(configuration)
         configuration = configuration or self.configuration
         try:
             assert "regex" in configuration.kwargs, "regex is required"
             assert isinstance(
                 configuration.kwargs["regex"], (str, dict)
-            ), "regex must be a string"
+            ), "regex must be a string or dict"
             if isinstance(configuration.kwargs["regex"], dict):
                 assert (
                     "$PARAMETER" in configuration.kwargs["regex"]

--- a/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_match_regex.py
@@ -189,7 +189,7 @@ class ExpectColumnValuesToNotMatchRegex(ColumnMapExpectation):
 
         Raises:
             `InvalidExpectationConfigurationError`: The configuration does not contain the values required by the
-                                                                           Expectation."
+                                  Expectation."
         """
         super().validate_configuration(configuration)
         configuration = configuration or self.configuration


### PR DESCRIPTION
Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- Add docstring for validate_configuration
- Updated assert message, seemed slightly outdated


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
