### PR TITLE
[MAINTENANCE] Move pact contract check into dedicated parallel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GX_CLOUD_BASE_URL: ${{vars.MERCURY_BASE_URL}}
-      PACT_BROKER_READ_WRITE_TOKEN: ${{secrets.PACT_BROKER_READ_WRITE_TOKEN}}
       AUTH0_DOMAIN: ${{secrets.AUTH0_DOMAIN}}
       AUTH0_API_AUDIENCE: ${{secrets.AUTH0_API_AUDIENCE}}
       AUTH0_MERCURY_API_CLIENT_ID: ${{secrets.AUTH0_MERCURY_API_CLIENT_ID}}
@@ -580,56 +579,14 @@ jobs:
       - name: Run the tests
         run: invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
-      - name: Publish pact contracts to PactFlow
-        if: >-
-          env.PACT_BROKER_READ_WRITE_TOKEN != ''
-          && github.event_name != 'merge_group'
-          && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
-        run: |
-          PACT_DIR="tests/integration/cloud/rest_contracts/pacts"
-          if [ ! -d "${PACT_DIR}" ] || ! compgen -G "${PACT_DIR}/*.json" > /dev/null; then
-            echo "No pact files found in ${PACT_DIR}, skipping publish"
-            exit 0
-          fi
-          echo "Publishing pact files from ${PACT_DIR}:"
-          ls -la ${PACT_DIR}/*.json
-
-          CONSUMER_VERSION="${{ github.event.pull_request.head.sha || github.sha }}"
-
-          # For merge_group events, resolve the target branch (e.g. "develop") from
-          # the base_ref instead of using the throwaway queue ref name
-          # (gh-readonly-queue/develop/pr-NNN-SHA).
-          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            PACT_BRANCH="${{ github.event.merge_group.base_ref }}"
-            PACT_BRANCH="${PACT_BRANCH#refs/heads/}"
-          else
-            PACT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          fi
-
-          echo "Publishing with version=${CONSUMER_VERSION} branch=${PACT_BRANCH}"
-          docker run --rm \
-            -v "$(pwd)/${PACT_DIR}:/pacts" \
-            pactfoundation/pact-cli:1.5.0.4 \
-            broker publish /pacts \
-            --broker-base-url=https://greatexpectations.pactflow.io \
-            --broker-token="${PACT_BROKER_READ_WRITE_TOKEN}" \
-            --consumer-app-version="${CONSUMER_VERSION}" \
-            --branch="${PACT_BRANCH}"
-
-      - name: Can I deploy?
-        if: >-
-          env.PACT_BROKER_READ_WRITE_TOKEN != ''
-          && github.event_name != 'merge_group'
-          && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
-        run: |
-          docker run --rm \
-            pactfoundation/pact-cli:1.5.0.4 \
-            broker can-i-deploy \
-            --pacticipant great_expectations \
-            --version "${{ github.event.pull_request.head.sha || github.sha }}" \
-            --to-environment production \
-            --broker-base-url https://greatexpectations.pactflow.io \
-            --broker-token "${PACT_BROKER_READ_WRITE_TOKEN}"
+      - name: Upload pact contracts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pact-contracts
+          path: tests/integration/cloud/rest_contracts/pacts/
+          if-no-files-found: ignore
+          retention-days: 1
 
       # upload coverage report to codecov
       - name: Upload coverage reports to Codecov
@@ -649,6 +606,60 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: cloud
+
+  pact-contract-check:
+    needs: [cloud-tests]
+    # Skip for merge_group (pacts are already verified on develop) and tag pushes.
+    # Naturally skipped when cloud-tests is skipped (draft PRs).
+    if: >-
+      github.event_name != 'merge_group'
+      && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-latest
+    env:
+      PACT_BROKER_READ_WRITE_TOKEN: ${{secrets.PACT_BROKER_READ_WRITE_TOKEN}}
+      PACT_DO_NOT_TRACK: true
+
+    steps:
+      - name: Download pact contracts
+        uses: actions/download-artifact@v4
+        with:
+          name: pact-contracts
+          path: pacts/
+
+      - name: Publish pact contracts to PactFlow
+        if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
+        run: |
+          if ! compgen -G "pacts/*.json" > /dev/null; then
+            echo "No pact files found, skipping publish"
+            exit 0
+          fi
+
+          CONSUMER_VERSION="${{ github.event.pull_request.head.sha || github.sha }}"
+          PACT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+
+          echo "Publishing with version=${CONSUMER_VERSION} branch=${PACT_BRANCH}"
+          docker run --rm \
+            -v "$(pwd)/pacts:/pacts" \
+            pactfoundation/pact-cli:1.5.0.4 \
+            broker publish /pacts \
+            --broker-base-url=https://greatexpectations.pactflow.io \
+            --broker-token="${PACT_BROKER_READ_WRITE_TOKEN}" \
+            --consumer-app-version="${CONSUMER_VERSION}" \
+            --branch="${PACT_BRANCH}"
+
+      - name: Can I deploy?
+        if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
+        run: |
+          docker run --rm \
+            pactfoundation/pact-cli:1.5.0.4 \
+            broker can-i-deploy \
+            --pacticipant great_expectations \
+            --version "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --to-environment production \
+            --retry-while-unknown 60 \
+            --retry-interval 10 \
+            --broker-base-url https://greatexpectations.pactflow.io \
+            --broker-token "${PACT_BROKER_READ_WRITE_TOKEN}"
 
   integration-tests:
     needs: [unit-tests, static-analysis, check-actor-permissions]
@@ -1123,6 +1134,7 @@ jobs:
       - docs-tests
       - docs-snippets
       - cloud-tests
+      - pact-contract-check
       - integration-tests
       - marker-tests
       - redshift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,7 @@ jobs:
       - name: Run pact contract tests
         run: |
           pytest tests/integration/cloud/rest_contracts/ \
+            --cloud \
             --verbose \
             -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,12 +601,9 @@ jobs:
   pact-contract-check:
     needs: [unit-tests, static-analysis, check-actor-permissions]
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || (
-        github.event.pull_request.draft == false
-        && github.event_name != 'merge_group'
-        && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
-      )
+      github.event.pull_request.draft == false
+      && github.event_name != 'merge_group'
+      && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     env:
       PACT_BROKER_READ_WRITE_TOKEN: ${{secrets.PACT_BROKER_READ_WRITE_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,9 +601,12 @@ jobs:
   pact-contract-check:
     needs: [unit-tests, static-analysis, check-actor-permissions]
     if: >-
-      github.event.pull_request.draft == false
-      && github.event_name != 'merge_group'
-      && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event.pull_request.draft == false
+        && github.event_name != 'merge_group'
+        && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+      )
     runs-on: ubuntu-latest
     env:
       PACT_BROKER_READ_WRITE_TOKEN: ${{secrets.PACT_BROKER_READ_WRITE_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,15 +579,6 @@ jobs:
       - name: Run the tests
         run: invoke ci-tests 'cloud' --up-services --verbose  --reports -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
-      - name: Upload pact contracts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pact-contracts
-          path: tests/integration/cloud/rest_contracts/pacts/
-          if-no-files-found: ignore
-          retention-days: 1
-
       # upload coverage report to codecov
       - name: Upload coverage reports to Codecov
         continue-on-error: true
@@ -608,29 +599,52 @@ jobs:
           flags: cloud
 
   pact-contract-check:
-    needs: [cloud-tests]
-    # Skip for merge_group (pacts are already verified on develop) and tag pushes.
-    # Naturally skipped when cloud-tests is skipped (draft PRs).
+    needs: [unit-tests, static-analysis, check-actor-permissions]
     if: >-
-      github.event_name != 'merge_group'
+      github.event.pull_request.draft == false
+      && github.event_name != 'merge_group'
       && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     env:
       PACT_BROKER_READ_WRITE_TOKEN: ${{secrets.PACT_BROKER_READ_WRITE_TOKEN}}
       PACT_DO_NOT_TRACK: true
+      # Pact consumer tests use a mock server; these env vars are required by
+      # CloudDataContext but point at the mock, not a real Mercury instance.
+      GX_CLOUD_BASE_URL: "http://localhost:9292"
+      GX_CLOUD_ACCESS_TOKEN: "dummy-pact-access-token"
+      GX_CLOUD_ORGANIZATION_ID: "d2179c7d-685d-49ec-b1e2-85e54308e8b6"
 
     steps:
-      - name: Download pact contracts
-        uses: actions/download-artifact@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          name: pact-contracts
-          path: pacts/
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache-dependency-path: |
+            reqs/requirements-dev-test.txt
+            setup.py
+
+      - name: Install dependencies
+        run: |
+          pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
+          invoke deps --gx-install -m 'cloud' -r test
+
+      - name: Run pact contract tests
+        run: |
+          pytest tests/integration/cloud/rest_contracts/ \
+            --verbose \
+            -W default::great_expectations.datasource.fluent.GxInvalidDatasourceWarning
 
       - name: Publish pact contracts to PactFlow
         if: env.PACT_BROKER_READ_WRITE_TOKEN != ''
         run: |
-          if ! compgen -G "pacts/*.json" > /dev/null; then
-            echo "No pact files found, skipping publish"
+          PACT_DIR="tests/integration/cloud/rest_contracts/pacts"
+          if [ ! -d "${PACT_DIR}" ] || ! compgen -G "${PACT_DIR}/*.json" > /dev/null; then
+            echo "No pact files found in ${PACT_DIR}, skipping publish"
             exit 0
           fi
 
@@ -639,7 +653,7 @@ jobs:
 
           echo "Publishing with version=${CONSUMER_VERSION} branch=${PACT_BRANCH}"
           docker run --rm \
-            -v "$(pwd)/pacts:/pacts" \
+            -v "$(pwd)/${PACT_DIR}:/pacts" \
             pactfoundation/pact-cli:1.5.0.4 \
             broker publish /pacts \
             --broker-base-url=https://greatexpectations.pactflow.io \


### PR DESCRIPTION
## Summary

Extracts the PactFlow publish and `can-i-deploy` steps from `cloud-tests` into a dedicated `pact-contract-check` job that runs after `cloud-tests` completes. Adds `--retry-while-unknown` to `can-i-deploy` so it waits for Mercury's provider verification to finish.

## Changes

- **`cloud-tests`**
  - Removed: "Publish pact contracts to PactFlow" and "Can I deploy?" steps.
  - Removed: `PACT_BROKER_READ_WRITE_TOKEN` from job-level `env` (no longer needed).
  - Added: "Upload pact contracts" step after tests run — uploads `tests/integration/cloud/rest_contracts/pacts/` as a 1-day artifact with `if: always()` so the artifact is available even when tests fail.

- **`pact-contract-check`** (new job)
  - `needs: [cloud-tests]` — runs after tests produce pact files.
  - Skipped for `merge_group` events and tag pushes (same conditions as the old per-step `if:`).
  - Downloads the pact artifact, publishes to PactFlow, then runs `can-i-deploy` with `--retry-while-unknown 60 --retry-interval 10` (polls for up to 10 min while verification is pending).
  - Minimal env: only `PACT_BROKER_READ_WRITE_TOKEN` and `PACT_DO_NOT_TRACK`.

- **`ci-required`** — `pact-contract-check` added to `needs`.

## Why

Two problems with the old setup:

1. `can-i-deploy` ran immediately after publishing, with no retry. The Mercury webhook-triggered provider verification (see greatexpectationslabs/mercury#6298) takes several minutes to complete. Without retry, `can-i-deploy` always saw `unknown: 1` and failed.

2. The pact publish/check steps were embedded in the long-running `cloud-tests` job alongside coverage uploads and other post-processing, making failures harder to isolate and retry independently.

## User impact

No behavior change for end users. For contributors: `can-i-deploy` now retries for up to 10 min (rather than failing instantly on `unknown`) and appears as a separate, independently-retryable CI check.

## How to review

- `ci.yml` diff: `cloud-tests` should have no pact references except `PACT_DO_NOT_TRACK` (used to suppress telemetry during test execution). The upload artifact step uses `if: always()` so pact files are preserved even on test failure.
- `pact-contract-check`: verify `needs: [cloud-tests]`, the `--retry-while-unknown 60 --retry-interval 10` flags, and that it's listed in `ci-required`.
- `merge_group` handling: the old publish steps used a special `PACT_BRANCH` for merge_group events. The new job skips entirely for merge_group — pacts published from the source branch are already sufficient.