### PR TITLE
[BUGFIX] ID/PK - Rendering `ColumnPair` and `MultiColumn` Expectations in DataDocs 

### DIFF
--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -64,6 +64,10 @@ class MissingTopLevelConfigKeyError(GreatExpectationsValidationError):
     pass
 
 
+class RenderingError(GreatExpectationsError):
+    pass
+
+
 class InvalidBaseYamlConfigError(GreatExpectationsValidationError):
     def __init__(self, message, validation_error=None, field_name=None) -> None:
         if validation_error is not None:

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -80,7 +80,7 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         """
         Validates the configuration for the Expectation.
 
-        For this expectation, `configuraton.kwargs` may contain `min_value` and `max_value` whose value is a number.
+        For this expectation, `configuration.kwargs` may contain `min_value` and `max_value` whose value is a number.
 
         Args:
             configuration: An `ExpectationConfiguration` to validate. If no configuration is provided,
@@ -103,6 +103,7 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         runtime_configuration: Optional[dict] = None,
         **kwargs,
     ) -> None:
+        # this is why
         pass
 
     @classmethod
@@ -114,4 +115,5 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         runtime_configuration: Optional[dict] = None,
         **kwargs,
     ) -> None:
+        # this is why
         pass

--- a/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
+++ b/great_expectations/expectations/core/expect_multicolumn_sum_to_equal.py
@@ -103,7 +103,7 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         runtime_configuration: Optional[dict] = None,
         **kwargs,
     ) -> None:
-        # this is why
+        # TODO: Need for prescriptive renderer for Expectation if we want to render in DataDocs.
         pass
 
     @classmethod
@@ -115,5 +115,5 @@ class ExpectMulticolumnSumToEqual(MulticolumnMapExpectation):
         runtime_configuration: Optional[dict] = None,
         **kwargs,
     ) -> None:
-        # this is why
+        # TODO: Need for diagnostic renderer for Expectation if we want to render in DataDocs.
         pass

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -297,59 +297,61 @@ def build_count_and_index_table(
     unexpected_count: int,
     unexpected_list: Optional[List[dict]] = None,
     unexpected_index_column_names: Optional[List[str]] = None,
-) -> Tuple[List[str], List[List[Any]]]:
+):
     """
-    Used by _diagnostic_unexpected_table_renderer() method in Expectation to render
-    Unexpected Counts and Indices table for ID/PK.
-
+        Used by _diagnostic_unexpected_table_renderer() method in Expectation to render
+        Unexpected Counts and Indices table for ID/PK.
     Args:
