### PR TITLE
[BUGFIX] pydantic>=1.10.4 - ImportError: cannot import name dataclass_transform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ packaging
 pandas>=1.1.0; python_version <= "3.8"
 pandas>=1.1.3; python_version == "3.9"
 pandas>=1.3.0; python_version >= "3.10"
-pydantic>=1.10,<2.0
+pydantic>=1.10.4,<2.0
 pyparsing>=2.4
 python-dateutil>=2.8.1
 pytz>=2021.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ packaging
 pandas>=1.1.0; python_version <= "3.8"
 pandas>=1.1.3; python_version == "3.9"
 pandas>=1.3.0; python_version >= "3.10"
+# patch version updates `typing_extensions` to the needed version
 pydantic>=1.10.4,<2.0
 pyparsing>=2.4
 python-dateutil>=2.8.1


### PR DESCRIPTION
## Changes proposed in this pull request:
- update `pydantic` lower bound to `v1.10.4`
https://docs.pydantic.dev/changelog/#v1104-2022-12-30

The `pydantic` `1.10.4` release updates the minimum version of `typing_extenions` which was the source of the `ImportError: cannot import name dataclass_transform` errors in some environments.
The issue stems from the fact the `pydantic` `v.1.10` had started to rely on a `typing_extension` import that didn't exist in the minimum `type_extension` version.

Consequently, if a user had an earlier version of `pydantic` or `typing_extentions` installed in the environment `pip` would consider the requirement satisfied and would not update the needed version.
This frequently happened in environments like `Databricks`.
With this change, `pip` will automatically update the `pydantic` and `typing_extension` versions if needed when installing `great_expectations`.

https://github.com/pydantic/pydantic/issues/4885

Fixes https://github.com/great-expectations/great_expectations/issues/6486

## Note:
This also fixes the ``RuntimeError: no validator found for <class 're.Pattern'>, see `arbitrary_types_allowed` in Config`` error that could result from an older pydantic version.