### PR TITLE
[MAINTENANCE] Threshold for public API report

### DIFF
--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -156,6 +156,13 @@ stages:
             python scripts/check_no_line_number_snippets.py
           name: LineNumberSnippetChecker
 
+    - job: public_api_report
+      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
+      steps:
+        - script: |
+            python scripts/public_api_report.py
+          name: PublicAPIReport
+
   - stage: import_ge
     dependsOn: scope_check
     pool:

--- a/ci/azure-pipelines-dev.yml
+++ b/ci/azure-pipelines-dev.yml
@@ -157,7 +157,6 @@ stages:
           name: LineNumberSnippetChecker
 
     - job: public_api_report
-      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
       steps:
         - script: |
             python scripts/public_api_report.py

--- a/ci/azure-pipelines-docs-integration.yml
+++ b/ci/azure-pipelines-docs-integration.yml
@@ -86,7 +86,7 @@ stages:
           name: LineNumberSnippetChecker
 
     - job: public_api_report
-      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
+      condition: or(eq(stageDependencies.scope_check.changes.outputs['CheckDocsChanges.DocsChanged'], true), eq(variables.isMain, true))
       steps:
         - script: |
             python scripts/public_api_report.py

--- a/ci/azure-pipelines-docs-integration.yml
+++ b/ci/azure-pipelines-docs-integration.yml
@@ -85,6 +85,13 @@ stages:
             python scripts/check_no_line_number_snippets.py
           name: LineNumberSnippetChecker
 
+    - job: public_api_report
+      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
+      steps:
+        - script: |
+            python scripts/public_api_report.py
+          name: PublicAPIReport
+
   - stage: docusaurus_tests
     dependsOn: scope_check
     pool:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -119,6 +119,13 @@ stages:
             python scripts/check_no_line_number_snippets.py
           name: LineNumberSnippetChecker
 
+    - job: public_api_report
+      condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))
+      steps:
+        - script: |
+            python scripts/public_api_report.py
+          name: PublicAPIReport
+
   - stage: docker_tests
     dependsOn: [lint, custom_checks]
     condition: or(eq(variables.isScheduled, true), eq(variables.isReleasePrep, true), eq(variables.isRelease, true), eq(variables.isManual, true))

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -1774,7 +1774,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 58
+    PUBLIC_API_MISSING_THRESHOLD = 57
     if not len(printable_definitions) == PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -1774,7 +1774,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 57
+    PUBLIC_API_MISSING_THRESHOLD = 58
     if not len(printable_definitions) == PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -51,6 +51,7 @@ import glob
 import logging
 import operator
 import pathlib
+import sys
 from dataclasses import dataclass
 from typing import List, Optional, Set, Union, cast
 
@@ -1765,6 +1766,22 @@ def main():
     printable_definitions = public_api_report.generate_printable_definitions()
     for printable_definition in printable_definitions:
         logger.info(printable_definition)
+
+    num_missing_msg = f"There are {len(printable_definitions)} items referenced in documentation that are not marked with the @public_api decorator and thus not rendered as part of our public API documentation."
+    logger.info(num_missing_msg)
+    # The PUBLIC_API_MISSING_THRESHOLD should be reduced and kept at 0. Please do
+    # not increase this threshold, but instead add to the public API by decorating
+    # any methods or classes you are adding to documentation with the @public_api
+    # decorator and any relevant "new" or "deprecated" public api decorators.
+    # If the actual is lower than the threshold, please reduce the threshold.
+    PUBLIC_API_MISSING_THRESHOLD = 58
+    if not len(printable_definitions) == PUBLIC_API_MISSING_THRESHOLD:
+        error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
+        if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:
+            logger.error(f"{error_msg_prefix} Please add to the public API.")
+        else:
+            logger.error(f"{error_msg_prefix} Please reduce the threshold.")
+        sys.exit(1)
 
     public_api_report.write_printable_definitions_to_file(
         filepath=_repo_root() / "public_api_report.txt",

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -1775,7 +1775,7 @@ def main():
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
     PUBLIC_API_MISSING_THRESHOLD = 58
-    if not len(printable_definitions) == PUBLIC_API_MISSING_THRESHOLD:
+    if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:
             logger.error(f"{error_msg_prefix} Please add to the public API.")


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a threshold for the public API report, throwing an error in our CI pipeline if a method or class is added to our documentation without also being added to our public API.
- This threshold is both lower and upper bound so that we are reminded to ratchet it down if we add to the public API.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run any local integration tests and made sure that nothing is broken.