### PR TITLE
[DOCS] Fix unsupported chars in API docs

### DIFF
--- a/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
@@ -140,7 +140,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -196,7 +196,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -252,7 +252,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -308,7 +308,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_azure_blob_storage_datasource.py
@@ -140,7 +140,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -196,7 +196,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -252,7 +252,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -308,7 +308,7 @@ class PandasAzureBlobStorageDatasource(_PandasFilePathDatasource):
             container: container name for Microsoft Azure Blob Storage
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -72,7 +72,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the CSV asset
             batching_regex: regex pattern that matches CSV filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "{+/-} key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/-  key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -118,7 +118,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the Excel asset
             batching_regex: regex pattern that matches Excel filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_excel`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -166,7 +166,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the JSON asset
             batching_regex: regex pattern that matches JSON filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_json`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -214,7 +214,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the Parquet asset
             batching_regex: regex pattern that matches Parquet filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_parquet`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_filesystem_datasource.py
@@ -72,7 +72,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the CSV asset
             batching_regex: regex pattern that matches CSV filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "+|- key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-} key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -118,7 +118,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the Excel asset
             batching_regex: regex pattern that matches Excel filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_excel`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -166,7 +166,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the JSON asset
             batching_regex: regex pattern that matches JSON filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_json`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -214,7 +214,7 @@ class PandasFilesystemDatasource(_PandasFilePathDatasource):
             name: The name of the Parquet asset
             batching_regex: regex pattern that matches Parquet filenames that is used to label the batches
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_parquet`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
@@ -145,7 +145,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -200,7 +200,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_excel`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -253,7 +253,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_json`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -306,7 +306,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_parquet`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_google_cloud_storage_datasource.py
@@ -145,7 +145,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -200,7 +200,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_excel`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -253,7 +253,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_json`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -306,7 +306,7 @@ class PandasGoogleCloudStorageDatasource(_PandasFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_parquet`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/pandas_s3_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_s3_datasource.py
@@ -119,7 +119,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -172,7 +172,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 object name max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_excel`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -225,7 +225,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 object name max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_json`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -278,7 +278,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 object name max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_parquet`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/pandas_s3_datasource.py
+++ b/great_expectations/datasource/fluent/pandas_s3_datasource.py
@@ -119,7 +119,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_csv`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -172,7 +172,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 object name max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_excel`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -225,7 +225,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 object name max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_json`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
@@ -278,7 +278,7 @@ class PandasS3Datasource(_PandasFilePathDatasource):
             prefix: S3 object name prefix
             delimiter: S3 object name delimiter
             max_keys: S3 object name max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
             kwargs: Extra keyword arguments should correspond to ``pandas.read_parquet`` keyword args
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -139,7 +139,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
             infer_schema: boolean (default False) instructing Spark to attempt to infer schema of CSV file heuristically
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex

--- a/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_azure_blob_storage_datasource.py
@@ -139,7 +139,7 @@ class SparkAzureBlobStorageDatasource(_SparkFilePathDatasource):
             infer_schema: boolean (default False) instructing Spark to attempt to infer schema of CSV file heuristically
             name_starts_with: Microsoft Azure Blob Storage object name prefix
             delimiter: Microsoft Azure Blob Storage object name delimiter
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex

--- a/great_expectations/datasource/fluent/spark_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/spark_filesystem_datasource.py
@@ -69,7 +69,7 @@ class SparkFilesystemDatasource(_SparkFilePathDatasource):
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
             header: boolean (default False) indicating whether or not first line of CSV file is header line
             infer_schema: boolean (default False) instructing Spark to attempt to infer schema of CSV file heuristically
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex

--- a/great_expectations/datasource/fluent/spark_filesystem_datasource.py
+++ b/great_expectations/datasource/fluent/spark_filesystem_datasource.py
@@ -69,7 +69,7 @@ class SparkFilesystemDatasource(_SparkFilePathDatasource):
             glob_directive: glob for selecting files in directory (defaults to `**/*`) or nested directories (e.g. `*/*/*.csv`)
             header: boolean (default False) indicating whether or not first line of CSV file is header line
             infer_schema: boolean (default False) instructing Spark to attempt to infer schema of CSV file heuristically
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex

--- a/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
@@ -144,7 +144,7 @@ class SparkGoogleCloudStorageDatasource(_SparkFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex

--- a/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
+++ b/great_expectations/datasource/fluent/spark_google_cloud_storage_datasource.py
@@ -144,7 +144,7 @@ class SparkGoogleCloudStorageDatasource(_SparkFilePathDatasource):
             prefix (str): Google Cloud Storage object name prefix
             delimiter (str): Google Cloud Storage object name delimiter
             max_results (int): Google Cloud Storage max_results (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex

--- a/great_expectations/datasource/fluent/spark_s3_datasource.py
+++ b/great_expectations/datasource/fluent/spark_s3_datasource.py
@@ -118,7 +118,7 @@ class SparkS3Datasource(_SparkFilePathDatasource):
             prefix: S3 prefix
             delimiter: S3 delimiter
             max_keys: S3 max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "+/- key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex

--- a/great_expectations/datasource/fluent/spark_s3_datasource.py
+++ b/great_expectations/datasource/fluent/spark_s3_datasource.py
@@ -118,7 +118,7 @@ class SparkS3Datasource(_SparkFilePathDatasource):
             prefix: S3 prefix
             delimiter: S3 delimiter
             max_keys: S3 max_keys (default is 1000)
-            order_by: sorting directive via either list[Sorter] or "{+|-}key" syntax: +/- (a/de)scending; + default
+            order_by: sorting directive via either list[Sorter] or "{+/-}key" syntax: +/- (a/de)scending; + default
         """
         batching_regex_pattern: re.Pattern = self.parse_batching_regex_string(
             batching_regex=batching_regex


### PR DESCRIPTION
Changes proposed in this pull request:
- `|`, `{`, `}` characters are not currently supported in docstring parameters.

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code