### PR TITLE
[FEATURE] Pass batch_definition_id to GET /expectation-parameters

### DIFF
--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -780,11 +780,8 @@ class CloudDataContext(SerializableDataContext):
         # call per distinct id and merge the responses; a checkpoint usually has
         # a single batch definition, so this is typically one call.
         distinct_batch_definition_ids = self._distinct_batch_definition_ids(checkpoint)
-        # If no validation definition carries a batch_definition_id, fall back
-        # to a single call without the query param so mercury applies its
-        # inline-computation path.
         if not distinct_batch_definition_ids:
-            distinct_batch_definition_ids = {None}
+            return
 
         # temporarily extend expectation parameter timeout to 10 minutes
         # while a more robust solution is implemented
@@ -827,15 +824,11 @@ class CloudDataContext(SerializableDataContext):
         batch_definition_id: Optional[str],
         checkpoint_id: Optional[str],
     ) -> Dict[str, Any]:
-        """Issue one ``GET /expectation-parameters`` call for the given
-        ``batch_definition_id`` and return the ``expectation_parameters`` dict
-        from the response body. When ``batch_definition_id`` is ``None`` the
-        query parameter is omitted so mercury applies its inline-computation
-        path.
+        """Issue one ``GET /expectation-parameters?batch_definition_id=X`` call
+        and return the ``expectation_parameters`` dict from the response body.
         """
         params: Dict[str, str] = {}
-        if batch_definition_id is not None:
-            params["batch_definition_id"] = batch_definition_id
+        params["batch_definition_id"] = batch_definition_id
         response = session.get(url=url, params=params)
         if not response.ok:
             raise gx_exceptions.GXCloudError(
@@ -852,20 +845,17 @@ class CloudDataContext(SerializableDataContext):
             ) from e
 
     @staticmethod
-    def _distinct_batch_definition_ids(checkpoint: Checkpoint) -> Set[Optional[str]]:
+    def _distinct_batch_definition_ids(checkpoint: Checkpoint) -> Set[str]:
         """Return the set of distinct ``batch_definition_id`` values across the
         checkpoint's validation definitions.
 
         Used to decide how many grouped ``GET /expectation-parameters`` calls to
-        make. ``None`` is a valid element — it signals that one of the validation
-        definitions has no batch definition id and mercury should apply its
-        inline-computation path for that subset.
+        make — one call per distinct id. Validation definitions without a
+        ``BatchDefinition`` are skipped; they are not in the forecast store path.
         """
-        ids: Set[Optional[str]] = set()
+        ids: Set[str] = set()
         for validation_def in checkpoint.validation_definitions:
             batch_definition = validation_def.data
-            if isinstance(batch_definition, BatchDefinition):
+            if isinstance(batch_definition, BatchDefinition) and batch_definition.id:
                 ids.add(batch_definition.id)
-            else:
-                ids.add(None)
         return ids

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -848,6 +848,6 @@ class CloudDataContext(SerializableDataContext):
             if not any(exp.windows is not None for exp in validation_def.suite.expectations):
                 continue
             batch_definition = validation_def.data
-            if isinstance(batch_definition, BatchDefinition):
-                ids.add(str(batch_definition.id))
+            if isinstance(batch_definition, BatchDefinition) and batch_definition.id is not None:
+                ids.add(batch_definition.id)
         return ids

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -785,7 +785,17 @@ class CloudDataContext(SerializableDataContext):
         parameter_name_to_batch_definition_id = self._build_parameter_name_to_batch_definition_id(
             checkpoint
         )
-        distinct_batch_definition_ids = set(parameter_name_to_batch_definition_id.values())
+        distinct_batch_definition_ids: set[Optional[str]] = set(
+            parameter_name_to_batch_definition_id.values()
+        )
+        # If the checkpoint reports windowed expectations but we could not walk
+        # any validation_definitions → expectations → windows to discover
+        # parameter names, fall back to a single call without the query
+        # parameter so mercury applies its inline-computation path. Without
+        # this, the loop below would be a no-op and the caller would see no
+        # ``expectation_parameters`` update.
+        if not distinct_batch_definition_ids:
+            distinct_batch_definition_ids = {None}
 
         # temporarily extend expectation parameter timeout to 10 minutes
         # while a more robust solution is implemented

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -787,20 +787,16 @@ class CloudDataContext(SerializableDataContext):
         # while a more robust solution is implemented
         EXPECTATION_PARAMS_TIMEOUT = 600
 
-        merged_parameters: Dict[str, Any] = {}
         with create_session(
             access_token=self.ge_cloud_config.access_token, timeout=EXPECTATION_PARAMS_TIMEOUT
         ) as session:
             for batch_definition_id in sorted(distinct_batch_definition_ids):
-                new_parameters = self._fetch_expectation_parameters(
+                self._fetch_expectation_parameters(
                     session=session,
                     url=expectation_parameters_url,
                     batch_definition_id=batch_definition_id,
                     expectation_parameters=expectation_parameters,
                 )
-                merged_parameters.update(new_parameters)
-
-        expectation_parameters.update(merged_parameters)
 
     def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:
         # Check if we have a windowed parameter
@@ -816,9 +812,9 @@ class CloudDataContext(SerializableDataContext):
         url: str,
         batch_definition_id: str,
         expectation_parameters: Dict[str, Any],
-    ) -> Dict[str, Any]:
+    ) -> None:
         """Issue one ``GET /expectation-parameters?batch_definition_id=X`` call
-        and return the ``expectation_parameters`` dict from the response body.
+        and update ``expectation_parameters`` in place with the response.
         """
         response = session.get(url=url, params={"batch_definition_id": batch_definition_id})
         if not response.ok:
@@ -837,7 +833,7 @@ class CloudDataContext(SerializableDataContext):
                     "Passed in expectation_parameters also found in GX Cloud. Overwriting "
                     f"passed in values with GX Cloud values for keys: {overlapping_keys}"
                 )
-            return data["data"]["expectation_parameters"]
+            expectation_parameters.update(data["data"]["expectation_parameters"])
         except KeyError as e:
             raise gx_exceptions.GXCloudError(
                 message="Malformed expectation_parameters response received from GX Cloud",

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -772,13 +772,23 @@ class CloudDataContext(SerializableDataContext):
                 url=f"/api/v1/organizations/{org_id}/checkpoints/{checkpoint.id}/expectation-parameters",
             )
 
+        # When the checkpoint has a single, unambiguous batch_definition_id, thread
+        # it through as a query parameter so mercury can look up forecasted bounds
+        # from the async forecast store instead of falling back to inline training.
+        # Omitting the param preserves backward compatibility with older mercury
+        # versions that do not understand it.
+        params: Dict[str, str] = {}
+        batch_definition_id = self._get_single_batch_definition_id(checkpoint)
+        if batch_definition_id is not None:
+            params["batch_definition_id"] = batch_definition_id
+
         # temporarily extend expectation parameter timeout to 10 minutes
         # while a more robust solution is implemented
         EXPECTATION_PARAMS_TIMEOUT = 600
         with create_session(
             access_token=self.ge_cloud_config.access_token, timeout=EXPECTATION_PARAMS_TIMEOUT
         ) as session:
-            response = session.get(url=expectation_parameters_url)
+            response = session.get(url=expectation_parameters_url, params=params)
 
         if not response.ok:
             raise gx_exceptions.GXCloudError(
@@ -810,3 +820,25 @@ class CloudDataContext(SerializableDataContext):
                 if expectation.windows is not None:
                     return True
         return False
+
+    @staticmethod
+    def _get_single_batch_definition_id(checkpoint: Checkpoint) -> Optional[str]:
+        """Return the batch_definition_id shared by all validation definitions,
+        or ``None`` if it cannot be unambiguously determined.
+
+        The forecast store is keyed by ``(expectation_id, batch_definition_id)``.
+        When a checkpoint's validation definitions all reference the same batch
+        definition we can supply it to ``GET /expectation-parameters``; if they
+        reference different batch definitions (or any id is missing) we omit the
+        parameter and let mercury fall back to inline computation.
+        """
+        ids = set()
+        for validation_def in checkpoint.validation_definitions:
+            batch_definition = getattr(validation_def, "data", None)
+            batch_definition_id = getattr(batch_definition, "id", None)
+            if not batch_definition_id:
+                return None
+            ids.add(batch_definition_id)
+        if len(ids) != 1:
+            return None
+        return next(iter(ids))

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -797,7 +797,6 @@ class CloudDataContext(SerializableDataContext):
                         session=session,
                         url=expectation_parameters_url,
                         batch_definition_id=batch_definition_id,
-                        checkpoint_id=checkpoint.id,
                     )
                 )
 
@@ -821,19 +820,16 @@ class CloudDataContext(SerializableDataContext):
     def _fetch_expectation_parameters(
         session: Any,
         url: str,
-        batch_definition_id: Optional[str],
-        checkpoint_id: Optional[str],
+        batch_definition_id: str,
     ) -> Dict[str, Any]:
         """Issue one ``GET /expectation-parameters?batch_definition_id=X`` call
         and return the ``expectation_parameters`` dict from the response body.
         """
-        params: Dict[str, str] = {}
-        params["batch_definition_id"] = batch_definition_id
-        response = session.get(url=url, params=params)
+        response = session.get(url=url, params={"batch_definition_id": batch_definition_id})
         if not response.ok:
             raise gx_exceptions.GXCloudError(
-                message="Unable to retrieve expectation_parameters for Checkpoint with "
-                f"ID={checkpoint_id}.",
+                message="Unable to retrieve expectation_parameters for "
+                f"batch_definition_id={batch_definition_id}.",
                 response=response,
             )
         try:

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -851,6 +851,8 @@ class CloudDataContext(SerializableDataContext):
         """
         ids: Set[str] = set()
         for validation_def in checkpoint.validation_definitions:
+            if not any(exp.windows for exp in validation_def.suite.expectations):
+                continue
             batch_definition = validation_def.data
             if isinstance(batch_definition, BatchDefinition) and batch_definition.id:
                 ids.add(batch_definition.id)

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -799,6 +799,12 @@ class CloudDataContext(SerializableDataContext):
                 )
                 merged_parameters.update(new_parameters)
 
+        overlapping_keys = set(expectation_parameters.keys()) & set(merged_parameters.keys())
+        if overlapping_keys:
+            logger.warning(
+                "Passed in expectation_parameters also found in GX Cloud. Overwriting "
+                f"passed in values with GX Cloud values for keys: {overlapping_keys}"
+            )
         expectation_parameters.update(merged_parameters)
 
     def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -839,8 +839,7 @@ class CloudDataContext(SerializableDataContext):
         whose ``parameter_name`` belongs to an expectation with that same id.
 
         When ``batch_definition_id`` is ``None`` the query parameter is omitted
