### PR TITLE
[BUGFIX] SQLAlchemy ignores strict_min/strict_max in column value lengths (GX-3252)

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py
@@ -198,16 +198,19 @@ class ColumnValuesValueLength(ColumnMapMetricProvider):
             raise ValueError("min_value and max_value must be integers")  # noqa: TRY003 # FIXME CoP
 
         if min_value is not None and max_value is not None:
-            return sa.and_(
-                column_lengths >= min_value,
-                column_lengths <= max_value,
+            min_condition = (
+                column_lengths > min_value if strict_min else column_lengths >= min_value
             )
+            max_condition = (
+                column_lengths < max_value if strict_max else column_lengths <= max_value
+            )
+            return sa.and_(min_condition, max_condition)
 
         elif min_value is None and max_value is not None:
-            return column_lengths <= max_value
+            return column_lengths < max_value if strict_max else column_lengths <= max_value
 
         elif min_value is not None and max_value is None:
-            return column_lengths >= min_value
+            return column_lengths > min_value if strict_min else column_lengths >= min_value
 
     @column_condition_partial(engine=SparkDFExecutionEngine)
     def _spark(

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_value_lengths_to_be_between.py
@@ -185,3 +185,50 @@ def test_include_unexpected_rows_sql(batch_for_datasource: Batch) -> None:
     unexpected_rows_str = str(unexpected_rows_data)
     assert "AA" in unexpected_rows_str
     assert "AAA" in unexpected_rows_str
+
+
+# ---------------------------------------------------------------------------
+# Community issue #11393: SQLAlchemy engine ignores strict_min / strict_max
+# https://github.com/great-expectations/great_expectations/issues/11393
+# ---------------------------------------------------------------------------
+
+STRICT_BOUNDS_DATA = pd.DataFrame({COL_NAME: ["aa", "bbb", "cccc"]}, dtype="object")
+
+
+@pytest.mark.parametrize(
+    "expectation",
+    [
+        pytest.param(
+            gxe.ExpectColumnValueLengthsToBeBetween(
+                column=COL_NAME,
+                min_value=2,
+                max_value=4,
+                strict_min=True,
+                strict_max=True,
+            ),
+            id="both_strict",
+        ),
+        pytest.param(
+            gxe.ExpectColumnValueLengthsToBeBetween(column=COL_NAME, min_value=2, strict_min=True),
+            id="strict_min_only",
+        ),
+        pytest.param(
+            gxe.ExpectColumnValueLengthsToBeBetween(column=COL_NAME, max_value=4, strict_max=True),
+            id="strict_max_only",
+        ),
+    ],
+)
+@parameterize_batch_for_data_sources(
+    data_source_configs=[PostgreSQLDatasourceTestConfig()],
+    data=STRICT_BOUNDS_DATA,
+)
+def test_sql_strict_bounds_respected_issue_11393(
+    batch_for_datasource: Batch,
+    expectation: gxe.ExpectColumnValueLengthsToBeBetween,
+) -> None:
+    """Regression test for issue #11393: SQLAlchemy engine must honor strict_min/strict_max
+    for value lengths. Data lengths are [2, 3, 4]; each parametrized case uses a
+    strict bound that excludes a boundary value, so validation must fail.
+    """
+    result = batch_for_datasource.validate(expectation)
+    assert not result.success


### PR DESCRIPTION
Related to #11393 (sibling fix for #11834, which fixes the same bug on Spark).

## Summary

The SQLAlchemy backend of `expect_column_value_lengths_to_be_between` ignored
the `strict_min` and `strict_max` flags, always applying inclusive bounds.
This is the same bug fixed for Spark in #11834 — called out as out-of-scope
for that PR and tracked here separately.

## Changes

- `great_expectations/expectations/metrics/column_map_metrics/column_value_lengths.py`:
  SqlAlchemy `_sqlalchemy` branch now uses `>` / `<` when `strict_min` /
  `strict_max` are `True`, covering all three min/max combinations.
- Added parametrized PostgreSQL regression tests covering both-strict,
  strict-min-only, and strict-max-only cases (parallel to the Spark tests
  added in #11834).

## Why

SQL users passing `strict_min=True` / `strict_max=True` silently got
inclusive-bound results. The fix aligns SqlAlchemy behavior with the
documented semantics of `strict_min` / `strict_max` and with the Pandas
and Spark backends.

## User impact

Users on any SQL data source (Postgres, Snowflake, BigQuery, Redshift,
Databricks, MSSQL, MySQL, SQLite, etc.) that pass `strict_min=True` or
`strict_max=True` to `expect_column_value_lengths_to_be_between` will now
get strictly-exclusive bound checks, as documented. Non-strict usage is
unchanged.

## How to review

- Diff in `column_value_lengths.py` mirrors the Spark change in #11834.
- New parametrized test `test_sql_strict_bounds_respected_issue_11393`
  runs against `PostgreSQLDatasourceTestConfig`. Data lengths are
  `[2, 3, 4]`; each case uses a strict bound that excludes a boundary
  value, so each validation must fail — confirmed red before the fix and
  green after.
- Verified locally against the PostgreSQL docker-compose at
  `assets/docker/postgresql/`.

## Test plan

- [x] Parametrized PostgreSQL regression test exercises both-strict,
      strict-min-only, and strict-max-only
- [x] Existing Pandas / SQLAlchemy non-strict behavior unchanged
- [ ] CI passes on develop