### PR TITLE
[BUGFIX] `expect_column_values_to_be_between` with string input

### DIFF
--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -405,12 +405,10 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                **{  # type: ignore[arg-type] # TODO: https://github.com/python/mypy/issues/5382
-                    "string_template": {
-                        "template": template_str,
-                        "params": params,
-                        "styling": styling,
-                    },
-                }
+                string_template={
+                    "template": template_str,
+                    "params": params,
+                    "styling": styling,
+                },
             )
         ]

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, List, Optional
 
 import great_expectations.exceptions as gx_exceptions

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -405,6 +405,7 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
+                # FIXME: https://github.com/python/mypy/issues/5382
                 **{
                     "content_block_type": "string_template",
                     "string_template": {

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -405,9 +405,7 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
-                # FIXME: https://github.com/python/mypy/issues/5382
-                **{
-                    "content_block_type": "string_template",
+                **{  # type: ignore[arg-type] # TODO: https://github.com/python/mypy/issues/5382
                     "string_template": {
                         "template": template_str,
                         "params": params,

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -269,12 +269,9 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
         super().validate_configuration(configuration)
         configuration = configuration or self.configuration
 
-        min_val = None
-        max_val = None
-        if "min_value" in configuration.kwargs:
-            min_val = configuration.kwargs["min_value"]
-        if "max_value" in configuration.kwargs:
-            max_val = configuration.kwargs["max_value"]
+        min_val = configuration.kwargs.get("min_value", None)
+        max_val = configuration.kwargs.get("max_value", None)
+
         try:
             assert (
                 min_val is not None or max_val is not None

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -1,10 +1,6 @@
 from typing import TYPE_CHECKING, List, Optional
 
 import great_expectations.exceptions as gx_exceptions
-from great_expectations.core import (
-    ExpectationConfiguration,  # noqa: TCH001
-    ExpectationValidationResult,  # noqa: TCH001
-)
 from great_expectations.core._docs_decorators import public_api
 from great_expectations.expectations.expectation import (
     ColumnMapExpectation,
@@ -36,6 +32,10 @@ from great_expectations.rule_based_profiler.parameter_container import (
 )
 
 if TYPE_CHECKING:
+    from great_expectations.core import (
+        ExpectationConfiguration,
+        ExpectationValidationResult,
+    )
     from great_expectations.render.renderer_configuration import AddParamArgs
 
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -308,12 +308,12 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
         else:
             at_least_str = "greater than or equal to"
             if params.strict_min:
-                at_least_str: str = cls._get_strict_min_string(
+                at_least_str = cls._get_strict_min_string(
                     renderer_configuration=renderer_configuration
                 )
             at_most_str = "less than or equal to"
             if params.strict_max:
-                at_most_str: str = cls._get_strict_max_string(
+                at_most_str = cls._get_strict_max_string(
                     renderer_configuration=renderer_configuration
                 )
 

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -402,6 +402,7 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
 
         return [
             RenderedStringTemplateContent(
+                content_block_type="string_template",
                 string_template={
                     "template": template_str,
                     "params": params,

--- a/great_expectations/expectations/core/expect_column_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_values_to_be_between.py
@@ -345,7 +345,7 @@ class ExpectColumnValuesToBeBetween(ColumnMapExpectation):
     @render_evaluation_parameter_string
     def _prescriptive_renderer(
         cls,
-        configuration: Optional[ExpectationConfiguration] = None,
+        configuration: ExpectationConfiguration,
         result: Optional[ExpectationValidationResult] = None,
         runtime_configuration: Optional[dict] = None,
         **kwargs,

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -29,8 +29,8 @@ from typing import (
     Union,
 )
 
+import dateutil.parser
 import pandas as pd
-from dateutil.parser import parse
 
 from great_expectations import __version__ as ge_version
 from great_expectations.core._docs_decorators import public_api
@@ -2379,13 +2379,13 @@ please see: https://greatexpectations.io/blog/why_we_dont_do_transformations_for
 
             if min_value is not None:
                 try:
-                    min_value = parse(min_value)
+                    min_value = dateutil.parser.parse(min_value)
                 except TypeError:
                     pass
 
             if max_value is not None:
                 try:
-                    max_value = parse(max_value)
+                    max_value = dateutil.parser.parse(max_value)
                 except TypeError:
                     pass
 
@@ -2395,7 +2395,7 @@ please see: https://greatexpectations.io/blog/why_we_dont_do_transformations_for
         if isinstance(metric_value, datetime.datetime):
             if isinstance(min_value, str):
                 try:
-                    min_value = parse(min_value)
+                    min_value = dateutil.parser.parse(min_value)
                 except TypeError:
                     raise ValueError(
                         f"""Could not parse "min_value" of {min_value} (of type "{str(type(min_value))}) into datetime \
@@ -2404,7 +2404,7 @@ representation."""
 
             if isinstance(max_value, str):
                 try:
-                    max_value = parse(max_value)
+                    max_value = dateutil.parser.parse(max_value)
                 except TypeError:
                     raise ValueError(
                         f"""Could not parse "max_value" of {max_value} (of type "{str(type(max_value))}) into datetime \

--- a/great_expectations/expectations/expectation.py
+++ b/great_expectations/expectations/expectation.py
@@ -2301,14 +2301,8 @@ class TableExpectation(Expectation, ABC):
             return True
 
         # Validating that Minimum and Maximum values are of the proper format and type
-        min_val = None
-        max_val = None
-
-        if "min_value" in configuration.kwargs:
-            min_val = configuration.kwargs["min_value"]
-
-        if "max_value" in configuration.kwargs:
-            max_val = configuration.kwargs["max_value"]
+        min_val = configuration.kwargs.get("min_value", None)
+        max_val = configuration.kwargs.get("max_value", None)
 
         try:
             assert (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ exclude = [
     'expectations/core/expect_column_values_to_be_in_set\.py', # 1
     'expectations/core/expect_column_values_to_be_decreasing\.py', # 1
     'expectations/core/expect_column_values_to_be_dateutil_parseable\.py', # 1
-    'expectations/core/expect_column_values_to_be_between\.py', # 3
     'expectations/core/expect_column_unique_value_count_to_be_between\.py', # 1
     'expectations/core/expect_column_to_exist\.py', # 4
     'expectations/core/expect_column_stdev_to_be_between\.py', # 1


### PR DESCRIPTION
## Changes proposed in this pull request:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.

