### PR TITLE
[BUGFIX] Patch broken Cloud test blocking 0.15.49 release

### DIFF
--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -10,12 +10,10 @@ from great_expectations.core import (
 )
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
-from great_expectations.data_context.data_context.cloud_data_context import (
-    CloudDataContext,
-)
 from great_expectations.data_context.types.refs import GXCloudResourceRef
 from great_expectations.render import RenderedAtomicContent
 from great_expectations.validator.validator import Validator
+from great_expectations.data_context import CloudDataContext
 
 
 @pytest.mark.cloud
@@ -24,7 +22,7 @@ def test_cloud_backed_data_context_save_expectation_suite_include_rendered_conte
     empty_cloud_data_context: CloudDataContext,
 ) -> None:
     """
-    Cloud-backed contexts  should save an ExpectationSuite with rendered_content by default.
+    Cloud-backed contexts should save an ExpectationSuite with rendered_content by default.
     """
     context = empty_cloud_data_context
 
@@ -56,7 +54,7 @@ def test_cloud_backed_data_context_save_expectation_suite_include_rendered_conte
     ), mock.patch(
         "great_expectations.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend._update"
     ) as mock_update:
-        context.update_expectation_suite(
+        context.save_expectation_suite(
             expectation_suite=expectation_suite,
         )
 

--- a/tests/data_context/cloud_data_context/test_include_rendered_content.py
+++ b/tests/data_context/cloud_data_context/test_include_rendered_content.py
@@ -10,6 +10,9 @@ from great_expectations.core import (
 )
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.data_context.cloud_constants import GXCloudRESTResource
+from great_expectations.data_context.data_context.cloud_data_context import (
+    CloudDataContext,
+)
 from great_expectations.data_context.types.refs import GXCloudResourceRef
 from great_expectations.render import RenderedAtomicContent
 from great_expectations.validator.validator import Validator
@@ -17,30 +20,13 @@ from great_expectations.validator.validator import Validator
 
 @pytest.mark.cloud
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "data_context_fixture_name",
-    [
-        # In order to leverage existing fixtures in parametrization, we provide
-        # their string names and dynamically retrieve them using pytest's built-in
-        # `request` fixture.
-        # Source: https://stackoverflow.com/a/64348247
-        pytest.param(
-            "empty_base_data_context_in_cloud_mode",
-            id="BaseDataContext",
-        ),
-        pytest.param("empty_data_context_in_cloud_mode", id="DataContext"),
-        pytest.param("empty_cloud_data_context", id="CloudDataContext"),
-    ],
-)
 def test_cloud_backed_data_context_save_expectation_suite_include_rendered_content(
-    data_context_fixture_name: str,
-    request,
+    empty_cloud_data_context: CloudDataContext,
 ) -> None:
     """
-    All Cloud-backed contexts (DataContext, BaseDataContext, and CloudDataContext) should save an ExpectationSuite
-    with rendered_content by default.
+    Cloud-backed contexts  should save an ExpectationSuite with rendered_content by default.
     """
-    context = request.getfixturevalue(data_context_fixture_name)
+    context = empty_cloud_data_context
 
     ge_cloud_id = "d581305a-cdce-483b-84ba-5c673d2ce009"
     cloud_ref = GXCloudResourceRef(
@@ -70,7 +56,7 @@ def test_cloud_backed_data_context_save_expectation_suite_include_rendered_conte
     ), mock.patch(
         "great_expectations.data_context.store.gx_cloud_store_backend.GXCloudStoreBackend._update"
     ) as mock_update:
-        context.add_expectation_suite(
+        context.update_expectation_suite(
             expectation_suite=expectation_suite,
         )
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Revert behavior to outdated method for the time being


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run any local integration tests and made sure that nothing is broken.
