### PR TITLE
[BUGFIX] Fix Renderer Configuration for expectation expect_column_values_to_not_be_in_set #6963

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
+++ b/great_expectations/expectations/core/expect_column_values_to_not_be_in_set.py
@@ -210,7 +210,7 @@ class ExpectColumnValuesToNotBeInSet(ColumnMapExpectation):
         runtime_configuration: Optional[dict] = None,
     ):
         renderer_configuration = RendererConfiguration(
-            configuraiton=configuration,
+            configuration=configuration,
             result=result,
             runtime_configuration=runtime_configuration,
         )


### PR DESCRIPTION
Fix Renderer Configuration for expectation expect_column_values_to_not_be_in_set.

Problem: 
- The docs are not being rendered for the expectation in question

Changes proposed in this pull request:
- fix typo from configuraiton to configuration