-        so mercury falls back to inline computation for those expectations
-        (also preserves backward compatibility with older mercury versions).
+        so mercury falls back to inline computation for those expectations.
         """
         params: Dict[str, str] = {}
         if batch_definition_id is not None:
@@ -861,8 +860,14 @@ class CloudDataContext(SerializableDataContext):
                 response=response,
             ) from e
 
-        # Values for expectations whose actual batch_definition_id doesn't
-        # match this call's query param are incorrect — discard them.
+        # Mercury returns an entry for every expectation in the checkpoint on
+        # every call. For expectations whose real batch_definition_id differs
+        # from this call's query param, mercury's forecast-store lookup misses
+        # and the entry holds an empty/baseline fallback. Those fallbacks
+        # aren't wrong per se, but if we merged them in they'd clobber the
+        # real values returned by the call keyed on the matching id. Keep
+        # only the entries whose owning batch_definition_id matches this
+        # call so the merge across calls composes cleanly.
         return {
             parameter_name: value
             for parameter_name, value in server_parameters.items()

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -798,14 +798,6 @@ class CloudDataContext(SerializableDataContext):
                     expectation_parameters=expectation_parameters,
                 )
 
-    def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:
-        # Check if we have a windowed parameter
-        for validation_def in checkpoint.validation_definitions:
-            for expectation in validation_def.suite.expectations:
-                if expectation.windows is not None:
-                    return True
-        return False
-
     @staticmethod
     def _fetch_expectation_parameters(
         session: Any,
@@ -839,6 +831,14 @@ class CloudDataContext(SerializableDataContext):
                 message="Malformed expectation_parameters response received from GX Cloud",
                 response=response,
             ) from e
+
+    def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:
+        # Check if we have a windowed parameter
+        for validation_def in checkpoint.validation_definitions:
+            for expectation in validation_def.suite.expectations:
+                if expectation.windows is not None:
+                    return True
+        return False
 
     @staticmethod
     def _distinct_batch_definition_ids(checkpoint: Checkpoint) -> Set[str]:

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -12,11 +12,12 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    Set,
     Union,
 )
 from urllib.parse import urljoin
 
-from requests import HTTPError, Response, Session
+from requests import HTTPError, Response
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations import __version__
@@ -773,27 +774,15 @@ class CloudDataContext(SerializableDataContext):
                 url=f"/api/v1/organizations/{org_id}/checkpoints/{checkpoint.id}/expectation-parameters",
             )
 
-        # Mercury's forecast store is keyed by (expectation_id, batch_definition_id).
-        # An expectation's dynamic parameters are only correct when the server
-        # looks them up with that expectation's own batch_definition_id — if the
-        # checkpoint spans multiple batch definitions, a single shared call would
-        # return wrong values (or empty bounds) for the expectations that don't
-        # match. Group expectations by their batch_definition_id and make one
-        # call per distinct id, then merge server responses, keeping each
-        # parameter_name only from the call whose batch_definition_id matches
-        # the expectation that owns that parameter.
-        parameter_name_to_batch_definition_id = self._build_parameter_name_to_batch_definition_id(
-            checkpoint
-        )
-        distinct_batch_definition_ids: set[Optional[str]] = set(
-            parameter_name_to_batch_definition_id.values()
-        )
-        # If the checkpoint reports windowed expectations but we could not walk
-        # any validation_definitions → expectations → windows to discover
-        # parameter names, fall back to a single call without the query
-        # parameter so mercury applies its inline-computation path. Without
-        # this, the loop below would be a no-op and the caller would see no
-        # ``expectation_parameters`` update.
+        # Mercury's ``GET /expectation-parameters?batch_definition_id=X`` returns
+        # entries only for expectations whose owning validation definition uses
+        # ``X``. When a checkpoint spans multiple batch definitions we make one
+        # call per distinct id and merge the responses; a checkpoint usually has
+        # a single batch definition, so this is typically one call.
+        distinct_batch_definition_ids = self._distinct_batch_definition_ids(checkpoint)
+        # If no validation definition carries a batch_definition_id, fall back
+        # to a single call without the query param so mercury applies its
+        # inline-computation path.
         if not distinct_batch_definition_ids:
             distinct_batch_definition_ids = {None}
 
@@ -807,13 +796,10 @@ class CloudDataContext(SerializableDataContext):
         ) as session:
             for batch_definition_id in distinct_batch_definition_ids:
                 merged_parameters.update(
-                    self._fetch_expectation_parameters_for_batch_definition_id(
+                    self._fetch_expectation_parameters(
                         session=session,
                         url=expectation_parameters_url,
                         batch_definition_id=batch_definition_id,
-                        parameter_name_to_batch_definition_id=(
-                            parameter_name_to_batch_definition_id
-                        ),
                         checkpoint_id=checkpoint.id,
                     )
                 )
@@ -826,54 +812,6 @@ class CloudDataContext(SerializableDataContext):
             )
         expectation_parameters.update(merged_parameters)
 
-    @staticmethod
-    def _fetch_expectation_parameters_for_batch_definition_id(
-        session: Session,
-        url: str,
-        batch_definition_id: Optional[str],
-        parameter_name_to_batch_definition_id: Dict[str, Optional[str]],
-        checkpoint_id: Optional[str],
-    ) -> Dict[str, Any]:
-        """Issue a single GET /expectation-parameters call for the given
-        ``batch_definition_id`` and return only the subset of response entries
-        whose ``parameter_name`` belongs to an expectation with that same id.
-
-        When ``batch_definition_id`` is ``None`` the query parameter is omitted
-        so mercury falls back to inline computation for those expectations.
-        """
-        params: Dict[str, str] = {}
-        if batch_definition_id is not None:
-            params["batch_definition_id"] = batch_definition_id
-
-        response = session.get(url=url, params=params)
-        if not response.ok:
-            raise gx_exceptions.GXCloudError(
-                message="Unable to retrieve expectation_parameters for Checkpoint with "
-                f"ID={checkpoint_id}.",
-                response=response,
-            )
-        try:
-            server_parameters = response.json()["data"]["expectation_parameters"]
-        except KeyError as e:
-            raise gx_exceptions.GXCloudError(
-                message="Malformed expectation_parameters response received from GX Cloud",
-                response=response,
-            ) from e
-
-        # Mercury returns an entry for every expectation in the checkpoint on
-        # every call. For expectations whose real batch_definition_id differs
-        # from this call's query param, mercury's forecast-store lookup misses
-        # and the entry holds an empty/baseline fallback. Those fallbacks
-        # aren't wrong per se, but if we merged them in they'd clobber the
-        # real values returned by the call keyed on the matching id. Keep
-        # only the entries whose owning batch_definition_id matches this
-        # call so the merge across calls composes cleanly.
-        return {
-            parameter_name: value
-            for parameter_name, value in server_parameters.items()
-            if parameter_name_to_batch_definition_id.get(parameter_name) == batch_definition_id
-        }
-
     def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:
         # Check if we have a windowed parameter
         for validation_def in checkpoint.validation_definitions:
@@ -883,30 +821,51 @@ class CloudDataContext(SerializableDataContext):
         return False
 
     @staticmethod
-    def _build_parameter_name_to_batch_definition_id(
-        checkpoint: Checkpoint,
-    ) -> Dict[str, Optional[str]]:
-        """Map each windowed expectation parameter_name to the batch_definition_id
-        of the validation definition that owns it.
-
-        The returned dict is the source of truth for the grouped-call merge in
-        ``prepare_checkpoint_run``. A parameter whose owning validation
-        definition has no batch_definition (or the id is missing) is mapped to
-        ``None``, which signals that mercury should fall back to inline
-        computation for that parameter.
+    def _fetch_expectation_parameters(
+        session: Any,
+        url: str,
+        batch_definition_id: Optional[str],
+        checkpoint_id: Optional[str],
+    ) -> Dict[str, Any]:
+        """Issue one ``GET /expectation-parameters`` call for the given
+        ``batch_definition_id`` and return the ``expectation_parameters`` dict
+        from the response body. When ``batch_definition_id`` is ``None`` the
+        query parameter is omitted so mercury applies its inline-computation
+        path.
         """
-        parameter_name_to_batch_definition_id: Dict[str, Optional[str]] = {}
+        params: Dict[str, str] = {}
+        if batch_definition_id is not None:
+            params["batch_definition_id"] = batch_definition_id
+        response = session.get(url=url, params=params)
+        if not response.ok:
+            raise gx_exceptions.GXCloudError(
+                message="Unable to retrieve expectation_parameters for Checkpoint with "
+                f"ID={checkpoint_id}.",
+                response=response,
+            )
+        try:
+            return response.json()["data"]["expectation_parameters"]
+        except KeyError as e:
+            raise gx_exceptions.GXCloudError(
+                message="Malformed expectation_parameters response received from GX Cloud",
+                response=response,
+            ) from e
+
+    @staticmethod
+    def _distinct_batch_definition_ids(checkpoint: Checkpoint) -> Set[Optional[str]]:
+        """Return the set of distinct ``batch_definition_id`` values across the
+        checkpoint's validation definitions.
+
+        Used to decide how many grouped ``GET /expectation-parameters`` calls to
+        make. ``None`` is a valid element — it signals that one of the validation
+        definitions has no batch definition id and mercury should apply its
+        inline-computation path for that subset.
+        """
+        ids: Set[Optional[str]] = set()
         for validation_def in checkpoint.validation_definitions:
             batch_definition = validation_def.data
             if isinstance(batch_definition, BatchDefinition):
-                batch_definition_id: Optional[str] = batch_definition.id
+                ids.add(batch_definition.id)
             else:
-                batch_definition_id = None
-            for expectation in validation_def.suite.expectations:
-                if expectation.windows is None:
-                    continue
-                for window in expectation.windows:
-                    parameter_name_to_batch_definition_id[window.parameter_name] = (
-                        batch_definition_id
-                    )
-        return parameter_name_to_batch_definition_id
+                ids.add(None)
+        return ids

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -796,15 +796,10 @@ class CloudDataContext(SerializableDataContext):
                     session=session,
                     url=expectation_parameters_url,
                     batch_definition_id=batch_definition_id,
+                    existing_parameters=expectation_parameters,
                 )
                 merged_parameters.update(new_parameters)
 
