### PR TITLE
[MAINTENANCE] Temporarily run CI on maint/shard-marker-tests branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ on:
     - cron: "0 */3 * * *"
   workflow_dispatch: # allows manual triggering with branch picker
   push:
+    # TEMPORARY: run develop's CI on this branch so workflow changes in PR #11850
+    # are actually exercised. Reverted by #11850 itself once merged.
+    branches:
+      - maint/shard-marker-tests
     # Semantic versioning syntax defined by PyPI: https://pythonpackaging.info/07-Package-Release.html#Versioning-your-code
     tags:
       # Stable release syntax


### PR DESCRIPTION
## Summary

Adds a temporary `push` trigger so develop's `ci.yml` runs whenever commits land on the `maint/shard-marker-tests` branch.

## Changes

- `.github/workflows/ci.yml`: add `branches: [maint/shard-marker-tests]` under the existing `push:` trigger.

## Why

PR #11850 reworks `ci.yml` (sharding snowflake marker-tests, adding xdist for bigquery/databricks). Because `pull_request_target` runs the workflow definition from the **base** branch (develop), the workflow changes inside #11850 are never exercised by that PR's own CI — they only take effect after merge. That makes it impossible to validate the new matrix without merging first.

Adding a branch-scoped `push` trigger here lets develop's CI fire on every push to `maint/shard-marker-tests`, so once this PR merges and #11850 rebases, the next push to that branch will run the new sharded workflow against real infra. PR #11850 will revert this trigger as part of its own diff, so the temporary hook is removed in the same commit that lands the real change.

## User impact

None — internal CI plumbing only.

## How to review

- Confirm the only change is the added `branches:` list under `push:`.
- The branch name is hard-coded; once #11850 merges and reverts this, no other branches are affected.
- Schedule, `pull_request_target`, `merge_group`, and tag-push triggers are untouched.