-         partial_unexpected_counts: list of dictionaries containing unexpected values and counts
-         unexpected_index_list: list of dictionaries containing unexpected indices and their values
-         unexpected_count: how many total unexpected values are there?
-         unexpected_list: optional list of all unexpected values. Used default Pandas unexpected
-             indices (without define id/pk columns)
-         unexpected_count: total number of unexpected values. Used to build the header.
+        partial_unexpected_counts: list of dictionaries containing unexpected values and counts
+        unexpected_index_list: list of dictionaries containing unexpected indices and their values
+        unexpected_count: how many total unexpected values are there?
+        unexpected_list: optional list of all unexpected values. Used with default Pandas unexpected
+             indices (without defined id/pk columns)
+        unexpected_index_column_names: list of unexpected_index_column_names
+
     Returns:
         List of strings that will be rendered into DataDocs
 
     """
     table_rows: List[List[str]] = []
     total_count: int = 0
-
     unexpected_index_df = _convert_unexpected_indices_to_df(
         unexpected_index_list=unexpected_index_list,
         unexpected_index_column_names=unexpected_index_column_names,
         unexpected_list=unexpected_list,
         partial_unexpected_counts=partial_unexpected_counts,
     )
+    if unexpected_index_df.empty:
+        raise Exception(
+            f"GX ran into an issue while building count and index table. Please check your settings."
+        )
+
     # if we are using pandas default unexpected_indices
-    if unexpected_index_df is not None and unexpected_index_column_names is None:
+    if unexpected_index_column_names is None:
         unexpected_index_column_names = ["Index"]
 
-    for unexpected_count_dict in partial_unexpected_counts:
-        value: Optional[Any] = unexpected_count_dict.get("value")
-        count: Optional[int] = unexpected_count_dict.get("count")
+    for index, row in unexpected_index_df.iterrows():
+        row_list: List[Union[str, int]] = []
+
+        unexpected_value = index
+        count = int(row.Count)
         if count:
             total_count += count
-
-        row_list: List[Union[str, int]] = []
-        if value is not None and value != "":
-            row_list.append(value)
+        if unexpected_value is not None and unexpected_value != "":
+            row_list.append(unexpected_value)
             row_list.append(count)
-        elif value == "":
+        elif unexpected_value == "":
             row_list.append("EMPTY")
             row_list.append(count)
         else:
-            # this value has already been replaced in the unexpected_index_df
-            value = "null"
+            unexpected_value = "null"
             row_list.append("null")
             row_list.append(count)
-        if unexpected_index_column_names:
-            for column_name in unexpected_index_column_names:
-                row_list.append(unexpected_index_df[[column_name]].loc[value].item())
+        for column_name in unexpected_index_column_names:
+            row_list.append(str(row[column_name]))
+
         if len(row_list) > 0:
             table_rows.append(row_list)
-
     # Check to see if we have *all* of the unexpected values accounted for. If so,
     # we show counts. If not, we only show "sampled" unexpected values.
     if total_count == unexpected_count:
@@ -369,30 +371,6 @@ def _convert_unexpected_indices_to_df(
     unexpected_index_column_names: Optional[List[str]] = None,
     unexpected_list: Optional[List[Any]] = None,
 ) -> Optional[pd.DataFrame]:
-    """
-    Helper method to convert the list of unexpected indices into a DataFrame that can be used to
-    display unexpected indices. domain_column (the column the Expectation is run on) is used
-    as the index for the DataFrame, and the columns are the unexpected_index_column_names, or a default
-    value in the case of Pandas, which provides default indices.
-
-    In cases where the number of indices is too great (max 10 by default), the remaining values are
-    truncated and the column contains "..." in their place.
-
-                pk_1
-    giraffe     3
-    lion        4
-    zebra       5 6 8 ...
-
-    Args:
-
-        unexpected_index_list : all unexpected values and indices
-        partial_unexpected_counts : counts for unexpected values (max 20 by default)
-        unexpected_index_column_names:  in the case of defining ID/PK columns
-        unexpected_list: if we are using default Pandas output.
-
-    Returns:
-        pd.DataFrame that contains indices for unexpected values
-    """
     if unexpected_index_column_names:
         # if we have defined unexpected_index_column_names for ID/PK
         unexpected_index_list_as_string: pd.DataFrame = pd.DataFrame(
@@ -401,10 +379,10 @@ def _convert_unexpected_indices_to_df(
         unexpected_index_list_as_string = unexpected_index_list_as_string.fillna(
             value="null"
         )
-        domain_column_name: str = (
-            set(unexpected_index_list[0].keys())
-            .difference(set(unexpected_index_column_names))
-            .pop()
+        domain_column_name_list: List[str] = list(
+            set(unexpected_index_list[0].keys()).difference(
+                set(unexpected_index_column_names)
+            )
         )
     elif unexpected_list:
         # if we are using default Pandas unexpected indices
@@ -416,36 +394,30 @@ def _convert_unexpected_indices_to_df(
         unexpected_index_list_as_string = unexpected_index_list_as_string.fillna(
             value="null"
         )
-        domain_column_name: str = "Value"
+        domain_column_name_list: List[str] = ["Value"]
         unexpected_index_column_names: List[str] = ["Index"]
+
     else:
         return None
 
-    # unexpected indices are joined as list
     all_unexpected_indices: pd.DataFrame = unexpected_index_list_as_string.groupby(
-        domain_column_name
+        domain_column_name_list
     ).agg(lambda y: list(y))
 
-    # filter all_unexpected_indices according to partial_unexpected_counts, since it has a maximum of 20 values by default
-    values_we_have_counts_for: List[str] = list(
-        pd.DataFrame(partial_unexpected_counts)["value"]
+    # add count
+    col_to_count: str = unexpected_index_column_names[0]
+    all_unexpected_indices["Count"] = all_unexpected_indices[col_to_count].apply(
+        lambda x: len(x)
     )
-    # list comprehension to replace None with 'null'
-    values_we_have_counts_for = [
-        "null" if val is None else val for val in values_we_have_counts_for
-    ]
+    all_unexpected_indices.index = all_unexpected_indices.index.map(str)
 
-    filtered_unexpected_indices = all_unexpected_indices[
-        all_unexpected_indices.index.isin(values_we_have_counts_for)
-    ]
-
-    # applying function to every row in Pandas
-    # https://www.geeksforgeeks.org/apply-function-to-every-row-in-a-pandas-dataframe/
     for column in unexpected_index_column_names:
-        filtered_unexpected_indices[column] = filtered_unexpected_indices[column].apply(
+        all_unexpected_indices[column] = all_unexpected_indices[column].apply(
             lambda row: truncate_list_of_indices(row)
         )
-
+    filtered_unexpected_indices = all_unexpected_indices.head(
+        len(partial_unexpected_counts)
+    )
     return filtered_unexpected_indices
 
 

--- a/great_expectations/render/util.py
+++ b/great_expectations/render/util.py
@@ -325,7 +325,7 @@ def build_count_and_index_table(
     )
     if unexpected_index_df.empty:
         raise RenderingError(
-            f"GX ran into an issue while building count and index table for rendering. Please check your configuration."
+            "GX ran into an issue while building count and index table for rendering. Please check your configuration."
         )
 
     # using default indices for Pandas

--- a/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
+++ b/tests/render/test_render_ValidationResultsTableContentBlockRenderer.py
@@ -1299,7 +1299,7 @@ def test_ValidationResultsTableContentBlockRenderer_get_unexpected_table_with_id
         "table": [
             ["giraffe", 1, "3"],
             ["lion", 1, "4"],
-            ["zebra", 1, "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, ..."],
+            ["zebra", 11, "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, ..."],
         ],
     }
 
@@ -1392,6 +1392,6 @@ def test_ValidationResultsTableContentBlockRenderer_get_unexpected_table_with_id
         "table": [
             ["giraffe", 1, "3"],
             ["lion", 1, "4"],
-            ["zebra", 1, "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, ..."],
+            ["zebra", 11, "5, 6, 7, 8, 9, 10, 11, 12, 13, 14, ..."],
         ],
     }

--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -372,8 +372,110 @@ def test_convert_unexpected_indices_to_df_multiple_with_truncation():
     assert res.iloc[0].tolist() == ["0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...", 13]
 
 
-# ADD TEST USING THE PAIRs
-# and for counts
+def test_convert_unexpected_indices_to_df_column_pair_expectation():
+    partial_unexpected_counts = [{"value": ("eraser", "desk"), "count": 3}]
+    unexpected_index_list = [
+        {"ordered_item": "eraser", "received_item": "desk", "pk_2": "three"},
+        {"ordered_item": "eraser", "received_item": "desk", "pk_2": "four"},
+        {"ordered_item": "eraser", "received_item": "desk", "pk_2": "five"},
+    ]
+    unexpected_index_column_names = ["pk_2"]
+    res = _convert_unexpected_indices_to_df(
+        unexpected_index_list=unexpected_index_list,
+        unexpected_index_column_names=unexpected_index_column_names,
+        partial_unexpected_counts=partial_unexpected_counts,
+    )
+    assert list(res) == ["pk_2", "Count"]
+    assert res.index.to_list() == ["('eraser', 'desk')"]
+    assert res.iloc[0].tolist() == ["three, four, five", 3]
+
+
+def test_convert_unexpected_indices_to_df_column_pair_expectation_no_id_pk():
+    partial_unexpected_counts = [{"value": ("eraser", "desk"), "count": 3}]
+    unexpected_index_list = [3, 4, 5]
+    unexpected_list = [("eraser", "desk"), ("eraser", "desk"), ("eraser", "desk")]
+    res = _convert_unexpected_indices_to_df(
+        unexpected_index_list=unexpected_index_list,
+        unexpected_index_column_names=None,
+        unexpected_list=unexpected_list,
+        partial_unexpected_counts=partial_unexpected_counts,
+    )
+    assert list(res) == ["Index", "Count"]
+    assert res.index.to_list() == ["('eraser', 'desk')"]
+    assert res.iloc[0].tolist() == ["3, 4, 5", 3]
+
+
+def test_convert_unexpected_indices_to_df_multiple_column_expectation():
+    partial_unexpected_counts = [
+        {"value": (20, 20, 20), "count": 1},
+        {"value": (30, 30, 30), "count": 1},
+        {"value": (40, 40, 40), "count": 1},
+        {"value": (50, 50, 50), "count": 1},
+        {"value": (60, 60, 60), "count": 1},
+    ]
+    unexpected_index_list = [
+        {"a": 20, "pk_1": 1, "b": 20, "c": 20},
+        {"a": 30, "pk_1": 2, "b": 30, "c": 30},
+        {"a": 40, "pk_1": 3, "b": 40, "c": 40},
+        {"a": 50, "pk_1": 4, "b": 50, "c": 50},
+        {"a": 60, "pk_1": 5, "b": 60, "c": 60},
+    ]
+    unexpected_index_column_names = ["pk_1"]
+    res = _convert_unexpected_indices_to_df(
+        unexpected_index_list=unexpected_index_list,
+        unexpected_index_column_names=unexpected_index_column_names,
+        partial_unexpected_counts=partial_unexpected_counts,
+    )
+    assert list(res) == ["pk_1", "Count"]
+    assert res.index.to_list() == [
+        "('20', '20', '20')",
+        "('30', '30', '30')",
+        "('40', '40', '40')",
+        "('50', '50', '50')",
+        "('60', '60', '60')",
+    ]
+    assert res.iloc[0].tolist() == ["1", 1]
+    assert res.iloc[1].tolist() == ["2", 1]
+    assert res.iloc[2].tolist() == ["3", 1]
+    assert res.iloc[3].tolist() == ["4", 1]
+    assert res.iloc[4].tolist() == ["5", 1]
+
+
+def test_convert_unexpected_indices_to_df_multiple_column_expectation_no_id_pk():
+    partial_unexpected_counts = [
+        {"value": (20, 20, 20), "count": 1},
+        {"value": (30, 30, 30), "count": 1},
+        {"value": (40, 40, 40), "count": 1},
+        {"value": (50, 50, 50), "count": 1},
+        {"value": (60, 60, 60), "count": 1},
+    ]
+    unexpected_list = [
+        (20, 20, 20),
+        (30, 30, 30),
+        (40, 40, 40),
+        (50, 50, 50),
+        (60, 60, 60),
+    ]
+    unexpected_index_list = [1, 2, 3, 4, 5]
+    res = _convert_unexpected_indices_to_df(
+        unexpected_index_list=unexpected_index_list,
+        unexpected_index_column_names=None,
+        unexpected_list=unexpected_list,
+        partial_unexpected_counts=partial_unexpected_counts,
+    )
+    assert list(res) == ["Index", "Count"]
+    assert res.index.to_list() == [
+        "(20, 20, 20)",
+        "(30, 30, 30)",
+        "(40, 40, 40)",
+        "(50, 50, 50)",
+        "(60, 60, 60)",
+    ]
+    assert res.iloc[0].tolist() == ["1", 1]
+    assert res.iloc[1].tolist() == ["2", 1]
+    assert res.iloc[2].tolist() == ["3", 1]
+    assert res.iloc[3].tolist() == ["4", 1]
+    assert res.iloc[4].tolist() == ["5", 1]
 
 
 def test_convert_unexpected_indices_to_df_actual_values():
@@ -542,7 +644,9 @@ def test_build_count_and_index_table_with_column_pair():
         unexpected_index_column_names=unexpected_index_column_names,
     )
     assert header_row == ["Unexpected Value", "Count", "pk_2"]
-    assert table_rows == [["('desk', 'eraser')", 3, "three, four, five"]]
+    assert table_rows == [
+        ["('desk', 'eraser')", 3, "three, four, five"]
+    ] or table_rows == [["('eraser', 'desk')", 3, "three, four, five"]]
 
 
 def test_build_count_and_index_table_with_null():

--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -309,11 +309,10 @@ def test_convert_unexpected_indices_to_df():
         unexpected_index_column_names=unexpected_index_column_names,
         partial_unexpected_counts=partial_unexpected_counts,
     )
-    assert list(res) == unexpected_index_column_names
-    print(res)
-    assert res.iloc[0].tolist() == ["3", "three"]
-    assert res.iloc[1].tolist() == ["4", "four"]
-    assert res.iloc[2].tolist() == ["5", "five"]
+    assert list(res) == ["pk_1", "pk_2", "Count"]
+    assert res.iloc[0].tolist() == ["3", "three", 1]
+    assert res.iloc[1].tolist() == ["4", "four", 1]
+    assert res.iloc[2].tolist() == ["5", "five", 1]
 
 
 def test_convert_unexpected_indices_to_df_multiple():
@@ -337,10 +336,13 @@ def test_convert_unexpected_indices_to_df_multiple():
         unexpected_index_column_names=unexpected_index_column_names,
         partial_unexpected_counts=partial_unexpected_counts,
     )
-    assert list(res) == unexpected_index_column_names
-    assert res.iloc[0].tolist() == ["3"]
-    assert res.iloc[1].tolist() == ["4"]
-    assert res.iloc[2].tolist() == ["5, 6, 7, 8"]
+    assert list(res) == ["pk_1", "Count"]
+    assert res.iloc[0, 0] == "3"
+    assert res.iloc[1, 0] == "4"
+    assert res.iloc[2, 0] == "5, 6, 7, 8"
+    assert res.iloc[0, 1] == 1
+    assert res.iloc[1, 1] == 1
+    assert res.iloc[2, 1] == 4
 
 
 def test_convert_unexpected_indices_to_df_multiple_with_truncation():
@@ -366,8 +368,12 @@ def test_convert_unexpected_indices_to_df_multiple_with_truncation():
         unexpected_index_column_names=unexpected_index_column_names,
         partial_unexpected_counts=partial_unexpected_counts,
     )
-    assert list(res) == unexpected_index_column_names
-    assert res.iloc[0].tolist() == ["0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ..."]
+    assert list(res) == ["pk_1", "Count"]
+    assert res.iloc[0].tolist() == ["0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...", 13]
+
+
+# ADD TEST USING THE PAIRs
+# and for counts
 
 
 def test_convert_unexpected_indices_to_df_actual_values():
@@ -387,10 +393,10 @@ def test_convert_unexpected_indices_to_df_actual_values():
         unexpected_list=unexpected_list,
         partial_unexpected_counts=partial_unexpected_counts,
     )
-    assert list(res) == ["Index"]
-    assert res.iloc[0].tolist() == ["3"]
-    assert res.iloc[1].tolist() == ["4"]
-    assert res.iloc[2].tolist() == ["5"]
+    assert list(res) == ["Index", "Count"]
+    assert res.iloc[0].tolist() == ["3", 1]
+    assert res.iloc[1].tolist() == ["4", 1]
+    assert res.iloc[2].tolist() == ["5", 1]
 
 
 def test_truncate_list_of_indices():
@@ -485,6 +491,58 @@ def test_build_count_and_index_table_with_empty_string():
     assert table_rows == [
         ["EMPTY", 1, "5", "five"],
     ]
+
+
+def test_build_count_and_index_table_with_multi_column():
+    partial_unexpected_counts = [
+        {"value": (20, 20, 20), "count": 1},
+        {"value": (30, 30, 30), "count": 1},
+        {"value": (40, 40, 40), "count": 1},
+        {"value": (50, 50, 50), "count": 1},
+        {"value": (60, 60, 60), "count": 1},
+    ]
+    unexpected_index_list = [
+        {"a": 20, "pk_1": 1, "b": 20, "c": 20},
+        {"a": 30, "pk_1": 2, "b": 30, "c": 30},
+        {"a": 40, "pk_1": 3, "b": 40, "c": 40},
+        {"a": 50, "pk_1": 4, "b": 50, "c": 50},
+        {"a": 60, "pk_1": 5, "b": 60, "c": 60},
+    ]
+    unexpected_count = 5
+    unexpected_index_column_names = ["pk_1"]
+    header_row, table_rows = build_count_and_index_table(
+        partial_unexpected_counts=partial_unexpected_counts,
+        unexpected_index_list=unexpected_index_list,
+        unexpected_count=unexpected_count,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert header_row == ["Unexpected Value", "Count", "pk_1"]
+    assert table_rows == [
+        ["('20', '20', '20')", 1, "1"],
+        ["('30', '30', '30')", 1, "2"],
+        ["('40', '40', '40')", 1, "3"],
+        ["('50', '50', '50')", 1, "4"],
+        ["('60', '60', '60')", 1, "5"],
+    ]
+
+
+def test_build_count_and_index_table_with_column_pair():
+    partial_unexpected_counts = [{"value": ("eraser", "desk"), "count": 3}]
+    unexpected_index_list = [
+        {"ordered_item": "eraser", "received_item": "desk", "pk_2": "three"},
+        {"ordered_item": "eraser", "received_item": "desk", "pk_2": "four"},
+        {"ordered_item": "eraser", "received_item": "desk", "pk_2": "five"},
+    ]
+    unexpected_count = 3
+    unexpected_index_column_names = ["pk_2"]
+    header_row, table_rows = build_count_and_index_table(
+        partial_unexpected_counts=partial_unexpected_counts,
+        unexpected_index_list=unexpected_index_list,
+        unexpected_count=unexpected_count,
+        unexpected_index_column_names=unexpected_index_column_names,
+    )
+    assert header_row == ["Unexpected Value", "Count", "pk_2"]
+    assert table_rows == [["('desk', 'eraser')", 3, "three, four, five"]]
 
 
 def test_build_count_and_index_table_with_null():


### PR DESCRIPTION
# What is in this PR? 
* `_convert_unexpected_indices_to_df()` has been refactored to take in domain column **list**, and generate counts, so there is no need to map back to `partial_unexpected_counts` dict. 
* `build_count_and_index_table()` has been refactored to use the DF outputted by `_convert_unexpected_indices_to_df()`. 
* Tests have been added to `test_util.py` to test MultiColumnExpectation and ColumnPairExpectation. 

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
