### PR TITLE
[BUGFIX] Correct a typographical error in specific path-forming template name for SparkDatasource-Microsoft Azure Blob Storage combination

### DIFF
--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -161,7 +161,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
             container=container,
             name_starts_with=name_starts_with,
             delimiter=delimiter,
-            file_path_template_map_fn=AzureUrl.AZURE_BLOB_STORAGE_HTTPS_URL_TEMPLATE.format,
+            file_path_template_map_fn=AzureUrl.AZURE_BLOB_STORAGE_WASBS_URL_TEMPLATE.format,
         )
         asset._test_connection_error_message = (
             AzureBlobStorageDataConnector.build_test_connection_error_message(


### PR DESCRIPTION
### Scope
Fix typo in specific path-forming template name for `SparkDatasource`-`Microsoft Azure Blob Storage` combination.

### Notes
Only integration or user-acceptance (UAT) test can exercise the functionality involved (specifically, UAT helped identify the issue).

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE],  [DOCS], or [MAINTENANCE]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1462/GREAT-1692/GREAT-1690/GREAT-1691/GREAT-1619
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in github issues or slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!