### PR TITLE
[FEATURE] F/great 1393/add sql multi col splitter

### DIFF
--- a/great_expectations/experimental/datasources/schemas/PostgresDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/PostgresDatasource.json
@@ -85,6 +85,32 @@
             ],
             "additionalProperties": false
         },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "ColumnSplitterDividedInteger": {
             "title": "ColumnSplitterDividedInteger",
             "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
@@ -272,6 +298,9 @@
                             "$ref": "#/definitions/ColumnSplitterColumnValue"
                         },
                         {
+                            "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                        },
+                        {
                             "$ref": "#/definitions/ColumnSplitterDividedInteger"
                         },
                         {
@@ -335,6 +364,9 @@
                     "anyOf": [
                         {
                             "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
                         },
                         {
                             "$ref": "#/definitions/ColumnSplitterDividedInteger"

--- a/great_expectations/experimental/datasources/schemas/PostgresDatasource/QueryAsset.json
+++ b/great_expectations/experimental/datasources/schemas/PostgresDatasource/QueryAsset.json
@@ -29,6 +29,9 @@
                     "$ref": "#/definitions/ColumnSplitterColumnValue"
                 },
                 {
+                    "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                },
+                {
                     "$ref": "#/definitions/ColumnSplitterDividedInteger"
                 },
                 {
@@ -97,6 +100,32 @@
             },
             "required": [
                 "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/experimental/datasources/schemas/PostgresDatasource/TableAsset.json
+++ b/great_expectations/experimental/datasources/schemas/PostgresDatasource/TableAsset.json
@@ -29,6 +29,9 @@
                     "$ref": "#/definitions/ColumnSplitterColumnValue"
                 },
                 {
+                    "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                },
+                {
                     "$ref": "#/definitions/ColumnSplitterDividedInteger"
                 },
                 {
@@ -101,6 +104,32 @@
             },
             "required": [
                 "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/experimental/datasources/schemas/SQLDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/SQLDatasource.json
@@ -82,6 +82,32 @@
             ],
             "additionalProperties": false
         },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "ColumnSplitterDividedInteger": {
             "title": "ColumnSplitterDividedInteger",
             "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
@@ -269,6 +295,9 @@
                             "$ref": "#/definitions/ColumnSplitterColumnValue"
                         },
                         {
+                            "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                        },
+                        {
                             "$ref": "#/definitions/ColumnSplitterDividedInteger"
                         },
                         {
@@ -332,6 +361,9 @@
                     "anyOf": [
                         {
                             "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
                         },
                         {
                             "$ref": "#/definitions/ColumnSplitterDividedInteger"

--- a/great_expectations/experimental/datasources/schemas/SQLDatasource/QueryAsset.json
+++ b/great_expectations/experimental/datasources/schemas/SQLDatasource/QueryAsset.json
@@ -29,6 +29,9 @@
                     "$ref": "#/definitions/ColumnSplitterColumnValue"
                 },
                 {
+                    "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                },
+                {
                     "$ref": "#/definitions/ColumnSplitterDividedInteger"
                 },
                 {
@@ -97,6 +100,32 @@
             },
             "required": [
                 "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/experimental/datasources/schemas/SQLDatasource/TableAsset.json
+++ b/great_expectations/experimental/datasources/schemas/SQLDatasource/TableAsset.json
@@ -29,6 +29,9 @@
                     "$ref": "#/definitions/ColumnSplitterColumnValue"
                 },
                 {
+                    "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                },
+                {
                     "$ref": "#/definitions/ColumnSplitterDividedInteger"
                 },
                 {
@@ -101,6 +104,32 @@
             },
             "required": [
                 "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/experimental/datasources/schemas/SqliteDatasource.json
+++ b/great_expectations/experimental/datasources/schemas/SqliteDatasource.json
@@ -85,6 +85,32 @@
             ],
             "additionalProperties": false
         },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
+            ],
+            "additionalProperties": false
+        },
         "ColumnSplitterDividedInteger": {
             "title": "ColumnSplitterDividedInteger",
             "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
@@ -272,6 +298,9 @@
                             "$ref": "#/definitions/ColumnSplitterColumnValue"
                         },
                         {
+                            "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                        },
+                        {
                             "$ref": "#/definitions/ColumnSplitterDividedInteger"
                         },
                         {
@@ -335,6 +364,9 @@
                     "anyOf": [
                         {
                             "$ref": "#/definitions/ColumnSplitterColumnValue"
+                        },
+                        {
+                            "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
                         },
                         {
                             "$ref": "#/definitions/ColumnSplitterDividedInteger"

--- a/great_expectations/experimental/datasources/schemas/SqliteDatasource/SqliteQueryAsset.json
+++ b/great_expectations/experimental/datasources/schemas/SqliteDatasource/SqliteQueryAsset.json
@@ -29,6 +29,9 @@
                     "$ref": "#/definitions/ColumnSplitterColumnValue"
                 },
                 {
+                    "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                },
+                {
                     "$ref": "#/definitions/ColumnSplitterDividedInteger"
                 },
                 {
@@ -103,6 +106,32 @@
             },
             "required": [
                 "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/experimental/datasources/schemas/SqliteDatasource/SqliteTableAsset.json
+++ b/great_expectations/experimental/datasources/schemas/SqliteDatasource/SqliteTableAsset.json
@@ -29,6 +29,9 @@
                     "$ref": "#/definitions/ColumnSplitterColumnValue"
                 },
                 {
+                    "$ref": "#/definitions/ColumnSplitterMultiColumnValue"
+                },
+                {
                     "$ref": "#/definitions/ColumnSplitterDividedInteger"
                 },
                 {
@@ -107,6 +110,32 @@
             },
             "required": [
                 "column_name"
+            ],
+            "additionalProperties": false
+        },
+        "ColumnSplitterMultiColumnValue": {
+            "title": "ColumnSplitterMultiColumnValue",
+            "description": "Base model for most ZEP pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "title": "Column Names",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method_name": {
+                    "title": "Method Name",
+                    "default": "split_on_multi_column_values",
+                    "enum": [
+                        "split_on_multi_column_values"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "column_names"
             ],
             "additionalProperties": false
         },

--- a/great_expectations/experimental/datasources/sqlite_datasource.py
+++ b/great_expectations/experimental/datasources/sqlite_datasource.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal, Self
 from great_expectations.experimental.datasources.sql_datasource import (
     ColumnSplitter,
     SQLDatasource,
-    _ColumnSplitter,
+    _ColumnSplitterOneColumnOneParam,
 )
 from great_expectations.experimental.datasources.sql_datasource import (
     QueryAsset as SqlQueryAsset,
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 # See SqliteDatasource, SqliteTableAsset, and SqliteQueryAsset below.
 
 
-class ColumnSplitterHashedColumn(_ColumnSplitter):
+class ColumnSplitterHashedColumn(_ColumnSplitterOneColumnOneParam):
     """Split on hash value of a column.
 
     Args:
@@ -42,6 +42,7 @@ class ColumnSplitterHashedColumn(_ColumnSplitter):
 
     # hash digits is the length of the hash. The md5 of the column is truncated to this length.
     hash_digits: int
+    column_name: str
     method_name: Literal["split_on_hashed_column"] = "split_on_hashed_column"
 
     @property
@@ -61,7 +62,7 @@ class ColumnSplitterHashedColumn(_ColumnSplitter):
         return {self.column_name: options["hash"]}
 
 
-class ColumnSplitterConvertedDateTime(_ColumnSplitter):
+class ColumnSplitterConvertedDateTime(_ColumnSplitterOneColumnOneParam):
     """A column splitter than can be used for sql engines that represents datetimes as strings.
 
     The SQL engine that this currently supports is SQLite since it stores its datetimes as
@@ -73,6 +74,7 @@ class ColumnSplitterConvertedDateTime(_ColumnSplitter):
     # https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
     # It allows for arbitrary strings so can't be validated until conversion time.
     date_format_string: str
+    column_name: str
     method_name: Literal["split_on_converted_datetime"] = "split_on_converted_datetime"
 
     @property
@@ -166,8 +168,8 @@ class SqliteDatasource(SQLDatasource):
     type: Literal["sqlite"] = "sqlite"  # type: ignore[assignment]
     connection_string: SqliteDsn
 
-    _TableAsset: Type[SqliteTableAsset] = pydantic.PrivateAttr(SqliteTableAsset)
-    _QueryAsset: Type[SqliteQueryAsset] = pydantic.PrivateAttr(SqliteQueryAsset)
+    _TableAsset: Type[SqlTableAsset] = pydantic.PrivateAttr(SqliteTableAsset)
+    _QueryAsset: Type[SqlQueryAsset] = pydantic.PrivateAttr(SqliteQueryAsset)
 
     def add_table_asset(
         self,

--- a/tests/experimental/datasources/integration/test_integration_datasource.py
+++ b/tests/experimental/datasources/integration/test_integration_datasource.py
@@ -316,6 +316,18 @@ def test_filesystem_data_asset_batching_regex(
             {"datetime": "2019-02-23"},
             id="converted_datetime",
         ),
+        pytest.param(
+            "yellow_tripdata.db",
+            "yellow_tripdata_sample_2019_02",
+            "add_splitter_multi_column_values",
+            {"column_names": ["passenger_count", "payment_type"]},
+            ["passenger_count", "payment_type"],
+            23,
+            {"passenger_count": 1, "payment_type": 1},
+            1,
+            {"passenger_count": 1, "payment_type": 1},
+            id="multi_column_values",
+        ),
     ],
 )
 def test_column_splitter(

--- a/tests/experimental/datasources/test_postgres_datasource.py
+++ b/tests/experimental/datasources/test_postgres_datasource.py
@@ -1032,7 +1032,7 @@ def test_splitter_year_and_month_and_day(
 @pytest.mark.unit
 @pytest.mark.parametrize(
     [
-        "splitter_name",
+        "add_splitter_method",
         "splitter_kwargs",
         "splitter_query_responses",
         "sorter_args",
@@ -1128,11 +1128,24 @@ def test_splitter_year_and_month_and_day(
             {"remainder": 2},
             id="mod_integer",
         ),
+        pytest.param(
+            "add_splitter_multi_column_values",
+            {"column_names": ["passenger_count", "payment_type"]},
+            # These types are (passenger_count, payment_type), that is in column_names order.
+            # datetime splitters return dicts while all other splitters return tuples.
+            [(3, 1), (1, 1), (1, 2)],
+            ["passenger_count", "payment_type"],
+            3,
+            {"passenger_count": 1},
+            2,
+            {"passenger_count": 1, "payment_type": 2},
+            id="multi_column_values",
+        ),
     ],
 )
 def test_column_splitter(
     create_source: CreateSourceFixture,
-    splitter_name,
+    add_splitter_method,
     splitter_kwargs,
     splitter_query_responses,
     sorter_args,
@@ -1147,7 +1160,7 @@ def test_column_splitter(
         splitter_query_response=[response for response in splitter_query_responses],
     ) as source:
         asset = source.add_query_asset(name="query_asset", query="SELECT * from table")
-        getattr(asset, splitter_name)(**splitter_kwargs)
+        getattr(asset, add_splitter_method)(**splitter_kwargs)
         asset.add_sorters(sorter_args)
         # Test getting all batches
         all_batches = asset.get_batch_list_from_batch_request(


### PR DESCRIPTION
This adds the last column splitter for fluent sql datasources.


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.

