### PR TITLE
[MAINTENANCE] Replace fluent data connector names with a constant

### DIFF
--- a/great_expectations/datasource/fluent/constants.py
+++ b/great_expectations/datasource/fluent/constants.py
@@ -9,3 +9,5 @@ _FIELDS_ALWAYS_SET: Final[Set[str]] = {
     "assets",
     "type",
 }
+
+_DATA_CONNECTOR_NAME: Final[str] = "fluent"

--- a/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
+++ b/great_expectations/datasource/fluent/data_asset/data_connector/file_path_data_connector.py
@@ -15,6 +15,7 @@ from great_expectations.datasource.data_connector.batch_filter import (
 from great_expectations.datasource.data_connector.util import (
     map_batch_definition_to_data_reference_string_using_regex,
 )
+from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME
 from great_expectations.datasource.fluent.data_asset.data_connector import (
     DataConnector,
 )
@@ -353,7 +354,7 @@ batch identifiers {batch_definition.batch_identifiers} from batch definition {ba
         return [
             BatchDefinition(
                 datasource_name=self._datasource_name,
-                data_connector_name="fluent",
+                data_connector_name=_DATA_CONNECTOR_NAME,
                 data_asset_name=self._data_asset_name,
                 batch_identifiers=IDDict(batch_identifiers),
             )

--- a/great_expectations/datasource/fluent/pandas_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_datasource.py
@@ -24,6 +24,7 @@ from typing_extensions import Literal
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch_spec import PandasBatchSpec, RuntimeDataBatchSpec
+from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME
 from great_expectations.datasource.fluent.dynamic_pandas import (
     _generate_pandas_data_asset_models,
 )
@@ -121,7 +122,7 @@ work-around, until "type" naming convention and method for obtaining 'reader_met
 
         batch_definition = BatchDefinition(
             datasource_name=self.datasource.name,
-            data_connector_name="fluent",
+            data_connector_name=_DATA_CONNECTOR_NAME,
             data_asset_name=self.name,
             batch_identifiers=IDDict(batch_request.options),
             batch_spec_passthrough=None,
@@ -294,7 +295,7 @@ class DataFrameAsset(_PandasDataAsset, Generic[_PandasDataFrameT]):
 
         batch_definition = BatchDefinition(
             datasource_name=self.datasource.name,
-            data_connector_name="experimental",
+            data_connector_name=_DATA_CONNECTOR_NAME,
             data_asset_name=self.name,
             batch_identifiers=IDDict(batch_request.options),
             batch_spec_passthrough=None,

--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -20,6 +20,7 @@ from typing_extensions import Literal, Protocol, Self
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
+from great_expectations.datasource.fluent.constants import _DATA_CONNECTOR_NAME
 from great_expectations.datasource.fluent.fluent_base_model import (
     FluentBaseModel,
 )
@@ -599,7 +600,7 @@ class _SQLAsset(DataAsset):
 
             batch_definition = BatchDefinition(
                 datasource_name=self.datasource.name,
-                data_connector_name="fluent_sql",
+                data_connector_name=_DATA_CONNECTOR_NAME,
                 data_asset_name=self.name,
                 batch_identifiers=IDDict(batch_spec["batch_identifiers"]),
                 batch_spec_passthrough=None,


### PR DESCRIPTION
Changes proposed in this pull request:
- GREAT-1719
- Replace fluent data connector names with a constant

### Definition of Done
- [X] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [X] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [X] I have run any local integration tests and made sure that nothing is broken.
