### PR TITLE
[MAINTENANCE] allow Can I deploy? step to continue on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,6 +621,7 @@ jobs:
           env.PACT_BROKER_READ_WRITE_TOKEN != ''
           && github.event_name != 'merge_group'
           && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        continue-on-error: true
         run: |
           docker run --rm \
             pactfoundation/pact-cli:1.5.0.4 \


### PR DESCRIPTION
## Summary

Mark the `Can I deploy?` pact-broker step in `ci.yml` as `continue-on-error: true` so a failure in that step no longer fails the job.

## Changes

- `.github/workflows/ci.yml`: add `continue-on-error: true` to the `Can I deploy?` step (single-line change).

## Why

The `Can I deploy?` check is currently failing and blocking all CI runs against `develop`. We need to merge fixes for the underlying pact issues, but they cannot land while this gate is red. Letting the step continue on failure keeps the signal visible without blocking unrelated work.

## User impact

No runtime behavior change. CI surface: `Can I deploy?` will still run and report failures, but will no longer fail the job.

## How to review

- Confirm the diff is a single-line addition of \`continue-on-error: true\` on the \`Can I deploy?\` step.
- Intentionally minimal — intended to be force-merged to unblock CI.