### PR TITLE
[MAINTENANCE] Use the upstream sqlalchemy-redshift dialect instead of the GX fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,8 +733,7 @@ jobs:
       fail-fast: false
       matrix:
         markers:
-          # - redshift
-          - gx-redshift
+          - redshift
         python-version: ["3.13"]
 
     steps:

--- a/.github/workflows/data_source_cleanup.yml
+++ b/.github/workflows/data_source_cleanup.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install $(grep -E '^(invoke)' reqs/requirements-dev-contrib.txt)
-          invoke deps --gx-install -m gx-redshift
+          invoke deps --gx-install -m redshift
           pip install -e .
       - name: Run Redshift cleanup script
         run: |

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql.md
@@ -20,7 +20,7 @@ To validate data stored on SQL databases with GX Core, you create your GX Python
    To install dependencies for a specific SQL dialect, use the corresponding command from the table above.
 
    :::note Redshift dialects
-   If you plan to use SQLAlchemy with Redshift outside of Great Expectations, we recommend installing the default Redshift dialect with SQLAlchemy 1.4. The Redshift GX fork with SQLAlchemy 2.0 may not support SQLAlchemy functions that aren't used directly by GX.
+   The `gx-redshift` extra is deprecated. It installs the same dependencies as `redshift`, so `pip install 'great_expectations[gx-redshift]'` still works, but it will be removed in a future major release. Use `redshift` instead.
    :::
 
 2. Configure your SQL database credentials.

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql_dialect_installation_commands.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/_install_additional_dependencies/_sql_dialect_installation_commands.md
@@ -10,7 +10,6 @@ The following table lists the installation commands used to install GX Core depe
 | Microsoft Fabric | `pip install 'great_expectations[fabric]'` |
 | Microsoft SQL Server | `pip install 'great_expectations[sql-server]'` |
 | PostgreSQL | `pip install 'great_expectations[postgresql]'` |
-| Redshift default with SQLAlchemy 1.4| `pip install 'great_expectations[redshift]'` |
-| Redshift GX fork with SQLAlchemy 2.0| `pip install 'great_expectations[gx-redshift]'` |
+| Redshift | `pip install 'great_expectations[redshift]'` |
 | Snowflake | `pip install 'great_expectations[snowflake]'` |
 | Trino | `pip install 'great_expectations[trino]'` |

--- a/reqs/requirements-dev-gx-redshift.txt
+++ b/reqs/requirements-dev-gx-redshift.txt
@@ -1,2 +1,10 @@
-gx-sqlalchemy-redshift
+# Deprecated alias for requirements-dev-redshift.txt.
+# Both files install the upstream sqlalchemy-redshift dialect; this one is kept
+# so that `pip install 'great_expectations[gx-redshift]'` keeps working. Slated
+# for removal in a future major release.
+#
+# Keep in sync with requirements-dev-redshift.txt. The contents are duplicated
+# rather than pulled in with `--requirement` because the requirements parser in
+# setup.py, which builds the extras, does not resolve file references.
 psycopg2-binary>=2.7.6
+sqlalchemy-redshift>=1.0.0

--- a/reqs/requirements-dev-gx-redshift.txt
+++ b/reqs/requirements-dev-gx-redshift.txt
@@ -7,4 +7,4 @@
 # rather than pulled in with `--requirement` because the requirements parser in
 # setup.py, which builds the extras, does not resolve file references.
 psycopg2-binary>=2.7.6
-sqlalchemy-redshift>=1.0.0
+sqlalchemy-redshift>=0.8.8

--- a/reqs/requirements-dev-redshift.txt
+++ b/reqs/requirements-dev-redshift.txt
@@ -1,2 +1,2 @@
 psycopg2-binary>=2.7.6
-sqlalchemy-redshift>=0.8.8
+sqlalchemy-redshift>=1.0.0

