### PR TITLE
[MAINTENANCE] Refactor `Store` and `StoreBackend` to leverage new CRUD methods

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -56,9 +56,6 @@ from great_expectations.core.config_provider import (
     _EnvironmentConfigurationProvider,
     _RuntimeEnvironmentConfigurationProvider,
 )
-from great_expectations.core.expectation_configuration import (
-    ExpectationConfiguration,  # noqa: TCH001
-)
 from great_expectations.core.expectation_validation_result import get_metric_kwargs_id
 from great_expectations.core.id_dict import BatchKwargs
 from great_expectations.core.run_identifier import RunIdentifier
@@ -73,19 +70,7 @@ from great_expectations.data_asset import DataAsset
 from great_expectations.data_context.config_validator.yaml_config_validator import (
     _YamlConfigValidator,
 )
-from great_expectations.data_context.data_context_variables import (
-    DataContextVariables,  # noqa: TCH001
-)
 from great_expectations.data_context.store import Store, TupleStoreBackend
-from great_expectations.data_context.store.expectations_store import (
-    ExpectationsStore,  # noqa: TCH001
-)
-from great_expectations.data_context.store.profiler_store import (
-    ProfilerStore,  # noqa: TCH001
-)
-from great_expectations.data_context.store.validations_store import (
-    ValidationsStore,  # noqa: TCH001
-)
 from great_expectations.data_context.templates import CONFIG_VARIABLES_TEMPLATE
 from great_expectations.data_context.types.base import (
     CURRENT_GX_CONFIG_VERSION,
@@ -123,7 +108,6 @@ from great_expectations.datasource.datasource_serializer import (
     NamedDatasourceSerializer,
 )
 from great_expectations.datasource.new_datasource import BaseDatasource, Datasource
-from great_expectations.execution_engine import ExecutionEngine  # noqa: TCH001
 from great_expectations.experimental.datasources.config import GxConfig
 from great_expectations.experimental.datasources.interfaces import Batch as XBatch
 from great_expectations.experimental.datasources.interfaces import (
@@ -162,13 +146,25 @@ except ImportError:
 if TYPE_CHECKING:
     from great_expectations.checkpoint import Checkpoint
     from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
+    from great_expectations.core.expectation_configuration import (
+        ExpectationConfiguration,
+    )
+    from great_expectations.data_context.data_context_variables import (
+        DataContextVariables,
+    )
     from great_expectations.data_context.store import (
         CheckpointStore,
         EvaluationParameterStore,
     )
+    from great_expectations.data_context.store.expectations_store import (
+        ExpectationsStore,
+    )
+    from great_expectations.data_context.store.profiler_store import ProfilerStore
+    from great_expectations.data_context.store.validations_store import ValidationsStore
     from great_expectations.data_context.types.resource_identifiers import (
         GXCloudIdentifier,
     )
+    from great_expectations.execution_engine import ExecutionEngine
     from great_expectations.render.renderer.site_builder import SiteBuilder
     from great_expectations.rule_based_profiler import RuleBasedProfilerResult
     from great_expectations.validation_operators.validation_operators import (
@@ -2742,16 +2738,14 @@ class AbstractDataContext(ConfigPeer, ABC):
 
         expectation_suite_name = expectation_suite.expectation_suite_name
         key = ExpectationSuiteIdentifier(expectation_suite_name=expectation_suite_name)
-        if (
-            self.expectations_store.has_key(key)  # noqa: W601
-            and not overwrite_existing
-        ):
-            raise gx_exceptions.DataContextError(
-                f"expectation_suite with name {expectation_suite_name} already exists."
-                " If you would like to overwrite this expectation_suite, please delete or"
-                " update it using `delete_expectation_suite` or `update_expectation_suite`, respectively."
-            )
-        self.expectations_store.set(key, expectation_suite, **kwargs)
+
+        fn: Callable
+        if overwrite_existing:
+            fn = self.expectations_store.add_or_update
+        else:
+            fn = self.expectations_store.add
+
+        fn(key=key, value=expectation_suite, **kwargs)
         return expectation_suite
 
     @public_api
@@ -2770,15 +2764,8 @@ class AbstractDataContext(ConfigPeer, ABC):
         """
         expectation_suite_name: str = expectation_suite.expectation_suite_name
         key = ExpectationSuiteIdentifier(expectation_suite_name=expectation_suite_name)
-        if not self.expectations_store.has_key(key):  # noqa: W601
-            raise gx_exceptions.DataContextError(
-                f"expectation_suite with name {expectation_suite_name} does not exist."
-            )
-
-        return self._add_expectation_suite(
-            expectation_suite=expectation_suite,
-            overwrite_existing=True,
-        )
+        self.expectations_store.update(key=key, value=expectation_suite)
+        return expectation_suite
 
     @overload
     def add_or_update_expectation_suite(

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -115,10 +115,6 @@ from great_expectations.experimental.datasources.interfaces import (
 )
 from great_expectations.experimental.datasources.sources import _SourceFactories
 from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
-from great_expectations.rule_based_profiler.config.base import (
-    RuleBasedProfilerConfig,
-    ruleBasedProfilerConfigSchema,
-)
 from great_expectations.rule_based_profiler.data_assistant.data_assistant_dispatcher import (
     DataAssistantDispatcher,
 )
@@ -2739,13 +2735,13 @@ class AbstractDataContext(ConfigPeer, ABC):
         expectation_suite_name = expectation_suite.expectation_suite_name
         key = ExpectationSuiteIdentifier(expectation_suite_name=expectation_suite_name)
 
-        fn: Callable
+        persistence_fn: Callable
         if overwrite_existing:
-            fn = self.expectations_store.add_or_update
+            persistence_fn = self.expectations_store.add_or_update
         else:
-            fn = self.expectations_store.add
+            persistence_fn = self.expectations_store.add
 
-        fn(key=key, value=expectation_suite, **kwargs)
+        persistence_fn(key=key, value=expectation_suite, **kwargs)
         return expectation_suite
 
     @public_api
@@ -2988,57 +2984,15 @@ class AbstractDataContext(ConfigPeer, ABC):
         Returns:
             The persisted Profiler constructed by the input arguments.
         """
-        return self._add_profiler(
+        return RuleBasedProfiler.add_profiler(
+            data_context=self,
+            profiler_store=self.profiler_store,
             name=name,
-            id=None,
             config_version=config_version,
             rules=rules,
             variables=variables,
             profiler=profiler,
         )
-
-    def _add_profiler(
-        self,
-        name: str | None,
-        id: str | None,
-        config_version: float | None,
-        rules: dict[str, dict] | None,
-        variables: dict | None,
-        profiler: RuleBasedProfiler | None,
-    ) -> RuleBasedProfiler:
-        if not (
-            (profiler is None)
-            ^ all(arg is None for arg in (name, config_version, rules))
-        ):
-            raise ValueError(
-                "Must either pass in an existing profiler or individual constructor arguments (but not both)"
-            )
-
-        if profiler:
-            config = profiler.config
-        else:
-            config_data = {
-                "name": name,
-                "id": id,
-                "config_version": config_version,
-                "rules": rules,
-                "variables": variables,
-            }
-
-            # Roundtrip through schema validation to remove any illegal fields add/or restore any missing fields.
-            validated_config: dict = ruleBasedProfilerConfigSchema.load(config_data)
-            profiler_config: dict = ruleBasedProfilerConfigSchema.dump(validated_config)
-            profiler_config.pop("class_name")
-            profiler_config.pop("module_name")
-
-            config = RuleBasedProfilerConfig(**profiler_config)
-
-        profiler = RuleBasedProfiler.add_profiler(
-            config=config,
-            data_context=self,
-            profiler_store=self.profiler_store,
-        )
-        return profiler
 
     @public_api
     @new_argument(
@@ -3120,9 +3074,9 @@ class AbstractDataContext(ConfigPeer, ABC):
             ProfilerNotFoundError: A profiler with the given name/id does not already exist.
         """
         return RuleBasedProfiler.update_profiler(
-            profiler=profiler,
             profiler_store=self.profiler_store,
             data_context=self,
+            profiler=profiler,
         )
 
     @overload
@@ -3179,7 +3133,9 @@ class AbstractDataContext(ConfigPeer, ABC):
         Returns:
             A new Profiler or an updated one (depending on whether or not it existed before this method call).
         """
-        return self._add_profiler(
+        return RuleBasedProfiler.add_or_update_profiler(
+            data_context=self,
+            profiler_store=self.profiler_store,
             name=name,
             id=id,
             config_version=config_version,

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -131,11 +131,17 @@ class StoreBackend(metaclass=ABCMeta):
             raise StoreBackendError("ValueError while calling _set on store backend.")
 
     def add(self, key, value, **kwargs):
+        """
+        TODO
+        """
         if self.has_key(key):
             raise StoreBackendError(f"Store already has the following key: {key}.")
         return self.set(key=key, value=value, **kwargs)
 
     def update(self, key, value, **kwargs):
+        """
+        TODO
+        """
         if not self.has_key(key):
             raise StoreBackendError(
                 f"Store does not have a value associated the following key: {key}."
@@ -143,6 +149,9 @@ class StoreBackend(metaclass=ABCMeta):
         return self.set(key=key, value=value, **kwargs)
 
     def add_or_update(self, key, value, **kwargs):
+        """
+        TODO
+        """
         if self.has_key(key):
             return self.update(key=key, value=value, **kwargs)
         return self.add(key=key, value=value, **kwargs)

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -130,6 +130,23 @@ class StoreBackend(metaclass=ABCMeta):
             logger.debug(str(e))
             raise StoreBackendError("ValueError while calling _set on store backend.")
 
+    def add(self, key, value, **kwargs):
+        if self.has_key(key):
+            raise StoreBackendError(f"Store already has the following key: {key}.")
+        return self.set(key=key, value=value, **kwargs)
+
+    def update(self, key, value, **kwargs):
+        if not self.has_key(key):
+            raise StoreBackendError(
+                f"Store does not have a value associated the following key: {key}."
+            )
+        return self.set(key=key, value=value, **kwargs)
+
+    def add_or_update(self, key, value, **kwargs):
+        if self.has_key(key):
+            return self.update(key=key, value=value, **kwargs)
+        return self.add(key=key, value=value, **kwargs)
+
     def move(self, source_key, dest_key, **kwargs):
         self._validate_key(source_key)
         self._validate_key(dest_key)

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -131,17 +131,11 @@ class StoreBackend(metaclass=ABCMeta):
             raise StoreBackendError("ValueError while calling _set on store backend.")
 
     def add(self, key, value, **kwargs):
-        """
-        TODO
-        """
         if self.has_key(key):
             raise StoreBackendError(f"Store already has the following key: {key}.")
         return self.set(key=key, value=value, **kwargs)
 
     def update(self, key, value, **kwargs):
-        """
-        TODO
-        """
         if not self.has_key(key):
             raise StoreBackendError(
                 f"Store does not have a value associated the following key: {key}."
@@ -149,9 +143,6 @@ class StoreBackend(metaclass=ABCMeta):
         return self.set(key=key, value=value, **kwargs)
 
     def add_or_update(self, key, value, **kwargs):
-        """
-        TODO
-        """
         if self.has_key(key):
             return self.update(key=key, value=value, **kwargs)
         return self.add(key=key, value=value, **kwargs)

--- a/great_expectations/data_context/store/_store_backend.py
+++ b/great_expectations/data_context/store/_store_backend.py
@@ -131,11 +131,17 @@ class StoreBackend(metaclass=ABCMeta):
             raise StoreBackendError("ValueError while calling _set on store backend.")
 
     def add(self, key, value, **kwargs):
+        """
+        Essentially `set` but validates that a given key-value pair does not already exist.
+        """
         if self.has_key(key):
             raise StoreBackendError(f"Store already has the following key: {key}.")
         return self.set(key=key, value=value, **kwargs)
 
     def update(self, key, value, **kwargs):
+        """
+        Essentially `set` but validates that a given key-value pair does already exist.
+        """
         if not self.has_key(key):
             raise StoreBackendError(
                 f"Store does not have a value associated the following key: {key}."
@@ -143,6 +149,9 @@ class StoreBackend(metaclass=ABCMeta):
         return self.set(key=key, value=value, **kwargs)
 
     def add_or_update(self, key, value, **kwargs):
+        """
+        Conditionally calls `add` or `update` based on the presence of the given key.
+        """
         if self.has_key(key):
             return self.update(key=key, value=value, **kwargs)
         return self.add(key=key, value=value, **kwargs)

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -177,8 +177,16 @@ class CheckpointStore(ConfigurationStore):
         return checkpoint_config
 
     def add_checkpoint(self, checkpoint: Checkpoint) -> Checkpoint:
-        """
-        TODO
+        """Persist a stand-alone Checkpoint object.
+
+        Args:
+            checkpoint: The Checkpoint to persist.
+
+        Returns:
+            The persisted Checkpoint (possibly modified state based on store backend).
+
+        Raises:
+            CheckpointError: If a Checkpoint with the given name already exists.
         """
         key = self._construct_key_from_checkpoint(checkpoint)
 
@@ -196,8 +204,16 @@ class CheckpointStore(ConfigurationStore):
         return checkpoint
 
     def update_checkpoint(self, checkpoint: Checkpoint) -> Checkpoint:
-        """
-        TODO
+        """Use a stand-alone Checkpoint object to update a persisted value.
+
+        Args:
+            checkpoint: The Checkpoint to use for updating.
+
+        Returns:
+            The persisted Checkpoint (possibly modified state based on store backend).
+
+        Raises:
+            CheckpointNotFoundError: If a Checkpoint with the given name does not exist in the store.
         """
         key = self._construct_key_from_checkpoint(checkpoint)
 
@@ -215,8 +231,13 @@ class CheckpointStore(ConfigurationStore):
         return checkpoint
 
     def add_or_update_checkpoint(self, checkpoint: Checkpoint) -> Checkpoint:
-        """
-        TODO
+        """Use a stand-alone Checkpoint object to either add or update a persisted value.
+
+        Args:
+            checkpoint: The Checkpoint to use for adding or updating.
+
+        Returns:
+            The persisted Checkpoint (possibly modified state based on store backend).
         """
         key = self._construct_key_from_checkpoint(checkpoint)
 

--- a/great_expectations/data_context/store/checkpoint_store.py
+++ b/great_expectations/data_context/store/checkpoint_store.py
@@ -186,7 +186,7 @@ class CheckpointStore(ConfigurationStore):
             checkpoint_ref = self.add(key=key, value=checkpoint.get_config())  # type: ignore[func-returns-value]
         except gx_exceptions.StoreBackendError:
             raise gx_exceptions.CheckpointError(
-                f"A Checkpoint named {checkpoint.name} already exists"
+                f"A Checkpoint named {checkpoint.name} already exists."
             )
 
         if isinstance(checkpoint_ref, GXCloudIDAwareRef):

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -2,6 +2,7 @@ import random
 import uuid
 from typing import Dict
 
+import great_expectations.exceptions as gx_exceptions
 from great_expectations.core import ExpectationSuite
 from great_expectations.core.expectation_suite import ExpectationSuiteSchema
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
@@ -176,6 +177,22 @@ class ExpectationsStore(Store):
         suite_dict["ge_cloud_id"] = ge_cloud_suite_id
 
         return suite_dict
+
+    def add(self, key, value, **kwargs):
+        try:
+            super().add(key=key, value=value, **kwargs)
+        except gx_exceptions.StoreBackendError:
+            raise gx_exceptions.ExpectationSuiteError(
+                f"An ExpectationSuite named {value.expectation_suite_name} already exists."
+            )
+
+    def update(self, key, value, **kwargs):
+        try:
+            super().update(key=key, value=value, **kwargs)
+        except gx_exceptions.StoreBackendError:
+            raise gx_exceptions.ExpectationSuiteError(
+                f"Could not find an existing ExpectationSuite named {value.expectation_suite_name}."
+            )
 
     def get(self, key) -> ExpectationSuite:
         return super().get(key)  # type: ignore[return-value]

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -2,6 +2,7 @@ import random
 import uuid
 from typing import Union
 
+import great_expectations.exceptions as gx_exceptions
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
 from great_expectations.data_context.store.configuration_store import ConfigurationStore
 from great_expectations.data_context.types.resource_identifiers import (
@@ -72,3 +73,19 @@ class ProfilerStore(ConfigurationStore):
         profiler_config_dict["id"] = ge_cloud_profiler_id
 
         return profiler_config_dict
+
+    def add(self, key, value, **kwargs):
+        try:
+            super().add(key=key, value=value, **kwargs)
+        except gx_exceptions.StoreBackendError:
+            raise gx_exceptions.ProfilerError(
+                f"A Profiler named {value.name} already exists."
+            )
+
+    def update(self, key, value, **kwargs):
+        try:
+            super().update(key=key, value=value, **kwargs)
+        except gx_exceptions.StoreBackendError:
+            raise gx_exceptions.ProfilerNotFoundError(
+                f"Could not find an existing Profiler named {value.name}."
+            )

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -184,18 +184,27 @@ class Store:
         )
 
     def add(self, key: DataContextKey, value: Any, **kwargs) -> None:
+        """
+        Essentially `set` but validates that a given key-value pair does not already exist.
+        """
         self._validate_key(key)
         return self._store_backend.add(
             self.key_to_tuple(key), self.serialize(value), **kwargs
         )
 
     def update(self, key: DataContextKey, value: Any, **kwargs) -> None:
+        """
+        Essentially `set` but validates that a given key-value pair does already exist.
+        """
         self._validate_key(key)
         return self._store_backend.update(
             self.key_to_tuple(key), self.serialize(value), **kwargs
         )
 
     def add_or_update(self, key: DataContextKey, value: Any, **kwargs) -> None:
+        """
+        Conditionally calls `add` or `update` based on the presence of the given key.
+        """
         self._validate_key(key)
         return self._store_backend.add_or_update(
             self.key_to_tuple(key), self.serialize(value), **kwargs

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -184,27 +184,18 @@ class Store:
         )
 
     def add(self, key: DataContextKey, value: Any, **kwargs) -> None:
-        """
-        TODO
-        """
         self._validate_key(key)
         return self._store_backend.add(
             self.key_to_tuple(key), self.serialize(value), **kwargs
         )
 
     def update(self, key: DataContextKey, value: Any, **kwargs) -> None:
-        """
-        TODO
-        """
         self._validate_key(key)
         return self._store_backend.update(
             self.key_to_tuple(key), self.serialize(value), **kwargs
         )
 
     def add_or_update(self, key: DataContextKey, value: Any, **kwargs) -> None:
-        """
-        TODO
-        """
         self._validate_key(key)
         return self._store_backend.add_or_update(
             self.key_to_tuple(key), self.serialize(value), **kwargs

--- a/great_expectations/data_context/store/store.py
+++ b/great_expectations/data_context/store/store.py
@@ -183,6 +183,33 @@ class Store:
             self.key_to_tuple(key), self.serialize(value), **kwargs
         )
 
+    def add(self, key: DataContextKey, value: Any, **kwargs) -> None:
+        """
+        TODO
+        """
+        self._validate_key(key)
+        return self._store_backend.add(
+            self.key_to_tuple(key), self.serialize(value), **kwargs
+        )
+
+    def update(self, key: DataContextKey, value: Any, **kwargs) -> None:
+        """
+        TODO
+        """
+        self._validate_key(key)
+        return self._store_backend.update(
+            self.key_to_tuple(key), self.serialize(value), **kwargs
+        )
+
+    def add_or_update(self, key: DataContextKey, value: Any, **kwargs) -> None:
+        """
+        TODO
+        """
+        self._validate_key(key)
+        return self._store_backend.add_or_update(
+            self.key_to_tuple(key), self.serialize(value), **kwargs
+        )
+
     def list_keys(self) -> List[DataContextKey]:
         keys_without_store_backend_id = [
             key

--- a/great_expectations/exceptions/exceptions.py
+++ b/great_expectations/exceptions/exceptions.py
@@ -36,6 +36,10 @@ class DataContextError(GreatExpectationsError):
     pass
 
 
+class ExpectationSuiteError(DataContextError):
+    pass
+
+
 class CheckpointError(DataContextError):
     pass
 

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -584,8 +584,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
         effective_rules.update(override_rules)
         return effective_rules
 
-    @staticmethod
+    @classmethod
     def _reconcile_rule_config(
+        cls,
         existing_rules: Dict[str, Rule],
         rule_name: str,
         rule_config: dict,
@@ -632,7 +633,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
             domain_builder_config: dict = rule_config.get("domain_builder", {})
             effective_domain_builder_config: dict = (
-                RuleBasedProfiler._reconcile_rule_domain_builder_config(
+                cls._reconcile_rule_domain_builder_config(
                     domain_builder=rule.domain_builder,
                     domain_builder_config=domain_builder_config,
                     reconciliation_strategy=reconciliation_directives.domain_builder,
@@ -644,7 +645,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
             )
             effective_parameter_builder_configs: Optional[
                 List[dict]
-            ] = RuleBasedProfiler._reconcile_rule_parameter_builder_configs(
+            ] = cls._reconcile_rule_parameter_builder_configs(
                 rule=rule,
                 parameter_builder_configs=parameter_builder_configs,
                 reconciliation_strategy=reconciliation_directives.parameter_builder,
@@ -655,7 +656,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
             )
             effective_expectation_configuration_builder_configs: List[
                 dict
-            ] = RuleBasedProfiler._reconcile_rule_expectation_configuration_builder_configs(
+            ] = cls._reconcile_rule_expectation_configuration_builder_configs(
                 rule=rule,
                 expectation_configuration_builder_configs=expectation_configuration_builder_configs,
                 reconciliation_strategy=reconciliation_directives.expectation_configuration_builder,
@@ -1053,8 +1054,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         return dest_property_value
 
-    @staticmethod
+    @classmethod
     def run_profiler(
+        cls,
         data_context: AbstractDataContext,
         profiler_store: ProfilerStore,
         batch_list: Optional[List[Batch]] = None,
@@ -1064,7 +1066,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         variables: Optional[dict] = None,
         rules: Optional[dict] = None,
     ) -> RuleBasedProfilerResult:
-        profiler: RuleBasedProfiler = RuleBasedProfiler.get_profiler(
+        profiler: RuleBasedProfiler = cls.get_profiler(
             data_context=data_context,
             profiler_store=profiler_store,
             name=name,
@@ -1083,8 +1085,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
             comment=None,
         )
 
-    @staticmethod
+    @classmethod
     def run_profiler_on_data(
+        cls,
         data_context: AbstractDataContext,
         profiler_store: ProfilerStore,
         batch_list: Optional[List[Batch]] = None,
@@ -1092,7 +1095,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         name: Optional[str] = None,
         id: Optional[str] = None,
     ) -> RuleBasedProfilerResult:
-        profiler: RuleBasedProfiler = RuleBasedProfiler.get_profiler(
+        profiler: RuleBasedProfiler = cls.get_profiler(
             data_context=data_context,
             profiler_store=profiler_store,
             name=name,
@@ -1116,8 +1119,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
             comment=None,
         )
 
-    @staticmethod
+    @classmethod
     def add_profiler(
+        cls,
         data_context: AbstractDataContext,
         profiler_store: ProfilerStore,
         name: str | None = None,
@@ -1127,7 +1131,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         variables: dict | None = None,
         profiler: RuleBasedProfiler | None = None,
     ) -> RuleBasedProfiler:
-        return RuleBasedProfiler._persist_profiler(
+        return cls._persist_profiler(
             data_context=data_context,
             persistence_fn=profiler_store.add,
             name=name,
@@ -1138,8 +1142,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
             profiler=profiler,
         )
 
-    @staticmethod
+    @classmethod
     def update_profiler(
+        cls,
         profiler_store: ProfilerStore,
         data_context: AbstractDataContext,
         name: str | None = None,
@@ -1149,7 +1154,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         variables: dict | None = None,
         profiler: RuleBasedProfiler | None = None,
     ) -> RuleBasedProfiler:
-        return RuleBasedProfiler._persist_profiler(
+        return cls._persist_profiler(
             data_context=data_context,
             persistence_fn=profiler_store.update,
             name=name,
@@ -1160,8 +1165,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
             profiler=profiler,
         )
 
-    @staticmethod
+    @classmethod
     def add_or_update_profiler(
+        cls,
         data_context: AbstractDataContext,
         profiler_store: ProfilerStore,
         name: str | None = None,
@@ -1171,7 +1177,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         variables: dict | None = None,
         profiler: RuleBasedProfiler | None = None,
     ) -> RuleBasedProfiler:
-        return RuleBasedProfiler._persist_profiler(
+        return cls._persist_profiler(
             data_context=data_context,
             persistence_fn=profiler_store.add_or_update,
             name=name,
@@ -1182,8 +1188,9 @@ class BaseRuleBasedProfiler(ConfigPeer):
             profiler=profiler,
         )
 
-    @staticmethod
+    @classmethod
     def _persist_profiler(
+        cls,
         data_context: AbstractDataContext,
         persistence_fn: Callable,
         name: str | None = None,
@@ -1308,14 +1315,15 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         return True
 
-    @staticmethod
+    @classmethod
     def get_profiler(
+        cls,
         data_context: AbstractDataContext,
         profiler_store: ProfilerStore,
         name: Optional[str] = None,
         id: Optional[str] = None,
     ) -> RuleBasedProfiler:
-        key = RuleBasedProfiler._construct_profiler_key(name=name, id=id)
+        key = cls._construct_profiler_key(name=name, id=id)
         try:
             profiler_config: RuleBasedProfilerConfig = profiler_store.get(key=key)
         except gx_exceptions.InvalidKeyError as exc_ik:
@@ -1347,13 +1355,14 @@ class BaseRuleBasedProfiler(ConfigPeer):
 
         return profiler
 
-    @staticmethod
+    @classmethod
     def delete_profiler(
+        cls,
         profiler_store: ProfilerStore,
         name: Optional[str] = None,
         id: Optional[str] = None,
     ) -> None:
-        key = RuleBasedProfiler._construct_profiler_key(name=name, id=id)
+        key = cls._construct_profiler_key(name=name, id=id)
 
         try:
             profiler_store.remove_key(key=key)

--- a/tests/data_context/store/test_checkpoint_store.py
+++ b/tests/data_context/store/test_checkpoint_store.py
@@ -525,7 +525,7 @@ def test_add_checkpoint(
 
     store.add_checkpoint(checkpoint=checkpoint)
 
-    mock_backend.set.assert_called_once_with(
+    mock_backend.add.assert_called_once_with(
         (checkpoint_name,),
         "name: my_checkpoint\nconfig_version:\nmodule_name: great_expectations.checkpoint\nclass_name: LegacyCheckpoint\n",
     )

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -56,9 +56,17 @@ class CheckpointStoreSpy(CheckpointStore):
         self.save_count = 0
         super().__init__(CheckpointStoreSpy.STORE_NAME)
 
-    def set(self, key, value, **kwargs):
+    def add(self, key, value, **kwargs):
         self.save_count += 1
-        return super().set(key=key, value=value, **kwargs)
+        return super().add(key=key, value=value, **kwargs)
+
+    def update(self, key, value, **kwargs):
+        self.save_count += 1
+        return super().update(key=key, value=value, **kwargs)
+
+    def add_or_update(self, key, value, **kwargs):
+        self.save_count += 1
+        return super().add_or_update(key=key, value=value, **kwargs)
 
 
 class EphemeralDataContextSpy(EphemeralDataContext):
@@ -871,7 +879,7 @@ def test_update_checkpoint_failure(in_memory_data_context: EphemeralDataContextS
     with pytest.raises(gx_exceptions.CheckpointNotFoundError) as e:
         context.update_checkpoint(checkpoint)
 
-    assert f"Could not find a Checkpoint named {name}" in str(e.value)
+    assert f"Could not find an existing Checkpoint named {name}" in str(e.value)
 
 
 @pytest.mark.unit

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -54,8 +54,18 @@ class ProfilerStoreSpy(ProfilerStore):
         self.save_count = 0
         super().__init__(ProfilerStoreSpy.STORE_NAME)
 
-    def set(self, key, value, **kwargs):
-        ret = super().set(key=key, value=value, **kwargs)
+    def add(self, key, value, **kwargs):
+        ret = super().add(key=key, value=value, **kwargs)
+        self.save_count += 1
+        return ret
+
+    def update(self, key, value, **kwargs):
+        ret = super().update(key=key, value=value, **kwargs)
+        self.save_count += 1
+        return ret
+
+    def add_or_update(self, key, value, **kwargs):
+        ret = super().add_or_update(key=key, value=value, **kwargs)
         self.save_count += 1
         return ret
 
@@ -664,20 +674,23 @@ def test_update_profiler_success(
 
 
 @pytest.mark.unit
-def test_update_profiler_failure(in_memory_data_context: EphemeralDataContextSpy):
+def test_update_profiler_failure(
+    in_memory_data_context: EphemeralDataContextSpy, profiler_rules: dict
+):
     context = in_memory_data_context
 
     name = "my_rbp"
     profiler = RuleBasedProfiler(
         name=name,
         config_version=1.0,
+        rules=profiler_rules,
         data_context=context,
     )
 
     with pytest.raises(gx_exceptions.ProfilerNotFoundError) as e:
         _ = context.update_profiler(profiler)
 
-    assert f"Non-existent Profiler configuration named {name}" in str(e.value)
+    assert f"Could not find an existing Profiler named {name}" in str(e.value)
 
 
 @pytest.mark.unit

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -30,8 +30,18 @@ class ExpectationsStoreSpy(ExpectationsStore):
         self.save_count = 0
         super().__init__()
 
-    def set(self, key, value, **kwargs):
-        ret = super().set(key=key, value=value, **kwargs)
+    def add(self, key, value, **kwargs):
+        ret = super().add(key=key, value=value, **kwargs)
+        self.save_count += 1
+        return ret
+
+    def update(self, key, value, **kwargs):
+        ret = super().update(key=key, value=value, **kwargs)
+        self.save_count += 1
+        return ret
+
+    def add_or_update(self, key, value, **kwargs):
+        ret = super().add_or_update(key=key, value=value, **kwargs)
         self.save_count += 1
         return ret
 
@@ -368,11 +378,7 @@ def test_add_expectation_suite_namespace_collision_failure(
     with pytest.raises(gx_exceptions.DataContextError) as e:
         context.add_expectation_suite(expectation_suite_name=suite_name)
 
-    assert f"expectation_suite with name {suite_name} already exists" in str(e.value)
-    assert (
-        "please delete or update it using `delete_expectation_suite` or `update_expectation_suite`"
-        in str(e.value)
-    )
+    assert f"An ExpectationSuite named {suite_name} already exists" in str(e.value)
     assert context.expectations_store.save_count == 1
 
 
@@ -439,10 +445,12 @@ def test_update_expectation_suite_failure(
     suite_name = "my_brand_new_suite"
     suite = ExpectationSuite(expectation_suite_name=suite_name)
 
-    with pytest.raises(gx_exceptions.DataContextError) as e:
+    with pytest.raises(gx_exceptions.ExpectationSuiteError) as e:
         _ = context.update_expectation_suite(suite)
 
-    assert f"expectation_suite with name {suite_name} does not exist." in str(e.value)
+    assert f"Could not find an existing ExpectationSuite named {suite_name}." in str(
+        e.value
+    )
 
 
 @pytest.mark.unit

--- a/tests/rule_based_profiler/test_rule_based_profiler.py
+++ b/tests/rule_based_profiler/test_rule_based_profiler.py
@@ -1171,17 +1171,20 @@ def test_add_profiler(
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
     mock_data_context.cloud_mode = False
+
+    profiler_args = profiler_config_with_placeholder_args.to_dict()
+    for attr in ("class_name", "module_name"):
+        profiler_args.pop(attr)
+
     profiler: RuleBasedProfiler = RuleBasedProfiler.add_profiler(
-        profiler_config_with_placeholder_args,
         data_context=mock_data_context,
         profiler_store=mock_data_context.profiler_store,
+        **profiler_args,
     )
 
     assert isinstance(profiler, RuleBasedProfiler)
     assert profiler.name == profiler_config_with_placeholder_args.name
-    assert mock_data_context.profiler_store.set.call_args == mock.call(
-        key=profiler_key, value=profiler_config_with_placeholder_args
-    )
+    mock_data_context.profiler_store.add.asset_called_once()
 
 
 @pytest.mark.cloud
@@ -1191,21 +1194,23 @@ def test_add_profiler_ge_cloud_mode(
     ge_cloud_profiler_key: GXCloudIdentifier,
     profiler_config_with_placeholder_args: RuleBasedProfilerConfig,
 ):
+    profiler_args = profiler_config_with_placeholder_args.to_dict()
+    for attr in ("class_name", "module_name"):
+        profiler_args.pop(attr)
+
     with mock.patch(
         "great_expectations.data_context.data_context.CloudDataContext",
         spec=CloudDataContext,
     ) as mock_data_context:
         profiler: RuleBasedProfiler = RuleBasedProfiler.add_profiler(
-            profiler_config_with_placeholder_args,
             data_context=mock_data_context,
             profiler_store=mock_data_context.profiler_store,
+            **profiler_args,
         )
 
     assert isinstance(profiler, RuleBasedProfiler)
     assert profiler.name == profiler_config_with_placeholder_args.name
-    assert mock_data_context.profiler_store.set.call_args == mock.call(
-        key=ge_cloud_profiler_key, value=profiler_config_with_placeholder_args
-    )
+    mock_data_context.profiler_store.add.assert_called_once()
 
 
 @mock.patch("great_expectations.data_context.data_context.AbstractDataContext")
@@ -1213,41 +1218,41 @@ def test_add_profiler_ge_cloud_mode(
 def test_add_profiler_with_batch_request_containing_batch_data_raises_error(
     mock_data_context: mock.MagicMock,
 ):
-    profiler_config = RuleBasedProfilerConfig(
-        name="my_profiler_config",
-        config_version=1.0,
-        rules={
-            "rule_1": {
-                "domain_builder": {
-                    "class_name": "TableDomainBuilder",
-                    "batch_request": {
-                        "runtime_parameters": {
-                            "batch_data": pd.DataFrame()  # Cannot be serialized in store
-                        }
-                    },
+    name = "my_profiler_config"
+    config_version = 1.0
+    rules = {
+        "rule_1": {
+            "domain_builder": {
+                "class_name": "TableDomainBuilder",
+                "batch_request": {
+                    "runtime_parameters": {
+                        "batch_data": pd.DataFrame()  # Cannot be serialized in store
+                    }
                 },
-                "parameter_builders": [
-                    {
-                        "class_name": "MetricMultiBatchParameterBuilder",
-                        "name": "my_parameter",
-                        "metric_name": "my_metric",
-                    },
-                ],
-                "expectation_configuration_builders": [
-                    {
-                        "class_name": "DefaultExpectationConfigurationBuilder",
-                        "expectation_type": "expect_column_pair_values_A_to_be_greater_than_B",
-                    },
-                ],
-            }
-        },
-    )
+            },
+            "parameter_builders": [
+                {
+                    "class_name": "MetricMultiBatchParameterBuilder",
+                    "name": "my_parameter",
+                    "metric_name": "my_metric",
+                },
+            ],
+            "expectation_configuration_builders": [
+                {
+                    "class_name": "DefaultExpectationConfigurationBuilder",
+                    "expectation_type": "expect_column_pair_values_A_to_be_greater_than_B",
+                },
+            ],
+        }
+    }
 
     with pytest.raises(InvalidConfigError) as e:
         RuleBasedProfiler.add_profiler(
-            profiler_config,
             data_context=mock_data_context,
             profiler_store=mock_data_context.profiler_store,
+            name=name,
+            config_version=config_version,
+            rules=rules,
         )
 
     assert "batch_data found in batch_request" in str(e.value)


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `add`, `update`, and `add_or_update` logic to `Store` and `StoreBackend`
- Refactor context CRUD to leverage these changes


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
