### PR TITLE
[BUGFIX] Spark ignores strict_min/strict_max in column value lengths (GX-3252)

### DIFF
--- a/great_expectations/compatibility/pyarrow.py
+++ b/great_expectations/compatibility/pyarrow.py
@@ -7,4 +7,4 @@ PYARROW_NOT_IMPORTED = NotImported("pyarrow is not installed, please 'pip instal
 try:
     import pyarrow
 except ImportError:
-    pyarrow = PYARROW_NOT_IMPORTED
+    pyarrow = PYARROW_NOT_IMPORTED  # type: ignore[assignment] # FIXME CoP

--- a/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
@@ -239,13 +239,19 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
             raise ValueError("min_value and max_value must be integers")  # noqa: TRY003 # FIXME CoP
 
         if min_value is not None and max_value is not None:
-            return (column_lengths >= min_value) & (column_lengths <= max_value)
+            min_condition = (
+                column_lengths > min_value if strict_min else column_lengths >= min_value
+            )
+            max_condition = (
+                column_lengths < max_value if strict_max else column_lengths <= max_value
+            )
+            return min_condition & max_condition
 
         elif min_value is None and max_value is not None:
-            return column_lengths <= max_value
+            return column_lengths < max_value if strict_max else column_lengths <= max_value
 
         elif min_value is not None and max_value is None:
-            return column_lengths >= min_value
+            return column_lengths > min_value if strict_min else column_lengths >= min_value
 
     @classmethod
     @override

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
@@ -9,7 +9,10 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
     ALL_DATA_SOURCES,
     JUST_PANDAS_DATA_SOURCES,
 )
-from tests.integration.test_utils.data_source_config import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config import (
+    PostgreSQLDatasourceTestConfig,
+    SparkFilesystemCsvDatasourceTestConfig,
+)
 
 COL_NAME = "my_strings"
 
@@ -185,3 +188,37 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     unexpected_rows_str = str(unexpected_rows_data)
     assert "AA" in unexpected_rows_str
     assert "AAA" in unexpected_rows_str
+
+
+# ---------------------------------------------------------------------------
+# Community issue #11393: Spark engine ignores strict_min / strict_max
+# https://github.com/great-expectations/great_expectations/issues/11393
+# ---------------------------------------------------------------------------
+
+STRICT_BOUNDS_DATA = pd.DataFrame({COL_NAME: ["aa", "bbb", "cccc"]}, dtype="object")
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[SparkFilesystemCsvDatasourceTestConfig()],
+    data=STRICT_BOUNDS_DATA,
+)
+def test_spark_strict_bounds_respected_issue_11393(batch_for_datasource: Batch) -> None:
+    """Spark engine must honor strict_min/strict_max for value lengths.
+
+    With min_value=2, max_value=4, strict_min=True, strict_max=True, only length 3
+    ("bbb") should be considered valid; "aa" (len 2) and "cccc" (len 4) should be
+    flagged as unexpected. The Spark implementation ignores the strict flags and
+    treats both bounds as inclusive, so the expectation incorrectly succeeds.
+    """
+    expectation = gxe.ExpectColumnValueLengthsToBeBetween(
+        column=COL_NAME,
+        min_value=2,
+        max_value=4,
+        strict_min=True,
+        strict_max=True,
+    )
+    result = batch_for_datasource.validate(expectation)
+    assert not result.success, (
+        "expected validation to fail because 'aa' (len 2) and 'cccc' (len 4) "
+        "violate strict bounds, but Spark engine ignores strict_min/strict_max"
+    )

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
@@ -198,27 +198,40 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
 STRICT_BOUNDS_DATA = pd.DataFrame({COL_NAME: ["aa", "bbb", "cccc"]}, dtype="object")
 
 
+@pytest.mark.parametrize(
+    "expectation",
+    [
+        pytest.param(
+            gxe.ExpectColumnValueLengthsToBeBetween(
+                column=COL_NAME,
+                min_value=2,
+                max_value=4,
+                strict_min=True,
+                strict_max=True,
+            ),
+            id="both_strict",
+        ),
+        pytest.param(
+            gxe.ExpectColumnValueLengthsToBeBetween(column=COL_NAME, min_value=2, strict_min=True),
+            id="strict_min_only",
+        ),
+        pytest.param(
+            gxe.ExpectColumnValueLengthsToBeBetween(column=COL_NAME, max_value=4, strict_max=True),
+            id="strict_max_only",
+        ),
+    ],
+)
 @parameterize_batch_for_data_sources(
     data_source_configs=[SparkFilesystemCsvDatasourceTestConfig()],
     data=STRICT_BOUNDS_DATA,
 )
-def test_spark_strict_bounds_respected_issue_11393(batch_for_datasource: Batch) -> None:
-    """Spark engine must honor strict_min/strict_max for value lengths.
-
-    With min_value=2, max_value=4, strict_min=True, strict_max=True, only length 3
-    ("bbb") should be considered valid; "aa" (len 2) and "cccc" (len 4) should be
-    flagged as unexpected. The Spark implementation ignores the strict flags and
-    treats both bounds as inclusive, so the expectation incorrectly succeeds.
+def test_spark_strict_bounds_respected_issue_11393(
+    batch_for_datasource: Batch,
+    expectation: gxe.ExpectColumnValueLengthsToBeBetween,
+) -> None:
+    """Regression test for issue #11393: Spark engine must honor strict_min/strict_max
+    for value lengths. Data lengths are [2, 3, 4]; each parametrized case uses a
+    strict bound that excludes a boundary value, so validation must fail.
     """
-    expectation = gxe.ExpectColumnValueLengthsToBeBetween(
-        column=COL_NAME,
-        min_value=2,
-        max_value=4,
-        strict_min=True,
-        strict_max=True,
-    )
     result = batch_for_datasource.validate(expectation)
-    assert not result.success, (
-        "expected validation to fail because 'aa' (len 2) and 'cccc' (len 4) "
-        "violate strict bounds, but Spark engine ignores strict_min/strict_max"
-    )
+    assert not result.success


### PR DESCRIPTION
Closes #11393

Ticket: https://greatexpectations.atlassian.net/browse/GX-3252

## Summary

The Spark backend of `expect_column_value_lengths_to_be_between` ignored the
`strict_min` and `strict_max` flags, always applying inclusive bounds. This
fix respects `strict_min`/`strict_max` in the Spark `_spark` implementation
so boundary lengths are correctly excluded when strict bounds are requested,
matching the Pandas backend. (The SQLAlchemy backend has the same bug — out
of scope for this PR, which is targeted at community issue #11393.)

## Changes

- `great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py`:
  Spark `_spark` branch now uses `>` / `<` when `strict_min` / `strict_max` are
  `True`, covering all three min/max combinations.
- Added parametrized Spark regression tests for community issue #11393 covering
  both-strict, strict-min-only, and strict-max-only cases.

## Why

Spark users passing `strict_min=True` / `strict_max=True` silently got
inclusive-bound results. The fix aligns Spark behavior with the documented
semantics of `strict_min` / `strict_max`.

## User impact

Spark users that pass `strict_min=True` or `strict_max=True` to
`expect_column_value_lengths_to_be_between` will now get strictly-exclusive
bound checks, as documented. Non-strict usage is unchanged.

## Test plan

- [x] Parametrized Spark regression test exercises both-strict, strict-min-only,
      and strict-max-only
- [x] Existing Pandas/SQLAlchemy behavior unchanged
- [ ] CI passes on develop