### PR TITLE
Add crud methods to context.sources

### DIFF
--- a/docs/sphinx_api_docs_source/public_api_report.py
+++ b/docs/sphinx_api_docs_source/public_api_report.py
@@ -1843,7 +1843,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 97  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
+    PUBLIC_API_MISSING_THRESHOLD = 99  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
     if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/great_expectations/data_context/data_context/abstract_data_context.py
+++ b/great_expectations/data_context/data_context/abstract_data_context.py
@@ -701,7 +701,7 @@ class AbstractDataContext(ConfigPeer, ABC):
     def sources(self) -> _SourceFactories:
         return self._sources
 
-    def _attach_datasource_to_context(self, datasource: FluentDatasource):
+    def _add_fluent_datasource(self, datasource: FluentDatasource) -> None:
         # We currently don't allow one to overwrite a datasource with this internal method
         if datasource.name in self.datasources:
             raise gx_exceptions.DataContextError(
@@ -709,6 +709,12 @@ class AbstractDataContext(ConfigPeer, ABC):
                 "name already exists in the data context."
             )
         self.datasources[datasource.name] = datasource
+
+    def _update_fluent_datasource(self, datasource: FluentDatasource) -> None:
+        self.datasources[datasource.name] = datasource
+
+    def _delete_fluent_datasource(self, datasource_name: str) -> None:
+        self.datasources.pop(datasource_name, None)
 
     def set_config(self, project_config: DataContextConfig) -> None:
         self._project_config = project_config
@@ -5446,7 +5452,7 @@ Generated, evaluated, and stored {total_expectations} Expectations during profil
         """Called at end of __init__"""
         for ds_name, datasource in config.datasources.items():
             logger.info(f"Loaded '{ds_name}' from fluent config")
-            self._attach_datasource_to_context(datasource)
+            self._add_fluent_datasource(datasource)
 
     def _synchronize_fluent_datasources(self) -> Dict[str, FluentDatasource]:
         """

--- a/great_expectations/datasource/fluent/metadatasource.py
+++ b/great_expectations/datasource/fluent/metadatasource.py
@@ -5,17 +5,12 @@ from __future__ import annotations
 
 import logging
 from pprint import pformat as pf
-from typing import TYPE_CHECKING, Set, Type
+from typing import Set, Type
 
 import pydantic
 
-from great_expectations.datasource.fluent.signatures import _merge_signatures
 from great_expectations.datasource.fluent.sources import _SourceFactories
 from great_expectations.datasource.fluent.type_lookup import TypeLookup
-
-if TYPE_CHECKING:
-    from great_expectations.datasource.fluent.interfaces import Datasource
-
 
 logger = logging.getLogger(__name__)
 
@@ -48,27 +43,11 @@ class MetaDatasource(pydantic.main.ModelMetaclass):
         meta_cls.__cls_set.add(cls)
         logger.debug(f"Datasources: {len(meta_cls.__cls_set)}")
 
-        def _datasource_factory(name: str, **kwargs) -> Datasource:
-            logger.debug(f"5. Adding '{name}' {cls_name}")
-            datasource = cls(name=name, **kwargs)
-            datasource.test_connection()
-            return datasource
-
-        _datasource_factory.__doc__ = cls.__doc__
-
-        # TODO: generate schemas from `cls` if needed
-
         if cls.__module__ == "__main__":
             logger.warning(
                 f"Datasource `{cls_name}` should not be defined as part of __main__ this may cause typing lookup collisions"
             )
         # instantiate new TypeLookup to prevent child classes conflicts with parent class asset types
         cls._type_lookup = TypeLookup()
-        _SourceFactories.register_types_and_ds_factory(cls, _datasource_factory)
-
-        # attr-defined issue
-        # https://github.com/python/mypy/issues/12472
-        _datasource_factory.__signature__ = _merge_signatures(  # type: ignore[attr-defined]
-            _datasource_factory, cls, exclude={"type", "assets"}, return_type=cls
-        )
+        _SourceFactories.register_datasource(cls)
         return cls

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -64,6 +65,13 @@ def _get_field_details(
     )
 
 
+class CrudMethodType(str, Enum):
+    ADD = "ADD"
+    DELETE = "DELETE"
+    UPDATE = "UPDATE"
+    ADD_OR_UPDATE = "ADD_OR_UPDATE"
+
+
 class _SourceFactories:
     """
     Contains a collection of datasource factory methods in the format `.add_<TYPE_NAME>()`
