### PR TITLE
[DOCS] Either Documentation tag style acceptable

### DIFF
--- a/docs/sphinx_api_docs_source/conf.py
+++ b/docs/sphinx_api_docs_source/conf.py
@@ -47,7 +47,7 @@ html_static_path = ["_static"]
 
 
 # Skip autodoc unless part of the Public API
-DOCUMENTATION_TAG = "--Documentation--"
+DOCUMENTATION_TAGS = ["---Documentation---", "--Documentation--"]
 
 
 def skip_if_not_whitelisted(app, what, name, obj, would_skip, options):
@@ -93,11 +93,12 @@ def _process_relevant_documentation_tag(app, what, name, obj, options, lines):
     Note: This method modifies lines in place per sphinx documentation.
     """
     for idx, line in enumerate(lines):
-        if DOCUMENTATION_TAG in line:
-            trimmed_line = line.replace(
-                DOCUMENTATION_TAG, "Relevant Documentation Links\n"
-            )
-            lines[idx] = trimmed_line
+        for DOCUMENTATION_TAG in DOCUMENTATION_TAGS:
+            if DOCUMENTATION_TAG in line:
+                trimmed_line = line.replace(
+                    DOCUMENTATION_TAG, "Relevant Documentation Links\n"
+                )
+                lines[idx] = trimmed_line
 
 
 FEATURE_MATURITY_INFO_TAG = "--ge-feature-maturity-info--"


### PR DESCRIPTION
Changes proposed in this pull request:
- DOCUMENTATION_TAGS = ["---Documentation---", "--Documentation--"]