### PR TITLE
[DOCS] Add rendering docstrings

### DIFF
--- a/great_expectations/expectations/core/expect_column_sum_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_sum_to_be_between.py
@@ -306,7 +306,7 @@ class ExpectColumnSumToBeBetween(ColumnExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": template_str,

--- a/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_be_between.py
@@ -271,7 +271,7 @@ class ExpectTableRowCountToBeBetween(TableExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": template_str,

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -146,7 +146,7 @@ class ExpectTableRowCountToEqual(TableExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": template_str,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -738,7 +738,7 @@ class Expectation(metaclass=MetaExpectation):
                 }
             )
 
-            exception_traceback_collapse = CollapseContent(
+            exception_traceback_collapse = CollapseContent(  # type: ignore[arg-type]
                 **{
                     "collapse_toggle_link": "Show exception traceback...",
                     "collapse": [

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -178,7 +178,7 @@ def render_evaluation_parameter_string(render_func) -> Callable:
                             app_params["eval_param"] = key
                             app_params["eval_param_value"] = val
                             rendered_content = RenderedStringTemplateContent(
-                                **{
+                                **{  # type: ignore[arg-type]
                                     "content_block_type": "string_template",
                                     "string_template": {
                                         "template": app_template_str,
@@ -532,7 +532,7 @@ class Expectation(metaclass=MetaExpectation):
         )
         return [
             RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "styling": {"parent": {"classes": ["alert", "alert-warning"]}},
                     "string_template": {
@@ -624,7 +624,7 @@ class Expectation(metaclass=MetaExpectation):
         assert result, "Must provide a result object."
         if result.exception_info["raised_exception"]:
             return RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": "$icon",
@@ -647,7 +647,7 @@ class Expectation(metaclass=MetaExpectation):
 
         if result.success:
             return RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": "$icon",
@@ -674,7 +674,7 @@ class Expectation(metaclass=MetaExpectation):
             )
         else:
             return RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": "$icon",
@@ -714,7 +714,7 @@ class Expectation(metaclass=MetaExpectation):
                 expectation_type = None
 
             exception_message = RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": exception_message_template_str,
@@ -738,12 +738,12 @@ class Expectation(metaclass=MetaExpectation):
                 }
             )
 
-            exception_traceback_collapse = CollapseContent(  # type: ignore[arg-type]
-                **{
+            exception_traceback_collapse = CollapseContent(
+                **{  # type: ignore[arg-type]
                     "collapse_toggle_link": "Show exception traceback...",
                     "collapse": [
                         RenderedStringTemplateContent(
-                            **{
+                            **{  # type: ignore[arg-type]
                                 "content_block_type": "string_template",
                                 "string_template": {
                                     "template": result.exception_info[
@@ -779,7 +779,7 @@ class Expectation(metaclass=MetaExpectation):
 
             return [
                 RenderedStringTemplateContent(
-                    **{
+                    **{  # type: ignore[arg-type]
                         "content_block_type": "string_template",
                         "string_template": {
                             "template": template_str,
@@ -867,7 +867,7 @@ class Expectation(metaclass=MetaExpectation):
                         sampled_values_set.add(string_unexpected_value)
 
         unexpected_table_content_block = RenderedTableContent(
-            **{
+            **{  # type: ignore[arg-type]
                 "content_block_type": "table",
                 "table": table_rows,
                 "header_row": header_row,
@@ -882,11 +882,11 @@ class Expectation(metaclass=MetaExpectation):
             if not isinstance(query, str):
                 query = str(query)
             query_info = CollapseContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "collapse_toggle_link": "To retrieve all unexpected values...",
                     "collapse": [
                         RenderedStringTemplateContent(
-                            **{
+                            **{  # type: ignore[arg-type]
                                 "content_block_type": "string_template",
                                 "string_template": {
                                     "template": query,

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -454,9 +454,24 @@ class RenderedMarkdownContent(RenderedComponentContent):
         return d
 
 
+@public_api
 class RenderedStringTemplateContent(RenderedComponentContent):
+    """RenderedStringTemplateContent is RenderedComponentContent that represents a templated string.
+
+    Args:
+        string_template: A dictionary containing:
+            template: The string to perform substitution on. Variables are denoted with a preceeding $.
+            params: A dictionary with keys that match variable names and values which will be substituted.
+            styling: A dictionary containing styling information.
+        styling: A dictionary containing styling information.
+        content_block_type: The type of content block.
+    """
+
     def __init__(
-        self, string_template, styling=None, content_block_type="string_template"
+        self,
+        string_template: dict,
+        styling: Optional[dict] = None,
+        content_block_type: str = "string_template",
     ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.string_template = string_template

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -296,9 +296,9 @@ class RenderedTableContent(RenderedComponentContent):
 
             icon-size: The size of the icons in the table. One of "sm", "md", or "lg".
         header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
-                            name and the values being a dictionary with the following form:
+            name and the values being a dictionary with the following form:
 
-                sortable: A boolean indicating whether the column is sortable.
+            sortable: A boolean indicating whether the column is sortable.
     """
 
     def __init__(

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -279,17 +279,35 @@ class RenderedGraphContent(RenderedComponentContent):
         return d
 
 
+@public_api
 class RenderedTableContent(RenderedComponentContent):
+    """RenderedTableContent is RenderedComponentContent that is a table.
+
+    Args:
+        table: The table to be rendered.
+        header: The header for this content block.
+        subheader: The subheader for this content block.
+        header_row: The header row for the table.
+        styling: A dictionary containing styling information.
+        content_block_type: The type of content block.
+        table_options: The options that can be set for the table.
+            search: A boolean indicating whether to include search with the table.
+            icon-size: The size of the icons in the table. One of "sm", "md", or "lg".
+        header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
+                            name and the values being a dictionary with the following form:
+                                sortable: A boolean indicating whether the column is sortable.
+    """
+
     def __init__(
         self,
-        table,
-        header=None,
-        subheader=None,
-        header_row=None,
-        styling=None,
-        content_block_type="table",
-        table_options=None,
-        header_row_options=None,
+        table: list[RenderedContent],
+        header: Optional[Union[RenderedContent, dict]] = None,
+        subheader: Optional[Union[RenderedContent, dict]] = None,
+        header_row: Optional[list[RenderedContent]] = None,
+        styling: Optional[dict] = None,
+        content_block_type: str = "table",
+        table_options: Optional[dict] = None,
+        header_row_options: Optional[dict] = None,
     ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.header = header

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -291,10 +291,13 @@ class RenderedTableContent(RenderedComponentContent):
         styling: A dictionary containing styling information.
         content_block_type: The type of content block.
         table_options: The options that can be set for the table.
+
             search: A boolean indicating whether to include search with the table.
+
             icon-size: The size of the icons in the table. One of "sm", "md", or "lg".
         header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
                             name and the values being a dictionary with the following form:
+
                                 sortable: A boolean indicating whether the column is sortable.
     """
 
@@ -478,8 +481,11 @@ class RenderedStringTemplateContent(RenderedComponentContent):
 
     Args:
         string_template: A dictionary containing:
+
             template: The string to perform substitution on. Variables are denoted with a preceeding $.
+
             params: A dictionary with keys that match variable names and values which will be substituted.
+
             styling: A dictionary containing styling information.
         styling: A dictionary containing styling information.
         content_block_type: The type of content block.

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -298,7 +298,7 @@ class RenderedTableContent(RenderedComponentContent):
         header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
                             name and the values being a dictionary with the following form:
 
-                                sortable: A boolean indicating whether the column is sortable.
+                sortable: A boolean indicating whether the column is sortable.
     """
 
     def __init__(

--- a/great_expectations/render/components.py
+++ b/great_expectations/render/components.py
@@ -588,16 +588,29 @@ class TextContent(RenderedComponentContent):
         return d
 
 
+@public_api
 class CollapseContent(RenderedComponentContent):
+    """CollapseContent is RenderedComponentContent that can be collapsed.
+
+    Args:
+        collapse: The content to be collapsed. If a list is provided, it can recursively contain RenderedContent.
+        collpase_toggle_link: The toggle link for this CollapseContent.
+        header: The header for this content block.
+        subheader: The subheader for this content block.
+        styling: A dictionary containing styling information.
+        content_block_type: The type of content block.
+        inline_link: Whether to include a link inline.
+    """
+
     def __init__(
         self,
-        collapse,
-        collapse_toggle_link=None,
-        header=None,
-        subheader=None,
-        styling=None,
-        content_block_type="collapse",
-        inline_link=False,
+        collapse: Union[RenderedContent, list],
+        collapse_toggle_link: Optional[Union[RenderedContent, dict]] = None,
+        header: Optional[Union[RenderedContent, dict]] = None,
+        subheader: Optional[Union[RenderedContent, dict]] = None,
+        styling: Optional[dict] = None,
+        content_block_type: str = "collapse",
+        inline_link: bool = False,
     ) -> None:
         super().__init__(content_block_type=content_block_type, styling=styling)
         self.collapse_toggle_link = collapse_toggle_link

--- a/great_expectations/render/renderer/column_section_renderer.py
+++ b/great_expectations/render/renderer/column_section_renderer.py
@@ -219,7 +219,7 @@ diagnose and repair the underlying issue.  Detailed information follows:
                 **{
                     "content_block_type": "bullet_list",
                     "header": RenderedStringTemplateContent(
-                        **{
+                        **{  # type: ignore[arg-type]
                             "content_block_type": "string_template",
                             "string_template": {
                                 "template": 'Expectation types <span class="mr-3 triangle"></span>',

--- a/great_expectations/render/renderer/content_block/expectation_string.py
+++ b/great_expectations/render/renderer/content_block/expectation_string.py
@@ -27,7 +27,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
         )
         return [
             RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "styling": {"parent": {"classes": ["alert", "alert-warning"]}},
                     "string_template": {

--- a/great_expectations/render/renderer/content_block/expectation_string.py
+++ b/great_expectations/render/renderer/content_block/expectation_string.py
@@ -59,7 +59,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
         assert result, "Must provide a result object."
         if result.exception_info["raised_exception"]:
             return RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": "$icon",
@@ -82,7 +82,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
 
         if result.success:
             return RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": "$icon",
@@ -109,7 +109,7 @@ class ExpectationStringRenderer(ContentBlockRenderer):
             )
         else:
             return RenderedStringTemplateContent(
-                **{
+                **{  # type: ignore[arg-type]
                     "content_block_type": "string_template",
                     "string_template": {
                         "template": "$icon",

--- a/great_expectations/render/renderer/renderer.py
+++ b/great_expectations/render/renderer/renderer.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from typing import Any
 
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.core.expectation_validation_result import (
     ExpectationValidationResult,
@@ -20,7 +21,10 @@ def renderer(renderer_type, **kwargs):
     return wrapper
 
 
+@public_api
 class Renderer:
+    """A convenience class to provide an explicit mechanism to instantiate any Renderer."""
+
     def __init__(self) -> None:
         # This is purely a convenience to provide an explicit mechanism to instantiate any Renderer, even ones that
         # used to be composed exclusively of classmethods

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -69,7 +69,13 @@ def _get_deprecation_warning_message(classname: str) -> str:
     )
 
 
-@deprecated_method_or_class
+@deprecated_method_or_class(
+    version="0.15.32",
+    message=f"Importing the class CollapseContent from "
+    "great_expectations.render.types is deprecated as of v0.15.32 "
+    "in v0.18. Please import class CollapseContent "
+    "from great_expectations.render.",
+)
 class CollapseContent(CollapseContentRender):
     # deprecated-v0.15.32
     """CollapseContent is RenderedComponentContent that can be collapsed.
@@ -386,7 +392,13 @@ class RenderedSectionContent(RenderedSectionContentRender):
         )
 
 
-@deprecated_method_or_class
+@deprecated_method_or_class(
+    version="0.15.32",
+    message=f"Importing the class RenderedStringTemplateContent from "
+    "great_expectations.render.types is deprecated as of v0.15.32 "
+    "in v0.18. Please import class RenderedStringTemplateContent "
+    "from great_expectations.render.",
+)
 class RenderedStringTemplateContent(RenderedStringTemplateContentRender):
     # deprecated-v0.15.32
     """RenderedStringTemplateContent is RenderedComponentContent that represents a templated string.

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -386,10 +386,22 @@ class RenderedSectionContent(RenderedSectionContentRender):
         )
 
 
+@deprecated_method_or_class
 class RenderedStringTemplateContent(RenderedStringTemplateContentRender):
     # deprecated-v0.15.32
+    """RenderedStringTemplateContent is RenderedComponentContent that represents a templated string.
+
+    Args:
+        string_template: A dictionary containing:
+            template: The string to perform substitution on. Variables are denoted with a preceeding $.
+            params: A dictionary with keys that match variable names and values which will be substituted.
+            styling: A dictionary containing styling information.
+        styling: A dictionary containing styling information.
+        content_block_type: The type of content block.
+    """
+
     def __init__(
-        self, string_template, styling=None, content_block_type="string_template"
+        self, string_template: dict, styling=None, content_block_type="string_template"
     ):
         warnings.warn(
             _get_deprecation_warning_message(classname=self.__class__.__name__),

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -450,7 +450,7 @@ class RenderedTableContent(RenderedTableContentRender):
 
             icon-size: The size of the icons in the table. One of "sm", "md", or "lg".
         header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
-                            name and the values being a dictionary with the following form:
+            name and the values being a dictionary with the following form:
 
             sortable: A boolean indicating whether the column is sortable.
     """

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -426,8 +426,32 @@ class RenderedStringTemplateContent(RenderedStringTemplateContentRender):
         )
 
 
+@deprecated_method_or_class(
+    version="0.15.32",
+    message=f"Importing the class RenderedTableContent from "
+    "great_expectations.render.types is deprecated as of v0.15.32 "
+    "in v0.18. Please import class RenderedTableContent "
+    "from great_expectations.render.",
+)
 class RenderedTableContent(RenderedTableContentRender):
     # deprecated-v0.15.32
+    """RenderedTableContent is RenderedComponentContent that is a table.
+
+    Args:
+        table: The table to be rendered.
+        header: The header for this content block.
+        subheader: The subheader for this content block.
+        header_row: The header row for the table.
+        styling: A dictionary containing styling information.
+        content_block_type: The type of content block.
+        table_options: The options that can be set for the table.
+            search: A boolean indicating whether to include search with the table.
+            icon-size: The size of the icons in the table. One of "sm", "md", or "lg".
+        header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
+                            name and the values being a dictionary with the following form:
+                                sortable: A boolean indicating whether the column is sortable.
+    """
+
     def __init__(
         self,
         table,

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -57,9 +57,6 @@ from great_expectations.render.renderer_configuration import (
     RendererTableValue as RendererTableValueRender,
 )
 
-if TYPE_CHECKING:
-    from great_expectations.render import RenderedContent
-
 
 # TODO: Remove this entire module for release 0.18.0
 def _get_deprecation_warning_message(classname: str) -> str:

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import List, Optional, Union
 
 from great_expectations.core._docs_decorators import deprecated_method_or_class
 from great_expectations.render import (
@@ -402,8 +402,11 @@ class RenderedStringTemplateContent(RenderedStringTemplateContentRender):
 
     Args:
         string_template: A dictionary containing:
+
             template: The string to perform substitution on. Variables are denoted with a preceeding $.
+
             params: A dictionary with keys that match variable names and values which will be substituted.
+
             styling: A dictionary containing styling information.
         styling: A dictionary containing styling information.
         content_block_type: The type of content block.
@@ -442,10 +445,13 @@ class RenderedTableContent(RenderedTableContentRender):
         styling: A dictionary containing styling information.
         content_block_type: The type of content block.
         table_options: The options that can be set for the table.
+
             search: A boolean indicating whether to include search with the table.
+
             icon-size: The size of the icons in the table. One of "sm", "md", or "lg".
         header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
                             name and the values being a dictionary with the following form:
+
                                 sortable: A boolean indicating whether the column is sortable.
     """
 

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -1,6 +1,7 @@
 import warnings
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
+from great_expectations.core._docs_decorators import deprecated_method_or_class
 from great_expectations.render import (
     AtomicDiagnosticRendererType,
     AtomicPrescriptiveRendererType,
@@ -56,6 +57,9 @@ from great_expectations.render.renderer_configuration import (
     RendererTableValue as RendererTableValueRender,
 )
 
+if TYPE_CHECKING:
+    from great_expectations.render import RenderedContent
+
 
 # TODO: Remove this entire module for release 0.18.0
 def _get_deprecation_warning_message(classname: str) -> str:
@@ -65,17 +69,30 @@ def _get_deprecation_warning_message(classname: str) -> str:
     )
 
 
+@deprecated_method_or_class
 class CollapseContent(CollapseContentRender):
     # deprecated-v0.15.32
+    """CollapseContent is RenderedComponentContent that can be collapsed.
+
+    Args:
+        collapse: The content to be collapsed. If a list is provided, it can recursively contain RenderedContent.
+        collpase_toggle_link: The toggle link for this CollapseContent.
+        header: The header for this content block.
+        subheader: The subheader for this content block.
+        styling: A dictionary containing styling information.
+        content_block_type: The type of content block.
+        inline_link: Whether to include a link inline.
+    """
+
     def __init__(
         self,
-        collapse,
-        collapse_toggle_link=None,
-        header=None,
-        subheader=None,
-        styling=None,
-        content_block_type="collapse",
-        inline_link=False,
+        collapse: Union[RenderedContent, list],
+        collapse_toggle_link: Optional[Union[RenderedContent, dict]] = None,
+        header: Optional[Union[RenderedContent, dict]] = None,
+        subheader: Optional[Union[RenderedContent, dict]] = None,
+        styling: Optional[dict] = None,
+        content_block_type: str = "collapse",
+        inline_link: bool = False,
     ):
         warnings.warn(
             _get_deprecation_warning_message(classname=self.__class__.__name__),

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -68,7 +68,7 @@ def _get_deprecation_warning_message(classname: str) -> str:
 
 @deprecated_method_or_class(
     version="0.15.32",
-    message=f"Importing the class CollapseContent from "
+    message="Importing the class CollapseContent from "
     "great_expectations.render.types is deprecated as of v0.15.32 "
     "in v0.18. Please import class CollapseContent "
     "from great_expectations.render.",
@@ -391,7 +391,7 @@ class RenderedSectionContent(RenderedSectionContentRender):
 
 @deprecated_method_or_class(
     version="0.15.32",
-    message=f"Importing the class RenderedStringTemplateContent from "
+    message="Importing the class RenderedStringTemplateContent from "
     "great_expectations.render.types is deprecated as of v0.15.32 "
     "in v0.18. Please import class RenderedStringTemplateContent "
     "from great_expectations.render.",
@@ -425,7 +425,7 @@ class RenderedStringTemplateContent(RenderedStringTemplateContentRender):
 
 @deprecated_method_or_class(
     version="0.15.32",
-    message=f"Importing the class RenderedTableContent from "
+    message="Importing the class RenderedTableContent from "
     "great_expectations.render.types is deprecated as of v0.15.32 "
     "in v0.18. Please import class RenderedTableContent "
     "from great_expectations.render.",

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -89,10 +89,10 @@ class CollapseContent(CollapseContentRender):
 
     def __init__(
         self,
-        collapse: Union[RenderedContent, list],
-        collapse_toggle_link: Optional[Union[RenderedContent, dict]] = None,
-        header: Optional[Union[RenderedContent, dict]] = None,
-        subheader: Optional[Union[RenderedContent, dict]] = None,
+        collapse: Union[RenderedContentRender, list],
+        collapse_toggle_link: Optional[Union[RenderedContentRender, dict]] = None,
+        header: Optional[Union[RenderedContentRender, dict]] = None,
+        subheader: Optional[Union[RenderedContentRender, dict]] = None,
         styling: Optional[dict] = None,
         content_block_type: str = "collapse",
         inline_link: bool = False,

--- a/great_expectations/render/types/__init__.py
+++ b/great_expectations/render/types/__init__.py
@@ -452,7 +452,7 @@ class RenderedTableContent(RenderedTableContentRender):
         header_row_options: The options that can be set for the header_row. A dictionary with the keys being the column
                             name and the values being a dictionary with the following form:
 
-                                sortable: A boolean indicating whether the column is sortable.
+            sortable: A boolean indicating whether the column is sortable.
     """
 
     def __init__(


### PR DESCRIPTION
Changes proposed in this pull request:
- DX-237
- Add docstrings and decorators for various classes of `RenderedComponentContent`

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.