### PR TITLE
[MAINTENANCE] Apply ruff path rules for contrib

### DIFF
--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_exclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_exclusive_threshold_range.py
@@ -191,7 +191,7 @@ class ExpectProfileNumericColumnsDiffBetweenExclusiveThresholdRange(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_inclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_between_inclusive_threshold_range.py
@@ -193,7 +193,7 @@ class ExpectProfileNumericColumnsDiffBetweenInclusiveThresholdRange(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_or_equal_to_threshold.py
@@ -192,7 +192,7 @@ class ExpectProfileNumericColumnsDiffGreaterThanOrEqualToThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_greater_than_threshold.py
@@ -188,7 +188,7 @@ class ExpectProfileNumericColumnsDiffGreaterThanThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_or_equal_to_threshold.py
@@ -190,7 +190,7 @@ class ExpectProfileNumericColumnsDiffLessThanOrEqualToThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_diff_less_than_threshold.py
@@ -188,7 +188,7 @@ class ExpectProfileNumericColumnsDiffLessThanThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_exclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_exclusive_threshold_range.py
@@ -234,7 +234,7 @@ class ExpectProfileNumericColumnsPercentDiffBetweenExclusiveThresholdRange(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_inclusive_threshold_range.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_between_inclusive_threshold_range.py
@@ -232,7 +232,7 @@ class ExpectProfileNumericColumnsPercentDiffBetweenInclusiveThresholdRange(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_or_equal_to_threshold.py
@@ -229,7 +229,7 @@ class ExpectProfileNumericColumnsPercentDiffGreaterThanOrEqualToThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_greater_than_threshold.py
@@ -229,7 +229,7 @@ class ExpectProfileNumericColumnsPercentDiffGreaterThanThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_or_equal_to_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_or_equal_to_threshold.py
@@ -229,7 +229,7 @@ class ExpectProfileNumericColumnsPercentDiffLessThanOrEqualToThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_threshold.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/expectations/expect_profile_numeric_columns_percent_diff_less_than_threshold.py
@@ -229,7 +229,7 @@ class ExpectProfileNumericColumnsPercentDiffLessThanThreshold(
         "/example_profiles/expect_profile_diff_less_than_threshold_profile.pkl"
     )
 
-    dir_path = os.path.dirname(os.path.abspath(__file__))
+    dir_path = os.path.dirname(os.path.abspath(__file__))  # noqa: PTH120, PTH100
     profile_path = dir_path + profile_path
 
     example_profile.save(filepath=profile_path)

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/conftest.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/conftest.py
@@ -3,7 +3,7 @@ import sys
 
 from great_expectations.self_check.util import build_test_backends_list
 
-sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath("../.."))  # noqa: PTH100
 
 
 def pytest_addoption(parser):

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/expectations/metrics/test_core.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/expectations/metrics/test_core.py
@@ -8,8 +8,8 @@ from great_expectations.self_check.util import build_pandas_engine
 from great_expectations.validator.metric_configuration import MetricConfiguration
 from tests.expectations.test_util import get_table_columns_metric
 
-test_root_path = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+test_root_path = os.path.dirname(  # noqa: PTH120
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))  # noqa: PTH120
 )
 
 
@@ -31,7 +31,7 @@ def test_data_profiler_column_profile_report_metric_pd():
         )
     )
 
