### PR TITLE
[BUGFIX]: Allow CLI to work with `RuntimeDataConnector`

### DIFF
--- a/great_expectations/cli/toolkit.py
+++ b/great_expectations/cli/toolkit.py
@@ -1113,5 +1113,8 @@ def get_batch_request_using_datasource_name(
         datasource=datasource,  # type: ignore[arg-type] # could be LegacyDatasource
         additional_batch_request_args=additional_batch_request_args,
     )
+    if "data_asset_name" not in batch_request:
+        # Some datasources don't always provide this (`RuntimeDataConnector`)
+        batch_request["data_asset_name"] = "default_data_asset_name"
 
     return batch_request

--- a/tests/cli/test_toolkit.py
+++ b/tests/cli/test_toolkit.py
@@ -524,3 +524,13 @@ def test_get_relative_path_from_config_file_to_data_base_file_path_from_misc_dir
     )
     obs = get_relative_path_from_config_file_to_base_path(ge_dir, absolute_path)
     assert obs == os.path.join("..", "..", "data", "pipeline1")
+
+
+def test_get_batch_request_using_datasource_name_has_data_asset_name_(
+    in_memory_runtime_context, basic_datasource
+):
+    in_memory_runtime_context.datasources["my_datasource"] = basic_datasource
+    batch_request = toolkit.get_batch_request_using_datasource_name(
+        in_memory_runtime_context, "my_datasource"
+    )
+    assert batch_request["data_asset_name"] == "default_data_asset_name"


### PR DESCRIPTION
Changes proposed in this pull request:
- Ensure `data_asset_name` is always in a `batch_request`.  A `RuntimeDataConnector` isn't gauranteed to give one.  If we detect this then stick a dummy `data_asset_name` in for the user to replace or edit in a notebook.


This bug has been reported in at least the following 2 issues:
closes #5462, closes #6814


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

### Notes:

Related to #7185.  That PR was more addressing the wider synmptoms caused by this issue.  In my opinion, #7185 is still a valid PR but less urgent once this has been merged.