### PR TITLE
fix(datasource): enable case-insensitive SQL schema name lookup

### DIFF
--- a/great_expectations/datasource/fluent/sql_datasource.py
+++ b/great_expectations/datasource/fluent/sql_datasource.py
@@ -1170,11 +1170,18 @@ class TableAsset(_SQLAsset):
         )
 
         effective_schema = self._effective_schema_name
-        if effective_schema and effective_schema not in schema_names:
-            raise TestConnectionError(  # noqa: TRY003 # FIXME CoP
-                f'Attempt to connect to table: "{self.qualified_name}" failed because the schema '
-                f'"{effective_schema}" does not exist.'
+        if effective_schema:
+            normalized_effective = self._to_lower_if_not_bracketed_by_quotes(effective_schema)
+            schema_exists = (
+                effective_schema in schema_names
+                or normalized_effective in schema_names
+                or effective_schema.lower() in [s.lower() for s in schema_names]
             )
+            if not schema_exists:
+                raise TestConnectionError(  # noqa: TRY003 # FIXME CoP
+                    f'Attempt to connect to table: "{self.qualified_name}" failed because the schema '
+                    f'"{effective_schema}" does not exist.'
+                )
 
         try:
             with engine.connect() as connection:


### PR DESCRIPTION
There is a problem related to schema checking previously failed when database schemas had different casing than user input.
So I fixed by using adding the below snippet in the sql_datasource.py file

schema_names = inspector.get_schema_names()
        schema_names = (
            [self._to_lower_if_not_bracketed_by_quotes(name) for name in schema_names]
            if schema_names
            else []
        )

        effective_schema = self._effective_schema_name
        if effective_schema:
            normalized_effective = self._to_lower_if_not_bracketed_by_quotes(effective_schema)
            schema_exists = (
                effective_schema in schema_names
                or normalized_effective in schema_names
                or effective_schema.lower() in [s.lower() for s in schema_names]
            )
            if not schema_exists:
                raise TestConnectionError(  # noqa: TRY003 # FIXME CoP
                    f'Attempt to connect to table: "{self.qualified_name}" failed because the schema '
                    f'"{effective_schema}" does not exist.'
                )