@@ -74,7 +82,7 @@ class _SourceFactories:
 
     # TODO (kilo59): split DataAsset & Datasource lookups
     type_lookup: ClassVar = TypeLookup()
-    __source_factories: ClassVar[Dict[str, SourceFactoryFn]] = {}
+    __crud_registry: ClassVar[Dict[str, SourceFactoryFn]] = {}
 
     _data_context: GXDataContext
 
@@ -82,14 +90,11 @@ class _SourceFactories:
         self._data_context = data_context
 
     @classmethod
-    def register_types_and_ds_factory(
-        cls,
-        ds_type: Type[Datasource],
-        factory_fn: SourceFactoryFn,
-    ) -> None:
+    def register_datasource(cls, ds_type: Type[Datasource]) -> None:
         """
-        Add/Register a datasource factory function and all related `Datasource`,
-        `DataAsset` and `ExecutionEngine` types.
+        Add/Register a datasource. This registers all the crud datasource methods:
+        add_<datasource>, delete_<datasource>, update_<datasource>, add_or_update_<datasource>
+        and all related `Datasource`, `DataAsset` and `ExecutionEngine` types.
 
         Creates mapping table between the `DataSource`/`DataAsset` classes and their
         declared `type` string.
@@ -118,18 +123,16 @@ class _SourceFactories:
 
             cls._register_assets(ds_type, asset_type_lookup=asset_type_lookup)
 
-            cls._register_datasource_and_factory_method(
+            cls._register_datasource(
                 ds_type,
-                factory_fn=factory_fn,
                 ds_type_name=ds_type_name,
                 datasource_type_lookup=ds_type_lookup,
             )
 
     @classmethod
-    def _register_datasource_and_factory_method(
+    def _register_datasource(
         cls,
         ds_type: Type[Datasource],
-        factory_fn: SourceFactoryFn,
         ds_type_name: str,
         datasource_type_lookup: TypeLookup,
     ) -> str:
@@ -137,24 +140,83 @@ class _SourceFactories:
         Register the `Datasource` class and add a factory method for the class on `sources`.
         The method name is pulled from the `Datasource.type` attribute.
         """
-        method_name = f"add_{ds_type_name}"
-        logger.debug(
-            f"2a. Registering {ds_type.__name__} as {ds_type_name} with {method_name}() factory"
-        )
-
-        pre_existing = cls.__source_factories.get(method_name)
-        if pre_existing:
+        if ds_type in datasource_type_lookup:
             raise TypeRegistrationError(
-                f"'{ds_type_name}' - `sources.{method_name}()` factory already exists",
+                f"'{ds_type_name}' is already a registered typed and there can only be 1 type "
+                "for a given name."
             )
-
         datasource_type_lookup[ds_type] = ds_type_name
         logger.debug(f"'{ds_type_name}' added to `type_lookup`")
-        factory_fn.__name__ = method_name
-        public_api(factory_fn)
 
-        cls.__source_factories[method_name] = factory_fn
+        cls._register_add_datasource(ds_type, ds_type_name)
+        cls._register_update_datasource(ds_type, ds_type_name)
+        cls._register_add_or_update_datasource(ds_type, ds_type_name)
+        cls._register_delete_datasource(ds_type, ds_type_name)
+
         return ds_type_name
