### PR TITLE
Update dependency on pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ packaging
 pandas>=1.1.0; python_version <= "3.8"
 pandas>=1.1.3; python_version == "3.9"
 pandas>=1.3.0; python_version >= "3.10"
-pydantic>=1.0,<2.0
+pydantic>=1.10,<2.0
 pyparsing>=2.4
 python-dateutil>=2.8.1
 pytz>=2021.3


### PR DESCRIPTION
Recent changes released in v0.15.48 (introduced in [PR#6780](https://github.com/great-expectations/great_expectations/pull/6780)) are causing a crash in pydantic 1.9.*

There seems to be no problem after updating to pydantic 1.10.* so I propose to bump the minimum required version here.