### PR TITLE
[MAINTENANCE] Enable ruff `TCH` rules

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# This contains a list of git commit hashes that should be ignored when viewing the git blame on github.
+# It can also be passed to `--ignore-revs-file` if using git locally.
+# https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt
+# A typical use of these would be if a large formatting change was applied across the whole codebase but otherwise
+# no runtime changes were made. Each entry should be preceded with a comment explaining the change.
+# https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame
+# Apply noqa markers for all TCH001 violations
+<REPLACE_WITH_FULL_COMMIT_HASH>

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,4 +5,4 @@
 # no runtime changes were made. Each entry should be preceded with a comment explaining the change.
 # https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame
 # Apply noqa markers for all TCH001 violations
-<REPLACE_WITH_FULL_COMMIT_HASH>
+f5e7df1846102d9a62cc9b9110387925ffae60cc

--- a/contrib/ruff.toml
+++ b/contrib/ruff.toml
@@ -7,7 +7,7 @@ extend-ignore = [
     # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
     # this likely to be a high touch set of rules that most contribs
     # don't need to care about. It may disincentivize type-hinting.
-    "TCH",
+    "TCH001",
 ]
 
 [isort]

--- a/contrib/ruff.toml
+++ b/contrib/ruff.toml
@@ -1,0 +1,15 @@
+# contrib/ specific ruff linter overrides
+
+# root linter settings are defined in the file below
+extend = "../pyproject.toml"
+
+extend-ignore = [
+    # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
+    # this likely to be a high touch set of rules that most contribs
+    # don't need to care about. It may disincentivize type-hinting.
+    "TCH",
+]
+
+[isort]
+known-first-party = ["great_expectations", "tests"]
+known-third-party = ["dataprofiler", "capitalone_dataprofiler_expectations"]

--- a/contrib/ruff.toml
+++ b/contrib/ruff.toml
@@ -5,8 +5,7 @@ extend = "../pyproject.toml"
 
 extend-ignore = [
     # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
-    # this likely to be a high touch set of rules that most contribs
-    # don't need to care about. It may disincentivize type-hinting.
+    # This is likely to be a high-touch rule that most contribs don't need to care about.
     "TCH001",
 ]
 

--- a/great_expectations/execution_engine/split_and_sample/sqlalchemy_data_sampler.py
+++ b/great_expectations/execution_engine/split_and_sample/sqlalchemy_data_sampler.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    import sqlalchemy as sa
+    import sqlalchemy as sa  # noqa: TCH004
 
     from great_expectations.execution_engine import SqlAlchemyExecutionEngine
 

--- a/great_expectations/execution_engine/split_and_sample/sqlalchemy_data_splitter.py
+++ b/great_expectations/execution_engine/split_and_sample/sqlalchemy_data_splitter.py
@@ -45,7 +45,7 @@ except ImportError:
     concat = None
 
 if TYPE_CHECKING:
-    import sqlalchemy as sa
+    import sqlalchemy as sa  # noqa: TCH004
     from sqlalchemy.sql.expression import Cast, ColumnOperators
 
     from great_expectations.execution_engine.sqlalchemy_execution_engine import (

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -203,7 +203,7 @@ except ImportError:
     teradatatypes = None
 
 if TYPE_CHECKING:
-    import sqlalchemy as sa
+    import sqlalchemy as sa  # noqa: TCH004
     from sqlalchemy.engine import Engine as SaEngine
 
 

--- a/great_expectations/expectations/row_conditions.py
+++ b/great_expectations/expectations/row_conditions.py
@@ -33,7 +33,7 @@ except ImportError:
     sa = None
 
 if TYPE_CHECKING:
-    import sqlalchemy as sa
+    import sqlalchemy as sa  # noqa: TCH004
     from sqlalchemy.sql.expression import ColumnElement
 
 

--- a/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
+++ b/great_expectations/rule_based_profiler/data_assistant/data_assistant.py
@@ -12,7 +12,9 @@ from great_expectations.core.metric_function_types import (
 from great_expectations.core.usage_statistics.usage_statistics import (
     UsageStatisticsHandler,  # noqa: TCH001
 )
-from great_expectations.experimental.datasources.interfaces import Batch as XBatch
+from great_expectations.experimental.datasources.interfaces import (
+    Batch as XBatch,  # noqa: TCH001
+)
 from great_expectations.rule_based_profiler import (
     RuleBasedProfilerResult,  # noqa: TCH001
 )

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -61,7 +61,9 @@ from great_expectations.expectations.registry import (
     get_expectation_impl,
     list_registered_expectation_implementations,
 )
-from great_expectations.experimental.datasources.interfaces import Batch as XBatch
+from great_expectations.experimental.datasources.interfaces import (
+    Batch as XBatch,  # noqa: TCH001
+)
 from great_expectations.rule_based_profiler import (
     RuleBasedProfilerResult,  # noqa: TCH001
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,8 @@ select = [
     "UP", # pyupgrade
     # https://github.com/charliermarsh/ruff#isort-i
     "I", # isort
+    # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
+    "TCH", # flake8-type-checking-tch
 ]
 ignore = [
     # https://github.com/charliermarsh/ruff#pyflakes-f
@@ -219,6 +221,13 @@ ignore = [
     # https://github.com/charliermarsh/ruff#pyupgrade-up
     "UP006", # use-pep585-annotation
     "UP007", # use-pep604-annotation
+    # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
+    # doesn't catch errors or help with circular imports and tedious to apply
+    "TCH002", # typing-only-third-party-import
+    # minimal cost for standard lib imports; keep this disabled
+    "TCH003", # typing-only-standard-library-import
+    # gives false positives if we use try imports and type-checking import
+    "TCH004", # runtime-import-in-type-checking-block
 ]
 extend-exclude = [
     "scripts/*",

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,0 +1,14 @@
+# tests/ specific ruff linter overrides
+
+# root linter settings are defined in the file below
+extend = "../pyproject.toml"
+
+extend-ignore = [
+    # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
+    # this likely to be a high touch set of rules.
+    # Let's differ this for tests until there are auto-fixes
+    "TCH",
+]
+
+[isort]
+known-first-party = ["great_expectations", "tests"]

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -5,7 +5,7 @@ extend = "../pyproject.toml"
 
 extend-ignore = [
     # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
-    # this likely to be a high touch set of rules.
+    # This is likely to be a high-touch rule. Doing this in `tests` doesn't help circular imports.
     # Let's differ this for tests until there are auto-fixes
     "TCH001",
 ]

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -7,7 +7,7 @@ extend-ignore = [
     # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
     # this likely to be a high touch set of rules.
     # Let's differ this for tests until there are auto-fixes
-    "TCH",
+    "TCH001",
 ]
 
 [isort]


### PR DESCRIPTION
Follow up to https://github.com/great-expectations/great_expectations/pull/7072 that enables the rule associated with these added `noqa` comments.

## Changes proposed in this pull request:
- turn on the [TCH rules](https://beta.ruff.rs/docs/rules/#flake8-type-checking-tch)
  -  TCH001
  -  TCH005
- adds directory specific ruff.toml configuration files for the directories below...
  - `tests/`
  - `contrib/`
  - Without excluding tests/, contrib/ we are approaching 1K errors for TCH001
- [x] add `.git-blame-ignore-revs` file to exclude the commit associated with https://github.com/great-expectations/great_expectations/pull/7072

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
