### PR TITLE
[DOCS] Exclude DataAssistantRunner.run()

### DIFF
--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -1243,6 +1243,13 @@ class CodeReferenceFilter:
             name="to_json_dict",
             filepath=pathlib.Path("great_expectations/validator/exception_info.py"),
         ),
+        IncludeExcludeDefinition(
+            reason="False match for DataAssistant.run()",
+            name="run",
+            filepath=pathlib.Path(
+                "great_expectations/rule_based_profiler/data_assistant/data_assistant_runner.py"
+            ),
+        ),
     ]
 
     def __init__(


### PR DESCRIPTION
Changes proposed in this pull request:
- `DataAssistant.run()` is part of the public API, not `DataAssistantRunner.run()`

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.