### PR TITLE
[DOCS] Docstrings for `DataContext` child classes and `DataAssistantResult.to_json_dict`

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -9,6 +9,7 @@ import requests
 import great_expectations.exceptions as gx_exceptions
 from great_expectations import __version__
 from great_expectations.core import ExpectationSuite
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.core.config_provider import (
     _CloudConfigurationProvider,
     _ConfigurationProvider,
@@ -54,10 +55,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@public_api
 class CloudDataContext(SerializableDataContext):
-    """
-    Subclass of AbstractDataContext that contains functionality necessary to hydrate state from cloud
-    """
+    """Subclass of AbstractDataContext that contains functionality necessary to work in a GX Cloud-backed environment."""
 
     def __init__(
         self,

--- a/great_expectations/data_context/data_context/ephemeral_data_context.py
+++ b/great_expectations/data_context/data_context/ephemeral_data_context.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Mapping, Optional, Union
 
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.core.serializer import DictConfigSerializer
 from great_expectations.data_context.data_context.abstract_data_context import (
     AbstractDataContext,
@@ -16,11 +17,9 @@ from great_expectations.data_context.types.base import (
 logger = logging.getLogger(__name__)
 
 
+@public_api
 class EphemeralDataContext(AbstractDataContext):
-    """
-    Will contain functionality to create DataContext at runtime (ie. passed in config object or from stores). Users will
-    be able to use EphemeralDataContext for having a temporary or in-memory DataContext
-    """
+    """Subclass of AbstractDataContext that uses runtime values to generate a temporary or in-memory DataContext."""
 
     def __init__(
         self,

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -8,6 +8,7 @@ from ruamel.yaml import YAML, YAMLError
 from ruamel.yaml.constructor import DuplicateKeyError
 
 import great_expectations.exceptions as gx_exceptions
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.data_context.data_context.serializable_data_context import (
     SerializableDataContext,
 )
@@ -33,10 +34,9 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 yaml.default_flow_style = False
 
 
+@public_api
 class FileDataContext(SerializableDataContext):
-    """
-    Extends AbstractDataContext, contains only functionality necessary to hydrate state from disk.
-    """
+    """Subclass of AbstractDataContext that contains functionality necessary to work in a filesystem-backed environment."""
 
     def __init__(
         self,

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -107,9 +107,12 @@ class RuleStats(SerializableDictDot):
         """
         return asdict(self)
 
+    @public_api
     def to_json_dict(self) -> dict:
-        """
-        Returns JSON dictionary equivalent of this object.
+        """Returns JSON dictionary equivalent of this object.
+
+        Returns:
+            A JSON-serializable dictionary representation of the DataAssistantResult object.
         """
         return convert_to_json_serializable(data=self.to_dict())
 

--- a/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
+++ b/great_expectations/rule_based_profiler/data_assistant_result/data_assistant_result.py
@@ -107,12 +107,9 @@ class RuleStats(SerializableDictDot):
         """
         return asdict(self)
 
-    @public_api
     def to_json_dict(self) -> dict:
-        """Returns JSON dictionary equivalent of this object.
-
-        Returns:
-            A JSON-serializable dictionary representation of the DataAssistantResult object.
+        """
+        Returns JSON dictionary equivalent of this object.
         """
         return convert_to_json_serializable(data=self.to_dict())
 
@@ -280,9 +277,12 @@ class DataAssistantResult(SerializableDictDot):
             "citation": convert_to_json_serializable(data=self.citation),
         }
 
+    @public_api
     def to_json_dict(self) -> dict:
-        """
-        Returns: This DataAssistantResult as JSON-serializable dictionary.
+        """Returns JSON dictionary equivalent of this object.
+
+        Returns:
+            A JSON-serializable dictionary representation of the DataAssistantResult object.
         """
         return self.to_dict()
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Docstring party :tada:


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation
