### PR TITLE
[MAINTENANCE] Replace `regex` with `batching_regex` for fluent filesystem-like datasources

### DIFF
--- a/great_expectations/experimental/datasources/data_asset/data_connector/filesystem_data_connector.py
+++ b/great_expectations/experimental/datasources/data_asset/data_connector/filesystem_data_connector.py
@@ -24,7 +24,7 @@ class FilesystemDataConnector(FilePathDataConnector):
     it requires more setup.
 
     Args:
-        regex (pattern): Optional regex pattern for filtering data references
+        batching_regex (pattern): Optional regex pattern for filtering data references
         glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
         # TODO: <Alex>ALEX_INCLUDE_SORTERS_FUNCTIONALITY_UNDER_PYDANTIC-MAKE_SURE_SORTER_CONFIGURATIONS_ARE_VALIDATED</Alex>
         # TODO: <Alex>ALEX</Alex>
@@ -37,7 +37,7 @@ class FilesystemDataConnector(FilePathDataConnector):
         datasource_name: str,
         data_asset_name: str,
         base_directory: pathlib.Path,
-        regex: re.Pattern,
+        batching_regex: re.Pattern,
         glob_directive: str = "**/*",
         data_context_root_directory: Optional[pathlib.Path] = None,
         # TODO: <Alex>ALEX_INCLUDE_SORTERS_FUNCTIONALITY_UNDER_PYDANTIC-MAKE_SURE_SORTER_CONFIGURATIONS_ARE_VALIDATED</Alex>