-        overlapping_keys = set(expectation_parameters.keys()) & set(merged_parameters.keys())
-        if overlapping_keys:
-            logger.warning(
-                "Passed in expectation_parameters also found in GX Cloud. Overwriting "
-                f"passed in values with GX Cloud values for keys: {overlapping_keys}"
-            )
         expectation_parameters.update(merged_parameters)
 
     def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:
@@ -820,6 +815,7 @@ class CloudDataContext(SerializableDataContext):
         session: Any,
         url: str,
         batch_definition_id: str,
+        existing_parameters: Dict[str, Any],
     ) -> Dict[str, Any]:
         """Issue one ``GET /expectation-parameters?batch_definition_id=X`` call
         and return the ``expectation_parameters`` dict from the response body.
@@ -832,7 +828,14 @@ class CloudDataContext(SerializableDataContext):
                 response=response,
             )
         try:
-            return response.json()["data"]["expectation_parameters"]
+            new_parameters = response.json()["data"]["expectation_parameters"]
+            overlapping_keys = set(existing_parameters.keys()) & set(new_parameters.keys())
+            if overlapping_keys:
+                logger.warning(
+                    "Passed in expectation_parameters also found in GX Cloud. Overwriting "
+                    f"passed in values with GX Cloud values for keys: {overlapping_keys}"
+                )
+            return new_parameters
         except KeyError as e:
             raise gx_exceptions.GXCloudError(
                 message="Malformed expectation_parameters response received from GX Cloud",

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -792,13 +792,18 @@ class CloudDataContext(SerializableDataContext):
             access_token=self.ge_cloud_config.access_token, timeout=EXPECTATION_PARAMS_TIMEOUT
         ) as session:
             for batch_definition_id in sorted(distinct_batch_definition_ids):
-                merged_parameters.update(
-                    self._fetch_expectation_parameters(
-                        session=session,
-                        url=expectation_parameters_url,
-                        batch_definition_id=batch_definition_id,
-                    )
+                new_parameters = self._fetch_expectation_parameters(
+                    session=session,
+                    url=expectation_parameters_url,
+                    batch_definition_id=batch_definition_id,
                 )
+                overlap = set(merged_parameters.keys()) & set(new_parameters.keys())
+                if overlap:
+                    logger.warning(
+                        "prepare_checkpoint_run.overlapping_parameters",
+                        extra={"overlapping_keys": sorted(overlap)},
+                    )
+                merged_parameters.update(new_parameters)
 
         overlapping_keys = set(expectation_parameters.keys()) & set(merged_parameters.keys())
         if overlapping_keys:
@@ -828,8 +833,8 @@ class CloudDataContext(SerializableDataContext):
         response = session.get(url=url, params={"batch_definition_id": batch_definition_id})
         if not response.ok:
             raise gx_exceptions.GXCloudError(
-                message="Unable to retrieve expectation_parameters for "
-                f"batch_definition_id={batch_definition_id}.",
+                message=f"Unable to retrieve expectation_parameters from {url} "
+                f"(batch_definition_id={batch_definition_id}).",
                 response=response,
             )
         try:
@@ -851,7 +856,7 @@ class CloudDataContext(SerializableDataContext):
         """
         ids: Set[str] = set()
         for validation_def in checkpoint.validation_definitions:
-            if not any(exp.windows for exp in validation_def.suite.expectations):
+            if not any(exp.windows is not None for exp in validation_def.suite.expectations):
                 continue
             batch_definition = validation_def.data
             if isinstance(batch_definition, BatchDefinition) and batch_definition.id:

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -797,12 +797,6 @@ class CloudDataContext(SerializableDataContext):
                     url=expectation_parameters_url,
                     batch_definition_id=batch_definition_id,
                 )
-                overlap = set(merged_parameters.keys()) & set(new_parameters.keys())
-                if overlap:
-                    logger.warning(
-                        "prepare_checkpoint_run.overlapping_parameters",
-                        extra={"overlapping_keys": sorted(overlap)},
-                    )
                 merged_parameters.update(new_parameters)
 
         overlapping_keys = set(expectation_parameters.keys()) & set(merged_parameters.keys())

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -799,12 +799,6 @@ class CloudDataContext(SerializableDataContext):
                 )
                 merged_parameters.update(new_parameters)
 
-        overlapping_keys = set(expectation_parameters.keys()) & set(merged_parameters.keys())
-        if overlapping_keys:
-            logger.warning(
-                "Passed in expectation_parameters also found in GX Cloud. Overwriting "
-                f"passed in values with GX Cloud values for keys: {overlapping_keys}"
-            )
         expectation_parameters.update(merged_parameters)
 
     def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:
@@ -845,14 +839,15 @@ class CloudDataContext(SerializableDataContext):
         checkpoint's validation definitions.
 
         Used to decide how many grouped ``GET /expectation-parameters`` calls to
-        make — one call per distinct id. Validation definitions without a
-        ``BatchDefinition`` are skipped; they are not in the forecast store path.
+        make — one call per distinct id. Validation definitions whose data source
+        is not a ``BatchDefinition`` are skipped; they are not in the forecast
+        store path.
         """
         ids: Set[str] = set()
         for validation_def in checkpoint.validation_definitions:
             if not any(exp.windows is not None for exp in validation_def.suite.expectations):
                 continue
             batch_definition = validation_def.data
-            if isinstance(batch_definition, BatchDefinition) and batch_definition.id:
-                ids.add(batch_definition.id)
+            if isinstance(batch_definition, BatchDefinition):
+                ids.add(str(batch_definition.id))
         return ids

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -16,12 +16,13 @@ from typing import (
 )
 from urllib.parse import urljoin
 
-from requests import HTTPError, Response
+from requests import HTTPError, Response, Session
 
 import great_expectations.exceptions as gx_exceptions
 from great_expectations import __version__
 from great_expectations._docs_decorators import public_api
 from great_expectations.compatibility.typing_extensions import override
+from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.config_provider import (
     _CloudConfigurationProvider,
     _ConfigurationProvider,
@@ -772,46 +773,91 @@ class CloudDataContext(SerializableDataContext):
                 url=f"/api/v1/organizations/{org_id}/checkpoints/{checkpoint.id}/expectation-parameters",
             )
 
-        # When the checkpoint has a single, unambiguous batch_definition_id, thread
-        # it through as a query parameter so mercury can look up forecasted bounds
-        # from the async forecast store instead of falling back to inline training.
-        # Omitting the param preserves backward compatibility with older mercury
-        # versions that do not understand it.
-        params: Dict[str, str] = {}
-        batch_definition_id = self._get_single_batch_definition_id(checkpoint)
-        if batch_definition_id is not None:
-            params["batch_definition_id"] = batch_definition_id
+        # Mercury's forecast store is keyed by (expectation_id, batch_definition_id).
+        # An expectation's dynamic parameters are only correct when the server
+        # looks them up with that expectation's own batch_definition_id — if the
+        # checkpoint spans multiple batch definitions, a single shared call would
+        # return wrong values (or empty bounds) for the expectations that don't
+        # match. Group expectations by their batch_definition_id and make one
+        # call per distinct id, then merge server responses, keeping each
+        # parameter_name only from the call whose batch_definition_id matches
+        # the expectation that owns that parameter.
+        parameter_name_to_batch_definition_id = self._build_parameter_name_to_batch_definition_id(
+            checkpoint
+        )
+        distinct_batch_definition_ids = set(parameter_name_to_batch_definition_id.values())
 
         # temporarily extend expectation parameter timeout to 10 minutes
         # while a more robust solution is implemented
         EXPECTATION_PARAMS_TIMEOUT = 600
+
+        merged_parameters: Dict[str, Any] = {}
         with create_session(
             access_token=self.ge_cloud_config.access_token, timeout=EXPECTATION_PARAMS_TIMEOUT
         ) as session:
-            response = session.get(url=expectation_parameters_url, params=params)
+            for batch_definition_id in distinct_batch_definition_ids:
+                merged_parameters.update(
+                    self._fetch_expectation_parameters_for_batch_definition_id(
+                        session=session,
+                        url=expectation_parameters_url,
+                        batch_definition_id=batch_definition_id,
+                        parameter_name_to_batch_definition_id=(
+                            parameter_name_to_batch_definition_id
+                        ),
+                        checkpoint_id=checkpoint.id,
+                    )
+                )
 
+        overlapping_keys = set(expectation_parameters.keys()) & set(merged_parameters.keys())
+        if overlapping_keys:
+            logger.warning(
+                "Passed in expectation_parameters also found in GX Cloud. Overwriting "
+                f"passed in values with GX Cloud values for keys: {overlapping_keys}"
+            )
+        expectation_parameters.update(merged_parameters)
+
+    @staticmethod
+    def _fetch_expectation_parameters_for_batch_definition_id(
+        session: Session,
+        url: str,
+        batch_definition_id: Optional[str],
+        parameter_name_to_batch_definition_id: Dict[str, Optional[str]],
+        checkpoint_id: Optional[str],
+    ) -> Dict[str, Any]:
+        """Issue a single GET /expectation-parameters call for the given
+        ``batch_definition_id`` and return only the subset of response entries
+        whose ``parameter_name`` belongs to an expectation with that same id.
+
+        When ``batch_definition_id`` is ``None`` the query parameter is omitted
+        so mercury falls back to inline computation for those expectations
+        (also preserves backward compatibility with older mercury versions).
+        """
+        params: Dict[str, str] = {}
+        if batch_definition_id is not None:
+            params["batch_definition_id"] = batch_definition_id
+
+        response = session.get(url=url, params=params)
         if not response.ok:
             raise gx_exceptions.GXCloudError(
                 message="Unable to retrieve expectation_parameters for Checkpoint with "
-                f"ID={checkpoint.id}.",
+                f"ID={checkpoint_id}.",
                 response=response,
             )
-        data = response.json()
         try:
-            overlapping_keys = set(expectation_parameters.keys()) & set(
-                data["data"]["expectation_parameters"].keys()
-            )
-            if overlapping_keys:
-                logger.warning(
-                    "Passed in expectation_parameters also found in GX Cloud. Overwriting "
-                    f"passed in values with GX Cloud values for keys: {overlapping_keys}"
-                )
-            expectation_parameters.update(data["data"]["expectation_parameters"])
+            server_parameters = response.json()["data"]["expectation_parameters"]
         except KeyError as e:
             raise gx_exceptions.GXCloudError(
                 message="Malformed expectation_parameters response received from GX Cloud",
                 response=response,
             ) from e
+
+        # Values for expectations whose actual batch_definition_id doesn't
+        # match this call's query param are incorrect — discard them.
+        return {
+            parameter_name: value
+            for parameter_name, value in server_parameters.items()
+            if parameter_name_to_batch_definition_id.get(parameter_name) == batch_definition_id
+        }
 
     def _checkpoint_has_windowed_expectations(self, checkpoint: Checkpoint) -> bool:
         # Check if we have a windowed parameter
@@ -822,23 +868,30 @@ class CloudDataContext(SerializableDataContext):
         return False
 
     @staticmethod
-    def _get_single_batch_definition_id(checkpoint: Checkpoint) -> Optional[str]:
-        """Return the batch_definition_id shared by all validation definitions,
-        or ``None`` if it cannot be unambiguously determined.
+    def _build_parameter_name_to_batch_definition_id(
+        checkpoint: Checkpoint,
+    ) -> Dict[str, Optional[str]]:
+        """Map each windowed expectation parameter_name to the batch_definition_id
+        of the validation definition that owns it.
 
-        The forecast store is keyed by ``(expectation_id, batch_definition_id)``.
-        When a checkpoint's validation definitions all reference the same batch
-        definition we can supply it to ``GET /expectation-parameters``; if they
-        reference different batch definitions (or any id is missing) we omit the
-        parameter and let mercury fall back to inline computation.
+        The returned dict is the source of truth for the grouped-call merge in
+        ``prepare_checkpoint_run``. A parameter whose owning validation
+        definition has no batch_definition (or the id is missing) is mapped to
+        ``None``, which signals that mercury should fall back to inline
+        computation for that parameter.
         """
