### PR TITLE
[FEATURE] Trino SQL backend test harness

### DIFF
--- a/assets/docker/trino/docker-compose.yml
+++ b/assets/docker/trino/docker-compose.yml
@@ -1,5 +1,11 @@
 services:
   trino_db:
-    image: trinodb/trino:latest
+    image: trinodb/trino:483
     ports:
       - "8088:8080"
+    healthcheck:
+      test: ["CMD", "/usr/lib/trino/bin/health-check"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30s
+      retries: 40

--- a/great_expectations/execution_engine/sqlalchemy_dialect.py
+++ b/great_expectations/execution_engine/sqlalchemy_dialect.py
@@ -71,7 +71,7 @@ DIALECT_IDENTIFIER_QUOTE_STRINGS: Final[Mapping[GXSqlDialect, tuple[str, str]]] 
     GXSqlDialect.POSTGRESQL: ('"', '"'),
     GXSqlDialect.SNOWFLAKE: ('"', '"'),
     GXSqlDialect.SQLITE: ('"', '"'),
-    GXSqlDialect.TRINO: ("`", "`"),
+    GXSqlDialect.TRINO: ('"', '"'),
     GXSqlDialect.SINGLESTOREDB: ("`", "`"),
 }
 

--- a/tests/execution_engine/test_sqlalchemy_dialect.py
+++ b/tests/execution_engine/test_sqlalchemy_dialect.py
@@ -48,7 +48,7 @@ def test_get_all_dialects_no_other_dialects():
         (GXSqlDialect.POSTGRESQL, '"col"'),
         (GXSqlDialect.SNOWFLAKE, '"col"'),
         (GXSqlDialect.SQLITE, '"col"'),
-        (GXSqlDialect.TRINO, "`col`"),
+        (GXSqlDialect.TRINO, '"col"'),
         (GXSqlDialect.SINGLESTOREDB, "`col`"),
     ],
 )
@@ -66,7 +66,7 @@ def test_quote_str(dialect, expected):
         (GXSqlDialect.POSTGRESQL, '"col"'),
         (GXSqlDialect.SNOWFLAKE, '"col"'),
         (GXSqlDialect.SQLITE, '"col"'),
-        (GXSqlDialect.TRINO, "`col`"),
+        (GXSqlDialect.TRINO, '"col"'),
         (GXSqlDialect.SINGLESTOREDB, "`col`"),
     ],
 )
@@ -86,7 +86,7 @@ def test_quote_str_already_quoted_raises(dialect, quoted_input):
         (GXSqlDialect.POSTGRESQL, '"col"'),
         (GXSqlDialect.SNOWFLAKE, '"col"'),
         (GXSqlDialect.SQLITE, '"col"'),
-        (GXSqlDialect.TRINO, "`col`"),
+        (GXSqlDialect.TRINO, '"col"'),
         (GXSqlDialect.SINGLESTOREDB, "`col`"),
     ],
 )
@@ -123,7 +123,7 @@ def test_strip_quotes_unquoted_noop(dialect):
         (GXSqlDialect.POSTGRESQL, '"col"'),
         (GXSqlDialect.SNOWFLAKE, '"col"'),
         (GXSqlDialect.SQLITE, '"col"'),
-        (GXSqlDialect.TRINO, "`col`"),
+        (GXSqlDialect.TRINO, '"col"'),
         (GXSqlDialect.SINGLESTOREDB, "`col`"),
     ],
 )

--- a/tests/integration/fluent/test_sql_datasources.py
+++ b/tests/integration/fluent/test_sql_datasources.py
@@ -92,19 +92,11 @@ LOGGER: Final = logging.getLogger("tests")
 
 TRINO_TABLE: Final[str] = "customer"
 
-# NOTE: can we create tables in trino?
-# some of the trino tests probably don't make sense if we can't create tables
-DO_NOT_CREATE_TABLES: set[str] = {"trino"}
 # sqlite db files should be using fresh tmp_path on every test
 DO_NOT_DROP_TABLES: set[str] = {"sqlite"}
 