@@ -55,7 +55,7 @@ class FilesystemDataConnector(FilePathDataConnector):
         super().__init__(
             datasource_name=datasource_name,
             data_asset_name=data_asset_name,
-            regex=regex,
+            batching_regex=batching_regex,
             # TODO: <Alex>ALEX_INCLUDE_SORTERS_FUNCTIONALITY_UNDER_PYDANTIC-MAKE_SURE_SORTER_CONFIGURATIONS_ARE_VALIDATED</Alex>
             # TODO: <Alex>ALEX</Alex>
             # sorters=sorters,

--- a/great_expectations/experimental/datasources/data_asset/data_connector/s3_data_connector.py
+++ b/great_expectations/experimental/datasources/data_asset/data_connector/s3_data_connector.py
@@ -33,7 +33,7 @@ class S3DataConnector(FilePathDataConnector):
     Args:
         datasource_name (str): required name for datasource
         bucket (str): bucket for S3
-        regex (dict): regex configuration for filtering data_references
+        batching_regex (dict): regex configuration for filtering data_references
         prefix (str): S3 prefix
         delimiter (str): S3 delimiter
         max_keys (int): S3 max_keys (default is 1000)
@@ -49,7 +49,7 @@ class S3DataConnector(FilePathDataConnector):
         datasource_name: str,
         data_asset_name: str,
         bucket: str,
-        regex: re.Pattern,
+        batching_regex: re.Pattern,
         prefix: str = "",
         delimiter: str = "/",
         max_keys: int = 1000,
@@ -77,7 +77,7 @@ class S3DataConnector(FilePathDataConnector):
         super().__init__(
             datasource_name=datasource_name,
             data_asset_name=data_asset_name,
-            regex=regex,
+            batching_regex=batching_regex,
             # TODO: <Alex>ALEX_INCLUDE_SORTERS_FUNCTIONALITY_UNDER_PYDANTIC-MAKE_SURE_SORTER_CONFIGURATIONS_ARE_VALIDATED</Alex>
             # TODO: <Alex>ALEX</Alex>
             # sorters=sorters,

--- a/great_expectations/experimental/datasources/file_path_data_asset.py
+++ b/great_expectations/experimental/datasources/file_path_data_asset.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 class _FilePathDataAsset(DataAsset):
     _EXCLUDE_FROM_READER_OPTIONS: ClassVar[Set[str]] = {
         "name",
-        "regex",
+        "batching_regex",
         "order_by",
         "type",
         "kwargs",  # kwargs need to be unpacked and passed separately
@@ -61,7 +61,7 @@ class _FilePathDataAsset(DataAsset):
     }
 
     # General file-path DataAsset pertaining attributes.
-    regex: Pattern
+    batching_regex: Pattern
 
     _unnamed_regex_param_prefix: str = pydantic.PrivateAttr(
         default="batch_request_param_"
@@ -88,7 +88,7 @@ class _FilePathDataAsset(DataAsset):
         super().__init__(**data)
 
         self._regex_parser = RegExParser(
-            regex_pattern=self.regex,
+            regex_pattern=self.batching_regex,
             unnamed_regex_group_prefix=self._unnamed_regex_param_prefix,
         )
 
@@ -101,11 +101,11 @@ class _FilePathDataAsset(DataAsset):
         self._all_group_names = self._regex_parser.get_all_group_names()
         self._data_connector = None
 
-    @pydantic.validator("regex", pre=True)
-    def _parse_regex_string(
-        cls, regex: Optional[Union[re.Pattern, str]] = None
+    @pydantic.validator("batching_regex", pre=True)
+    def _parse_batching_regex_string(
+        cls, batching_regex: Optional[Union[re.Pattern, str]] = None
     ) -> re.Pattern:
-        return Datasource.parse_regex_string(regex=regex)
+        return Datasource.parse_batching_regex_string(batching_regex=batching_regex)
 
     def batch_request_options_template(
         self,
@@ -126,7 +126,7 @@ class _FilePathDataAsset(DataAsset):
                     and not isinstance(value, str)
                 ):
                     raise gx_exceptions.InvalidBatchRequestError(
-                        f"All regex matching options must be strings. The value of '{option}' is "
+                        f"All batching_regex matching options must be strings. The value of '{option}' is "
                         f"not a string: {value}"
                     )
 

--- a/great_expectations/experimental/datasources/filesystem_data_asset.py
+++ b/great_expectations/experimental/datasources/filesystem_data_asset.py
@@ -56,10 +56,10 @@ to use as its "include" directive for Filesystem style DataAsset processing."""
         """
         success = False
         for filepath in self.datasource.base_directory.glob("**/*.*"):
-            if self.regex.match(
+            if self.batching_regex.match(
                 str(filepath.relative_to(self.datasource.base_directory))
             ):
-                # if one file in the path matches the regex, we consider this asset valid
+                # if one file in the path matches the batching_regex, we consider this asset valid
                 success = True
                 break
         if not success:
@@ -147,7 +147,7 @@ to use as its "include" directive for Filesystem style DataAsset processing."""
                     and not isinstance(value, str)
                 ):
                     raise ge_exceptions.InvalidBatchRequestError(
-                        f"All regex matching options must be strings. The value of '{option}' is "
+                        f"All batching_regex matching options must be strings. The value of '{option}' is "
                         f"not a string: {value}"
                     )
 
@@ -222,14 +222,14 @@ to use as its "include" directive for Filesystem style DataAsset processing."""
         return batch_list
 
     def _build_test_connection_error_message(self) -> str:
-        return f"""No file at base_directory path "{self.datasource.base_directory.resolve()}" matched regular expressions pattern "{self.regex.pattern}" and/or glob_directive "{self.glob_directive}" for DataAsset "{self.name}"."""
+        return f"""No file at base_directory path "{self.datasource.base_directory.resolve()}" matched regular expressions pattern "{self.batching_regex.pattern}" and/or glob_directive "{self.glob_directive}" for DataAsset "{self.name}"."""
 
     def _build_data_connector(self) -> DataConnector:
         data_connector: DataConnector = FilesystemDataConnector(
             datasource_name=self.datasource.name,
             data_asset_name=self.name,
             base_directory=self.datasource.base_directory,
-            regex=self.regex,
+            batching_regex=self.batching_regex,
             glob_directive=self.glob_directive,
             data_context_root_directory=self.datasource.data_context_root_directory,
         )

--- a/great_expectations/experimental/datasources/interfaces.py
+++ b/great_expectations/experimental/datasources/interfaces.py
@@ -466,18 +466,18 @@ class Datasource(
         return order_by_sorters
 
     @staticmethod
-    def parse_regex_string(
-        regex: Optional[Union[re.Pattern, str]] = None
+    def parse_batching_regex_string(
+        batching_regex: Optional[Union[re.Pattern, str]] = None
     ) -> re.Pattern:
         pattern: re.Pattern
-        if not regex:
+        if not batching_regex:
             pattern = re.compile(".*")
-        elif isinstance(regex, str):
-            pattern = re.compile(regex)
-        elif isinstance(regex, re.Pattern):
-            pattern = regex
+        elif isinstance(batching_regex, str):
+            pattern = re.compile(batching_regex)
+        elif isinstance(batching_regex, re.Pattern):
+            pattern = batching_regex
         else:
-            raise ValueError('"regex" must be either re.Pattern, str, or None')
+            raise ValueError('"batching_regex" must be either re.Pattern, str, or None')
         return pattern
 
     # Abstract Methods

--- a/great_expectations/experimental/datasources/pandas_filesystem_datasource.py
+++ b/great_expectations/experimental/datasources/pandas_filesystem_datasource.py
@@ -116,7 +116,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
     def add_csv_asset(
         self,
         name: str,
-        regex: Optional[Union[re.Pattern, str]] = None,
+        batching_regex: Optional[Union[re.Pattern, str]] = None,
         glob_directive: str = "**/*",
         order_by: Optional[BatchSortersDefinition] = None,
         **kwargs,  # TODO: update signature to have specific keys & types
@@ -125,19 +125,21 @@ class PandasFilesystemDatasource(_PandasDatasource):
 
         Args:
             name: The name of the csv asset
-            regex: regex pattern that matches csv filenames that is used to label the batches
+            batching_regex: regex pattern that matches csv filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
             order_by: sorting directive via either list[BatchSorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
-        regex_pattern: re.Pattern = self.parse_regex_string(regex=regex)
+        batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
+            batching_regex=batching_regex
+        )
         order_by_sorters: list[BatchSorter] = self.parse_order_by_sorters(
             order_by=order_by
         )
 
         asset = CSVAsset(
             name=name,
-            regex=regex_pattern,
+            batching_regex=batching_regex_pattern,
             glob_directive=glob_directive,
             order_by=order_by_sorters,
             **kwargs,
@@ -148,7 +150,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
     def add_excel_asset(
         self,
         name: str,
-        regex: Optional[Union[str, re.Pattern]] = None,
+        batching_regex: Optional[Union[str, re.Pattern]] = None,
         glob_directive: str = "**/*",
         order_by: Optional[BatchSortersDefinition] = None,
         **kwargs,  # TODO: update signature to have specific keys & types
@@ -157,19 +159,21 @@ class PandasFilesystemDatasource(_PandasDatasource):
 
         Args:
             name: The name of the csv asset
-            regex: regex pattern that matches csv filenames that is used to label the batches
+            batching_regex: regex pattern that matches csv filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
             order_by: sorting directive via either list[BatchSorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_excel`` keyword args
         """
-        regex_pattern: re.Pattern = self.parse_regex_string(regex=regex)
+        batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
+            batching_regex=batching_regex
+        )
         order_by_sorters: list[BatchSorter] = self.parse_order_by_sorters(
             order_by=order_by
         )
 
         asset = ExcelAsset(
             name=name,
-            regex=regex_pattern,
+            batching_regex=batching_regex_pattern,
             glob_directive=glob_directive,
             order_by=order_by_sorters,
             **kwargs,
@@ -180,7 +184,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
     def add_json_asset(
         self,
         name: str,
-        regex: Optional[Union[str, re.Pattern]] = None,
+        batching_regex: Optional[Union[str, re.Pattern]] = None,
         glob_directive: str = "**/*",
         order_by: Optional[BatchSortersDefinition] = None,
         **kwargs,  # TODO: update signature to have specific keys & types
@@ -189,19 +193,21 @@ class PandasFilesystemDatasource(_PandasDatasource):
 
         Args:
             name: The name of the csv asset
-            regex: regex pattern that matches csv filenames that is used to label the batches
+            batching_regex: regex pattern that matches csv filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
             order_by: sorting directive via either list[BatchSorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_json`` keyword args
         """
-        regex_pattern: re.Pattern = self.parse_regex_string(regex=regex)
+        batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
+            batching_regex=batching_regex
+        )
         order_by_sorters: list[BatchSorter] = self.parse_order_by_sorters(
             order_by=order_by
         )
 
         asset = JSONAsset(
             name=name,
-            regex=regex_pattern,
+            batching_regex=batching_regex_pattern,
             glob_directive=glob_directive,
             order_by=order_by_sorters,
             **kwargs,
@@ -212,7 +218,7 @@ class PandasFilesystemDatasource(_PandasDatasource):
     def add_parquet_asset(
         self,
         name: str,
-        regex: Optional[Union[str, re.Pattern]] = None,
+        batching_regex: Optional[Union[str, re.Pattern]] = None,
         glob_directive: str = "**/*",
         order_by: Optional[BatchSortersDefinition] = None,
         **kwargs,  # TODO: update signature to have specific keys & types
@@ -221,19 +227,21 @@ class PandasFilesystemDatasource(_PandasDatasource):
 
         Args:
             name: The name of the csv asset
-            regex: regex pattern that matches csv filenames that is used to label the batches
+            batching_regex: regex pattern that matches csv filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
             order_by: sorting directive via either list[BatchSorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_parquet`` keyword args
         """
-        regex_pattern: re.Pattern = self.parse_regex_string(regex=regex)
+        batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
+            batching_regex=batching_regex
+        )
         order_by_sorters: list[BatchSorter] = self.parse_order_by_sorters(
             order_by=order_by
         )
 
         asset = ParquetAsset(
             name=name,
-            regex=regex_pattern,
+            batching_regex=batching_regex_pattern,
             glob_directive=glob_directive,
             order_by=order_by_sorters,
             **kwargs,

--- a/great_expectations/experimental/datasources/schemas/CSVAsset.json
+++ b/great_expectations/experimental/datasources/schemas/CSVAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -245,7 +245,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/CSVSparkAsset.json
+++ b/great_expectations/experimental/datasources/schemas/CSVSparkAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -45,7 +45,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "definitions": {
         "BatchSorter": {

--- a/great_expectations/experimental/datasources/schemas/ExcelAsset.json
+++ b/great_expectations/experimental/datasources/schemas/ExcelAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -146,7 +146,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/FeatherAsset.json
+++ b/great_expectations/experimental/datasources/schemas/FeatherAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -47,7 +47,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/HDFAsset.json
+++ b/great_expectations/experimental/datasources/schemas/HDFAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -75,7 +75,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/HTMLAsset.json
+++ b/great_expectations/experimental/datasources/schemas/HTMLAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -137,7 +137,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/JSONAsset.json
+++ b/great_expectations/experimental/datasources/schemas/JSONAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -117,7 +117,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/ORCAsset.json
+++ b/great_expectations/experimental/datasources/schemas/ORCAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -47,7 +47,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/PandasFilesystemDatasource.json
@@ -78,8 +78,8 @@
                         "$ref": "#/definitions/BatchSorter"
                     }
                 },
-                "regex": {
-                    "title": "Regex",
+                "batching_regex": {
+                    "title": "Batching Regex",
                     "type": "string",
                     "format": "regex"
                 },
@@ -92,7 +92,7 @@
             "required": [
                 "name",
                 "type",
-                "regex"
+                "batching_regex"
             ]
         }
     }

--- a/great_expectations/experimental/datasources/schemas/ParquetAsset.json
+++ b/great_expectations/experimental/datasources/schemas/ParquetAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -57,7 +57,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/PickleAsset.json
+++ b/great_expectations/experimental/datasources/schemas/PickleAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -51,7 +51,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/SPSSAsset.json
+++ b/great_expectations/experimental/datasources/schemas/SPSSAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -57,7 +57,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/STATAAsset.json
+++ b/great_expectations/experimental/datasources/schemas/STATAAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -105,7 +105,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/schemas/SparkFilesystemDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/SparkFilesystemDatasource.json
@@ -82,8 +82,8 @@
                         "$ref": "#/definitions/BatchSorter"
                     }
                 },
-                "regex": {
-                    "title": "Regex",
+                "batching_regex": {
+                    "title": "Batching Regex",
                     "type": "string",
                     "format": "regex"
                 },
@@ -105,7 +105,7 @@
             },
             "required": [
                 "name",
-                "regex"
+                "batching_regex"
             ]
         }
     }

--- a/great_expectations/experimental/datasources/schemas/XMLAsset.json
+++ b/great_expectations/experimental/datasources/schemas/XMLAsset.json
@@ -22,8 +22,8 @@
                 "$ref": "#/definitions/BatchSorter"
             }
         },
-        "regex": {
-            "title": "Regex",
+        "batching_regex": {
+            "title": "Batching Regex",
             "type": "string",
             "format": "regex"
         },
@@ -101,7 +101,7 @@
     },
     "required": [
         "name",
-        "regex"
+        "batching_regex"
     ],
     "additionalProperties": false,
     "definitions": {

--- a/great_expectations/experimental/datasources/spark_datasource.py
+++ b/great_expectations/experimental/datasources/spark_datasource.py
@@ -109,7 +109,7 @@ class SparkFilesystemDatasource(_SparkDatasource):
     def add_csv_asset(
         self,
         name: str,
-        regex: Optional[Union[re.Pattern, str]] = None,
+        batching_regex: Optional[Union[re.Pattern, str]] = None,
         glob_directive: str = "**/*",
         header: bool = False,
         infer_schema: bool = False,
@@ -119,20 +119,22 @@ class SparkFilesystemDatasource(_SparkDatasource):
 
         Args:
             name: The name of the csv asset
-            regex: regex pattern that matches csv filenames that is used to label the batches
+            batching_regex: regex pattern that matches csv filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
             header: boolean (default False) indicating whether or not first line of CSV file is header line
             infer_schema: boolean (default False) instructing Spark to attempt to infer schema of CSV file heuristically
             order_by: sorting directive via either list[BatchSorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
         """
-        regex_pattern: re.Pattern = self.parse_regex_string(regex=regex)
+        batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
+            batching_regex=batching_regex
+        )
         order_by_sorters: list[BatchSorter] = self.parse_order_by_sorters(
             order_by=order_by
         )
 
         asset = CSVSparkAsset(
             name=name,
-            regex=regex_pattern,
+            batching_regex=batching_regex_pattern,
             glob_directive=glob_directive,
             header=header,
             inferSchema=infer_schema,

--- a/tests/experimental/datasources/data_asset/data_connector/test_filesystem_data_connector.py
+++ b/tests/experimental/datasources/data_asset/data_connector/test_filesystem_data_connector.py
@@ -31,7 +31,7 @@ def test_basic_instantiation(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory),
-        regex=re.compile(r"alpha-(.*)\.csv"),
+        batching_regex=re.compile(r"alpha-(.*)\.csv"),
         glob_directive="*.csv",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -56,10 +56,10 @@ def test_basic_instantiation(tmp_path_factory):
 
 @pytest.mark.integration
 @pytest.mark.slow  # creating small number of`file handles in temporary file system
-def test_instantiation_regex_does_not_match_paths(tmp_path_factory):
+def test_instantiation_batching_regex_does_not_match_paths(tmp_path_factory):
     base_directory = str(
         tmp_path_factory.mktemp(
-            "test_instantiation_from_a_config_regex_does_not_match_paths"
+            "test_instantiation_from_a_config_batching_regex_does_not_match_paths"
         )
     )
     create_files_in_directory(
@@ -75,7 +75,7 @@ def test_instantiation_regex_does_not_match_paths(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory),
-        regex=re.compile(r"beta-(.*)\.csv"),
+        batching_regex=re.compile(r"beta-(.*)\.csv"),
         glob_directive="*.csv",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -118,7 +118,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory),
-        regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
         glob_directive="*.csv",
     )
     # with missing BatchRequest arguments
@@ -259,7 +259,7 @@ def test_return_all_batch_definitions_unsorted(tmp_path_factory):
 #         datasource_name="my_dataframe_datasource",
 #         data_asset_name="my_filesystem_data_asset",
 #         base_directory=pathlib.Path(base_directory),
-#         regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
+#         batching_regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
 #         glob_directive="*.csv",
 #     )
 #     assert my_data_connector.get_data_reference_count() == 3
@@ -443,7 +443,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory),
-        regex=re.compile(r"(?P<name>.+)/.+\.csv"),
+        batching_regex=re.compile(r"(?P<name>.+)/.+\.csv"),
         # glob_directive="*.csv",  # omitting for purposes of this test
     )
     assert my_data_connector.get_data_reference_count() == 7
@@ -495,7 +495,7 @@ def test_return_only_unique_batch_definitions(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory),
-        regex=re.compile(r"(?P<directory>.+)/(?P<filename>.+\.csv)"),
+        batching_regex=re.compile(r"(?P<directory>.+)/(?P<filename>.+\.csv)"),
         # glob_directive="*.csv",  # omitting for purposes of this test
     )
     unsorted_batch_definition_list: List[
@@ -528,7 +528,7 @@ def test_alpha(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory) / "test_dir_alpha",
-        regex=re.compile(r"(?P<part_1>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)\.csv"),
         glob_directive="*.csv",
     )
     assert my_data_connector.get_data_reference_count() == 4
@@ -595,7 +595,7 @@ def test_foxtrot(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory) / "test_dir_foxtrot",
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
         glob_directive="*.csv",
     )
     assert my_data_connector.get_data_reference_count() == 0
@@ -607,7 +607,7 @@ def test_foxtrot(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory) / "test_dir_foxtrot" / "A",
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
         glob_directive="*.csv",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -623,7 +623,7 @@ def test_foxtrot(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory) / "test_dir_foxtrot" / "B",
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.txt"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.txt"),
         glob_directive="*.*",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -639,7 +639,7 @@ def test_foxtrot(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory) / "test_dir_foxtrot" / "C",
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
         glob_directive="*",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -682,7 +682,7 @@ def test_relative_base_directory_path(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory) / "test_dir_0" / "A",
-        regex=re.compile(r"(?P<part_1>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)\.csv"),
         glob_directive="*",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -700,7 +700,7 @@ def test_relative_base_directory_path(tmp_path_factory):
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_filesystem_data_asset",
         base_directory=pathlib.Path(base_directory) / "test_dir_0" / "A" / "B" / "C",
-        regex=re.compile(r"(?P<name>.+)_(?P<number>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<name>.+)_(?P<number>.+)\.csv"),
         glob_directive="log*.csv",
     )
     assert my_data_connector.get_data_reference_count() == 1

--- a/tests/experimental/datasources/data_asset/data_connector/test_s3_data_connector.py
+++ b/tests/experimental/datasources/data_asset/data_connector/test_s3_data_connector.py
@@ -45,7 +45,7 @@ def test_basic_instantiation():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"alpha-(.*)\.csv"),
+        batching_regex=re.compile(r"alpha-(.*)\.csv"),
         prefix="",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -70,7 +70,7 @@ def test_basic_instantiation():
 
 @pytest.mark.integration
 @mock_s3
-def test_instantiation_regex_does_not_match_paths():
+def test_instantiation_batching_regex_does_not_match_paths():
     region_name: str = "us-east-1"
     bucket: str = "test_bucket"
     conn = boto3.resource("s3", region_name=region_name)
@@ -93,7 +93,7 @@ def test_instantiation_regex_does_not_match_paths():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"beta-(.*)\.csv"),
+        batching_regex=re.compile(r"beta-(.*)\.csv"),
         prefix="",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -142,7 +142,7 @@ def test_return_all_batch_definitions_unsorted():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
         prefix="",
     )
     # with missing BatchRequest arguments
@@ -289,7 +289,7 @@ def test_return_all_batch_definitions_unsorted():
 #         datasource_name="my_dataframe_datasource",
 #         data_asset_name="my_s3_data_asset",
 #         bucket=bucket,
-#         regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
+#         batching_regex=re.compile(r"(?P<name>.+)_(?P<timestamp>.+)_(?P<price>.+)\.csv"),
 #         prefix="",
 #     )
 #     # noinspection PyProtectedMember
@@ -482,7 +482,7 @@ def test_return_only_unique_batch_definitions():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<name>.+)/.+\.csv"),
+        batching_regex=re.compile(r"(?P<name>.+)/.+\.csv"),
         prefix="A",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -513,7 +513,7 @@ def test_return_only_unique_batch_definitions():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<directory>.+)/(?P<filename>.+\.csv)"),
+        batching_regex=re.compile(r"(?P<directory>.+)/(?P<filename>.+\.csv)"),
         prefix="B",
     )
 