-        ids = set()
+        parameter_name_to_batch_definition_id: Dict[str, Optional[str]] = {}
         for validation_def in checkpoint.validation_definitions:
-            batch_definition = getattr(validation_def, "data", None)
-            batch_definition_id = getattr(batch_definition, "id", None)
-            if not batch_definition_id:
-                return None
-            ids.add(batch_definition_id)
-        if len(ids) != 1:
-            return None
-        return next(iter(ids))
+            batch_definition = validation_def.data
+            if isinstance(batch_definition, BatchDefinition):
+                batch_definition_id: Optional[str] = batch_definition.id
+            else:
+                batch_definition_id = None
+            for expectation in validation_def.suite.expectations:
+                if expectation.windows is None:
+                    continue
+                for window in expectation.windows:
+                    parameter_name_to_batch_definition_id[window.parameter_name] = (
+                        batch_definition_id
+                    )
+        return parameter_name_to_batch_definition_id

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -796,7 +796,7 @@ class CloudDataContext(SerializableDataContext):
                     session=session,
                     url=expectation_parameters_url,
                     batch_definition_id=batch_definition_id,
-                    existing_parameters=expectation_parameters,
+                    expectation_parameters=expectation_parameters,
                 )
                 merged_parameters.update(new_parameters)
 
@@ -815,7 +815,7 @@ class CloudDataContext(SerializableDataContext):
         session: Any,
         url: str,
         batch_definition_id: str,
-        existing_parameters: Dict[str, Any],
+        expectation_parameters: Dict[str, Any],
     ) -> Dict[str, Any]:
         """Issue one ``GET /expectation-parameters?batch_definition_id=X`` call
         and return the ``expectation_parameters`` dict from the response body.
@@ -827,15 +827,17 @@ class CloudDataContext(SerializableDataContext):
                 f"(batch_definition_id={batch_definition_id}).",
                 response=response,
             )
+        data = response.json()
         try:
-            new_parameters = response.json()["data"]["expectation_parameters"]
-            overlapping_keys = set(existing_parameters.keys()) & set(new_parameters.keys())
+            overlapping_keys = set(expectation_parameters.keys()) & set(
+                data["data"]["expectation_parameters"].keys()
+            )
             if overlapping_keys:
                 logger.warning(
                     "Passed in expectation_parameters also found in GX Cloud. Overwriting "
                     f"passed in values with GX Cloud values for keys: {overlapping_keys}"
                 )
-            return new_parameters
+            return data["data"]["expectation_parameters"]
         except KeyError as e:
             raise gx_exceptions.GXCloudError(
                 message="Malformed expectation_parameters response received from GX Cloud",

--- a/great_expectations/data_context/data_context/cloud_data_context.py
+++ b/great_expectations/data_context/data_context/cloud_data_context.py
@@ -791,7 +791,7 @@ class CloudDataContext(SerializableDataContext):
         with create_session(
             access_token=self.ge_cloud_config.access_token, timeout=EXPECTATION_PARAMS_TIMEOUT
         ) as session:
-            for batch_definition_id in distinct_batch_definition_ids:
+            for batch_definition_id in sorted(distinct_batch_definition_ids):
                 merged_parameters.update(
                     self._fetch_expectation_parameters(
                         session=session,

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -194,11 +194,6 @@ def test_warns_when_workspace_id_env_var_unset(unset_gx_env_variables: None):
     assert "GX_CLOUD_WORKSPACE_ID" in warning_message
 
 
-# ---------------------------------------------------------------------------
-# prepare_checkpoint_run: batch_definition_id query param
-# ---------------------------------------------------------------------------
-
-
 CHECKPOINT_ID = str(uuid.uuid4())
 BATCH_DEFINITION_ID = str(uuid.uuid4())
 # urljoin() with an absolute URL path replaces the base URL's path, so the

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -397,27 +397,17 @@ class TestPrepareCheckpointRun:
 
     @responses.activate
     @pytest.mark.unit
-    def test_mixes_batch_definition_ids_and_none(self, make_checkpoint) -> None:
-        """Some validation definitions have a batch_definition_id, others don't
-        → one call with the id (mercury returns only the scoped entries), one
-        without (mercury returns entries for expectations without a batch
-        definition via its inline path). Merge is a clean union.
+    def test_skips_expectations_without_batch_definition_id(self, make_checkpoint) -> None:
+        """Validation definitions without a batch_definition_id are not in the
+        forecast store path and are skipped; only the scoped call is made.
         """
         batch_definition_id_a = str(uuid.uuid4())
 
