### PR TITLE
F/great 1393/date splitters 1

### DIFF
--- a/sql_splitters.py
+++ b/sql_splitters.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from enum import Enum
+import datetime
+
+
+class TimeInterval(str, Enum):
+    YEAR = "year"
+    MONTH = "month"
+    DAY = "day"
+    HOUR = "hour"
+    MINUTE = "minute"
+    SECOND = "second"
+
+
+def datetimes(
+    start: datetime.datetime, end: datetime.datetime, interval: TimeInterval
+) -> list[datetime.datetime]:
+    """Yields datetimes from start to end inclusive, separated by interval.
+
+    Note, start is truncated so it falls onto the nearest interval boundary. For example
+    if start=2/7/2023 and we are incrementing by month the first returned valued will be
+    2/0/2023. This is because we are only concerned with the month resolution so all days
+    are equivalent. Our canonical representation sets the equivalent datetime fields to
+    their minimum value (0 or 1).
+
+    Args:
+        start: The start time to iterate over
+        end: The end time to iterate over. The end will be included in the output, truncated
+             to the desired resolution.
+
+    Returns:
+        A list of datetimes starting at start, ending at end, seperated by interval.
+    """
+    bins: list[datetime.datetime] = []
+    current_dt = _truncate_datetime(start, interval)
+    while current_dt <= end:
+        yield current_dt
+        bins.append(current_dt)
+        current_dt = _increment_by_interval(current_dt, interval)
+
+
+def _truncate_datetime(dt: datetime, interval: TimeInterval) -> datetime.datetime:
+    if interval == TimeInterval.YEAR:
+        return datetime.datetime(year=dt.year, month=1, day=1)
+    elif interval == TimeInterval.MONTH:
+        return datetime.datetime(year=dt.year, month=dt.month, day=1)
+    elif interval == TimeInterval.DAY:
+        return datetime.datetime(year=dt.year, month=dt.month, day=dt.day)
+    elif interval == TimeInterval.HOUR:
+        return datetime.datetime(year=dt.year, month=dt.month, day=dt.day, hour=dt.hour)
+    elif interval == TimeInterval.MINUTE:
+        return datetime.datetime(
+            year=dt.year, month=dt.month, day=dt.day, hour=dt.hour, minute=dt.minute
+        )
+    elif interval == TimeInterval.SECOND:
+        return datetime.datetime(
+            year=dt.year,
+            month=dt.month,
+            day=dt.day,
+            hour=dt.hour,
+            minute=dt.minute,
+            second=dt.second,
+        )
+    else:
+        raise ValueError(
+            f"{interval} is not a valid TimeInterval for truncate_datetime"
+        )
+
+
+def _increment_by_interval(dt: datetime, interval: TimeInterval) -> datetime.datetime:
+    if interval == TimeInterval.MONTH:
+        return _increment_month(dt)
+    # We could cache the delta associated with a key.
+    delta_key = interval + "s"
+    delta = datetime.timedelta(**{delta_key: 1})
+    return dt + delta
+
+
+def _increment_month(dt: datetime) -> datetime:
+    if dt.month == 12:
+        return dt.replace(year=dt.year + 1, month=1)
+    return dt.replace(month=dt.month + 1)


### PR DESCRIPTION
This is very much a work in progress but I wanted to create a PR in case it helps our discussion @NathanFarmer. Eventually this will be a refactor PR that lets us more easily add additional splitters. It does a few things:

* It defines the `test_connection` method as part of the interface for `_SQLAsset`. This defines the contract explicitly on the base class. It also makes it so we don't need to define it on all the subclasses since the default implementation is a no-op.
* This PR allows removal on code the the SQL datasource subclasses, namely sqlite here.
* It also fixes a bug where we are not currently testing the sqlite connection when we add a sqlite table asset.
* Adds some utility methods for stepping through time to make it easier to split by different time intervals.

Work I currently know is outstanding:
* I need to look into how we are currently choosing the correctly splitter when we deserialize from config. It could be we aren't doing anything now since we only have 1. 
* Testing

I haven't done any linting, typing, etc either.