### PR TITLE
[BUGFIX] Use uuid4 for test datasource names to avoid global-RNG collisions

### DIFF
--- a/tests/integration/test_utils/data_source_config/base.py
+++ b/tests/integration/test_utils/data_source_config/base.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import random
-import string
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -154,7 +152,10 @@ class BatchTestSetup(ABC, Generic[_ConfigT, _AssetT]):
 
     @staticmethod
     def _random_resource_name() -> str:
-        return "".join(random.choices(string.ascii_lowercase, k=10))
+        # Use uuid4 rather than the global `random` module: tests/conftest.py and
+        # tests/execution_engine/conftest.py reseed `random` with a fixed seed,
+        # which makes "random" names deterministic and prone to in-session collisions.
+        return uuid4().hex[:10]
 
     @cached_property
     def id(self) -> UUID:


### PR DESCRIPTION
## Summary

`tests/integration/test_utils/data_source_config/base.BatchTestSetup._random_resource_name` now uses `uuid4().hex[:10]` instead of `random.choices(string.ascii_lowercase, k=10)`. This eliminates a class of intermittent CI failures where two datasources end up with the same generated name.

## Changes

- `tests/integration/test_utils/data_source_config/base.py`
  - Drop `import random` / `import string`.
  - `_random_resource_name()` now returns `uuid4().hex[:10]`.
  - Added a comment explaining why we deliberately avoid the global `random` module.

## Why

`_random_resource_name` reads from the process-wide `random` RNG. Two test fixtures call `random.seed(1)` mid-session (`tests/conftest.py:1613` in the `test_df` fixture, and `tests/execution_engine/conftest.py:149`), which makes subsequent "random" names deterministic. Combined with the session-scoped `_cached_test_configs` in `tests/integration/conftest.py` — which keeps previously-created datasources registered in the shared `DataContext` — a regenerated name can collide with one that's already there, raising:

```
DataContextError: Can not write the fluent datasource <name> because a datasource of that name already exists in the data context.
```

Two scheduled CI runs over the weekend (run 25282919694 on Py 3.10 and run 25269704051 on Py 3.13, both at commit 53d3fccfb) failed at fixture setup of `tests/integration/data_sources_and_expectations/expectations/test_expect_column_distinct_values_to_contain_set.py::test_ignores_nulls[pandas-data-frame]` with the **identical** generated datasource name `uqzuossvmh` — a sequence that has probability ~26⁻¹⁰ ≈ 7×10⁻¹⁵ if the names were truly random, confirming the determinism.

`uuid4()` uses `os.urandom`, which is not affected by `random.seed`.

## User impact

None — test-only change, no library code modified.

## How to review

- Confirm the import diff and the body of `_random_resource_name` are the only changes.
- Sanity-check: `uuid4().hex[:10]` returns 10 lowercase hex characters, which is a strict subset of the previous alphabet — any code that pattern-matches against `[a-z]{10}` still works (existing matchers do not exist; this is just a safety note).
- The two `random.seed(1)` call sites in `tests/conftest.py` and `tests/execution_engine/conftest.py` are unchanged. They still pollute the global RNG for any *other* code that happens to call `random.*`, but resource-name generation is now decoupled from that.