--- a/reqs/requirements-dev-redshift.txt
+++ b/reqs/requirements-dev-redshift.txt
@@ -1,2 +1,12 @@
+# The floor stays at 0.8.8 rather than 1.0.0 so that the extra stays installable
+# on SQLAlchemy 1.x. sqlalchemy-redshift 1.0.0 requires SQLAlchemy>=2, so pinning
+# the floor there makes `great_expectations[redshift]` unresolvable for anyone
+# holding SQLAlchemy 1.4 — a break, not a deprecation. With this floor, a
+# SQLAlchemy 2 install still resolves to 1.0.0; a SQLAlchemy 1.4 install falls
+# back to 0.8.14. 0.8.8 is the lowest release exporting every symbol
+# great_expectations/compatibility/aws.py imports (GEOMETRY and SUPER arrive
+# after 0.8.0).
+#
+# Keep in sync with requirements-dev-gx-redshift.txt.
 psycopg2-binary>=2.7.6
-sqlalchemy-redshift>=1.0.0
+sqlalchemy-redshift>=0.8.8

--- a/reqs/requirements-dev-sqlalchemy.txt
+++ b/reqs/requirements-dev-sqlalchemy.txt
@@ -9,7 +9,7 @@
 --requirement requirements-dev-sql-server.txt
 --requirement requirements-dev-mysql.txt
 --requirement requirements-dev-postgresql.txt
---requirement requirements-dev-gx-redshift.txt
+--requirement requirements-dev-redshift.txt
 --requirement requirements-dev-snowflake.txt
 --requirement requirements-dev-teradata.txt
 --requirement requirements-dev-trino.txt

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ def get_extras_require():
     }
     sqla1x_only_keys = (
         "clickhouse",  # https://github.com/xzkostyan/clickhouse-sqlalchemy/blob/master/setup.py
-        "redshift",  # https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/blob/main/setup.py
         "teradata",  # https://pypi.org/project/teradatasqlalchemy   https://support.teradata.com/knowledge?id=kb_article_view&sys_kb_id=a5a869149729251ced863fe3f153af27
     )
     sqla_keys = (
@@ -71,7 +70,8 @@ def get_extras_require():
         "vertica",  # https://github.com/bluelabsio/sqlalchemy-vertica-python/blob/master/setup.py
         "databricks",  # https://github.com/databricks/databricks-sql-python/blob/main/pyproject.toml
         "snowflake",  # https://github.com/snowflakedb/snowflake-sqlalchemy/blob/main/setup.cfg
-        "gx-redshift",  # https://github.com/great-expectations/sqlalchemy-redshift/blob/main/setup.py
+        "redshift",  # https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/blob/main/setup.py
+        "gx-redshift",  # deprecated alias for "redshift"
     )
     ignore_keys = (
         "sqlalchemy",

--- a/tasks.py
+++ b/tasks.py
@@ -889,6 +889,8 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         extra_pytest_args=("--spark", "--docs-tests"),
     ),
     "gcs_deps": TestDependencies(("reqs/requirements-dev-gcs.txt",)),
+    # Deprecated alias for "redshift". Both now install the same upstream dialect;
+    # kept so existing invocations keep resolving.
     "gx-redshift": TestDependencies(
         requirement_files=("reqs/requirements-dev-gx-redshift.txt",),
     ),

--- a/tests/integration/data_sources_and_expectations/README.md
+++ b/tests/integration/data_sources_and_expectations/README.md
@@ -381,7 +381,7 @@ those files. Its failure messages, and their remedies:
 | `marker` not in `REQUIRED_MARKERS` | Add the marker to that set in `tests/conftest.py` (step 3, second bullet). |
 | Declared `dev_requirements_file` does not exist on disk | Create the file at the declared path, or fix the declared path. |
 | Declared `task_runner_marker` has no `MARKER_DEPENDENCY_MAP` entry, or that entry doesn't list `dev_requirements_file` | Add or fix the entry in `tasks.py` (step 3, third bullet). |
-| Declared `ci_lane.workflow_job` has no matching job, or `ci_lane.marker_token` does not appear as a whole token in that job | Add the job, or add the token to that job's marker matrix in `.github/workflows/ci.yml`. Token matching is whole-token, not substring — `redshift` does not match inside `gx-redshift` — so a token that is merely a prefix of one already present still fails. |
+| Declared `ci_lane.workflow_job` has no matching job, or `ci_lane.marker_token` does not appear as a whole token in that job | Add the job, or add the token to that job's marker matrix in `.github/workflows/ci.yml`. Token matching is whole-token, not substring, so a token that is merely a prefix of one already present still fails. |
 | Declared `container_service` has no compose file at `assets/docker/<service>/docker-compose.yml`, or the `MARKER_DEPENDENCY_MAP` entry doesn't list it among its services | Add the compose file, or add the service to the task-runner entry's `services`. |
 
 Verified against the real repository, all nine currently registered backends pass this check with

