### PR TITLE
[MAINTENANCE] Rename default pandas ephemeral data asset

### DIFF
--- a/great_expectations/experimental/datasources/sources.py
+++ b/great_expectations/experimental/datasources/sources.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PANDAS_DATASOURCE_NAME: Final[str] = "default_pandas_datasource"
 
-DEFAULT_PANDAS_DATA_ASSET_NAME: Final[str] = "#ephemeral_data_asset"
+DEFAULT_PANDAS_DATA_ASSET_NAME: Final[str] = "#ephemeral_pandas_asset"
 
 
 class DefaultPandasDatasourceError(Exception):


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1623
- Decide on a name for the default pandas ephemeral data asset

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.