### PR TITLE
[MAINTENANCE] In Fluent Datasources: Configuration Serialization Methods Do Not Need to be Public

### DIFF
--- a/docs/sphinx_api_docs_source/public_api_report.py
+++ b/docs/sphinx_api_docs_source/public_api_report.py
@@ -1844,7 +1844,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 100  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
+    PUBLIC_API_MISSING_THRESHOLD = 102  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
     if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/docs/sphinx_api_docs_source/public_api_report.py
+++ b/docs/sphinx_api_docs_source/public_api_report.py
@@ -834,14 +834,22 @@ class CodeReferenceFilter:
             ),
         ),
         IncludeExcludeDefinition(
-            reason="Experimental is not part of the public API",
+            reason="Fluent is not part of the public API",
             filepath=pathlib.Path(
-                "great_expectations/experimental/datasources/interfaces.py"
+                "great_expectations/datasources/fluent/interfaces.py"
             ),
         ),
         IncludeExcludeDefinition(
-            reason="Experimental is not part of the public API",
-            filepath=pathlib.Path("great_expectations/experimental/context.py"),
+            reason="Fluent is not part of the public API",
+            name="read_csv",
+            filepath=pathlib.Path("great_expectations/datasources/fluent/config.py"),
+        ),
+        IncludeExcludeDefinition(
+            reason="Fluent-style read_csv is not referenced in the docs yet, but due to string matching it is being flagged.",
+            name="read_csv",
+            filepath=pathlib.Path(
+                "great_expectations/datasources/fluent/pandas_datasource.py"
+            ),
         ),
         IncludeExcludeDefinition(
             reason="Marshmallow dump methods are not part of the public API",
@@ -1471,13 +1479,6 @@ class CodeReferenceFilter:
             name="get_available_data_asset_names",
             filepath=pathlib.Path("great_expectations/datasource/datasource.py"),
         ),
