### PR TITLE
[DOCS] Add docstring for `ExpectationValidationResult`

### DIFF
--- a/great_expectations/core/expectation_validation_result.py
+++ b/great_expectations/core/expectation_validation_result.py
@@ -12,6 +12,7 @@ from typing_extensions import TypedDict
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations import __version__ as ge_version
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.core.batch import BatchDefinition, BatchMarkers
 from great_expectations.core.expectation_configuration import (
     ExpectationConfigurationSchema,
@@ -61,7 +62,25 @@ def get_metric_kwargs_id(metric_name, metric_kwargs):
     return None
 
 
+@public_api
 class ExpectationValidationResult(SerializableDictDot):
+    """An Expectation validation result.
+
+    Args:
+        success: Whether the Expectation validation was successful.
+        expectation_config: The configuration of the Expectation that was validated.
+        result: The result details that can take one of many result formats.
+        meta: Metadata associated with the validation result.
+        exception_info: Any exception information that was raised during validation. Takes the form:
+            raised_exception: boolean
+            exception_traceback: Optional, str
+            exception_message: Optional, str
+        rendered_content: Inline content for rendering.
+
+    Raises:
+        InvalidCacheValueError: Raised if the result does not pass validation.
+    """
+
     def __init__(
         self,
         success: Optional[bool] = None,


### PR DESCRIPTION
Changes proposed in this pull request:
- DX-237
- Add docstring and `public_api` decorator for `ExpectationValidationResult`

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
