### PR TITLE
[MAINTENANCE] Declarative SQL backend records for the integration test harness (foundation)

### DIFF
--- a/tests/integration/test_utils/data_source_config/backend_spec.py
+++ b/tests/integration/test_utils/data_source_config/backend_spec.py
@@ -1,0 +1,165 @@
+"""Declarative facts about a SQL backend used by the integration test harness.
+
+This module holds only data: the types a SQL backend declares to describe itself, with no
+dependency on the harness that consumes them. It imports nothing from this package's other
+modules, so a throwaway record can be constructed here without importing a backend, and so this
+module sits to the left of everything that consumes it in the dependency graph.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Callable, FrozenSet, Mapping, Optional, Sequence, Union
+
+import pytest
+
+if TYPE_CHECKING:
+    import sqlalchemy as sa
+
+    from great_expectations.compatibility.sqlalchemy import TypeEngine
+
+
+class TransactionMode(Enum):
+    """How a backend handles transaction boundaries during setup and teardown."""
+
+    EXPLICIT_COMMIT = "explicit_commit"
+    """The default: the harness calls ``conn.commit()`` after setup and before teardown."""
+
+    AUTOCOMMIT = "autocommit"
+    """The backend has no standard transactions; the harness skips explicit commits."""
+
+
+class BackendProvisioning(Enum):
+    """Where a test run gets an instance of this backend."""
+
+    LOCAL_CONTAINER = "local_container"
+    """Started from a compose file for the duration of the test run."""
+
+    LOCAL_FILE = "local_file"
+    """No server at all; the backend is a local file (e.g. SQLite)."""
+
+    EXTERNAL_CREDENTIALS = "external_credentials"
+    """Hosted; reached with credentials read from the environment."""
+
+
+class BackendTier(Enum):
+    """Named suites a backend can participate in."""
+
+    STANDARD_SQL = "standard_sql"
+    """The shared standard SQL data-source list."""
+
+    CURATED_SQL = "curated_sql"
+    """The smaller curated suite."""
+
+
+@dataclass(frozen=True)
+class CiLaneRef:
+    """Where a backend's tests run in the CI workflow."""
+
+    workflow_job: str
+    """A key under ``jobs:`` in the CI workflow file."""
+
+    marker_token: str
+    """The marker token that job selects tests on."""
+
+
+# Produces the dialect-required positional schema items for ONE table. Called once per table so
+# that each table gets its own freshly constructed items; a schema item that binds to a table on
+# attachment cannot be reused across tables. `sa` is imported under TYPE_CHECKING only, the
+# pattern `sql.py` already uses, so this module needs no dialect and no runtime SQLAlchemy symbol
+# it does not already have.
+TableSchemaItemFactory = Callable[[], Sequence["sa.sql.schema.SchemaItem"]]
+
+
+@dataclass(frozen=True)
+class SqlBackendSpec:
+    """Every dialect fact about a SQL backend that is data rather than behavior."""
+
+    # identity
+    label: str
+    """Appears in the parameterized test id."""
+
+    marker: str
+    """The pytest marker name; may differ from ``label`` (e.g. SQL Server's label is ``mssql``
+    while its marker is ``sql_server``)."""
+
+    # runtime shape
+    provisioning: BackendProvisioning
+    ci_lane: CiLaneRef
+    uses_schema: bool
+    transaction_mode: TransactionMode = TransactionMode.EXPLICIT_COMMIT
+
+    table_schema_items: Optional[TableSchemaItemFactory] = None
+    """A zero-argument callable returning a sequence of positional SQLAlchemy schema items,
+    or ``None`` (the default) when the backend contributes nothing.
+
+    This is a factory, not a stored instance, for two independent reasons, plus a third that
+    governs where it can be declared:
+
+    - *Positional, not keyword.* SQLAlchemy accepts dialect-specific ``Table`` keyword arguments
+      only when the dialect registers them in ``construct_arguments``; a dialect storage-engine
+      construct is not one of those, so it cannot be passed as a ``Table`` keyword argument at
+      all — it must arrive positionally, alongside the generated columns.
+    - *A factory, not a stored instance.* Such a construct binds to the first ``Table`` it is
+      attached to, so reusing one instance across tables corrupts the second table's schema.
+      Each table therefore needs freshly constructed items, which only a callable invoked once
+      per table can provide.
+    - *Deferred construction.* Building the items requires the dialect package, and this
+      declaration module is imported in lanes where that package is not installed. A
+      zero-argument callable defers construction to the point where the backend has been
+      selected by marker and its dialect is installed; a stored instance could not be built
+      where the declaration lives.
+    """
+
+    column_type_overrides: Mapping[type, Union[type[TypeEngine], TypeEngine]] = field(
+        default_factory=dict
+    )
+    """Python-type-to-SQLAlchemy-type overrides merged over the shared default inference
+    mapping, defaulting to empty.
+
+    This is a mapping, not a callable, because there is no per-table freshness requirement:
+    the values are inert data with no construction cost, so no callable indirection is
+    warranted. The consequence is that the field cannot be made lazy the way
+    ``table_schema_items`` is — assigning the result of a function call still evaluates at
+    declaration time, because it is the value that is stored, not the callable. A backend whose
+    override values come from its dialect package therefore builds the mapping at module scope
+    behind an import guard that yields an empty mapping when the package is absent. That is the
+    supported shape: the declared record is populated where the dialect is installed and empty
+    where it is not.
+    """
+
+    insert_parameter_limit: Optional[int] = None
+    tiers: FrozenSet[BackendTier] = frozenset()
+    """The named test tiers this backend participates in, e.g.
+    ``tiers=frozenset({BackendTier.CURATED_SQL})``.
+
+    Always write a ``frozenset(...)`` literal, never a bare set literal: a bare
+    ``{BackendTier.CURATED_SQL}`` is a ``set``, which mypy rejects against this ``FrozenSet``
+    field, and ``tests/`` is inside mypy's ``files``, so that is a hard failure rather than a
+    lint note. A backend joining both tiers writes
+    ``frozenset({BackendTier.STANDARD_SQL, BackendTier.CURATED_SQL})``; a backend joining
+    neither tier omits this field.
+    """
+
+    tier_case_exclusions: Mapping[str, str] = field(default_factory=dict)
+    """Case key to reason string, defaulting to empty. Lets a tier member sit out one named case
+    within that tier's suite, with a required reason recorded next to the declaration."""
+
+    # wiring coordinates
+    dev_requirements_file: Optional[str] = None
+    """Repo-relative path, e.g. ``"reqs/requirements-dev-mysql.txt"``."""
+
+    task_runner_marker: Optional[str] = None
+    """Dependency-map key; ``None`` means no entry is needed."""
+
+    container_service: Optional[str] = None
+    """Compose directory name under ``assets/docker/``."""
+
+    @property
+    def pytest_mark(self) -> pytest.MarkDecorator:
+        """Resolve the declared marker name to a pytest mark decorator.
+
+        Compares equal to the literal ``pytest.mark.<name>`` the existing configs return today.
+        """
+        return getattr(pytest.mark, self.marker)

