### PR TITLE
[DOCS] Fix reference to M1 Mac installation guide

### DIFF
--- a/docs/docusaurus/docs/guides/setup/installation/components_local/_preface.mdx
+++ b/docs/docusaurus/docs/guides/setup/installation/components_local/_preface.mdx
@@ -20,6 +20,6 @@ This guide assumes you have:
 
 :::note
 - Great Expectations is developed and tested on macOS and Linux Ubuntu. Installation for Windows users may vary from the steps listed below. If you have questions, feel free to reach out to the community on our [Slack channel](https://greatexpectationstalk.slack.com/join/shared_invite/zt-sugx45gn-SFe_ucDBbfi0FZC0mRNm_A#/shared-invite/email).
-- If you have the Mac M1, you may need to follow the instructions in this blog post: [Installing Great Expectations on a Mac M1](https://greatexpectations.io/blog/m-one-mac-instructions/).
+- If you have the Mac M1, you may need to follow the instructions in this blog post: [Installing Great Expectations on a Mac M1](https://greatexpectations.io/blog/installing-great-expectations-on-a-mac-m1).
 :::
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Use proper link (currently 404s)


### Definition of Done
- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have made corresponding changes to the documentation