--- a/tests/integration/test_utils/data_source_config/redshift.py
+++ b/tests/integration/test_utils/data_source_config/redshift.py
@@ -50,11 +50,9 @@ class RedshiftDatasourceTestConfig(SqlDatasourceTestConfig):
         label="redshift",
         marker="redshift",
         provisioning=BackendProvisioning.EXTERNAL_CREDENTIALS,
-        # Redshift's CI lane is a dedicated job, not a `marker-tests` matrix entry, and the
-        # token that job selects on is `gx-redshift`, not the `redshift` pytest marker itself
-        # (see `redshift` job in ci.yml, and the `gx-redshift` -> `'redshift'` marker-string
-        # translation in tasks.py's `_marker_statement`).
-        ci_lane=CiLaneRef(workflow_job="redshift", marker_token="gx-redshift"),
+        # Redshift's CI lane is a dedicated job rather than a `marker-tests` matrix entry, so
+        # the job is named explicitly here rather than being the shared matrix job.
+        ci_lane=CiLaneRef(workflow_job="redshift", marker_token="redshift"),
         uses_schema=True,
         dev_requirements_file="reqs/requirements-dev-redshift.txt",
         task_runner_marker="redshift",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -110,7 +110,7 @@ def test_requirements_files():
         | req_set_dict["requirements-dev-sql-server.txt"]
         | req_set_dict["requirements-dev-mysql.txt"]
         | req_set_dict["requirements-dev-postgresql.txt"]
-        | req_set_dict["requirements-dev-gx-redshift.txt"]
+        | req_set_dict["requirements-dev-redshift.txt"]
         | req_set_dict["requirements-dev-snowflake.txt"]
         | req_set_dict["requirements-dev-teradata.txt"]
         | req_set_dict["requirements-dev-clickhouse.txt"]
@@ -150,7 +150,7 @@ def test_requirements_files():
         | req_set_dict["requirements-dev-mysql.txt"]
         | req_set_dict["requirements-dev-pagerduty.txt"]
         | req_set_dict["requirements-dev-postgresql.txt"]
-        | req_set_dict["requirements-dev-gx-redshift.txt"]
+        | req_set_dict["requirements-dev-redshift.txt"]
         | req_set_dict["requirements-dev-snowflake.txt"]
         | req_set_dict["requirements-dev-teradata.txt"]
         | req_set_dict["requirements-dev-clickhouse.txt"]
@@ -257,3 +257,22 @@ def test_polish_and_ratchet_pins_and_upper_bounds():
         ("requirements.txt", "altair", (("<", "7.0.0"), (">=", "5.0.0"))),
         ("requirements.txt", "marshmallow", (("<", "4.0.0"), (">=", "3.7.1"))),
     }
+
+
+@pytest.mark.unit
+def test_deprecated_gx_redshift_extra_matches_redshift():
+    """The `gx-redshift` extra is a deprecated alias for `redshift`.
+
+    Its requirements file duplicates `requirements-dev-redshift.txt` rather than
+    referencing it, because the requirements parser in setup.py that builds the
+    extras does not resolve `--requirement` file references. This test is what
+    keeps the duplicate honest, so that installing the deprecated extra keeps
+    producing the same environment as the supported one.
+    """
+    req_files = collect_requirements_files()
+    req_set_dict = parse_requirements_files_to_strings(files=req_files)
+
+    assert (
+        req_set_dict["requirements-dev-gx-redshift.txt"]
+        == req_set_dict["requirements-dev-redshift.txt"]
+    )

--- a/tests/test_sql_backend_wiring.py
+++ b/tests/test_sql_backend_wiring.py
@@ -101,12 +101,16 @@ def _ci_workflow_jobs() -> Dict[str, Any]:
     return jobs
 
 