--- a/tests/integration/test_utils/data_source_config/mysql.py
+++ b/tests/integration/test_utils/data_source_config/mysql.py
@@ -8,26 +8,34 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from tests.integration.sql_session_manager import SessionSQLEngineManager
-from tests.integration.test_utils.data_source_config.base import (
-    BatchTestSetup,
-    DataSourceTestConfig,
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    CiLaneRef,
+    SqlBackendSpec,
 )
+from tests.integration.test_utils.data_source_config.base import BatchTestSetup
+from tests.integration.test_utils.data_source_config.registry import register_sql_backend
 from tests.integration.test_utils.data_source_config.sql import (
     InferrableTypesLookup,
     SQLBatchTestSetup,
 )
+from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 
-class MySQLDatasourceTestConfig(DataSourceTestConfig):
-    @property
-    @override
-    def label(self) -> str:
-        return "mysql"
-
-    @property
-    @override
-    def pytest_mark(self) -> pytest.MarkDecorator:
-        return pytest.mark.mysql
+@register_sql_backend
+class MySQLDatasourceTestConfig(SqlDatasourceTestConfig):
+    BACKEND_SPEC = SqlBackendSpec(
+        label="mysql",
+        marker="mysql",
+        provisioning=BackendProvisioning.LOCAL_CONTAINER,
+        ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="mysql"),
+        uses_schema=True,
+        # mysql requires a length for VARCHAR
+        column_type_overrides={str: sqltypes.VARCHAR(255)},
+        dev_requirements_file="reqs/requirements-dev-mysql.txt",
+        task_runner_marker="mysql",
+        container_service="mysql",
+    )
 
     @override
     def create_batch_setup(

--- a/tests/integration/test_utils/data_source_config/mysql.py
+++ b/tests/integration/test_utils/data_source_config/mysql.py
@@ -30,7 +30,11 @@ class MySQLDatasourceTestConfig(SqlDatasourceTestConfig):
         provisioning=BackendProvisioning.LOCAL_CONTAINER,
         ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="mysql"),
         uses_schema=True,
-        # mysql requires a length for VARCHAR
+        # mysql requires a length for VARCHAR.
+        # This restates `MySQLBatchTestSetup.inferrable_types_lookup` below, which is still the
+        # value actually in use: nothing reads the declared overrides yet. The two must agree
+        # until the shared setup merges this field, at which point the override below is deleted
+        # and this becomes the single statement of the fact.
         column_type_overrides={str: sqltypes.VARCHAR(255)},
         dev_requirements_file="reqs/requirements-dev-mysql.txt",
         task_runner_marker="mysql",

--- a/tests/integration/test_utils/data_source_config/postgres.py
+++ b/tests/integration/test_utils/data_source_config/postgres.py
@@ -8,23 +8,31 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from tests.integration.sql_session_manager import SessionSQLEngineManager
-from tests.integration.test_utils.data_source_config.base import (
-    BatchTestSetup,
-    DataSourceTestConfig,
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    BackendTier,
+    CiLaneRef,
+    SqlBackendSpec,
 )
+from tests.integration.test_utils.data_source_config.base import BatchTestSetup
+from tests.integration.test_utils.data_source_config.registry import register_sql_backend
 from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 
