### PR TITLE
[DOCS] Nest sidebar by shortest import path

### DIFF
--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -327,6 +327,9 @@ class SphinxInvokeDocsBuilder:
         if path_prefix.parts[0] == "great_expectations":
             path_prefix = pathlib.Path(*path_prefix.parts[1:])
 
+        # Use the `_class` suffix to differentiate between classes and folders with
+        # the same name since the docusaurus sidebar is case insensitive. E.g.
+        # great_expectations/checkpoint path and Checkpoint class
         definition_path = path_prefix / f"{definition.name}_class"
 
         return definition_path.with_suffix(".mdx")

--- a/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
+++ b/docs/sphinx_api_docs_source/build_sphinx_api_docs.py
@@ -316,15 +316,18 @@ class SphinxInvokeDocsBuilder:
     def _get_class_mdx_relative_filepath(self, definition: Definition) -> pathlib.Path:
         """Get the filepath to use for the docusaurus mdx file from a class definition."""
 
-        if definition.filepath.is_absolute():
-            definition_path = definition.filepath.relative_to(self.gx_path)
-        else:
-            definition_path = definition.filepath
+        shortest_dotted_path = get_shortest_dotted_path(
+            definition=definition, repo_root_path=self.repo_root
+        )
+        # Use parent since file will create sidebar entry with class name
+        # (if .parent is not used, then there will be a duplicate).
+        path_prefix = pathlib.Path(shortest_dotted_path.replace(".", "/")).parent
 
-        if isinstance(definition.ast_definition, ast.ClassDef):
-            definition_path = (
-                definition_path.with_suffix("") / f"{definition.name}_class"
-            )
+        # Remove the `great_expectations` top level
+        if path_prefix.parts[0] == "great_expectations":
+            path_prefix = pathlib.Path(*path_prefix.parts[1:])
+
+        definition_path = path_prefix / f"{definition.name}_class"
 
         return definition_path.with_suffix(".mdx")
 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -39,6 +39,9 @@
     /* make pagination look like the nice buttons */
     --ifm-pagination-nav-border-radius: 35px;
     --ifm-pagination-nav-padding: 16px;
+
+    /* enlarge the sidebar width */
+    --doc-sidebar-width: 350px !important;
 }
 
 /* override huge h1 */


### PR DESCRIPTION
Changes proposed in this pull request:
- Nest the sidebar by the shortest import path instead of the file path.