### PR TITLE
[MAINTENANCE ] Include all `.pyi` files in package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ config = {
     "entry_points": {
         "console_scripts": ["great_expectations=great_expectations.cli:main"]
     },
-    "package_data": {"great_expectations": ["py.typed"]},
+    "package_data": {"great_expectations": ["py.typed", "**/*.pyi"]},
     "name": "great_expectations",
     "long_description": long_description,
     "license": "Apache-2.0",


### PR DESCRIPTION
## Changes proposed in this pull request:
- update `package_data` to include all `.pyi` files

https://setuptools.pypa.io/en/latest/deprecated/distutils/setupscript.html#installing-package-data
https://packaging.python.org/en/latest/guides/using-manifest-in/#how-files-are-included-in-an-sdist