-class PostgreSQLDatasourceTestConfig(DataSourceTestConfig):
-    @property
-    @override
-    def label(self) -> str:
-        return "postgresql"
-
-    @property
-    @override
-    def pytest_mark(self) -> pytest.MarkDecorator:
-        return pytest.mark.postgresql
+@register_sql_backend
+class PostgreSQLDatasourceTestConfig(SqlDatasourceTestConfig):
+    BACKEND_SPEC = SqlBackendSpec(
+        label="postgresql",
+        marker="postgresql",
+        provisioning=BackendProvisioning.LOCAL_CONTAINER,
+        ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="postgresql"),
+        uses_schema=True,
+        tiers=frozenset({BackendTier.STANDARD_SQL}),
+        dev_requirements_file="reqs/requirements-dev-postgresql.txt",
+        task_runner_marker="postgresql",
+        container_service="postgresql",
+    )
 
     @override
     def create_batch_setup(

--- a/tests/integration/test_utils/data_source_config/registry.py
+++ b/tests/integration/test_utils/data_source_config/registry.py
@@ -1,0 +1,215 @@
+"""Process-global registry of SQL backend declarations.
+
+A `SqlBackendSpec` (see `backend_spec.py`) is free to construct; nothing about building one has
+any side effect. Registration is the separate, deliberate act that enrols a config class's spec
+into the set the harness treats as "the SQL backends that exist" — the set completeness checks,
+derived suite membership, and CI wiring checks all walk. That split is what lets a test build a
+throwaway spec, or even a throwaway registered class, without polluting the set that gates CI.
+
+This module imports only `backend_spec`. It does not import the SQL config base, `sql.py`, or any
+backend module — those sit to this module's right in the dependency direction
+(`backend_spec` -> `registry` -> `sql_config` -> `sql` -> backend modules -> `tiers`), and a
+module is only ever allowed to import from modules to its own left.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import ClassVar, Dict, Iterator, Protocol, Tuple, Type, TypeVar
+
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    BackendTier,
+    SqlBackendSpec,
+)
+
+# The ceiling on tier_case_exclusions per backend. See _validate_tier_case_exclusion_ceiling: a
+# reason makes one exclusion answerable, but only a count makes the whole set answerable, so the
+# count is enforced here rather than left to per-exclusion review.
+_MAX_TIER_CASE_EXCLUSIONS = 2
+
+
+class _DeclaresBackendSpec(Protocol):
+    """Structural shape a config class must have to be enrolled.
+
+    Registration only needs one class attribute. Describing that as a `Protocol` here, rather than
+    importing the concrete SQL config base, is what lets this module stay to the left of that base
+    in the dependency direction while still type-checking the decorator's argument.
+    """
+
+    BACKEND_SPEC: ClassVar[SqlBackendSpec]
+
+
+_C = TypeVar("_C", bound=_DeclaresBackendSpec)
+
+_by_label: Dict[str, Type[_DeclaresBackendSpec]] = {}
+_by_marker: Dict[str, Type[_DeclaresBackendSpec]] = {}
+
+
+def _validate_identity(config_class: type, spec: SqlBackendSpec) -> None:
+    if not spec.label:
+        raise ValueError(
+            f"{config_class.__name__} declares an empty SQL backend label; it must be a "
+            f"non-empty string, since it appears in the parameterized test id used to select "
+            f"this backend's cases"
+        )
+    if not spec.marker:
+        raise ValueError(
+            f"{config_class.__name__} declares an empty SQL backend marker; it must be a "
+            f"non-empty string naming the pytest mark used to select this backend's tests"
+        )
+    if not spec.ci_lane.marker_token:
+        raise ValueError(
+            f"{config_class.__name__} declares an empty CI lane marker token; it must be a "
+            f"non-empty string identifying which CI lane runs this backend's marker-selected tests"
+        )
+
+
+def _validate_insert_parameter_limit(config_class: type, spec: SqlBackendSpec) -> None:
+    if spec.insert_parameter_limit is not None and spec.insert_parameter_limit <= 0:
+        raise ValueError(
+            f"{config_class.__name__} declares a non-positive insert_parameter_limit "
+            f"({spec.insert_parameter_limit!r}); it must be a positive integer, or omitted "
+            f"entirely when the backend has no chunking limit"
+        )
+
+
+def _validate_container_provisioning(config_class: type, spec: SqlBackendSpec) -> None:
+    has_container_service = spec.container_service is not None
+    is_local_container = spec.provisioning is BackendProvisioning.LOCAL_CONTAINER
+
+    if is_local_container and not has_container_service:
+        raise ValueError(
+            f"{config_class.__name__} declares LOCAL_CONTAINER provisioning without a "
+            f"container_service; a locally containerized backend must name the compose service "
+            f"that starts it"
+        )
+    if has_container_service and not is_local_container:
+        raise ValueError(
+            f"{config_class.__name__} declares a container_service "
+            f"({spec.container_service!r}) without LOCAL_CONTAINER provisioning; a container "
+            f"service is only meaningful for a backend the harness starts locally"
+        )
+
+
+def _validate_table_schema_items(config_class: type, spec: SqlBackendSpec) -> None:
+    # Checked for callability only, never invoked: calling it would require the backend's dialect
+    # package, and registration must never assume that package is installed (this module is
+    # imported in lanes that install no SQL dialect at all).
+    if spec.table_schema_items is not None and not callable(spec.table_schema_items):
+        raise ValueError(
+            f"{config_class.__name__} declares table_schema_items "
+            f"({spec.table_schema_items!r}) that is not callable; it must be a zero-argument "
+            f"factory, or omitted entirely"
+        )
+
+
+def _validate_tier_case_exclusion_reasons(config_class: type, spec: SqlBackendSpec) -> None:
+    for key, reason in spec.tier_case_exclusions.items():
+        if not key:
+            raise ValueError(
+                f"{config_class.__name__} declares a tier case exclusion with an empty case key; "
+                f"every excluded case must be named"
+            )
+        if not reason or not reason.strip():
+            raise ValueError(
+                f"{config_class.__name__} declares a tier case exclusion for case {key!r} with no "
+                f"reason (or a whitespace-only one); an unexplained exclusion is exactly the "
+                f"silent narrowing this mechanism exists to prevent, so every exclusion must "
+                f"record why it exists"
+            )
+
+
+def _validate_tier_case_exclusion_ceiling(config_class: type, spec: SqlBackendSpec) -> None:
+    count = len(spec.tier_case_exclusions)
+    if count <= _MAX_TIER_CASE_EXCLUSIONS:
+        return
+    keys = sorted(spec.tier_case_exclusions)
+    raise ValueError(
+        f"{config_class.__name__} declares {count} tier case exclusions {keys!r}, exceeding the "
+        f"ceiling of {_MAX_TIER_CASE_EXCLUSIONS}. The count is taken over the whole mapping "
+        f"regardless of what each individual reason records — an exclusion for observed "
+        f"non-determinism subtracts exactly as much coverage as one for a dialect gap. A reason "
+        f"makes one exclusion answerable; only a count makes the set of exclusions answerable, "
+        f"which is why this check exists on top of the per-exclusion reason requirement. The "
+        f"remedy is to escalate this backend's tier participation, not to raise the ceiling"
+    )
+
+
+def _validate_tier_case_exclusions(config_class: type, spec: SqlBackendSpec) -> None:
+    _validate_tier_case_exclusion_reasons(config_class, spec)
+    _validate_tier_case_exclusion_ceiling(config_class, spec)
+
+
+def _validate_spec(config_class: type, spec: SqlBackendSpec) -> None:
+    _validate_identity(config_class, spec)
+    _validate_insert_parameter_limit(config_class, spec)
+    _validate_container_provisioning(config_class, spec)
+    _validate_table_schema_items(config_class, spec)
+    _validate_tier_case_exclusions(config_class, spec)
+
+
+def register_sql_backend(config_class: type[_C]) -> type[_C]:
+    """Enrol a SQL config class. Raises `ValueError` at decoration time on a duplicate label,
+    duplicate marker, or any invariant violation in its declared spec.
+    """
+    spec = config_class.BACKEND_SPEC
+    _validate_spec(config_class, spec)
+
+    duplicate_label = _by_label.get(spec.label)
+    if duplicate_label is not None:
+        raise ValueError(
+            f"duplicate SQL backend label {spec.label!r} declared by "
+            f"{duplicate_label.__name__} and {config_class.__name__}"
+        )
+    duplicate_marker = _by_marker.get(spec.marker)
+    if duplicate_marker is not None:
+        raise ValueError(
+            f"duplicate SQL backend marker {spec.marker!r} declared by "
+            f"{duplicate_marker.__name__} and {config_class.__name__}"
+        )
+
+    _by_label[spec.label] = config_class
+    _by_marker[spec.marker] = config_class
+    return config_class
+
+
+def iter_sql_backends() -> Tuple[Type[_DeclaresBackendSpec], ...]:
+    """Registered config classes, ordered by spec label."""
+    return tuple(_by_label[label] for label in sorted(_by_label))
+
+
+def sql_backends_for_tier(tier: BackendTier) -> Tuple[Type[_DeclaresBackendSpec], ...]:
+    """Registered config classes declaring membership in `tier`, ordered by spec label."""
+    return tuple(
+        config_class
+        for config_class in iter_sql_backends()
+        if tier in config_class.BACKEND_SPEC.tiers
+    )
+
+
+@contextmanager
+def isolated_registry() -> Iterator[None]:
+    """Snapshot the registry, clear it, yield an isolated empty registry, then restore the
+    snapshot verbatim regardless of what happens inside.
+
+    The registry is process-global module state, so a test that registers a throwaway backend —
+    including every duplicate-rejection test, which needs one successful registration before the
+    conflicting one — must not leave that backend behind for later tests or for the real registry
+    consumers (the wiring drift check and the registered-set pin) to trip over. Clearing before
+    yielding, rather than only restoring after, is what makes the empty registry inside the seam
+    genuinely isolated rather than merely a live view onto whatever the real registry happens to
+    hold at the time — which in turn is what lets a test assert whole-registry equality exactly,
+    without that assertion depending on how many real backends happen to be registered elsewhere.
+    """
+    saved_by_label = dict(_by_label)
+    saved_by_marker = dict(_by_marker)
+    _by_label.clear()
+    _by_marker.clear()
+    try:
+        yield
+    finally:
+        _by_label.clear()
+        _by_label.update(saved_by_label)
+        _by_marker.clear()
+        _by_marker.update(saved_by_marker)

--- a/tests/integration/test_utils/data_source_config/registry.py
+++ b/tests/integration/test_utils/data_source_config/registry.py
@@ -58,6 +58,13 @@ def _validate_identity(config_class: type, spec: SqlBackendSpec) -> None:
             f"{config_class.__name__} declares an empty SQL backend marker; it must be a "
             f"non-empty string naming the pytest mark used to select this backend's tests"
         )
+    if not spec.ci_lane.workflow_job:
+        raise ValueError(
+            f"{config_class.__name__} declares an empty CI lane workflow job; it must be a "
+            f"non-empty string naming the workflow job that runs this backend's lane. A lane "
+            f"naming no job cannot be located in the workflow file, so its wiring cannot be "
+            f"checked at all"
+        )
     if not spec.ci_lane.marker_token:
         raise ValueError(
             f"{config_class.__name__} declares an empty CI lane marker token; it must be a "

--- a/tests/integration/test_utils/data_source_config/registry.py
+++ b/tests/integration/test_utils/data_source_config/registry.py
@@ -1,7 +1,7 @@
 """Process-global registry of SQL backend declarations.
 
 A `SqlBackendSpec` (see `backend_spec.py`) is free to construct; nothing about building one has
-any side effect. Registration is the separate, deliberate act that enrols a config class's spec
+any side effect. Registration is the separate, deliberate act that enrolls a config class's spec
 into the set the harness treats as "the SQL backends that exist" — the set completeness checks,
 derived suite membership, and CI wiring checks all walk. That split is what lets a test build a
 throwaway spec, or even a throwaway registered class, without polluting the set that gates CI.
@@ -157,7 +157,7 @@ def _validate_spec(config_class: type, spec: SqlBackendSpec) -> None:
 
 
 def register_sql_backend(config_class: type[_C]) -> type[_C]:
-    """Enrol a SQL config class. Raises `ValueError` at decoration time on a duplicate label,
+    """Enroll a SQL config class. Raises `ValueError` at decoration time on a duplicate label,
     duplicate marker, or any invariant violation in its declared spec.
     """
     spec = config_class.BACKEND_SPEC

--- a/tests/integration/test_utils/data_source_config/sql_config.py
+++ b/tests/integration/test_utils/data_source_config/sql_config.py
@@ -80,7 +80,15 @@ class SqlDatasourceTestConfig(DataSourceTestConfig):
     backend_spec_override: Optional[SqlBackendSpec] = None
     """Per-instance declaration override. `None` (the default) means "use `BACKEND_SPEC`"; every
     concrete backend except the generic-SQL escape hatch leaves this unset. See the class
-    docstring for why this seam exists and why it is per-instance rather than per-class."""
+    docstring for why this seam exists and why it is per-instance rather than per-class.
+
+    **An override must also vary the label.** This field takes no part in equality: two instances
+    of one class whose overrides differ but whose labels agree compare equal. The session-scoped
+    batch-setup cache is keyed on a wrapper whose own equality defers to config equality, so such
+    instances share a single `BatchTestSetup` — the second one silently reusing the first one's
+    tables, built from the first one's declaration. That surfaces as wrong data rather than as an
+    error, so a caller varying the declaration per instance must vary the label with it.
+    """
 
     @property
     def backend_spec(self) -> SqlBackendSpec:

--- a/tests/integration/test_utils/data_source_config/sql_config.py
+++ b/tests/integration/test_utils/data_source_config/sql_config.py
@@ -1,0 +1,107 @@
+"""The SQL config base: identity derived from a declared `SqlBackendSpec`.
+
+Every dialect-specific config used to hand-write `label` and `pytest_mark` as properties. Once a
+backend's identity is captured declaratively in a `SqlBackendSpec` (see `backend_spec.py`), the
+hand-written properties become redundant with the declaration and a source of drift between the
+two. `SqlDatasourceTestConfig` removes that redundancy: it carries the declaration once, as a
+class variable, and derives `label` and `pytest_mark` from it so a concrete backend config states
+its identity in exactly one place.
+
+This module imports from `base.py`, `backend_spec.py`, and `registry.py` only. It must not import
+`sql.py` or any backend module: those sit to this module's right in the dependency direction
+(`base` -> `backend_spec` -> `registry` -> `sql_config` -> `sql` -> backend modules -> `tiers`),
+and a module is only ever allowed to import from modules to its own left.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, Optional, TypeVar
+
+from great_expectations.compatibility.typing_extensions import override
+from tests.integration.test_utils.data_source_config.base import DataSourceTestConfig
+
+if TYPE_CHECKING:
+    import pytest
+
+    from tests.integration.test_utils.data_source_config.backend_spec import SqlBackendSpec
+
+
+@dataclass(frozen=True, eq=False)
+class SqlDatasourceTestConfig(DataSourceTestConfig):
+    """Base for SQL backend configs that derive `label` and `pytest_mark` from a declaration.
+
+    A concrete subclass declares its identity once, as a class variable:
+
+        class PostgreSQLDatasourceTestConfig(SqlDatasourceTestConfig):
+            BACKEND_SPEC = SqlBackendSpec(label="postgresql", marker="postgresql", ...)
+
+    `label` and `pytest_mark` are then derived from that declaration rather than hand-written,
+    so the declaration is the single place a backend's identity is stated.
+
+    One consumer, however, cannot know its declaration until construction time: the generic-SQL
+    escape hatch is a single registered-or-not config class used against a caller-supplied
+    connection string, and its identity (in particular its dialect-derived table schema items and
+    type overrides) varies per call, not per class. A class variable alone cannot express that —
+    it is shared by every instance of the class. `backend_spec_override` is the seam that closes
+    that gap: an optional per-instance field that, when set, takes precedence over the class-level
+    `BACKEND_SPEC`. The `backend_spec` property below is the single place that resolves the two,
+    so every other property and every consumer reads identity through one name regardless of which
+    of the two supplied it.
+
+    Adding `backend_spec_override` as a dataclass field, rather than a plain attribute, requires
+    decorating this class with `@dataclass` itself. `eq=False` is deliberate: `@dataclass` only
+    ever leaves `__eq__`/`__hash__` untouched when a class either defines its own or opts out of
+    generation entirely. `DataSourceTestConfig.__eq__`/`__hash__` are hand-written to reduce
+    `extra_column_types` to a hashable tuple before hashing it; the naive generated `__hash__`
+    that `@dataclass(frozen=True)` would otherwise install here hashes that field's raw `dict`
+    value and raises `TypeError` on every instance. `eq=False` keeps this class, and every
+    subclass that is not itself re-decorated, on the inherited, dict-safe implementation.
+
+    That protection does not survive re-decoration. A subclass adding a field of its own must
+    decorate itself with `@dataclass`, and a bare `@dataclass(frozen=True)` regenerates both
+    dunders — reintroducing the raw-`dict` hash without redeclaring anything by hand, and so
+    without any obvious signal that it has done so. Any subclass that re-decorates must therefore
+    pass `eq=False` as well.
+
+    The existing field set inherited from `DataSourceTestConfig` (`name`, `table_name`,
+    `schema_name`, `column_types`, `extra_column_types`) is untouched, so equality, hashing, and
+    `test_id` — all of which are defined in terms of `label`, `pytest_mark`, and those fields —
+    keep their existing meaning. `create_batch_setup` remains abstract; only identity derivation
+    is added here.
+    """
+
+    BACKEND_SPEC: ClassVar[SqlBackendSpec]
+    """The declaration a concrete subclass states once. Annotated `ClassVar` so the dataclass
+    machinery treats it as a plain class attribute rather than a frozen-dataclass field — it is
+    not part of instance equality or hashing, and assigning it does not require passing it to
+    `__init__`."""
+
+    backend_spec_override: Optional[SqlBackendSpec] = None
+    """Per-instance declaration override. `None` (the default) means "use `BACKEND_SPEC`"; every
+    concrete backend except the generic-SQL escape hatch leaves this unset. See the class
+    docstring for why this seam exists and why it is per-instance rather than per-class."""
+
+    @property
+    def backend_spec(self) -> SqlBackendSpec:
+        """The declaration that governs this instance: `backend_spec_override` when set, the
+        class-level `BACKEND_SPEC` otherwise."""
+        if self.backend_spec_override is not None:
+            return self.backend_spec_override
+        return self.BACKEND_SPEC
+
+    @property
+    @override
+    def label(self) -> str:
+        return self.backend_spec.label
+
+    @property
+    @override
+    def pytest_mark(self) -> pytest.MarkDecorator:
+        return self.backend_spec.pytest_mark
+
+
+_SqlConfigT = TypeVar("_SqlConfigT", bound=SqlDatasourceTestConfig)  # noqa: PYI018
+"""Bound to `SqlDatasourceTestConfig` rather than the wider `_ConfigT` (`base.py`). Unused within
+this module by design: re-binding the shared SQL setup's generic parameter to it is a later,
+separate task, so nothing in this module consumes it yet."""

--- a/tests/integration/test_utils/data_source_config/sql_server.py
+++ b/tests/integration/test_utils/data_source_config/sql_server.py
@@ -12,11 +12,15 @@ from great_expectations.datasource.fluent.sql_server_datasource import (
     SQLServerAuthConnectionDetails,
 )
 from tests.integration.sql_session_manager import ConnectionDetails, SessionSQLEngineManager
-from tests.integration.test_utils.data_source_config.base import (
-    BatchTestSetup,
-    DataSourceTestConfig,
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    CiLaneRef,
+    SqlBackendSpec,
 )
+from tests.integration.test_utils.data_source_config.base import BatchTestSetup
+from tests.integration.test_utils.data_source_config.registry import register_sql_backend
 from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 from tests.test_utils import (
     SQL_SERVER_DATABASE,
     SQL_SERVER_DRIVER,
@@ -31,16 +35,18 @@ from tests.test_utils import (
 logger = logging.getLogger(__name__)
 
 
-class SQLServerDatasourceTestConfig(DataSourceTestConfig):
-    @property
-    @override
-    def label(self) -> str:
-        return "mssql"
-
-    @property
-    @override
-    def pytest_mark(self) -> pytest.MarkDecorator:
-        return pytest.mark.sql_server
+@register_sql_backend
+class SQLServerDatasourceTestConfig(SqlDatasourceTestConfig):
+    BACKEND_SPEC = SqlBackendSpec(
+        label="mssql",
+        marker="sql_server",
+        provisioning=BackendProvisioning.LOCAL_CONTAINER,
+        ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="sql_server"),
+        uses_schema=True,
+        dev_requirements_file="reqs/requirements-dev-sql-server.txt",
+        task_runner_marker="sql_server",
+        container_service="mssql",
+    )
 
     @override
     def create_batch_setup(

--- a/tests/integration/test_utils/data_source_config/sqlite.py
+++ b/tests/integration/test_utils/data_source_config/sqlite.py
@@ -8,23 +8,29 @@ from great_expectations.compatibility.typing_extensions import override
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from tests.integration.sql_session_manager import SessionSQLEngineManager
-from tests.integration.test_utils.data_source_config.base import (
-    BatchTestSetup,
-    DataSourceTestConfig,
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    BackendTier,
+    CiLaneRef,
+    SqlBackendSpec,
 )
+from tests.integration.test_utils.data_source_config.base import BatchTestSetup
+from tests.integration.test_utils.data_source_config.registry import register_sql_backend
 from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 
-class SqliteDatasourceTestConfig(DataSourceTestConfig):
-    @property
-    @override
-    def label(self) -> str:
-        return "sqlite"
-
-    @property
-    @override
-    def pytest_mark(self) -> pytest.MarkDecorator:
-        return pytest.mark.sqlite
+@register_sql_backend
+class SqliteDatasourceTestConfig(SqlDatasourceTestConfig):
+    BACKEND_SPEC = SqlBackendSpec(
+        label="sqlite",
+        marker="sqlite",
+        provisioning=BackendProvisioning.LOCAL_FILE,
+        ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="sqlite"),
+        uses_schema=False,
+        tiers=frozenset({BackendTier.STANDARD_SQL}),
+        # SQLite has neither a dev-requirements file nor a task-runner entry.
+    )
 
     @override
     def create_batch_setup(

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    BackendTier,
+    CiLaneRef,
+    SqlBackendSpec,
+)
+
+pytestmark = pytest.mark.project
+
+
+def _make_spec(**overrides: object) -> SqlBackendSpec:
+    defaults: dict[str, object] = dict(
+        label="throwaway",
+        marker="throwaway",
+        provisioning=BackendProvisioning.LOCAL_FILE,
+        ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="throwaway"),
+        uses_schema=False,
+    )
+    defaults.update(overrides)
+    return SqlBackendSpec(**defaults)  # type: ignore[arg-type]
+
+
+class TestSqlBackendSpecMarkRoundTrip:
+    def test_pytest_mark_round_trips_marker_name_to_literal_mark(self) -> None:
+        spec = _make_spec(marker="mysql")
+
+        assert spec.pytest_mark == pytest.mark.mysql
+
+    def test_pytest_mark_round_trips_a_different_marker_name(self) -> None:
+        spec = _make_spec(marker="singlestore", tiers=frozenset({BackendTier.CURATED_SQL}))
+
+        assert spec.pytest_mark == pytest.mark.singlestore
+
+
+class TestSqlBackendSpecTableSchemaItemsDefault:
+    def test_spec_with_no_table_schema_item_factory_reports_it_as_absent(self) -> None:
+        spec = _make_spec()
+
+        assert spec.table_schema_items is None

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Iterator, List
+
 import pytest
 
 from tests.integration.test_utils.data_source_config.backend_spec import (
@@ -7,6 +9,12 @@ from tests.integration.test_utils.data_source_config.backend_spec import (
     BackendTier,
     CiLaneRef,
     SqlBackendSpec,
+)
+from tests.integration.test_utils.data_source_config.registry import (
+    isolated_registry,
+    iter_sql_backends,
+    register_sql_backend,
+    sql_backends_for_tier,
 )
 
 pytestmark = pytest.mark.project
@@ -22,6 +30,22 @@ def _make_spec(**overrides: object) -> SqlBackendSpec:
     )
     defaults.update(overrides)
     return SqlBackendSpec(**defaults)  # type: ignore[arg-type]
+
+
+def _make_config_class(name: str, spec: SqlBackendSpec) -> type:
+    return type(name, (), {"BACKEND_SPEC": spec})
+
+
+@pytest.fixture(autouse=True)
+def _snapshot_registry() -> Iterator[None]:
+    """Wrap every test in this module in the registry's snapshot/restore seam.
+
+    The registry is process-global, so a throwaway registration in one test must not survive to
+    the next test, and must not survive into the real registry that the wiring drift check and
+    other consumers rely on.
+    """
+    with isolated_registry():
+        yield
 
 
 class TestSqlBackendSpecMarkRoundTrip:
@@ -41,3 +65,244 @@ class TestSqlBackendSpecTableSchemaItemsDefault:
         spec = _make_spec()
 
         assert spec.table_schema_items is None
+
+
+class TestIsolatedSnapshotEmptyRegistryCase:
+    def test_registry_is_empty_within_a_fresh_isolated_snapshot(self) -> None:
+        with isolated_registry():
+            assert iter_sql_backends() == ()
+
+
+class TestIsolatedSnapshotRestoresRealRegistry:
+    def test_registering_a_throwaway_does_not_survive_the_snapshot(self) -> None:
+        # Establish a populated baseline inside the module's own autouse isolation, so this test
+        # proves both halves of the seam: that entering it clears down to empty, and that exiting
+        # it restores exactly what was there beforehand — regardless of what the real registry
+        # elsewhere happens to hold.
+        register_sql_backend(_make_config_class("Baseline", _make_spec(label="baseline")))
+        before = iter_sql_backends()
+        assert before != ()
+
+        with isolated_registry():
+            assert iter_sql_backends() == ()
+            register_sql_backend(_make_config_class("Throwaway", _make_spec()))
+            assert iter_sql_backends() != before
+
+        assert iter_sql_backends() == before
+
+
+class TestRegisterSqlBackendOrdering:
+    def test_iter_sql_backends_orders_registrations_by_label_not_registration_order(self) -> None:
+        zebra = _make_config_class("Zebra", _make_spec(label="zebra", marker="zebra_marker"))
+        apple = _make_config_class("Apple", _make_spec(label="apple", marker="apple_marker"))
+
+        register_sql_backend(zebra)
+        register_sql_backend(apple)
+
+        assert iter_sql_backends() == (apple, zebra)
+
+
+class TestSqlBackendsForTier:
+    def test_returns_only_backends_declaring_the_tier_ordered_by_label(self) -> None:
+        member = _make_config_class(
+            "Member",
+            _make_spec(
+                label="member",
+                marker="member_marker",
+                tiers=frozenset({BackendTier.CURATED_SQL}),
+            ),
+        )
+        non_member = _make_config_class(
+            "NonMember", _make_spec(label="non-member", marker="non_member_marker")
+        )
+
+        register_sql_backend(member)
+        register_sql_backend(non_member)
+
+        assert sql_backends_for_tier(BackendTier.CURATED_SQL) == (member,)
+
+
+class TestRegisterSqlBackendDuplicateLabel:
+    def test_duplicate_label_raises_naming_both_classes(self) -> None:
+        first = _make_config_class("First", _make_spec(label="dup-label", marker="first_marker"))
+        second = _make_config_class("Second", _make_spec(label="dup-label", marker="second_marker"))
+        register_sql_backend(first)
+
+        with pytest.raises(ValueError) as excinfo:
+            register_sql_backend(second)
+
+        message = str(excinfo.value)
+        assert "First" in message
+        assert "Second" in message
+        assert "dup-label" in message
+
+
+class TestRegisterSqlBackendDuplicateMarker:
+    def test_duplicate_marker_raises_naming_both_classes(self) -> None:
+        first = _make_config_class("First", _make_spec(label="first-label", marker="dup_marker"))
+        second = _make_config_class("Second", _make_spec(label="second-label", marker="dup_marker"))
+        register_sql_backend(first)
+
+        with pytest.raises(ValueError) as excinfo:
+            register_sql_backend(second)
+
+        message = str(excinfo.value)
+        assert "First" in message
+        assert "Second" in message
+        assert "dup_marker" in message
+
+
+class TestRegisterSqlBackendContainerProvisioning:
+    def test_local_container_without_container_service_raises(self) -> None:
+        config_class = _make_config_class(
+            "NoService",
+            _make_spec(provisioning=BackendProvisioning.LOCAL_CONTAINER, container_service=None),
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            register_sql_backend(config_class)
+
+        assert "NoService" in str(excinfo.value)
+
+    def test_container_service_without_local_container_raises(self) -> None:
+        config_class = _make_config_class(
+            "StrayService",
+            _make_spec(provisioning=BackendProvisioning.LOCAL_FILE, container_service="throwaway"),
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            register_sql_backend(config_class)
+
+        assert "StrayService" in str(excinfo.value)
+
+
+class TestRegisterSqlBackendEmptyFields:
+    def test_empty_label_raises(self) -> None:
+        config_class = _make_config_class("BlankLabel", _make_spec(label=""))
+
+        with pytest.raises(ValueError, match="BlankLabel"):
+            register_sql_backend(config_class)
+
+    def test_empty_marker_raises(self) -> None:
+        config_class = _make_config_class("BlankMarker", _make_spec(marker=""))
+
+        with pytest.raises(ValueError, match="BlankMarker"):
+            register_sql_backend(config_class)
+
+    def test_empty_ci_lane_marker_token_raises(self) -> None:
+        config_class = _make_config_class(
+            "BlankCiLane",
+            _make_spec(ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="")),
+        )
+
+        with pytest.raises(ValueError, match="BlankCiLane"):
+            register_sql_backend(config_class)
+
+    def test_non_positive_insert_parameter_limit_raises(self) -> None:
+        config_class = _make_config_class("ZeroLimit", _make_spec(insert_parameter_limit=0))
+
+        with pytest.raises(ValueError, match="ZeroLimit"):
+            register_sql_backend(config_class)
+
+    def test_negative_insert_parameter_limit_raises(self) -> None:
+        config_class = _make_config_class("NegativeLimit", _make_spec(insert_parameter_limit=-1))
+
+        with pytest.raises(ValueError, match="NegativeLimit"):
+            register_sql_backend(config_class)
+
+
+class TestRegisterSqlBackendTierCaseExclusionReasons:
+    def test_empty_case_key_raises(self) -> None:
+        config_class = _make_config_class(
+            "BlankKey", _make_spec(tier_case_exclusions={"": "a reason"})
+        )
+
+        with pytest.raises(ValueError, match="BlankKey"):
+            register_sql_backend(config_class)
+
+    def test_empty_reason_raises_naming_class_and_case_key(self) -> None:
+        config_class = _make_config_class(
+            "BlankReason", _make_spec(tier_case_exclusions={"some_case": ""})
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            register_sql_backend(config_class)
+
+        message = str(excinfo.value)
+        assert "BlankReason" in message
+        assert "some_case" in message
+
+    def test_whitespace_only_reason_raises_naming_class_and_case_key(self) -> None:
+        config_class = _make_config_class(
+            "WhitespaceReason", _make_spec(tier_case_exclusions={"some_case": "   "})
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            register_sql_backend(config_class)
+
+        message = str(excinfo.value)
+        assert "WhitespaceReason" in message
+        assert "some_case" in message
+
+
+class TestRegisterSqlBackendTierCaseExclusionCeiling:
+    def test_exactly_two_exclusions_registers_cleanly(self) -> None:
+        config_class = _make_config_class(
+            "TwoExclusions",
+            _make_spec(
+                tier_case_exclusions={
+                    "case_one": "dialect gap, see issue #1",
+                    "case_two": "dialect gap, see issue #2",
+                }
+            ),
+        )
+
+        register_sql_backend(config_class)
+
+        assert config_class in iter_sql_backends()
+
+    def test_three_exclusions_raises_naming_class_count_and_all_keys(self) -> None:
+        config_class = _make_config_class(
+            "ThreeExclusions",
+            _make_spec(
+                tier_case_exclusions={
+                    "case_one": "dialect gap, see issue #1",
+                    "case_two": "dialect gap, see issue #2",
+                    "case_three": "observed non-determinism, see issue #3",
+                }
+            ),
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            register_sql_backend(config_class)
+
+        message = str(excinfo.value)
+        assert "ThreeExclusions" in message
+        assert "3" in message
+        assert "case_one" in message
+        assert "case_two" in message
+        assert "case_three" in message
+
+
+class TestRegisterSqlBackendTableSchemaItems:
+    def test_non_callable_table_schema_items_raises(self) -> None:
+        config_class = _make_config_class(
+            "NotCallable",
+            _make_spec(table_schema_items="not-a-callable"),  # type: ignore[arg-type]
+        )
+
+        with pytest.raises(ValueError, match="NotCallable"):
+            register_sql_backend(config_class)
+
+    def test_callable_table_schema_items_is_validated_without_being_invoked(self) -> None:
+        calls: List[None] = []
+
+        def factory() -> List[object]:
+            calls.append(None)
+            return []
+
+        config_class = _make_config_class("Callable", _make_spec(table_schema_items=factory))
+
+        register_sql_backend(config_class)
+
+        assert calls == []

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -203,6 +203,15 @@ class TestRegisterSqlBackendEmptyFields:
         with pytest.raises(ValueError, match="BlankMarker"):
             register_sql_backend(config_class)
 
+    def test_empty_ci_lane_workflow_job_raises(self) -> None:
+        config_class = _make_config_class(
+            "BlankWorkflowJob",
+            _make_spec(ci_lane=CiLaneRef(workflow_job="", marker_token="postgresql")),
+        )
+
+        with pytest.raises(ValueError, match="BlankWorkflowJob"):
+            register_sql_backend(config_class)
+
     def test_empty_ci_lane_marker_token_raises(self) -> None:
         config_class = _make_config_class(
             "BlankCiLane",
@@ -459,3 +468,47 @@ class TestLocallyVerifiableBackendsRegisterInLabelOrder:
             PostgreSQLDatasourceTestConfig,  # postgresql
             SqliteDatasourceTestConfig,  # sqlite
         )
+
+
+class TestRegisteredBackendsKeepTheInheritedHash:
+    def test_no_registered_backend_regenerated_eq_or_hash(self) -> None:
+        """Every registered config must inherit `DataSourceTestConfig`'s `__eq__`/`__hash__`.
+
+        Those are hand-written to reduce `extra_column_types` to a hashable tuple first. A config
+        re-decorated with a bare `@dataclass(frozen=True)` silently regenerates both, and the
+        generated `__hash__` hashes that raw `dict` and raises `TypeError` on every instance.
+
+        This is checked here rather than in `__init_subclass__` because a class decorator runs
+        *after* class creation: `__init_subclass__` observes the class before `@dataclass` has
+        replaced anything, so it cannot see the regeneration it would be trying to prevent.
+
+        The failure this guards against costs session time rather than turning a test red — a
+        config that cannot be hashed, or that hashes inconsistently, degrades the batch-setup
+        cache instead of failing — which is why it needs a mechanical check rather than a
+        convention.
+        """
+
+        # Walks subclasses rather than the registry: this module's autouse fixture wraps every
+        # test in the isolation seam, which clears the registry, so iterating it here would
+        # examine nothing and pass vacuously. Subclasses also reach configs that are declared
+        # but deliberately unregistered.
+        def _descendants(cls: type) -> Iterator[type]:
+            for sub in cls.__subclasses__():
+                yield sub
+                yield from _descendants(sub)
+
+        checked = [
+            c for c in _descendants(SqlDatasourceTestConfig) if not c.__name__.startswith("_")
+        ]
+        assert checked, "no concrete SQL config subclasses were found to check"
+
+        for config_class in checked:
+            assert config_class.__eq__ is DataSourceTestConfig.__eq__, (
+                f"{config_class.__name__} regenerated __eq__; a subclass re-decorated with "
+                f"@dataclass must pass eq=False"
+            )
+            assert config_class.__hash__ is DataSourceTestConfig.__hash__, (
+                f"{config_class.__name__} regenerated __hash__; a subclass re-decorated with "
+                f"@dataclass must pass eq=False"
+            )
+            hash(config_class())  # a regenerated hash raises TypeError here

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -302,7 +302,7 @@ class TestRegisterSqlBackendTableSchemaItems:
     def test_non_callable_table_schema_items_raises(self) -> None:
         config_class = _make_config_class(
             "NotCallable",
-            _make_spec(table_schema_items="not-a-callable"),  # type: ignore[arg-type]
+            _make_spec(table_schema_items="not-a-callable"),
         )
 
         with pytest.raises(ValueError, match="NotCallable"):

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from typing import Iterator, List
+from typing import TYPE_CHECKING, Iterator, List, Mapping, Optional
 
 import pytest
 
+from great_expectations.compatibility.typing_extensions import override
 from tests.integration.test_utils.data_source_config.backend_spec import (
     BackendProvisioning,
     BackendTier,
     CiLaneRef,
     SqlBackendSpec,
+)
+from tests.integration.test_utils.data_source_config.base import (
+    BatchTestSetup,
+    DataSourceTestConfig,
 )
 from tests.integration.test_utils.data_source_config.registry import (
     isolated_registry,
@@ -16,6 +21,15 @@ from tests.integration.test_utils.data_source_config.registry import (
     register_sql_backend,
     sql_backends_for_tier,
 )
+from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from great_expectations.data_context.data_context.abstract_data_context import (
+        AbstractDataContext,
+    )
+    from tests.integration.test_utils.data_source_config.sql import SessionSQLEngineManager
 
 pytestmark = pytest.mark.project
 
@@ -306,3 +320,105 @@ class TestRegisterSqlBackendTableSchemaItems:
         register_sql_backend(config_class)
 
         assert calls == []
+
+
+class _HandWrittenControlConfig(DataSourceTestConfig):
+    """A config written the way today's backends are, with `label` and `pytest_mark` as
+    hand-coded properties. Used as the behavior-preservation control for
+    `SqlDatasourceTestConfig`: the divergent label/marker pair (SQL Server's label is `mssql`,
+    its marker is `sql_server`) is the case that most directly exercises whether a declaration-
+    derived config produces the same identity as one written by hand.
+    """
+
+    @property
+    @override
+    def label(self) -> str:
+        return "mssql"
+
+    @property
+    @override
+    def pytest_mark(self) -> pytest.MarkDecorator:
+        return pytest.mark.sql_server
+
+    @override
+    def create_batch_setup(
+        self,
+        request: pytest.FixtureRequest,
+        data: pd.DataFrame,
+        extra_data: Mapping[str, pd.DataFrame],
+        context: AbstractDataContext,
+        engine_manager: Optional[SessionSQLEngineManager] = None,
+    ) -> BatchTestSetup:
+        raise NotImplementedError("not exercised by these tests")
+
+
+_THROWAWAY_DECLARED_SPEC = SqlBackendSpec(
+    label="mssql",
+    marker="sql_server",
+    provisioning=BackendProvisioning.LOCAL_FILE,
+    ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="sql_server"),
+    uses_schema=True,
+)
+
+
+class _DeclaredConfig(SqlDatasourceTestConfig):
+    """Throwaway config that derives its identity from a declared `SqlBackendSpec`, mirroring
+    `_HandWrittenControlConfig`'s label and marker exactly."""
+
+    BACKEND_SPEC = _THROWAWAY_DECLARED_SPEC
+
+    @override
+    def create_batch_setup(
+        self,
+        request: pytest.FixtureRequest,
+        data: pd.DataFrame,
+        extra_data: Mapping[str, pd.DataFrame],
+        context: AbstractDataContext,
+        engine_manager: Optional[SessionSQLEngineManager] = None,
+    ) -> BatchTestSetup:
+        raise NotImplementedError("not exercised by these tests")
+
+
+class TestSqlDatasourceTestConfigDerivesIdentity:
+    def test_derives_label_and_mark_matching_a_hand_written_control(self) -> None:
+        control = _HandWrittenControlConfig()
+        declared = _DeclaredConfig()
+
+        assert declared.label == control.label == "mssql"
+        assert declared.pytest_mark == control.pytest_mark == pytest.mark.sql_server
+        assert declared.test_id == control.test_id
+        assert hash(declared) == hash(control)
+        assert declared == control
+
+
+class TestSqlDatasourceTestConfigOverrideSeam:
+    def test_instance_level_backend_spec_overrides_the_class_declaration(self) -> None:
+        override_spec = SqlBackendSpec(
+            label="ad-hoc",
+            marker="generic_sql",
+            provisioning=BackendProvisioning.EXTERNAL_CREDENTIALS,
+            ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="generic_sql"),
+            uses_schema=False,
+        )
+
+        default_instance = _DeclaredConfig()
+        overridden_instance = _DeclaredConfig(backend_spec_override=override_spec)
+
+        assert default_instance.label == "mssql"
+        assert default_instance.pytest_mark == pytest.mark.sql_server
+        assert overridden_instance.label == "ad-hoc"
+        assert overridden_instance.pytest_mark == pytest.mark.generic_sql
+        # The class-level declaration itself is untouched by the per-instance override.
+        assert _DeclaredConfig.BACKEND_SPEC is _THROWAWAY_DECLARED_SPEC
+
+
+class TestSqlDatasourceTestConfigSatisfiesRegistrationProtocol:
+    def test_a_declared_config_class_registers_successfully(self) -> None:
+        # `register_sql_backend` is typed to accept only a class exposing
+        # `BACKEND_SPEC: ClassVar[SqlBackendSpec]`. This call site is the first proof, under
+        # mypy, that a real config class built on the declaration-derived base satisfies that
+        # shape structurally rather than by explicit inheritance.
+        with isolated_registry():
+            register_sql_backend(_DeclaredConfig)
+
+            assert _DeclaredConfig in iter_sql_backends()

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -422,3 +422,40 @@ class TestSqlDatasourceTestConfigSatisfiesRegistrationProtocol:
             register_sql_backend(_DeclaredConfig)
 
             assert _DeclaredConfig in iter_sql_backends()
