### PR TITLE
[BUGFIX] Add error handling to CLI get a default suite name

### DIFF
--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -144,12 +144,11 @@ def get_default_expectation_suite_name(
 ) -> str:
     suite_name: str
     if data_asset_name:
-        suite_name = f"{data_asset_name}.warning"
-    elif batch_request:
-        suite_name = f"batch-{BatchRequest(**batch_request).id}"  # type: ignore[arg-type] # cannot unpack str
-    else:
-        suite_name = "warning"
-    return suite_name
+        return f"{data_asset_name}.warning"
+    try:
+        return f"batch-{BatchRequest(**batch_request).id}"  # type: ignore[arg-type] # cannot unpack str
+    except Exception:
+        return "warning"
 
 
 def tell_user_suite_exists(

--- a/tests/cli/test_toolkit.py
+++ b/tests/cli/test_toolkit.py
@@ -524,3 +524,15 @@ def test_get_relative_path_from_config_file_to_data_base_file_path_from_misc_dir
     )
     obs = get_relative_path_from_config_file_to_base_path(ge_dir, absolute_path)
     assert obs == os.path.join("..", "..", "data", "pipeline1")
+
+
+def test_get_default_expectation_suite_name_with_partial_batch_request_definition():
+    batch_request = {
+        "datasource_name": "snowflake",
+        "data_connector_name": "default_runtime_data_connector_name",
+        "limit": 1000,
+    }
+    suite_name = toolkit.get_default_expectation_suite_name(
+        data_asset_name=None, batch_request=batch_request
+    )
+    assert suite_name == "warning"


### PR DESCRIPTION
Changes proposed in this pull request:
- Add error handling to a CLI method to get a default suite name.  This method can sometimes be passed incomplete `BatchRequest` information.  This leads to a `TypeError` as shown in screenshot from CLI.  Added a basic unit test for this behaviour.

<img width="1225" alt="Screenshot 2023-02-20 at 16 36 17" src="https://user-images.githubusercontent.com/1042275/220160954-fa7aaff9-9930-4bb9-abd9-f67b4b5454fd.png">


### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.