### PR TITLE
[MAINTENANCE] Misc `DataContext` state management & API cleanup

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -1761,7 +1761,16 @@ class AbstractDataContext(ConfigPeer, ABC):
             checkpoint=checkpoint,
         )
 
-        return self.checkpoint_store.add_checkpoint(checkpoint)
+        try:
+            return self.checkpoint_store.add_checkpoint(checkpoint)
+        except gx_exceptions.CheckpointError as e:
+            # deprecated-v0.15.50
+            warnings.warn(
+                f"{e.message}; using add_checkpoint to overwrite an existing value is deprecated as of v0.15.50 "
+                "and will be removed in v0.18. Please use add_or_update_checkpoint instead.",
+                DeprecationWarning,
+            )
+            return self.checkpoint_store.add_or_update_checkpoint(checkpoint)
 
     @public_api
     @new_method_or_class(version="0.15.48")
@@ -1783,6 +1792,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     def add_or_update_checkpoint(
         self,
         name: str = ...,
+        id: str | None = ...,
         config_version: int | float | None = ...,
         template_name: str | None = ...,
         module_name: str | None = ...,
@@ -1795,19 +1805,12 @@ class AbstractDataContext(ConfigPeer, ABC):
         runtime_configuration: dict | None = ...,
         validations: list[dict] | None = ...,
         profilers: list[dict] | None = ...,
-        # Next two fields are for LegacyCheckpoint configuration
-        validation_operator_name: str | None = ...,
-        batches: list[dict] | None = ...,
-        # the following four arguments are used by SimpleCheckpoint
         site_names: str | list[str] | None = ...,
         slack_webhook: str | None = ...,
         notify_on: str | None = ...,
         notify_with: str | list[str] | None = ...,
-        ge_cloud_id: str | None = ...,
-        expectation_suite_ge_cloud_id: str | None = ...,
-        default_validation_id: str | None = ...,
-        id: str | None = ...,
         expectation_suite_id: str | None = ...,
+        default_validation_id: str | None = ...,
         checkpoint: None = ...,
     ) -> Checkpoint:
         """
@@ -1820,6 +1823,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     def add_or_update_checkpoint(
         self,
         name: None = ...,
+        id: None = ...,
         config_version: None = ...,
         template_name: None = ...,
         module_name: None = ...,
@@ -1832,17 +1836,12 @@ class AbstractDataContext(ConfigPeer, ABC):
         runtime_configuration: None = ...,
         validations: None = ...,
         profilers: None = ...,
-        validation_operator_name: None = ...,
-        batches: None = ...,
         site_names: None = ...,
         slack_webhook: None = ...,
         notify_on: None = ...,
         notify_with: None = ...,
-        ge_cloud_id: None = ...,
-        expectation_suite_ge_cloud_id: None = ...,
-        default_validation_id: None = ...,
-        id: None = ...,
         expectation_suite_id: None = ...,
+        default_validation_id: None = ...,
         checkpoint: Checkpoint = ...,
     ) -> Checkpoint:
         """
