### PR TITLE
[DOCS] Fix Checkpoint docstring whitespace

### DIFF
--- a/great_expectations/checkpoint/checkpoint.py
+++ b/great_expectations/checkpoint/checkpoint.py
@@ -121,7 +121,7 @@ class BaseCheckpoint(ConfigPeer):
         expectation_suite_ge_cloud_id: Optional[str] = None,
     ) -> CheckpointResult:
         """Validate against current Checkpoint.
-        
+
         Arguments allow for override of the current Checkpoint configuration.
 
         Args:
@@ -1327,7 +1327,7 @@ class SimpleCheckpoint(Checkpoint):
         expectation_suite_ge_cloud_id: Optional[str] = None,
     ) -> CheckpointResult:
         """Validate against the current SimpleCheckpoint.
-        
+
         Arguments allow for override of the current SimpleCheckpoint configuration.
 
         Args:


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove extraneous whitespace

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.