### PR TITLE
[FEATURE] ClickHouse SQL backend test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,9 +556,6 @@ jobs:
           - python-version: ${{ github.event_name == 'workflow_dispatch' && '3.10' }}
           - python-version: ${{ github.event_name == 'workflow_dispatch' && '3.11' }}
           - python-version: ${{ github.event_name == 'workflow_dispatch' && '3.12' }}
-            # clickhouse needs dependency update
-          - python-version: "3.12"
-            markers: clickhouse
 
     steps:
       - name: Checkout

--- a/assets/docker/clickhouse/docker-compose.yml
+++ b/assets/docker/clickhouse/docker-compose.yml
@@ -1,11 +1,37 @@
 services:
-  server:
-    image: yandex/clickhouse-server
+  clickhouse_db:
+    # Maintained repository (the pre-rename "yandex/clickhouse-server" repository is
+    # abandoned), pinned to a long-term-support patch release rather than a floating
+    # minor tag, so the lane doesn't silently pick up an untested server version.
+    image: clickhouse/clickhouse-server:25.8.29
+    environment:
+      CLICKHOUSE_DB: test_ci
+      # Without this, the entrypoint restricts the unauthenticated default user to
+      # localhost-only when no password is set, which blocks the published port. This
+      # keeps the shipped default user/network config (open, no password) intact,
+      # matching the connection string GX Core already uses for this dialect.
+      CLICKHOUSE_SKIP_USER_SETUP: 1
+    # Native-protocol port only. The dialect offers both a native driver (port 9000)
+    # and an HTTP driver (port 8123); the native one is chosen because it is what the
+    # existing ClickHouse connection-string logic in this codebase already uses, so
+    # container, connection string and dependencies all agree on one driver. The HTTP
+    # port has no consumer here and stays unpublished.
     ports:
       - "9000:9000"
-
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30s
+      retries: 40
+    networks:
+      - dbnet
     ulimits:
       nproc: 65535
       nofile:
         soft: 262144
         hard: 262144
+
+networks:
+  dbnet:
+    driver: bridge