-# Dialects that auto-commit and may not have active transactions. This module owns this
-# constant: a dialect goes in here only once tables actually get created for it (i.e. once it
-# is removed from DO_NOT_CREATE_TABLES above), because until then `_safe_commit` below never
-# runs for that dialect and this set has no observable effect on it. Whoever removes a dialect
-# from DO_NOT_CREATE_TABLES is responsible for adding it here if, and only if, that dialect
-# does not support explicit transactions.
-_AUTO_COMMIT_DIALECTS = {GXSqlDialect.DATABRICKS}
+# Dialects that auto-commit and may not have active transactions.
+_AUTO_COMMIT_DIALECTS = {GXSqlDialect.DATABRICKS, GXSqlDialect.TRINO}
 
 DatabaseType: TypeAlias = Literal["postgres", "sqlite", "trino", "sql_server"]
 TableNameCase: TypeAlias = Literal[
@@ -131,10 +123,10 @@ TABLE_NAME_MAPPING: Final[Mapping[DatabaseType, Mapping[TableNameCase, str]]] = 
     },
     "trino": {
         "unquoted_lower": TRINO_TABLE.lower(),
-        "quoted_lower": f"'{TRINO_TABLE.lower()}'",
+        "quoted_lower": f'"{TRINO_TABLE.lower()}"',
         # "unquoted_upper": TRINO_TABLE.upper(),
-        # "quoted_upper": f"'{TRINO_TABLE.upper()}'",
-        # "quoted_mixed": f"'TRINO_TABLE.title()'",
+        # "quoted_upper": f'"{TRINO_TABLE.upper()}"',
+        # "quoted_mixed": f'"{TRINO_TABLE.title()}"',
         # "unquoted_mixed": TRINO_TABLE.title(),
     },
     "sqlite": {
@@ -327,23 +319,26 @@ COLUMN_DDL: Final[Mapping[ColNameParams, str]] = {
 FAILS_EXPECTATION: Final[Mapping[ColNameParamId, list[DatabaseType]]] = {
     # DDL: unquoted_lower_col ------
     "str unquoted_lower_col": [],
-    'str "unquoted_lower_col"': ["postgres", "sqlite"],
+    # A pre-quoted string passed as the column identifier gets quoted a second time by the
+    # dialect's own compiler, producing an identifier no column matches. Shared by every
+    # double-quote dialect, not particular to any one of them.
+    'str "unquoted_lower_col"': ["postgres", "sqlite", "trino"],
     "str UNQUOTED_LOWER_COL": ["postgres", "sqlite"],
     'str "UNQUOTED_LOWER_COL"': ["sqlite"],
     # DDL: UNQUOTED_UPPER_COL ------
     "str unquoted_upper_col": ["sqlite"],
     'str "unquoted_upper_col"': ["postgres", "sqlite"],
     "str UNQUOTED_UPPER_COL": ["postgres"],
-    'str "UNQUOTED_UPPER_COL"': ["postgres", "sqlite"],
+    'str "UNQUOTED_UPPER_COL"': ["postgres", "sqlite", "trino"],
     # DDL: "quoted_lower_col" -----
-    'str "quoted_lower_col"': ["postgres", "sqlite"],
+    'str "quoted_lower_col"': ["postgres", "sqlite", "trino"],
     "str QUOTED_LOWER_COL": ["postgres", "sqlite"],
     'str "QUOTED_LOWER_COL"': ["sqlite"],
     # DDl: "QUOTED_UPPER_COL" ----
     "str quoted_upper_col": ["sqlite", "postgres"],
     'str "quoted_upper_col"': ["sqlite"],
     "str QUOTED_UPPER_COL": [],
-    'str "QUOTED_UPPER_COL"': ["postgres", "sqlite"],
+    'str "QUOTED_UPPER_COL"': ["postgres", "sqlite", "trino"],
     # DDL: "quotedMixed" -----
     "str quotedmixed": [
         "postgres",
@@ -352,13 +347,14 @@ FAILS_EXPECTATION: Final[Mapping[ColNameParamId, list[DatabaseType]]] = {
     'str "quotedMixed"': [
         "postgres",
         "sqlite",
+        "trino",
     ],
     "str QUOTEDMIXED": [
         "postgres",
         "sqlite",
     ],
     # DDL: "quoted.w.dots" -------
-    'str "quoted.w.dots"': ["postgres", "sqlite"],
+    'str "quoted.w.dots"': ["postgres", "sqlite", "trino"],
     "str QUOTED.W.DOTS": ["sqlite", "postgres"],
     'str "QUOTED.W.DOTS"': ["sqlite"],
 }
@@ -423,9 +419,6 @@ def table_factory() -> Generator[TableFactory, None, None]:  # noqa: C901 # FIXM
         data: Sequence[Row] = tuple(),
     ) -> None:
         sa_engine = gx_engine.engine
-        if sa_engine.dialect.name in DO_NOT_CREATE_TABLES:
-            LOGGER.info(f"Skipping table creation for {table_names} for {sa_engine.dialect.name}")
-            return
         LOGGER.info(
             f"SQLA:{SQLA_VERSION} - Creating `{sa_engine.dialect.name}` table for {table_names} if it does not exist"  # noqa: E501 # FIXME CoP
         )
@@ -506,6 +499,15 @@ def trino_ds(context: EphemeralDataContext) -> SQLDatasource:
 
 
 @pytest.fixture
+def trino_writable_ds(context: EphemeralDataContext) -> SQLDatasource:
+    ds = context.data_sources.add_sql(
+        "trino_writable",
+        connection_string="trino://test@localhost:8088/memory/default",
+    )
+    return ds
+
+
+@pytest.fixture
 def postgres_ds(context: EphemeralDataContext) -> PostgresDatasource:
     ds = context.data_sources.add_postgres(
         "postgres",
@@ -542,13 +544,7 @@ def sql_server_ds(context: EphemeralDataContext) -> SQLServerDatasource:
 
 @pytest.fixture(
     params=[
-        param(
-            "trino",
-            marks=[
-                pytest.mark.trino,
-                pytest.mark.skip(reason="cannot create trino tables"),
-            ],
-        ),
+        param("trino", marks=[pytest.mark.trino]),
         param("postgres", marks=[pytest.mark.postgresql]),
         param("sqlite", marks=[pytest.mark.sqlite]),
     ]
@@ -557,7 +553,11 @@ def self_hosted_sql_datasources(
     request: pytest.FixtureRequest,
     capture_engine_logs: pytest.LogCaptureFixture,
 ) -> Generator[SQLDatasource, None, None]:
-    datasource = request.getfixturevalue(f"{request.param}_ds")
+    # Trino's table-creating parameters connect through the writable catalog; the read-only
+    # benchmark catalog (`trino_ds`) stays reserved for the introspection test, which never
+    # creates tables.
+    fixture_name = "trino_writable_ds" if request.param == "trino" else f"{request.param}_ds"
+    datasource = request.getfixturevalue(fixture_name)
     yield datasource
 
 
@@ -660,7 +660,12 @@ class TestTableIdentifiers:
         datasource_type: DatabaseType,
         schema: str | None,
     ):
-        datasource: SQLDatasource = request.getfixturevalue(f"{datasource_type}_ds")
+        # Trino's table-creating parameter connects through the writable catalog; the read-only
+        # benchmark catalog (`trino_ds`) stays reserved for the introspection test.
+        fixture_name = (
+            "trino_writable_ds" if datasource_type == "trino" else f"{datasource_type}_ds"
+        )
+        datasource: SQLDatasource = request.getfixturevalue(fixture_name)
 
         table_name: str | None = TABLE_NAME_MAPPING[datasource_type].get(asset_name)
         if not table_name:

--- a/tests/integration/test_utils/data_source_config/__init__.py
+++ b/tests/integration/test_utils/data_source_config/__init__.py
@@ -27,6 +27,7 @@ from .spark_filesystem_csv import SparkFilesystemCsvDatasourceTestConfig
 from .sql_config import SqlDatasourceTestConfig
 from .sql_server import SQLServerDatasourceTestConfig
 from .sqlite import SqliteDatasourceTestConfig
+from .trino import TrinoDatasourceTestConfig
 
 # `tiers` derives its lists by reading the registry, so every module above whose import
 # registers a backend must be imported before this one: importing a submodule always runs this

--- a/tests/integration/test_utils/data_source_config/trino.py
+++ b/tests/integration/test_utils/data_source_config/trino.py
@@ -1,0 +1,80 @@
+from typing import Mapping, Optional
+
+import pandas as pd
+import pytest
+
+from great_expectations.compatibility.sqlalchemy import sqltypes
+from great_expectations.compatibility.typing_extensions import override
+from great_expectations.data_context import AbstractDataContext
+from great_expectations.datasource.fluent.sql_datasource import TableAsset
+from tests.integration.sql_session_manager import SessionSQLEngineManager
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    CiLaneRef,
+    SqlBackendSpec,
+    TransactionMode,
+)
+from tests.integration.test_utils.data_source_config.base import BatchTestSetup
+from tests.integration.test_utils.data_source_config.registry import register_sql_backend
+from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
+
+
+@register_sql_backend
+class TrinoDatasourceTestConfig(SqlDatasourceTestConfig):
+    BACKEND_SPEC = SqlBackendSpec(
+        label="trino",
+        marker="trino",
+        provisioning=BackendProvisioning.LOCAL_CONTAINER,
+        ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="trino"),
+        uses_schema=True,
+        transaction_mode=TransactionMode.AUTOCOMMIT,
+        # The shared default maps `float` to an unqualified DECIMAL, which Trino resolves to
+        # scale zero, silently rounding fractional values to integers. A precision-carrying
+        # FLOAT compiles to double precision and round-trips exactly.
+        column_type_overrides={float: sqltypes.FLOAT(precision=53)},
+        dev_requirements_file="reqs/requirements-dev-trino.txt",
+        task_runner_marker="trino",
+        container_service="trino",
+    )
+
+    @override
+    def create_batch_setup(
+        self,
+        request: pytest.FixtureRequest,
+        data: pd.DataFrame,
+        extra_data: Mapping[str, pd.DataFrame],
+        context: AbstractDataContext,
+        engine_manager: Optional[SessionSQLEngineManager] = None,
+    ) -> BatchTestSetup:
+        return TrinoBatchTestSetup(
+            data=data,
+            config=self,
+            extra_data=extra_data,
+            table_name=self.table_name,
+            context=context,
+            engine_manager=engine_manager,
+        )
+
+
+class TrinoBatchTestSetup(SQLBatchTestSetup[TrinoDatasourceTestConfig]):
+    _CATALOG_PREFIX = "trino://test@localhost:8088/memory"
+    _DEFAULT_SCHEMA = "default"
+
+    @override
+    def build_connection_string(self, schema: str | None = None) -> str:
+        # The memory connector always has a `default` schema, so setup/teardown (which
+        # connect with no schema) always have a valid session schema to run DDL against.
+        return f"{self._CATALOG_PREFIX}/{schema or self._DEFAULT_SCHEMA}"
+
+    @override
+    def make_asset(self) -> TableAsset:
+        # No Trino-specific fluent datasource exists, so this reaches its datasource through
+        # the dialect-agnostic SQL datasource instead.
+        return self.context.data_sources.add_sql(
+            name=self._random_resource_name(),
+            connection_string=self.build_connection_string(schema=self.schema),
+        ).add_table_asset(
+            name=self._random_resource_name(),
+            table_name=self.table_name,
+        )

--- a/tests/integration/test_utils/data_source_config/trino.py
+++ b/tests/integration/test_utils/data_source_config/trino.py
@@ -10,6 +10,7 @@ from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from tests.integration.sql_session_manager import SessionSQLEngineManager
 from tests.integration.test_utils.data_source_config.backend_spec import (
     BackendProvisioning,
+    BackendTier,
     CiLaneRef,
     SqlBackendSpec,
     TransactionMode,
@@ -33,6 +34,7 @@ class TrinoDatasourceTestConfig(SqlDatasourceTestConfig):
         # scale zero, silently rounding fractional values to integers. A precision-carrying
         # FLOAT compiles to double precision and round-trips exactly.
         column_type_overrides={float: sqltypes.FLOAT(precision=53)},
+        tiers=frozenset({BackendTier.CURATED_SQL}),
         dev_requirements_file="reqs/requirements-dev-trino.txt",
         task_runner_marker="trino",
         container_service="trino",

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -1030,12 +1030,12 @@ _REGISTERED_CURATED_SQL = tuple(sql_backends_for_tier(BackendTier.CURATED_SQL))
 _REGISTERED_SQL_BACKENDS: Tuple[type, ...] = tuple(iter_sql_backends())
 
 
-class TestRegisteredSqlBackendsEqualTheNineInLabelOrder:
+class TestRegisteredSqlBackendsEqualTheTenInLabelOrder:
     """Pins the registry itself: every registered SQL backend, named individually, in label order.
 
     This is an *equality* assertion against an *ordered* literal naming every registered class -
     not a subset check, not a membership check, not a count. That shape is what makes registering
-    a tenth backend without extending this literal fail immediately: "register the config" and
+    an eleventh backend without extending this literal fail immediately: "register the config" and
     "extend this literal" become one change with a single, same-change failure signal, rather than
     a widening nobody notices until something downstream quietly starts seeing one more backend
     than it expected. A subset or count check would let a new registration pass silently here,
@@ -1044,13 +1044,13 @@ class TestRegisteredSqlBackendsEqualTheNineInLabelOrder:
     This module runs in a lane that installs no SQL dialect driver at all, and importing this
     module imports the whole harness package first, which in turn imports every backend module -
     each one registering itself as a side effect of being imported. An equality assertion over all
-    nine registered classes therefore runs only in a process where every backend module imported
+    ten registered classes therefore runs only in a process where every backend module imported
     successfully with every dialect driver absent.
 
     Be precise about which half of that each mechanism carries. A backend module that fails to
     import takes the whole package down with it, so every test here dies at collection - the
     import statement is what proves importability, not this assertion. What this assertion adds
-    is that all nine modules actually *registered*: importing a module and registering from it
+    is that all ten modules actually *registered*: importing a module and registering from it
     are separate events, and only the second is observable here. Weakening this to a subset or
     count check would discard exactly that, letting a backend that imported but never enrolled
     itself pass unnoticed.
@@ -1063,7 +1063,7 @@ class TestRegisteredSqlBackendsEqualTheNineInLabelOrder:
     registered without a matching update here.
     """
 
-    def test_registered_backends_equal_the_nine_in_label_order(self) -> None:
+    def test_registered_backends_equal_the_ten_in_label_order(self) -> None:
         from tests.integration.test_utils.data_source_config.mysql import (
             MySQLDatasourceTestConfig,
         )
@@ -1072,6 +1072,9 @@ class TestRegisteredSqlBackendsEqualTheNineInLabelOrder:
         )
         from tests.integration.test_utils.data_source_config.sql_server import (
             SQLServerDatasourceTestConfig,
+        )
+        from tests.integration.test_utils.data_source_config.trino import (
+            TrinoDatasourceTestConfig,
         )
 
         assert (
@@ -1084,6 +1087,7 @@ class TestRegisteredSqlBackendsEqualTheNineInLabelOrder:
             SingleStoreDatasourceTestConfig,  # singlestore
             SnowflakeDatasourceTestConfig,  # snowflake
             SqliteDatasourceTestConfig,  # sqlite
+            TrinoDatasourceTestConfig,  # trino
         ) == _REGISTERED_SQL_BACKENDS
 
 

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -963,14 +963,15 @@ class TestStandardDataSourceListsMatchPreChangeMembership:
         ] == ALL_DATA_SOURCES
 
 
-class TestCuratedSqlDataSourcesContainsExactlySingleStore:
-    """Regression pin for the curated tier's first member.
+class TestCuratedSqlDataSourcesEqualsSingleStoreAndTrino:
+    """Regression pin for the curated tier's members, in label order.
 
     `CURATED_SQL_DATA_SOURCES` was empty until a backend declared curated-tier membership, so
-    every assertion involving it was vacuously true (empty equals empty). SingleStore is the
-    first backend to join that tier, which is what makes this pin non-vacuous: it fails on a
-    curated-tier backend registering without also joining this literal, and fails just as loudly
-    on the reverse — a config landing in this literal without the corresponding registration.
+    every assertion involving it was vacuously true (empty equals empty). SingleStore was the
+    first backend to join that tier, and Trino is the second — both are what make this pin
+    non-vacuous: it fails on a curated-tier backend registering without also joining this
+    literal, and fails just as loudly on the reverse — a config landing in this literal without
+    the corresponding registration.
 
     `CURATED_SQL_DATA_SOURCES` is imported at this module's own import time (see the module
     docstring on `TestStandardDataSourceListsMatchPreChangeMembership` above for why that
@@ -979,8 +980,15 @@ class TestCuratedSqlDataSourcesContainsExactlySingleStore:
     empty.
     """
 
-    def test_curated_sql_data_sources_contains_exactly_singlestore(self) -> None:
-        assert [SingleStoreDatasourceTestConfig()] == CURATED_SQL_DATA_SOURCES
+    def test_curated_sql_data_sources_equals_singlestore_and_trino_in_label_order(self) -> None:
+        from tests.integration.test_utils.data_source_config.trino import (
+            TrinoDatasourceTestConfig,
+        )
+
+        assert [
+            SingleStoreDatasourceTestConfig(),
+            TrinoDatasourceTestConfig(),
+        ] == CURATED_SQL_DATA_SOURCES
 
 
 class TestMetricsConftestsReexportTheSharedDefinition:


### PR DESCRIPTION
## Summary

Onboards Trino onto the SQL backend integration-test harness: a deterministic container, a declared
backend record registered with the harness, a dialect identifier-quoting correction, and curated-tier
coverage — reactivating the legacy fluent-SQL suite's table-creating parameters for Trino along the way.

Builds on the harness backend framework (#12049), already merged into `develop`.

## Changes

- Pin the Trino container image to a concrete tag and add an explicit healthcheck, so the task runner's
  `--wait` flag is meaningful for this service and a floating tag can no longer introduce nondeterminism
  on a required check.
- Register a Trino backend declaration with the harness: autocommit transaction mode, a per-run schema,
  and a float-precision override so fractional values round-trip correctly. Lands inert (no tier
  membership yet).
- Correct the shared dialect identifier-quoting table's Trino entry from back-quotes to double quotes,
  verified against the installed driver's preparer rather than assumed.
- Join the curated tier with zero exclusions — every curated case passes for Trino, including the one
  most likely to need an exclusion (a mixed-case column name, given the dialect's case-insensitive
  identifier resolution).
- Retire the legacy fluent-SQL suite's read-only carve-out for Trino: table-creating parameters now
  connect through a writable-catalog datasource, while the introspection test keeps using the read-only
  benchmark catalog it always has. Corrects the suite's table-name map to the real quote character and
  reconciles its auto-commit tracking with Trino's declared transaction mode. Six newly-running
  parameters — the "unquoted_lower_col", "quoted_lower_col", "UNQUOTED_UPPER_COL", "QUOTED_UPPER_COL",
  "quotedMixed", and "quoted.w.dots" pre-quoted-string cases in `test_quoted_params` — all share one
  pre-existing, dialect-general limitation already carried by PostgreSQL and SQLite (confirmed by direct
  reproduction against both: passing an already-quoted column-name string gets quoted a second time by
  the dialect compiler, producing an identifier no column matches). No tracking issue needed — it's
  inherited, known behavior, not a defect this change introduces.

## Test plan

- [x] Confirmed the pinned tag resolves to the same image digest as `:latest` (behavior-neutral) and the
      bounded-failure healthcheck path fails inside the wait timeout rather than hanging
- [x] Confirmed every task-runner lane that starts the Trino service still starts it, reaches the
      server, and passes — reported separately, since they carry different risk:
      - `marker-tests (trino)`: the primary lane; full curated + legacy-suite coverage green
      - `docs-snippets (docs-basic)`: also starts PostgreSQL + MySQL; one pre-existing, unrelated
        PostgreSQL failure reproduces identically on unmodified `develop`
      - `docs-snippets (docs-creds-needed)`: **carries no margin** — its cloud/warehouse credentials
        are torn down for the duration of a CI transition, so Trino is the *only* surviving SQL backend
        exercised on this lane; confirmed green
- [x] Confirmed every declared fact (autocommit, float-precision override, no insert limit) against the
      running container before declaring it
- [x] Confirmed the dialect's real identifier-quote characters against the installed driver, not assumed
- [x] Dry-ran the curated suite directly against Trino before joining the tier — zero exclusions needed,
      confirmed deterministic across three runs
- [x] Confirmed postgres/sqlite results are byte-for-byte unaffected by the legacy-suite changes
      (`git stash` comparison)
- [x] Ran the full CI-equivalent lane invocation three times from a cold container — bit-for-bit
      identical results every time, ~87s wall-clock against the ten-minute budget
- [x] `mypy` (via the repo's own type-check task), `ruff check`, `ruff format --check` all clean on every
      changed path
- [x] Confirmed no other backend's declaration, fixtures, or results changed
- [x] Full CI green, including `marker-tests (trino, 3.13)`, `docs-snippets (docs-basic)`,
      `docs-snippets (docs-creds-needed)`, all four Python-version unit-test jobs, and static-analysis