### PR TITLE
[FEATURE] F/great 1393/add initial non datetime sql splitters

### DIFF
--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -275,7 +275,9 @@ class DataAsset(ExperimentalBaseModel, Generic[_DatasourceT]):
         for sorter in reversed(self.order_by):
             try:
                 batch_list.sort(
-                    key=functools.cmp_to_key(_sort_batches_with_none(sorter.key)),
+                    key=functools.cmp_to_key(
+                        _sort_batches_with_none_metadata_values(sorter.key)
+                    ),
                     reverse=sorter.reverse,
                 )
             except KeyError as e:
@@ -285,7 +287,7 @@ class DataAsset(ExperimentalBaseModel, Generic[_DatasourceT]):
                 ) from e
 
 
-def _sort_batches_with_none(
+def _sort_batches_with_none_metadata_values(
     key: str,
 ) -> Callable[[Batch, Batch], int]:
     def _compare_function(a: Batch, b: Batch) -> int:

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -287,8 +287,8 @@ class DataAsset(ExperimentalBaseModel, Generic[_DatasourceT]):
 
 def _sort_batches_with_none(
     key: str,
-) -> Callable[[Optional[Batch], Optional[Batch]], int]:
-    def _compare_function(a: Optional[Batch], b: Optional[Batch]) -> int:
+) -> Callable[[Batch, Batch], int]:
+    def _compare_function(a: Batch, b: Batch) -> int:
         if a.metadata[key] is not None and b.metadata[key] is not None:
             if a.metadata[key] < b.metadata[key]:
                 return -1

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -302,8 +302,8 @@ def _sort_batches_with_none_metadata_values(
             return 0
         elif a.metadata[key] is None:  # b.metadata[key] is not None
             return -1
-        else:  # b.metadata[key] is None, a.metadata[key] is not None
-            return 0
+        # b.metadata[key] is None, a.metadata[key] is not None
+        return 0
 
     return _compare_function
 

--- a/great_expectations/experimental/datasources/schemas/PostgresDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/PostgresDatasource.json
@@ -62,8 +62,9 @@
                 "key"
             ]
         },
-        "ColumnSplitter": {
-            "title": "ColumnSplitter",
+        "ColumnSplitterColumnValue": {
+            "title": "ColumnSplitterColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -72,13 +73,145 @@
                 },
                 "method_name": {
                     "title": "Method Name",
+                    "default": "split_on_column_value",
+                    "enum": [
+                        "split_on_column_value"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDividedInteger": {
+            "title": "ColumnSplitterDividedInteger",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_divided_integer",
+                    "enum": [
+                        "split_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
                 "column_name",
-                "method_name"
-            ]
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDatetimePart": {
+            "title": "ColumnSplitterDatetimePart",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_date_parts",
+                    "enum": [
+                        "split_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonthAndDay": {
+            "title": "ColumnSplitterYearAndMonthAndDay",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month_and_day",
+                    "enum": [
+                        "split_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonth": {
+            "title": "ColumnSplitterYearAndMonth",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month",
+                    "enum": [
+                        "split_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYear": {
+            "title": "ColumnSplitterYear",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year",
+                    "enum": [
+                        "split_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -105,7 +238,27 @@
                     }
                 },
                 "column_splitter": {
-                    "$ref": "#/definitions/ColumnSplitter"
+                    "title": "Column Splitter",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYear"
+                        }
+                    ]
                 },
                 "table_name": {
                     "title": "Table Name",
@@ -147,7 +300,27 @@
                     }
                 },
                 "column_splitter": {
-                    "$ref": "#/definitions/ColumnSplitter"
+                    "title": "Column Splitter",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYear"
+                        }
+                    ]
                 },
                 "query": {
                     "title": "Query",

--- a/great_expectations/experimental/datasources/schemas/QueryAsset.json
+++ b/great_expectations/experimental/datasources/schemas/QueryAsset.json
@@ -23,7 +23,27 @@
             }
         },
         "column_splitter": {
-            "$ref": "#/definitions/ColumnSplitter"
+            "title": "Column Splitter",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ColumnSplitterColumnValue"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterYear"
+                }
+            ]
         },
         "query": {
             "title": "Query",
@@ -54,8 +74,9 @@
                 "key"
             ]
         },