@@ -555,7 +555,7 @@ def test_alpha():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<part_1>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)\.csv"),
         prefix="test_dir_alpha",
     )
     assert my_data_connector.get_data_reference_count() == 4
@@ -630,7 +630,7 @@ def test_foxtrot():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
         prefix="",
     )
     assert my_data_connector.get_data_reference_count() == 0
@@ -642,7 +642,7 @@ def test_foxtrot():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
         prefix="test_dir_foxtrot/A",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -658,7 +658,7 @@ def test_foxtrot():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.txt"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.txt"),
         prefix="test_dir_foxtrot/B",
     )
     assert my_data_connector.get_data_reference_count() == 3
@@ -674,7 +674,7 @@ def test_foxtrot():
         datasource_name="my_dataframe_datasource",
         data_asset_name="my_s3_data_asset",
         bucket=bucket,
-        regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
+        batching_regex=re.compile(r"(?P<part_1>.+)-(?P<part_2>.+)\.csv"),
         prefix="test_dir_foxtrot/C",
     )
     assert my_data_connector.get_data_reference_count() == 3

--- a/tests/experimental/datasources/integration/conftest.py
+++ b/tests/experimental/datasources/integration/conftest.py
@@ -59,7 +59,7 @@ def pandas_data(
     pandas_ds = pandas_datasource(context=context)
     asset = pandas_ds.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         order_by=["year", "month"],
     )
     batch_request = asset.build_batch_request({"year": "2019", "month": "01"})  # type: ignore[attr-defined]