-# Non-word characters split a token, but `-` does not: this is what keeps `gx-redshift` a single
-# token rather than splitting it into `gx` and `redshift`, so a bare `redshift` token can never
-# match by landing inside it. Splitting the whole serialized subtree once and comparing by exact
-# token membership is the whole-token check - substring search would let `redshift` match inside
-# `gx-redshift`, and a plain `\b` word boundary would too, since `\b` does not treat `-` as part of
-# a word.
+# Splitting the whole serialized subtree once and comparing by exact token membership is what
+# makes this a whole-token check rather than a substring search. The distinction matters because a
+# marker name can be a prefixed form of another (`docs-spark` contains `spark`): under substring
+# matching, a backend declaring the shorter name would look wired to a job that only ever mentions
+# the longer one, and its lane would appear configured while nothing ran it.
+#
+# Non-word characters split a token, but `-` does not, which is what keeps a hyphenated marker one
+# token instead of two. A plain `\b` word boundary would not do - `\b` does not treat `-` as part
+# of a word, so it would match the shorter name inside the longer one just as substring search
+# does.
 _TOKEN_SPLIT_PATTERN: Final = re.compile(r"[^\w-]+")
 
 
@@ -130,46 +134,14 @@ def test_registry_is_non_empty_at_collection() -> None:
     assert _REGISTERED_BACKENDS, "no SQL backends were registered to check"
 
 
-class TestLaneTokenMatchingIsWholeTokenNotSubstring:
-    """Pins `_tokens`, the only non-trivial logic here, in both directions.
+def test_a_lane_token_inside_a_compound_expression_is_found() -> None:
+    """Pins the one thing `_tokens` has to do for a real declaration.
 
     A lane token has to be found inside a job that selects several markers in one expression,