+
+
+class TestLocallyVerifiableBackendsRegisterInLabelOrder:
+    def test_postgres_mysql_sql_server_and_sqlite_appear_in_label_order(self) -> None:
+        # Re-register the four real, locally verifiable backend configs inside this module's
+        # isolation seam. Each class is already enrolled once, for real, at import time via its
+        # own `@register_sql_backend` decorator; re-registering it here (against the seam's
+        # cleared, isolated dicts, not the real registry) proves the same fact the real import
+        # already established, without depending on import order relative to the eight other
+        # backend modules that will be added in later tasks.
+        from tests.integration.test_utils.data_source_config.mysql import (
+            MySQLDatasourceTestConfig,
+        )
+        from tests.integration.test_utils.data_source_config.postgres import (
+            PostgreSQLDatasourceTestConfig,
+        )
+        from tests.integration.test_utils.data_source_config.sql_server import (
+            SQLServerDatasourceTestConfig,
+        )
+        from tests.integration.test_utils.data_source_config.sqlite import (
+            SqliteDatasourceTestConfig,
+        )
+
+        for config_class in (
+            PostgreSQLDatasourceTestConfig,
+            MySQLDatasourceTestConfig,
+            SQLServerDatasourceTestConfig,
+            SqliteDatasourceTestConfig,
+        ):
+            register_sql_backend(config_class)
+
+        assert iter_sql_backends() == (
+            SQLServerDatasourceTestConfig,  # mssql
+            MySQLDatasourceTestConfig,  # mysql
+            PostgreSQLDatasourceTestConfig,  # postgresql
+            SqliteDatasourceTestConfig,  # sqlite
+        )


