### PR TITLE
[BUGFIX] Report an unmet expectation when a column has no quantiles

### DIFF
--- a/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
+++ b/great_expectations/expectations/core/expect_column_quantile_values_to_be_between.py
@@ -770,17 +770,7 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
             for (lower_bound, upper_bound) in quantile_value_ranges
         ]
         success_details = [
-            isclose(
-                operand_a=quantile_vals[idx],
-                operand_b=range_[0],
-                rtol=1.0e-4,
-            )
-            or isclose(
-                operand_a=quantile_vals[idx],
-                operand_b=range_[1],
-                rtol=1.0e-4,
-            )
-            or range_[0] <= quantile_vals[idx] <= range_[1]
+            _quantile_is_in_range(value=quantile_vals[idx], range_=range_)
             for idx, range_ in enumerate(comparison_quantile_ranges)
         ]
 
@@ -791,3 +781,20 @@ class ExpectColumnQuantileValuesToBeBetween(ColumnAggregateExpectation):
                 "details": {"success_details": success_details},
             },
         }
+
+
+def _quantile_is_in_range(value, range_) -> bool:
+    """Whether an observed quantile falls within its expected range.
+
+    A column with no non-null values has no quantiles. The backends report that absence
+    differently -- SQL engines return NULL and pandas returns NaN -- and neither can satisfy
+    a range, so both are reported as an unmet expectation rather than being compared.
+    """
+    if value is None:
+        return False
+
+    return (
+        isclose(operand_a=value, operand_b=range_[0], rtol=1.0e-4)
+        or isclose(operand_a=value, operand_b=range_[1], rtol=1.0e-4)
+        or range_[0] <= value <= range_[1]
+    )

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
@@ -180,7 +180,16 @@ class ColumnQuantileValues(ColumnAggregateMetricProvider):
                 "SparkDFExecutionEngine requires relative error to be False or to be a float between 0 and 1."  # noqa: E501 # FIXME CoP
             )
 
-        return df.approxQuantile(column, list(quantiles), allow_relative_error)  # type: ignore[attr-defined] # FIXME CoP
+        quantiles = list(quantiles)
+        quantile_values = df.approxQuantile(column, quantiles, allow_relative_error)  # type: ignore[attr-defined] # FIXME CoP
+
+        # "approxQuantile" returns an empty list for a column with no non-null values, where the
+        # other backends return one null per requested quantile. Keep the metric the same shape
+        # on every backend, so that consumers can index it by quantile.
+        if not quantile_values:
+            return [None] * len(quantiles)
+
+        return quantile_values
 
 
 def _get_column_quantiles_sql_server(

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_quantile_values_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_quantile_values_to_be_between.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from sqlalchemy import types as sqlatypes
 
 import great_expectations.expectations as gxe
 from great_expectations.core.result_format import ResultFormat
@@ -12,15 +13,58 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
     ALL_DATA_SOURCES,
     JUST_PANDAS_DATA_SOURCES,
 )
