### PR TITLE
[MAINTENANCE] Fix CI dev pipeline - skip orphaned schema check on min pandas version

### DIFF
--- a/tests/experimental/datasources/test_schemas.py
+++ b/tests/experimental/datasources/test_schemas.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import json
 import pathlib
 import sys
-from typing import Any, Generator, Type
 from pprint import pformat as pf
+from typing import Any, Generator, Type
 
 import pandas
 import pytest

--- a/tests/experimental/datasources/test_schemas.py
+++ b/tests/experimental/datasources/test_schemas.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 import sys
 from typing import Any, Generator, Type
+from pprint import pformat as pf
 
 import pandas
 import pytest
@@ -106,12 +107,24 @@ def test_vcs_schemas_match(
     ), "Schemas are out of sync. Run `invoke schema --sync`. Also check your pandas version."
 
 
+@pytest.mark.skipif(
+    _PANDAS_SCHEMA_VERSION != PANDAS_VERSION,
+    reason=f"schemas generated with pandas {_PANDAS_SCHEMA_VERSION}",
+)
 def test_no_orphaned_schemas():
     """Ensure that there are no schemas that have no corresponding type."""
+    print(f"python version: {sys.version.split()[0]}")
+    print(f"pandas version: {PANDAS_VERSION}\n")
+
     # NOTE: this is a very low fidelity check
     all_schemas: set[str] = {t[1].__name__ for t in _iter_all_registered_types()}
 
+    orphans: list[pathlib.Path] = []
+
     for schema in _SCHEMAS_DIR.glob("**/*.json"):
-        assert (
-            schema.stem in all_schemas
-        ), f"{schema} appears to be orphaned and should be removed. Run `invoke schema --sync --clean`"
+        if schema.stem not in all_schemas:
+            orphans.append(schema)
+
+    assert (
+        not orphans
+    ), f"The following schemas appear to be orphaned and should be removed. Run `invoke schema --sync --clean`\n{pf(orphans)}"


### PR DESCRIPTION
## Changes proposed in this pull request:
- skip the `test_no_orphaned_schemas` if not using the `pandas` version the schemas were generated with.
- check for all orphans rather than failing on the first one.

These changes are needed because in earlier versions of pandas things like `XMLAsset`/`read_xml` don't exist, so the pipeline that tests our min pandas version the test would consider `XMLAsset.json` an orphaned schema.
