### PR TITLE
[MAINTENANCE] Read the GCS test bucket from a repository variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
       GE_TEST_GCP_PROJECT: ${{secrets.GE_TEST_GCP_PROJECT}}
       GE_TEST_BIGQUERY_DATASET: ${{secrets.GE_TEST_BIGQUERY_DATASET}}
       GOOGLE_APPLICATION_CREDENTIALS: "gcp-credentials.json"
+      GX_GCS_TEST_BUCKET: ${{vars.GX_GCS_TEST_BUCKET}}
       # aws
       AWS_ACCESS_KEY_ID: ${{secrets.CI_AWS_ACCESS_KEY_ID}}
       AWS_DEFAULT_REGION: ${{secrets.CI_AWS_DEFAULT_REGION}}

--- a/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_gcs_pandas_no_assets/gx/great_expectations.yml
+++ b/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_gcs_pandas_no_assets/gx/great_expectations.yml
@@ -81,6 +81,6 @@ analytics_enabled: true
 fluent_datasources:
   my_filesystem_data_source:
     type: pandas_gcs
-    bucket_or_name: test_docs_data
+    bucket_or_name: ${GX_GCS_TEST_BUCKET}
     gcs_options: {}
 data_context_id: eafe985b-3eef-4514-889b-6f5d88e63f16

--- a/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_gcs_spark_no_assets/gx/great_expectations.yml
+++ b/docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_gcs_spark_no_assets/gx/great_expectations.yml
@@ -81,6 +81,6 @@ analytics_enabled: true
 fluent_datasources:
   my_filesystem_data_source:
     type: spark_gcs
-    bucket_or_name: test_docs_data
+    bucket_or_name: ${GX_GCS_TEST_BUCKET}
     gcs_options: {}
 data_context_id: 0c00c690-20a1-4774-a254-d480127d624b

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_pandas.py
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_pandas.py
@@ -1,12 +1,16 @@
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_pandas.py - full example">
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
 
 # Define the Data Source's parameters:
 data_source_name = "my_filesystem_data_source"
-bucket_or_name = "test_docs_data"
+bucket_or_name = "my_bucket"
 gcs_options = {}
+
+bucket_or_name = os.environ["GX_GCS_TEST_BUCKET"]
 
 # Create the Data Source:
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_pandas.py - add Data Source">

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_spark.py
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_spark.py
@@ -1,4 +1,6 @@
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_spark.py - full example">
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
@@ -6,9 +8,11 @@ context = gx.get_context()
 # Define the Data Source's parameters:
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_spark.py - define Data Source parameters">
 data_source_name = "my_filesystem_data_source"
-bucket_or_name = "test_docs_data"
+bucket_or_name = "my_bucket"
 gcs_options = {}
 # </snippet>
+
+bucket_or_name = os.environ["GX_GCS_TEST_BUCKET"]
 
 # Create the Data Source:
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_spark.py - add Data Source">

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
@@ -22,8 +22,6 @@ azure_options = {
 }
 # </snippet>
 
