### PR TITLE
[BUGFIX] Avoid .toPandas() in Spark multicolumn unexpected values (#11633)

### DIFF
--- a/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_condition_auxilliary_methods.py
@@ -251,16 +251,13 @@ def _spark_multicolumn_map_condition_values(
 
     column_selector = [F.col(column_name).alias(column_name) for column_name in column_list]
 
+    limit = MAX_RESULT_RECORDS
     result_format = metric_value_kwargs["result_format"]
-    if result_format["result_format"] == "COMPLETE":
-        domain_values = (
-            filtered.select(column_selector).limit(MAX_RESULT_RECORDS).toPandas().to_dict("records")
-        )
-    else:
+    if result_format["result_format"] != "COMPLETE":
         limit = min(result_format["partial_unexpected_count"], MAX_RESULT_RECORDS)
-        domain_values = filtered.select(column_selector).limit(limit).toPandas().to_dict("records")
 
-    return domain_values
+    domain_values = filtered.select(column_selector).limit(limit)
+    return [row.asDict() for row in domain_values.collect()]
 
 
 def _spark_multicolumn_map_condition_filtered_row_count(

--- a/tests/expectations/metrics/test_core.py
+++ b/tests/expectations/metrics/test_core.py
@@ -6682,8 +6682,7 @@ def test_map_select_column_values_unique_within_record_spark(  # noqa: PLR0915 #
     unexpected_values = []
     for unexpected_value_dict in metrics[unexpected_values_metric.id]:
         updated_unexpected_value_dict = {
-            key: "NULL" if np.isnan(value) else value
-            for key, value in unexpected_value_dict.items()
+            key: "NULL" if value is None else value for key, value in unexpected_value_dict.items()
         }
         unexpected_values.append(updated_unexpected_value_dict)
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_compound_column_values_to_be_unique.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_compound_column_values_to_be_unique.py
@@ -247,12 +247,15 @@ def test_invalid_config(column_list: list[str]) -> None:
         gxe.ExpectCompoundColumnsToBeUnique(column_list=column_list)
 
 
+# Naive datetimes are intentional: Spark's CSV roundtrip and timestamp parsing
+# behave deterministically when input/output stay tz-naive, avoiding session/local
+# timezone interactions that would otherwise make the comparison flaky.
 DATA_WITH_TIMESTAMP_DUPLICATES = pd.DataFrame(
     {
         EVENT_TS: [
-            datetime(2024, 1, 1),
-            datetime(2024, 1, 1),
-            datetime(2024, 1, 2),
+            datetime(2024, 1, 1),  # noqa: DTZ001
+            datetime(2024, 1, 1),  # noqa: DTZ001
+            datetime(2024, 1, 2),  # noqa: DTZ001
         ],
         CATEGORY: ["A", "A", "B"],
     }
@@ -280,7 +283,7 @@ def test_partial_unexpected_list_spark_with_timestamp_columns(batch_for_datasour
 
     rows = result.result["partial_unexpected_list"]
     assert len(rows) == 2
-    expected_ts = datetime(2024, 1, 1)
+    expected_ts = datetime(2024, 1, 1)  # noqa: DTZ001
     for row in rows:
         # pd.Timestamp and datetime.datetime compare equal for the same moment, so this
         # assertion is independent of which Python type the metric returns.

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_compound_column_values_to_be_unique.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_compound_column_values_to_be_unique.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pandas as pd
 import pytest
 
@@ -9,12 +11,17 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
     ALL_DATA_SOURCES,
     JUST_PANDAS_DATA_SOURCES,
 )
-from tests.integration.test_utils.data_source_config import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config import (
+    PostgreSQLDatasourceTestConfig,
+    SparkFilesystemCsvDatasourceTestConfig,
+)
 
 STRING_COL = "string_col"
 INT_COL = "int_col"
 INT_COL_2 = "int_col_2"
 DUPLICATES = "duplicates"
+EVENT_TS = "event_ts"
+CATEGORY = "category"
 
 try:
     from great_expectations.compatibility.pyspark import types as PYSPARK_TYPES
@@ -25,8 +32,13 @@ try:
         INT_COL_2: PYSPARK_TYPES.IntegerType,
         DUPLICATES: PYSPARK_TYPES.IntegerType,
     }
+    SPARK_TIMESTAMP_COLUMN_TYPES = {
+        EVENT_TS: PYSPARK_TYPES.TimestampType,
+        CATEGORY: PYSPARK_TYPES.StringType,
+    }
 except ModuleNotFoundError:
     SPARK_COLUMN_TYPES = {}
+    SPARK_TIMESTAMP_COLUMN_TYPES = {}
 
 
 DATA = pd.DataFrame(
@@ -233,3 +245,44 @@ def test_unexpected_index_query_sql_suppressed(batch_for_datasource: Batch) -> N
 def test_invalid_config(column_list: list[str]) -> None:
     with pytest.raises(pydantic.ValidationError):
         gxe.ExpectCompoundColumnsToBeUnique(column_list=column_list)
+
+
+DATA_WITH_TIMESTAMP_DUPLICATES = pd.DataFrame(
+    {
+        EVENT_TS: [
+            datetime(2024, 1, 1),
+            datetime(2024, 1, 1),
+            datetime(2024, 1, 2),
+        ],
+        CATEGORY: ["A", "A", "B"],
+    }
+)
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[
+        SparkFilesystemCsvDatasourceTestConfig(column_types=SPARK_TIMESTAMP_COLUMN_TYPES),
+    ],
+    data=DATA_WITH_TIMESTAMP_DUPLICATES,
+)
+def test_partial_unexpected_list_spark_with_timestamp_columns(batch_for_datasource: Batch) -> None:
+    # Regression test for https://github.com/great-expectations/great_expectations/issues/11633:
+    # the Spark codepath used .toPandas() to materialize unexpected rows, which fails on
+    # PySpark 3.1.x + Pandas 2.x because the corrected pandas type for TimestampType was
+    # bare ``np.datetime64`` (no precision) — Pandas 2.x rejects that with
+    # "Passing in 'datetime64' dtype with no precision is not allowed".
+    result = batch_for_datasource.validate(
+        gxe.ExpectCompoundColumnsToBeUnique(column_list=[EVENT_TS, CATEGORY]),
+        result_format={"result_format": "COMPLETE"},
+    )
+    assert not result.success
+    assert result.result["unexpected_count"] == 2
+
+    rows = result.result["partial_unexpected_list"]
+    assert len(rows) == 2
+    expected_ts = datetime(2024, 1, 1)
+    for row in rows:
+        # pd.Timestamp and datetime.datetime compare equal for the same moment, so this
+        # assertion is independent of which Python type the metric returns.
+        assert row[EVENT_TS] == expected_ts
+        assert row[CATEGORY] == "A"


### PR DESCRIPTION
## Summary

Closes #11633. Fixes `expect_compound_columns_to_be_unique` (and `expect_select_column_values_to_be_unique_within_record`) crashing on Spark DataFrames with timestamp columns under Pandas 2.x. This supersedes the stalled #11782 and incorporates the review feedback there (broken `np.isnan` test plus a Spark+timestamp regression test).

## Changes

- `_spark_multicolumn_map_condition_values` in `great_expectations/expectations/metrics/map_metric_provider/multicolumn_map_condition_auxilliary_methods.py`: replace `.toPandas().to_dict("records")` with `[row.asDict() for row in ....collect()]`. Pull `limit` selection out of the conditional so the same expression handles both `COMPLETE` and the partial cases.
- `tests/expectations/metrics/test_core.py::test_map_select_column_values_unique_within_record_spark`: switch the null check from `np.isnan(value)` to `value is None`. Spark `Row.asDict()` returns Python `None` for nulls instead of the `numpy.nan` that `.toPandas()` produced. The pandas-engine test in the same file is unchanged because it still goes through pandas.
- `tests/integration/data_sources_and_expectations/expectations/test_expect_compound_column_values_to_be_unique.py`: add a Spark integration test that runs compound uniqueness against a CSV-backed dataset with a `TimestampType` column and verifies `partial_unexpected_list` contents.

## Why

`pyspark.DataFrame.toPandas()` on PySpark < 3.4 maps `TimestampType` to bare `np.datetime64` (no precision) when constructing the pandas dtype dict. Pandas 2.x rejects that with `ValueError: Passing in 'datetime64' dtype with no precision is not allowed.` (See SPARK-43194 for the upstream fix in PySpark 3.4.)

Going through `.collect()` + `Row.asDict()` produces the list of dicts the metric needs without ever materializing a pandas DataFrame, so the dtype-translation step where the bug lives is avoided entirely. This also matches what the SQLAlchemy variant of this method already does (`val._asdict()` from a `fetchmany` result).

## User impact

- Spark + timestamp column users on Pandas 2.x can now run compound uniqueness expectations (and `select_column_values_to_be_unique_within_record`) without hitting the `datetime64` ValueError.
- One subtle behavior shift in the metric output: `partial_unexpected_list` entries now contain native Python types from Spark (`datetime.datetime`, `None`, `int`, `Decimal`, ...) instead of the pandas-converted equivalents (`pandas.Timestamp`, `numpy.nan`, `numpy.int64`, ...). Equality comparisons against equivalent native values continue to work; code that specifically introspected the pandas/numpy types will need to switch to native checks (e.g. `value is None` instead of `np.isnan(value)`), as done in the test_core update.

## How to review

- Confirm the new aux-method body is equivalent to the SQLAlchemy and pandas siblings: select the columns, apply the limit, return a list of plain dicts. The `limit` selection block was rewritten so the diff highlights the ternary; the values it picks are unchanged.
- The added integration test uses `SparkFilesystemCsvDatasourceTestConfig` with `column_types={EVENT_TS: TimestampType, CATEGORY: StringType}`. Naive datetimes are intentional to avoid timezone interactions in the CSV roundtrip — there is a comment to that effect.
- The bug only reproduces on PySpark < 3.4 (production users on the older Spark are the affected population). On the project's CI Spark version the test will pass either way; it serves both as a regression test for the new code path and as a guard against re-introducing `.toPandas()` here.