### PR TITLE
[MAINTENANCE] Add a BigQuery integration test for bundled metric alias collisions

### DIFF
--- a/tests/integration/data_sources_and_expectations/test_metric_bundling.py
+++ b/tests/integration/data_sources_and_expectations/test_metric_bundling.py
@@ -1,0 +1,42 @@
+"""Tests for validating suites whose expectations share an underlying metric.
+
+The SQL execution engine bundles the metrics required by a suite into as few
+queries as possible. Two expectations on different columns can resolve to the
+same metric name, so the bundled query needs to give each one a distinct
+column alias; backends that reject duplicate output column names fail to
+compile the query otherwise.
+"""
+
+import pandas as pd
+
+import great_expectations.expectations as gxe
+from great_expectations.core.expectation_suite import ExpectationSuite
+from tests.integration.conftest import parameterize_batch_for_data_sources
+from tests.integration.test_utils.data_source_config import (
+    BigQueryDatasourceTestConfig,
+)
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=[BigQueryDatasourceTestConfig()],
+    data=pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}),
+)
+def test_expectations_sharing_a_metric_are_bundled_into_one_query(batch_for_datasource) -> None:
+    """Expectations that resolve to the same metric must not collide when bundled.
+
+    Each of these expectations resolves to column_values.nonnull.unexpected_count,
+    so all three land in a single bundled query against the same domain.
+    """
+    suite = ExpectationSuite(
+        name="expectations_sharing_a_metric",
+        expectations=[
+            gxe.ExpectColumnValuesToNotBeNull(column="a"),
+            gxe.ExpectColumnValuesToNotBeNull(column="b"),
+            gxe.ExpectColumnValuesToNotBeNull(column="c"),
+        ],
+    )
+
+    result = batch_for_datasource.validate(suite)
+
+    assert result.success, [r.exception_info for r in result.results]
+    assert len(result.results) == 3


### PR DESCRIPTION
## Summary

Adds a single BigQuery integration test that validates an expectation suite whose expectations all resolve to the same metric name (`column_values.nonnull.unexpected_count` on three different columns).

This test is expected to **fail** on `develop`. It is being pushed to confirm that BigQuery reproduces the duplicate-alias failure described in #10926, so the fix proposed in #11905 can be validated against a backend that actually rejects the query.

## Why

The SQL execution engine bundles the metrics a suite needs into as few queries as possible. Expectations on different columns can resolve to the same metric name, and today every one of them is labeled with that bare metric name — so a bundled query emits several identical output column aliases:

    ['column_values.nonnull.unexpected_count',
     'column_values.nonnull.unexpected_count',
     'column_values.nonnull.unexpected_count']

Permissive backends (SQLite, Postgres) accept that; strict ones reject the query outright. ClickHouse is currently worked around with a dialect-specific random-suffix branch in `_organize_metrics_by_domain`; the question this test answers is whether BigQuery needs the same treatment, which would argue for making the deduplication general rather than dialect-specific.

## User impact

None — test-only change, no library code is touched.

## How to review

Check the `marker-tests (bigquery, ...)` job. A failure there is the intended signal: it confirms BigQuery rejects the bundled query. If it passes, BigQuery tolerates duplicate aliases and the reproduction needs another angle.

Note this PR is intentionally open as non-draft: the marker test jobs are gated on `github.event.pull_request.draft == false`, so BigQuery CI does not run otherwise.
