### PR TITLE
[MAINTENANCE] Extend pact can-i-deploy retry window to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,7 +671,7 @@ jobs:
             --pacticipant great_expectations \
             --version "${{ github.event.pull_request.head.sha || github.sha }}" \
             --to-environment production \
-            --retry-while-unknown 60 \
+            --retry-while-unknown 120 \
             --retry-interval 10 \
             --broker-base-url https://greatexpectations.pactflow.io \
             --broker-token "${PACT_BROKER_READ_WRITE_TOKEN}"


### PR DESCRIPTION
## Summary

Raise `--retry-while-unknown` on the `pact-contract-check` job's `Can I deploy?` step from 60 to 120 (with the existing 10s interval, 600s → 1200s / 20 min) so the consumer-side check can outwait a cold-start provider verification triggered by the PactFlow webhook.

## Changes

`.github/workflows/ci.yml` — one-line change in the `pact-contract-check` job: `--retry-while-unknown 60` → `--retry-while-unknown 120`.

## Why

A 48h audit of the `pact-contract-check` job found 14 `Can I deploy?` failures in one window, all with the same error:

> There is no verified pact between version &lt;sha&gt; of great_expectations and the version of mercury currently in production (&lt;sha&gt;)

The [GX-2733](https://greatexpectations.atlassian.net/browse/GX-2733) webhook (`mercury#6298`, merged 2026-04-17) correctly fires on every consumer pact publish and the per-PR `pact-verify-on-dispatch` runs on Mercury succeed (82/83 in the same window). The issue is purely timing: Mercury's provider-verify cold-starts its API + Postgres + seed, so total time from "webhook fires" to "verification result visible in PactFlow" routinely exceeds the consumer's 600s retry ceiling. Doubling the retry window absorbs that latency without lengthening the happy path (successful checks still return immediately).

## User impact

- Developers and `develop` scheduled runs should stop seeing spurious `Can I deploy?` failures caused by webhook-triggered verification running long.
- Failed `Can I deploy?` steps will still fail, just up to 10 minutes later if the verification never arrives — acceptable given how much noise the current ceiling generates.

## How to review

- Confirm the only edit is the retry count in the `pact-contract-check` → `Can I deploy?` step.
- The `--retry-interval 10` stays the same, so polling frequency is unchanged; only the ceiling moves.
- Consider in a follow-up whether Mercury's `contract-tests.yml` `can-i-deploy` (no retry args today) should get symmetric retries, but that's a separate concern on a different flow.

[GX-2733]: https://greatexpectations.atlassian.net/browse/GX-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