+
+    @classmethod
+    def _register_add_datasource(cls, ds_type: Type[Datasource], ds_type_name: str):
+        method_name = f"add_{ds_type_name}"
+
+        def crud_method_info() -> tuple[CrudMethodType, Type[Datasource]]:
+            return CrudMethodType.ADD, ds_type
+
+        cls._register_crud_method(method_name, cls.__doc__, crud_method_info)
+
+    @classmethod
+    def _register_update_datasource(cls, ds_type: Type[Datasource], ds_type_name: str):
+        method_name = f"update_{ds_type_name}"
+
+        def crud_method_info() -> tuple[CrudMethodType, Type[Datasource]]:
+            return CrudMethodType.UPDATE, ds_type
+
+        cls._register_crud_method(
+            method_name, f"Updates a {ds_type_name} data source.", crud_method_info
+        )
+
+    @classmethod
+    def _register_add_or_update_datasource(
+        cls, ds_type: Type[Datasource], ds_type_name: str
+    ):
+        method_name = f"add_or_update_{ds_type_name}"
+
+        def crud_method_info() -> tuple[CrudMethodType, Type[Datasource], str]:
+            return CrudMethodType.ADD_OR_UPDATE, ds_type
+
+        cls._register_crud_method(
+            method_name,
+            f"Adds or updates a {ds_type_name} data source.",
+            crud_method_info,
+        )
+
+    @classmethod
+    def _register_delete_datasource(cls, ds_type: Type[Datasource], ds_type_name: str):
+        method_name = f"delete_{ds_type_name}"
+
+        def crud_method_info() -> tuple[CrudMethodType, Type[Datasource], str]:
+            return CrudMethodType.DELETE, ds_type
+
+        cls._register_crud_method(
+            method_name, f"Deletes a {ds_type_name} data source.", crud_method_info
+        )
+
+    @classmethod
+    def _register_crud_method(
+        cls, crud_fn_name: str, crud_fn_doc: str, crud_method_info: SourceFactoryFn
+    ):
+        # We set the name and doc and the crud_method_info because that will be used as a proxy
+        # for the real crud method so we can call public_api to generate docs for these dynamically
+        # generated methods.
+        crud_method_info.__name__ = crud_fn_name
+        crud_method_info.__doc__ = crud_fn_doc
+        if crud_fn_name in cls.__crud_registry:
+            raise TypeRegistrationError(
+                f"'`sources.{crud_fn_name}()` already exists",
+            )
+        logger.debug(f"2a. Registering data_context.source.{crud_fn_name}()")
+        public_api(crud_method_info)
+        cls.__crud_registry[crud_fn_name] = crud_method_info
 
     @classmethod
     def _register_assets(cls, ds_type: Type[Datasource], asset_type_lookup: TypeLookup):
@@ -268,29 +330,130 @@ class _SourceFactories:
 
     @property
     def factories(self) -> List[str]:
-        return list(self.__source_factories.keys())
+        return list(self.__crud_registry.keys())
+
+    def _validate_datasource_type(
+        self, name: str, datasource_type: Type[Datasource], raise_if_none: bool = True
+    ) -> None:
+        try:
+            old_datasource = self._data_context.get_datasource(name)
+        except ValueError as e:
+            if raise_if_none:
+                raise ValueError(
+                    f"There is no datasource {name} in the data context."
+                ) from e
+            old_datasource = None
+        if old_datasource and not isinstance(old_datasource, datasource_type):
+            raise ValueError(
+                f"Trying to update datasource {name} but it is not the correct type. "
+                f"Expected {datasource_type} but got {type(old_datasource)}"
+            )
+
+    def create_add_crud_method(
+        self,
+        datasource_type: Type[Datasource],
+        doc_string: str = "",
+    ) -> SourceFactoryFn:
+        def add_datasource(name: str, **kwargs) -> Datasource:
+            logger.debug(f"Adding {datasource_type} with {name}")
+            datasource = datasource_type(name=name, **kwargs)
+            # config provider needed for config substitution
+            # datasource._config_provider = self._data_context.config_provider
+            # using try/except because hasattr will fail to find pydantic PrivateAttrs
+            # also datasource._data_context is not defined on a generic datasource
+            try:
+                datasource._data_context = self._data_context
+            except ValueError:
+                logger.debug(
+                    f'Failed to attach data context to datasource "{name}" because {datasource} has no attribute "_data_context".'
+                )
+                pass
+            datasource.test_connection()
+            self._data_context._add_fluent_datasource(datasource)
+            self._data_context._save_project_config()
+            return datasource
+
+        add_datasource.__doc__ = doc_string
+        add_datasource.__signature__ = _merge_signatures(
+            add_datasource,
+            datasource_type,
+            exclude={"type", "assets"},
+            return_type=datasource_type,
+        )
+        return add_datasource
+
+    def create_update_crud_method(
+        self,
+        datasource_type: Type[Datasource],
+        doc_string: str = "",
+    ) -> SourceFactoryFn:
+        def update_datasource(name: str, **kwargs) -> Datasource:
+            logger.debug(f"Updating {datasource_type} with {name}")
+            self._validate_datasource_type(name, datasource_type)
+            self._data_context._delete_fluent_datasource(datasource_name=name)
+            return self.create_add_crud_method(datasource_type)(name=name, **kwargs)
+
+        update_datasource.__doc__ = doc_string
+        # TODO: update signature
+        return update_datasource
+
+    def create_add_or_update_crud_method(
+        self,
+        datasource_type: Type[Datasource],
+        doc_string: str = "",
+    ) -> SourceFactoryFn:
+        def add_or_update_datasource(name: str, **kwargs) -> Datasource:
+            logger.debug(f"Adding or updating {datasource_type} with {name}")
+            self._validate_datasource_type(name, datasource_type, raise_if_none=False)
+            self._data_context._delete_fluent_datasource(datasource_name=name)
+            return self.create_add_crud_method(datasource_type)(name=name, **kwargs)
+
+        add_or_update_datasource.__doc__ = doc_string
+        # TODO: update signature
+        return add_or_update_datasource
+
+    def create_delete_crud_method(
+        self,
+        datasource_type: Type[Datasource],
+        doc_string: str = "",
+    ) -> Callable[[str], None]:
+        def delete_datasource(name: str) -> None:
+            logger.debug(f"Delete {datasource_type} with {name}")
+            self._validate_datasource_type(name, datasource_type)
+            self._data_context._delete_fluent_datasource(datasource_name=name)
+
+        delete_datasource.__doc__ = doc_string
+        # TODO: update signature
+        return delete_datasource
 
     def __getattr__(self, attr_name: str):
         try:
