### PR TITLE
correct typo in data assistants portion of the getting started tutorial

### DIFF
--- a/docs/tutorials/getting_started/tutorial_create_expectations.md
+++ b/docs/tutorials/getting_started/tutorial_create_expectations.md
@@ -103,7 +103,7 @@ Since notebooks are often less permanent, creating Expectations in a notebook al
 **Cell 3**
 ![Cell3](../../images/getting_started_tutorial/tutorial_create_expectations_cell3_onboarding_assistant.png)
 
-3. Cell 3 is where you run a Data Assistant.  In this case, the assistant being used is the Onboarding Assistant, which will Data Assistant the data provided by your Batch Request and create the relevant Expectations to add to your `taxi.demo` suite.
+3. Cell 3 is where you run a Data Assistant.  In this case, the assistant being used is the Onboarding Assistant, which will analyze the data provided by your Batch Request and create the relevant Expectations to add to your `taxi.demo` suite.
 
 **Cell 4**
 ![Cell4](../../images/getting_started_tutorial/tutorial_create_expectations_cell4.png)


### PR DESCRIPTION

Changes proposed in this pull request:
- correct typo in getting started tutorial section on jupyter notebooks/creating expectations

### Definition of Done
Please delete options that are not relevant.

- [X] I have made corresponding changes to the documentation


