### PR TITLE
[MAINTENANCE] Allow marker-tests jobs to run on push events (testing aid for #11850)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,7 +740,10 @@ jobs:
 
   marker-tests:
     needs: [unit-tests, static-analysis, check-actor-permissions]
-    if: github.event.pull_request.draft == false
+    # TEMPORARY: also run on push events from this branch so the sharded
+    # workflow can be exercised via #11858's push trigger. Reverted before
+    # this PR merges.
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
     env:
       GX_PYTHON_EXPERIMENTAL: true # allow for python 3.13+
       # google
@@ -880,7 +883,10 @@ jobs:
 
   marker-tests-snowflake:
     needs: [unit-tests, static-analysis, check-actor-permissions]
-    if: github.event.pull_request.draft == false
+    # TEMPORARY: also run on push events from this branch so the sharded
+    # workflow can be exercised via #11858's push trigger. Reverted before
+    # this PR merges.
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
     env:
       GX_PYTHON_EXPERIMENTAL: true # allow for python 3.13+
       # snowflake


### PR DESCRIPTION
## Summary

Targets `maint/shard-marker-tests` (the #11850 branch). Loosens the `if:` gate on `marker-tests` and `marker-tests-snowflake` so they also run on `push` events, not only on `pull_request_target`.

## Changes

- `.github/workflows/ci.yml`: change `if: github.event.pull_request.draft == false` to `if: github.event.pull_request.draft == false || github.event_name == 'push'` on both `marker-tests` and `marker-tests-snowflake`.

## Why

#11858 added a `push` trigger on this branch so develop's CI fires on each push. But `pull_request_target` runs the workflow file from the **base** branch (develop) — meaning the sharded snowflake matrix from #11850 never executes through that path.

The `push` event uses the **branch's** workflow file (which has the sharding), but `marker-tests` and `marker-tests-snowflake` are gated on `github.event.pull_request.draft == false`. On a push event, `github.event.pull_request` is null, so the gate evaluates false and these jobs are skipped.

Adding `|| github.event_name == 'push'` lets push runs from this branch actually exercise the sharded matrix, so we can validate runtime improvements before merging #11850.

## User impact

None — temporary, branch-scoped change for CI validation. Reverted before #11850 merges into develop.

## How to review

- Confirm the only changes are the two `if:` lines.
- Normal PR runs (`pull_request_target`) are unchanged: the first clause still evaluates `true` for non-draft PRs.
- After merge, push to `maint/shard-marker-tests` and confirm `marker-tests-snowflake (3.13, 1/3)`, `(3.13, 2/3)`, `(3.13, 3/3)` jobs appear in the run.