### PR TITLE
[MAINTENANCE] Cache dependency installation during build of `Dockerfile.tests`

### DIFF
--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -15,21 +15,27 @@ ARG BRANCH=develop
 RUN git clone --filter=tree:0 --branch ${BRANCH} https://github.com/great-expectations/great_expectations.git
 WORKDIR /great_expectations
 
+FROM base as build_local
+WORKDIR /great_expectations
+COPY ./requirements.txt ./requirements.txt
+COPY ./requirements-dev.txt ./requirements-dev.txt
+COPY ./constraints-dev.txt ./constraints-dev.txt
+COPY ./reqs ./reqs
+
 FROM build_${SOURCE} AS dev
 ARG GE_USAGE_STATISTICS_URL="https://dev.stats.greatexpectations.io/great_expectations/v1/usage_statistics"
 env GE_USAGE_STATISTICS_URL="${GE_USAGE_STATISTICS_URL}"
 RUN pip install --no-cache-dir --requirement requirements-dev.txt --constraint constraints-dev.txt
-RUN pip install .
 CMD [ "python", "--version"]
 
 FROM dev as test
 RUN pip install --no-cache-dir --requirement requirements-dev.txt --requirement reqs/requirements-dev-test.txt \
     --constraint constraints-dev.txt
+COPY . .
+RUN pip install .
 
 FROM dev as dev-tools
 RUN pip install --no-cache-dir --requirement requirements-dev.txt --requirement reqs/requirements-dev-test.txt \
     --requirement reqs/requirements-dev-tools.txt --constraint constraints-dev.txt
-
-FROM base as build_local
-WORKDIR /great_expectations
 COPY . .
+RUN pip install .

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -8,19 +8,17 @@ FROM python:${PYTHON_VERSION} AS base
 RUN apt update && apt install default-jre unixodbc unixodbc-dev default-mysql-client locales locales-all -y && apt clean
 RUN python -m pip install --no-cache-dir --upgrade pip
 
+FROM base as build_local
+WORKDIR /great_expectations
+COPY ./requirements.txt ./requirements-dev.txt ./constraints-dev.txt ./
+COPY ./reqs ./reqs
+
 FROM base AS build_github
 # BRANCH is the branch name you want to build
 ARG BRANCH=develop
 # We use --filter=tree:0 instead of --depth 1 because we really on git to get version information
 RUN git clone --filter=tree:0 --branch ${BRANCH} https://github.com/great-expectations/great_expectations.git
 WORKDIR /great_expectations
-
-FROM base as build_local
-WORKDIR /great_expectations
-COPY ./requirements.txt ./requirements.txt
-COPY ./requirements-dev.txt ./requirements-dev.txt
-COPY ./constraints-dev.txt ./constraints-dev.txt
-COPY ./reqs ./reqs
 
 FROM build_${SOURCE} AS dev
 ARG GE_USAGE_STATISTICS_URL="https://dev.stats.greatexpectations.io/great_expectations/v1/usage_statistics"

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -8,10 +8,6 @@ FROM python:${PYTHON_VERSION} AS base
 RUN apt update && apt install default-jre unixodbc unixodbc-dev default-mysql-client locales locales-all -y && apt clean
 RUN python -m pip install --no-cache-dir --upgrade pip
 
-FROM base as build_local
-WORKDIR /great_expectations
-COPY . .
-
 FROM base AS build_github
 # BRANCH is the branch name you want to build
 ARG BRANCH=develop
@@ -33,3 +29,7 @@ RUN pip install --no-cache-dir --requirement requirements-dev.txt --requirement 
 FROM dev as dev-tools
 RUN pip install --no-cache-dir --requirement requirements-dev.txt --requirement reqs/requirements-dev-test.txt \
     --requirement reqs/requirements-dev-tools.txt --constraint constraints-dev.txt
+
+FROM base as build_local
+WORKDIR /great_expectations
+COPY . .


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1677
- Reduce test image build times for `SOURCE=local` as much as 90%
- Move `COPY . .` to after `pip install` ensuring caching if requirements are unchanged
- 813.0s -> 74.4s

### Before:
813.0s
<img width="1642" alt="image" src="https://user-images.githubusercontent.com/19361723/217392254-32ae9da4-e1f9-472a-b3a0-749c8c15ec3b.png">

### After

Run 1: 987.0s
<img width="1642" alt="image" src="https://user-images.githubusercontent.com/19361723/217397028-ee74f636-2a99-4a0b-8c19-a5894bb0db5b.png">

Run 2 - After non-dependency code change: 74.4s
<img width="1642" alt="image" src="https://user-images.githubusercontent.com/19361723/217388230-6960260a-73ff-4e22-bff9-9a52dce914db.png">

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