@@ -124,7 +124,7 @@ def spark_data(
     spark_ds = spark_datasource(context=context)
     asset = spark_ds.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         order_by=["year", "month"],
         header=True,
         infer_schema=True,
@@ -148,7 +148,7 @@ def multibatch_pandas_data(
     )
     asset = pandas_ds.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         order_by=["year", "month"],
     )
     batch_request = asset.build_batch_request({"year": "2020"})
@@ -188,7 +188,7 @@ def multibatch_spark_data(
     )
     asset = spark_ds.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         order_by=["year", "month"],
         header=True,
         infer_schema=True,

--- a/tests/experimental/datasources/integration/test_integration_datasource.py
+++ b/tests/experimental/datasources/integration/test_integration_datasource.py
@@ -123,7 +123,7 @@ def test_sql_query_data_asset(empty_data_context):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    ["base_directory", "regex", "raises_test_connection_error"],
+    ["base_directory", "batching_regex", "raises_test_connection_error"],
     [
         pytest.param(
             pathlib.Path(__file__).parent.joinpath(
@@ -173,18 +173,22 @@ def test_sql_query_data_asset(empty_data_context):
         ),
     ],
 )
-def test_filesystem_data_asset_regex(
+def test_filesystem_data_asset_batching_regex(
     filesystem_datasource: PandasFilesystemDatasource | SparkFilesystemDatasource,
     base_directory: pathlib.Path,
-    regex: str | None,
+    batching_regex: str | None,
     raises_test_connection_error: bool,
 ):
     filesystem_datasource.base_directory = base_directory
     if raises_test_connection_error:
         with pytest.raises(TestConnectionError):
-            filesystem_datasource.add_csv_asset(name="csv_asset", regex=regex)
+            filesystem_datasource.add_csv_asset(
+                name="csv_asset", batching_regex=batching_regex
+            )
     else:
-        filesystem_datasource.add_csv_asset(name="csv_asset", regex=regex)
+        filesystem_datasource.add_csv_asset(
+            name="csv_asset", batching_regex=batching_regex
+        )
 
 
 @pytest.mark.integration

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -76,14 +76,14 @@ PG_COMPLEX_CONFIG_DICT = {
                 "my_csv_asset": {
                     "name": "my_csv_asset",
                     "type": "csv",
-                    "regex": r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv",
+                    "batching_regex": r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv",
                     "sep": "|",
                     "names": ["col1", "col2"],
                 },
                 "my_json_asset": {
                     "name": "my_json_asset",
                     "type": "json",
-                    "regex": r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).json",
+                    "batching_regex": r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).json",
                     "orient": "records",
                 },
             },
