### PR TITLE
[MAINTENANCE] `ruff` -> `0.0.236`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-json
@@ -17,11 +17,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.230'
+    rev: 'v0.0.236'
     hooks:
       - id: ruff
         files: ^(great_expectations/core)  # TODO: expand to all of gx

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -1,6 +1,6 @@
-black==22.3.0
+black==22.12.0
 invoke>=2.0.0
 isort==5.10.1
 mypy==0.991
 pre-commit>=2.21.0
-ruff==0.0.230
+ruff==0.0.236

--- a/reqs/requirements-dev-contrib.txt
+++ b/reqs/requirements-dev-contrib.txt
@@ -1,4 +1,4 @@
-black==22.12.0
+black==22.3.0
 invoke>=2.0.0
 isort==5.10.1
 mypy==0.991


### PR DESCRIPTION
Changes proposed in this pull request:
- update ruff from `0.0.230` -> `0.0.236`
- update pre-commit hooks

Notable `ruff` releases since last update
https://github.com/charliermarsh/ruff/releases/tag/v0.0.236
https://github.com/charliermarsh/ruff/releases/tag/v0.0.234
https://github.com/charliermarsh/ruff/releases/tag/v0.0.232
https://github.com/charliermarsh/ruff/releases/tag/v0.0.231

These new plugins have been added
[flake8-use-pathlib](https://github.com/charliermarsh/ruff#flake8-use-pathlib-pth)
[tryceratops](https://github.com/charliermarsh/ruff#tryceratops-try)

Note: any new ruff plugins need to be explicitly enabled.