-bucket_or_name = "test_docs_data"
-
 # Python
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py create_datasource">
 datasource = context.data_sources.add_pandas_abs(

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
@@ -21,8 +21,6 @@ azure_options = {
 }
 # </snippet>
 
-bucket_or_name = "test_docs_data"
-
 # Python
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py create_datasource">
 datasource = context.data_sources.add_spark_abs(

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
@@ -5,6 +5,8 @@ pytest -v --docs-tests -k "how_to_connect_to_data_on_gcs_using_pandas" tests/int
 ```
 """
 
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
@@ -16,7 +18,7 @@ bucket_or_name = "my_bucket"
 gcs_options = {}
 # </snippet>
 
-bucket_or_name = "test_docs_data"
+bucket_or_name = os.environ["GX_GCS_TEST_BUCKET"]
 
 # Python
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py create_datasource">

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
@@ -5,6 +5,8 @@ pytest -v --docs-tests -k "how_to_connect_to_data_on_gcs_using_spark" tests/inte
 ```
 """
 
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
@@ -16,7 +18,7 @@ bucket_or_name = "my_bucket"
 gcs_options = {}
 # </snippet>
 
-bucket_or_name = "test_docs_data"
+bucket_or_name = os.environ["GX_GCS_TEST_BUCKET"]
 
 # Python
 # <snippet name="docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py create_datasource">

--- a/tests/integration/integration_test_fixture.py
+++ b/tests/integration/integration_test_fixture.py
@@ -1,7 +1,12 @@
+import os
+import pathlib
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from tests.integration.backend_dependencies import BackendDependencies
+
+GCS_TEST_BUCKET_ENV_VAR = "GX_GCS_TEST_BUCKET"
+GCS_TEST_BUCKET_TEMPLATE = "${" + GCS_TEST_BUCKET_ENV_VAR + "}"
 
 
 @dataclass
@@ -30,3 +35,29 @@ class IntegrationTestFixture:
     data_dir: Optional[str] = None
     other_files: Optional[Tuple[Tuple[str, str]]] = None
     util_script: Optional[str] = None
+
+
+def substitute_gcs_test_bucket(config_path: pathlib.Path) -> None:
+    """Resolve the GCS bucket placeholder in a copied test Data Context config.
+
+    The GCS-backed `data_context_dir` configs name their bucket with a placeholder rather
+    than a literal, so the bucket can be changed without editing the fixtures. GX applies
+    config substitution to credential fields only, not to `bucket_or_name`, so the
+    placeholder is resolved here — on the copy the test runs against, never the checked-in
+    fixture.
+
+    Only this one placeholder is substituted. Other config templates are left for GX to
+    resolve, since exercising that path is the point of the fixtures that use them.
+    """
+    if not config_path.exists():
+        return
+    config = config_path.read_text()
+    if GCS_TEST_BUCKET_TEMPLATE not in config:
+        return
+    bucket = os.environ.get(GCS_TEST_BUCKET_ENV_VAR)
+    if not bucket:
+        raise RuntimeError(
+            f"{config_path.name} requires a GCS bucket, but the"
+            f" {GCS_TEST_BUCKET_ENV_VAR} environment variable is not set."
+        )
+    config_path.write_text(config.replace(GCS_TEST_BUCKET_TEMPLATE, bucket))

--- a/tests/integration/test_definitions/gcs/README.md
+++ b/tests/integration/test_definitions/gcs/README.md
@@ -3,3 +3,12 @@
 GCS = Google Cloud Storage
 
 GCS is a blob store similar to AWS S3 and Microsoft ABS.
+
+## Configuration
+
+These tests read from a real GCS bucket, named by the `GX_GCS_TEST_BUCKET` environment
+variable. The bucket is expected to contain the taxi sample data at
+`data/taxi_yellow_tripdata_samples/`, and the credentials in use must be able to read it.
+The variable is required — the test scripts fail immediately if it is not set — so that a
+missing or misconfigured bucket name is reported directly instead of surfacing as an
+object-not-found error.

--- a/tests/integration/test_definitions/gcs/partitioned_on_datetime.py
+++ b/tests/integration/test_definitions/gcs/partitioned_on_datetime.py
@@ -1,9 +1,11 @@
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
 
 datasource_name = "my_gcs_datasource"
-bucket_or_name = "test_docs_data"
+bucket_or_name = os.environ["GX_GCS_TEST_BUCKET"]
 
 datasource = context.data_sources.add_pandas_gcs(
     name=datasource_name, bucket_or_name=bucket_or_name, gcs_options={}

--- a/tests/integration/test_definitions/gcs/select_batch_by_path.py
+++ b/tests/integration/test_definitions/gcs/select_batch_by_path.py
@@ -1,9 +1,11 @@
+import os
+
 import great_expectations as gx
 
 context = gx.get_context()
 
 datasource_name = "my_gcs_datasource"
-bucket_or_name = "test_docs_data"
+bucket_or_name = os.environ["GX_GCS_TEST_BUCKET"]
 
 datasource = context.data_sources.add_pandas_gcs(
     name=datasource_name, bucket_or_name=bucket_or_name, gcs_options={}

--- a/tests/integration/test_integration_test_fixture.py
+++ b/tests/integration/test_integration_test_fixture.py
@@ -1,0 +1,48 @@
+import pathlib
+
+import pytest
+
+from tests.integration.integration_test_fixture import substitute_gcs_test_bucket
+
+
+@pytest.mark.filesystem
+def test_substitute_gcs_test_bucket(monkeypatch, tmp_path: pathlib.Path):
+    monkeypatch.setenv("GX_GCS_TEST_BUCKET", "bucket_from_the_environment")
+    config = tmp_path / "great_expectations.yml"
+    config.write_text("    bucket_or_name: ${GX_GCS_TEST_BUCKET}\n")
+
+    substitute_gcs_test_bucket(config)
+
+    assert config.read_text() == "    bucket_or_name: bucket_from_the_environment\n"
+
+
+@pytest.mark.filesystem
+def test_substitute_gcs_test_bucket_raises_when_env_var_unset(monkeypatch, tmp_path: pathlib.Path):
+    monkeypatch.delenv("GX_GCS_TEST_BUCKET", raising=False)
+    config = tmp_path / "great_expectations.yml"
+    config.write_text("    bucket_or_name: ${GX_GCS_TEST_BUCKET}\n")
+
+    with pytest.raises(RuntimeError, match="GX_GCS_TEST_BUCKET"):
+        substitute_gcs_test_bucket(config)
+
+
+@pytest.mark.filesystem
+def test_substitute_gcs_test_bucket_leaves_other_templates_alone(
+    monkeypatch, tmp_path: pathlib.Path
+):
+    """Templates GX resolves itself must survive, so those fixtures still exercise that path."""
+    monkeypatch.setenv("GX_GCS_TEST_BUCKET", "bucket_from_the_environment")
+    monkeypatch.setenv("AZURE_CREDENTIAL", "should_not_be_substituted")
+    original = "      credential: ${AZURE_CREDENTIAL}\n"
+    config = tmp_path / "great_expectations.yml"
+    config.write_text(original)
+
+    substitute_gcs_test_bucket(config)
+
+    assert config.read_text() == original
+
+
+@pytest.mark.filesystem
+def test_substitute_gcs_test_bucket_is_a_noop_without_a_config(tmp_path: pathlib.Path):
+    """A fixture with no Data Context config of its own must not raise."""
+    substitute_gcs_test_bucket(tmp_path / "does_not_exist.yml")

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -28,7 +28,10 @@ from great_expectations.data_context.data_context.file_data_context import (
 )
 from great_expectations.data_context.util import file_relative_path
 from tests.integration.backend_dependencies import BackendDependencies
-from tests.integration.integration_test_fixture import IntegrationTestFixture
+from tests.integration.integration_test_fixture import (
+    IntegrationTestFixture,
+    substitute_gcs_test_bucket,
+)
 from tests.integration.test_definitions.abs.integration_tests import (
     abs_integration_tests,
 )
@@ -425,6 +428,7 @@ def _execute_integration_test(  # noqa: C901, PLR0915 # FIXME CoP
                 context_source_dir,
                 test_context_dir,
             )
+            substitute_gcs_test_bucket(test_context_dir / FileDataContext.GX_YML)
 
         # Test Data
         data_dir = integration_test_fixture.data_dir


### PR DESCRIPTION
## Summary

The GCS-backed tests hard-coded their bucket name in eight places — two test scripts, four docs snippets, and two checked-in Data Context fixtures. Changing the bucket meant editing all eight together, and a missed reference surfaced as an object-not-found error rather than a configuration error.

This replaces the literal with `GX_GCS_TEST_BUCKET`, supplied to the `docs-snippets` job as a repository variable (`vars.GX_GCS_TEST_BUCKET`). The variable is **required** — the scripts read `os.environ[...]` and raise on a missing key — so a misconfigured bucket name is reported directly instead of as a storage error.

## Changes

**Test scripts and docs snippets** read the bucket from the environment:

- `tests/integration/test_definitions/gcs/{select_batch_by_path,partitioned_on_datetime}.py`
- `docs/.../fluent/filesystem/how_to_connect_to_data_on_gcs_using_{pandas,spark}.py`
- `docs/.../_create_a_data_source/_gcs/{_pandas,_spark}.py`

**Published docs improve.** `_spark.py`'s "define Data Source parameters" snippet is rendered in `_gcs.md` under "Update the variables in the following code", and it was showing the real CI bucket to readers. It now shows a `my_bucket` placeholder, with the test value applied outside the snippet — the same pattern the OSS GCS guides already use. `_pandas.py` follows suit so the sibling files read identically.

**Data Context fixtures** name the bucket with a `${GX_GCS_TEST_BUCKET}` placeholder. GX applies config substitution to credential fields, not to `bucket_or_name`, so `substitute_gcs_test_bucket` resolves it in the test harness — on the copy the test runs against, never the checked-in fixture. Only that one placeholder is substituted, so the Azure fixtures keep exercising GX's own substitution path.

**Also**: two dead `bucket_or_name` assignments in the Azure guides named the GCS bucket but were never read (`add_pandas_abs`/`add_spark_abs` take no such argument). Dropped.

The 0.18 versioned docs keep the literal, as frozen released documentation.

## Testing

`tests/integration/test_integration_test_fixture.py` covers the harness helper: substitution, the raise when the variable is unset, that other config templates survive untouched, and the no-op when a fixture has no config of its own. Each was checked against a mutated implementation to confirm it fails when the behavior regresses.

Verified locally: `ruff check` / `ruff format` clean, `invoke type-check --ci` clean (757 files, plus the stub-source pass), and `tests/datasource/fluent/test_schemas.py`, `test_config_str.py`, `test_config.py` pass with no regressions. Snippet tag balance confirmed for every edited docs file, and every snippet name referenced from `.md`/`.mdx` still resolves.

## Note for reviewers

The `GX_GCS_TEST_BUCKET` repository variable must be set before this lands, or the GCS docs fixtures will raise instead of skipping once they are re-enabled. Those fixtures are currently skipped by the existing CI-transition gate in `test_script_runner.py`, so **CI here cannot exercise the GCS path end-to-end** — this change is verified by the unit tests above and by local inspection, not by a green GCS test run.