-            ds_constructor = self.__source_factories[attr_name]
-        except KeyError:
-            raise AttributeError(f"No factory {attr_name} in {self.factories}")
-
-        def wrapped(name: str, **kwargs):
-            datasource = ds_constructor(name=name, **kwargs)
-            datasource._data_context = self._data_context
-
-            # config provider needed for config substitution
-            datasource._config_provider = self._data_context.config_provider
-
-            # TODO (bdirks): _attach_datasource_to_context to the AbstractDataContext class
-            self._data_context._attach_datasource_to_context(datasource)
-            return datasource
-
-        wrapped.__doc__ = ds_constructor.__doc__
-        # attr-defined issue https://github.com/python/mypy/issues/12472
-        wrapped.__signature__ = ds_constructor.__signature__  # type: ignore[attr-defined]
-        return wrapped
+            crud_method_info = self.__crud_registry[attr_name]
+            crud_method_type, datasource_type = crud_method_info()
+            if crud_method_type == CrudMethodType.ADD:
+                return self.create_add_crud_method(
+                    datasource_type, crud_method_info.__doc__
+                )
+            elif crud_method_type == CrudMethodType.UPDATE:
+                return self.create_update_crud_method(
+                    datasource_type, crud_method_info.__doc__
+                )
+            elif crud_method_type == CrudMethodType.ADD_OR_UPDATE:
+                return self.create_add_or_update_crud_method(
+                    datasource_type, crud_method_info.__doc__
+                )
+            elif crud_method_type == CrudMethodType.DELETE:
+                return self.create_delete_crud_method(
+                    datasource_type, crud_method_info.__doc__
+                )
+            else:
+                raise TypeRegistrationError(
+                    f"Unknown crud method registered for {attr_name} with type {crud_method_type}"
+                )
+        except KeyError as e:
+            raise AttributeError(
+                f"No crud method '{attr_name}' in {self.factories}"
+            ) from e
 
     def __dir__(self) -> List[str]:
         """Preserves autocompletion for dynamic attributes."""

--- a/great_expectations/datasource/fluent/sources.py
+++ b/great_expectations/datasource/fluent/sources.py
@@ -214,7 +214,7 @@ class _SourceFactories:
             raise TypeRegistrationError(
                 f"'`sources.{crud_fn_name}()` already exists",
             )
-        logger.debug(f"2a. Registering data_context.source.{crud_fn_name}()")
+        logger.debug(f"Registering data_context.source.{crud_fn_name}()")
         public_api(crud_method_info)
         cls.__crud_registry[crud_fn_name] = crud_method_info
 
@@ -240,7 +240,7 @@ class _SourceFactories:
                         f"{t.__name__} `type` field must be assigned and cannot be `None`"
                     )
                 logger.debug(
-                    f"2b. Registering `{ds_type.__name__}` `DataAsset` `{t.__name__}` as '{asset_type_name}'"
+                    f"Registering `{ds_type.__name__}` `DataAsset` `{t.__name__}` as '{asset_type_name}'"
                 )
                 asset_type_lookup[t] = asset_type_name
             except (AttributeError, KeyError, TypeError) as bad_field_exc:
@@ -357,17 +357,9 @@ class _SourceFactories:
         def add_datasource(name: str, **kwargs) -> Datasource:
             logger.debug(f"Adding {datasource_type} with {name}")
             datasource = datasource_type(name=name, **kwargs)
+            datasource._data_context = self._data_context
             # config provider needed for config substitution
