### PR TITLE
[BUGFIX] Restore SQLAlchemy 1.4 compatibility in column_values_unique (fixes #11875)

### DIFF
--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
@@ -4,6 +4,8 @@ from great_expectations.compatibility import pyspark
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import (
     Select,
+)
+from great_expectations.compatibility.sqlalchemy import (
     sqlalchemy as sa,
 )
 from great_expectations.core.metric_function_types import MetricPartialFunctionTypes

--- a/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
+++ b/great_expectations/expectations/metrics/column_map_metrics/column_values_unique.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from great_expectations.compatibility import pyspark
 from great_expectations.compatibility.pyspark import functions as F
 from great_expectations.compatibility.sqlalchemy import (
+    Select,
     sqlalchemy as sa,
 )
 from great_expectations.core.metric_function_types import MetricPartialFunctionTypes
@@ -65,7 +66,7 @@ class ColumnValuesUnique(ColumnMapMetricProvider):
             gx_dialect = GXSqlDialect(dialect_name)
             quoted_col = quote_str(column.name, gx_dialect)
             temp_table_name = generate_temporary_table_name()
-            if isinstance(_table, sa.Select):
+            if isinstance(_table, Select):
                 from_clause = _table.subquery().alias("tmp")
             else:
                 from_clause = _table
@@ -86,7 +87,7 @@ class ColumnValuesUnique(ColumnMapMetricProvider):
             execution_engine.execute_query_in_transaction(sa.text(dup_stmt))
             dup_query = sa.select(column).select_from(sa.text(dup_table_name))
         else:
-            from_clause = _table.subquery() if isinstance(_table, sa.Select) else _table
+            from_clause = _table.subquery() if isinstance(_table, Select) else _table
             dup_query = (
                 sa.select(column)
                 .select_from(from_clause)


### PR DESCRIPTION
## Summary

Fixes #11875 — great-expectations 1.17.0 introduced `isinstance(_table, sa.Select)` in `column_values_unique.py` (PR #11828). `Select` is not a top-level attribute on the `sqlalchemy` module in 1.4 — it was promoted there only in 2.0. Users on SQLAlchemy 1.4 hit:

```
AttributeError: module 'sqlalchemy' has no attribute 'Select'. Did you mean: 'select'?
```

wrapped in a `MetricResolutionError` whenever an expectation resolves the `column_values.unique.condition` metric.

## Root cause

In SQLAlchemy 1.4 the `Select` type lives at `sqlalchemy.sql.expression.Select`, not `sqlalchemy.Select`. PR #11828 added two references to the 2.0-only top-level alias.

## Fix

`great_expectations.compatibility.sqlalchemy` already re-exports a version-safe `Select` from `sqlalchemy.sql.expression` (works in both 1.4 and 2.0). Import it from there and use it in place of `sa.Select` — matches the existing pattern enforced by the `pyproject.toml` lint rule (*"Please do not import sqlalchemy directly, import from great_expectations.compatibility.sqlalchemy instead."*).

```diff
 from great_expectations.compatibility.sqlalchemy import (
+    Select,
     sqlalchemy as sa,
 )
```

```diff
-if isinstance(_table, sa.Select):
+if isinstance(_table, Select):
```

```diff
-from_clause = _table.subquery() if isinstance(_table, sa.Select) else _table
+from_clause = _table.subquery() if isinstance(_table, Select) else _table
```

## Why this is the right scope

SQLAlchemy 1.4 is still officially supported per `reqs/requirements-dev-sqlalchemy1.txt` (`sqlalchemy<2.0.0`, *"for sqlalchemy dialects that are not yet compatible with sqlalchemy 2.x"*) and the `sqla1x_only_keys` branch in `setup.py` (clickhouse, redshift, teradata). The regression here looks unintentional, not a deliberate API drop.

## Checklist

- [x] Description of PR changes above includes a link to an existing GitHub issue (#11875)
- [x] PR title is prefixed with `[BUGFIX]`