### PR TITLE
[DOCS] DOC-461 remove unlinked link

### DIFF
--- a/docs/guides/setup/configuring_data_docs/components_how_to_host_and_share_data_docs_on_amazon_s3/_additional_notes.mdx
+++ b/docs/guides/setup/configuring_data_docs/components_how_to_host_and_share_data_docs_on_amazon_s3/_additional_notes.mdx
@@ -25,5 +25,3 @@ index.html file or a custom error file:
         show_cta_footer: true
    ```
 
-
-Additional resources


### PR DESCRIPTION

Changes proposed in this pull request:
- Remove a phrase that appears to have been intended as a link, but was never actually linked.
    - This update should cascade to all of the AWS integration tutorials.


### Definition of Done
Please delete options that are not relevant.

- [X] I have made corresponding changes to the documentation


