### PR TITLE
[BUGFIX] `params_with_json_schema` is undefined in `ExpectSelectColumnValuesToBeUniqueWithinRecord._prescriptive_renderer`

### DIFF
--- a/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
+++ b/great_expectations/expectations/core/expect_select_column_values_to_be_unique_within_record.py
@@ -179,9 +179,9 @@ class ExpectSelectColumnValuesToBeUniqueWithinRecord(MulticolumnMapExpectation):
         )
 
         if params["mostly"] is not None and params["mostly"] < 1.0:
-            params_with_json_schema["mostly_pct"][  # noqa: F821 # FIXME: this breaks
-                "value"
-            ] = num_to_str(params["mostly"] * 100, precision=15, no_scientific=True)
+            params["mostly_pct"]["value"] = num_to_str(
+                params["mostly"] * 100, precision=15, no_scientific=True
+            )
             template_str = "Values must be unique across columns, at least $mostly_pct % of the time: "
         else:
             template_str = "Values must always be unique across columns: "


### PR DESCRIPTION
Changes proposed in this pull request:
- Same issue as https://github.com/great-expectations/great_expectations/issues/5938


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.
