### PR TITLE
[MAINTENANCE] Keep repo root consistent

### DIFF
--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -141,6 +141,11 @@ stages:
           ruff --select F401 great_expectations tests
         name: UnusedImportChecker
 
+    - job: check_repo_root_size
+      steps:
+        - script: ./scripts/check_repo_root_size.sh
+          name: CheckRepoRootSize
+
     - job: docs_snippet_checker
       condition: eq(stageDependencies.scope_check.changes.outputs['CheckChanges.DocsChanged'], true)
       steps:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -119,6 +119,12 @@ stages:
             python scripts/check_no_line_number_snippets.py
           name: LineNumberSnippetChecker
 
+    - job: check_repo_root_size
+      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
+      steps:
+        - script: ./scripts/check_repo_root_size.sh
+          name: CheckRepoRootSize
+
   - stage: docker_tests
     dependsOn: [lint, custom_checks]
     condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))

--- a/scripts/check_repo_root_size.sh
+++ b/scripts/check_repo_root_size.sh
@@ -5,7 +5,7 @@
 # Please take care to only add files or directories to the repo root unless they are
 # required to be in the repo root, otherwise please find a more appropriate location.
 
-NUM_ITEMS_SHOULD_BE=47
+NUM_ITEMS_SHOULD_BE=40
 NUM_ITEMS=$(ls -la | wc -l)
 
 echo "Items found in repo root:"

--- a/scripts/check_repo_root_size.sh
+++ b/scripts/check_repo_root_size.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# If you need to add or remove from the repo root please change NUM_ITEMS_SHOULD_BE
+# Please take care to only add files or directories to the repo root unless they are
+# required to be in the repo root, otherwise please find a more appropriate location.
+
+NUM_ITEMS_SHOULD_BE=27
+NUM_ITEMS=$(ls -l | wc -l)
+
+if [ $NUM_ITEMS -ne $NUM_ITEMS_SHOULD_BE ];
+then
+  echo "There should be ${NUM_ITEMS_SHOULD_BE} items in the repo root, you have ${NUM_ITEMS}"
+  exit 1
+fi

--- a/scripts/check_repo_root_size.sh
+++ b/scripts/check_repo_root_size.sh
@@ -5,8 +5,11 @@
 # Please take care to only add files or directories to the repo root unless they are
 # required to be in the repo root, otherwise please find a more appropriate location.
 
-NUM_ITEMS_SHOULD_BE=27
+NUM_ITEMS_SHOULD_BE=29
 NUM_ITEMS=$(ls -l | wc -l)
+
+echo "Items found in repo root:"
+ls -l
 
 if [ $NUM_ITEMS -ne $NUM_ITEMS_SHOULD_BE ];
 then

--- a/scripts/check_repo_root_size.sh
+++ b/scripts/check_repo_root_size.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # If you need to add or remove from the repo root please change NUM_ITEMS_SHOULD_BE
+
 # Please take care to only add files or directories to the repo root unless they are
 # required to be in the repo root, otherwise please find a more appropriate location.
 

--- a/scripts/check_repo_root_size.sh
+++ b/scripts/check_repo_root_size.sh
@@ -5,11 +5,11 @@
 # Please take care to only add files or directories to the repo root unless they are
 # required to be in the repo root, otherwise please find a more appropriate location.
 
-NUM_ITEMS_SHOULD_BE=29
-NUM_ITEMS=$(ls -l | wc -l)
+NUM_ITEMS_SHOULD_BE=47
+NUM_ITEMS=$(ls -la | wc -l)
 
 echo "Items found in repo root:"
-ls -l
+ls -la
 
 if [ $NUM_ITEMS -ne $NUM_ITEMS_SHOULD_BE ];
 then


### PR DESCRIPTION
Changes proposed in this pull request:
- Keep the repo root clean and consistent by limiting the number of files and directories. The limit can be changed but this is intended to be a reminder that we should do so only when necessary. It is also set as a not equal (rather than a greater than) limit so that we remember to lower this number when removing items.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.