+from tests.integration.test_utils.data_source_config import (
+    GenericSQLDatasourceTestConfig,
+    RedshiftDatasourceTestConfig,
+)
 from tests.integration.test_utils.data_source_config.big_query import BigQueryDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.databricks import (
+    DatabricksDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.mysql import MySQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.pandas_data_frame import (
+    PandasDataFrameDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.pandas_filesystem_csv import (
+    PandasFilesystemCsvDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.postgres import PostgreSQLDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.snowflake import SnowflakeDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.spark_filesystem_csv import (
+    SparkFilesystemCsvDatasourceTestConfig,
+)
+from tests.integration.test_utils.data_source_config.sql_server import SQLServerDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.sqlite import SqliteDatasourceTestConfig
 
 COL_NAME = "my_col"
 
 DATA = pd.DataFrame({COL_NAME: [1, 2, 2, 3, 3, 3, 4]})
 
-# A column with no non-null values has no quantiles. The dtype keeps the column nullable on the
-# SQL backends rather than being inferred as all-NaN floats.
 ALL_NULLS = pd.DataFrame({COL_NAME: [None, None, None]}, dtype="object")
+
+# An all-null column carries no type of its own, so each backend is told what to make it.
+ALL_NULLS_COLUMN_TYPES = {COL_NAME: sqlatypes.INTEGER}
+try:
+    from great_expectations.compatibility.pyspark import types as PYSPARK_TYPES
+
+    ALL_NULLS_SPARK_COLUMN_TYPES = {COL_NAME: PYSPARK_TYPES.IntegerType}
+except ModuleNotFoundError:
+    ALL_NULLS_SPARK_COLUMN_TYPES = {}
+
+ALL_NULLS_DATA_SOURCES = [
+    BigQueryDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    DatabricksDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    SQLServerDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    MySQLDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    PandasDataFrameDatasourceTestConfig(),
+    PandasFilesystemCsvDatasourceTestConfig(),
+    PostgreSQLDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    RedshiftDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    GenericSQLDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    SnowflakeDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+    SparkFilesystemCsvDatasourceTestConfig(column_types=ALL_NULLS_SPARK_COLUMN_TYPES),
+    SqliteDatasourceTestConfig(column_types=ALL_NULLS_COLUMN_TYPES),
+]
 
 ALL_DATA_SOURCES_EXCEPT_BIGQUERY = [
     ds for ds in ALL_DATA_SOURCES if not isinstance(ds, BigQueryDatasourceTestConfig)
@@ -55,7 +99,7 @@ def test_success_complete_results(batch_for_datasource: Batch) -> None:
 
 # Every backend, including BigQuery: this asserts only that no quantile was observed, so unlike
 # the cases above it does not depend on the type or shape of a returned value.
-@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ALL_NULLS)
+@parameterize_batch_for_data_sources(data_source_configs=ALL_NULLS_DATA_SOURCES, data=ALL_NULLS)
 def test_all_null_column_reports_unmet_expectation(batch_for_datasource: Batch) -> None:
     """A column with no quantiles fails the expectation instead of raising.
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_quantile_values_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_quantile_values_to_be_between.py
@@ -18,6 +18,10 @@ COL_NAME = "my_col"
 
 DATA = pd.DataFrame({COL_NAME: [1, 2, 2, 3, 3, 3, 4]})
 
+# A column with no non-null values has no quantiles. The dtype keeps the column nullable on the
+# SQL backends rather than being inferred as all-NaN floats.
+ALL_NULLS = pd.DataFrame({COL_NAME: [None, None, None]}, dtype="object")
+
 ALL_DATA_SOURCES_EXCEPT_BIGQUERY = [
     ds for ds in ALL_DATA_SOURCES if not isinstance(ds, BigQueryDatasourceTestConfig)
 ]
@@ -45,6 +49,32 @@ def test_success_complete_results(batch_for_datasource: Batch) -> None:
         },
         "details": {
             "success_details": [True, True, True, True],
+        },
+    }
+
+
+# Every backend, including BigQuery: this asserts only that no quantile was observed, so unlike
+# the cases above it does not depend on the type or shape of a returned value.
+@parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=ALL_NULLS)
+def test_all_null_column_reports_unmet_expectation(batch_for_datasource: Batch) -> None:
+    """A column with no quantiles fails the expectation instead of raising.
+
+    The backends report the absent quantile differently -- SQL engines return NULL and pandas
+    returns NaN -- and every one of them must report it as an unmet expectation.
+    """
+    expectation = gxe.ExpectColumnQuantileValuesToBeBetween(
+        column=COL_NAME,
+        quantile_ranges=QuantileRange(quantiles=[0.25, 0.5], value_ranges=[[0, 99], [0, 99]]),
+    )
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+    assert not result.success
+    assert result.to_json_dict()["result"] == {
+        "observed_value": {
+            "quantiles": [0.25, 0.5],
+            "values": [None, None],
+        },
+        "details": {
+            "success_details": [False, False],
         },
     }
 

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_quantile_values_to_be_between.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_quantile_values_to_be_between.py
@@ -103,8 +103,9 @@ def test_success_complete_results(batch_for_datasource: Batch) -> None:
 def test_all_null_column_reports_unmet_expectation(batch_for_datasource: Batch) -> None:
     """A column with no quantiles fails the expectation instead of raising.
 
-    The backends report the absent quantile differently -- SQL engines return NULL and pandas
-    returns NaN -- and every one of them must report it as an unmet expectation.
+    The backends report the absent quantile differently -- SQL engines return NULL, pandas
+    returns NaN, and Spark returns no values at all -- and every one of them must report it as
+    an unmet expectation.
     """
     expectation = gxe.ExpectColumnQuantileValuesToBeBetween(
         column=COL_NAME,


### PR DESCRIPTION
## Summary

`ExpectColumnQuantileValuesToBeBetween` raises instead of reporting a result when a column has no quantiles to observe.

A column with no non-null values has no quantiles, and the backends signal that absence in three different ways:

- the SQL engines return `NULL`
- pandas returns `NaN`
- Spark's `approxQuantile` returns no values at all

The range comparison in `_validate` tolerated `NaN`, but raised on `None`, so on every SQL backend the expectation aborted with

```
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```

and raised `IndexError` on Spark, where there was no value to compare at all.

This makes two changes:

- `_validate` reports an absent quantile as an unmet expectation rather than comparing it.
- The Spark metric returns one null per requested quantile instead of an empty list, so `column.quantile_values` has the same shape on every backend and stays indexable by quantile.

## Why

An unmet expectation is a validation result, not an error. Aborting the expectation loses the observed value and the per-quantile success details that a user would otherwise get, and it makes the outcome depend on which backend the same data is validated against. The pandas backend already behaved this way; this brings the rest in line.

## User impact

Validating an all-null column with this expectation now returns `success: false` with `observed_value.values` of `null` and `success_details` of `false`, instead of raising. The expectation was already unsuccessful in this case, so no validation changes from passing to failing. No API changes.

`column.quantile_values` on Spark returns `[None, ...]` rather than `[]` for a column with no non-null values. The previous empty list could not be indexed by quantile and had no consumer that handled it.

## How to review

Against `develop`, an all-null column raises on every SQL backend and on Spark, and reports `observed_value: null`. On this branch all backends report:

```
success=False  observed_value={'quantiles': [0.25, 0.5], 'values': [None, None]}
               details={'success_details': [False, False]}
```

`test_all_null_column_reports_unmet_expectation` covers this across every data source. Two things there are worth a second opinion:

- It is parameterized over its own data source list rather than the `ALL_DATA_SOURCES_EXCEPT_BIGQUERY` list the other cases in that file use. It asserts only that no quantile was observed, so it does not depend on the type or shape of a returned value, and it passes on BigQuery. That exclusion is undocumented, so including BigQuery is deliberate.
- An all-null column carries no type of its own, so the column type is declared per backend, matching how the other all-null test data in the suite is configured.