### PR TITLE
[DOCS] Use markdown style code blocks

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1935,25 +1935,27 @@ class AbstractDataContext(ConfigPeer, ABC):
 
         Note that this method can be called by itself or run within the get_validator workflow.
 
-        When run with create_expectation_suite()::
+        When run with create_expectation_suite():
 
-            expectation_suite_name = "genres_movies.fkey"
-            context.create_expectation_suite(expectation_suite_name, overwrite_existing=True)
-            batch = context.get_batch(
-                expectation_suite_name=expectation_suite_name
-            )
+        ```python
+        expectation_suite_name = "genres_movies.fkey"
+        context.create_expectation_suite(expectation_suite_name, overwrite_existing=True)
+        batch = context.get_batch(
+            expectation_suite_name=expectation_suite_name
+        )
+        ```
 
+        When run as part of get_validator():
 
-        When run as part of get_validator()::
-
-            validator = context.get_validator(
-                datasource_name="my_datasource",
-                data_connector_name="whole_table",
-                data_asset_name="my_table",
-                create_expectation_suite_with_name="my_expectation_suite",
-            )
-            validator.expect_column_values_to_be_in_set("c1", [4,5,6])
-
+        ```python
+        validator = context.get_validator(
+            datasource_name="my_datasource",
+            data_connector_name="whole_table",
+            data_asset_name="my_table",
+            create_expectation_suite_with_name="my_expectation_suite",
+        )
+        validator.expect_column_values_to_be_in_set("c1", [4,5,6])
+        ```
 
         Args:
             expectation_suite_name: The name of the suite to create.


### PR DESCRIPTION
Changes proposed in this pull request:
- Use markdown style code blocks

Before:
![image](https://user-images.githubusercontent.com/9903066/215186181-153cfc57-8821-476a-9388-b84d3fba8325.png)


After:
![image](https://user-images.githubusercontent.com/9903066/215186124-0806d95c-0dbc-4e70-b1e0-daa44140e2e7.png)
