### PR TITLE
[BUGFIX] Patch broken rendered content Cloud tests

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -71,6 +71,7 @@ from great_expectations.data_context.config_validator.yaml_config_validator impo
     _YamlConfigValidator,
 )
 from great_expectations.data_context.store import Store, TupleStoreBackend
+from great_expectations.data_context.store.profiler_store import ProfilerStore
 from great_expectations.data_context.templates import CONFIG_VARIABLES_TEMPLATE
 from great_expectations.data_context.types.base import (
     CURRENT_GX_CONFIG_VERSION,
@@ -154,9 +155,6 @@ if TYPE_CHECKING:
     )
     from great_expectations.data_context.store.expectations_store import (
         ExpectationsStore,
-    )
-    from great_expectations.data_context.store.profiler_store import (
-        ProfilerStore,  # noqa: TCH004
     )
     from great_expectations.data_context.store.validations_store import ValidationsStore
     from great_expectations.data_context.types.resource_identifiers import (
@@ -2849,8 +2847,21 @@ class AbstractDataContext(ConfigPeer, ABC):
                 meta=meta,
             )
 
-        expectation_suite_name = expectation_suite.expectation_suite_name
-        key = ExpectationSuiteIdentifier(expectation_suite_name=expectation_suite_name)
+        return self._persist_suite_with_store(
+            expectation_suite=expectation_suite,
+            overwrite_existing=overwrite_existing,
+            **kwargs,
+        )
+
+    def _persist_suite_with_store(
+        self,
+        expectation_suite: ExpectationSuite,
+        overwrite_existing: bool,
+        **kwargs,
+    ) -> ExpectationSuite:
+        key = ExpectationSuiteIdentifier(
+            expectation_suite_name=expectation_suite.expectation_suite_name
+        )
 
         persistence_fn: Callable
         if overwrite_existing:

--- a/great_expectations/data_context/store/expectations_store.py
+++ b/great_expectations/data_context/store/expectations_store.py
@@ -180,7 +180,7 @@ class ExpectationsStore(Store):
 
     def add(self, key, value, **kwargs):
         try:
-            super().add(key=key, value=value, **kwargs)
+            return super().add(key=key, value=value, **kwargs)
         except gx_exceptions.StoreBackendError:
             raise gx_exceptions.ExpectationSuiteError(
                 f"An ExpectationSuite named {value.expectation_suite_name} already exists."
@@ -188,7 +188,7 @@ class ExpectationsStore(Store):
 
     def update(self, key, value, **kwargs):
         try:
-            super().update(key=key, value=value, **kwargs)
+            return super().update(key=key, value=value, **kwargs)
         except gx_exceptions.StoreBackendError:
             raise gx_exceptions.ExpectationSuiteError(
                 f"Could not find an existing ExpectationSuite named {value.expectation_suite_name}."

--- a/great_expectations/data_context/store/profiler_store.py
+++ b/great_expectations/data_context/store/profiler_store.py
@@ -76,7 +76,7 @@ class ProfilerStore(ConfigurationStore):
 
     def add(self, key, value, **kwargs):
         try:
-            super().add(key=key, value=value, **kwargs)
+            return super().add(key=key, value=value, **kwargs)
         except gx_exceptions.StoreBackendError:
             raise gx_exceptions.ProfilerError(
                 f"A Profiler named {value.name} already exists."
@@ -84,7 +84,7 @@ class ProfilerStore(ConfigurationStore):
 
     def update(self, key, value, **kwargs):
         try:
-            super().update(key=key, value=value, **kwargs)
+            return super().update(key=key, value=value, **kwargs)
         except gx_exceptions.StoreBackendError:
             raise gx_exceptions.ProfilerNotFoundError(
                 f"Could not find an existing Profiler named {value.name}."


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure that `CloudDataContext` has its own logic to deal with ids (parity with `create_expectation_suite`)


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.