--- a/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
+++ b/great_expectations/expectations/metrics/column_aggregate_metrics/column_quantile_values.py
@@ -361,9 +361,9 @@ def _get_column_quantiles_clickhouse(
     quantiles_list = list(quantiles)
     sql_approx: str = f"quantilesExact({', '.join([str(x) for x in quantiles_list])})({column})"
     selects_approx: list[sqlalchemy.TextClause] = [sa.text(sql_approx)]
-    quantiles_query: sqlalchemy.Select = sa.select(selects_approx).select_from(selectable)  # type: ignore[call-overload] # FIXME CoP
+    quantiles_query: sqlalchemy.Select = sa.select(*selects_approx).select_from(selectable)
     try:
-        quantiles_results = execution_engine.execute(quantiles_query).fetchone()[0]
+        quantiles_results = execution_engine.execute_query(quantiles_query).fetchone()[0]
         return quantiles_results
 
     except sqlalchemy.ProgrammingError as pe:

--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -296,12 +296,22 @@ def _sqlalchemy_map_condition_unexpected_count_value(
     selectable = execution_engine.get_domain_records(domain_kwargs=domain_kwargs)
 
     # The integral values are cast to SQL Numeric in order to avoid a bug in AWS Redshift (converted to integer later).  # noqa: E501 # FIXME CoP
+    # ClickHouse rejects a bare, unparameterized Numeric cast at the server (it compiles to a
+    # `Decimal` with no precision/scale, which this dialect's server refuses), so this dialect
+    # needs an explicitly-precisioned Numeric for the same two casts. 38 digits with zero decimal
+    # places is enough to hold a `SUM` of the 1/0 flags below regardless of table size, and every
+    # other dialect keeps the bare `sa.Numeric` this cast already relied on.
+    numeric_type = (
+        sa.Numeric(38, 0)
+        if execution_engine.dialect_name == GXSqlDialect.CLICKHOUSE
+        else sa.Numeric
+    )
     count_case_statement: List[sqlalchemy.Label] = sa.case(  # type: ignore[assignment] # FIXME CoP
         (
             unexpected_condition,
-            sa.sql.expression.cast(1, sa.Numeric),
+            sa.sql.expression.cast(1, numeric_type),
         ),
-        else_=sa.sql.expression.cast(0, sa.Numeric),
+        else_=sa.sql.expression.cast(0, numeric_type),
     ).label("condition")
 
     count_selectable: sqlalchemy.Select = sa.select(count_case_statement)  # type: ignore[call-overload] # FIXME CoP

--- a/tasks.py
+++ b/tasks.py
@@ -814,7 +814,10 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
     "athena": TestDependencies(("reqs/requirements-dev-athena.txt",)),
     "aws_deps": TestDependencies(("reqs/requirements-dev-lite.txt",)),
     "bigquery": TestDependencies(("reqs/requirements-dev-bigquery.txt",)),
-    "clickhouse": TestDependencies(("reqs/requirements-dev-clickhouse.txt",)),
+    "clickhouse": TestDependencies(
+        ("reqs/requirements-dev-clickhouse.txt",),
+        services=("clickhouse",),
+    ),
     "cloud": TestDependencies(
         (
             "reqs/requirements-dev-cloud.txt",

--- a/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
@@ -31,7 +31,11 @@ from datetime import date, datetime, timezone
 
 import pandas as pd
 import pytest
-from clickhouse_sqlalchemy import types as clickhouse_types
+
+try:
+    from clickhouse_sqlalchemy import types as clickhouse_types
+except ImportError:
+    clickhouse_types = None
 
 import great_expectations.expectations as gxe
 from great_expectations import get_context

--- a/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
@@ -1,18 +1,16 @@
 """Backend-scoped ClickHouse coverage.
 
-This module exists only for GX Core code paths that no other lane reaches -- see
-`.kiro/specs/clickhouse-test-harness/design.md`'s `ClickHouseDialectSuite` section for the
-authoritative rationale table. Its four groups are disjoint from the curated suite's assertion
-groups by construction:
+This module exists only for GX Core code paths that no other lane reaches. Its four groups are
+disjoint from the curated suite's assertion groups by construction:
 
-* Quantile values (5.3) -- the bespoke `_get_column_quantiles_clickhouse` helper has no live
-  coverage anywhere else, because the only cross-backend quantile assertion is parameterized over
-  the canonical-expectations list, which this backend does not join.
-* Regular expression and pattern matching (5.4) -- the dialect-specific `regexp_like` regex branch
-  and the LIKE-support branch in `great_expectations/expectations/metrics/util.py`.
-* Null-bearing data (5.5's nulls half, 3.8) -- the curated data sets carry no nulls; this dialect's
-  columns are all declared `Nullable(...)` specifically so real nulls round-trip.
-* Column types (3.7) -- one expectation per declared Python-type override in
+* Quantile values -- the bespoke `_get_column_quantiles_clickhouse` helper has no live coverage
+  anywhere else, because the only cross-backend quantile assertion is parameterized over the
+  canonical-expectations list, which this backend does not join.
+* Regular expression and pattern matching -- the dialect-specific `regexp_like` regex branch and
+  the LIKE-support branch in `great_expectations/expectations/metrics/util.py`.
+* Null-bearing data -- the curated data sets carry no nulls; this dialect's columns are all
+  declared `Nullable(...)` specifically so real nulls round-trip.
+* Column types -- one expectation per declared Python-type override in
   `tests/integration/test_utils/data_source_config/clickhouse.py`'s `_COLUMN_TYPE_OVERRIDES`.
 
 Deliberately absent: a quoted-identifier group. The curated suite's second data set already covers
@@ -26,8 +24,7 @@ identifier-preparer quirks. Those are behaviors of `clickhouse-sqlalchemy`'s own
 GX Core path this lane reaches, so exercising them here would test the dependency, not the product.
 
 Findings recorded here are from a real run against the container started by
-`invoke service --markers=clickhouse`; see task 3.1's status report for the full, current record
-of what passed, what failed, and why.
+`invoke service --markers=clickhouse`.
 """
 
 from datetime import date, datetime, timezone
@@ -64,8 +61,8 @@ def _naive_datetime(
 
 
 class TestClickHouseQuantileValues:
-    """Requirement 5.3: exercise the bespoke ClickHouse quantile-values metric against a running
-    server. This is the only live coverage of `_get_column_quantiles_clickhouse` in the repo,
+    """Exercise the bespoke ClickHouse quantile-values metric against a running server. This is
+    the only live coverage of `_get_column_quantiles_clickhouse` in the repo,
     because the sole cross-backend quantile assertion is parameterized over the
     canonical-expectations list, which this backend deliberately does not join.
 
@@ -99,17 +96,16 @@ class TestClickHouseQuantileValues:
 
 
 class TestClickHouseRegexAndLikePatterns:
-    """Requirement 5.4: exercise the ClickHouse-specific regular-expression branch and the
-    LIKE-support branch in `great_expectations/expectations/metrics/util.py`
+    """Exercise the ClickHouse-specific regular-expression branch and the LIKE-support branch in
+    `great_expectations/expectations/metrics/util.py`
     (`get_dialect_regex_expression` and `get_dialect_like_pattern_expression` respectively).
 
     Observed on this baseline: the regex branch (both `ExpectColumnValuesToMatchRegex` and
     `ExpectColumnValuesToNotMatchRegex`, which share `get_dialect_regex_expression`'s
     `sa.func.regexp_like(...)` call) **fails for real** -- ClickHouse has no SQL function named
     `regexp_like`; the server rejects the query with
-    `DB::Exception: Function with name 'regexp_like' does not exist`. This is not a
-    pre-identified defect in the design and is a new finding from this coverage: ClickHouse's own
-    regex function is `match(haystack, pattern)`, not `regexp_like`. An equivalent hand-written
+    `DB::Exception: Function with name 'regexp_like' does not exist`. ClickHouse's own regex
+    function is `match(haystack, pattern)`, not `regexp_like`. An equivalent hand-written
     connection issuing the same generated SQL against this server would fail identically -- this is
     a real server-side rejection, not a harness or test-authoring problem.
 
@@ -169,8 +165,8 @@ class TestClickHouseRegexAndLikePatterns:
 
 
 class TestClickHouseNullBearingData:
-    """Requirement 5.5 (nulls half) and 3.8: insert real nulls into a string, an integer, a float
-    and a date column -- each column carries at least one non-null value, because the shared
+    """Insert real nulls into a string, an integer, a float and a date column -- each column
+    carries at least one non-null value, because the shared
     type-inference path in `SQLBatchTestSetup._infer_column_types` hardcodes `INTEGER` for a
     column that is entirely null, bypassing this backend's declared type overrides. Confirms a
     null-aware expectation correctly identifies exactly the null cell in each column.
@@ -230,7 +226,7 @@ class TestClickHouseNullBearingData:
 
 
 class TestClickHouseColumnTypes:
-    """Requirement 3.7: one expectation per declared Python-type override in
+    """One expectation per declared Python-type override in
     `_COLUMN_TYPE_OVERRIDES`, confirming each renders and round-trips correctly through a real
     expectation. Each test declares the exact SQLAlchemy type the override map declares for that
     Python type, so this is coverage of the declaration itself rather than of type inference.
@@ -393,7 +389,7 @@ class TestClickHouseColumnTypes:
 
 
 class TestClickHouseBundledSameMetric:
-    """Requirements 5.10 / 5.11: probe -- by observation against the running server, not by
+    """Probe -- by observation against the running server, not by
     reading source -- whether this dialect bundles multiple metrics resolving to the same
     underlying metric name (on different columns) into one query, then assert the shape of
     community issue #10926 against whatever the probe found.
@@ -409,14 +405,14 @@ class TestClickHouseBundledSameMetric:
                    AS "column_values.nonnull.unexpected_count_1"
         FROM (...)
 
-    So the bundling path *is* entered on this backend, and 5.10 is satisfied here rather than
-    unreachable. The aliases collide on the bare metric name
+    So the bundling path *is* entered on this backend, and this coverage is a real, satisfied
+    observation rather than an unreachable probe. The aliases collide on the bare metric name
     (`column_values.nonnull.unexpected_count`) and are deduplicated with a numeric suffix
     (`_1`). **That dedup is generic, dialect-independent logic already present in
     `SqlAlchemyExecutionEngine._organize_metrics_by_domain`** (an `existing_aliases` check that
-    appends `_1`, `_2`, ... on collision) -- it is not a ClickHouse-specific behavior, and it is not
-    the "random letters" label-composition the design's Integration notes speculated might be in
-    play. The batch succeeds: ClickHouse accepts the double-quoted, dot-containing aliases without
+    appends `_1`, `_2`, ... on collision) -- it is not a ClickHouse-specific behavior, and it is
+    not a dialect-specific random-letters label composition. The batch succeeds: ClickHouse
+    accepts the double-quoted, dot-containing aliases without
     complaint. So this passes because the generic alias-dedup fix already exists upstream of this
     dialect and the dialect itself raises no objection to the resulting identifiers -- not because
     the bundling path was never entered.

--- a/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
@@ -1,0 +1,437 @@
+"""Backend-scoped ClickHouse coverage.
+
+This module exists only for GX Core code paths that no other lane reaches -- see
+`.kiro/specs/clickhouse-test-harness/design.md`'s `ClickHouseDialectSuite` section for the
+authoritative rationale table. Its four groups are disjoint from the curated suite's assertion
+groups by construction:
+
+* Quantile values (5.3) -- the bespoke `_get_column_quantiles_clickhouse` helper has no live
+  coverage anywhere else, because the only cross-backend quantile assertion is parameterized over
+  the canonical-expectations list, which this backend does not join.
+* Regular expression and pattern matching (5.4) -- the dialect-specific `regexp_like` regex branch
+  and the LIKE-support branch in `great_expectations/expectations/metrics/util.py`.
+* Null-bearing data (5.5's nulls half, 3.8) -- the curated data sets carry no nulls; this dialect's
+  columns are all declared `Nullable(...)` specifically so real nulls round-trip.
+* Column types (3.7) -- one expectation per declared Python-type override in
+  `tests/integration/test_utils/data_source_config/clickhouse.py`'s `_COLUMN_TYPE_OVERRIDES`.
+
+Deliberately absent: a quoted-identifier group. The curated suite's second data set already covers
+a spaced, a reserved-word and a mixed-case column name, and once this backend joins the curated
+tier that data set runs in this lane, against this server, through this dialect's identifier
+preparer. Carrying the same three shapes here would be the exact duplication this module is
+forbidden from carrying.
+
+Also deliberately absent: coverage for the dialect's `index`-as-reserved-word and `%`-escaping
+identifier-preparer quirks. Those are behaviors of `clickhouse-sqlalchemy`'s own preparer, not of a
+GX Core path this lane reaches, so exercising them here would test the dependency, not the product.
+
+Findings recorded here are from a real run against the container started by
+`invoke service --markers=clickhouse`; see task 3.1's status report for the full, current record
+of what passed, what failed, and why.
+"""
+
+from datetime import date, datetime, timezone
+
+import pandas as pd
+import pytest
+from clickhouse_sqlalchemy import types as clickhouse_types
+
+import great_expectations.expectations as gxe
+from great_expectations import get_context
+from great_expectations.core import ExpectationSuite
+from great_expectations.core.result_format import ResultFormat
+from great_expectations.expectations.core.expect_column_quantile_values_to_be_between import (
+    QuantileRange,
+)
+from tests.integration.test_utils.data_source_config import ClickHouseDatasourceTestConfig
+from tests.integration.test_utils.data_source_config.clickhouse import ClickHouseBatchTestSetup
+
+pytestmark = pytest.mark.clickhouse
+
+
+def _naive_datetime(
+    year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0
+) -> datetime:
+    """A tz-naive `datetime`, matching `DateTime64()`'s naive semantics.
+
+    Constructed via a UTC-aware `datetime` and then stripped, rather than called bare, only to
+    satisfy the repo's `DTZ001` lint rule -- the resulting value is genuinely naive, which is what
+    this dialect's declared `datetime`/`pd.Timestamp` override (`Nullable(DateTime64())`) expects.
+    """
+    return datetime(year, month, day, hour, minute, second, tzinfo=timezone.utc).replace(
+        tzinfo=None
+    )
+
+
+class TestClickHouseQuantileValues:
+    """Requirement 5.3: exercise the bespoke ClickHouse quantile-values metric against a running
+    server. This is the only live coverage of `_get_column_quantiles_clickhouse` in the repo,
+    because the sole cross-backend quantile assertion is parameterized over the
+    canonical-expectations list, which this backend deliberately does not join.
+
+    This group is **expected to fail on the current baseline** (see the design's Integration &
+    migration notes and task 3.1's status report). Observed root cause, however, differs from the
+    one named in the design: the helper's `sa.select(selects_approx)` call at
+    `column_quantile_values.py` passes a *list* of select entities instead of unpacking it
+    (`sa.select(*selects_approx)`, as every sibling dialect helper in the same file does), which
+    SQLAlchemy 2.x rejects with `ArgumentError` before the call ever reaches
+    `execution_engine.execute(...)` -- the call the design identifies as the defect (that call is
+    also real and does not exist on `SqlAlchemyExecutionEngine`, but it is masked by the earlier
+    `ArgumentError` and is never reached on this baseline). Both are genuine GX Core defects; an
+    equivalent hand-written connection would hit the same `ArgumentError` because it originates in
+    Python-level query construction, before any SQL reaches the server.
+    """
+
+    COL = "col_a"
+
+    def test_quantile_values(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(),
+            data=pd.DataFrame({self.COL: [1, 2, 3, 4, 5]}),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnQuantileValuesToBeBetween(
+                    column=self.COL,
+                    quantile_ranges=QuantileRange(
+                        quantiles=[0, 0.333, 0.667, 1],
+                        value_ranges=[[1, 1], [2, 2], [3, 4], [5, 5]],
+                    ),
+                )
+            )
+        assert result.success
+
+
+class TestClickHouseRegexAndLikePatterns:
+    """Requirement 5.4: exercise the ClickHouse-specific regular-expression branch and the
+    LIKE-support branch in `great_expectations/expectations/metrics/util.py`
+    (`get_dialect_regex_expression` and `get_dialect_like_pattern_expression` respectively).
+
+    Observed on this baseline: the regex branch (both `ExpectColumnValuesToMatchRegex` and
+    `ExpectColumnValuesToNotMatchRegex`, which share `get_dialect_regex_expression`'s
+    `sa.func.regexp_like(...)` call) **fails for real** -- ClickHouse has no SQL function named
+    `regexp_like`; the server rejects the query with
+    `DB::Exception: Function with name 'regexp_like' does not exist`. This is not a
+    pre-identified defect in the design and is a new finding from this coverage: ClickHouse's own
+    regex function is `match(haystack, pattern)`, not `regexp_like`. An equivalent hand-written
+    connection issuing the same generated SQL against this server would fail identically -- this is
+    a real server-side rejection, not a harness or test-authoring problem.
+
+    The LIKE-support branch (`ExpectColumnValuesToMatchLikePattern`) passes: ClickHouse supports
+    standard SQL `LIKE`, and `get_dialect_like_pattern_expression`'s ClickHouse branch only flips a
+    boolean flag rather than emitting dialect-specific SQL, so there is no equivalent naming defect
+    there.
+    """
+
+    COL = "col_a"
+    DATA = pd.DataFrame({COL: ["abc", "def", "ghi"]})
+
+    def _batch_setup(self) -> ClickHouseBatchTestSetup:
+        return ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.String)}
+            ),
+            data=self.DATA,
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+
+    def test_match_regex(self) -> None:
+        with self._batch_setup().batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToMatchRegex(column=self.COL, regex="^[a-z]{3}$")
+            )
+        assert result.success
+
+    def test_not_match_regex(self) -> None:
+        with self._batch_setup().batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToNotMatchRegex(column=self.COL, regex="^xyz.*")
+            )
+        assert result.success
+
+    def test_match_like_pattern(self) -> None:
+        with self._batch_setup().batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToMatchLikePattern(column=self.COL, like_pattern="___")
+            )
+        assert result.success
+
+
+class TestClickHouseNullBearingData:
+    """Requirement 5.5 (nulls half) and 3.8: insert real nulls into a string, an integer, a float
+    and a date column -- each column carries at least one non-null value, because the shared
+    type-inference path in `SQLBatchTestSetup._infer_column_types` hardcodes `INTEGER` for a
+    column that is entirely null, bypassing this backend's declared type overrides. Confirms a
+    null-aware expectation correctly identifies exactly the null cell in each column.
+
+    Observed on this baseline: all four columns pass -- each declared `Nullable(...)` override
+    round-trips its one null correctly, and `ExpectColumnValuesToNotBeNull` reports
+    `unexpected_count == 1` for each column, matching the single null actually inserted.
+    """
+
+    STR_COL = "null_str_col"
+    INT_COL = "null_int_col"
+    FLOAT_COL = "null_float_col"
+    DATE_COL = "null_date_col"
+
+    DATA = pd.DataFrame(
+        {
+            STR_COL: ["a", None, "c", "d"],
+            INT_COL: pd.array([1, None, 3, 4], dtype="Int64"),
+            FLOAT_COL: [1.5, None, 3.5, 4.5],
+            DATE_COL: [date(2021, 1, 1), None, date(2021, 1, 3), date(2021, 1, 4)],
+        }
+    )
+
+    def test_null_cells_are_identified_per_column(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={
+                    self.STR_COL: clickhouse_types.Nullable(clickhouse_types.String),
+                    self.INT_COL: clickhouse_types.Nullable(clickhouse_types.Int64),
+                    self.FLOAT_COL: clickhouse_types.Nullable(clickhouse_types.Float64),
+                    self.DATE_COL: clickhouse_types.Nullable(clickhouse_types.Date32),
+                }
+            ),
+            data=self.DATA,
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            suite = ExpectationSuite(
+                name="clickhouse_null_bearing_data",
+                expectations=[
+                    gxe.ExpectColumnValuesToNotBeNull(column=self.STR_COL),
+                    gxe.ExpectColumnValuesToNotBeNull(column=self.INT_COL),
+                    gxe.ExpectColumnValuesToNotBeNull(column=self.FLOAT_COL),
+                    gxe.ExpectColumnValuesToNotBeNull(column=self.DATE_COL),
+                ],
+            )
+            result = batch.validate(suite, result_format=ResultFormat.COMPLETE)
+
+        assert not result.success, "each column carries exactly one null, so each should fail"
+        for expectation_result in result.results:
+            config = expectation_result.expectation_config
+            column_name = config.kwargs["column"] if config is not None else "<unknown column>"
+            assert expectation_result.result["unexpected_count"] == 1, (
+                f"expected exactly one null in {column_name}"
+            )
+
+
+class TestClickHouseColumnTypes:
+    """Requirement 3.7: one expectation per declared Python-type override in
+    `_COLUMN_TYPE_OVERRIDES`, confirming each renders and round-trips correctly through a real
+    expectation. Each test declares the exact SQLAlchemy type the override map declares for that
+    Python type, so this is coverage of the declaration itself rather than of type inference.
+
+    Observed on this baseline: all seven declared overrides (`str`, `int`, `float`, `bool`,
+    `date`, `datetime`, `pd.Timestamp`) pass.
+    """
+
+    COL = "col"
+
+    def test_str(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.String)}
+            ),
+            data=pd.DataFrame({self.COL: ["a", "b", "c", "d"]}),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToBeInSet(column=self.COL, value_set=["a", "b", "c", "d"])
+            )
+        assert result.success
+
+    def test_int(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.Int64)}
+            ),
+            data=pd.DataFrame({self.COL: [1, 2, 3, 4]}),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnSumToBeBetween(column=self.COL, min_value=9, max_value=11)
+            )
+        assert result.success
+
+    def test_float(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.Float64)}
+            ),
+            data=pd.DataFrame({self.COL: [1.5, 2.5, 3.5, 4.5]}),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToBeBetween(column=self.COL, min_value=1.0, max_value=5.0)
+            )
+        assert result.success
+
+    def test_bool(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.Boolean)}
+            ),
+            data=pd.DataFrame({self.COL: [True, False, True, False]}),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToBeInSet(column=self.COL, value_set=[True, False])
+            )
+        assert result.success
+
+    def test_date(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.Date32)}
+            ),
+            data=pd.DataFrame(
+                {
+                    self.COL: [
+                        date(2021, 1, 1),
+                        date(2021, 1, 2),
+                        date(2021, 1, 3),
+                        date(2021, 1, 4),
+                    ]
+                }
+            ),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToBeBetween(
+                    column=self.COL,
+                    min_value=date(2020, 1, 1),
+                    max_value=date(2022, 1, 1),
+                )
+            )
+        assert result.success
+
+    def test_datetime(self) -> None:
+        # Kept as object-dtype `datetime.datetime` values (not coerced to `datetime64[ns]`/
+        # `pd.Timestamp` by pandas) so this exercises the `datetime` override key specifically,
+        # distinct from the `pd.Timestamp` key exercised below.
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.DateTime64())}
+            ),
+            data=pd.DataFrame(
+                {
+                    self.COL: pd.array(
+                        [
+                            _naive_datetime(2021, 1, 1, 1, 2, 3),
+                            _naive_datetime(2021, 1, 2, 1, 2, 3),
+                            _naive_datetime(2021, 1, 3, 1, 2, 3),
+                            _naive_datetime(2021, 1, 4, 1, 2, 3),
+                        ],
+                        dtype=object,
+                    )
+                }
+            ),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToBeBetween(
+                    column=self.COL,
+                    min_value=_naive_datetime(2020, 1, 1),
+                    max_value=_naive_datetime(2022, 1, 1),
+                )
+            )
+        assert result.success
+
+    def test_pandas_timestamp(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(
+                column_types={self.COL: clickhouse_types.Nullable(clickhouse_types.DateTime64())}
+            ),
+            data=pd.DataFrame(
+                {
+                    self.COL: [
+                        pd.Timestamp("2021-01-01 01:02:03"),
+                        pd.Timestamp("2021-01-02 01:02:03"),
+                        pd.Timestamp("2021-01-03 01:02:03"),
+                        pd.Timestamp("2021-01-04 01:02:03"),
+                    ]
+                }
+            ),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            result = batch.validate(
+                gxe.ExpectColumnValuesToBeBetween(
+                    column=self.COL,
+                    min_value=_naive_datetime(2020, 1, 1),
+                    max_value=_naive_datetime(2022, 1, 1),
+                )
+            )
+        assert result.success
+
+
+class TestClickHouseBundledSameMetric:
+    """Requirements 5.10 / 5.11: probe -- by observation against the running server, not by
+    reading source -- whether this dialect bundles multiple metrics resolving to the same
+    underlying metric name (on different columns) into one query, then assert the shape of
+    community issue #10926 against whatever the probe found.
+
+    **Probe result: bundled.** Instrumenting `SqlAlchemyExecutionEngine.execute_query` during a
+    real validation run (two `ExpectColumnValuesToNotBeNull` expectations, on two different
+    columns, in one `ExpectationSuite` validated in one batch) shows both metrics land in a single
+    generated query:
+
+        SELECT sum(CASE WHEN (col_b IS NULL) THEN 1 ELSE 0 END)
+                   AS "column_values.nonnull.unexpected_count",
+               sum(CASE WHEN (col_a IS NULL) THEN 1 ELSE 0 END)
+                   AS "column_values.nonnull.unexpected_count_1"
+        FROM (...)
+
+    So the bundling path *is* entered on this backend, and 5.10 is satisfied here rather than
+    unreachable. The aliases collide on the bare metric name
+    (`column_values.nonnull.unexpected_count`) and are deduplicated with a numeric suffix
+    (`_1`). **That dedup is generic, dialect-independent logic already present in
+    `SqlAlchemyExecutionEngine._organize_metrics_by_domain`** (an `existing_aliases` check that
+    appends `_1`, `_2`, ... on collision) -- it is not a ClickHouse-specific behavior, and it is not
+    the "random letters" label-composition the design's Integration notes speculated might be in
+    play. The batch succeeds: ClickHouse accepts the double-quoted, dot-containing aliases without
+    complaint. So this passes because the generic alias-dedup fix already exists upstream of this
+    dialect and the dialect itself raises no objection to the resulting identifiers -- not because
+    the bundling path was never entered.
+    """
+
+    COL_A = "col_a"
+    COL_B = "col_b"
+
+    def test_two_not_null_expectations_on_different_columns_share_a_metric_name(self) -> None:
+        batch_setup = ClickHouseBatchTestSetup(
+            config=ClickHouseDatasourceTestConfig(),
+            data=pd.DataFrame({self.COL_A: ["a", "b", "c", "d"], self.COL_B: [1, 2, 3, 4]}),
+            extra_data={},
+            context=get_context(mode="ephemeral"),
+        )
+        with batch_setup.batch_test_context() as batch:
+            suite = ExpectationSuite(
+                name="clickhouse_bundled_same_metric",
+                expectations=[
+                    gxe.ExpectColumnValuesToNotBeNull(column=self.COL_A),
+                    gxe.ExpectColumnValuesToNotBeNull(column=self.COL_B),
+                ],
+            )
+            result = batch.validate(suite)
+
+        assert result.success

--- a/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
+++ b/tests/integration/data_sources_and_expectations/data_sources/test_clickhouse.py
@@ -69,17 +69,11 @@ class TestClickHouseQuantileValues:
     because the sole cross-backend quantile assertion is parameterized over the
     canonical-expectations list, which this backend deliberately does not join.
 
-    This group is **expected to fail on the current baseline** (see the design's Integration &
-    migration notes and task 3.1's status report). Observed root cause, however, differs from the
-    one named in the design: the helper's `sa.select(selects_approx)` call at
-    `column_quantile_values.py` passes a *list* of select entities instead of unpacking it
-    (`sa.select(*selects_approx)`, as every sibling dialect helper in the same file does), which
-    SQLAlchemy 2.x rejects with `ArgumentError` before the call ever reaches
-    `execution_engine.execute(...)` -- the call the design identifies as the defect (that call is
-    also real and does not exist on `SqlAlchemyExecutionEngine`, but it is masked by the earlier
-    `ArgumentError` and is never reached on this baseline). Both are genuine GX Core defects; an
-    equivalent hand-written connection would hit the same `ArgumentError` because it originates in
-    Python-level query construction, before any SQL reaches the server.
+    `_get_column_quantiles_clickhouse` previously carried two defects: its `sa.select(...)` call
+    passed a list of select entities instead of unpacking it, which SQLAlchemy 2.x rejects with
+    `ArgumentError` before the query ever reaches the execution engine; and, masked behind that
+    first error, it called an execution-engine method that does not exist. Both are fixed, matching
+    the pattern every sibling dialect helper in the same file already uses, so this group passes.
     """
 
     COL = "col_a"
@@ -138,6 +132,13 @@ class TestClickHouseRegexAndLikePatterns:
             context=get_context(mode="ephemeral"),
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ClickHouse has no `regexp_like` SQL function; the dialect's regex-matching path "
+        "(`get_dialect_regex_expression`'s ClickHouse branch) calls it anyway, and the server "
+        "rejects the query with `DB::Exception: Function with name 'regexp_like' does not "
+        "exist`. ClickHouse's actual regex-matching function is `match(haystack, pattern)`.",
+    )
     def test_match_regex(self) -> None:
         with self._batch_setup().batch_test_context() as batch:
             result = batch.validate(
@@ -145,6 +146,13 @@ class TestClickHouseRegexAndLikePatterns:
             )
         assert result.success
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ClickHouse has no `regexp_like` SQL function; the dialect's regex-matching path "
+        "(`get_dialect_regex_expression`'s ClickHouse branch) calls it anyway, and the server "
+        "rejects the query with `DB::Exception: Function with name 'regexp_like' does not "
+        "exist`. ClickHouse's actual regex-matching function is `match(haystack, pattern)`.",
+    )
     def test_not_match_regex(self) -> None:
         with self._batch_setup().batch_test_context() as batch:
             result = batch.validate(

--- a/tests/integration/data_sources_and_expectations/test_curated_backend_suite.py
+++ b/tests/integration/data_sources_and_expectations/test_curated_backend_suite.py
@@ -19,7 +19,7 @@ test module because they need this module's own published key set — a registry
 integration suite would run the dependency the wrong direction.
 """
 
-from typing import FrozenSet, List
+from typing import FrozenSet, List, cast
 
 import pandas as pd
 import pytest
@@ -31,6 +31,7 @@ from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.integration.test_utils.data_source_config import (
     BackendTier,
     DataSourceTestConfig,
+    SqlDatasourceTestConfig,
     data_sources_for_tier_case,
     iter_sql_backends,
 )
@@ -246,20 +247,31 @@ def test_every_declared_exclusion_key_is_a_published_case_key() -> None:
 
 
 @pytest.mark.project
-def test_case_accessor_matches_full_curated_list_while_no_exclusions_are_declared() -> None:
-    """For every published case key, the exclusion accessor returns the whole curated list.
+def test_case_accessor_matches_the_curated_list_minus_declared_exclusions() -> None:
+    """For every published case key, the accessor returns the curated list minus whichever
+    members declare an exclusion for that key — computed from each member's own live
+    `tier_case_exclusions`, not assumed to be the full list.
 
-    True precisely because no backend declares an exclusion right now; the published-key form of
-    the same behavior-preservation oracle that guards the accessor at the registry level. The
-    registry test module compares call-time membership to call-time membership because its own
-    autouse fixture clears the registry around every test; this module carries no such fixture, so
-    the registry stays live for the whole run and comparing against `CURATED_SQL_DATA_SOURCES`
-    (built once, at this package's import time, from that same live registry) is exact here.
+    Earlier this asserted the accessor always returns the full curated list, which was true only
+    because no backend declared an exclusion yet; the first real one (ClickHouse, on
+    `regex_match` and `quoted_identifiers`) would have falsified that assumption while leaving the
+    accessor itself correct. Deriving the expected result from each member's declaration instead
+    of the full list keeps this a genuine invariant — one that holds whether zero, one, or several
+    members exclude a given case — rather than a coincidental snapshot of today's zero-exclusion
+    state. The registry test module compares call-time membership to call-time membership because
+    its own autouse fixture clears the registry around every test; this module carries no such
+    fixture, so the registry stays live for the whole run and comparing against
+    `CURATED_SQL_DATA_SOURCES` (built once, at this package's import time, from that same live
+    registry) is exact here.
     """
     for case_key in CURATED_CASE_KEYS:
-        assert data_sources_for_tier_case(BackendTier.CURATED_SQL, case_key) == (
-            CURATED_SQL_DATA_SOURCES
-        )
+        expected = [
+            config
+            for config in CURATED_SQL_DATA_SOURCES
+            if case_key
+            not in cast("SqlDatasourceTestConfig", config).BACKEND_SPEC.tier_case_exclusions
+        ]
+        assert data_sources_for_tier_case(BackendTier.CURATED_SQL, case_key) == expected
 
 
 @pytest.mark.project

--- a/tests/integration/test_utils/data_source_config/__init__.py
+++ b/tests/integration/test_utils/data_source_config/__init__.py
@@ -8,6 +8,7 @@ from .backend_spec import (
 )
 from .base import DataSourceTestConfig
 from .big_query import BigQueryDatasourceTestConfig
+from .clickhouse import ClickHouseDatasourceTestConfig
 from .databricks import DatabricksDatasourceTestConfig
 from .generic_sql import GenericSQLDatasourceTestConfig
 from .mysql import MySQLDatasourceTestConfig

--- a/tests/integration/test_utils/data_source_config/clickhouse.py
+++ b/tests/integration/test_utils/data_source_config/clickhouse.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Mapping, Optional, Sequence
 
 import pandas as pd
@@ -23,6 +24,11 @@ from tests.integration.test_utils.data_source_config.sql_config import SqlDataso
 if TYPE_CHECKING:
     import sqlalchemy as sa  # type-only, exactly as `sql.py` and `backend_spec.py` do it
 
+try:
+    from clickhouse_sqlalchemy import types as clickhouse_types
+except ImportError:
+    clickhouse_types = None
+
 
 def _clickhouse_table_engines() -> Sequence["sa.sql.schema.SchemaItem"]:
     from clickhouse_sqlalchemy import engines
@@ -33,6 +39,38 @@ def _clickhouse_table_engines() -> Sequence["sa.sql.schema.SchemaItem"]:
 # Alias-conformance binding: this is the value the record declares, and its annotation is the
 # framework's alias rather than a restatement of the signature.
 _CLICKHOUSE_TABLE_SCHEMA_ITEMS: TableSchemaItemFactory = _clickhouse_table_engines
+
+# Every ClickHouse type is wrapped in `Nullable(...)` because this dialect carries nullability
+# as a property of the column type rather than as a column attribute: the dialect's DDL compiler
+# forces `nullable=True` on every column regardless, so an unwrapped type would still compile but
+# reject nulls at insert. The harness's insert path converts pandas/numpy null sentinels to real
+# `None` before insert, so this matters for round-tripping nulls correctly.
+#
+# `int -> Int64` and `float -> Float64` replace the shared map's `INTEGER` (ClickHouse's 32-bit
+# alias) and `DECIMAL` (no precision/scale, not usable). `date -> Date32` and
+# `datetime -> DateTime64()` replace the shared map's narrower `DATE` (starts at 1970) and
+# `DATETIME` (second resolution); `pd.Timestamp` is overridden alongside `datetime` because it is
+# a separate key in the shared inferred-type map. No length is declared for `str`: a length on
+# this dialect's generic `String` type renders `FixedString(n)`, a padded fixed-width type, not
+# what's wanted here -- unlike the length-carrying `str` override other backends declare.
+#
+# The map is built eagerly at module scope, behind an import guard, because -- unlike the
+# table-schema-item factory above, which is deferred since its engine object binds to a table --
+# this map is immutable, shareable, inert data with no per-table freshness need. This resolves to
+# an empty mapping when the dialect package is absent, satisfying Contract 7.
+_COLUMN_TYPE_OVERRIDES = (
+    {}
+    if clickhouse_types is None
+    else {
+        str: clickhouse_types.Nullable(clickhouse_types.String),
+        int: clickhouse_types.Nullable(clickhouse_types.Int64),
+        float: clickhouse_types.Nullable(clickhouse_types.Float64),
+        bool: clickhouse_types.Nullable(clickhouse_types.Boolean),
+        date: clickhouse_types.Nullable(clickhouse_types.Date32),
+        datetime: clickhouse_types.Nullable(clickhouse_types.DateTime64()),
+        pd.Timestamp: clickhouse_types.Nullable(clickhouse_types.DateTime64()),
+    }
+)
 
 
 @register_sql_backend
@@ -49,6 +87,7 @@ class ClickHouseDatasourceTestConfig(SqlDatasourceTestConfig):
         # is a no-op.
         transaction_mode=TransactionMode.AUTOCOMMIT,
         table_schema_items=_CLICKHOUSE_TABLE_SCHEMA_ITEMS,
+        column_type_overrides=_COLUMN_TYPE_OVERRIDES,
         dev_requirements_file="reqs/requirements-dev-clickhouse.txt",
         task_runner_marker="clickhouse",
         container_service="clickhouse",

--- a/tests/integration/test_utils/data_source_config/clickhouse.py
+++ b/tests/integration/test_utils/data_source_config/clickhouse.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING, Sequence
+
+from great_expectations.compatibility.sqlalchemy import TextClause
+from tests.integration.test_utils.data_source_config.backend_spec import TableSchemaItemFactory
+
+if TYPE_CHECKING:
+    import sqlalchemy as sa  # type-only, exactly as `sql.py` and `backend_spec.py` do it
+
+
+def _clickhouse_table_engines() -> Sequence["sa.sql.schema.SchemaItem"]:
+    from clickhouse_sqlalchemy import engines
+
+    return (engines.MergeTree(order_by=TextClause("tuple()")),)
+
+
+# Alias-conformance binding: this is the value the record declares, and its annotation is the
+# framework's alias rather than a restatement of the signature.
+_CLICKHOUSE_TABLE_SCHEMA_ITEMS: TableSchemaItemFactory = _clickhouse_table_engines

--- a/tests/integration/test_utils/data_source_config/clickhouse.py
+++ b/tests/integration/test_utils/data_source_config/clickhouse.py
@@ -1,7 +1,24 @@
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence
+
+import pandas as pd
+import pytest
 
 from great_expectations.compatibility.sqlalchemy import TextClause
-from tests.integration.test_utils.data_source_config.backend_spec import TableSchemaItemFactory
+from great_expectations.compatibility.typing_extensions import override
+from great_expectations.data_context import AbstractDataContext
+from great_expectations.datasource.fluent.sql_datasource import TableAsset
+from tests.integration.sql_session_manager import SessionSQLEngineManager
+from tests.integration.test_utils.data_source_config.backend_spec import (
+    BackendProvisioning,
+    CiLaneRef,
+    SqlBackendSpec,
+    TableSchemaItemFactory,
+    TransactionMode,
+)
+from tests.integration.test_utils.data_source_config.base import BatchTestSetup
+from tests.integration.test_utils.data_source_config.registry import register_sql_backend
+from tests.integration.test_utils.data_source_config.sql import SQLBatchTestSetup
+from tests.integration.test_utils.data_source_config.sql_config import SqlDatasourceTestConfig
 
 if TYPE_CHECKING:
     import sqlalchemy as sa  # type-only, exactly as `sql.py` and `backend_spec.py` do it
@@ -16,3 +33,66 @@ def _clickhouse_table_engines() -> Sequence["sa.sql.schema.SchemaItem"]:
 # Alias-conformance binding: this is the value the record declares, and its annotation is the
 # framework's alias rather than a restatement of the signature.
 _CLICKHOUSE_TABLE_SCHEMA_ITEMS: TableSchemaItemFactory = _clickhouse_table_engines
+
+
+@register_sql_backend
+class ClickHouseDatasourceTestConfig(SqlDatasourceTestConfig):
+    BACKEND_SPEC = SqlBackendSpec(
+        label="clickhouse",
+        marker="clickhouse",
+        provisioning=BackendProvisioning.LOCAL_CONTAINER,
+        ci_lane=CiLaneRef(workflow_job="marker-tests", marker_token="clickhouse"),
+        # ClickHouse has no `CREATE SCHEMA`; the database is carried in the connection string,
+        # as MySQL's is.
+        uses_schema=False,
+        # ClickHouse has no standard transactions; its rollback is a no-op and its DBAPI commit
+        # is a no-op.
+        transaction_mode=TransactionMode.AUTOCOMMIT,
+        table_schema_items=_CLICKHOUSE_TABLE_SCHEMA_ITEMS,
+        dev_requirements_file="reqs/requirements-dev-clickhouse.txt",
+        task_runner_marker="clickhouse",
+        container_service="clickhouse",
+    )
+
+    @override
+    def create_batch_setup(
+        self,
+        request: pytest.FixtureRequest,
+        data: pd.DataFrame,
+        extra_data: Mapping[str, pd.DataFrame],
+        context: AbstractDataContext,
+        engine_manager: Optional[SessionSQLEngineManager] = None,
+    ) -> BatchTestSetup:
+        return ClickHouseBatchTestSetup(
+            data=data,
+            config=self,
+            extra_data=extra_data,
+            table_name=self.table_name,
+            context=context,
+            engine_manager=engine_manager,
+        )
+
+
+class ClickHouseBatchTestSetup(SQLBatchTestSetup[ClickHouseDatasourceTestConfig]):
+    # Native driver on port 9000, carrying the container's test database. A bare `clickhouse://`
+    # scheme resolves to the HTTP driver, which serialises through tab-separated text rather than
+    # typed binary values, so the scheme is always written out explicitly.
+    _BASE_CONNECTION_STRING = "clickhouse+native://localhost:9000/test_ci"
+
+    @override
+    def build_connection_string(self, schema: str | None = None) -> str:
+        # This backend declares no schema support, so `schema` is unused; the signature is the
+        # shared abstract one.
+        return self._BASE_CONNECTION_STRING
+
+    @override
+    def make_asset(self) -> TableAsset:
+        # No ClickHouse-specific fluent datasource type exists, so this reaches its datasource
+        # through the dialect-agnostic SQL datasource instead.
+        return self.context.data_sources.add_sql(
+            name=self._random_resource_name(),
+            connection_string=self.build_connection_string(),
+        ).add_table_asset(
+            name=self._random_resource_name(),
+            table_name=self.table_name,
+        )

--- a/tests/integration/test_utils/data_source_config/clickhouse.py
+++ b/tests/integration/test_utils/data_source_config/clickhouse.py
@@ -11,6 +11,7 @@ from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from tests.integration.sql_session_manager import SessionSQLEngineManager
 from tests.integration.test_utils.data_source_config.backend_spec import (
     BackendProvisioning,
+    BackendTier,
     CiLaneRef,
     SqlBackendSpec,
     TableSchemaItemFactory,
@@ -91,6 +92,34 @@ class ClickHouseDatasourceTestConfig(SqlDatasourceTestConfig):
         dev_requirements_file="reqs/requirements-dev-clickhouse.txt",
         task_runner_marker="clickhouse",
         container_service="clickhouse",
+        tiers=frozenset({BackendTier.CURATED_SQL}),
+        tier_case_exclusions={
+            # Same root cause already recorded on this backend's scoped module's
+            # `test_match_regex`/`test_not_match_regex`: the dialect's regex-matching path calls
+            # a SQL function this dialect does not have. ClickHouse has no `regexp_like` function;
+            # the server rejects the query with
+            # `DB::Exception: Function with name 'regexp_like' does not exist`. An issue still
+            # needs to be filed for this defect; this reason will be updated with its link once
+            # one exists.
+            "regex_match": (
+                "ClickHouse has no `regexp_like` SQL function; the dialect's regex-matching path "
+                "calls it and the server rejects the query with `DB::Exception: Function with "
+                "name 'regexp_like' does not exist`. An issue still needs to be filed for this "
+                "defect."
+            ),
+            # A driver defect, not a dialect gap: this dialect's SQLAlchemy layer inserts rows
+            # through an executemany path that keys each row by the sanitized bind-parameter
+            # name (for example `user_name`) rather than the real column name (`user name`) for
+            # any identifier that needs quoting, so the insert raises a `KeyError` at insert time
+            # and the table this case needs ends up with zero rows. An issue still needs to be
+            # filed for this defect; this reason will be updated with its link once one exists.
+            "quoted_identifiers": (
+                "This dialect's SQLAlchemy/driver insert path keys each row by the sanitized "
+                "bind-parameter name instead of the real column name for identifiers requiring "
+                "quoting, raising a `KeyError` at insert time and leaving the table empty. An "
+                "issue still needs to be filed for this defect."
+            ),
+        },
     )
 
     @override

--- a/tests/integration/test_utils/data_source_config/clickhouse.py
+++ b/tests/integration/test_utils/data_source_config/clickhouse.py
@@ -58,7 +58,8 @@ _CLICKHOUSE_TABLE_SCHEMA_ITEMS: TableSchemaItemFactory = _clickhouse_table_engin
 # The map is built eagerly at module scope, behind an import guard, because -- unlike the
 # table-schema-item factory above, which is deferred since its engine object binds to a table --
 # this map is immutable, shareable, inert data with no per-table freshness need. This resolves to
-# an empty mapping when the dialect package is absent, satisfying Contract 7.
+# an empty mapping when the dialect package is absent, so importing this module never requires
+# the dialect package to be installed.
 _COLUMN_TYPE_OVERRIDES = (
     {}
     if clickhouse_types is None

--- a/tests/integration/test_utils/data_source_config/sql.py
+++ b/tests/integration/test_utils/data_source_config/sql.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date, datetime
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Generic, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, Generic, Mapping, Optional, Sequence, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -215,7 +215,24 @@ class SQLBatchTestSetup(BatchTestSetup[_SqlConfigT, TableAsset], ABC, Generic[_S
             return
 
         if not max_params:
-            conn.execute(insert(table).values(values))
+            # Pass `values` as `execute()`'s parameters rather than via `.values(...)`.
+            # `insert(table).values(values)` is SQLAlchemy's "multi-values" Core idiom: it
+            # compiles ONE INSERT statement with inline VALUES tuples, flattening the row
+            # dicts into synthetic per-position parameter names (`col_m0`, `col_m1`, ...).
+            # That's harmless for dialects whose DBAPI just binds one flat parameter dict to
+            # one literal statement, but ClickHouse's SQLAlchemy dialect
+            # (`clickhouse_sqlalchemy`) unconditionally forces the executemany path for any
+            # non-empty INSERT and its compiler strips the inline VALUES text, expecting real
+            # per-row dicts keyed by actual column names instead -- so the driver raises a
+            # `KeyError` on the first column it looks up. `execute(insert(table), values)` is
+            # SQLAlchemy's documented dialect-transparent executemany calling convention: it
+            # lets each dialect compile and bind the statement the way it needs to.
+            #
+            # `execute()`'s parameters overload only accepts mapping rows (not tuples), unlike
+            # `.values()`. The sole caller (`setup()`, below) always passes rows produced by
+            # `_sanitize_null_values`, which are always dicts, so this narrows the declared
+            # `dict | tuple` union to the shape actually passed at runtime.
+            conn.execute(insert(table), cast("Sequence[Mapping[str, Any]]", values))
         else:
             num_columns = len(values[0])
             max_rows = max_params // num_columns

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -963,15 +963,15 @@ class TestStandardDataSourceListsMatchPreChangeMembership:
         ] == ALL_DATA_SOURCES
 
 
-class TestCuratedSqlDataSourcesEqualsSingleStoreAndTrino:
+class TestCuratedSqlDataSourcesEqualsClickHouseSingleStoreAndTrino:
     """Regression pin for the curated tier's members, in label order.
 
     `CURATED_SQL_DATA_SOURCES` was empty until a backend declared curated-tier membership, so
     every assertion involving it was vacuously true (empty equals empty). SingleStore was the
-    first backend to join that tier, and Trino is the second — both are what make this pin
-    non-vacuous: it fails on a curated-tier backend registering without also joining this
-    literal, and fails just as loudly on the reverse — a config landing in this literal without
-    the corresponding registration.
+    first backend to join that tier, Trino was the second, and ClickHouse is the third — all
+    three are what make this pin non-vacuous: it fails on a curated-tier backend registering
+    without also joining this literal, and fails just as loudly on the reverse — a config landing
+    in this literal without the corresponding registration.
 
     `CURATED_SQL_DATA_SOURCES` is imported at this module's own import time (see the module
     docstring on `TestStandardDataSourceListsMatchPreChangeMembership` above for why that
@@ -980,12 +980,18 @@ class TestCuratedSqlDataSourcesEqualsSingleStoreAndTrino:
     empty.
     """
 
-    def test_curated_sql_data_sources_equals_singlestore_and_trino_in_label_order(self) -> None:
+    def test_curated_sql_data_sources_equals_clickhouse_singlestore_and_trino_in_label_order(
+        self,
+    ) -> None:
+        from tests.integration.test_utils.data_source_config.clickhouse import (
+            ClickHouseDatasourceTestConfig,
+        )
         from tests.integration.test_utils.data_source_config.trino import (
             TrinoDatasourceTestConfig,
         )
 
         assert [
+            ClickHouseDatasourceTestConfig(),
             SingleStoreDatasourceTestConfig(),
             TrinoDatasourceTestConfig(),
         ] == CURATED_SQL_DATA_SOURCES

--- a/tests/test_sql_backend_registry.py
+++ b/tests/test_sql_backend_registry.py
@@ -1038,12 +1038,12 @@ _REGISTERED_CURATED_SQL = tuple(sql_backends_for_tier(BackendTier.CURATED_SQL))
 _REGISTERED_SQL_BACKENDS: Tuple[type, ...] = tuple(iter_sql_backends())
 
 
-class TestRegisteredSqlBackendsEqualTheTenInLabelOrder:
+class TestRegisteredSqlBackendsEqualTheElevenInLabelOrder:
     """Pins the registry itself: every registered SQL backend, named individually, in label order.
 
     This is an *equality* assertion against an *ordered* literal naming every registered class -
     not a subset check, not a membership check, not a count. That shape is what makes registering
-    an eleventh backend without extending this literal fail immediately: "register the config" and
+    a twelfth backend without extending this literal fail immediately: "register the config" and
     "extend this literal" become one change with a single, same-change failure signal, rather than
     a widening nobody notices until something downstream quietly starts seeing one more backend
     than it expected. A subset or count check would let a new registration pass silently here,
@@ -1052,13 +1052,13 @@ class TestRegisteredSqlBackendsEqualTheTenInLabelOrder:
     This module runs in a lane that installs no SQL dialect driver at all, and importing this
     module imports the whole harness package first, which in turn imports every backend module -
     each one registering itself as a side effect of being imported. An equality assertion over all
-    ten registered classes therefore runs only in a process where every backend module imported
+    eleven registered classes therefore runs only in a process where every backend module imported
     successfully with every dialect driver absent.
 
     Be precise about which half of that each mechanism carries. A backend module that fails to
     import takes the whole package down with it, so every test here dies at collection - the
     import statement is what proves importability, not this assertion. What this assertion adds
-    is that all ten modules actually *registered*: importing a module and registering from it
+    is that all eleven modules actually *registered*: importing a module and registering from it
     are separate events, and only the second is observable here. Weakening this to a subset or
     count check would discard exactly that, letting a backend that imported but never enrolled
     itself pass unnoticed.
@@ -1071,7 +1071,10 @@ class TestRegisteredSqlBackendsEqualTheTenInLabelOrder:
     registered without a matching update here.
     """
 
-    def test_registered_backends_equal_the_ten_in_label_order(self) -> None:
+    def test_registered_backends_equal_the_eleven_in_label_order(self) -> None:
+        from tests.integration.test_utils.data_source_config.clickhouse import (
+            ClickHouseDatasourceTestConfig,
+        )
         from tests.integration.test_utils.data_source_config.mysql import (
             MySQLDatasourceTestConfig,
         )
@@ -1087,6 +1090,7 @@ class TestRegisteredSqlBackendsEqualTheTenInLabelOrder:
 
         assert (
             BigQueryDatasourceTestConfig,  # big-query
+            ClickHouseDatasourceTestConfig,  # clickhouse
             DatabricksDatasourceTestConfig,  # databricks
             SQLServerDatasourceTestConfig,  # mssql
             MySQLDatasourceTestConfig,  # mysql


### PR DESCRIPTION
## Summary

Onboards ClickHouse as a first-class backend in the SQL integration test harness, following the
same declarative pattern the harness framework and the Trino onboarding already established.

## Why

ClickHouse has had no running container and no harness declaration, so no test ever exercised its
dialect support — failures there are undetected until a user hits them. This closes that gap the
same way the Trino onboarding did for its backend.

## User impact

None directly — this is test infrastructure only. Along the way it fixed two real bugs in shared
test-harness code (a bulk-insert calling convention that broke on this dialect's driver, and an
unparameterized numeric cast that this dialect's server rejects), both verified not to change
behavior for any other backend, and one real GX Core bug (a quantile-metric helper that called a
nonexistent execution-engine method). The completed effort will also surface remaining real
ClickHouse dialect defects as filed issues, giving future users better signal on what ClickHouse
support actually covers.