### PR TITLE
[MAINTENANCE] Restore the GCS datasource tests and run them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,6 +535,7 @@ jobs:
           - bigquery
           - databricks
           - filesystem
+          - gcs_deps
           - sql_server
           - mysql
           - postgresql

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -692,6 +692,7 @@ markers = [
     "docs: mark a test as a docs test.",
     "external_sqldialect: mark test as requiring install of an external sql dialect.",
     "filesystem: mark tests using the filesystem as the storage backend.",
+    "gcs_deps: mark tests that need google cloud storage dependencies but no credentials",
     "integration: mark test as an integration test.",
     "sql_server: mark a test as SQL Server-dependent.",
     "mysql: mark a test as mysql-dependent.",

--- a/reqs/requirements-dev-gcs.txt
+++ b/reqs/requirements-dev-gcs.txt
@@ -1,0 +1,3 @@
+# needed to prevent excessive pip backtracking on python 3.11
+google-cloud-storage>=2.10.0;python_version >= '3.11'
+google-cloud-storage>=1.28.0;python_version < '3.11'

--- a/tasks.py
+++ b/tasks.py
@@ -879,6 +879,7 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         services=("spark",),
         extra_pytest_args=("--spark", "--docs-tests"),
     ),
+    "gcs_deps": TestDependencies(("reqs/requirements-dev-gcs.txt",)),
     "gx-redshift": TestDependencies(
         requirement_files=("reqs/requirements-dev-gx-redshift.txt",),
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,7 @@ REQUIRED_MARKERS: Final[set[str]] = {
     "databricks",
     "docs",
     "filesystem",
+    "gcs_deps",
     "generic_sql",
     "integration",
     "mysql",

--- a/tests/datasource/fluent/test_pandas_google_cloud_storage_datasource.py
+++ b/tests/datasource/fluent/test_pandas_google_cloud_storage_datasource.py
@@ -81,7 +81,7 @@ def object_keys() -> List[str]:
     ]
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 def test_construct_pandas_gcs_datasource_without_gcs_options():
     google_cred_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
     if not google_cred_file:
@@ -97,9 +97,9 @@ def test_construct_pandas_gcs_datasource_without_gcs_options():
     assert pandas_gcs_datasource.name == "pandas_gcs_datasource"
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.oauth2.service_account.Credentials.from_service_account_file")
 @mock.patch("google.cloud.storage.Client")
@@ -118,9 +118,9 @@ def test_construct_pandas_gcs_datasource_with_filename_in_gcs_options(
     assert pandas_gcs_datasource.name == "pandas_gcs_datasource"
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.oauth2.service_account.Credentials.from_service_account_info")
 @mock.patch("google.cloud.storage.Client")
@@ -139,9 +139,9 @@ def test_construct_pandas_gcs_datasource_with_info_in_gcs_options(
     assert pandas_gcs_datasource.name == "pandas_gcs_datasource"
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_add_csv_asset_to_datasource(
@@ -157,9 +157,9 @@ def test_add_csv_asset_to_datasource(
     assert asset.name == "csv_asset"
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_construct_csv_asset_directly(mock_gcs_client, mock_list_keys, object_keys: List[str]):
@@ -170,9 +170,9 @@ def test_construct_csv_asset_directly(mock_gcs_client, mock_list_keys, object_ke
     assert asset.name == "csv_asset"
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_csv_asset_with_batching_regex_named_parameters(
@@ -192,9 +192,9 @@ def test_csv_asset_with_batching_regex_named_parameters(
     assert options == ("path", "year", "month")
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_csv_asset_with_non_string_batching_regex_named_parameters(
@@ -212,9 +212,9 @@ def test_csv_asset_with_non_string_batching_regex_named_parameters(
         asset.build_batch_request({"name": "alex", "timestamp": "1234567890", "price": 1300})
 
 
-@pytest.mark.unit
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_add_csv_asset_with_recursive_file_discovery_to_datasource(

--- a/tests/datasource/fluent/test_spark_google_cloud_storage_datasource.py
+++ b/tests/datasource/fluent/test_spark_google_cloud_storage_datasource.py
@@ -81,7 +81,7 @@ def object_keys() -> List[str]:
 
 @pytest.fixture
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 def csv_asset(
     mock_list_keys,
@@ -95,7 +95,7 @@ def csv_asset(
     return asset
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 def test_construct_spark_gcs_datasource_without_gcs_options():
     google_cred_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
     if not google_cred_file:
@@ -112,9 +112,9 @@ def test_construct_spark_gcs_datasource_without_gcs_options():
     assert spark_gcs_datasource.name == "spark_gcs_datasource"
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.oauth2.service_account.Credentials.from_service_account_file")
 @mock.patch("google.cloud.storage.Client")
@@ -134,9 +134,9 @@ def test_construct_spark_gcs_datasource_with_filename_in_gcs_options(
     assert spark_gcs_datasource.name == "spark_gcs_datasource"
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.oauth2.service_account.Credentials.from_service_account_info")
 @mock.patch("google.cloud.storage.Client")
@@ -156,9 +156,9 @@ def test_construct_spark_gcs_datasource_with_info_in_gcs_options(
     assert spark_gcs_datasource.name == "spark_gcs_datasource"
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_add_csv_asset_to_datasource(
@@ -177,9 +177,9 @@ def test_add_csv_asset_to_datasource(
     assert asset.batch_metadata == asset_specified_metadata
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_construct_csv_asset_directly(mock_gcs_client, mock_list_keys, object_keys: List[str]):
@@ -190,9 +190,9 @@ def test_construct_csv_asset_directly(mock_gcs_client, mock_list_keys, object_ke
     assert asset.name == "csv_asset"
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_csv_asset_with_batching_regex_named_parameters(
@@ -211,9 +211,9 @@ def test_csv_asset_with_batching_regex_named_parameters(
     assert options == ("path", "year", "month")
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_csv_asset_with_non_string_batching_regex_named_parameters(
@@ -235,9 +235,9 @@ def test_csv_asset_with_non_string_batching_regex_named_parameters(
         )
 
 
-@pytest.mark.big
+@pytest.mark.gcs_deps
 @mock.patch(
-    "great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
+    "great_expectations.datasource.fluent.data_connector.google_cloud_storage_data_connector.list_gcs_keys"
 )
 @mock.patch("google.cloud.storage.Client")
 def test_add_csv_asset_with_recursive_file_discovery_to_datasource(


### PR DESCRIPTION
## Summary

The 14 tests in the pandas and Spark GCS datasource test modules all failed on `develop`. They patch:

```
great_expectations.datasource.fluent.data_asset.data_connector.google_cloud_storage_data_connector.list_gcs_keys
```

but that module lives at `great_expectations.datasource.fluent.data_connector....` — there is no `data_asset` segment. Every `mock.patch` raised `AttributeError: module '...fluent.data_asset' has no attribute 'data_connector'`.

Nothing caught it, because these tests could not run anywhere:

- Both modules skip at import via `if not google.storage: pytest.skip(allow_module_level=True)`.
- `google-cloud-storage` ships only in `reqs/requirements-dev-bigquery.txt`.
- The one job that installs it — `marker-tests (bigquery)` — selects `-m bigquery`, which matches none of these tests (they were `unit` / `big`).

So this PR does two things: corrects the paths, and makes the tests actually run in CI.

## Changes

**Patch paths corrected** in `test_pandas_google_cloud_storage_datasource.py` and `test_spark_google_cloud_storage_datasource.py`. This alone takes the 14 tests from failing to passing.

**New `gcs_deps` marker**, mirroring the existing `aws_deps` pattern that already covers the S3 datasource tests — SDK required, no credentials:

| | |
|---|---|
| `reqs/requirements-dev-gcs.txt` | new; `google-cloud-storage` only |
| `tasks.py` | `MARKER_DEPENDENCY_MAP["gcs_deps"]` → that file |
| `pyproject.toml` | marker registered |
| `tests/conftest.py` | added to `REQUIRED_MARKERS` |
| `ci.yml` | `gcs_deps` added to the `marker-tests` matrix |

The 16 tests move from `unit`/`big` to `gcs_deps`.

**Why a marker rather than adding the SDK to shared requirements:** putting `google-cloud-storage` in `requirements-dev-lite.txt` would also un-skip `tests/datasource/fluent/data_asset/data_connector/test_google_cloud_storage_data_connector.py`, which is broken by a separate, unrelated change — `AzureBlobStorageDataConnector.__init__()` and its GCS sibling no longer accept `batching_regex`. That would turn CI red. The marker selects only the two modules being fixed here, leaving that one dormant until it is rewritten against the current connector API.

The new requirements file duplicates the `google-cloud-storage` pin from `requirements-dev-bigquery.txt` rather than reusing that file, so the leg installs the storage client without the BigQuery SQL stack (`sqlalchemy-bigquery`, `pandas_gbq`, `gcsfs`).

## Testing

- `pytest -m gcs_deps` selects exactly these 16 tests: **14 passed, 2 skipped**. The 2 skips are the `GOOGLE_APPLICATION_CREDENTIALS` gate in `test_construct_*_gcs_datasource_without_gcs_options`.
- `marker-tests` writes `gcp-credentials.json` unconditionally for every leg, so those 2 will **execute** rather than skip in the new leg. Verified that path works by pointing `GOOGLE_APPLICATION_CREDENTIALS` at a locally generated throwaway service-account file: all **16 pass**, and `storage.Client()` construction needs no network.
- `pytest --verify-marker-coverage-and-exit` succeeds (exactly one required marker per test).
- `tests/test_packaging.py` passes — the new requirements file does not disturb the inter-file set assertions.
- `pip install --dry-run -r reqs/requirements-dev-gcs.txt -r reqs/requirements-dev-test.txt -c constraints-dev.txt` resolves cleanly.
- `ruff check` / `ruff format` clean; `invoke type-check --ci` clean (757 files + stub-source pass).

## Known remaining work, not in this PR

`tests/datasource/fluent/data_asset/data_connector/test_{google_cloud_storage,azure_blob_storage}_data_connector.py` carry the same stale patch path **and** 14 tests written against the pre-partitioner connector constructor. Correcting only their paths leaves them failing on `TypeError: ... unexpected keyword argument 'batching_regex'`, so they are untouched here; rewriting them against the current API is a separate change. They remain skipped in CI, exactly as before.

## The new leg cannot be exercised by this PR's CI

`ci.yml` triggers on `pull_request_target`, and GitHub always evaluates that event against the workflow definition on the **base branch**. The `marker-tests` matrix that ran here is `develop`'s, so `gcs_deps` produced no job — the 15 legs on this PR are the pre-existing set.

Everything the leg does was verified locally instead, by running the exact command the workflow issues:

```
$ invoke ci-tests 'gcs_deps' --up-services --verbose
pytest -m 'gcs_deps' --durations=5 -rEf -vv
...
14 passed, 4 skipped, 9202 deselected
```

That covers marker selection, the requirements mapping, and `--up-services` correctly no-opping on an empty service list (same as `aws_deps`). What it cannot cover is GitHub materialising a job from the new matrix entry.

**Suggestion for whoever merges:** route this through the merge queue rather than merging directly. The `merge_group` event evaluates the workflow from the queue's temporary branch, which *does* include this change — so the `gcs_deps` leg will run and gate the merge instead of first appearing on `develop` after the fact.
