### PR TITLE
[MAINTENANCE] Fluent Datasources - initial snippet tests

### DIFF
--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 
 @public_api
 class PandasFilesystemDatasource(_PandasFilePathDatasource):
+    """Pandas based Datasource for local filesystem based data assets."""
+
     # instance attributes
     type: Literal["pandas_filesystem"] = "pandas_filesystem"
 

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -27,6 +27,7 @@ from great_expectations.datasource.fluent.signatures import _merge_signatures
 logger = logging.getLogger(__name__)
 
 
+@public_api
 class PandasFilesystemDatasource(_PandasFilePathDatasource):
     # instance attributes
     type: Literal["pandas_filesystem"] = "pandas_filesystem"
@@ -53,6 +54,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             for asset in self.assets.values():
                 asset.test_connection()
 
+    @public_api
     def add_csv_asset(
         self,
         name: str,
@@ -98,6 +100,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
         )
         return self.add_asset(asset=asset)
 
+    @public_api
     def add_excel_asset(
         self,
         name: str,
@@ -145,6 +148,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
         )
         return self.add_asset(asset=asset)
 
+    @public_api
     def add_json_asset(
         self,
         name: str,
@@ -192,6 +196,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
         )
         return self.add_asset(asset=asset)
 
+    @public_api
     def add_parquet_asset(
         self,
         name: str,

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 
 from typing_extensions import Literal
 
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.datasource.fluent import _PandasFilePathDatasource
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     FilesystemDataConnector,

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "PandasFilesystemDatasource",
-    "description": "--Public API--Pandas based Datasource for local filesystem data assets.",
+    "description": "--Public API--Pandas based Datasource for local filesystem based data assets.",
     "type": "object",
     "properties": {
         "type": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "PandasFilesystemDatasource",
-    "description": "Base model for most fluent datasource related pydantic models.\n\nAdds yaml dumping and parsing methods.\n\nExtra fields are not allowed.\n\nSerialization methods default to `exclude_unset = True` to prevent serializing\nconfigs full of mostly unset default values.\nAlso prevents passing along unset kwargs to BatchSpec.\nhttps://docs.pydantic.dev/usage/exporting_models/",
+    "description": "--Public API--Pandas based Datasource for local filesystem based data assets.",
     "type": "object",
     "properties": {
         "type": {

--- a/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/PandasFilesystemDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "PandasFilesystemDatasource",
-    "description": "--Public API--Pandas based Datasource for local filesystem based data assets.",
+    "description": "--Public API--Pandas based Datasource for local filesystem data assets.",
     "type": "object",
     "properties": {
         "type": {

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -148,6 +148,9 @@ class _SourceFactories:
 
         datasource_type_lookup[ds_type] = ds_type_name
         logger.debug(f"'{ds_type_name}' added to `type_lookup`")
+        factory_fn.__name__ = method_name
+        public_api(factory_fn)
+
         cls.__source_factories[method_name] = factory_fn
         return ds_type_name
 
@@ -209,6 +212,7 @@ class _SourceFactories:
             _add_asset_factory.__signature__ = _merge_signatures(  # type: ignore[attr-defined]
                 _add_asset_factory, asset_type, exclude={"type"}
             )
+            _add_asset_factory.__name__ = add_asset_factory_method_name
             setattr(ds_type, add_asset_factory_method_name, _add_asset_factory)
 
             # add the public api decorator

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -211,6 +211,9 @@ class _SourceFactories:
             )
             setattr(ds_type, add_asset_factory_method_name, _add_asset_factory)
 
+            # add the public api decorator
+            public_api(getattr(ds_type, add_asset_factory_method_name))
+
             def _read_asset_factory(
                 self: Datasource, asset_name: str | None = None, **kwargs
             ) -> Validator:

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -15,6 +15,7 @@ from typing import (
 
 from typing_extensions import Final, TypeAlias
 
+from great_expectations.core._docs_decorators import public_api
 from great_expectations.datasource.fluent.signatures import _merge_signatures
 from great_expectations.datasource.fluent.type_lookup import TypeLookup
 

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -1843,7 +1843,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 96  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
+    PUBLIC_API_MISSING_THRESHOLD = 95  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
     if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -1843,7 +1843,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 91
+    PUBLIC_API_MISSING_THRESHOLD = 96  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
     if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/scripts/public_api_report.py
+++ b/scripts/public_api_report.py
@@ -1843,7 +1843,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 95  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
+    PUBLIC_API_MISSING_THRESHOLD = 100  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
     if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
@@ -1,0 +1,35 @@
+# Python
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py get_context">
+import great_expectations as gx
+
+context = gx.get_context()
+# </snippet>
+
+# Python
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py define_args">
+datasource_name = "my_new_datasource"
+path_to_csv_files = "<INSERT_PATH_TO_FILES_HERE>"
+# </snippet>
+
+
+path_to_csv_files = "./data/single_directory_one_data_asset/yellow_tripdata_2019-01.csv"
+
+# Python
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py create_datasource">
+datasource = context.sources.add_pandas_filesystem(
+    name=datasource_name, base_directory=path_to_csv_files
+)
+# </snippet>
+
+assert datasource_name in context.datasources
+
+# Python
+# <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py add_asset">
+asset_name = "my_csv_asset"
+filename_as_regex = "yellow_tripdata_2019-01/.csv"
+datasource.add_csv_asset(name=asset_name, batching_regex=filename_as_regex)
+
+print(datasource)
+# </snippet>
+
+assert asset_name in datasource.assets

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
@@ -4,6 +4,8 @@ To run this code as a local test, use the following console command:
 pytest -v --docs-tests -m integration -k "how_to_connect_to_one_or_more_files_using_pandas" tests/integration/test_script_runner.py
 ```
 """
+import pathlib
+
 
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py get_context">
@@ -18,8 +20,16 @@ datasource_name = "my_new_datasource"
 path_to_csv_files = "<INSERT_PATH_TO_FILES_HERE>"
 # </snippet>
 
-# TODO: create an abs path here
-path_to_csv_files = "./data/single_directory_one_data_asset/yellow_tripdata_2019-01.csv"
+path_to_csv_files = str(
+    pathlib.Path(
+        gx.__file__,
+        "..",
+        "..",
+        "tests",
+        "test_sets",
+        "taxi_yellow_tripdata_samples",
+    ).resolve(strict=True)
+)
 
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py create_datasource">
@@ -33,7 +43,7 @@ assert datasource_name in context.datasources
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py add_asset">
 asset_name = "my_csv_asset"
-filename_as_regex = "yellow_tripdata_2019-01/.csv"
+filename_as_regex = r"yellow_tripdata_sample_2018-01\.csv"
 datasource.add_csv_asset(name=asset_name, batching_regex=filename_as_regex)
 
 print(datasource)

--- a/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
+++ b/tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py
@@ -1,3 +1,10 @@
+"""
+To run this code as a local test, use the following console command:
+```
+pytest -v --docs-tests -m integration -k "how_to_connect_to_one_or_more_files_using_pandas" tests/integration/test_script_runner.py
+```
+"""
+
 # Python
 # <snippet name="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py get_context">
 import great_expectations as gx
@@ -11,7 +18,7 @@ datasource_name = "my_new_datasource"
 path_to_csv_files = "<INSERT_PATH_TO_FILES_HERE>"
 # </snippet>
 
-
+# TODO: create an abs path here
 path_to_csv_files = "./data/single_directory_one_data_asset/yellow_tripdata_2019-01.csv"
 
 # Python

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -372,6 +372,13 @@ local_tests = [
         name="how_to_configure_result_format_parameter",
         user_flow_script="tests/integration/docusaurus/reference/core_concepts/result_format.py",
     ),
+    # Fluent Datasources
+    IntegrationTestFixture(
+        name="how_to_connect_to_one_or_more_files_using_pandas",
+        user_flow_script="tests/integration/docusaurus/connecting_to_your_data/fluent_datasources/how_to_connect_to_one_or_more_files_using_pandas.py",
+        data_context_dir="tests/integration/fixtures/no_datasources/great_expectations",
+        data_dir="tests/test_sets/taxi_yellow_tripdata_samples/first_3_files",
+    ),
 ]
 
 dockerized_db_tests = [


### PR DESCRIPTION
## Changes proposed in this pull request:
- add snippet `how_to_connect_to_one_or_more_files_using_pandas`
- test the snippet
- add `@public_api` decorator to methods used in the new snippet.

### Note
Because of how the `get_public_api_definitions()` collects the `public_api` methods by parsing static code, we have to temporarily raise the `PUBLIC_API_MISSING_THRESHOLD` from `86` -> `95`

### Definition of Done


- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.