@@ -157,7 +157,9 @@ class TestExcludeUnsetAssetFields:
         asset_dict.update(
             {
                 "name": "my_asset",
-                "regex": re.compile(r"sample_(?P<year>\d{4})-(?P<month>\d{2}).csv"),
+                "batching_regex": re.compile(
+                    r"sample_(?P<year>\d{4})-(?P<month>\d{2}).csv"
+                ),
             }
         )
         asset_name = asset_dict["name"]
@@ -177,7 +179,9 @@ class TestExcludeUnsetAssetFields:
         asset_dict.update(
             {
                 "name": "my_asset",
-                "regex": re.compile(r"sample_(?P<year>\d{4})-(?P<month>\d{2}).csv"),
+                "batching_regex": re.compile(
+                    r"sample_(?P<year>\d{4})-(?P<month>\d{2}).csv"
+                ),
             }
         )
         asset_name = asset_dict["name"]

--- a/tests/experimental/datasources/test_pandas_filesystem_datasource.py
+++ b/tests/experimental/datasources/test_pandas_filesystem_datasource.py
@@ -187,7 +187,7 @@ class TestDynamicPandasAssets:
         with pytest.raises(pydantic.ValidationError) as exc_info:
             method(
                 f"{asset_class.__name__}_add_asset_test",
-                regex="great_expectations",
+                batching_regex="great_expectations",
                 _invalid_key="foobar",
             )
         # importantly check that the method creates (or attempts to create) the intended asset
