### PR TITLE
[DOCS] Remove the `great_expectations` path prefix for API docs

### DIFF
--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -252,12 +252,19 @@ class SphinxInvokeDocsBuilder:
             # (if .parent is not used, then there will be a duplicate).
             path_prefix = pathlib.Path(shortest_dotted_path.replace(".", "/")).parent
 
+            # Remove the `great_expectations` top level
+            if path_prefix.parts[0] == "great_expectations":
+                path_prefix = pathlib.Path(*path_prefix.parts[1:])
+
             # Join the shortest path and write output
             output_path = (path_prefix / html_file_path.stem).with_suffix(".mdx")
         else:
             output_path = html_file_path.relative_to(static_html_file_path).with_suffix(
                 ".mdx"
             )
+            # Remove the `great_expectations` top level
+            if output_path.parts[0] == "great_expectations":
+                output_path = pathlib.Path(*output_path.parts[1:])
 
         return output_path
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove the parent `great_expectations` path prefix for API docs.
- Note: there are other issues to address e.g. consistency with Checkpoint that will be addressed separately.
- New sidebar looks like:
![image](https://user-images.githubusercontent.com/9903066/214907392-cb8e5514-456c-458a-aca1-5bd13460a7be.png)