-        "ColumnSplitter": {
-            "title": "ColumnSplitter",
+        "ColumnSplitterColumnValue": {
+            "title": "ColumnSplitterColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -64,13 +85,145 @@
                 },
                 "method_name": {
                     "title": "Method Name",
+                    "default": "split_on_column_value",
+                    "enum": [
+                        "split_on_column_value"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDividedInteger": {
+            "title": "ColumnSplitterDividedInteger",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_divided_integer",
+                    "enum": [
+                        "split_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
                 "column_name",
-                "method_name"
-            ]
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDatetimePart": {
+            "title": "ColumnSplitterDatetimePart",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_date_parts",
+                    "enum": [
+                        "split_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonthAndDay": {
+            "title": "ColumnSplitterYearAndMonthAndDay",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month_and_day",
+                    "enum": [
+                        "split_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonth": {
+            "title": "ColumnSplitterYearAndMonth",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month",
+                    "enum": [
+                        "split_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYear": {
+            "title": "ColumnSplitterYear",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year",
+                    "enum": [
+                        "split_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
         }
     }
 }

--- a/great_expectations/experimental/datasources/schemas/SQLDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/SQLDatasource.json
@@ -59,8 +59,9 @@
                 "key"
             ]
         },
-        "ColumnSplitter": {
-            "title": "ColumnSplitter",
+        "ColumnSplitterColumnValue": {
+            "title": "ColumnSplitterColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -69,13 +70,145 @@
                 },
                 "method_name": {
                     "title": "Method Name",
+                    "default": "split_on_column_value",
+                    "enum": [
+                        "split_on_column_value"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDividedInteger": {
+            "title": "ColumnSplitterDividedInteger",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_divided_integer",
+                    "enum": [
+                        "split_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
                 "column_name",
-                "method_name"
-            ]
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDatetimePart": {
+            "title": "ColumnSplitterDatetimePart",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_date_parts",
+                    "enum": [
+                        "split_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonthAndDay": {
+            "title": "ColumnSplitterYearAndMonthAndDay",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month_and_day",
+                    "enum": [
+                        "split_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonth": {
+            "title": "ColumnSplitterYearAndMonth",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month",
+                    "enum": [
+                        "split_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYear": {
+            "title": "ColumnSplitterYear",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year",
+                    "enum": [
+                        "split_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -102,7 +235,27 @@
                     }
                 },
                 "column_splitter": {
-                    "$ref": "#/definitions/ColumnSplitter"
+                    "title": "Column Splitter",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYear"
+                        }
+                    ]
                 },
                 "table_name": {
                     "title": "Table Name",
@@ -144,7 +297,27 @@
                     }
                 },
                 "column_splitter": {
-                    "$ref": "#/definitions/ColumnSplitter"
+                    "title": "Column Splitter",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYear"
+                        }
+                    ]
                 },
                 "query": {
                     "title": "Query",

--- a/great_expectations/experimental/datasources/schemas/SqliteDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/SqliteDatasource.json
@@ -62,8 +62,9 @@
                 "key"
             ]
         },
-        "ColumnSplitter": {
-            "title": "ColumnSplitter",
+        "ColumnSplitterColumnValue": {
+            "title": "ColumnSplitterColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -72,13 +73,145 @@
                 },
                 "method_name": {
                     "title": "Method Name",
+                    "default": "split_on_column_value",
+                    "enum": [
+                        "split_on_column_value"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDividedInteger": {
+            "title": "ColumnSplitterDividedInteger",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_divided_integer",
+                    "enum": [
+                        "split_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
                 "column_name",
-                "method_name"
-            ]
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDatetimePart": {
+            "title": "ColumnSplitterDatetimePart",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_date_parts",
+                    "enum": [
+                        "split_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonthAndDay": {
+            "title": "ColumnSplitterYearAndMonthAndDay",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month_and_day",
+                    "enum": [
+                        "split_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonth": {
+            "title": "ColumnSplitterYearAndMonth",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month",
+                    "enum": [
+                        "split_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYear": {
+            "title": "ColumnSplitterYear",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year",
+                    "enum": [
+                        "split_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
         },
         "TableAsset": {
             "title": "TableAsset",
@@ -105,7 +238,27 @@
                     }
                 },
                 "column_splitter": {
-                    "$ref": "#/definitions/ColumnSplitter"
+                    "title": "Column Splitter",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYear"
+                        }
+                    ]
                 },
                 "table_name": {
                     "title": "Table Name",
@@ -147,7 +300,27 @@
                     }
                 },
                 "column_splitter": {
-                    "$ref": "#/definitions/ColumnSplitter"
+                    "title": "Column Splitter",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterYear"
+                        }
+                    ]
                 },
                 "query": {
                     "title": "Query",

--- a/great_expectations/experimental/datasources/schemas/TableAsset.json
+++ b/great_expectations/experimental/datasources/schemas/TableAsset.json
@@ -23,7 +23,27 @@
             }
         },
         "column_splitter": {
-            "$ref": "#/definitions/ColumnSplitter"
+            "title": "Column Splitter",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ColumnSplitterColumnValue"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterDividedInteger"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterDatetimePart"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterYearAndMonthAndDay"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterYearAndMonth"
+                },
+                {
+                    "$ref": "#/definitions/ColumnSplitterYear"
+                }
+            ]
         },
         "table_name": {
             "title": "Table Name",
@@ -58,8 +78,9 @@
                 "key"
             ]
         },
-        "ColumnSplitter": {
-            "title": "ColumnSplitter",
+        "ColumnSplitterColumnValue": {
+            "title": "ColumnSplitterColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
             "type": "object",
             "properties": {
                 "column_name": {
@@ -68,13 +89,145 @@
                 },
                 "method_name": {
                     "title": "Method Name",
+                    "default": "split_on_column_value",
+                    "enum": [
+                        "split_on_column_value"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDividedInteger": {
+            "title": "ColumnSplitterDividedInteger",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_divided_integer",
+                    "enum": [
+                        "split_on_divided_integer"
+                    ],
+                    "type": "string"
+                },
+                "divisor": {
+                    "title": "Divisor",
+                    "type": "integer"
+                }
+            },
+            "required": [
                 "column_name",
-                "method_name"
-            ]
+                "divisor"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterDatetimePart": {
+            "title": "ColumnSplitterDatetimePart",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_date_parts",
+                    "enum": [
+                        "split_on_date_parts"
+                    ],
+                    "type": "string"
+                },
+                "datetime_parts": {
+                    "title": "Datetime Parts",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "column_name",
+                "datetime_parts"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonthAndDay": {
+            "title": "ColumnSplitterYearAndMonthAndDay",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month_and_day",
+                    "enum": [
+                        "split_on_year_and_month_and_day"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYearAndMonth": {
+            "title": "ColumnSplitterYearAndMonth",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year_and_month",
+                    "enum": [
+                        "split_on_year_and_month"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterYear": {
+            "title": "ColumnSplitterYear",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_name": {
+                    "title": "Column Name",
+                    "type": "string"
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_year",
+                    "enum": [
+                        "split_on_year"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_name"
+            ],
+            "additionalProperties": false
         }
     }
 }

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -261,7 +261,7 @@ class ColumnSplitterDividedInteger(_ColumnSplitter):
 
     @property
     def param_names(self) -> List[str]:
-        return ["divisor"]
+        return ["quotient"]
 
     def splitter_method_kwargs(self) -> Dict[str, Any]:
         return {"column_name": self.column_name, "divisor": self.divisor}
@@ -269,11 +269,11 @@ class ColumnSplitterDividedInteger(_ColumnSplitter):
     def request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
-        if "divisor" not in options:
+        if "quotient" not in options:
             raise ValueError(
-                "'divisor' must be specified in the batch request options to create a batch identifier"
+                "'quotient' must be specified in the batch request options to create a batch identifier"
             )
-        return {self.column_name: options["divisor"]}
+        return {self.column_name: options["quotient"]}
 
 
 ColumnSplitter = Union[

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -399,7 +399,7 @@ class _SQLAsset(DataAsset):
         candidate: Dict, requested_options: BatchRequestOptions
     ) -> bool:
         for k, v in requested_options.items():
-            if candidate[k] != v:
+            if v is not None and candidate[k] != v:
                 return False
         return True
 

--- a/great_expectations/experimental/datasources/sql_datasource.py
+++ b/great_expectations/experimental/datasources/sql_datasource.py
@@ -60,12 +60,26 @@ class _ColumnSplitter(ExperimentalBaseModel):
 
     @property
     def param_names(self) -> List[str]:
+        """Returns the parameter names that specify a batch derived from this column splitter
+
+        For example, for ColumnSplitterYearMonth this returns ["year", "month"]. For more
+        examples, please see _ColumnSplitter subclasses.
+        """
         raise NotImplementedError
 
     def splitter_method_kwargs(self) -> Dict[str, Any]:
+        """A shim to our sqlalchemy execution engine splitter methods
+
+        We translate any internal _ColumnSplitter state and what is passed in from
+        a batch_request to the splitter_kwargs required by our execution engine
+        data splitters defined in:
+        great_expectations.execution_engine.split_and_sample.sqlalchemy_data_splitter
+
+        Look at _ColumnSplitter subclasses for concrete examples.
+        """
         raise NotImplementedError
 
-    def request_options_to_batch_spec_kwarg_identifiers(
+    def batch_batch_request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
         """Translate the batch request options to the dictionary needed to by our execution engine
@@ -144,7 +158,7 @@ class ColumnSplitterYear(_ColumnSplitter):
     def splitter_method_kwargs(self) -> Dict[str, Any]:
         return {"column_name": self.column_name}
 
-    def request_options_to_batch_spec_kwarg_identifiers(
+    def batch_request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
         return _request_options_to_datetime_batch_spec_kwargs(self, options)
@@ -160,7 +174,7 @@ class ColumnSplitterYearAndMonth(_ColumnSplitter):
     def splitter_method_kwargs(self) -> Dict[str, Any]:
         return {"column_name": self.column_name}
 
-    def request_options_to_batch_spec_kwarg_identifiers(
+    def batch_request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
         return _request_options_to_datetime_batch_spec_kwargs(self, options)
@@ -178,7 +192,7 @@ class ColumnSplitterYearAndMonthAndDay(_ColumnSplitter):
     def splitter_method_kwargs(self) -> Dict[str, Any]:
         return {"column_name": self.column_name}
 
-    def request_options_to_batch_spec_kwarg_identifiers(
+    def batch_request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
         return _request_options_to_datetime_batch_spec_kwargs(self, options)
@@ -196,7 +210,7 @@ class ColumnSplitterDatetimePart(_ColumnSplitter):
     def splitter_method_kwargs(self) -> Dict[str, Any]:
         return {"column_name": self.column_name, "date_parts": self.param_names}
 
-    def request_options_to_batch_spec_kwarg_identifiers(
+    def batch_request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
         return _request_options_to_datetime_batch_spec_kwargs(self, options)
@@ -245,7 +259,7 @@ class ColumnSplitterColumnValue(_ColumnSplitter):
     def splitter_method_kwargs(self) -> Dict[str, Any]:
         return {"column_name": self.column_name}
 
-    def request_options_to_batch_spec_kwarg_identifiers(
+    def batch_request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
         if self.column_name not in options:
@@ -266,7 +280,7 @@ class ColumnSplitterDividedInteger(_ColumnSplitter):
     def splitter_method_kwargs(self) -> Dict[str, Any]:
         return {"column_name": self.column_name, "divisor": self.divisor}
 
-    def request_options_to_batch_spec_kwarg_identifiers(
+    def batch_request_options_to_batch_spec_kwarg_identifiers(
         self, options: BatchRequestOptions
     ) -> Dict[str, Any]:
         if "quotient" not in options:
@@ -464,7 +478,7 @@ class _SQLAsset(DataAsset):
                 # mypy infers that batch_spec_kwargs["batch_identifiers"] is a collection, but
                 # it is hardcoded to a dict above, so we cast it here.
                 cast(Dict, batch_spec_kwargs["batch_identifiers"]).update(
-                    column_splitter.request_options_to_batch_spec_kwarg_identifiers(
+                    column_splitter.batch_request_options_to_batch_spec_kwarg_identifiers(
                         request.options
                     )
                 )

--- a/tests/experimental/datasources/conftest.py
+++ b/tests/experimental/datasources/conftest.py
@@ -98,8 +98,7 @@ def sqlachemy_execution_engine_mock_cls(
             # Otherwise, a list of values is returned.
             if isinstance(splitter_query_response[0], dict):
                 return [Row(row_dict) for row_dict in splitter_query_response]
-            else:
-                return splitter_query_response
+            return splitter_query_response
 
     return MockSqlAlchemyExecutionEngine
 

--- a/tests/experimental/datasources/conftest.py
+++ b/tests/experimental/datasources/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, List, Type
+from typing import Any, Callable, Dict, Generator, List, Type, Union
 
 import pytest
 from pytest import MonkeyPatch
@@ -56,7 +56,7 @@ class MockSaEngine:
 def sqlachemy_execution_engine_mock_cls(
     validate_batch_spec: Callable[[SqlAlchemyDatasourceBatchSpec], None],
     dialect: str,
-    splitter_query_response: List[Dict[str, Any]],
+    splitter_query_response: Union[List[Dict[str, Any]], List[Any]],
 ):
     """Creates a mock gx sql alchemy engine class
 
@@ -68,6 +68,9 @@ def sqlachemy_execution_engine_mock_cls(
             the splitter query. The keys are the column names and the value is the column values, eg:
             [{'year': 2021, 'month': 1}, {'year': 2021, 'month': 2}]
     """
+
+    if not splitter_query_response:
+        raise ValueError("splitter_query_response must be a non-empty list.")
 
     class MockSqlAlchemyExecutionEngine(SqlAlchemyExecutionEngine):
         def __init__(self, *args, **kwargs):
@@ -88,7 +91,15 @@ def sqlachemy_execution_engine_mock_cls(
                     for k, v in attributes.items():
                         setattr(self, k, v)
 
-            return [Row(row_dict) for row_dict in splitter_query_response]
+            # We know that splitter_query_response is non-empty because of validation
+            # at the top of the outer function.
+            # In some cases, such as in the datetime splitters,
+            # a dictionary is returned our from out splitter query with the key as the parameter_name.
+            # Otherwise, a list of values is returned.
+            if isinstance(splitter_query_response[0], dict):
+                return [Row(row_dict) for row_dict in splitter_query_response]
+            else:
+                return splitter_query_response
 
     return MockSqlAlchemyExecutionEngine
 

--- a/tests/experimental/datasources/great_expectations.yml
+++ b/tests/experimental/datasources/great_expectations.yml
@@ -15,10 +15,6 @@ xdatasources:
         column_splitter:
               method_name: split_on_year_and_month
               column_name: my_column
-              name: my_year_and_month_splitter
-              param_names:
-                - year
-                - month
       with_sorters:
         type: table
         name: with_sorters

--- a/tests/experimental/datasources/integration/test_integration_datasource.py
+++ b/tests/experimental/datasources/integration/test_integration_datasource.py
@@ -111,3 +111,125 @@ def test_sql_query_data_asset(empty_data_context):
         result_format={"result_format": "BOOLEAN_ONLY"},
     )
     assert result.success
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    [
+        "database",
+        "table_name",
+        "splitter_name",
+        "splitter_kwargs",
+        "sorter_args",
+        "all_batches_cnt",
+        "specified_batch_request",
+        "specified_batch_cnt",
+        "last_specified_batch_metadata",
+    ],
+    [
+        pytest.param(
+            "yellow_tripdata_sample_2020_all_months_combined.db",
+            "yellow_tripdata_sample_2020",
+            "add_splitter_year",
+            {"column_name": "pickup_datetime"},
+            ["year"],
+            1,
+            {"year": 2020},
+            1,
+            {"year": 2020},
+            id="year",
+        ),
+        pytest.param(
+            "yellow_tripdata_sample_2020_all_months_combined.db",
+            "yellow_tripdata_sample_2020",
+            "add_splitter_year_and_month",
+            {"column_name": "pickup_datetime"},
+            ["year", "month"],
+            12,
+            {"year": 2020, "month": 6},
+            1,
+            {"year": 2020, "month": 6},
+            id="year_and_month",
+        ),
+        pytest.param(
+            "yellow_tripdata.db",
+            "yellow_tripdata_sample_2019_02",
+            "add_splitter_year_and_month_and_day",
+            {"column_name": "pickup_datetime"},
+            ["year", "month", "day"],
+            28,
+            {"year": 2019, "month": 2, "day": 10},
+            1,
+            {"year": 2019, "month": 2, "day": 10},
+            id="year_and_month_and_day",
+        ),
+        pytest.param(
+            "yellow_tripdata.db",
+            "yellow_tripdata_sample_2019_02",
+            "add_splitter_datetime_part",
+            {
+                "column_name": "pickup_datetime",
+                "datetime_parts": ["year", "month", "day"],
+            },
+            ["year", "month", "day"],
+            28,
+            {"year": 2019, "month": 2},
+            28,
+            {"year": 2019, "month": 2, "day": 28},
+            id="datetime_part",
+        ),
+        pytest.param(
+            "yellow_tripdata.db",
+            "yellow_tripdata_sample_2019_02",
+            "add_splitter_column_value",
+            {"column_name": "passenger_count"},
+            ["passenger_count"],
+            7,
+            {"passenger_count": 3},
+            1,
+            {"passenger_count": 3},
+            id="column_value",
+        ),
+        pytest.param(
+            "yellow_tripdata.db",
+            "yellow_tripdata_sample_2019_02",
+            "add_splitter_divided_integer",
+            {"column_name": "passenger_count", "divisor": 3},
+            ["quotient"],
+            3,
+            {"quotient": 2},
+            1,
+            {"quotient": 2},
+            id="divisor",
+        ),
+    ],
+)
+def test_column_splitter(
+    empty_data_context,
+    database,
+    table_name,
+    splitter_name,
+    splitter_kwargs,
+    sorter_args,
+    all_batches_cnt,
+    specified_batch_request,
+    specified_batch_cnt,
+    last_specified_batch_metadata,
+):
+    context = empty_data_context
+    datasource = sqlite_datasource(context, database)
+    asset = datasource.add_table_asset(
+        name="table_asset",
+        table_name=table_name,
+    )
+    getattr(asset, splitter_name)(**splitter_kwargs)
+    asset.add_sorters(sorter_args)
+    # Test getting all batches
+    all_batches = asset.get_batch_list_from_batch_request(asset.build_batch_request())
+    assert len(all_batches) == all_batches_cnt
+    # Test getting specified batches
+    specified_batches = asset.get_batch_list_from_batch_request(
+        asset.build_batch_request(specified_batch_request)
+    )
+    assert len(specified_batches) == specified_batch_cnt
+    assert specified_batches[-1].metadata == last_specified_batch_metadata

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -46,8 +46,6 @@ PG_COMPLEX_CONFIG_DICT = {
                     "column_splitter": {
                         "column_name": "my_column",
                         "method_name": "split_on_year_and_month",
-                        "name": "y_m_splitter",
-                        "param_names": ["year", "month"],
                     },
                     "name": "with_splitter",
                     "table_name": "another_table",
@@ -335,9 +333,8 @@ def test_catch_bad_asset_configs(
             {
                 "column_name": "flavor",
                 "method_name": "NOT_VALID",
-                "param_names": ["cherry", "strawberry"],
             },
-            "value_error",
+            "value_error.const",
             "unexpected value; permitted:",
         )
     ],
@@ -348,8 +345,6 @@ def test_general_column_splitter_errors(
     expected_error_type: str,
     expected_msg: str,
 ):
-
-    # BDIRKS - should i test others
     with pytest.raises(pydantic.ValidationError) as exc_info:
         ColumnSplitterYearAndMonth(**bad_column_kwargs)
 
@@ -357,7 +352,6 @@ def test_general_column_splitter_errors(
 
     all_errors = exc_info.value.errors()
     assert len(all_errors) == 1, "Expected 1 error"
-    # BDIRKS this error is different
     assert expected_error_type == all_errors[0]["type"]
     assert all_errors[0]["msg"].startswith(expected_msg)
 

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -321,7 +321,6 @@ def test_catch_bad_asset_configs(
         if expected_error_loc == all_errors[0]["loc"]:
             test_msg = error["msg"]
             break
-    # BDIRKS this error message is now different
     assert test_msg.startswith(expected_msg)
 
 

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -13,7 +13,7 @@ from great_expectations.experimental.datasources.config import GxConfig
 from great_expectations.experimental.datasources.interfaces import Datasource
 from great_expectations.experimental.datasources.sources import _SourceFactories
 from great_expectations.experimental.datasources.sql_datasource import (
-    ColumnSplitter,
+    ColumnSplitterYearAndMonth,
     TableAsset,
 )
 
@@ -323,6 +323,7 @@ def test_catch_bad_asset_configs(
         if expected_error_loc == all_errors[0]["loc"]:
             test_msg = error["msg"]
             break
+    # BDIRKS this error message is now different
     assert test_msg.startswith(expected_msg)
 
 
@@ -348,13 +349,15 @@ def test_general_column_splitter_errors(
     expected_msg: str,
 ):
 
+    # BDIRKS - should i test others
     with pytest.raises(pydantic.ValidationError) as exc_info:
-        ColumnSplitter(**bad_column_kwargs)
+        ColumnSplitterYearAndMonth(**bad_column_kwargs)
 
     print(f"\n{exc_info.typename}:{exc_info.value}")
 
     all_errors = exc_info.value.errors()
     assert len(all_errors) == 1, "Expected 1 error"
+    # BDIRKS this error is different
     assert expected_error_type == all_errors[0]["type"]
     assert all_errors[0]["msg"].startswith(expected_msg)
 
@@ -448,7 +451,7 @@ def test_splitters_deserialization(
     table_asset: TableAsset = from_json_gx_config.datasources["my_pg_ds"].assets[
         "with_splitter"
     ]
-    assert isinstance(table_asset.column_splitter, ColumnSplitter)
+    assert isinstance(table_asset.column_splitter, ColumnSplitterYearAndMonth)
     assert table_asset.column_splitter.method_name == "split_on_year_and_month"
 
 

--- a/tests/experimental/datasources/test_postgres_datasource.py
+++ b/tests/experimental/datasources/test_postgres_datasource.py
@@ -22,6 +22,7 @@ from great_expectations.experimental.datasources.postgres_datasource import (
 )
 from great_expectations.experimental.datasources.sql_datasource import (
     ColumnSplitter,
+    ColumnSplitterYearAndMonth,
     TableAsset,
 )
 from tests.experimental.datasources.conftest import (
@@ -207,8 +208,8 @@ def create_and_add_table_asset_without_testing_connection(
     return source, table_asset
 
 
-def year_month_splitter(column_name: str) -> ColumnSplitter:
-    return ColumnSplitter(
+def year_month_splitter(column_name: str) -> ColumnSplitterYearAndMonth:
+    return ColumnSplitterYearAndMonth(
         column_name=column_name,
         method_name="split_on_year_and_month",
     )

--- a/tests/experimental/datasources/test_viral_snippets.py
+++ b/tests/experimental/datasources/test_viral_snippets.py
@@ -48,8 +48,6 @@ def zep_config_dict(db_file) -> dict:
                         "column_splitter": {
                             "column_name": "pickup_datetime",
                             "method_name": "split_on_year_and_month",
-                            "name": "y_m_splitter",
-                            "param_names": ["year", "month"],
                         },
                         "order_by": [
                             {"key": "year"},


### PR DESCRIPTION
This adds a few column splitters for sql datasources: `ColumnSplitterColumnValue`, `ColumnSplitterDividedInteger`, `ColumnSplitterDatetimePart`.

This PR looks big by line count but most lines by far are autogenerated schemas and I've added lost of test:

* autogenerated json schemas: `5 files changed, 853 insertions(+), 28 deletions(-)`
* tests: `6 files changed, 333 insertions(+), 27 deletions(-)`
* functional code: ` 2 files changed, 282 insertions(+), 60 deletions(-)`

### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
