### PR TITLE
[BUGFIX] Parse pandas version correctly for development builds

### DIFF
--- a/great_expectations/experimental/datasources/dynamic_pandas.py
+++ b/great_expectations/experimental/datasources/dynamic_pandas.py
@@ -28,6 +28,7 @@ from typing import (
 
 import pandas as pd
 import pydantic
+from packaging.version import Version
 from pydantic import Field, FilePath
 
 # from pydantic.typing import resolve_annotations
@@ -63,7 +64,9 @@ except ImportError:
 
 logger = logging.getLogger(__file__)
 
-PANDAS_VERSION: float = float(pd.__version__.rsplit(".", maxsplit=1)[0])
+PANDAS_VERSION: float = float(
+    f"{Version(pd.__version__).major}.{Version(pd.__version__).minor}"
+)
 
 DataFrameFactoryFn: TypeAlias = Callable[..., pd.DataFrame]
 


### PR DESCRIPTION
Currently, Great Expectations will fail on import with [a nightly pandas build](https://pandas.pydata.org/docs/dev/getting_started/install.html#installing-the-development-version-of-pandas):

```
python -c "import great_expectations"                 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jtilly/great_expectations/great_expectations/__init__.py", line 6, in <module>
    from great_expectations.data_context.migrator.cloud_migrator import CloudMigrator
  File "/Users/jtilly/great_expectations/great_expectations/data_context/__init__.py", line 1, in <module>
    from great_expectations.data_context.data_context import (
  File "/Users/jtilly/great_expectations/great_expectations/data_context/data_context/__init__.py", line 1, in <module>
    from great_expectations.data_context.data_context.abstract_data_context import (
  File "/Users/jtilly/great_expectations/great_expectations/data_context/data_context/abstract_data_context.py", line 70, in <module>
    from great_expectations.data_context.config_validator.yaml_config_validator import (
  File "/Users/jtilly/great_expectations/great_expectations/data_context/config_validator/yaml_config_validator.py", line 22, in <module>
    from great_expectations.checkpoint import Checkpoint, SimpleCheckpoint
  File "/Users/jtilly/great_expectations/great_expectations/checkpoint/__init__.py", line 16, in <module>
    from .checkpoint import Checkpoint, LegacyCheckpoint, SimpleCheckpoint
  File "/Users/jtilly/great_expectations/great_expectations/checkpoint/checkpoint.py", line 63, in <module>
    from great_expectations.validator.validator import Validator
  File "/Users/jtilly/great_expectations/great_expectations/validator/validator.py", line 64, in <module>
    from great_expectations.experimental.datasources.interfaces import (
  File "/Users/jtilly/great_expectations/great_expectations/experimental/__init__.py", line 1, in <module>
    from great_expectations.experimental import datasources
  File "/Users/jtilly/great_expectations/great_expectations/experimental/datasources/__init__.py", line 3, in <module>
    from great_expectations.experimental.datasources.pandas_datasource import (
  File "/Users/jtilly/great_expectations/great_expectations/experimental/datasources/pandas_datasource.py", line 10, in <module>
    from great_expectations.experimental.datasources.dynamic_pandas import (
  File "/Users/jtilly/great_expectations/great_expectations/experimental/datasources/dynamic_pandas.py", line 66, in <module>
    PANDAS_VERSION: float = float(pd.__version__.rsplit(".", maxsplit=1)[0])
ValueError: could not convert string to float: '2.0.0.dev0+1541'
```

With this PR, I'm using the `packaging` package to parse the pandas version and avoid the value error. `packaging` is already a [dependency](https://github.com/great-expectations/great_expectations/blob/a603eaa7add93d4a2e2146867f27c6bfcc87965d/requirements.txt#L19).


Note: It would probably be better to make `PANDAS_VERSION` a `packaging.version.Version` instead of a float, but I wanted to keep this PR as minimal as possible.

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
