### PR TITLE
[MAINTENANCE] Pin SingleStore dev image to 0.2.82 instead of :latest

### DIFF
--- a/assets/docker/singlestore/docker-compose.yml
+++ b/assets/docker/singlestore/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   singlestore_db:
-    image: ghcr.io/singlestore-labs/singlestoredb-dev:latest
+    image: ghcr.io/singlestore-labs/singlestoredb-dev:0.2.82
     environment:
       ROOT_PASSWORD: ${SINGLESTORE_ROOT_PASSWORD:-test_superuser}
     volumes:


### PR DESCRIPTION
## Summary

Pins the SingleStore dev image used by the `singlestore` CI backend lane to `ghcr.io/singlestore-labs/singlestoredb-dev:0.2.82`, replacing the unpinned `:latest` tag. `0.2.82` is the tag `:latest` currently resolves to.

## Why

Every other backend service image under `assets/docker/` is pinned to a specific version (e.g. `clickhouse-server:25.8.29`, `trino:483`, `mysql:8.0.20`, `postgres:15.1`). The SingleStore compose file was the one exception, pulling `:latest`. An unpinned tag means the SingleStore CI lane can start failing (or silently change behavior) whenever a new image is published upstream, with no way to bisect which image version caused it.

## User impact

None. This only affects the SingleStore backend test lane in CI; no library code changed.

## How to review

Single-line change in `assets/docker/singlestore/docker-compose.yml`. Confirm the `singlestore` marker job in CI still passes with the pinned image.