### PR DESCRIPTION
Onboarding a SQL backend to the integration test harness currently means editing shared setup
code in several places and hand-maintaining six configuration surfaces that nothing verifies.
This series moves the dialect facts that are *data* into a single declared record per backend,
so onboarding becomes a declaration rather than a set of edits to shared code.

This first PR lands the foundation. It is additive: the declarations exist but nothing reads
them yet, so no behavior changes. Later PRs flip the shared setup over to them one decision
point at a time.

### What's here

- **`backend_spec.py`** — `SqlBackendSpec`, a frozen record holding every dialect fact that is
  data: identity, provisioning, CI lane, schema usage, transaction mode, a table-schema-item
  factory, column-type overrides, insert parameter limit, tier membership, and wiring
  coordinates. It imports nothing from the harness, so it sits to the left of everything that
  consumes it and a test can build a throwaway record without importing a backend.
- **`registry.py`** — a registration decorator plus label-ordered accessors, with validation
  that rejects duplicate identities, inconsistent container provisioning, empty required
  fields, and unexplained or excessive per-case tier exclusions. Tests reach the process-global
  registry through a seam that clears on entry and restores on exit.
- **`sql_config.py`** — `SqlDatasourceTestConfig`, which derives a backend's test label and
  pytest mark from its declaration, so a backend states its identity once instead of writing
  two properties that must agree.