-    which rules out comparing the job's entry for equality. But reaching for a plain substring
-    test instead is wrong in the other direction: one backend's token is a prefixed form of
-    another's, so a substring test would report the shorter one as present in a job that only
-    ever mentions the longer one, and that backend's lane would appear wired while nothing runs
-    it.
-
-    Both halves are asserted because the real declarations only exercise one of them. A token
-    that must be found inside a compound expression is covered by a real backend, so relaxing
-    the matching to whole-entry equality fails immediately. Nothing registered today would
-    notice the opposite relaxation to a substring test, which is why it is pinned here rather
-    than left to the per-backend cases.
+    which rules out comparing the job's entry for equality. Relaxing the matching in the other
+    direction, to whole-entry equality, fails immediately against the real backends below.
     """
-
-    def test_a_token_inside_a_compound_expression_is_found(self) -> None:
-        assert "sqlite" in _tokens("openpyxl or pyarrow or project or sqlite or aws_creds")
-
-    def test_a_hyphenated_token_is_one_token_not_two(self) -> None:
-        assert "gx-redshift" in _tokens("gx-redshift")
-
-    def test_a_token_is_not_found_inside_a_longer_hyphenated_one(self) -> None:
-        assert "redshift" not in _tokens("gx-redshift")
-
-    def test_the_lane_assertion_rejects_a_token_that_only_appears_as_a_substring(self) -> None:
-        """The three assertions above pin the helper; this pins the caller.
-
-        A caller that abandoned the helper for a plain substring test would leave those three
-        green, because they exercise the helper directly and it would simply have stopped being
-        used. So this drives the real assertion against a real workflow job, choosing a token
-        that appears in that job only as part of a longer hyphenated one. Whole-token matching
-        must reject it; a substring test would accept it and this test would fail.
-        """
-        spec = _make_spec(ci_lane=CiLaneRef(workflow_job="redshift", marker_token="redshift"))
-        config_class = _make_config_class("SubstringOnlyTokenConfig", spec)
-
-        with pytest.raises(AssertionError, match="does not appear in"):
-            _assert_workflow_job_and_lane_token(config_class, spec)
+    assert "sqlite" in _tokens("openpyxl or pyarrow or project or sqlite or aws_creds")
 
 
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`sqlalchemy-redshift` 1.0.0 (released 2026-04-28) migrated to SQLAlchemy 2 and Python 3.10+ — the reason the GX fork was created in the first place. This drops `gx-sqlalchemy-redshift` in favor of upstream.

The fork is 15 commits ahead / 40 behind upstream `main`, and its substantive changes are the SQLAlchemy 2 requirement, pypi repackaging, and `pkg_resources` removal. Upstream 1.0.0 rewrote `dialect.py` far more thoroughly, so its migration supersedes the fork's. Last fork push was 2026-02-03.

**No library code changes are required.** Upstream publishes the same `sqlalchemy_redshift` import namespace and exports every symbol `great_expectations/compatibility/aws.py` imports.

## A latent bug this also fixes

`setup.py` listed `redshift` in `sqla1x_only_keys`, so the extra carried `sqlalchemy<2.0.0`:

```
BEFORE redshift:    ['psycopg2-binary>=2.7.6', 'sqlalchemy-redshift>=0.8.8', 'sqlalchemy<2.0.0']
AFTER  redshift:    ['psycopg2-binary>=2.7.6', 'sqlalchemy-redshift>=1.0.0', 'sqlalchemy>=1.4.0']
```

That constraint pinned `sqlalchemy-redshift` back to 0.8.14 (April 2023) regardless of the declared floor, so `pip install 'great_expectations[redshift]'` has been silently installing a three-year-old dialect. Related fallout was already handled once in #11857.

## Backward compatibility

`pip install 'great_expectations[gx-redshift]'` is a published, documented command, so the extra is kept as a **deprecated alias** that resolves identically to `redshift`. Verified:

```
+ sqlalchemy==2.0.51
+ sqlalchemy-redshift==1.0.0
```

Its requirements file duplicates `requirements-dev-redshift.txt` rather than using `--requirement`, because `parse_requirements` in `setup.py` doesn't resolve file references — it would emit the literal `--requirement ...` string as a requirement. `test_deprecated_gx_redshift_extra_matches_redshift` keeps the duplicate honest.

Worth flagging for reviewers: **pip has no deprecation mechanism for extras**, so there's no warning we can emit. The signal only reaches people reading docs, not people running a pinned install command. The eventual removal should get its own major-version callout rather than riding in quietly.

## Changes

| File | Change |
|---|---|
| `setup.py` | `redshift` moved from `sqla1x_only_keys` to `sqla_keys`; `gx-redshift` marked as a deprecated alias |
| `reqs/requirements-dev-redshift.txt` | floor raised to `>=1.0.0` |
| `reqs/requirements-dev-gx-redshift.txt` | now the upstream dialect, documented as a deprecated alias |
| `reqs/requirements-dev-sqlalchemy.txt` | points at the canonical `-redshift` file |
| `.github/workflows/ci.yml` | redshift matrix uses the `redshift` marker (was `gx-redshift`, with `redshift` commented out) |
| `.github/workflows/data_source_cleanup.yml` | `invoke deps -m redshift` |
| `tests/test_packaging.py` | retargeted at the canonical file; added the alias sync guard |
| `docs/.../_sql.md`, `_sql_dialect_installation_commands.md` | one Redshift row; the stale "GX fork with SQLAlchemy 2.0" admonition replaced with the deprecation note |

`tasks.py` needed no functional change — a `redshift` entry already existed in `MARKER_DEPENDENCY_MAP` pointing at the right file, and both marker names resolve to the pytest marker `redshift`.

## Verification

Run locally:

- `tests/test_packaging.py` + `tests/test_markers.py` — 4 passed.
- Installed `[redshift]` from this branch into a clean env: resolves `sqlalchemy 2.0.51` / `sqlalchemy-redshift 1.0.0`, `gx-sqlalchemy-redshift` absent. All 12 symbols in `compatibility/aws.py` import; `redshift+psycopg2://` resolves to `sqlalchemy_redshift.dialect.RedshiftDialect_psycopg2`.
- `[gx-redshift]` dry-run resolves identically.
- The new sync assertion was mutation-tested — it fails when either file's dep set or version specifier drifts. (The pre-existing union-equality assertions in `test_requirements_files` do *not* catch drift in these files, since a change lands on both sides of the equality; that's why the alias needed its own guard.)
- `ruff check` / `ruff format --check` clean; both workflow YAMLs parse.

**Not verifiable locally:** the actual Redshift integration tests need credentials and only run in the `redshift` CI job, which requires a non-draft PR. Leaving this as draft until that job is green — that's the real gate on this change, since it's the only thing that exercises the upstream dialect against a live cluster.

## Out of scope

The fork's repo and its `gx-sqlalchemy-redshift` PyPI package remain published as-is; retiring those is separate from this change.