-        IncludeExcludeDefinition(
-            reason="Fluent-style read_csv is not referenced in the docs yet, but due to string matching it is being flagged.",
-            name="read_csv",
-            filepath=pathlib.Path(
-                "great_expectations/experimental/datasources/pandas_datasource.py"
-            ),
-        ),
     ]
 
     def __init__(
@@ -1844,7 +1845,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 102  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
+    PUBLIC_API_MISSING_THRESHOLD = 101  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
     if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/docs/sphinx_api_docs_source/public_api_report.py
+++ b/docs/sphinx_api_docs_source/public_api_report.py
@@ -1843,7 +1843,7 @@ def main():
     # any methods or classes you are adding to documentation with the @public_api
     # decorator and any relevant "new" or "deprecated" public api decorators.
     # If the actual is lower than the threshold, please reduce the threshold.
-    PUBLIC_API_MISSING_THRESHOLD = 101  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
+    PUBLIC_API_MISSING_THRESHOLD = 97  # TODO: reduce this number again once this works for the Fluent DS dynamic methods
     if len(printable_definitions) != PUBLIC_API_MISSING_THRESHOLD:
         error_msg_prefix = f"There are {len(printable_definitions)} items missing from the public API, we currently allow {PUBLIC_API_MISSING_THRESHOLD}."
         if len(printable_definitions) > PUBLIC_API_MISSING_THRESHOLD:

--- a/docs/sphinx_api_docs_source/public_api_report.py
+++ b/docs/sphinx_api_docs_source/public_api_report.py
@@ -835,20 +835,18 @@ class CodeReferenceFilter:
         ),
         IncludeExcludeDefinition(
             reason="Fluent is not part of the public API",
-            filepath=pathlib.Path(
-                "great_expectations/datasources/fluent/interfaces.py"
-            ),
+            filepath=pathlib.Path("great_expectations/datasource/fluent/interfaces.py"),
         ),
         IncludeExcludeDefinition(
             reason="Fluent is not part of the public API",
             name="read_csv",
-            filepath=pathlib.Path("great_expectations/datasources/fluent/config.py"),
+            filepath=pathlib.Path("great_expectations/datasource/fluent/config.py"),
         ),
         IncludeExcludeDefinition(
             reason="Fluent-style read_csv is not referenced in the docs yet, but due to string matching it is being flagged.",
             name="read_csv",
             filepath=pathlib.Path(
-                "great_expectations/datasources/fluent/pandas_datasource.py"
+                "great_expectations/datasource/fluent/pandas_datasource.py"
             ),
         ),
         IncludeExcludeDefinition(

--- a/great_expectations/datasource/fluent/config.py
+++ b/great_expectations/datasource/fluent/config.py
@@ -24,7 +24,6 @@ from pydantic import Extra, Field, ValidationError, validator
 from ruamel.yaml import YAML
 from typing_extensions import Final
 
-from great_expectations.core._docs_decorators import public_api
 from great_expectations.datasource.fluent.fluent_base_model import (
     FluentBaseModel,
     _recursively_set_config_value,
@@ -212,7 +211,6 @@ class GxConfig(FluentBaseModel):
     ) -> pathlib.Path:
         ...
 
-    @public_api
     def yaml(
         self,
         stream_or_path: Union[StringIO, pathlib.Path, None] = None,
@@ -255,7 +253,6 @@ class GxConfig(FluentBaseModel):
 
         return stream_or_path.getvalue()
 
-    @public_api
     def json(
         self,
         *,
@@ -328,7 +325,6 @@ class GxConfig(FluentBaseModel):
             )
         )
 
-    @public_api
     def dict(
         self,
         *,

--- a/great_expectations/datasource/fluent/fluent_base_model.py
+++ b/great_expectations/datasource/fluent/fluent_base_model.py
@@ -22,7 +22,6 @@ from typing import (
 import pydantic
 from ruamel.yaml import YAML
 
-from great_expectations.core._docs_decorators import public_api
 from great_expectations.datasource.fluent.config_str import ConfigStr
 from great_expectations.datasource.fluent.constants import _FIELDS_ALWAYS_SET
 
@@ -102,7 +101,6 @@ class FluentBaseModel(pydantic.BaseModel):
     ) -> pathlib.Path:
         ...
 
-    @public_api
     def yaml(
         self,
         stream_or_path: Union[StringIO, pathlib.Path, None] = None,
@@ -144,7 +142,6 @@ class FluentBaseModel(pydantic.BaseModel):
             return stream_or_path
         return stream_or_path.getvalue()
 
-    @public_api
     def json(
         self,
         *,
@@ -216,7 +213,6 @@ class FluentBaseModel(pydantic.BaseModel):
             )
         )
 
-    @public_api
     def dict(
         self,
         *,


### PR DESCRIPTION
### Scope
* Configuration serialization methods do not need to be public.
* Allowed maximum count of non-decorated public methods is increased, due to the addition of Fluent Datasources configuration serialization method overrides.

Please annotate your PR title to describe what the PR does, then give a brief bulleted description of your PR below. PR titles should begin with [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], or [CONTRIB]. If a new feature introduces breaking changes for the Great Expectations API or configuration files, please also add [BREAKING]. You can read about the tags in our [contributor checklist](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

Changes proposed in this pull request:
- JIRA: GREAT-1709/GREAT-1726
-
-


After submitting your PR, CI checks will run and @cla-bot will check for your CLA signature.

For a PR with nontrivial changes, we review with both design-centric and code-centric lenses.

In a design review, we aim to ensure that the PR is consistent with our relationship to the open source community, with our software architecture and abstractions, and with our users' needs and expectations. That review often starts well before a PR, for example in GitHub issues or Slack, so please link to relevant conversations in notes below to help reviewers understand and approve your PR more quickly (e.g. `closes #123`).

Previous Design Review notes:
-
-
-


### Definition of Done
Please delete options that are not relevant.

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added [unit tests](https://docs.greatexpectations.io/docs/contributing/contributing_test#writing-unit-and-integration-tests) where applicable and made sure that new and existing tests are passing.
- [x] I have run any local integration tests and made sure that nothing is broken.


Thank you for submitting!