-        def callback(request):
-            bd_id = parse_qs(urlparse(request.url).query).get("batch_definition_id", [None])[0]
-            if bd_id == batch_definition_id_a:
-                body = {"data": {"expectation_parameters": {"p_a_max": 111}}}
-            else:
-                body = {"data": {"expectation_parameters": {"p_none_max": 222}}}
-            return (200, {}, json.dumps(body))
-
-        responses.add_callback(
+        responses.add(
             responses.GET,
             EXPECTATION_PARAMETERS_URL,
-            callback=callback,
-            content_type="application/json",
+            json={"data": {"expectation_parameters": {"p_a_max": 111}}},
+            status=200,
         )
 
         checkpoint = make_checkpoint(
@@ -435,9 +425,6 @@ class TestPrepareCheckpointRun:
         )
 
         ep_calls = self._expectation_parameter_calls()
-        assert len(ep_calls) == 2
-        calls_with_param = [c for c in ep_calls if self._batch_definition_id_on_call(c) is not None]
-        assert len(calls_with_param) == 1
-
-        # Disjoint keys from the two calls; merge is a clean union.
-        assert expectation_parameters == {"p_a_max": 111, "p_none_max": 222}
+        assert len(ep_calls) == 1
+        assert self._batch_definition_id_on_call(ep_calls[0]) == batch_definition_id_a
+        assert expectation_parameters == {"p_a_max": 111}

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -1,5 +1,6 @@
+import json
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -209,113 +210,234 @@ EXPECTATION_PARAMETERS_URL = (
 )
 
 
-def _build_cloud_context() -> CloudDataContext:
-    """Construct a CloudDataContext whose /data-context-configuration call is mocked."""
-    responses.add(
-        responses.GET,
-        CONTEXT_CONFIGURATION_URL,
-        json=V1_CONFIG,
-        status=200,
-    )
-    return CloudDataContext(
-        cloud_base_url=CLOUD_BASE_URL,
-        cloud_access_token=ACCESS_TOKEN,
-        cloud_organization_id=ORG_ID,
-        cloud_workspace_id=WORKSPACE_ID,
-    )
+class TestPrepareCheckpointRun:
+    """Tests for ``CloudDataContext.prepare_checkpoint_run`` grouped-call
+    behavior against ``GET /expectation-parameters`` (GX-3229).
 
-
-def _build_checkpoint(mocker: MockerFixture, batch_definition_id: Optional[str]):
-    """Build a minimal Checkpoint with a single ValidationDefinition whose
-    BatchDefinition has the given id.
+    Mercury's forecast store is keyed by ``(expectation_id, batch_definition_id)``,
+    so an expectation's dynamic parameters are only correct when the server
+    resolves them using that expectation's own ``batch_definition_id``. When
+    a checkpoint spans multiple batch definitions, the client issues one call
+    per distinct id and merges responses by ``parameter_name``, keeping each
+    parameter only from the call whose ``batch_definition_id`` matches the
+    expectation that owns it.
     """
-    from great_expectations.checkpoint.checkpoint import Checkpoint
 
-    batch_definition = mocker.Mock(spec=BatchDefinition)
-    batch_definition.id = batch_definition_id
+    @pytest.fixture
+    def cloud_context(self) -> CloudDataContext:
+        """CloudDataContext whose /data-context-configuration call is mocked."""
+        responses.add(
+            responses.GET,
+            CONTEXT_CONFIGURATION_URL,
+            json=V1_CONFIG,
+            status=200,
+        )
+        return CloudDataContext(
+            cloud_base_url=CLOUD_BASE_URL,
+            cloud_access_token=ACCESS_TOKEN,
+            cloud_organization_id=ORG_ID,
+            cloud_workspace_id=WORKSPACE_ID,
+        )
 
-    validation_definition = ValidationDefinition.construct(
-        name="my_validation_definition",
-        data=batch_definition,
-        suite=mocker.Mock(spec=ExpectationSuite),
-        id=str(uuid.uuid4()),
-    )
+    @pytest.fixture
+    def make_checkpoint(self, mocker: MockerFixture):
+        """Factory fixture: build a Checkpoint from a list of tuples of the form
+        ``(batch_definition_id, [parameter_names])`` — one tuple per
+        ValidationDefinition. Each parameter_name becomes a single windowed
+        expectation under that validation definition's suite.
+        """
+        from great_expectations.checkpoint.checkpoint import Checkpoint
 
-    return Checkpoint.construct(
-        name="my_checkpoint",
-        validation_definitions=[validation_definition],
-        actions=[],
-        id=CHECKPOINT_ID,
-    )
+        def _build(
+            validation_defs: List[Tuple[Optional[str], List[str]]],
+        ) -> Checkpoint:
+            vds = []
+            for batch_definition_id, parameter_names in validation_defs:
+                batch_definition = mocker.Mock(spec=BatchDefinition)
+                batch_definition.id = batch_definition_id
 
+                expectations = []
+                for parameter_name in parameter_names:
+                    window = mocker.Mock()
+                    window.parameter_name = parameter_name
+                    expectation = mocker.Mock()
+                    expectation.windows = [window]
+                    expectations.append(expectation)
 
-@responses.activate
-@pytest.mark.unit
-def test_prepare_checkpoint_run_passes_batch_definition_id_when_available(
-    mocker: MockerFixture,
-) -> None:
-    """SDK passes batch_definition_id as a query parameter when the checkpoint's
-    validation definition has a batch_definition with an id.
-    """
-    responses.add(
-        responses.GET,
-        EXPECTATION_PARAMETERS_URL,
-        json={"data": {"expectation_parameters": {}}},
-        status=200,
-    )
+                suite = mocker.Mock(spec=ExpectationSuite)
+                suite.expectations = expectations
 
-    ctx = _build_cloud_context()
-    checkpoint = _build_checkpoint(mocker, batch_definition_id=BATCH_DEFINITION_ID)
+                vd = ValidationDefinition.construct(
+                    name=f"vd_{batch_definition_id}",
+                    data=batch_definition,
+                    suite=suite,
+                    id=str(uuid.uuid4()),
+                )
+                vds.append(vd)
 
-    mocker.patch.object(
-        type(ctx),
-        "_checkpoint_has_windowed_expectations",
-        return_value=True,
-    )
-    ctx.prepare_checkpoint_run(
-        checkpoint=checkpoint,
-        batch_parameters={},
-        expectation_parameters={},
-    )
+            return Checkpoint.construct(
+                name="my_checkpoint",
+                validation_definitions=vds,
+                actions=[],
+                id=CHECKPOINT_ID,
+            )
 
-    # The last call should be the expectation-parameters GET.
-    expectation_params_call = responses.calls[-1]
-    parsed = urlparse(expectation_params_call.request.url)
-    query = parse_qs(parsed.query)
-    assert query.get("batch_definition_id") == [BATCH_DEFINITION_ID]
+        return _build
 
+    @staticmethod
+    def _expectation_parameter_calls() -> List[responses.Call]:
+        return [call for call in responses.calls if "expectation-parameters" in call.request.url]
 
-@responses.activate
-@pytest.mark.unit
-def test_prepare_checkpoint_run_omits_batch_definition_id_when_unavailable(
-    mocker: MockerFixture,
-) -> None:
-    """SDK does not pass batch_definition_id when it is not available. This
-    preserves backward compatibility with older mercury versions that do not
-    understand the query parameter.
-    """
-    responses.add(
-        responses.GET,
-        EXPECTATION_PARAMETERS_URL,
-        json={"data": {"expectation_parameters": {}}},
-        status=200,
-    )
+    @staticmethod
+    def _batch_definition_id_on_call(call: responses.Call) -> Optional[str]:
+        return parse_qs(urlparse(call.request.url).query).get("batch_definition_id", [None])[0]
 
-    ctx = _build_cloud_context()
-    checkpoint = _build_checkpoint(mocker, batch_definition_id=None)
+    @responses.activate
+    @pytest.mark.unit
+    def test_passes_batch_definition_id_when_available(
+        self, cloud_context, make_checkpoint
+    ) -> None:
+        responses.add(
+            responses.GET,
+            EXPECTATION_PARAMETERS_URL,
+            json={"data": {"expectation_parameters": {"p_max": 42}}},
+            status=200,
+        )
+        checkpoint = make_checkpoint([(BATCH_DEFINITION_ID, ["p_max"])])
 
-    mocker.patch.object(
-        type(ctx),
-        "_checkpoint_has_windowed_expectations",
-        return_value=True,
-    )
-    ctx.prepare_checkpoint_run(
-        checkpoint=checkpoint,
-        batch_parameters={},
-        expectation_parameters={},
-    )
+        cloud_context.prepare_checkpoint_run(
+            checkpoint=checkpoint,
+            batch_parameters={},
+            expectation_parameters={},
+        )
 
-    expectation_params_call = responses.calls[-1]
-    parsed = urlparse(expectation_params_call.request.url)
-    query = parse_qs(parsed.query)
-    assert "batch_definition_id" not in query
+        ep_calls = self._expectation_parameter_calls()
+        assert len(ep_calls) == 1
+        assert self._batch_definition_id_on_call(ep_calls[0]) == BATCH_DEFINITION_ID
+
+    @responses.activate
+    @pytest.mark.unit
+    def test_omits_batch_definition_id_when_unavailable(
+        self, cloud_context, make_checkpoint
+    ) -> None:
+        """Preserves backward compatibility with older mercury versions that do
+        not understand the query parameter.
+        """
+        responses.add(
+            responses.GET,
+            EXPECTATION_PARAMETERS_URL,
+            json={"data": {"expectation_parameters": {"p_max": 42}}},
+            status=200,
+        )
+        checkpoint = make_checkpoint([(None, ["p_max"])])
+
+        cloud_context.prepare_checkpoint_run(
+            checkpoint=checkpoint,
+            batch_parameters={},
+            expectation_parameters={},
+        )
+
+        ep_calls = self._expectation_parameter_calls()
+        assert len(ep_calls) == 1
+        assert self._batch_definition_id_on_call(ep_calls[0]) is None
+
+    @responses.activate
+    @pytest.mark.unit
+    def test_groups_calls_by_distinct_batch_definition_id(
+        self, cloud_context, make_checkpoint
+    ) -> None:
+        """Checkpoint spans two batch definitions → two grouped calls, merge
+        keeps each parameter only from the matching call.
+        """
+        batch_definition_id_a = str(uuid.uuid4())
+        batch_definition_id_b = str(uuid.uuid4())
+
+        # Mercury always returns parameters for every expectation in the
+        # checkpoint, but values for expectations whose actual
+        # batch_definition_id doesn't match the query param are "wrong"
+        # (empty bounds or baseline). The SDK must discard those entries.
+        def callback(request):
+            bd_id = parse_qs(urlparse(request.url).query).get("batch_definition_id", [None])[0]
+            if bd_id == batch_definition_id_a:
+                body = {"data": {"expectation_parameters": {"p_a_max": 111, "p_b_max": 999}}}
+            elif bd_id == batch_definition_id_b:
+                body = {"data": {"expectation_parameters": {"p_a_max": 999, "p_b_max": 222}}}
+            else:
+                body = {"data": {"expectation_parameters": {}}}
+            return (200, {}, json.dumps(body))
+
+        responses.add_callback(
+            responses.GET,
+            EXPECTATION_PARAMETERS_URL,
+            callback=callback,
+            content_type="application/json",
+        )
+
+        checkpoint = make_checkpoint(
+            [
+                (batch_definition_id_a, ["p_a_max"]),
+                (batch_definition_id_b, ["p_b_max"]),
+            ]
+        )
+        expectation_parameters: dict = {}
+
+        cloud_context.prepare_checkpoint_run(
+            checkpoint=checkpoint,
+            batch_parameters={},
+            expectation_parameters=expectation_parameters,
+        )
+
+        ep_calls = self._expectation_parameter_calls()
+        assert len(ep_calls) == 2
+        bd_ids_used = sorted(self._batch_definition_id_on_call(c) for c in ep_calls)
+        assert bd_ids_used == sorted([batch_definition_id_a, batch_definition_id_b])
+
+        # Merge is correct: each parameter keeps the value from the matched
+        # call; the 999s from the mismatched calls must NOT win.
+        assert expectation_parameters == {"p_a_max": 111, "p_b_max": 222}
+
+    @responses.activate
+    @pytest.mark.unit
+    def test_mixes_batch_definition_ids_and_none(self, cloud_context, make_checkpoint) -> None:
+        """Some validation definitions have a batch_definition_id, others don't
+        → one call with the id, one without (inline fallback); merge keeps each
+        parameter from the matching call.
+        """
+        batch_definition_id_a = str(uuid.uuid4())
+
+        def callback(request):
+            bd_id = parse_qs(urlparse(request.url).query).get("batch_definition_id", [None])[0]
+            if bd_id == batch_definition_id_a:
+                body = {"data": {"expectation_parameters": {"p_a_max": 111, "p_none_max": 999}}}
+            else:
+                body = {"data": {"expectation_parameters": {"p_a_max": 999, "p_none_max": 222}}}
+            return (200, {}, json.dumps(body))
+
+        responses.add_callback(
+            responses.GET,
+            EXPECTATION_PARAMETERS_URL,
+            callback=callback,
+            content_type="application/json",
+        )
+
+        checkpoint = make_checkpoint(
+            [
+                (batch_definition_id_a, ["p_a_max"]),
+                (None, ["p_none_max"]),
+            ]
+        )
+        expectation_parameters: dict = {}
+
+        cloud_context.prepare_checkpoint_run(
+            checkpoint=checkpoint,
+            batch_parameters={},
+            expectation_parameters=expectation_parameters,
+        )
+
+        ep_calls = self._expectation_parameter_calls()
+        assert len(ep_calls) == 2
+        calls_with_param = [c for c in ep_calls if self._batch_definition_id_on_call(c) is not None]
+        assert len(calls_with_param) == 1
+
+        # Merge picks the matched values, discards the mismatched 999s.
+        assert expectation_parameters == {"p_a_max": 111, "p_none_max": 222}

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -223,9 +223,15 @@ class TestPrepareCheckpointRun:
     expectation that owns it.
     """
 
-    @pytest.fixture
-    def cloud_context(self) -> CloudDataContext:
-        """CloudDataContext whose /data-context-configuration call is mocked."""
+    @staticmethod
+    def _build_cloud_context() -> CloudDataContext:
+        """CloudDataContext whose /data-context-configuration call is mocked.
+
+        This is a static helper (not a ``@pytest.fixture``) because
+        ``responses.add`` has to execute inside the test's ``@responses.activate``
+        wrapper — fixtures resolve before the wrapper takes effect, so mocks
+        registered in a fixture don't intercept the ``__init__`` HTTP call.
+        """
         responses.add(
             responses.GET,
             CONTEXT_CONFIGURATION_URL,
@@ -286,17 +292,23 @@ class TestPrepareCheckpointRun:
 
     @staticmethod
     def _expectation_parameter_calls() -> List[responses.Call]:
-        return [call for call in responses.calls if "expectation-parameters" in call.request.url]
+        return [
+            call
+            for call in responses.calls
+            if call.request.url and "expectation-parameters" in call.request.url
+        ]
 
     @staticmethod
     def _batch_definition_id_on_call(call: responses.Call) -> Optional[str]:
-        return parse_qs(urlparse(call.request.url).query).get("batch_definition_id", [None])[0]
+        url = call.request.url
+        if url is None:
+            return None
+        values = parse_qs(urlparse(url).query).get("batch_definition_id")
+        return values[0] if values else None
 
     @responses.activate
     @pytest.mark.unit
-    def test_passes_batch_definition_id_when_available(
-        self, cloud_context, make_checkpoint
-    ) -> None:
+    def test_passes_batch_definition_id_when_available(self, make_checkpoint) -> None:
         responses.add(
             responses.GET,
             EXPECTATION_PARAMETERS_URL,
@@ -305,7 +317,7 @@ class TestPrepareCheckpointRun:
         )
         checkpoint = make_checkpoint([(BATCH_DEFINITION_ID, ["p_max"])])
 
-        cloud_context.prepare_checkpoint_run(
+        self._build_cloud_context().prepare_checkpoint_run(
             checkpoint=checkpoint,
             batch_parameters={},
             expectation_parameters={},
@@ -317,9 +329,7 @@ class TestPrepareCheckpointRun:
 
     @responses.activate
     @pytest.mark.unit
-    def test_omits_batch_definition_id_when_unavailable(
-        self, cloud_context, make_checkpoint
-    ) -> None:
+    def test_omits_batch_definition_id_when_unavailable(self, make_checkpoint) -> None:
         """Preserves backward compatibility with older mercury versions that do
         not understand the query parameter.
         """
@@ -331,7 +341,7 @@ class TestPrepareCheckpointRun:
         )
         checkpoint = make_checkpoint([(None, ["p_max"])])
 
-        cloud_context.prepare_checkpoint_run(
+        self._build_cloud_context().prepare_checkpoint_run(
             checkpoint=checkpoint,
             batch_parameters={},
             expectation_parameters={},
@@ -343,9 +353,7 @@ class TestPrepareCheckpointRun:
 
     @responses.activate
     @pytest.mark.unit
-    def test_groups_calls_by_distinct_batch_definition_id(
-        self, cloud_context, make_checkpoint
-    ) -> None:
+    def test_groups_calls_by_distinct_batch_definition_id(self, make_checkpoint) -> None:
         """Checkpoint spans two batch definitions → two grouped calls, merge
         keeps each parameter only from the matching call.
         """
@@ -381,7 +389,7 @@ class TestPrepareCheckpointRun:
         )
         expectation_parameters: dict = {}
 
-        cloud_context.prepare_checkpoint_run(
+        self._build_cloud_context().prepare_checkpoint_run(
             checkpoint=checkpoint,
             batch_parameters={},
             expectation_parameters=expectation_parameters,
@@ -389,7 +397,11 @@ class TestPrepareCheckpointRun:
 
         ep_calls = self._expectation_parameter_calls()
         assert len(ep_calls) == 2
-        bd_ids_used = sorted(self._batch_definition_id_on_call(c) for c in ep_calls)
+        bd_ids_used = sorted(
+            bd_id
+            for bd_id in (self._batch_definition_id_on_call(c) for c in ep_calls)
+            if bd_id is not None
+        )
         assert bd_ids_used == sorted([batch_definition_id_a, batch_definition_id_b])
 
         # Merge is correct: each parameter keeps the value from the matched
@@ -398,7 +410,7 @@ class TestPrepareCheckpointRun:
 
     @responses.activate
     @pytest.mark.unit
-    def test_mixes_batch_definition_ids_and_none(self, cloud_context, make_checkpoint) -> None:
+    def test_mixes_batch_definition_ids_and_none(self, make_checkpoint) -> None:
         """Some validation definitions have a batch_definition_id, others don't
         → one call with the id, one without (inline fallback); merge keeps each
         parameter from the matching call.
@@ -428,7 +440,7 @@ class TestPrepareCheckpointRun:
         )
         expectation_parameters: dict = {}
 
-        cloud_context.prepare_checkpoint_run(
+        self._build_cloud_context().prepare_checkpoint_run(
             checkpoint=checkpoint,
             batch_parameters={},
             expectation_parameters=expectation_parameters,

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -1,12 +1,13 @@
 import json
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
 from pytest_mock import MockerFixture
 
+from great_expectations.checkpoint.checkpoint import Checkpoint
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.core.expectation_suite import ExpectationSuite
 from great_expectations.core.validation_definition import ValidationDefinition
@@ -247,10 +248,9 @@ class TestPrepareCheckpointRun:
         ValidationDefinition. Each parameter_name becomes a single windowed
         expectation under that validation definition's suite.
         """
-        from great_expectations.checkpoint.checkpoint import Checkpoint
 
         def _build(
-            validation_defs: List[Tuple[Optional[str], List[str]]],
+            validation_defs: List[Tuple[str, List[str]]],
         ) -> Checkpoint:
             vds = []
             for batch_definition_id, parameter_names in validation_defs:
@@ -294,7 +294,7 @@ class TestPrepareCheckpointRun:
         ]
 
     @staticmethod
-    def _batch_definition_id_on_call(call: responses.Call) -> Optional[str]:
+    def _batch_definition_id_on_call(call: responses.Call) -> str | None:
         url = call.request.url
         if url is None:
             return None
@@ -321,25 +321,6 @@ class TestPrepareCheckpointRun:
         ep_calls = self._expectation_parameter_calls()
         assert len(ep_calls) == 1
         assert self._batch_definition_id_on_call(ep_calls[0]) == BATCH_DEFINITION_ID
-
-    @responses.activate
-    @pytest.mark.unit
-    def test_skips_call_when_no_batch_definition_id_available(self, make_checkpoint) -> None:
-        """When no validation definition carries a batch_definition_id the
-        method returns early without calling mercury — those expectations are
-        not in the forecast store path.
-        """
-        checkpoint = make_checkpoint([(None, ["p_max"])])
-        expectation_parameters: dict = {}
-
-        self._build_cloud_context().prepare_checkpoint_run(
-            checkpoint=checkpoint,
-            batch_parameters={},
-            expectation_parameters=expectation_parameters,
-        )
-
-        assert self._expectation_parameter_calls() == []
-        assert expectation_parameters == {}
 
     @responses.activate
     @pytest.mark.unit
@@ -394,37 +375,3 @@ class TestPrepareCheckpointRun:
 
         # Responses from each call carry disjoint keys; the merge is a union.
         assert expectation_parameters == {"p_a_max": 111, "p_b_max": 222}
-
-    @responses.activate
-    @pytest.mark.unit
-    def test_skips_expectations_without_batch_definition_id(self, make_checkpoint) -> None:
-        """Validation definitions without a batch_definition_id are not in the
-        forecast store path and are skipped; only the scoped call is made.
-        """
-        batch_definition_id_a = str(uuid.uuid4())
-
-        responses.add(
-            responses.GET,
-            EXPECTATION_PARAMETERS_URL,
-            json={"data": {"expectation_parameters": {"p_a_max": 111}}},
-            status=200,
-        )
-
-        checkpoint = make_checkpoint(
-            [
-                (batch_definition_id_a, ["p_a_max"]),
-                (None, ["p_none_max"]),
-            ]
-        )
-        expectation_parameters: dict = {}
-
-        self._build_cloud_context().prepare_checkpoint_run(
-            checkpoint=checkpoint,
-            batch_parameters={},
-            expectation_parameters=expectation_parameters,
-        )
-
-        ep_calls = self._expectation_parameter_calls()
-        assert len(ep_calls) == 1
-        assert self._batch_definition_id_on_call(ep_calls[0]) == batch_definition_id_a
-        assert expectation_parameters == {"p_a_max": 111}

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -329,27 +329,22 @@ class TestPrepareCheckpointRun:
 
     @responses.activate
     @pytest.mark.unit
-    def test_omits_batch_definition_id_when_unavailable(self, make_checkpoint) -> None:
-        """Preserves backward compatibility with older mercury versions that do
-        not understand the query parameter.
+    def test_skips_call_when_no_batch_definition_id_available(self, make_checkpoint) -> None:
+        """When no validation definition carries a batch_definition_id the
+        method returns early without calling mercury — those expectations are
+        not in the forecast store path.
         """
-        responses.add(
-            responses.GET,
-            EXPECTATION_PARAMETERS_URL,
-            json={"data": {"expectation_parameters": {"p_max": 42}}},
-            status=200,
-        )
         checkpoint = make_checkpoint([(None, ["p_max"])])
+        expectation_parameters: dict = {}
 
         self._build_cloud_context().prepare_checkpoint_run(
             checkpoint=checkpoint,
             batch_parameters={},
-            expectation_parameters={},
+            expectation_parameters=expectation_parameters,
         )
 
-        ep_calls = self._expectation_parameter_calls()
-        assert len(ep_calls) == 1
-        assert self._batch_definition_id_on_call(ep_calls[0]) is None
+        assert self._expectation_parameter_calls() == []
+        assert expectation_parameters == {}
 
     @responses.activate
     @pytest.mark.unit

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -195,7 +195,7 @@ def test_warns_when_workspace_id_env_var_unset(unset_gx_env_variables: None):
 
 
 # ---------------------------------------------------------------------------
-# prepare_checkpoint_run: batch_definition_id query param (GX-3229)
+# prepare_checkpoint_run: batch_definition_id query param
 # ---------------------------------------------------------------------------
 
 
@@ -212,7 +212,7 @@ EXPECTATION_PARAMETERS_URL = (
 
 class TestPrepareCheckpointRun:
     """Tests for ``CloudDataContext.prepare_checkpoint_run`` grouped-call
-    behavior against ``GET /expectation-parameters`` (GX-3229).
+    behavior against ``GET /expectation-parameters``.
 
     Mercury's forecast store is keyed by ``(expectation_id, batch_definition_id)``,
     so an expectation's dynamic parameters are only correct when the server
@@ -354,22 +354,20 @@ class TestPrepareCheckpointRun:
     @responses.activate
     @pytest.mark.unit
     def test_groups_calls_by_distinct_batch_definition_id(self, make_checkpoint) -> None:
-        """Checkpoint spans two batch definitions → two grouped calls, merge
-        keeps each parameter only from the matching call.
+        """Checkpoint spans two batch definitions → two grouped calls, one per
+        distinct id. Mercury returns entries only for expectations whose owning
+        validation definition uses the passed batch_definition_id, so the
+        responses carry disjoint keys and merge cleanly.
         """
         batch_definition_id_a = str(uuid.uuid4())
         batch_definition_id_b = str(uuid.uuid4())
 
-        # Mercury always returns parameters for every expectation in the
-        # checkpoint, but values for expectations whose actual
-        # batch_definition_id doesn't match the query param are "wrong"
-        # (empty bounds or baseline). The SDK must discard those entries.
         def callback(request):
             bd_id = parse_qs(urlparse(request.url).query).get("batch_definition_id", [None])[0]
             if bd_id == batch_definition_id_a:
-                body = {"data": {"expectation_parameters": {"p_a_max": 111, "p_b_max": 999}}}
+                body = {"data": {"expectation_parameters": {"p_a_max": 111}}}
             elif bd_id == batch_definition_id_b:
-                body = {"data": {"expectation_parameters": {"p_a_max": 999, "p_b_max": 222}}}
+                body = {"data": {"expectation_parameters": {"p_b_max": 222}}}
             else:
                 body = {"data": {"expectation_parameters": {}}}
             return (200, {}, json.dumps(body))
@@ -404,25 +402,25 @@ class TestPrepareCheckpointRun:
         )
         assert bd_ids_used == sorted([batch_definition_id_a, batch_definition_id_b])
 
-        # Merge is correct: each parameter keeps the value from the matched
-        # call; the 999s from the mismatched calls must NOT win.
+        # Responses from each call carry disjoint keys; the merge is a union.
         assert expectation_parameters == {"p_a_max": 111, "p_b_max": 222}
 
     @responses.activate
     @pytest.mark.unit
     def test_mixes_batch_definition_ids_and_none(self, make_checkpoint) -> None:
         """Some validation definitions have a batch_definition_id, others don't
-        → one call with the id, one without (inline fallback); merge keeps each
-        parameter from the matching call.
+        → one call with the id (mercury returns only the scoped entries), one
+        without (mercury returns entries for expectations without a batch
+        definition via its inline path). Merge is a clean union.
         """
         batch_definition_id_a = str(uuid.uuid4())
 
         def callback(request):
             bd_id = parse_qs(urlparse(request.url).query).get("batch_definition_id", [None])[0]
             if bd_id == batch_definition_id_a:
-                body = {"data": {"expectation_parameters": {"p_a_max": 111, "p_none_max": 999}}}
+                body = {"data": {"expectation_parameters": {"p_a_max": 111}}}
             else:
-                body = {"data": {"expectation_parameters": {"p_a_max": 999, "p_none_max": 222}}}
+                body = {"data": {"expectation_parameters": {"p_none_max": 222}}}
             return (200, {}, json.dumps(body))
 
         responses.add_callback(
@@ -451,5 +449,5 @@ class TestPrepareCheckpointRun:
         calls_with_param = [c for c in ep_calls if self._batch_definition_id_on_call(c) is not None]
         assert len(calls_with_param) == 1
 
-        # Merge picks the matched values, discards the mismatched 999s.
+        # Disjoint keys from the two calls; merge is a clean union.
         assert expectation_parameters == {"p_a_max": 111, "p_none_max": 222}

--- a/tests/data_context/test_cloud_data_context.py
+++ b/tests/data_context/test_cloud_data_context.py
@@ -1,9 +1,14 @@
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
+from pytest_mock import MockerFixture
 
+from great_expectations.core.batch_definition import BatchDefinition
+from great_expectations.core.expectation_suite import ExpectationSuite
+from great_expectations.core.validation_definition import ValidationDefinition
 from great_expectations.data_context.data_context.cloud_data_context import CloudDataContext
 
 CLOUD_BASE_URL = "https://api.greatexpectations.io/fake"
@@ -186,3 +191,131 @@ def test_warns_when_workspace_id_env_var_unset(unset_gx_env_variables: None):
         "Workspace id is not set when instantiating a CloudDataContext."
     )
     assert "GX_CLOUD_WORKSPACE_ID" in warning_message
+
+
+# ---------------------------------------------------------------------------
+# prepare_checkpoint_run: batch_definition_id query param (GX-3229)
+# ---------------------------------------------------------------------------
+
+
+CHECKPOINT_ID = str(uuid.uuid4())
+BATCH_DEFINITION_ID = str(uuid.uuid4())
+# urljoin() with an absolute URL path replaces the base URL's path, so the
+# resulting request goes to the host root, not to ``{CLOUD_BASE_URL}``.
+EXPECTATION_PARAMETERS_URL = (
+    "https://api.greatexpectations.io"
+    f"/api/v1/organizations/{ORG_ID}"
+    f"/workspaces/{WORKSPACE_ID}/checkpoints/{CHECKPOINT_ID}/expectation-parameters"
+)
+
+
+def _build_cloud_context() -> CloudDataContext:
+    """Construct a CloudDataContext whose /data-context-configuration call is mocked."""
+    responses.add(
+        responses.GET,
+        CONTEXT_CONFIGURATION_URL,
+        json=V1_CONFIG,
+        status=200,
+    )
+    return CloudDataContext(
+        cloud_base_url=CLOUD_BASE_URL,
+        cloud_access_token=ACCESS_TOKEN,
+        cloud_organization_id=ORG_ID,
+        cloud_workspace_id=WORKSPACE_ID,
+    )
+
+
+def _build_checkpoint(mocker: MockerFixture, batch_definition_id: Optional[str]):
+    """Build a minimal Checkpoint with a single ValidationDefinition whose
+    BatchDefinition has the given id.
+    """
+    from great_expectations.checkpoint.checkpoint import Checkpoint
+
+    batch_definition = mocker.Mock(spec=BatchDefinition)
+    batch_definition.id = batch_definition_id
+
+    validation_definition = ValidationDefinition.construct(
+        name="my_validation_definition",
+        data=batch_definition,
+        suite=mocker.Mock(spec=ExpectationSuite),
+        id=str(uuid.uuid4()),
+    )
+
+    return Checkpoint.construct(
+        name="my_checkpoint",
+        validation_definitions=[validation_definition],
+        actions=[],
+        id=CHECKPOINT_ID,
+    )
+
+
+@responses.activate
+@pytest.mark.unit
+def test_prepare_checkpoint_run_passes_batch_definition_id_when_available(
+    mocker: MockerFixture,
+) -> None:
+    """SDK passes batch_definition_id as a query parameter when the checkpoint's
+    validation definition has a batch_definition with an id.
+    """
+    responses.add(
+        responses.GET,
+        EXPECTATION_PARAMETERS_URL,
+        json={"data": {"expectation_parameters": {}}},
+        status=200,
+    )
+
+    ctx = _build_cloud_context()
+    checkpoint = _build_checkpoint(mocker, batch_definition_id=BATCH_DEFINITION_ID)
+
+    mocker.patch.object(
+        type(ctx),
+        "_checkpoint_has_windowed_expectations",
+        return_value=True,
+    )
+    ctx.prepare_checkpoint_run(
+        checkpoint=checkpoint,
+        batch_parameters={},
+        expectation_parameters={},
+    )
+
+    # The last call should be the expectation-parameters GET.
+    expectation_params_call = responses.calls[-1]
+    parsed = urlparse(expectation_params_call.request.url)
+    query = parse_qs(parsed.query)
+    assert query.get("batch_definition_id") == [BATCH_DEFINITION_ID]
+
+
+@responses.activate
+@pytest.mark.unit
+def test_prepare_checkpoint_run_omits_batch_definition_id_when_unavailable(
+    mocker: MockerFixture,
+) -> None:
+    """SDK does not pass batch_definition_id when it is not available. This
+    preserves backward compatibility with older mercury versions that do not
+    understand the query parameter.
+    """
+    responses.add(
+        responses.GET,
+        EXPECTATION_PARAMETERS_URL,
+        json={"data": {"expectation_parameters": {}}},
+        status=200,
+    )
+
+    ctx = _build_cloud_context()
+    checkpoint = _build_checkpoint(mocker, batch_definition_id=None)
+
+    mocker.patch.object(
+        type(ctx),
+        "_checkpoint_has_windowed_expectations",
+        return_value=True,
+    )
+    ctx.prepare_checkpoint_run(
+        checkpoint=checkpoint,
+        batch_parameters={},
+        expectation_parameters={},
+    )
+
+    expectation_params_call = responses.calls[-1]
+    parsed = urlparse(expectation_params_call.request.url)
+    query = parse_qs(parsed.query)
+    assert "batch_definition_id" not in query

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -1049,6 +1049,7 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
         )
         .given("a checkpoint with expectation parameters exists")
         .with_request("GET", CHECKPOINT_EXPECTATION_PARAMS_PATH)
+        .with_query_parameters({"batch_definition_id": match.like(EXISTING_BATCH_DEF_ID)})
         .with_headers(headers)
         .will_respond_with(200)
         .with_body(expectation_params_response, content_type="application/json")

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -1046,11 +1046,8 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
             "a request to get checkpoint expectation parameters (client-driven)"
         )
         .given("a checkpoint with expectation parameters exists")
-        .with_request(
-            "GET",
-            CHECKPOINT_EXPECTATION_PARAMS_PATH,
-            query={"batch_definition_id": [match.like(EXISTING_BATCH_DEF_ID)]},
-        )
+        .with_request("GET", CHECKPOINT_EXPECTATION_PARAMS_PATH)
+        .with_query_parameters({"batch_definition_id": match.like(EXISTING_BATCH_DEF_ID)})
         .with_headers(headers)
         .will_respond_with(200)
         .with_body(expectation_params_response, content_type="application/json")
@@ -1072,13 +1069,13 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
         from great_expectations.core.expectation_suite import ExpectationSuite
         from great_expectations.core.validation_definition import ValidationDefinition
         from great_expectations.expectations.core import ExpectTableRowCountToBeBetween
-        from great_expectations.expectations.window import Window
+        from great_expectations.expectations.window import Offset, Window
 
         window = Window(
             constraint_fn="mean",
             parameter_name="expect_table_row_count_to_be_between_min",
             range=5,
-            offset={"positive": 0.1, "negative": 0.1},
+            offset=Offset(positive=0.1, negative=0.1),
         )
         exp = ExpectTableRowCountToBeBetween(windows=[window])
         suite = ExpectationSuite(name="test_suite", expectations=[exp])

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -1016,9 +1016,11 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
 
     When a checkpoint has windowed expectations, ``CloudDataContext
     .prepare_checkpoint_run()`` issues a GET to
-    ``/checkpoints/{id}/expectation-parameters?batch_definition_id=X`` to
-    retrieve computed parameter values. The response contains a
-    ``data.expectation_parameters`` dict.
+    ``/checkpoints/{id}/expectation-parameters`` to retrieve computed parameter
+    values.  The response contains a ``data.expectation_parameters`` dict.
+
+    This test patches ``_checkpoint_has_windowed_expectations`` to return True
+    so the HTTP call is made without needing actual windowed expectations.
 
     Full interaction sequence:
       1.  GET /data-context-configuration                       (context init)
@@ -1033,7 +1035,7 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
         description_suffix="get-checkpoint-expectation-parameters",
     )
 
-    # 2. GET /checkpoints/{id}/expectation-parameters?batch_definition_id=X
+    # 2. GET /checkpoints/{id}/expectation-parameters
     expectation_params_response: dict = {
         "data": match.like(
             {
@@ -1047,7 +1049,6 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
         )
         .given("a checkpoint with expectation parameters exists")
         .with_request("GET", CHECKPOINT_EXPECTATION_PARAMS_PATH)
-        .with_query_parameters({"batch_definition_id": match.like(EXISTING_BATCH_DEF_ID)})
         .with_headers(headers)
         .will_respond_with(200)
         .with_body(expectation_params_response, content_type="application/json")
@@ -1062,40 +1063,29 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
             cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
         )
 
-        # Build a real minimal checkpoint with a windowed expectation so the
-        # full code path is exercised without patching implementation internals.
+        # Build a minimal checkpoint stand-in with the known ID
         from great_expectations.checkpoint.checkpoint import Checkpoint
-        from great_expectations.core.batch_definition import BatchDefinition
-        from great_expectations.core.expectation_suite import ExpectationSuite
-        from great_expectations.core.validation_definition import ValidationDefinition
-        from great_expectations.expectations.core import ExpectTableRowCountToBeBetween
-        from great_expectations.expectations.window import Offset, Window
 
-        window = Window(
-            constraint_fn="mean",
-            parameter_name="expect_table_row_count_to_be_between_min",
-            range=5,
-            offset=Offset(positive=0.1, negative=0.1),
-        )
-        exp = ExpectTableRowCountToBeBetween(windows=[window])
-        suite = ExpectationSuite(name="test_suite", expectations=[exp])
-        bd = BatchDefinition.construct(name="bd", id=EXISTING_BATCH_DEF_ID)
-        vd = ValidationDefinition.construct(
-            name="vd",
-            data=bd,
-            suite=suite,
-            id="vvvv0001-0001-0001-0001-000000000001",
-        )
-        checkpoint = Checkpoint.construct(
-            name=CHECKPOINT_NAME,
-            validation_definitions=[vd],
-            actions=[],
-            id=EXISTING_CHECKPOINT_ID,
-        )
+        checkpoint = Checkpoint(name=CHECKPOINT_NAME, validation_definitions=[])
+        checkpoint.id = EXISTING_CHECKPOINT_ID
 
+        # Patch so the method proceeds to the HTTP call without needing
+        # actual windowed expectations on the checkpoint.
         expectation_parameters: dict = {}
-        ctx.prepare_checkpoint_run(
-            checkpoint=checkpoint,
-            batch_parameters={},
-            expectation_parameters=expectation_parameters,
-        )
+        with (
+            patch.object(
+                type(ctx),
+                "_checkpoint_has_windowed_expectations",
+                return_value=True,
+            ),
+            patch.object(
+                type(ctx),
+                "_distinct_batch_definition_ids",
+                return_value={EXISTING_BATCH_DEF_ID},
+            ),
+        ):
+            ctx.prepare_checkpoint_run(
+                checkpoint=checkpoint,
+                batch_parameters={},
+                expectation_parameters=expectation_parameters,
+            )

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -1011,16 +1011,14 @@ CHECKPOINT_EXPECTATION_PARAMS_PATH: Final[str] = f"{CHECKPOINT_BY_ID_PATH}/expec
 
 
 @pytest.mark.cloud
-def test_get_checkpoint_expectation_parameters(pact_test: Pact, mocker) -> None:
+def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
     """context.prepare_checkpoint_run() fetches expectation parameters.
 
     When a checkpoint has windowed expectations, ``CloudDataContext
     .prepare_checkpoint_run()`` issues a GET to
-    ``/checkpoints/{id}/expectation-parameters`` to retrieve computed parameter
-    values.  The response contains a ``data.expectation_parameters`` dict.
-
-    This test patches ``_checkpoint_has_windowed_expectations`` to return True
-    so the HTTP call is made without needing actual windowed expectations.
+    ``/checkpoints/{id}/expectation-parameters?batch_definition_id=X`` to
+    retrieve computed parameter values. The response contains a
+    ``data.expectation_parameters`` dict.
 
     Full interaction sequence:
       1.  GET /data-context-configuration                       (context init)
@@ -1035,7 +1033,7 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact, mocker) -> None:
         description_suffix="get-checkpoint-expectation-parameters",
     )
 
-    # 2. GET /checkpoints/{id}/expectation-parameters
+    # 2. GET /checkpoints/{id}/expectation-parameters?batch_definition_id=X
     expectation_params_response: dict = {
         "data": match.like(
             {
@@ -1048,7 +1046,11 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact, mocker) -> None:
             "a request to get checkpoint expectation parameters (client-driven)"
         )
         .given("a checkpoint with expectation parameters exists")
-        .with_request("GET", CHECKPOINT_EXPECTATION_PARAMS_PATH)
+        .with_request(
+            "GET",
+            CHECKPOINT_EXPECTATION_PARAMS_PATH,
+            query={"batch_definition_id": [match.like(EXISTING_BATCH_DEF_ID)]},
+        )
         .with_headers(headers)
         .will_respond_with(200)
         .with_body(expectation_params_response, content_type="application/json")
@@ -1063,35 +1065,40 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact, mocker) -> None:
             cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
         )
 
-        # Build a minimal checkpoint stand-in with the known ID. The
-        # validation definition carries EXISTING_BATCH_DEF_ID so
-        # _distinct_batch_definition_ids returns a non-empty set and the
-        # client issues the GET /expectation-parameters call.
+        # Build a real minimal checkpoint with a windowed expectation so the
+        # full code path is exercised without patching implementation internals.
         from great_expectations.checkpoint.checkpoint import Checkpoint
         from great_expectations.core.batch_definition import BatchDefinition
+        from great_expectations.core.expectation_suite import ExpectationSuite
+        from great_expectations.core.validation_definition import ValidationDefinition
+        from great_expectations.expectations.core import ExpectTableRowCountToBeBetween
+        from great_expectations.expectations.window import Window
 
-        batch_def_mock = mocker.Mock(spec=BatchDefinition)
-        batch_def_mock.id = EXISTING_BATCH_DEF_ID
-        val_def_mock = mocker.Mock()
-        val_def_mock.data = batch_def_mock
-
+        window = Window(
+            constraint_fn="mean",
+            parameter_name="expect_table_row_count_to_be_between_min",
+            range=5,
+            offset={"positive": 0.1, "negative": 0.1},
+        )
+        exp = ExpectTableRowCountToBeBetween(windows=[window])
+        suite = ExpectationSuite(name="test_suite", expectations=[exp])
+        bd = BatchDefinition.construct(name="bd", id=EXISTING_BATCH_DEF_ID)
+        vd = ValidationDefinition.construct(
+            name="vd",
+            data=bd,
+            suite=suite,
+            id="vvvv0001-0001-0001-0001-000000000001",
+        )
         checkpoint = Checkpoint.construct(
             name=CHECKPOINT_NAME,
-            validation_definitions=[val_def_mock],
+            validation_definitions=[vd],
             actions=[],
             id=EXISTING_CHECKPOINT_ID,
         )
 
-        # Patch so the method proceeds to the HTTP call without needing
-        # actual windowed expectations on the checkpoint.
         expectation_parameters: dict = {}
-        with patch.object(
-            type(ctx),
-            "_checkpoint_has_windowed_expectations",
-            return_value=True,
-        ):
-            ctx.prepare_checkpoint_run(
-                checkpoint=checkpoint,
-                batch_parameters={},
-                expectation_parameters=expectation_parameters,
-            )
+        ctx.prepare_checkpoint_run(
+            checkpoint=checkpoint,
+            batch_parameters={},
+            expectation_parameters=expectation_parameters,
+        )

--- a/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
+++ b/tests/integration/cloud/rest_contracts/test_valdef_checkpoint_contracts.py
@@ -1011,7 +1011,7 @@ CHECKPOINT_EXPECTATION_PARAMS_PATH: Final[str] = f"{CHECKPOINT_BY_ID_PATH}/expec
 
 
 @pytest.mark.cloud
-def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
+def test_get_checkpoint_expectation_parameters(pact_test: Pact, mocker) -> None:
     """context.prepare_checkpoint_run() fetches expectation parameters.
 
     When a checkpoint has windowed expectations, ``CloudDataContext
@@ -1063,11 +1063,24 @@ def test_get_checkpoint_expectation_parameters(pact_test: Pact) -> None:
             cloud_access_token=PACT_DUMMY_ACCESS_TOKEN,
         )
 
-        # Build a minimal checkpoint stand-in with the known ID
+        # Build a minimal checkpoint stand-in with the known ID. The
+        # validation definition carries EXISTING_BATCH_DEF_ID so
+        # _distinct_batch_definition_ids returns a non-empty set and the
+        # client issues the GET /expectation-parameters call.
         from great_expectations.checkpoint.checkpoint import Checkpoint
+        from great_expectations.core.batch_definition import BatchDefinition
 
-        checkpoint = Checkpoint(name=CHECKPOINT_NAME, validation_definitions=[])
-        checkpoint.id = EXISTING_CHECKPOINT_ID
+        batch_def_mock = mocker.Mock(spec=BatchDefinition)
+        batch_def_mock.id = EXISTING_BATCH_DEF_ID
+        val_def_mock = mocker.Mock()
+        val_def_mock.data = batch_def_mock
+
+        checkpoint = Checkpoint.construct(
+            name=CHECKPOINT_NAME,
+            validation_definitions=[val_def_mock],
+            actions=[],
+            id=EXISTING_CHECKPOINT_ID,
+        )
 
         # Patch so the method proceeds to the HTTP call without needing
         # actual windowed expectations on the checkpoint.


### PR DESCRIPTION
## Summary

Thread each windowed expectation's `batch_definition_id` through to mercury's `GET /checkpoints/{id}/expectation-parameters` endpoint so users on the async forecast store path receive forecast store bounds instead of falling back to inline Prophet training.

When a checkpoint spans multiple batch definitions, the client makes one call per distinct id and merges the responses. A checkpoint usually has a single batch definition, so this is typically one call.