### PR TITLE
[DOCS] link integration pages to response pages

### DIFF
--- a/docs/docusaurus/docs/cloud/integrations/integrate_jira.md
+++ b/docs/docusaurus/docs/cloud/integrations/integrate_jira.md
@@ -55,6 +55,8 @@ Follow the steps below to add credentials for the Atlassian service account:
 3. Click **Connect**.
 4. Click **Finish**.
 
+Now you can link Expectation failures and Jira work items to [manage incidents](/docs/cloud/alerts/manage_incidents.md#create-an-incident). 
+
 ## Reconnect to Jira
 
 Your Jira integration may **Error** if, for example, the user who created the authorizing Atlassian service account leaves your Atlassian organization. If this happens, you won’t be able to link issues, but your existing issue links will be kept intact. To reconnect the integration, do the following:

--- a/docs/docusaurus/docs/cloud/integrations/integrate_slack.md
+++ b/docs/docusaurus/docs/cloud/integrations/integrate_slack.md
@@ -20,6 +20,8 @@ Keep the following in mind when integrating Slack:
 2. Locate the **Slack** integration and click **Connect**.
 3. Follow the prompts to sign in to Slack and **Allow** the connection.
 
+Now you can [create an alert](/cloud/alerts/alert_about_failures.md#create-an-alert) that notifies Slack channels about Expectation failures. 
+
 ## Reconnect to Slack
 
 Your Slack integration may **Error** if, for example, the GX Cloud Slack app is removed or its bot token is revoked. If this happens, notifications will not be sent to Slack channels, but your existing alert configurations will be kept intact so that Slack notifications will resume when the integration is reconnected. To reconnect the integration, do the following:

--- a/docs/docusaurus/docs/cloud/integrations/integrate_teams.md
+++ b/docs/docusaurus/docs/cloud/integrations/integrate_teams.md
@@ -36,7 +36,7 @@ To connect or reconnect a Microsoft Teams integration, you must have the followi
 2. Locate the **Microsoft Teams** integration and click **Connect**.
 3. Follow the prompts to sign in to Microsoft Teams, provide your **Tenant ID**, grant permissions, and connect.
 
-The integration will be **Pending** while the GX Cloud app is installed for your Microsoft Teams tenant. When the installation completes, the integration will be **Connected** and you can start configuring alerts for Teams.
+The integration will be **Pending** while the GX Cloud app is installed for your Microsoft Teams tenant. When the installation completes, the integration will be **Connected** and you can start [configuring alerts](/docs/cloud/alerts/alert_about_failures.md#create-an-alert) for Teams.
 
 ## Reconnect to Microsoft Teams
 


### PR DESCRIPTION
This issueless PR makes it easier to navigate from setting up an integration to using that integration. 

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [ ] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB], [MINORBUMP]
- [ ] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [ ] Appropriate tests and docs have been updated

For more information about contributing, visit our [community resources](https://docs.greatexpectations.io/docs/core/introduction/community_resources#contribute-code-or-documentation).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
