### PR TITLE
[MAINTENANCE] Use docusaurus style code block in api docs

### DIFF
--- a/docs/sphinx_api_docs_source/README.md
+++ b/docs/sphinx_api_docs_source/README.md
@@ -43,3 +43,16 @@ info.
 Our API docs styling is based on `pydata-sphinx-theme` with some modifications. 
 You can find the stylesheets linked from the docusaurus custom CSS `custom.scss`
 Typically you will not need to modify the styling.
+
+Code blocks in docstrings are supported, use markdown triple backticks to add a code snippet:
+
+````
+```yaml
+my_yaml:
+  - code_snippet
+```
+````
+
+Note:
+1. There must be an opening and closing set of triple backticks.
+2. The opening backticks can have an optional language (see docusaurus for supported languages).

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -199,10 +199,12 @@ class SphinxInvokeDocsBuilder:
 
                 doc_str = str(doc)
 
-                import_code_block = "CodeBlock" in doc_str
+                code_block_exists = "CodeBlock" in doc_str
                 doc_str = self._add_doc_front_matter(
-                    doc=doc_str, title=title_str, import_code_block=import_code_block
+                    doc=doc_str, title=title_str, import_code_block=code_block_exists
                 )
+                if code_block_exists:
+                    doc_str = self._clean_up_code_blocks(doc_str)
 
                 # Write out mdx files
                 output_path = self.docusaurus_api_docs_path / self._get_mdx_file_path(
@@ -401,4 +403,15 @@ class SphinxInvokeDocsBuilder:
         )
         doc = doc_front_matter + doc
 
+        return doc
+
+    def _clean_up_code_blocks(self, doc: str) -> str:
+        """Revert escaped characters in code blocks.
+
+        CodeBlock common characters <,>,` get escaped when generating HTML.
+        Also quotes use a different quote character. This method cleans up
+        these items so that the code block is rendered appropriately.
+        """
+        doc = doc.replace("&lt;", "<").replace("&gt;", ">").replace("”", '"')
+        doc = doc.replace("<cite>{", "`").replace("}</cite>", "`")
         return doc

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -199,6 +199,11 @@ class SphinxInvokeDocsBuilder:
 
                 doc_str = str(doc)
 
+                import_code_block = False
+                self._add_doc_front_matter(
+                    doc=doc_str, title=title_str, import_code_block=import_code_block
+                )
+
                 # Add front matter
                 doc_front_matter = (
                     "---\n"
@@ -378,3 +383,32 @@ class SphinxInvokeDocsBuilder:
         for file in all_files:
             if file not in excluded_files:
                 file.unlink()
+
+    def _add_doc_front_matter(
+        self, doc: str, title: str, import_code_block: bool = False
+    ) -> str:
+        """Add front matter to the beginning of doc.
+
+        Args:
+            doc: Document to add front matter to.
+            title: Desired title for the doc.
+            import_code_block: Whether to include import of docusaurus code block component.
+
+        Returns:
+            Document with front matter added.
+        """
+        import_code_block_content = ""
+        if import_code_block:
+            import_code_block_content = "\nimport CodeBlock from '@theme/CodeBlock';\n"
+
+        doc_front_matter = (
+            "---\n"
+            f"title: {title}\n"
+            f"sidebar_label: {title}\n"
+            "---\n"
+            "\n"
+            f"{import_code_block_content}"
+        )
+        doc = doc_front_matter + doc
+
+        return doc

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -199,7 +199,7 @@ class SphinxInvokeDocsBuilder:
 
                 doc_str = str(doc)
 
-                import_code_block = False
+                import_code_block = "CodeBlock" in doc_str
                 doc_str = self._add_doc_front_matter(
                     doc=doc_str, title=title_str, import_code_block=import_code_block
                 )
@@ -389,15 +389,15 @@ class SphinxInvokeDocsBuilder:
         """
         import_code_block_content = ""
         if import_code_block:
-            import_code_block_content = "\nimport CodeBlock from '@theme/CodeBlock';\n"
+            import_code_block_content = "import CodeBlock from '@theme/CodeBlock';"
 
         doc_front_matter = (
             "---\n"
             f"title: {title}\n"
             f"sidebar_label: {title}\n"
             "---\n"
-            "\n"
             f"{import_code_block_content}"
+            "\n"
         )
         doc = doc_front_matter + doc
 

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -200,19 +200,9 @@ class SphinxInvokeDocsBuilder:
                 doc_str = str(doc)
 
                 import_code_block = False
-                self._add_doc_front_matter(
+                doc_str = self._add_doc_front_matter(
                     doc=doc_str, title=title_str, import_code_block=import_code_block
                 )
-
-                # Add front matter
-                doc_front_matter = (
-                    "---\n"
-                    f"title: {title_str}\n"
-                    f"sidebar_label: {title_str}\n"
-                    "---\n"
-                    "\n"
-                )
-                doc_str = doc_front_matter + doc_str
 
                 # Write out mdx files
                 output_path = self.docusaurus_api_docs_path / self._get_mdx_file_path(

--- a/docs/sphinx_api_docs_source/conf.py
+++ b/docs/sphinx_api_docs_source/conf.py
@@ -121,7 +121,18 @@ def _remove_feature_maturity_info(app, what, name, obj, options, lines):
 
 
 def _convert_code_snippets_to_docusaurus(app, what, name, obj, options, lines):
-    """Convert code snippets to docusaurus style using CodeBlock component."""
+    """Convert code snippets to docusaurus style using CodeBlock component.
+
+    Code snippets
+    ```yaml
+    my_yaml:
+      - code_snippet
+    ```
+
+    Note:
+    1. There must be an opening and closing set of triple backticks.
+    2. The opening backticks can have an optional language (see docusaurus for supported languages).
+    """
 
     code_snippet_start: None | int = None
     code_snippet_end: None | int = None

--- a/src/css/api_docs/api_docs.scss
+++ b/src/css/api_docs/api_docs.scss
@@ -28,6 +28,12 @@
       padding: .1rem .25rem
     }
 
+    // Manually set code background color to match the rest of the site
+    // This does not change for light or dark mode
+    pre.prism-code {
+      background-color: #1e1e1e;
+    }
+
 }
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Process code blocks in docstrings and render as code blocks that match the rest of the site.
- Instructions for code blocks added to readme.
- See below for an example of how it renders:

![image](https://user-images.githubusercontent.com/9903066/214176739-de5eb183-d083-421a-a759-077794aaf191.png)

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.