### PR TITLE
[FEATURE] ZEP general `add_asset()` method

### DIFF
--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -16,6 +16,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    get_args,
 )
 
 import pandas as pd
@@ -280,6 +281,16 @@ class DataAsset(ExperimentalBaseModel, Generic[_DatasourceT]):
                     f"Trying to sort {self.name} table asset batches on key {sorter.key} "
                     "which isn't available on all batches."
                 ) from e
+
+    @classmethod
+    def _get_type_field_value(cls) -> str:
+        """Get the default value of the `type` field."""
+        default = cls.__fields__["type"].default
+        literal_values = get_args(cls.__fields__["type"].type_)
+        assert (
+            default in literal_values
+        ), f"{cls.__name__}'s `type` field's default value '{default}' is not a member of {literal_values}"
+        return default
 
 
 # If a Datasource can have more than 1 _DataAssetT, this will need to change.

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -329,10 +329,18 @@ class Datasource(
     _execution_engine: Union[_ExecutionEngineT, None] = pydantic.PrivateAttr(None)
 
     def add_asset(self, *, type: str, name: str, **kwargs) -> _DataAssetT:
+        """Generic method for adding any asset type to the current Datasource.
+
+        Only accepts keyword arguments.
+        """
         asset_type: Type[_DataAssetT] = _SourceFactories.type_lookup[type]
         assert issubclass(
             asset_type, DataAsset
         ), f"{type} maps to {asset_type.__name__} which is not a {DataAsset.__name__}"
+        assert (
+            asset_type in self.asset_types
+        ), f"{asset_type.__name__} is not a valid asset for {self.__class__.__name__}"
+
         asset = asset_type(type=type, name=name, **kwargs)
         return self._add_asset(asset)
 

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -328,6 +328,7 @@ class Datasource(
     _cached_execution_engine_kwargs: Dict[str, Any] = pydantic.PrivateAttr({})
     _execution_engine: Union[_ExecutionEngineT, None] = pydantic.PrivateAttr(None)
 
+    # keyword only arguments to prevent passing wrong positional arguments
     def add_asset(self, *, type: str, name: str, **kwargs) -> _DataAssetT:
         """Generic method for adding any asset type to the current Datasource.
 

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -398,7 +398,7 @@ class Datasource(
                 f"'{asset_name}' not found. Available assets are {list(self.assets.keys())}"
             ) from exc
 
-    def add_asset(self, asset: _DataAssetT) -> _DataAssetT:
+    def _add_asset(self, asset: _DataAssetT) -> _DataAssetT:
         """Adds an asset to a datasource
 
         Args:

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -328,6 +328,14 @@ class Datasource(
     _cached_execution_engine_kwargs: Dict[str, Any] = pydantic.PrivateAttr({})
     _execution_engine: Union[_ExecutionEngineT, None] = pydantic.PrivateAttr(None)
 
+    def add_asset(self, *, type: str, name: str, **kwargs) -> _DataAssetT:
+        asset_type: Type[_DataAssetT] = _SourceFactories.type_lookup[type]
+        assert issubclass(
+            asset_type, DataAsset
+        ), f"{type} maps to {asset_type.__name__} which is not a {DataAsset.__name__}"
+        asset = asset_type(type=type, name=name, **kwargs)
+        return self._add_asset(asset)
+
     @pydantic.validator("assets", each_item=True)
     @classmethod
     def _load_asset_subtype(

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -16,7 +16,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    get_args,
 )
 
 import pandas as pd
@@ -281,16 +280,6 @@ class DataAsset(ExperimentalBaseModel, Generic[_DatasourceT]):
                     f"Trying to sort {self.name} table asset batches on key {sorter.key} "
                     "which isn't available on all batches."
                 ) from e
-
-    @classmethod
-    def _get_type_field_value(cls) -> str:
-        """Get the default value of the `type` field."""
-        default = cls.__fields__["type"].default
-        literal_values = get_args(cls.__fields__["type"].type_)
-        assert (
-            default in literal_values
-        ), f"{cls.__name__}'s `type` field's default value '{default}' is not a member of {literal_values}"
-        return default
 
 
 # If a Datasource can have more than 1 _DataAssetT, this will need to change.

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -342,7 +342,7 @@ class Datasource(
         ), f"{asset_type.__name__} is not a valid asset for {self.__class__.__name__}"
 
         asset = asset_type(type=type, name=name, **kwargs)
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)
 
     @pydantic.validator("assets", each_item=True)
     @classmethod
@@ -414,7 +414,7 @@ class Datasource(
                 f"'{asset_name}' not found. Available assets are {list(self.assets.keys())}"
             ) from exc
 
-    def _add_asset(self, asset: _DataAssetT) -> _DataAssetT:
+    def _add_asset_and_test_connection(self, asset: _DataAssetT) -> _DataAssetT:
         """Adds an asset to a datasource
 
         Args:

--- a/great_expectations/experimental/datasources/pandas_datasource.py
+++ b/great_expectations/experimental/datasources/pandas_datasource.py
@@ -164,7 +164,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)
 
     def add_excel_asset(
         self,
@@ -189,7 +189,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)
 
     def add_json_asset(
         self,
@@ -214,7 +214,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)
 
     def add_parquet_asset(
         self,
@@ -239,4 +239,4 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)

--- a/great_expectations/experimental/datasources/pandas_datasource.py
+++ b/great_expectations/experimental/datasources/pandas_datasource.py
@@ -164,7 +164,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)
 
     def add_excel_asset(
         self,
@@ -189,7 +189,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)
 
     def add_json_asset(
         self,
@@ -214,7 +214,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)
 
     def add_parquet_asset(
         self,
@@ -239,4 +239,4 @@ class PandasFilesystemDatasource(_PandasDatasource):
             order_by=_batch_sorter_from_list(order_by or []),
             **kwargs,
         )
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)

--- a/great_expectations/experimental/datasources/sources.py
+++ b/great_expectations/experimental/datasources/sources.py
@@ -191,7 +191,7 @@ class _SourceFactories:
                 self: Datasource, name: str, **kwargs
             ) -> pydantic.BaseModel:
                 asset = asset_type(name=name, **kwargs)
-                return self.add_asset(asset)
+                return self._add_asset(asset)
 
             setattr(ds_type, asset_factory_method_name, _add_asset_factory)
         else:

--- a/great_expectations/experimental/datasources/sources.py
+++ b/great_expectations/experimental/datasources/sources.py
@@ -154,11 +154,11 @@ class _SourceFactories:
     ):
         # TODO: let asset/ds define how the type_name should look.
         asset_factory_method_name = f"add_{asset_type_name}_asset"
-        # TODO: check if the class already has a add_asset method defined
-        asset_factory_defined: bool = False
+        asset_factory_defined: bool = asset_factory_method_name in ds_type.__dict__
+
         if not asset_factory_defined:
-            logger.debug(
-                f"No `{asset_factory_method_name}()` method found for {ds_type} generating the method..."
+            logger.info(
+                f"No `{asset_factory_method_name}()` method found for `{ds_type.__name__}` generating the method..."
             )
 
             def _add_asset_factory(self: Datasource, name: str, **kwargs):
@@ -167,7 +167,9 @@ class _SourceFactories:
 
             setattr(ds_type, asset_factory_method_name, _add_asset_factory)
         else:
-            logger.debug(f"`{asset_factory_method_name}()` already defined {ds_type}")
+            logger.info(
+                f"`{asset_factory_method_name}()` already defined `{ds_type.__name__}`"
+            )
 
     @property
     def factories(self) -> List[str]:

--- a/great_expectations/experimental/datasources/sources.py
+++ b/great_expectations/experimental/datasources/sources.py
@@ -165,7 +165,7 @@ class _SourceFactories:
                 asset = asset_type(name=name, **kwargs)
                 return self.add_asset(asset)
 
-            setattr(asset_type, asset_factory_method_name, _add_asset_factory)
+            setattr(ds_type, asset_factory_method_name, _add_asset_factory)
         else:
             logger.debug(f"`{asset_factory_method_name}()` already defined {ds_type}")
 

--- a/great_expectations/experimental/datasources/sources.py
+++ b/great_expectations/experimental/datasources/sources.py
@@ -179,12 +179,11 @@ class _SourceFactories:
         asset_type: Type[DataAsset],
         asset_type_name: str,
     ):
-        # TODO: let asset/ds define how the type_name should look.
         asset_factory_method_name = f"add_{asset_type_name}_asset"
         asset_factory_defined: bool = asset_factory_method_name in ds_type.__dict__
 
         if not asset_factory_defined:
-            logger.info(
+            logger.debug(
                 f"No `{asset_factory_method_name}()` method found for `{ds_type.__name__}` generating the method..."
             )
 
@@ -196,7 +195,7 @@ class _SourceFactories:
 
             setattr(ds_type, asset_factory_method_name, _add_asset_factory)
         else:
-            logger.info(
+            logger.debug(
                 f"`{asset_factory_method_name}()` already defined `{ds_type.__name__}`"
             )
 

--- a/great_expectations/experimental/datasources/sources.py
+++ b/great_expectations/experimental/datasources/sources.py
@@ -188,7 +188,9 @@ class _SourceFactories:
                 f"No `{asset_factory_method_name}()` method found for `{ds_type.__name__}` generating the method..."
             )
 
-            def _add_asset_factory(self: Datasource, name: str, **kwargs):
+            def _add_asset_factory(
+                self: Datasource, name: str, **kwargs
+            ) -> pydantic.BaseModel:
                 asset = asset_type(name=name, **kwargs)
                 return self.add_asset(asset)
 

--- a/great_expectations/experimental/datasources/sources.py
+++ b/great_expectations/experimental/datasources/sources.py
@@ -170,35 +170,6 @@ class _SourceFactories:
                     f"No `type` field found for `{ds_type.__name__}.asset_types` -> `{t.__name__}` unable to register asset type",
                 ) from bad_field_exc
 
-            cls._bind_asset_factory_method_if_not_present(ds_type, t, asset_type_name)
-
-    @classmethod
-    def _bind_asset_factory_method_if_not_present(
-        cls,
-        ds_type: Type[Datasource],
-        asset_type: Type[DataAsset],
-        asset_type_name: str,
-    ):
-        asset_factory_method_name = f"add_{asset_type_name}_asset"
-        asset_factory_defined: bool = asset_factory_method_name in ds_type.__dict__
-
-        if not asset_factory_defined:
-            logger.debug(
-                f"No `{asset_factory_method_name}()` method found for `{ds_type.__name__}` generating the method..."
-            )
-
-            def _add_asset_factory(
-                self: Datasource, name: str, **kwargs
-            ) -> pydantic.BaseModel:
-                asset = asset_type(name=name, **kwargs)
-                return self._add_asset(asset)
-
-            setattr(ds_type, asset_factory_method_name, _add_asset_factory)
-        else:
-            logger.debug(
-                f"`{asset_factory_method_name}()` already defined `{ds_type.__name__}`"
-            )
-
     @property
     def factories(self) -> List[str]:
         return list(self.__source_factories.keys())

--- a/great_expectations/experimental/datasources/spark_datasource.py
+++ b/great_expectations/experimental/datasources/spark_datasource.py
@@ -133,4 +133,4 @@ class SparkDatasource(_SparkDatasource):
             inferSchema=infer_schema,
             order_by=_batch_sorter_from_list(order_by or []),
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)

--- a/great_expectations/experimental/datasources/spark_datasource.py
+++ b/great_expectations/experimental/datasources/spark_datasource.py
@@ -133,4 +133,4 @@ class SparkDatasource(_SparkDatasource):
             inferSchema=infer_schema,
             order_by=_batch_sorter_from_list(order_by or []),
         )
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -649,7 +649,7 @@ class SQLDatasource(Datasource):
             order_by=_batch_sorter_from_list(order_by or []),
             # see DataAsset._parse_order_by_sorter()
         )
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)
 
     def add_query_asset(
         self,
@@ -672,4 +672,4 @@ class SQLDatasource(Datasource):
             query=query,
             order_by=_batch_sorter_from_list(order_by or []),
         )
-        return self._add_asset(asset)
+        return self._add_asset_and_test_connection(asset)

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -649,7 +649,7 @@ class SQLDatasource(Datasource):
             order_by=_batch_sorter_from_list(order_by or []),
             # see DataAsset._parse_order_by_sorter()
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)
 
     def add_query_asset(
         self,
@@ -672,4 +672,4 @@ class SQLDatasource(Datasource):
             query=query,
             order_by=_batch_sorter_from_list(order_by or []),
         )
-        return self.add_asset(asset)
+        return self._add_asset(asset)

--- a/tests/experimental/datasources/test_pandas_datasource.py
+++ b/tests/experimental/datasources/test_pandas_datasource.py
@@ -159,6 +159,29 @@ class TestDynamicPandasAssets:
 
         assert type_name in asset_class_names
 
+    @pytest.mark.parametrize("asset_class", PandasDatasource.asset_types)
+    def test_add_asset_method_exists_and_is_functional(
+        self, asset_class: Type[_FilesystemDataAsset]
+    ):
+        method_name: str = f"add_{asset_class._get_type_field_value()}_asset"
+
+        print(f"{method_name}() -> {asset_class.__name__}")
+
+        assert method_name in PandasDatasource.__dict__
+
+        ds = PandasDatasource(name="ds_for_testing_add_asset_methods")
+        method = getattr(ds, method_name)
+
+        with pytest.raises(pydantic.ValidationError) as exc_info:
+            method(
+                f"{asset_class.__name__}_add_asset_test",
+                base_directory=pathlib.Path.cwd(),
+                regex="great_expectations",
+                _invalid_key="foobar",
+            )
+        # importantly check that the method creates (or attempts to create) the intended asset
+        assert exc_info.value.model == asset_class
+
     @pytest.mark.parametrize("asset_class", PandasFilesystemDatasource.asset_types)
     def test_minimal_validation(self, asset_class: Type[_FilesystemDataAsset]):
         """

--- a/tests/experimental/datasources/test_pandas_datasource.py
+++ b/tests/experimental/datasources/test_pandas_datasource.py
@@ -21,6 +21,7 @@ from great_expectations.experimental.datasources.pandas_datasource import (
     PandasFilesystemDatasource,
     _FilesystemDataAsset,
 )
+from great_expectations.experimental.datasources.sources import _get_field_details
 
 if TYPE_CHECKING:
     from great_expectations.alias_types import PathStr
@@ -163,7 +164,8 @@ class TestDynamicPandasAssets:
     def test_add_asset_method_exists_and_is_functional(
         self, asset_class: Type[_FilesystemDataAsset]
     ):
-        method_name: str = f"add_{asset_class._get_type_field_value()}_asset"
+        type_name: str = _get_field_details(asset_class, "type").default_value
+        method_name: str = f"add_{type_name}_asset"
 
         print(f"{method_name}() -> {asset_class.__name__}")
 

--- a/tests/experimental/datasources/test_pandas_datasource.py
+++ b/tests/experimental/datasources/test_pandas_datasource.py
@@ -159,7 +159,7 @@ class TestDynamicPandasAssets:
 
         assert type_name in asset_class_names
 
-    @pytest.mark.parametrize("asset_class", PandasDatasource.asset_types)
+    @pytest.mark.parametrize("asset_class", PandasFilesystemDatasource.asset_types)
     def test_add_asset_method_exists_and_is_functional(
         self, asset_class: Type[_FilesystemDataAsset]
     ):
@@ -167,15 +167,17 @@ class TestDynamicPandasAssets:
 
         print(f"{method_name}() -> {asset_class.__name__}")
 
-        assert method_name in PandasDatasource.__dict__
+        assert method_name in PandasFilesystemDatasource.__dict__
 
-        ds = PandasDatasource(name="ds_for_testing_add_asset_methods")
+        ds = PandasFilesystemDatasource(
+            name="ds_for_testing_add_asset_methods",
+            base_directory=pathlib.Path.cwd(),
+        )
         method = getattr(ds, method_name)
 
         with pytest.raises(pydantic.ValidationError) as exc_info:
             method(
                 f"{asset_class.__name__}_add_asset_test",
-                base_directory=pathlib.Path.cwd(),
                 regex="great_expectations",
                 _invalid_key="foobar",
             )


### PR DESCRIPTION
This is an alternative to #7121 only one of these should be merged.

The main benefit of this approach is that it is much less opaque and more discoverable than dynamically adding methods and counting on our users to know the naming pattern for these methods.

## Changes proposed in this pull request:
- rename `add_asset` -> `_add_asset_and_test_connection`
- add a new `add_asset()`  method as an alternative to dynamically creating `add_<ASSET_NAME>_asset()` methods for each asset
  - `add_asset` takes a `type: str` in addition to `name` and asset `kwargs`

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

