### PR TITLE
[MAINTENANCE] Remove deprecated str support for Validator.validate run_id

### DIFF
--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -27,7 +27,6 @@ import pandas as pd
 from marshmallow import ValidationError
 
 from great_expectations import __version__ as ge_version
-from great_expectations._docs_decorators import deprecated_argument
 from great_expectations.compatibility.typing_extensions import override
 from great_expectations.core.expectation_suite import (
     ExpectationSuite,
@@ -1083,15 +1082,10 @@ class Validator:
         else:
             raise ValueError("Unable to save config: filepath or data_context must be available.")  # noqa: TRY003 # FIXME CoP
 
-    @deprecated_argument(
-        argument_name="run_id",
-        message="Only the str version of this argument is deprecated. run_id should be a RunIdentifier or dict. Support will be removed in 0.16.0.",  # noqa: E501 # FIXME CoP
-        version="0.13.0",
-    )
     def validate(  # noqa: C901, PLR0912, PLR0913 # FIXME CoP
         self,
         expectation_suite: str | ExpectationSuite | None = None,
-        run_id: str | RunIdentifier | Dict[str, str] | None = None,
+        run_id: RunIdentifier | Dict[str, str] | None = None,
         data_context: Optional[Any] = None,  # Cannot type DataContext due to circular import
         suite_parameters: Optional[dict] = None,
         catch_exceptions: bool = True,


### PR DESCRIPTION
## Summary
- Remove `str` from the `run_id` parameter type union on `Validator.validate()` (`great_expectations/validator/validator.py`).
- Remove the accompanying `@deprecated_argument` decorator and the now-unused `deprecated_argument` import.

The str form of `run_id` was deprecated in v0.13.0 with removal stated for v0.16.0. We are now on v1.16.1 — well past the removal window. No call sites in this repo, `cloud`, or `gx-runner` pass a string `run_id` to `Validator.validate`, and neither `Validator` nor `Validator.validate` is marked `@public_api`.

Original deprecation message (for reference):
> Only the str version of this argument is deprecated. run_id should be a RunIdentifier or dict. Support will be removed in 0.16.0.

## Test plan
- [ ] CI green (lint, types, unit, integration)