### PR TITLE
[MAINTENANCE] Update `update_` methods in `DataContext` to return persisted object

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -768,7 +768,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         self,
         datasource: Union[LegacyDatasource, BaseDatasource],
         save_changes: bool | None = None,
-    ) -> None:
+    ) -> Datasource:
         """Updates a Datasource that already exists in the store.
 
         Args:
@@ -776,7 +776,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             save_changes: do I save changes to disk?
         """
         save_changes = self._determine_save_changes_flag(save_changes)
-        self._update_datasource(datasource=datasource, save_changes=save_changes)
+        return self._update_datasource(datasource=datasource, save_changes=save_changes)
 
     def _update_datasource(
         self,
@@ -2241,7 +2241,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     def update_expectation_suite(
         self,
         expectation_suite: ExpectationSuite,
-    ) -> None:
+    ) -> ExpectationSuite:
         """Update an ExpectationSuite that already exists.
 
         Args:
@@ -2257,7 +2257,7 @@ class AbstractDataContext(ConfigPeer, ABC):
                 f"expectation_suite with name {expectation_suite_name} does not exist."
             )
 
-        self._add_expectation_suite(
+        return self._add_expectation_suite(
             expectation_suite_name=expectation_suite_name,
             id=expectation_suite.ge_cloud_id,
             expectations=expectation_suite.expectations,
@@ -2493,7 +2493,7 @@ class AbstractDataContext(ConfigPeer, ABC):
             ge_cloud_id=ge_cloud_id,
         )
 
-    def update_profiler(self, profiler: RuleBasedProfiler) -> None:
+    def update_profiler(self, profiler: RuleBasedProfiler) -> RuleBasedProfiler:
         """Update a Profiler that already exists.
 
         Args:
@@ -2502,7 +2502,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         Raises:
             ProfilerNotFoundError: A profiler with the given name/id does not already exist.
         """
-        RuleBasedProfiler.update_profiler(
+        return RuleBasedProfiler.update_profiler(
             profiler=profiler,
             profiler_store=self.profiler_store,
             data_context=self,

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -44,6 +44,7 @@ from great_expectations.rule_based_profiler.config.base import (
     domainBuilderConfigSchema,
     expectationConfigurationBuilderConfigSchema,
     parameterBuilderConfigSchema,
+    ruleBasedProfilerConfigSchema,
 )
 from great_expectations.rule_based_profiler.domain_builder.domain_builder import (
     DomainBuilder,
@@ -1268,8 +1269,13 @@ class BaseRuleBasedProfiler(ConfigPeer):
         else:
             RuleBasedProfiler.delete_profiler(name=name, profiler_store=profiler_store)
 
-        _ = RuleBasedProfiler.add_profiler(
-            config=profiler.config,
+        config = profiler.config
+        config.config_version = profiler.config_version
+        config.rules = {rule.name: rule.to_dict() for rule in profiler.rules}
+        config.variables = convert_variables_to_dict(profiler.variables)
+
+        return RuleBasedProfiler.add_profiler(
+            config=config,
             data_context=data_context,
             profiler_store=profiler_store,
         )

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -44,7 +44,6 @@ from great_expectations.rule_based_profiler.config.base import (
     domainBuilderConfigSchema,
     expectationConfigurationBuilderConfigSchema,
     parameterBuilderConfigSchema,
-    ruleBasedProfilerConfigSchema,
 )
 from great_expectations.rule_based_profiler.domain_builder.domain_builder import (
     DomainBuilder,
@@ -1248,7 +1247,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         profiler: RuleBasedProfiler,
         profiler_store: ProfilerStore,
         data_context: AbstractDataContext,
-    ) -> None:
+    ) -> RuleBasedProfiler:
         name = profiler.name
         id = profiler.ge_cloud_id
 

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -333,8 +333,9 @@ def test_update_expectation_suite_success(
             kwargs={"column": "x", "value_set": [1, 2, 4]},
         ),
     ]
-    context.update_expectation_suite(suite)
+    updated_suite = context.update_expectation_suite(suite)
 
+    assert updated_suite.expectations == suite.expectations
     assert context.expectations_store.save_count == 2
 
 
@@ -348,7 +349,7 @@ def test_update_expectation_suite_failure(
     suite = ExpectationSuite(expectation_suite_name=suite_name)
 
     with pytest.raises(gx_exceptions.DataContextError) as e:
-        context.update_expectation_suite(suite)
+        _ = context.update_expectation_suite(suite)
 
     assert f"expectation_suite with name {suite_name} does not exist." in str(e.value)
 
@@ -443,9 +444,10 @@ def test_update_profiler_success(
 
     assert context.profiler_store.save_count == 1
 
-    profiler.rules = {}
-    context.update_profiler(profiler)
+    profiler.rules = []
+    updated_profiler = context.update_profiler(profiler)
 
+    assert updated_profiler.rules == profiler.rules
     assert context.profiler_store.save_count == 2
 
 
@@ -461,7 +463,7 @@ def test_update_profiler_failure(in_memory_data_context: EphemeralDataContextSpy
     )
 
     with pytest.raises(gx_exceptions.ProfilerNotFoundError) as e:
-        context.update_profiler(profiler)
+        _ = context.update_profiler(profiler)
 
     assert f"Non-existent Profiler configuration named {name}" in str(e.value)
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Some store updates impact the state of the updated object - we should reflect that in our return value.


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
