### PR TITLE
[DOCS] `Expectations` related DocStrings

### DIFF
--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -78,8 +78,10 @@ class ExpectTableRowCountToEqual(TableExpectation):
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
-        """
-        Validate the configuration of an Expectation.
+        """Validate the configuration of an Expectation.
+
+        For `expect_table_row_count_to_equal` we require that the `configuraton.kwargs` contain
+        a `value` key that is either an `int` or a `dict` with an Evaluation Parameter.
 
         The configuration will also be validated using each of the `validate_configuration` methods in its Expectation
         superclass hierarchy.

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -4,6 +4,7 @@ from great_expectations.core import (
     ExpectationConfiguration,
     ExpectationValidationResult,
 )
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.execution_engine import ExecutionEngine
 from great_expectations.expectations.expectation import (
     InvalidExpectationConfigurationError,

--- a/great_expectations/expectations/core/expect_table_row_count_to_equal.py
+++ b/great_expectations/expectations/core/expect_table_row_count_to_equal.py
@@ -73,18 +73,23 @@ class ExpectTableRowCountToEqual(TableExpectation):
     }
     args_keys = ("value",)
 
+    @public_api
     def validate_configuration(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> None:
         """
-        Validates that a configuration has been set, and sets a configuration if it has yet to be set. Ensures that
-        necessary configuration arguments have been provided for the validation of the expectation.
+        Validate the configuration of an Expectation.
+
+        The configuration will also be validated using each of the `validate_configuration` methods in its Expectation
+        superclass hierarchy.
 
         Args:
-            configuration (OPTIONAL[ExpectationConfiguration]): \
-                An optional Expectation Configuration entry that will be used to configure the expectation
-        Returns:
-            None. Raises InvalidExpectationConfigurationError if the config is not validated successfully
+            configuration: An `ExpectationConfiguration` to validate. If no configuration is provided, it will be pulled
+                from the configuration attribute of the Expectation instance.
+
+        Raises:
+            `InvalidExpectationConfigurationError`: The configuration does not contain the values required
+                by the Expectation.
         """
 
         # Setting up a configuration

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1488,7 +1488,6 @@ class Expectation(metaclass=MetaExpectation):
             for test in diagnostics.tests:
                 if test.test_passed is False:
                     print(f"=== {test.test_title} ({test.backend}) ===\n")
-                    print(test.stack_trace)
                     print(f"{80 * '='}\n")
 
         checklist: str = diagnostics.generate_checklist()

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1132,11 +1132,11 @@ class Expectation(metaclass=MetaExpectation):
     def get_success_kwargs(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> Dict[str, Any]:
-        """Retrieve the success kwargs
+        """Retrieve the success kwargs.
 
         Args:
             configuration: The `ExpectationConfiguration` that contains the kwargs. If no configuration arg is provided,
-            the success kwargs from the configuration attribute of the Expectation instance will be returned.
+                the success kwargs from the configuration attribute of the Expectation instance will be returned.
         """
         if not configuration:
             configuration = self.configuration
@@ -1311,10 +1311,10 @@ class Expectation(metaclass=MetaExpectation):
             raise_exceptions_for_backends: Bool object that when True will raise an Exception if a backend fails to connect.
             ignore_suppress:  Bool object that when True will ignore the suppress_test_for list on Expectation sample tests.
             ignore_only_for:  Bool object that when True will ignore the only_for list on Expectation sample tests.
-            for_gallery:  Bool object that when True will create empty arrays to use as examples for the Expectation Diagnostics
+            for_gallery:  Bool object that when True will create empty arrays to use as examples for the Expectation Diagnostics.
             debug_logger (optional[logging.Logger]):  Logger object to use for sending debug messages to.
-            only_consider_these_backends (optional[List[str]])  List of backends to consider
-            context (optional[AbstractDataContext]): Instance of any child of "AbstractDataContext" class
+            only_consider_these_backends (optional[List[str]])  List of backends to consider.
+            context (optional[AbstractDataContext]): Instance of any child of "AbstractDataContext" class.
 
         Returns:
             An Expectation Diagnostics report object

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1247,6 +1247,7 @@ class Expectation(metaclass=MetaExpectation):
             )
         return self._configuration
 
+    @public_api
     def run_diagnostics(
         self,
         raise_exceptions_for_backends: bool = False,
@@ -1276,6 +1277,18 @@ class Expectation(metaclass=MetaExpectation):
         If errors are encountered in the process of running the diagnostics, they are assumed to be due to
         incompleteness of the Expectation's implementation (e.g., declaring a dependency on Metrics
         that do not exist). These errors are added under "errors" key in the report.
+
+        Args:
+            raise_exceptions_for_backends (bool)
+            ignore_suppress (bool)
+            ignore_only_for (bool)
+            for_gallery (bool)
+            debug_logger (optional[logging.Logger])
+            only_consider_these_backends (optional[List[str]])
+            context (optional[AbstractDataContext])
+
+        Returns:
+            An Expectation Diagnostics report object
         """
 
         if debug_logger is not None:

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1115,9 +1115,16 @@ class Expectation(metaclass=MetaExpectation):
             )
         return domain_kwargs
 
+    @public_api
     def get_success_kwargs(
         self, configuration: Optional[ExpectationConfiguration] = None
     ) -> Dict[str, Any]:
+        """Retrieve the success kwargs
+
+        Args:
+            configuration: The `ExpectationConfiguration` that contains the kwargs. If no configuration arg is provided,
+            the success kwargs from the configuration attribute of the Expectation instance will be returned.
+        """
         if not configuration:
             configuration = self.configuration
 
@@ -1445,6 +1452,7 @@ class Expectation(metaclass=MetaExpectation):
                 UserWarning,
             )
 
