### PR TITLE
[FEATURE] Fluent Datasource config substitution support

### DIFF
--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -258,8 +258,6 @@ class AbstractDataContext(ConfigPeer, ABC):
             runtime_environment (dict): a dictionary of config variables that
                 override those set in config_variables.yml and the environment
         """
-        self.zep_config = self._load_zep_config()
-
         if runtime_environment is None:
             runtime_environment = {}
         self.runtime_environment = runtime_environment
@@ -267,6 +265,8 @@ class AbstractDataContext(ConfigPeer, ABC):
         self._config_provider = self._init_config_provider()
         self._config_variables = self._load_config_variables()
         self._variables = self._init_variables()
+
+        self.zep_config = self._load_zep_config()
 
         # Init plugin support
         if self.plugins_directory is not None and os.path.exists(
@@ -5420,11 +5420,11 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
             yaml.dump(config_variables, config_variables_file)
 
     def _load_zep_config(self) -> GxConfig:
-        """Called at beginning of DataContext __init__"""
+        """Called at beginning of DataContext __init__ after config_providers init."""
         logger.info(
             f"{self.__class__.__name__} has not implemented `_load_zep_config()` returning empty `GxConfig`"
         )
-        return GxConfig(xdatasources={})
+        return GxConfig(xdatasources={}, _config_provider=self.config_provider)
 
     def _attach_zep_config_datasources(self, config: GxConfig):
         """Called at end of __init__"""

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -266,6 +266,7 @@ class AbstractDataContext(ConfigPeer, ABC):
         self._config_variables = self._load_config_variables()
         self._variables = self._init_variables()
 
+        # config providers must be provisioned before loading zep_config
         self.zep_config = self._load_zep_config()
 
         # Init plugin support
@@ -5424,7 +5425,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         logger.info(
             f"{self.__class__.__name__} has not implemented `_load_zep_config()` returning empty `GxConfig`"
         )
-        return GxConfig(xdatasources={}, _config_provider=self.config_provider)
+        return GxConfig(xdatasources={})
 
     def _attach_zep_config_datasources(self, config: GxConfig):
         """Called at end of __init__"""

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -160,11 +160,16 @@ class FileDataContext(SerializableDataContext):
 
     def _load_zep_config(self) -> GxConfig:
         logger.info(f"{type(self).__name__} loading zep config")
+        # TODO: nope
+        GxConfig._cfg_prvdr_global = self.config_provider
         if not self.root_directory:
             logger.warning("`root_directory` not set, cannot load zep config")
         else:
             path_to_zep_yaml = pathlib.Path(self.root_directory) / self.GX_YML
             if path_to_zep_yaml.exists():
-                return GxConfig.parse_yaml(path_to_zep_yaml, _allow_empty=True)
+                return GxConfig.parse_yaml(
+                    path_to_zep_yaml,
+                    _allow_empty=True,
+                )
             logger.info(f"no zep config at {path_to_zep_yaml.absolute()}")
         return GxConfig(xdatasources={})

--- a/great_expectations/data_context/data_context/file_data_context.py
+++ b/great_expectations/data_context/data_context/file_data_context.py
@@ -160,8 +160,6 @@ class FileDataContext(SerializableDataContext):
 
     def _load_zep_config(self) -> GxConfig:
         logger.info(f"{type(self).__name__} loading zep config")
-        # TODO: nope
-        GxConfig._cfg_prvdr_global = self.config_provider
         if not self.root_directory:
             logger.warning("`root_directory` not set, cannot load zep config")
         else:
@@ -170,6 +168,7 @@ class FileDataContext(SerializableDataContext):
                 return GxConfig.parse_yaml(
                     path_to_zep_yaml,
                     _allow_empty=True,
+                    _config_provider=self.config_provider,
                 )
             logger.info(f"no zep config at {path_to_zep_yaml.absolute()}")
         return GxConfig(xdatasources={})

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -102,6 +102,9 @@ class SerializableDataContext(AbstractDataContext):
                     )
                     zep_json_dict: dict[str, JSONValues] = self.zep_config._json_dict()
                     self.config._commented_map.update(
+                        # re-combine the original raw config to preserve the original config ${FOO} place holders
+                        # NOTE: this could cause issues depending on what values have config
+                        # TODO: Only update fields that had config placeholders
                         {**zep_json_dict, **self.zep_config._raw_config}
                     )
 

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -101,12 +101,13 @@ class SerializableDataContext(AbstractDataContext):
                         f"Saving {len(self.zep_config.datasources)} ZEP Datasources to {config_filepath}"
                     )
                     zep_json_dict: dict[str, JSONValues] = self.zep_config._json_dict()
-                    self.config._commented_map.update(
-                        # re-combine the original raw config to preserve the original config ${FOO} place holders
-                        # NOTE: this could cause issues depending on what values have config
-                        # TODO: Only update fields that had config placeholders
-                        {**zep_json_dict, **self.zep_config._raw_config}
+                    # re-combine the original raw config to preserve the original config ${FOO} placeholders
+                    # NOTE: this could cause issues depending on what values have the placeholders
+                    # TODO: Only update fields that had config placeholders
+                    zep_json_dict["xdatasources"].update(
+                        self.zep_config._xdatasources_raw_config
                     )
+                    self.config._commented_map.update(zep_json_dict)
 
                 self.config.to_yaml(outfile)
         except PermissionError as e:

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -7,6 +7,8 @@ import shutil
 import warnings
 from typing import TYPE_CHECKING, ClassVar, Optional, Union
 
+# from pprint import pformat as pf
+from pydantic.utils import deep_update
 from ruamel.yaml import YAML
 
 import great_expectations.exceptions as gx_exceptions
@@ -103,10 +105,16 @@ class SerializableDataContext(AbstractDataContext):
                     zep_json_dict: dict[str, JSONValues] = self.zep_config._json_dict()
                     # re-combine the original raw config to preserve the original config ${FOO} placeholders
                     # NOTE: this could cause issues depending on what values have the placeholders
-                    # TODO: Only update fields that had config placeholders
-                    zep_json_dict["xdatasources"].update(
-                        self.zep_config._xdatasources_raw_config
+                    # TODO: Only update fields that had config placeholders?
+                    # TODO: cleanup
+                    updated_xdatasources = deep_update(
+                        zep_json_dict["xdatasources"],
+                        self.zep_config._xdatasources_raw_config,
                     )
+                    zep_json_dict["xdatasources"] = updated_xdatasources
+                    # print(
+                    #     f"original\n{pf(zep_json_dict['xdatasources'])}\n\n\nupdated\n{pf(updated_xdatasources)}"
+                    # )
                     self.config._commented_map.update(zep_json_dict)
 
                 self.config.to_yaml(outfile)

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -108,8 +108,8 @@ class SerializableDataContext(AbstractDataContext):
                     # TODO: Only update fields that had config placeholders?
                     # TODO: cleanup
                     updated_xdatasources = deep_update(
-                        zep_json_dict["xdatasources"],
-                        self.zep_config._xdatasources_raw_config,  # type: ignore[arg-type]
+                        zep_json_dict["xdatasources"],  # type: ignore[arg-type]
+                        self.zep_config._xdatasources_raw_config,
                     )
                     zep_json_dict["xdatasources"] = updated_xdatasources
                     # print(

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -109,7 +109,7 @@ class SerializableDataContext(AbstractDataContext):
                     # TODO: cleanup
                     updated_xdatasources = deep_update(
                         zep_json_dict["xdatasources"],
-                        self.zep_config._xdatasources_raw_config,
+                        self.zep_config._xdatasources_raw_config,  # type: ignore[arg-type]
                     )
                     zep_json_dict["xdatasources"] = updated_xdatasources
                     # print(

--- a/great_expectations/data_context/data_context/serializable_data_context.py
+++ b/great_expectations/data_context/data_context/serializable_data_context.py
@@ -101,7 +101,9 @@ class SerializableDataContext(AbstractDataContext):
                         f"Saving {len(self.zep_config.datasources)} ZEP Datasources to {config_filepath}"
                     )
                     zep_json_dict: dict[str, JSONValues] = self.zep_config._json_dict()
-                    self.config._commented_map.update(zep_json_dict)
+                    self.config._commented_map.update(
+                        {**zep_json_dict, **self.zep_config._raw_config}
+                    )
 
                 self.config.to_yaml(outfile)
         except PermissionError as e:

--- a/great_expectations/experimental/datasources/config.py
+++ b/great_expectations/experimental/datasources/config.py
@@ -56,7 +56,7 @@ class GxConfig(ExperimentalBaseModel):
     xdatasources: Dict[str, Datasource] = Field(..., description=_ZEP_STYLE_DESCRIPTION)
 
     # private non-field attributes
-    _raw_config: Union[Dict[str, Any], None] = PrivateAttr(default=None)
+    _raw_config: Dict[str, Any] = PrivateAttr(default_factory=dict)
 
     @property
     def datasources(self) -> Dict[str, Datasource]:

--- a/tests/experimental/datasources/great_expectations.yml
+++ b/tests/experimental/datasources/great_expectations.yml
@@ -30,3 +30,13 @@ xdatasources:
         order_by:
           - year
           - -month
+  my_pandas_ds_w_cfg_subs:
+    type: pandas_filesystem
+    name: my_pandas_ds_w_cfg_subs
+    base_directory: ${MY_PANDAS_BASE_DIR}
+    assets:
+      my_csv_asset:
+        type: csv
+        name: my_csv_asset
+        sep: ${MY_SEP}
+        batching_regex: ".*"

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -5,11 +5,11 @@ import logging
 import pathlib
 import re
 from pprint import pformat as pf
-from typing import Callable, Dict, List
-from ruamel.yaml import YAML
+from typing import TYPE_CHECKING, Callable, Dict, List
 
 import pydantic
 import pytest
+from ruamel.yaml import YAML
 
 from great_expectations.core.config_provider import (
     _ConfigurationProvider,
@@ -32,6 +32,11 @@ try:
     from devtools import debug as pp
 except ImportError:
     from pprint import pprint as pp
+
+if TYPE_CHECKING:
+    from great_expectations.experimental.datasources import (
+        PandasFilesystemDatasource,
+    )
 
 yaml = YAML(typ="safe")
 LOGGER = logging.getLogger(__file__)
@@ -651,7 +656,9 @@ def test_config_substitution_on_dc_init(
     print(context.zep_config)
 
     # TODO: improve the fixtures or do all the setup in the test
-    subbed_ds = context.zep_config.datasources["my_pandas_ds_w_cfg_subs"]
+    subbed_ds: PandasFilesystemDatasource = context.zep_config.datasources[  # type: ignore[assignment]
+        "my_pandas_ds_w_cfg_subs"
+    ]
     assert subbed_ds.get_asset("my_csv_asset").sep == ","
 
     assert subbed_ds.base_directory == pathlib.Path(__file__).parent
@@ -673,7 +680,9 @@ def test_config_substitution_retains_original_value_on_save(
     print(context.zep_config)
 
     # TODO: improve the fixtures or do all the setup in the test
-    subbed_ds = context.zep_config.datasources["my_pandas_ds_w_cfg_subs"]
+    subbed_ds: PandasFilesystemDatasource = context.zep_config.datasources[  # type: ignore[assignment]
+        "my_pandas_ds_w_cfg_subs"
+    ]
     assert subbed_ds.get_asset("my_csv_asset").sep == ","
 
     assert subbed_ds.base_directory == pathlib.Path(__file__).parent

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -716,7 +716,7 @@ def test_config_substitution_retains_original_value_on_save_w_run_time_mods(
     )
 
     assert (
-        subbed_datasources["my_pandas_ds_w_cfg_subs"].base_directory
+        subbed_datasources["my_pandas_ds_w_cfg_subs"].base_directory  # type: ignore[attr-defined]
         == pathlib.Path(__file__).parent
     )
 
@@ -724,7 +724,7 @@ def test_config_substitution_retains_original_value_on_save_w_run_time_mods(
     context.sources.add_sqlite("my_sqlite", connection_string="sqlite://")
 
     # add a new asset to an existing data
-    pandas_ds_w_cfg_sub: PandasFilesystemDatasource = context.get_datasource(
+    pandas_ds_w_cfg_sub: PandasFilesystemDatasource = context.get_datasource(  # type: ignore[assignment]
         "my_pandas_ds_w_cfg_subs"
     )
     pandas_ds_w_cfg_sub.add_csv_asset("new_asset")

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -698,10 +698,6 @@ def test_config_substitution_retains_original_value_on_save(
 def test_config_substitution_retains_original_value_on_save_w_run_time_mods(
     inject_config_env_vars, file_dc_config_file_with_substitutions: pathlib.Path
 ):
-    original: dict = yaml.load(file_dc_config_file_with_substitutions.read_text())[
-        "xdatasources"
-    ]
-
     from great_expectations import get_context
 
     context = get_context(

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -1,15 +1,19 @@
 import copy
 import functools
 import json
+import logging
 import pathlib
 import re
-import logging
 from pprint import pformat as pf
-from typing import Callable, List, Dict
+from typing import Callable, Dict, List
 
 import pydantic
 import pytest
 
+from great_expectations.core.config_provider import (
+    _ConfigurationProvider,
+    _EnvironmentConfigurationProvider,
+)
 from great_expectations.data_context import FileDataContext
 from great_expectations.experimental.datasources.config import GxConfig
 from great_expectations.experimental.datasources.interfaces import Datasource
@@ -21,10 +25,6 @@ from great_expectations.experimental.datasources.sources import (
 from great_expectations.experimental.datasources.sql_datasource import (
     ColumnSplitterYearAndMonth,
     TableAsset,
-)
-from great_expectations.core.config_provider import (
-    _ConfigurationProvider,
-    _EnvironmentConfigurationProvider,
 )
 
 try:

--- a/tests/experimental/datasources/test_config.py
+++ b/tests/experimental/datasources/test_config.py
@@ -732,4 +732,4 @@ def test_config_substitution_retains_original_value_on_save_w_run_time_mods(
     )["xdatasources"]
 
     assert round_tripped_datasources["my_sqlite"]
-    assert round_tripped_datasources["my_pandas_ds_w_cfg_subs"]["new_asset"]
+    assert round_tripped_datasources["my_pandas_ds_w_cfg_subs"]["assets"]["new_asset"]


### PR DESCRIPTION
## Changes proposed in this pull request:
- [x] substitute `${FOO}` variables set for `xdatasources`/ Fluent-Datasources when loading from yaml
- [x] retain `${FOO}` values when persisting back to config
   - [x] make sure this still works if assets/datasources are modified after loading from config
      - [x] fix the tests 
- [ ] ensure sensitive values do not leak as part of validation errors
- [ ] cleanup comments/debugging



### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
