### PR TITLE
[MAINTENANCE] Fluent Datasources - don't register "private" Datasource classes

### DIFF
--- a/great_expectations/experimental/datasources/metadatasource.py
+++ b/great_expectations/experimental/datasources/metadatasource.py
@@ -36,9 +36,9 @@ class MetaDatasource(pydantic.main.ModelMetaclass):
 
         cls = super().__new__(meta_cls, cls_name, bases, cls_dict)
 
-        if cls_name == "Datasource":
+        if cls_name == "Datasource" or cls_name.startswith("_"):
             # NOTE: the above check is brittle and must be kept in-line with the Datasource.__name__
-            logger.debug("1c. Skip factory registration of base `Datasource`")
+            logger.debug(f"1c. Skip factory registration of base `{cls_name}`")
             return cls
 
         logger.debug(f"  {cls_name} __dict__ ->\n{pf(cls.__dict__, depth=3)}")

--- a/great_expectations/experimental/datasources/pandas_datasource.py
+++ b/great_expectations/experimental/datasources/pandas_datasource.py
@@ -5,7 +5,6 @@ import pathlib
 import re
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Type, Union
 
-import pydantic
 from typing_extensions import Literal
 
 from great_expectations.experimental.datasources.dynamic_pandas import (
@@ -80,7 +79,6 @@ class _PandasDatasource(Datasource):
     asset_types: ClassVar[List[Type[DataAsset]]] = list(_ASSET_MODELS.values())
 
     # instance attributes
-    type: str = pydantic.Field("_pandas")
     assets: Dict[
         str,
         _FilesystemDataAsset,

--- a/great_expectations/experimental/datasources/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/PandasFilesystemDatasource.json
@@ -1,0 +1,89 @@
+{
+    "title": "PandasFilesystemDatasource",
+    "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+    "type": "object",
+    "properties": {
+        "type": {
+            "title": "Type",
+            "default": "pandas_filesystem",
+            "enum": [
+                "pandas_filesystem"
+            ],
+            "type": "string"
+        },
+        "name": {
+            "title": "Name",
+            "type": "string"
+        },
+        "assets": {
+            "title": "Assets",
+            "default": {},
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/_FilesystemDataAsset"
+            }
+        },
+        "base_directory": {
+            "title": "Base Directory",
+            "type": "string",
+            "format": "path"
+        }
+    },
+    "required": [
+        "name",
+        "base_directory"
+    ],
+    "additionalProperties": false,
+    "definitions": {
+        "BatchSorter": {
+            "title": "BatchSorter",
+            "type": "object",
+            "properties": {
+                "key": {
+                    "title": "Key",
+                    "type": "string"
+                },
+                "reverse": {
+                    "title": "Reverse",
+                    "default": false,
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "key"
+            ]
+        },
+        "_FilesystemDataAsset": {
+            "title": "_FilesystemDataAsset",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "type": {
+                    "title": "Type",
+                    "type": "string"
+                },
+                "order_by": {
+                    "title": "Order By",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/BatchSorter"
+                    }
+                },
+                "regex": {
+                    "title": "Regex",
+                    "type": "string",
+                    "format": "regex"
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "regex"
+            ]
+        }
+    }
+}

--- a/great_expectations/experimental/datasources/schemas/SparkDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/SparkDatasource.json
@@ -22,10 +22,16 @@
             "additionalProperties": {
                 "$ref": "#/definitions/CSVSparkAsset"
             }
+        },
+        "base_directory": {
+            "title": "Base Directory",
+            "type": "string",
+            "format": "path"
         }
     },
     "required": [
-        "name"
+        "name",
+        "base_directory"
     ],
     "additionalProperties": false,
     "definitions": {
@@ -71,11 +77,6 @@
                         "$ref": "#/definitions/BatchSorter"
                     }
                 },
-                "base_directory": {
-                    "title": "Base Directory",
-                    "type": "string",
-                    "format": "path"
-                },
                 "regex": {
                     "title": "Regex",
                     "type": "string",
@@ -94,7 +95,6 @@
             },
             "required": [
                 "name",
-                "base_directory",
                 "regex"
             ]
         }

--- a/great_expectations/experimental/datasources/spark_datasource.py
+++ b/great_expectations/experimental/datasources/spark_datasource.py
@@ -5,7 +5,6 @@ import pathlib
 import re
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Type, Union
 