+    @public_api
     def print_diagnostic_checklist(
         self,
         diagnostics: Optional[ExpectationDiagnostics] = None,
@@ -1454,6 +1462,10 @@ class Expectation(metaclass=MetaExpectation):
 
         This output from this method is a thin wrapper for ExpectationDiagnostics.generate_checklist()
         This method is experimental.
+
+        Args:
+            diagnostics (optional[ExpectationDiagnostics]): If diagnostics are not provided, diagnostics will be ran on self.
+            show_failed_tests (bool): If true, failing tests will be printed.
         """
 
         if diagnostics is None:

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1488,7 +1488,7 @@ class Expectation(metaclass=MetaExpectation):
             for test in diagnostics.tests:
                 if test.test_passed is False:
                     print(f"=== {test.test_title} ({test.backend}) ===\n")
-                    print(test.stack_trace)  # type: ignore[attr-defined]
+                    print(test.stack_trace)
                     print(f"{80 * '='}\n")
 
         checklist: str = diagnostics.generate_checklist()

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -1279,13 +1279,13 @@ class Expectation(metaclass=MetaExpectation):
         that do not exist). These errors are added under "errors" key in the report.
 
         Args:
-            raise_exceptions_for_backends (bool)
-            ignore_suppress (bool)
-            ignore_only_for (bool)
-            for_gallery (bool)
-            debug_logger (optional[logging.Logger])
-            only_consider_these_backends (optional[List[str]])
-            context (optional[AbstractDataContext])
+            raise_exceptions_for_backends: Bool object that when True will raise an Exception if a backend fails to connect.
+            ignore_suppress:  Bool object that when True will ignore the suppress_test_for list on Expectation sample tests.
+            ignore_only_for:  Bool object that when True will ignore the only_for list on Expectation sample tests.
+            for_gallery:  Bool object that when True will create empty arrays to use as examples for the Expectation Diagnostics
+            debug_logger (optional[logging.Logger]):  Logger object to use for sending debug messages to.
+            only_consider_these_backends (optional[List[str]])  List of backends to consider
+            context (optional[AbstractDataContext]): Instance of any child of "AbstractDataContext" class
 
         Returns:
             An Expectation Diagnostics report object


### PR DESCRIPTION
DX-237
Add docstrings:
get_success_kwargs
print_diagnostic_checklist
run_diagnostics
expect_table_row_count_to_equal > validate_configuration


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
