### PR TITLE
[BUGFIX] Fix issues rendering code blocks in API docs

### DIFF
--- a/docs/sphinx_api_docs_source/README.md
+++ b/docs/sphinx_api_docs_source/README.md
@@ -56,3 +56,5 @@ my_yaml:
 Note:
 1. There must be an opening and closing set of triple backticks.
 2. The opening backticks can have an optional language (see docusaurus for supported languages).
+
+Tables are also supported, using [Sphinx table style](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#tables).

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -399,7 +399,7 @@ class SphinxInvokeDocsBuilder:
             f"sidebar_label: {title}\n"
             "---\n"
             f"{import_code_block_content}"
-            "\n"
+            "\n\n"
         )
         doc = doc_front_matter + doc
 
@@ -412,6 +412,7 @@ class SphinxInvokeDocsBuilder:
         Also quotes use a different quote character. This method cleans up
         these items so that the code block is rendered appropriately.
         """
-        doc = doc.replace("&lt;", "<").replace("&gt;", ">").replace("”", '"')
+        doc = doc.replace("&lt;", "<").replace("&gt;", ">")
+        doc = doc.replace("”", '"').replace("‘", "'").replace("’", "'")
         doc = doc.replace("<cite>{", "`").replace("}</cite>", "`")
         return doc


### PR DESCRIPTION
Changes proposed in this pull request:
- Update readme with link to Tables info
- Fix issues rendering code blocks. Issues were showing up with code blocks that looked like the attached image:
![code_blocks_with_curly_braces](https://user-images.githubusercontent.com/9903066/214418401-79ca5190-8679-4167-af3c-4cb55ccf1878.png)


### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.