-import pydantic
 from typing_extensions import Literal
 
 from great_expectations.experimental.datasources.filesystem_data_asset import (
@@ -49,7 +48,6 @@ class _SparkDatasource(Datasource):
     asset_types: ClassVar[List[Type[DataAsset]]] = [CSVSparkAsset]
 
     # instance attributes
-    type: str = pydantic.Field("_spark")
     assets: Dict[
         str,
         CSVSparkAsset,

--- a/tasks.py
+++ b/tasks.py
@@ -498,8 +498,8 @@ def type_schema(
 
     from great_expectations.experimental.datasources import _PANDAS_SCHEMA_VERSION
     from great_expectations.experimental.datasources.pandas_datasource import (
-        _PandasDatasource,
         PandasFilesystemDatasource,
+        _PandasDatasource,
     )
     from great_expectations.experimental.datasources.sources import _SourceFactories
 

--- a/tasks.py
+++ b/tasks.py
@@ -548,7 +548,7 @@ def type_schema(
                         continue
 
                 schema_path.write_text(json_str)
-                print(f"✅  {name} - {schema_path.name} schema updated")
+                print(f"🔃  {name} - {schema_path.name} schema updated")
             except TypeError as err:
                 print(f"❌  {name} - Could not sync schema - {type(err).__name__}:{err}")
 

--- a/tasks.py
+++ b/tasks.py
@@ -553,6 +553,7 @@ def type_schema(
                 print(f"🔃  {name} - {schema_path.name} schema updated")
             except TypeError as err:
                 print(f"❌  {name} - Could not sync schema - {type(err).__name__}:{err}")
+        raise invoke.Exit(code=0)
 
     text: str = buffer.getvalue()
     if save_path:

--- a/tasks.py
+++ b/tasks.py
@@ -538,10 +538,6 @@ def type_schema(
                 schema_path = schema_dir.joinpath(f"{model.__name__}.json")
                 json_str: str = model.schema_json(indent=indent) + "\n"
 
-                if issubclass(model, Datasource):
-                    print(f"🙈  {name} - is a Datasource; skipping")
-                    continue
-
                 if schema_path.exists():
                     if json_str == schema_path.read_text():
                         print(f"✅  {name} - {schema_path.name} unchanged")

--- a/tasks.py
+++ b/tasks.py
@@ -497,8 +497,8 @@ def type_schema(
     import pandas
 
     from great_expectations.experimental.datasources import _PANDAS_SCHEMA_VERSION
-    from great_expectations.experimental.datasources.interfaces import Datasource
     from great_expectations.experimental.datasources.pandas_datasource import (
+        _PandasDatasource,
         PandasFilesystemDatasource,
     )
     from great_expectations.experimental.datasources.sources import _SourceFactories
@@ -524,10 +524,14 @@ def type_schema(
         for name in _SourceFactories.type_lookup.type_names():
             model = _SourceFactories.type_lookup[name]
 
-            # TODO: use more robust subclass checks
             if (
-                model
-                in {*PandasFilesystemDatasource.asset_types, PandasFilesystemDatasource}
+                issubclass(
+                    model,
+                    (
+                        _PandasDatasource,
+                        *PandasFilesystemDatasource.asset_types,
+                    ),
+                )
                 and _PANDAS_SCHEMA_VERSION != pandas.__version__
             ):
                 print(

--- a/tasks.py
+++ b/tasks.py
@@ -535,7 +535,8 @@ def type_schema(
                 and _PANDAS_SCHEMA_VERSION != pandas.__version__
             ):
                 print(
-                    f"🙈  {name} - was generated with pandas {_PANDAS_SCHEMA_VERSION}; skipping"
+                    f"🙈  {name} - was generated with pandas"
+                    f" {_PANDAS_SCHEMA_VERSION} but you have {pandas.__version__}; skipping"
                 )
                 continue
 

--- a/tasks.py
+++ b/tasks.py
@@ -524,6 +524,7 @@ def type_schema(
         for name in _SourceFactories.type_lookup.type_names():
             model = _SourceFactories.type_lookup[name]
 
+            # TODO: use more robust subclass checks
             if (
                 model
                 in {*PandasFilesystemDatasource.asset_types, PandasFilesystemDatasource}

--- a/tests/experimental/datasources/test_schemas.py
+++ b/tests/experimental/datasources/test_schemas.py
@@ -69,12 +69,6 @@ def test_vcs_schemas_match(zep_ds_or_asset_model: Type[pydantic.BaseModel]):
         "SqliteTableAsset.json",
         "SqliteQueryAsset.json",
         "SASAsset.json",
-        "SQLDatasource.json",
-        "PostgresDatasource.json",
-        "PandasFilesystemDatasource.json",
-        "SparkDatasource.json",
-        "_PandasDatasource.json",
-        "_SparkDatasource.json",
     ):
         pytest.xfail(f"{schema_path.name} does not exist")
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- don't register private `Datasource` classes (ex `_PandasDatasource`)
- improve `invoke schema --sync` to be more transparent about when and why schemas are updated (or not updated)
  - start saving/committing `Datasource` schemas in addition to `DataAsset` schemas

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
