### PR TITLE
[MAINTENANCE] Remove Extra Character from ID/PK Example README

### DIFF
--- a/examples/demos/primary_keys_in_validation_results/README.md
+++ b/examples/demos/primary_keys_in_validation_results/README.md
@@ -1,6 +1,6 @@
 ---
 title: Examples for configuring primary key (PK) values in Validation results.
-author: @Shinnnyshinshin
+author: Shinnnyshinshin
 date: 20220118
 ---
 ## Overview


### PR DESCRIPTION
# What does this PR do? 
- Removes extra `@` character from README, which prevented proper rendering

This is before
![Screen Shot 2023-02-09 at 1 10 29 PM](https://user-images.githubusercontent.com/25670697/217939938-e1f818aa-7893-4e29-8140-1999fe70a55a.png)

This is after
![Screen Shot 2023-02-09 at 1 10 03 PM](https://user-images.githubusercontent.com/25670697/217939841-d903214f-50bb-40ac-9dbd-c88cf7b202ae.png)