### PR TITLE
[MAINTENANCE] ZEP - use parameter that exists on min pandas version

### DIFF
--- a/tests/experimental/datasources/test_pandas_datasource.py
+++ b/tests/experimental/datasources/test_pandas_datasource.py
@@ -136,7 +136,7 @@ class TestDynamicPandasAssets:
         ["asset_model", "extra_kwargs"],
         [
             (CSVAsset, {"sep": "|", "names": ["col1", "col2", "col3"]}),
-            (JSONAsset, {"orient": "records", "encoding_errors": "strict"}),
+            (JSONAsset, {"orient": "records", "convert_dates": True}),
         ],
     )
     def test_data_asset_defaults(


### PR DESCRIPTION
Changes proposed in this pull request:
- update tests to use `read_json`/`JSONAsset` params that exist on all supported `pandas` version.


v1.1 -  https://pandas.pydata.org/pandas-docs/version/1.1/reference/api/pandas.read_json.html#pandas.read_json

v1.5 - https://pandas.pydata.org/docs/reference/api/pandas.read_json.html#pandas.read_json


