### PR TITLE
[MAINTENANCE] Remove DeprecatedMetaMetricProvider and ColumnMetricProvider

### DIFF
--- a/great_expectations/expectations/metrics/__init__.py
+++ b/great_expectations/expectations/metrics/__init__.py
@@ -1,10 +1,8 @@
 from .meta_metric_provider import (  # isort:skip
     MetaMetricProvider,
-    DeprecatedMetaMetricProvider,
 )
 from .column_aggregate_metric_provider import (
     ColumnAggregateMetricProvider,
-    ColumnMetricProvider,  # This class name is being deprecated (use "ColumnAggregateMetricProvider" going forward).  # noqa: E501 # FIXME CoP
     column_aggregate_partial,
     column_aggregate_value,
 )

--- a/great_expectations/expectations/metrics/column_aggregate_metric_provider.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metric_provider.py
@@ -16,7 +16,6 @@ from great_expectations.execution_engine.sparkdf_execution_engine import (
 from great_expectations.execution_engine.sqlalchemy_execution_engine import (
     SqlAlchemyExecutionEngine,
 )
-from great_expectations.expectations.metrics import DeprecatedMetaMetricProvider
 from great_expectations.expectations.metrics.metric_provider import (
     metric_partial,
     metric_value,
@@ -315,7 +314,3 @@ class ColumnAggregateMetricProvider(TableMetricProvider):
             metric_value_kwargs=None,
         )
         return dependencies
-
-
-class ColumnMetricProvider(ColumnAggregateMetricProvider, metaclass=DeprecatedMetaMetricProvider):
-    _DeprecatedMetaMetricProvider__alias = ColumnAggregateMetricProvider

--- a/great_expectations/expectations/metrics/meta_metric_provider.py
+++ b/great_expectations/expectations/metrics/meta_metric_provider.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -14,76 +13,3 @@ class MetaMetricProvider(type):
         # noinspection PyUnresolvedReferences
         newclass._register_metric_functions()
         return newclass
-
-
-# The following is based on "https://stackoverflow.com/questions/9008444/how-to-warn-about-class-name-deprecation".
-class DeprecatedMetaMetricProvider(MetaMetricProvider):
-    """
-    Goals:
-        Instantiation of a deprecated class should raise a warning;
-        Subclassing of a deprecated class should raise a warning;
-        Support isinstance and issubclass checks.
-    """
-
-    # TODO: <Alex>All logging/warning directives should be placed into a common module to be imported as needed.</Alex>  # noqa: E501 # FIXME CoP
-    # deprecated-v0.13.12
-    warnings.simplefilter("default", category=DeprecationWarning)
-
-    # Arguments: True -- suppresses the warnings; False -- outputs the warnings (to stderr).
-    logging.captureWarnings(False)
-
-    def __new__(cls, name, bases, classdict, *args, **kwargs):
-        alias = classdict.get("_DeprecatedMetaMetricProvider__alias")
-
-        if alias is not None:
-
-            def new(cls, *args, **kwargs):
-                alias = cls._DeprecatedMetaMetricProvider__alias
-
-                if alias is not None:
-                    # deprecated-v0.13.12
-                    warnings.warn(
-                        f"""{cls.__name__} has been renamed to {alias} -- the alias {cls.__name__} is \
-deprecated as of v0.13.12 and will be removed in v0.16.
-""",  # noqa: E501 # FIXME CoP
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-
-                return alias(*args, **kwargs)
-
-            classdict["__new__"] = new
-            classdict["_DeprecatedMetaMetricProvider__alias"] = alias
-
-        fixed_bases = []
-
-        for b in bases:
-            alias = getattr(b, "_DeprecatedMetaMetricProvider__alias", None)
-
-            if alias is not None:
-                # deprecated-v0.13.12
-                warnings.warn(
-                    f"""{b.__name__} has been renamed to {alias.__name__} -- the alias {b.__name__} is deprecated \
-as of v0.13.12 and will be removed in v0.16.
-""",  # noqa: E501 # FIXME CoP
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            # Avoid duplicate base classes.
-            b = alias or b  # noqa: PLW2901 # FIXME CoP
-            if b not in fixed_bases:
-                fixed_bases.append(b)
-
-        fixed_bases = tuple(fixed_bases)
-
-        return super().__new__(cls, name, fixed_bases, classdict, *args, **kwargs)
-
-    def __instancecheck__(cls, instance):  # type: ignore[explicit-override] # FIXME
-        return any(cls.__subclasscheck__(c) for c in (type(instance), instance.__class__))
-
-    def __subclasscheck__(cls, subclass):  # type: ignore[explicit-override] # FIXME
-        if subclass is cls:
-            return True
-        else:
-            return issubclass(subclass, cls._DeprecatedMetaMetricProvider__alias)


### PR DESCRIPTION
## Summary
- Removes `DeprecatedMetaMetricProvider` metaclass and `ColumnMetricProvider` alias class, both deprecated in v0.13.12 with planned removal in v0.16.
- Current GX version is 1.16.1 — these are well past the removal window.
- `DeprecatedMetaMetricProvider` existed solely to emit `DeprecationWarning`s for the rename `ColumnMetricProvider` → `ColumnAggregateMetricProvider` (three `warnings.warn(...)` call sites, all annotated `# deprecated-v0.13.12`).

No non-versioned-docs references remain. No `@public_api` markers were attached to either symbol, and no usage exists in the sibling `cloud` or `gx-runner` repos.

## Test plan
- [ ] `invoke lint` passes
- [ ] `invoke types --ci --pretty` does not introduce new errors
- [ ] CI green