@@ -3125,15 +3124,32 @@ class AbstractDataContext(ConfigPeer, ABC):
         Returns:
             The persisted Profiler constructed by the input arguments.
         """
-        return RuleBasedProfiler.add_profiler(
-            data_context=self,
-            profiler_store=self.profiler_store,
-            name=name,
-            config_version=config_version,
-            rules=rules,
-            variables=variables,
-            profiler=profiler,
-        )
+        try:
+            return RuleBasedProfiler.add_profiler(
+                data_context=self,
+                profiler_store=self.profiler_store,
+                name=name,
+                config_version=config_version,
+                rules=rules,
+                variables=variables,
+                profiler=profiler,
+            )
+        except gx_exceptions.ProfilerError as e:
+            # deprecated-v0.15.50
+            warnings.warn(
+                f"{e.message}; using add_profiler to overwrite an existing value is deprecated as of v0.15.50 "
+                "and will be removed in v0.18. Please use add_or_update_profiler instead.",
+                DeprecationWarning,
+            )
+            return RuleBasedProfiler.add_or_update_profiler(
+                data_context=self,
+                profiler_store=self.profiler_store,
+                name=name,
+                config_version=config_version,
+                rules=rules,
+                variables=variables,
+                profiler=profiler,
+            )
 
     @public_api
     @new_argument(

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -1246,7 +1246,7 @@ class BaseRuleBasedProfiler(ConfigPeer):
         except gx_exceptions.StoreBackendError as e:
             raise gx_exceptions.ProfilerError(
                 f"{e.message}; could not persist profiler"
-            )
+            ) from e
 
         if isinstance(response, GXCloudResourceRef):
             new_profiler.ge_cloud_id = response.cloud_id

--- a/great_expectations/rule_based_profiler/rule_based_profiler.py
+++ b/great_expectations/rule_based_profiler/rule_based_profiler.py
@@ -1241,7 +1241,13 @@ class BaseRuleBasedProfiler(ConfigPeer):
                 configuration_key=config.name,
             )
 
-        response = persistence_fn(key=key, value=config)
+        try:
+            response = persistence_fn(key=key, value=config)
+        except gx_exceptions.StoreBackendError as e:
+            raise gx_exceptions.ProfilerError(
+                f"{e.message}; could not persist profiler"
+            )
+
         if isinstance(response, GXCloudResourceRef):
             new_profiler.ge_cloud_id = response.cloud_id
 

--- a/tests/data_context/test_data_context_state_management.py
+++ b/tests/data_context/test_data_context_state_management.py
@@ -761,7 +761,7 @@ def test_add_profiler_with_existing_profiler(
 
 
 @pytest.mark.unit
-def test_add_profiler_namespace_collision_failure(
+def test_add_profiler_namespace_collision_raises_deprecation(
     in_memory_data_context: EphemeralDataContextSpy,
     profiler_rules: dict,
 ):
@@ -778,11 +778,10 @@ def test_add_profiler_namespace_collision_failure(
     _ = context.add_profiler(profiler=profiler)
     assert context.profiler_store.save_count == 1
 
-    with pytest.raises(gx_exceptions.ProfilerError) as e:
+    with pytest.deprecated_call():
         _ = context.add_profiler(profiler=profiler)
 
-    assert f"Profiler named {name} already exists" in str(e.value)
-    assert context.profiler_store.save_count == 1  # Should not have changed
+    assert context.profiler_store.save_count == 2
 
 
 @pytest.mark.unit
@@ -986,7 +985,7 @@ def test_add_checkpoint_with_existing_checkpoint(
 
 
 @pytest.mark.unit
-def test_add_checkpoint_namespace_collision_failure(
+def test_add_checkpoint_namespace_collision_raises_deprecation(
     in_memory_data_context: EphemeralDataContextSpy,
 ):
     context = in_memory_data_context
@@ -995,11 +994,10 @@ def test_add_checkpoint_namespace_collision_failure(
     _ = context.add_checkpoint(name=checkpoint_name, class_name="Checkpoint")
     assert context.checkpoint_store.save_count == 1
 
-    with pytest.raises(gx_exceptions.CheckpointError) as e:
+    with pytest.deprecated_call():
         _ = context.add_checkpoint(name=checkpoint_name, class_name="Checkpoint")
 
-    assert f"Checkpoint named {checkpoint_name} already exists" in str(e.value)
-    assert context.checkpoint_store.save_count == 1  # Should not have changed
+    assert context.checkpoint_store.save_count == 2
 
 
 @pytest.mark.unit

--- a/tests/experimental/integration/test_convert_to_file_context.py
+++ b/tests/experimental/integration/test_convert_to_file_context.py
@@ -1,0 +1,9 @@
+import great_expectations as gx
+
+
+def test_foo():
+    context = gx.get_context()
+    breakpoint()
+    context.sources.add_pandas(
+        "my_pandas",
+    )

--- a/tests/experimental/integration/test_convert_to_file_context.py
+++ b/tests/experimental/integration/test_convert_to_file_context.py
@@ -1,9 +1,0 @@
-import great_expectations as gx
-
-
-def test_foo():
-    context = gx.get_context()
-    breakpoint()
-    context.sources.add_pandas(
-        "my_pandas",
-    )


### PR DESCRIPTION
Changes proposed in this pull request:
- Revert breaking changes to `add_` methods
- Remove unnecessary refs to `ge_cloud_id` in new methods


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
