### PR TITLE
[BUGFIX] `ColumnPairExpectation` tests need to consider 2 possible GroupBy results

### DIFF
--- a/tests/render/test_util.py
+++ b/tests/render/test_util.py
@@ -386,7 +386,9 @@ def test_convert_unexpected_indices_to_df_column_pair_expectation():
         partial_unexpected_counts=partial_unexpected_counts,
     )
     assert list(res) == ["pk_2", "Count"]
-    assert res.index.to_list() == ["('eraser', 'desk')"]
+    assert res.index.to_list() == ["('eraser', 'desk')"] or res.index.to_list() == [
+        "('desk', 'eraser')"
+    ]
     assert res.iloc[0].tolist() == ["three, four, five", 3]
 
 
@@ -401,7 +403,9 @@ def test_convert_unexpected_indices_to_df_column_pair_expectation_no_id_pk():
         partial_unexpected_counts=partial_unexpected_counts,
     )
     assert list(res) == ["Index", "Count"]
-    assert res.index.to_list() == ["('eraser', 'desk')"]
+    assert res.index.to_list() == ["('eraser', 'desk')"] or res.index.to_list() == [
+        "('desk', 'eraser')"
+    ]
     assert res.iloc[0].tolist() == ["3, 4, 5", 3]
 
 


### PR DESCRIPTION
- Pandas `groupby()` can output 2 possibilities for `ColumnPairExpectations`. Tests now use a `or` condition to test either possibility

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