- **PostgreSQL, MySQL, SQL Server, SQLite** converted onto that base.

### Two details worth a reviewer's attention

**`eq=False` on the config base is load-bearing.** `DataSourceTestConfig` hand-writes
`__eq__`/`__hash__` to reduce `extra_column_types` to a hashable tuple. A bare
`@dataclass(frozen=True)` on a subclass silently regenerates both, and the generated `__hash__`
hashes the raw dict and raises `TypeError`. Config hashing is what the session-scoped
batch-setup cache keys on, so this fails as lost session time rather than a red test. Any
subclass that re-decorates must also pass `eq=False`; the class docstring says so.

**Tier membership is declared to reproduce today's data-source list — but only partly, in this
PR.** `SQL_DATA_SOURCES` has five entries (BigQuery, Databricks, PostgreSQL, Snowflake, SQLite).
Two of them are converted here and declare `STANDARD_SQL`; the other three are converted in the
next PR in this series. Tier membership is therefore incomplete until that one lands, and the
lists derived from tier membership must not be flipped over to the registry before then — doing
so would drop three backends from every metrics test with no failing test to show for it. The
change that derives those lists pins them against the pre-change membership for exactly that
reason.

### Verification

All five locally runnable suites pass against real servers, with no test module edited:
PostgreSQL 472 passed, MySQL 160, SQLite 539, SQL Server 181 (identical to the `develop`
baseline measured in a separate worktree), plus the registry and marker suites. Test collection
is unchanged at 3332. `ruff` clean; `mypy` adds no diagnostics over an untouched-file baseline.

For each converted backend, `label`, `pytest_mark`, `test_id`, and `hash()` were compared
before and after the change and are bit-identical.

