### PR TITLE
[BUGFIX] Disable `RendererConfiguration` constraint to support legacy renderer fallback behavior

### DIFF
--- a/great_expectations/render/renderer_configuration.py
+++ b/great_expectations/render/renderer_configuration.py
@@ -158,7 +158,8 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
         validate_assignment = True
         arbitrary_types_allowed = True
 
-    @root_validator(pre=True)
+    # TODO: Reintroduce this constraint once legacy renderers are deprecated/removed
+    # @root_validator(pre=True)
     def _validate_configuration_or_result(cls, values: dict) -> dict:
         if ("configuration" not in values or values["configuration"] is None) and (
             "result" not in values or values["result"] is None
@@ -299,9 +300,10 @@ class RendererConfiguration(GenericModel, Generic[RendererParams]):
                     if "_params" in values and values["_params"]
                     else renderer_params_args
                 )
-        else:
+        elif "configuration" in values and values["configuration"] is not None:
             values["expectation_type"] = values["configuration"].expectation_type
             values["kwargs"] = values["configuration"].kwargs
+
         return values
 
     @root_validator()

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -91,6 +91,10 @@ def test_successful_renderer_configuration_instantiation(
 
 
 @pytest.mark.unit
+@pytest.mark.xfail(
+    reason="This test will fail until RendererConfiguration._validate_configuration_or_result is re-enabled.",
+    strict=True,
+)
 def test_failed_renderer_configuration_instantiation():
     with pytest.raises(ValidationError) as e:
         RendererConfiguration(

--- a/tests/render/test_renderer_configuration.py
+++ b/tests/render/test_renderer_configuration.py
@@ -92,7 +92,7 @@ def test_successful_renderer_configuration_instantiation(
 
 @pytest.mark.unit
 @pytest.mark.xfail(
-    reason="This test will fail until RendererConfiguration._validate_configuration_or_result is re-enabled.",
+    reason="As of v0.15.46 test will fail until RendererConfiguration._validate_configuration_or_result is re-enabled.",
     strict=True,
 )
 def test_failed_renderer_configuration_instantiation():


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1610
- Do not enforce `configuration` or `result` constraint until all legacy renderers are deprecated or removed

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