-    profile_path = os.path.join(
+    profile_path = os.path.join(  # noqa: PTH118
         test_root_path,
         "data_profiler_files",
         "profile.pkl",

--- a/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
+++ b/contrib/capitalone_dataprofiler_expectations/capitalone_dataprofiler_expectations/tests/rule_based_profiler/data_assistant/test_data_profiler_structured_data_assistant.py
@@ -27,8 +27,8 @@ from great_expectations.rule_based_profiler.parameter_container import (
 
 # noinspection PyUnresolvedReferences
 
-test_root_path = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+test_root_path = os.path.dirname(  # noqa: PTH120
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))  # noqa: PTH120
 )
 
 
@@ -54,7 +54,7 @@ def bobby_profile_data_profiler_structured_data_assistant_result_usage_stats_ena
     data_assistant_result: DataAssistantResult = context.assistants.data_profiler.run(
         batch_request=batch_request,
         numeric_rule={
-            "profile_path": os.path.join(
+            "profile_path": os.path.join(  # noqa: PTH118
                 test_root_path,
                 "data_profiler_files",
                 "profile.pkl",
@@ -91,7 +91,7 @@ def bobby_profile_data_profiler_structured_data_assistant_result(
         batch_request=batch_request,
         exclude_column_names=exclude_column_names,
         numeric_rule={
-            "profile_path": os.path.join(
+            "profile_path": os.path.join(  # noqa: PTH118
                 test_root_path,
                 "data_profiler_files",
                 "profile.pkl",

--- a/contrib/cli/great_expectations_contrib/cli.py
+++ b/contrib/cli/great_expectations_contrib/cli.py
@@ -12,7 +12,9 @@ from great_expectations_contrib.package import GreatExpectationsContribPackageMa
 
 # The following link points to the repo where the Cookiecutter template is hosted
 URL = "https://github.com/great-expectations/great-expectations-contrib-cookiecutter"
-PACKAGE_PATH = os.path.join(os.getcwd(), ".great_expectations_package.json")  # noqa: PTH118, PTH109
+PACKAGE_PATH = os.path.join(
+    os.getcwd(), ".great_expectations_package.json"
+)  # noqa: PTH118, PTH109
 
 
 @click.group()

--- a/contrib/cli/great_expectations_contrib/cli.py
+++ b/contrib/cli/great_expectations_contrib/cli.py
@@ -12,8 +12,8 @@ from great_expectations_contrib.package import GreatExpectationsContribPackageMa
 
 # The following link points to the repo where the Cookiecutter template is hosted
 URL = "https://github.com/great-expectations/great-expectations-contrib-cookiecutter"
-PACKAGE_PATH = os.path.join(
-    os.getcwd(), ".great_expectations_package.json"
+PACKAGE_PATH = os.path.join(  # noqa: PTH118
+    os.getcwd(), ".great_expectations_package.json"  # noqa: PTH109
 )  # noqa: PTH118, PTH109
 
 

--- a/contrib/cli/great_expectations_contrib/cli.py
+++ b/contrib/cli/great_expectations_contrib/cli.py
@@ -12,7 +12,7 @@ from great_expectations_contrib.package import GreatExpectationsContribPackageMa
 
 # The following link points to the repo where the Cookiecutter template is hosted
 URL = "https://github.com/great-expectations/great-expectations-contrib-cookiecutter"
-PACKAGE_PATH = os.path.join(os.getcwd(), ".great_expectations_package.json")
+PACKAGE_PATH = os.path.join(os.getcwd(), ".great_expectations_package.json")  # noqa: PTH118, PTH109
 
 
 @click.group()

--- a/contrib/cli/great_expectations_contrib/commands.py
+++ b/contrib/cli/great_expectations_contrib/commands.py
@@ -156,7 +156,7 @@ def read_package_from_file(path: str) -> GreatExpectationsContribPackageManifest
         A GreatExpectationsContribPackageManifest instance to represent the current package's state.
     """
     # If config file isn't found, create a blank JSON and write to disk
-    if not os.path.exists(path):
+    if not os.path.exists(path):  # noqa: PTH110
         instance = GreatExpectationsContribPackageManifest()
         logger.debug("Could not find existing package JSON; instantiated a new one")
         return instance

--- a/contrib/cli/great_expectations_contrib/package.py
+++ b/contrib/cli/great_expectations_contrib/package.py
@@ -120,7 +120,7 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
         self._update_contributors(diagnostics)
 
     def _update_from_package_info(self, path: str) -> None:
-        if not os.path.exists(path):
+        if not os.path.exists(path):  # noqa: PTH110
             logger.warning(f"Could not find package info file {path}")
             return
 
@@ -139,9 +139,9 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
                     # If the user has provided an icon, we need to check if it is a relative URL.
                     # If it is, we need to convert to the HTTPS path that will show up when merged into `develop`.
                     icon: Optional[str] = general.get(attr)
-                    if icon and os.path.exists(icon):
-                        package_name: str = os.path.basename(os.getcwd())
-                        url: str = os.path.join(
+                    if icon and os.path.exists(icon):  # noqa: PTH110
+                        package_name: str = os.path.basename(os.getcwd())  # noqa: PTH119, PTH109
+                        url: str = os.path.join(  # noqa: PTH118
                             "https://raw.githubusercontent.com/great-expectations/great_expectations/develop/contrib",
                             package_name,
                             icon,
@@ -169,9 +169,9 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
                 # If the user has provided a picture, we need to check if it is a relative URL.
                 # If it is, we need to convert to the HTTPS path that will show up when merged into `develop`.
                 picture_path: Optional[str] = expert.get("picture")
-                if picture_path and os.path.exists(picture_path):
-                    package_name: str = os.path.basename(os.getcwd())
-                    url: str = os.path.join(
+                if picture_path and os.path.exists(picture_path):  # noqa: PTH110
+                    package_name: str = os.path.basename(os.getcwd())  # noqa: PTH119, PTH109
+                    url: str = os.path.join(  # noqa: PTH118
                         "https://raw.githubusercontent.com/great-expectations/great_expectations/develop/contrib",
                         package_name,
                         picture_path,
@@ -203,7 +203,7 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
         self.maturity = Maturity[maturity]
 
     def _update_dependencies(self, path: str) -> None:
-        if not os.path.exists(path):
+        if not os.path.exists(path):  # noqa: PTH110
             logger.warning(f"Could not find requirements file {path}")
             return
 
@@ -266,7 +266,7 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
     def _identify_user_package() -> str:
         # Guaranteed to have a dir named '<MY_PACKAGE>_expectations' through Cookiecutter validation
         packages = [
-            d for d in os.listdir() if os.path.isdir(d) and d.endswith("_expectations")
+            d for d in os.listdir() if os.path.isdir(d) and d.endswith("_expectations")  # noqa: PTH112
         ]
 
         # A sanity check in case the user modifies the Cookiecutter template in unexpected ways
@@ -280,7 +280,7 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
     @staticmethod
     def _import_expectations_module(package: str) -> Any:
         # Need to add user's project to the PYTHONPATH
-        cwd = os.getcwd()
+        cwd = os.getcwd()  # noqa: PTH109
         sys.path.append(cwd)
         try:
             expectations_module = importlib.import_module(f"{package}.expectations")

--- a/contrib/cli/great_expectations_contrib/package.py
+++ b/contrib/cli/great_expectations_contrib/package.py
@@ -140,7 +140,9 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
                     # If it is, we need to convert to the HTTPS path that will show up when merged into `develop`.
                     icon: Optional[str] = general.get(attr)
                     if icon and os.path.exists(icon):  # noqa: PTH110
-                        package_name: str = os.path.basename(os.getcwd())  # noqa: PTH119, PTH109
+                        package_name: str = os.path.basename(
+                            os.getcwd()
+                        )  # noqa: PTH119, PTH109
                         url: str = os.path.join(  # noqa: PTH118
                             "https://raw.githubusercontent.com/great-expectations/great_expectations/develop/contrib",
                             package_name,
@@ -170,7 +172,9 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
                 # If it is, we need to convert to the HTTPS path that will show up when merged into `develop`.
                 picture_path: Optional[str] = expert.get("picture")
                 if picture_path and os.path.exists(picture_path):  # noqa: PTH110
-                    package_name: str = os.path.basename(os.getcwd())  # noqa: PTH119, PTH109
+                    package_name: str = os.path.basename(
+                        os.getcwd()
+                    )  # noqa: PTH119, PTH109
                     url: str = os.path.join(  # noqa: PTH118
                         "https://raw.githubusercontent.com/great-expectations/great_expectations/develop/contrib",
                         package_name,
@@ -266,7 +270,9 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
     def _identify_user_package() -> str:
         # Guaranteed to have a dir named '<MY_PACKAGE>_expectations' through Cookiecutter validation
         packages = [
-            d for d in os.listdir() if os.path.isdir(d) and d.endswith("_expectations")  # noqa: PTH112
+            d
+            for d in os.listdir()
+            if os.path.isdir(d) and d.endswith("_expectations")  # noqa: PTH112
         ]
 
         # A sanity check in case the user modifies the Cookiecutter template in unexpected ways

--- a/contrib/cli/great_expectations_contrib/package.py
+++ b/contrib/cli/great_expectations_contrib/package.py
@@ -140,8 +140,8 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
                     # If it is, we need to convert to the HTTPS path that will show up when merged into `develop`.
                     icon: Optional[str] = general.get(attr)
                     if icon and os.path.exists(icon):  # noqa: PTH110
-                        package_name: str = os.path.basename(
-                            os.getcwd()
+                        package_name: str = os.path.basename(  # noqa: PTH119
+                            os.getcwd()  # noqa: PTH109
                         )  # noqa: PTH119, PTH109
                         url: str = os.path.join(  # noqa: PTH118
                             "https://raw.githubusercontent.com/great-expectations/great_expectations/develop/contrib",
@@ -172,8 +172,8 @@ class GreatExpectationsContribPackageManifest(SerializableDictDot):
                 # If it is, we need to convert to the HTTPS path that will show up when merged into `develop`.
                 picture_path: Optional[str] = expert.get("picture")
                 if picture_path and os.path.exists(picture_path):  # noqa: PTH110
-                    package_name: str = os.path.basename(
-                        os.getcwd()
+                    package_name: str = os.path.basename(  # noqa: PTH119
+                        os.getcwd()  # noqa: PTH109
                     )  # noqa: PTH119, PTH109
                     url: str = os.path.join(  # noqa: PTH118
                         "https://raw.githubusercontent.com/great-expectations/great_expectations/develop/contrib",

--- a/contrib/experimental/great_expectations_experimental/expectations/__init__.py
+++ b/contrib/experimental/great_expectations_experimental/expectations/__init__.py
@@ -1,9 +1,9 @@
 import glob
 from os.path import basename, dirname, isfile, join
 
-modules = glob.glob(join(dirname(__file__), "*.py"))
+modules = glob.glob(join(dirname(__file__), "*.py"))  # noqa: PTH118, PTH120
 __all__ = [
-    basename(f)[:-3]
+    basename(f)[:-3]  # noqa: PTH119
     for f in modules
-    if isfile(f) is True and not f.endswith("__init__.py")
+    if isfile(f) is True and not f.endswith("__init__.py")  # noqa: PTH113
 ]

--- a/contrib/experimental/great_expectations_experimental/metrics/__init__.py
+++ b/contrib/experimental/great_expectations_experimental/metrics/__init__.py
@@ -1,9 +1,9 @@
 import glob
 from os.path import basename, dirname, isfile, join
 
-modules = glob.glob(join(dirname(__file__), "*.py"))
+modules = glob.glob(join(dirname(__file__), "*.py"))  # noqa: PTH118, PTH120
 __all__ = [
-    basename(f)[:-3]
+    basename(f)[:-3]  # noqa: PTH119
     for f in modules
-    if isfile(f) is True and not f.endswith("__init__.py")
+    if isfile(f) is True and not f.endswith("__init__.py")  # noqa: PTH113
 ]

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
@@ -419,7 +419,7 @@ def test_spark_happy_path_growth_numeric_data_assistant(
     data_context: gx.DataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
         __file__,
-        os.path.join(
+        os.path.join(  # noqa: PTH118
             "..", "..", "test_sets", "taxi_yellow_tripdata_samples"
         ),  # noqa: PTH118
     )

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
@@ -418,7 +418,10 @@ def test_spark_happy_path_growth_numeric_data_assistant(
     schema: StructType = spark_df_taxi_data_schema
     data_context: gx.DataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
-        __file__, os.path.join("..", "..", "test_sets", "taxi_yellow_tripdata_samples")  # noqa: PTH118
+        __file__,
+        os.path.join(
+            "..", "..", "test_sets", "taxi_yellow_tripdata_samples"
+        ),  # noqa: PTH118
     )
 
     datasource_config: dict = {

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_growth_numeric_data_assistant.py
@@ -308,7 +308,7 @@ def test_pandas_happy_path_growth_numeric_data_assistant(empty_data_context) -> 
     data_context: gx.DataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
         __file__,
-        os.path.join(
+        os.path.join(  # noqa: PTH118
             "..",
             "..",
             "..",
@@ -418,7 +418,7 @@ def test_spark_happy_path_growth_numeric_data_assistant(
     schema: StructType = spark_df_taxi_data_schema
     data_context: gx.DataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
-        __file__, os.path.join("..", "..", "test_sets", "taxi_yellow_tripdata_samples")
+        __file__, os.path.join("..", "..", "test_sets", "taxi_yellow_tripdata_samples")  # noqa: PTH118
     )
 
     datasource_config: dict = {

--- a/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_statistics_data_assistant.py
+++ b/contrib/experimental/great_expectations_experimental/tests/rule_based_profiler/data_assistant/test_statistics_data_assistant.py
@@ -233,7 +233,7 @@ def test_pandas_happy_path_statistics_data_assistant(empty_data_context) -> None
     data_context: gx.DataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
         __file__,
-        os.path.join(
+        os.path.join(  # noqa: PTH118
             "..",
             "..",
             "..",
@@ -380,7 +380,7 @@ def test_spark_happy_path_statistics_data_assistant(
     data_context: gx.DataContext = empty_data_context
     taxi_data_path: str = file_relative_path(
         __file__,
-        os.path.join(
+        os.path.join(  # noqa: PTH118
             "..",
             "..",
             "..",

--- a/contrib/experimental/great_expectations_experimental/tests/test_utils.py
+++ b/contrib/experimental/great_expectations_experimental/tests/test_utils.py
@@ -23,7 +23,7 @@ def load_data_into_postgres_database(sa):
     data_paths: List[str] = [
         file_relative_path(
             __file__,
-            os.path.join(
+            os.path.join(  # noqa: PTH118
                 "..",
                 "..",
                 "..",
@@ -74,7 +74,7 @@ def load_data_into_postgres_database(sa):
     data_paths: List[str] = [
         file_relative_path(
             __file__,
-            os.path.join(
+            os.path.join(  # noqa: PTH118
                 "..",
                 "..",
                 "..",

--- a/contrib/experimental/setup.py
+++ b/contrib/experimental/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), "./PACKAGE_VERSION")) as versionfile:
+with open(os.path.join(os.path.dirname(__file__), "./PACKAGE_VERSION")) as versionfile:  # noqa: PTH118, PTH120
     version = versionfile.read().strip()
 
 long_description = "Great Expectations community contributions package. (See https://github.com/great-expectations/great_expectations for full description)."

--- a/contrib/experimental/setup.py
+++ b/contrib/experimental/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 
 with open(
-    os.path.join(os.path.dirname(__file__), "./PACKAGE_VERSION")
+    os.path.join(os.path.dirname(__file__), "./PACKAGE_VERSION")  # noqa: PTH118, PTH120
 ) as versionfile:  # noqa: PTH118, PTH120
     version = versionfile.read().strip()
 

--- a/contrib/experimental/setup.py
+++ b/contrib/experimental/setup.py
@@ -2,7 +2,9 @@ import os
 
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), "./PACKAGE_VERSION")) as versionfile:  # noqa: PTH118, PTH120
+with open(
+    os.path.join(os.path.dirname(__file__), "./PACKAGE_VERSION")
+) as versionfile:  # noqa: PTH118, PTH120
     version = versionfile.read().strip()
 
 long_description = "Great Expectations community contributions package. (See https://github.com/great-expectations/great_expectations for full description)."

--- a/contrib/ruff.toml
+++ b/contrib/ruff.toml
@@ -7,8 +7,6 @@ extend-ignore = [
     # https://github.com/charliermarsh/ruff#flake8-type-checking-tch
     # This is likely to be a high-touch rule that most contribs don't need to care about.
     "TCH001",
-    # https://beta.ruff.rs/docs/rules/#flake8-use-pathlib-pth
-    "PTH",
 ]
 
 [isort]

--- a/contrib/time_series_expectations/assets/generate_test_time_series_data.py
+++ b/contrib/time_series_expectations/assets/generate_test_time_series_data.py
@@ -45,7 +45,7 @@ def generate_time_series_data_and_plot(
     )
 
     df.to_csv(
-        os.path.join(
+        os.path.join(  # noqa: PTH118
             file_relative_path(__file__, "data"), f"{filename}.csv"
         ),  # noqa: PTH118
         index=None,
@@ -53,7 +53,7 @@ def generate_time_series_data_and_plot(
 
     plt.plot(df.y)
     plt.savefig(
-        os.path.join(
+        os.path.join(  # noqa: PTH118
             file_relative_path(__file__, "pics"), f"{filename}.png"
         ),  # noqa: PTH118
     )

--- a/contrib/time_series_expectations/assets/generate_test_time_series_data.py
+++ b/contrib/time_series_expectations/assets/generate_test_time_series_data.py
@@ -45,13 +45,13 @@ def generate_time_series_data_and_plot(
     )
 
     df.to_csv(
-        os.path.join(file_relative_path(__file__, "data"), f"{filename}.csv"),
+        os.path.join(file_relative_path(__file__, "data"), f"{filename}.csv"),  # noqa: PTH118
         index=None,
     )
 
     plt.plot(df.y)
     plt.savefig(
-        os.path.join(file_relative_path(__file__, "pics"), f"{filename}.png"),
+        os.path.join(file_relative_path(__file__, "pics"), f"{filename}.png"),  # noqa: PTH118
     )
     plt.clf()
 

--- a/contrib/time_series_expectations/assets/generate_test_time_series_data.py
+++ b/contrib/time_series_expectations/assets/generate_test_time_series_data.py
@@ -45,13 +45,17 @@ def generate_time_series_data_and_plot(
     )
 
     df.to_csv(
-        os.path.join(file_relative_path(__file__, "data"), f"{filename}.csv"),  # noqa: PTH118
+        os.path.join(
+            file_relative_path(__file__, "data"), f"{filename}.csv"
+        ),  # noqa: PTH118
         index=None,
     )
 
     plt.plot(df.y)
     plt.savefig(
-        os.path.join(file_relative_path(__file__, "pics"), f"{filename}.png"),  # noqa: PTH118
+        os.path.join(
+            file_relative_path(__file__, "pics"), f"{filename}.png"
+        ),  # noqa: PTH118
     )
     plt.clf()
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Apply ruff path rules also to the contrib/ folder. Ignore existing errors, but put this folder under test to avoid new errors creeping in.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have run any local integration tests and made sure that nothing is broken.