-            # datasource._config_provider = self._data_context.config_provider
-            # using try/except because hasattr will fail to find pydantic PrivateAttrs
-            # also datasource._data_context is not defined on a generic datasource
-            try:
-                datasource._data_context = self._data_context
-            except ValueError:
-                logger.debug(
-                    f'Failed to attach data context to datasource "{name}" because {datasource} has no attribute "_data_context".'
-                )
-                pass
+            datasource._config_provider = self._data_context.config_provider
             datasource.test_connection()
             self._data_context._add_fluent_datasource(datasource)
             self._data_context._save_project_config()

--- a/great_expectations/datasource/fluent/sources.pyi
+++ b/great_expectations/datasource/fluent/sources.pyi
@@ -64,8 +64,9 @@ class _SourceFactories:
     type_lookup: ClassVar
     def __init__(self, data_context: GXDataContext) -> None: ...
     @classmethod
-    def register_types_and_ds_factory(
-        cls, ds_type: Type[Datasource], factory_fn: SourceFactoryFn
+    def register_datasource(
+        cls,
+        ds_type: Type[Datasource],
     ) -> None: ...
     @property
     def pandas_default(self) -> PandasDatasource: ...

--- a/tests/datasource/fluent/conftest.py
+++ b/tests/datasource/fluent/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import pathlib
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, List, Type, Union
 
@@ -12,6 +13,7 @@ from great_expectations.core.batch_spec import (
     BatchMarkers,
     SqlAlchemyDatasourceBatchSpec,
 )
+from great_expectations.data_context import FileDataContext
 from great_expectations.datasource.fluent.interfaces import Datasource
 from great_expectations.datasource.fluent.sources import _SourceFactories
 from great_expectations.execution_engine import (
@@ -132,3 +134,19 @@ def inject_engine_lookup_double(
     finally:
         for source, engine in original_engine_override.items():
             source.execution_engine_override = engine
+
+
+@pytest.fixture
+def file_dc_config_dir_init(tmp_path: pathlib.Path) -> pathlib.Path:
+    """
+    Initialize an regular/old-style FileDataContext project config directory.
+    Removed on teardown.
+    """
+    gx_yml = tmp_path / FileDataContext.GX_DIR / FileDataContext.GX_YML
+    assert gx_yml.exists() is False
+    FileDataContext.create(tmp_path)
+    assert gx_yml.exists()
+
+    tmp_gx_dir = gx_yml.parent.absolute()
+    logger.info(f"tmp_gx_dir -> {tmp_gx_dir}")
+    return tmp_gx_dir

--- a/tests/datasource/fluent/test_metadatasource.py
+++ b/tests/datasource/fluent/test_metadatasource.py
@@ -5,12 +5,13 @@ import inspect
 import logging
 import pathlib
 from pprint import pformat as pf
-from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Type, Union, Tuple
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Tuple, Type, Union
 
 import pytest
+import ruamel.yaml
 from pydantic import DirectoryPath, validate_arguments
 
-from great_expectations.data_context import FileDataContext, AbstractDataContext
+from great_expectations.data_context import AbstractDataContext, FileDataContext
 from great_expectations.datasource.fluent.config import GxConfig
 from great_expectations.datasource.fluent.interfaces import (
     BatchRequest,
@@ -24,7 +25,6 @@ from great_expectations.datasource.fluent.sources import (
     _SourceFactories,
 )
 from great_expectations.execution_engine import ExecutionEngine
-import ruamel.yaml
 from great_expectations.util import get_context as get_gx_context
 
 if TYPE_CHECKING:

--- a/tests/datasource/fluent/test_metadatasource.py
+++ b/tests/datasource/fluent/test_metadatasource.py
@@ -75,8 +75,8 @@ class DataContext:
         self._sources: _SourceFactories = _SourceFactories(self)
         self._datasources: Dict[str, Datasource] = {}
         self.config_provider: _ConfigurationProvider | None = None
-        logger.info(f"4a. Available Factories - {self._sources.factories}")
-        logger.debug(f"4b. `type_lookup` mapping ->\n{pf(self._sources.type_lookup)}")
+        logger.info(f"Available Factories - {self._sources.factories}")
+        logger.debug(f"`type_lookup` mapping ->\n{pf(self._sources.type_lookup)}")
 
     @property
     def sources(self) -> _SourceFactories:
@@ -103,7 +103,7 @@ def get_context(
     context_root_dir: Optional[DirectoryPath] = None, **kwargs
 ) -> DataContext:
     """Experimental get_context placeholder function."""
-    logger.info(f"3. Getting context {context_root_dir or ''}")
+    logger.info(f"Getting context {context_root_dir or ''}")
     context = DataContext.get_context(context_root_dir=context_root_dir, **kwargs)
     return context
 

--- a/tests/datasource/fluent/test_metadatasource.py
+++ b/tests/datasource/fluent/test_metadatasource.py
@@ -5,11 +5,12 @@ import inspect
 import logging
 import pathlib
 from pprint import pformat as pf
-from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Type, Union, Tuple
 
 import pytest
 from pydantic import DirectoryPath, validate_arguments
 
+from great_expectations.data_context import FileDataContext, AbstractDataContext
 from great_expectations.datasource.fluent.config import GxConfig
 from great_expectations.datasource.fluent.interfaces import (
     BatchRequest,
@@ -23,6 +24,8 @@ from great_expectations.datasource.fluent.sources import (
     _SourceFactories,
 )
 from great_expectations.execution_engine import ExecutionEngine
+import ruamel.yaml
+from great_expectations.util import get_context as get_gx_context
 
 if TYPE_CHECKING:
     from great_expectations.core.config_provider import _ConfigurationProvider
@@ -61,7 +64,7 @@ class DataContext:
             cls._config = GxConfig.parse_yaml(config_path)
             for ds_name, datasource in cls._config.datasources.items():
                 logger.info(f"Loaded '{ds_name}' from config")
-                cls._context._attach_datasource_to_context(datasource)
+                cls._context._add_fluent_datasource(datasource)
                 # TODO: add assets?
 
         return cls._context
@@ -79,7 +82,7 @@ class DataContext:
     def sources(self) -> _SourceFactories:
         return self._sources
 
-    def _attach_datasource_to_context(self, datasource: Datasource) -> None:
+    def _add_fluent_datasource(self, datasource: Datasource) -> None:
         self._datasources[datasource.name] = datasource
 
     def get_datasource(self, datasource_name: str) -> Datasource:
@@ -91,6 +94,9 @@ class DataContext:
             raise LookupError(
                 f"'{datasource_name}' not found. Available datasources are {list(self._datasources.keys())}"
             ) from exc
+
+    def _save_project_config(self) -> None:
+        ...
 
 
 def get_context(
@@ -116,9 +122,7 @@ def context_sources_cleanup() -> _SourceFactories:
     """Return the sources object and reset types/factories on teardown"""
     try:
         # setup
-        sources_copy = copy.deepcopy(
-            _SourceFactories._SourceFactories__source_factories
-        )
+        sources_copy = copy.deepcopy(_SourceFactories._SourceFactories__crud_registry)
         type_lookup_copy = copy.deepcopy(_SourceFactories.type_lookup)
         sources = get_context().sources
 
@@ -128,13 +132,13 @@ def context_sources_cleanup() -> _SourceFactories:
 
         yield sources
     finally:
-        _SourceFactories._SourceFactories__source_factories = sources_copy
+        _SourceFactories._SourceFactories__crud_registry = sources_copy
         _SourceFactories.type_lookup = type_lookup_copy
 
 
 @pytest.fixture(scope="function")
 def empty_sources(context_sources_cleanup) -> _SourceFactories:
-    _SourceFactories._SourceFactories__source_factories.clear()
+    _SourceFactories._SourceFactories__crud_registry.clear()
     _SourceFactories.type_lookup.clear()
     assert not _SourceFactories.type_lookup
     yield context_sources_cleanup
@@ -161,10 +165,11 @@ class TestMetaDatasource:
             def execution_engine_type(self) -> Type[ExecutionEngine]:
                 return DummyExecutionEngine
 
-        expected_registrants = 1
-
-        assert len(empty_sources.factories) == expected_registrants
-        assert len(empty_sources.type_lookup) == 2 * expected_registrants
+        # One for each crud method: add, update, add_or_update, delete
+        assert len(empty_sources.factories) == 4
+        # type_lookup maps the MyTestDatasource.type str to the class and vis versa
+        assert len(empty_sources.type_lookup) == 2
+        assert "my_test" in empty_sources.type_lookup
 
     def test__new__registers_sources_factory_method(
         self, context_sources_cleanup: _SourceFactories
@@ -362,6 +367,153 @@ def test_minimal_ds_to_asset_flow(context_sources_cleanup):
 
     # 5. Get an asset by name - (method defined in parent `Datasource`)
     assert red_asset is purple_ds.get_asset("my_asset_name")
+
+
+# Testing crud methods
+DEFAULT_CRUD_DATASOURCE_NAME = "pandas_datasource"
+
+
+@pytest.fixture
+def context_config_data(
+    file_dc_config_dir_init: pathlib.Path,
+) -> Tuple[AbstractDataContext, pathlib.Path, pathlib.Path]:
+    config_file_path = file_dc_config_dir_init / FileDataContext.GX_YML
+    assert config_file_path.exists() is True
+    context = get_gx_context(context_root_dir=file_dc_config_dir_init)
+    data_dir = file_dc_config_dir_init.parent / "data"
+    data_dir.mkdir()
+    return context, config_file_path, data_dir
+
+
+def assert_fluent_datasource_content(
+    config_file_path: str, fluent_datasource_config: dict
+):
+    config = ruamel.yaml.safe_load(config_file_path.read_text())
+    assert "fluent_datasources" in config
+    assert config["fluent_datasources"] == fluent_datasource_config
+
+
+@pytest.fixture
+def context_with_fluent_datasource(
+    context_config_data: Tuple[AbstractDataContext, pathlib.Path, pathlib.Path]
+) -> Tuple[AbstractDataContext, pathlib.Path, pathlib.Path]:
+    context, config_file_path, data_dir = context_config_data
+    assert 0 == len(context.datasources)
+    context.sources.add_pandas_filesystem(
+        name=DEFAULT_CRUD_DATASOURCE_NAME,
+        base_directory=data_dir,
+        data_context_root_directory=config_file_path.parent,
+    )
+    assert 1 == len(context.datasources)
+    assert_fluent_datasource_content(
+        config_file_path,
+        {
+            DEFAULT_CRUD_DATASOURCE_NAME: {
+                "assets": {},
+                "base_directory": str(data_dir),
+                "data_context_root_directory": str(config_file_path.parent),
+                "name": DEFAULT_CRUD_DATASOURCE_NAME,
+                "type": "pandas_filesystem",
+            }
+        },
+    )
+    return context, config_file_path, data_dir
+
+
+@pytest.mark.unit
+def test_add_datasource(context_with_fluent_datasource):
+    pass
+
+
+@pytest.mark.unit
+def test_update_datasource(context_with_fluent_datasource):
+    context, config_file_path, data_dir = context_with_fluent_datasource
+    data_dir_2 = data_dir.parent / "data2"
+    data_dir_2.mkdir()
+    context.sources.update_pandas_filesystem(
+        name=DEFAULT_CRUD_DATASOURCE_NAME,
+        base_directory=data_dir_2,
+        data_context_root_directory=config_file_path.parent,
+    )
+    assert_fluent_datasource_content(
+        config_file_path,
+        {
+            DEFAULT_CRUD_DATASOURCE_NAME: {
+                "assets": {},
+                "base_directory": str(data_dir_2),
+                "data_context_root_directory": str(config_file_path.parent),
+                "name": DEFAULT_CRUD_DATASOURCE_NAME,
+                "type": "pandas_filesystem",
+            }
+        },
+    )
+
+
+@pytest.mark.unit
+def test_add_or_update_datasource_using_add(context_with_fluent_datasource):
+    context, config_file_path, data_dir = context_with_fluent_datasource
+    data_dir_2 = data_dir.parent / "data2"
+    data_dir_2.mkdir()
+    context.sources.add_or_update_pandas_filesystem(
+        name=f"{DEFAULT_CRUD_DATASOURCE_NAME}_2",
+        base_directory=data_dir_2,
+        data_context_root_directory=config_file_path.parent,
+    )
+    assert_fluent_datasource_content(
+        config_file_path,
+        {
+            DEFAULT_CRUD_DATASOURCE_NAME: {
+                "assets": {},
+                "base_directory": str(data_dir),
+                "data_context_root_directory": str(config_file_path.parent),
+                "name": DEFAULT_CRUD_DATASOURCE_NAME,
+                "type": "pandas_filesystem",
+            },
+            f"{DEFAULT_CRUD_DATASOURCE_NAME}_2": {
+                "assets": {},
+                "base_directory": str(data_dir_2),
+                "data_context_root_directory": str(config_file_path.parent),
+                "name": f"{DEFAULT_CRUD_DATASOURCE_NAME}_2",
+                "type": "pandas_filesystem",
+            },
+        },
+    )
+
+
+@pytest.mark.unit
+def test_add_or_update_datasource_using_update(context_with_fluent_datasource):
+    context, config_file_path, data_dir = context_with_fluent_datasource
+    data_dir_2 = data_dir.parent / "data2"
+    data_dir_2.mkdir()
+    context.sources.add_or_update_pandas_filesystem(
+        name=DEFAULT_CRUD_DATASOURCE_NAME,
+        base_directory=data_dir_2,
+        data_context_root_directory=config_file_path.parent,
+    )
+    assert_fluent_datasource_content(
+        config_file_path,
+        {
+            DEFAULT_CRUD_DATASOURCE_NAME: {
+                "assets": {},
+                "base_directory": str(data_dir_2),
+                "data_context_root_directory": str(config_file_path.parent),
+                "name": DEFAULT_CRUD_DATASOURCE_NAME,
+                "type": "pandas_filesystem",
+            }
+        },
+    )
+
+
+@pytest.mark.xfail(
+    reason="There is a bug in context._save_config where deletions don't get persisted",
+    run=True,
+    strict=True,
+)
+@pytest.mark.unit
+def test_delete_datasource(context_with_fluent_datasource):
+    context, config_file_path, data_dir = context_with_fluent_datasource
+    context.sources.delete_pandas_filesystem(name=DEFAULT_CRUD_DATASOURCE_NAME)
+    assert_fluent_datasource_content(config_file_path, {})
 
 
 if __name__ == "__main__":

--- a/tests/datasource/fluent/test_viral_snippets.py
+++ b/tests/datasource/fluent/test_viral_snippets.py
@@ -194,8 +194,6 @@ def test_add_and_save_fluent_datasource(
     ds = context.sources.add_sqlite(
         name=datasource_name, connection_string=f"sqlite:///{db_file}"
     )
-    # BDIRKS should i remove?
-    context._save_project_config()
 
     final_yaml = config_file.read_text()
     diff = difflib.ndiff(initial_yaml.splitlines(), final_yaml.splitlines())

--- a/tests/datasource/fluent/test_viral_snippets.py
+++ b/tests/datasource/fluent/test_viral_snippets.py
@@ -69,22 +69,6 @@ def fluent_only_config(fluent_config_dict: dict) -> GxConfig:
 
 
 @pytest.fixture
-def file_dc_config_dir_init(tmp_path: pathlib.Path) -> pathlib.Path:
-    """
-    Initialize an regular/old-style FileDataContext project config directory.
-    Removed on teardown.
-    """
-    gx_yml = tmp_path / FileDataContext.GX_DIR / FileDataContext.GX_YML
-    assert gx_yml.exists() is False
-    FileDataContext.create(tmp_path)
-    assert gx_yml.exists()
-
-    tmp_gx_dir = gx_yml.parent.absolute()
-    logger.info(f"tmp_gx_dir -> {tmp_gx_dir}")
-    return tmp_gx_dir
-
-
-@pytest.fixture
 def fluent_yaml_config_file(
     file_dc_config_dir_init: pathlib.Path, fluent_only_config: GxConfig
 ) -> pathlib.Path:
@@ -210,6 +194,7 @@ def test_add_and_save_fluent_datasource(
     ds = context.sources.add_sqlite(
         name=datasource_name, connection_string=f"sqlite:///{db_file}"
     )
+    # BDIRKS should i remove?
     context._save_project_config()
 
     final_yaml = config_file.read_text()


### PR DESCRIPTION
This add crud methods to `context.sources`. 

I should rename `factories` to `crud_methods` throughout since we store more than the `add_<datasource>` factory that constructs a datasource now. I can do this in this PR or as a fast follow.

Here is an example workflow:
```
import great_expectations as gx
context = gx.get_context()

# Add
context.sources.add_postgres(name="pg", connection_string="postgresql+psycopg2://postgres:@localhost/test_ci")
print(context.datasources)

# Update
context.sources.update_postgres(name="pg", connection_string="postgresql://postgres:@localhost/test_ci")
print(context.datasources)

# Add or Update
context.sources.add_or_update_postgres(name="pg", connection_string="postgresql://postgres:@localhost/test_ci")
context.sources.add_or_update_postgres(name="pg2", connection_string="postgresql://postgres:@localhost/test_ci")
print(context.datasources)

# Delete
context.sources.delete_postgres(name="pg2")
print(context.datasources)
```

### Definition of Done
Please delete options that are not relevant.

- [ ] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [ ] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [ ] I have run any local integration tests and made sure that nothing is broken.
