### PR TITLE
[MAINTENANCE] Silence mypy assignment error after pyarrow 24.0.0

### DIFF
--- a/great_expectations/compatibility/pyarrow.py
+++ b/great_expectations/compatibility/pyarrow.py
@@ -7,4 +7,4 @@ PYARROW_NOT_IMPORTED = NotImported("pyarrow is not installed, please 'pip instal
 try:
     import pyarrow
 except ImportError:
-    pyarrow = PYARROW_NOT_IMPORTED
+    pyarrow = PYARROW_NOT_IMPORTED  # type: ignore[assignment] # FIXME CoP


### PR DESCRIPTION
## Summary

Add `# type: ignore[assignment] # FIXME CoP` to `great_expectations/compatibility/pyarrow.py:10` to unblock static-analysis on `develop` and every open PR.

## Changes

- `great_expectations/compatibility/pyarrow.py`: annotate the `except ImportError` fallback assignment with `# type: ignore[assignment] # FIXME CoP`, matching the pattern already in place in `sqlalchemy.py`, `google.py`, `aws.py`, and the other `compatibility/*.py` modules whose upstream packages ship type info.

## Why

`pyarrow` 24.0.0 was released on 2026-04-21 and ships type information for the first time. Until today, mypy couldn't resolve `import pyarrow` and fell back to `Any`, so reassigning `pyarrow = PYARROW_NOT_IMPORTED` in the `except` branch was silently accepted. With pyarrow 24.0.0, mypy now infers `pyarrow: Module`, and the reassignment to a `NotImported` instance trips `[assignment]`.

Evidence that the trigger is the pyarrow release (same `develop` commit `6f966e1c`, same mypy 1.19.0):

| Run | Time (UTC) | pyarrow | static-analysis |
|---|---|---|---|
| `24715117460` | 09:35 | 23.0.1 | pass |
| `24722294672` | 12:27 | 24.0.0 | fail |

`pyarrow` is unpinned in `reqs/requirements-dev-arrow.txt` (`pyarrow>=14`) and pulled transitively via `databricks-sqlalchemy`, so CI picks up whatever's latest on PyPI.

## User impact

None — comment-only change in a dev/type-check code path. Runtime behavior unchanged.

## How to review

- Diff is a one-line comment addition.
- Compare against the existing `# type: ignore[assignment] # FIXME CoP` usages in `great_expectations/compatibility/sqlalchemy.py:13,23,28,…` — same pattern, same rationale.
- Pinning `pyarrow<24` was considered and rejected: the ignore will still be needed on the eventual upgrade, so kicking the can adds no value.

## Test plan

- [x] Change matches the pattern used by sibling compatibility modules
- [ ] `static-analysis` passes in CI on this branch