@@ -234,7 +234,7 @@ class TestDynamicPandasAssets:
             asset_class(  # type: ignore[call-arg]
                 name="test",
                 base_directory=pathlib.Path(__file__),
-                regex=re.compile(r"yellow_tripdata_sample_(\d{4})-(\d{2})"),
+                batching_regex=re.compile(r"yellow_tripdata_sample_(\d{4})-(\d{2})"),
                 invalid_keyword_arg="bad",
             )
 
@@ -265,7 +265,7 @@ class TestDynamicPandasAssets:
         """
         kwargs: dict[str, Any] = {
             "name": "test",
-            "regex": re.compile(r"yellow_tripdata_sample_(\d{4})-(\d{2})"),
+            "batching_regex": re.compile(r"yellow_tripdata_sample_(\d{4})-(\d{2})"),
         }
         kwargs.update(extra_kwargs)
         print(f"extra_kwargs\n{pf(extra_kwargs)}")
@@ -294,7 +294,7 @@ class TestDynamicPandasAssets:
             )
             .add_csv_asset(
                 "my_csv",
-                regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv",
+                batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv",
                 **extra_kwargs,
             )
             .build_batch_request({"year": "2018"})
@@ -324,22 +324,22 @@ def test_add_csv_asset_to_datasource(
         name="csv_asset",
     )
     assert asset.name == "csv_asset"  # type: ignore[attr-defined]
-    m1 = asset.regex.match("this_can_be_named_anything.csv")  # type: ignore[attr-defined]
+    m1 = asset.batching_regex.match("this_can_be_named_anything.csv")  # type: ignore[attr-defined]
     assert m1 is not None
 
 
 @pytest.mark.unit
-def test_add_csv_asset_with_regex_to_datasource(
+def test_add_csv_asset_with_batching_regex_to_datasource(
     pandas_filesystem_datasource: PandasFilesystemDatasource,
 ):
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
     )
     assert asset.name == "csv_asset"  # type: ignore[attr-defined]
-    assert asset.regex.match("random string") is None  # type: ignore[attr-defined]
-    assert asset.regex.match("yellow_tripdata_sample_11D1-22.csv") is None  # type: ignore[attr-defined]
-    m1 = asset.regex.match("yellow_tripdata_sample_1111-22.csv")  # type: ignore[attr-defined]
+    assert asset.batching_regex.match("random string") is None  # type: ignore[attr-defined]
+    assert asset.batching_regex.match("yellow_tripdata_sample_11D1-22.csv") is None  # type: ignore[attr-defined]
+    m1 = asset.batching_regex.match("yellow_tripdata_sample_1111-22.csv")  # type: ignore[attr-defined]
     assert m1 is not None
 
 
@@ -348,22 +348,22 @@ def test_construct_csv_asset_directly():
     # noinspection PyTypeChecker
     asset = CSVAsset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
     )
     assert asset.name == "csv_asset"
-    assert asset.regex.match("random string") is None
-    assert asset.regex.match("yellow_tripdata_sample_11D1-22.csv") is None
-    m1 = asset.regex.match("yellow_tripdata_sample_1111-22.csv")
+    assert asset.batching_regex.match("random string") is None
+    assert asset.batching_regex.match("yellow_tripdata_sample_11D1-22.csv") is None
+    m1 = asset.batching_regex.match("yellow_tripdata_sample_1111-22.csv")
     assert m1 is not None
 
 
 @pytest.mark.unit
-def test_csv_asset_with_regex_unnamed_parameters(
+def test_csv_asset_with_batching_regex_unnamed_parameters(
     pandas_filesystem_datasource: PandasFilesystemDatasource,
 ):
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
     )
     options = asset.batch_request_options_template()  # type: ignore[attr-defined]
     assert options == {
@@ -374,36 +374,36 @@ def test_csv_asset_with_regex_unnamed_parameters(
 
 
 @pytest.mark.unit
-def test_csv_asset_with_regex_named_parameters(
+def test_csv_asset_with_batching_regex_named_parameters(
     pandas_filesystem_datasource: PandasFilesystemDatasource,
 ):
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
     )
     options = asset.batch_request_options_template()  # type: ignore[attr-defined]
     assert options == {"year": None, "month": None, "path": None}
 
 
 @pytest.mark.unit
-def test_csv_asset_with_some_regex_named_parameters(
+def test_csv_asset_with_some_batching_regex_named_parameters(
     pandas_filesystem_datasource: PandasFilesystemDatasource,
 ):
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
     )
     options = asset.batch_request_options_template()  # type: ignore[attr-defined]
     assert options == {"batch_request_param_1": None, "month": None, "path": None}
 
 
 @pytest.mark.unit
-def test_csv_asset_with_non_string_regex_named_parameters(
+def test_csv_asset_with_non_string_batching_regex_named_parameters(
     pandas_filesystem_datasource: PandasFilesystemDatasource,
 ):
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
     )
     with pytest.raises(ge_exceptions.InvalidBatchRequestError):
         # year is an int which will raise an error
@@ -416,7 +416,7 @@ def test_get_batch_list_from_fully_specified_batch_request(
 ):
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
     )
     path = "yellow_tripdata_sample_2018-04.csv"
     request = asset.build_batch_request({"year": "2018", "month": "04", "path": path})  # type: ignore[attr-defined]
@@ -461,7 +461,7 @@ def test_get_batch_list_from_partially_specified_batch_request(
 
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
     )
     request = asset.build_batch_request({"year": "2018"})  # type: ignore[attr-defined]
     batches = asset.get_batch_list_from_batch_request(request)  # type: ignore[attr-defined]
@@ -533,7 +533,7 @@ def test_pandas_sorter(
 
     asset = pandas_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         order_by=order_by,
     )
     batches = asset.get_batch_list_from_batch_request(asset.build_batch_request())  # type: ignore[attr-defined]
@@ -568,27 +568,31 @@ def test_pandas_sorter(
             assert metadata[key2] == range2
 
 
-def bad_regex_config(csv_path: pathlib.Path) -> tuple[re.Pattern, TestConnectionError]:
-    regex = re.compile(r"green_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv")
+def bad_batching_regex_config(
+    csv_path: pathlib.Path,
+) -> tuple[re.Pattern, TestConnectionError]:
+    batching_regex = re.compile(
+        r"green_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2}).csv"
+    )
     test_connection_error = TestConnectionError(
         "No file at base_directory path "
         f'"{csv_path.resolve()}" matched regular expressions pattern '
-        f'"{regex.pattern}" and/or glob_directive "**/*" for '
+        f'"{batching_regex.pattern}" and/or glob_directive "**/*" for '
         'DataAsset "csv_asset".'
     )
-    return regex, test_connection_error
+    return batching_regex, test_connection_error
 
 
-@pytest.fixture(params=[bad_regex_config])
+@pytest.fixture(params=[bad_batching_regex_config])
 def datasource_test_connection_error_messages(
     csv_path: pathlib.Path,
     pandas_filesystem_datasource: PandasFilesystemDatasource,
     request,
 ) -> tuple[PandasFilesystemDatasource, TestConnectionError]:
-    regex, test_connection_error = request.param(csv_path=csv_path)
+    batching_regex, test_connection_error = request.param(csv_path=csv_path)
     csv_asset = CSVAsset(  # type: ignore[call-arg]
         name="csv_asset",
-        regex=regex,
+        batching_regex=batching_regex,
     )
     csv_asset._datasource = pandas_filesystem_datasource
     pandas_filesystem_datasource.assets = {"csv_asset": csv_asset}

--- a/tests/experimental/datasources/test_spark_datasource.py
+++ b/tests/experimental/datasources/test_spark_datasource.py
@@ -67,24 +67,24 @@ def test_add_csv_asset_to_datasource(
         name="csv_asset",
     )
     assert asset.name == "csv_asset"
-    m1 = asset.regex.match("this_can_be_named_anything.csv")
+    m1 = asset.batching_regex.match("this_can_be_named_anything.csv")
     assert m1 is not None
 
 
 @pytest.mark.unit
-def test_add_csv_asset_with_regex_to_datasource(
+def test_add_csv_asset_with_batching_regex_to_datasource(
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
         header=True,
         infer_schema=True,
     )
     assert asset.name == "csv_asset"
-    assert asset.regex.match("random string") is None
-    assert asset.regex.match("yellow_tripdata_sample_11D1-22.csv") is None
-    m1 = asset.regex.match("yellow_tripdata_sample_1111-22.csv")
+    assert asset.batching_regex.match("random string") is None
+    assert asset.batching_regex.match("yellow_tripdata_sample_11D1-22.csv") is None
+    m1 = asset.batching_regex.match("yellow_tripdata_sample_1111-22.csv")
     assert m1 is not None
 
 
@@ -93,22 +93,22 @@ def test_construct_csv_asset_directly():
     # noinspection PyTypeChecker
     asset = CSVSparkAsset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",  # Ignoring IDE warning (type declarations are consistent).
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",  # Ignoring IDE warning (type declarations are consistent).
     )
     assert asset.name == "csv_asset"
-    assert asset.regex.match("random string") is None
-    assert asset.regex.match("yellow_tripdata_sample_11D1-22.csv") is None
-    m1 = asset.regex.match("yellow_tripdata_sample_1111-22.csv")
+    assert asset.batching_regex.match("random string") is None
+    assert asset.batching_regex.match("yellow_tripdata_sample_11D1-22.csv") is None
+    m1 = asset.batching_regex.match("yellow_tripdata_sample_1111-22.csv")
     assert m1 is not None
 
 
 @pytest.mark.unit
-def test_csv_asset_with_regex_unnamed_parameters(
+def test_csv_asset_with_batching_regex_unnamed_parameters(
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(\d{2})\.csv",
         header=True,
         infer_schema=True,
     )
@@ -121,12 +121,12 @@ def test_csv_asset_with_regex_unnamed_parameters(
 
 
 @pytest.mark.unit
-def test_csv_asset_with_regex_named_parameters(
+def test_csv_asset_with_batching_regex_named_parameters(
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         header=True,
         infer_schema=True,
     )
@@ -135,12 +135,12 @@ def test_csv_asset_with_regex_named_parameters(
 
 
 @pytest.mark.unit
-def test_csv_asset_with_some_regex_named_parameters(
+def test_csv_asset_with_some_batching_regex_named_parameters(
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
         header=True,
         infer_schema=True,
     )
@@ -149,12 +149,12 @@ def test_csv_asset_with_some_regex_named_parameters(
 
 
 @pytest.mark.unit
-def test_csv_asset_with_non_string_regex_named_parameters(
+def test_csv_asset_with_non_string_batching_regex_named_parameters(
     spark_filesystem_datasource: SparkFilesystemDatasource,
 ):
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(\d{4})-(?P<month>\d{2})\.csv",
         header=True,
         infer_schema=True,
     )
@@ -169,7 +169,7 @@ def test_get_batch_list_from_fully_specified_batch_request(
 ):
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         header=True,
         infer_schema=True,
     )
@@ -216,7 +216,7 @@ def test_get_batch_list_from_partially_specified_batch_request(
 
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         header=True,
         infer_schema=True,
     )
@@ -290,7 +290,7 @@ def test_spark_sorter(
 
     asset = spark_filesystem_datasource.add_csv_asset(
         name="csv_asset",
-        regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
+        batching_regex=r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv",
         order_by=order_by,
     )
     batches = asset.get_batch_list_from_batch_request(asset.build_batch_request())
@@ -325,24 +325,28 @@ def test_spark_sorter(
             assert metadata[key2] == range2
 
 
-def bad_regex_config(csv_path: pathlib.Path) -> tuple[re.Pattern, TestConnectionError]:
-    regex = re.compile(r"green_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv")
-    test_connection_error = TestConnectionError(
-        f"""No file at base_directory path "{csv_path.resolve()}" matched regular expressions pattern "{regex.pattern}" and/or glob_directive "**/*" for DataAsset "csv_spark_asset"."""
+def bad_batching_regex_config(
+    csv_path: pathlib.Path,
+) -> tuple[re.Pattern, TestConnectionError]:
+    batching_regex = re.compile(
+        r"green_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
     )
-    return regex, test_connection_error
+    test_connection_error = TestConnectionError(
+        f"""No file at base_directory path "{csv_path.resolve()}" matched regular expressions pattern "{batching_regex.pattern}" and/or glob_directive "**/*" for DataAsset "csv_spark_asset"."""
+    )
+    return batching_regex, test_connection_error
 
 
-@pytest.fixture(params=[bad_regex_config])
+@pytest.fixture(params=[bad_batching_regex_config])
 def datasource_test_connection_error_messages(
     csv_path: pathlib.Path,
     spark_filesystem_datasource: SparkFilesystemDatasource,
     request,
 ) -> tuple[SparkFilesystemDatasource, TestConnectionError]:
-    regex, test_connection_error = request.param(csv_path=csv_path)
+    batching_regex, test_connection_error = request.param(csv_path=csv_path)
     csv_spark_asset = CSVSparkAsset(
         name="csv_spark_asset",
-        regex=regex,
+        batching_regex=batching_regex,
     )
     csv_spark_asset._datasource = spark_filesystem_datasource
     spark_filesystem_datasource.assets = {"csv_spark_asset": csv_spark_asset}


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1716
- Find and replace `regex` with `batching_regex`

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
