### PR TITLE
[BUGFIX] Spark column names with dots not recognized in BatchData (GX-3274)

### DIFF
--- a/great_expectations/expectations/metrics/util.py
+++ b/great_expectations/expectations/metrics/util.py
@@ -893,6 +893,21 @@ def _verify_column_names_exist_and_get_normalized_typed_column_names_map(  # noq
             ) or (column_name == str(typed_column_name_cursor)):
                 return column_name, typed_column_name_cursor
 
+            # Spark wraps dotted column names in backticks in the "table.column_types"
+            # metric output (see `_get_spark_column_metadata`) so that Spark SQL does
+            # not interpret the dot as nested-field access. Match the user's unwrapped
+            # name against the backticked typed name and return the backticked form,
+            # so downstream consumers (e.g. `F.col(...)`) receive a properly-escaped
+            # identifier.  See community issue #11199.
+            if (
+                isinstance(typed_column_name_cursor, str)
+                and typed_column_name_cursor.startswith("`")
+                and typed_column_name_cursor.endswith("`")
+                and len(typed_column_name_cursor) >= 2  # noqa: PLR2004
+                and column_name.casefold() == typed_column_name_cursor[1:-1].casefold()
+            ):
+                return column_name, typed_column_name_cursor
+
             # use explicit identifier if passed in by user
             if isinstance(typed_column_name_cursor, str) and (
                 (column_name.casefold().strip('"') == typed_column_name_cursor.casefold())

--- a/tests/integration/data_sources_and_expectations/data_sources/test_spark_column_names_with_dots.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_spark_column_names_with_dots.py
@@ -1,0 +1,45 @@
+"""
+Reproduction for community issue #11199.
+
+Spark CSV assets fail to recognize columns whose names contain a dot (e.g.
+``Data.Entrega``). Any expectation targeting such a column raises
+``The column "Data.Entrega" in BatchData does not exist`` because Spark SQL
+treats ``.`` as nested field access unless the identifier is backtick-quoted.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+import great_expectations.expectations as gxe
+from great_expectations.datasource.fluent.interfaces import Batch
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import (
+    SparkFilesystemCsvDatasourceTestConfig,
+)
+
+COLUMN_WITH_DOT = "Data.Entrega"
+
+DATA = pd.DataFrame(
+    {
+        COLUMN_WITH_DOT: ["2024-01-01", "2024-02-01", "2024-03-01"],
+    }
+)
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[SparkFilesystemCsvDatasourceTestConfig()],
+    data=DATA,
+)
+def test_spark_column_with_dot_in_name_is_recognized(batch_for_datasource: Batch) -> None:
+    """Spark should recognize columns whose names contain a dot.
+
+    Reported in community issue #11199: validating any expectation on a
+    column like ``Data.Entrega`` raises ``The column "Data.Entrega" in
+    BatchData does not exist`` because Spark parses the dot as nested field
+    access.
+    """
+    result = batch_for_datasource.validate(
+        gxe.ExpectColumnValuesToNotBeNull(column=COLUMN_WITH_DOT)
+    )
+    assert result.success

--- a/tests/integration/data_sources_and_expectations/data_sources/test_spark_column_names_with_dots.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_spark_column_names_with_dots.py
@@ -9,14 +9,18 @@ treats ``.`` as nested field access unless the identifier is backtick-quoted.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pandas as pd
 
 import great_expectations.expectations as gxe
-from great_expectations.datasource.fluent.interfaces import Batch
 from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.integration.test_utils.data_source_config import (
     SparkFilesystemCsvDatasourceTestConfig,
 )
+
+if TYPE_CHECKING:
+    from great_expectations.datasource.fluent.interfaces import Batch
 
 COLUMN_WITH_DOT = "Data.Entrega"
 


### PR DESCRIPTION
Closes #11199

Ticket: https://greatexpectations.atlassian.net/browse/GX-3274

## Summary

Spark DataFrames with column names containing dots (e.g. `Data.Entrega`) were not recognized correctly in `BatchData`. The column-lookup helper `_verify_column_names_exist_and_get_normalized_typed_column_names_map` compared user-supplied names against the typed names emitted by the Spark metadata layer, which backtick-wraps dotted identifiers (e.g. `` `Data.Entrega` ``) to prevent Spark SQL from interpreting the dot as nested struct access. Because the comparison did not account for the backtick wrapping, the lookup failed and every expectation targeting such a column raised _"The column X in BatchData does not exist"_.

The fix adds a match arm that strips the backtick delimiters from the typed-name candidate before comparing, and—when a match is found—returns the backtick-wrapped form to downstream consumers (e.g. `F.col(...)`) so the column is correctly resolved.

## Changes

- **`great_expectations/expectations/metrics/util.py`** — added a new branch in `_verify_column_names_exist_and_get_normalized_typed_column_names_map` to match user-supplied bare column names against backtick-wrapped typed names; returns the backtick-escaped identifier for correct Spark SQL resolution.
- **`tests/integration/data_sources_and_expectations/data_sources/test_spark_column_names_with_dots.py`** — new integration test that creates a Spark CSV asset with a dotted column name (`Data.Entrega`) and asserts that `ExpectColumnValuesToNotBeNull` succeeds.

No public API, schema, or protocol changes.

## Why

Community reporters on issue #11199 observed that any Spark-backed data asset with dotted column names was entirely unusable: every column-level expectation would fail with a spurious "column does not exist" error. The root cause was that Spark silently backtick-escapes such names in its metadata output, and the GX lookup never handled that encoding.

## User impact

Users running Spark-backed data sources (filesystem CSV, Delta, etc.) with column names that contain dots will now be able to run expectations against those columns without error.

## How to review

- The logic change is a single guard block in `util.py`; the surrounding existing match arms are unchanged.
- The integration test (`test_spark_column_with_dot_in_name_is_recognized`) directly reproduces the community-reported failure; it should be run against a Spark environment (skipped otherwise).
- Edge cases considered: column name is exactly `` ` `` (length < 2 guard), mixed-case dotted names (`.casefold()` comparison), non-string typed names (isinstance guard).