### PR TITLE
[MAINTENANCE] Run the GCS docs snippet tests

### DIFF
--- a/docs/docusaurus/docs/components/examples_under_test.py
+++ b/docs/docusaurus/docs/components/examples_under_test.py
@@ -103,14 +103,14 @@ connect_to_filesystem_data_create_a_data_source = [
     # GCS, pandas/spark
     IntegrationTestFixture(
         # To test, run:
-        # pytest --docs-tests --bigquery -k "create_a_data_source_filesystem_gcs_pandas" tests/integration/test_script_runner.py
+        # pytest --docs-tests --gcs -k "create_a_data_source_filesystem_gcs_pandas" tests/integration/test_script_runner.py
         name="create_a_data_source_filesystem_gcs_pandas",
         user_flow_script="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_pandas.py",
         backend_dependencies=[BackendDependencies.GCS],
     ),
     IntegrationTestFixture(
         # To test, run:
-        # pytest --docs-tests --bigquery --spark -k "create_a_data_source_filesystem_gcs_spark" tests/integration/test_script_runner.py
+        # pytest --docs-tests --gcs --spark -k "create_a_data_source_filesystem_gcs_spark" tests/integration/test_script_runner.py
         name="create_a_data_source_filesystem_gcs_spark",
         user_flow_script="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_source/_gcs/_spark.py",
         backend_dependencies=[BackendDependencies.GCS, BackendDependencies.SPARK],
@@ -172,7 +172,7 @@ connect_to_filesystem_data_create_a_data_asset = [
     # GCS, directory asset/file asset
     IntegrationTestFixture(
         # To test, run:
-        # pytest --docs-tests --bigquery -k "create_a_data_asset_filesystem_gcs_file_asset" tests/integration/test_script_runner.py
+        # pytest --docs-tests --gcs -k "create_a_data_asset_filesystem_gcs_file_asset" tests/integration/test_script_runner.py
         name="create_a_data_asset_filesystem_gcs_file_asset",
         user_flow_script="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_gcs/_file_asset.py",
         data_context_dir="docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_gcs_pandas_no_assets/gx",
@@ -180,7 +180,7 @@ connect_to_filesystem_data_create_a_data_asset = [
     ),
     IntegrationTestFixture(
         # To test, run:
-        # pytest --docs-tests --bigquery --spark -k "create_a_data_asset_filesystem_gcs_directory_asset" tests/integration/test_script_runner.py
+        # pytest --docs-tests --gcs --spark -k "create_a_data_asset_filesystem_gcs_directory_asset" tests/integration/test_script_runner.py
         name="create_a_data_asset_filesystem_gcs_directory_asset",
         user_flow_script="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_data_asset/_gcs/_directory_asset.py",
         data_context_dir="docs/docusaurus/docs/components/_testing/test_data_contexts/filesystem_datasource_gcs_spark_no_assets/gx",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
@@ -44,10 +44,7 @@ assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 my_batch_definition = data_asset.add_batch_definition_monthly(
     name="Monthly Taxi Data", regex=batching_regex
 )
-my_batch_request = my_batch_definition.build_batch_request(
-    {"year": "2019", "month": "03"}
-)
-batch = data_asset.get_batch(my_batch_request)
+batch = my_batch_definition.get_batch(batch_parameters={"year": "2019", "month": "03"})
 assert set(batch.columns()) == {
     "vendor_id",
     "pickup_datetime",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
@@ -36,7 +36,6 @@ gcs_prefix = "data/taxi_yellow_tripdata_samples/"
 batching_regex = r"yellow_tripdata_sample_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
 data_asset = datasource.add_csv_asset(
     name=asset_name,
-    batching_regex=batching_regex,
     gcs_prefix=gcs_prefix,
     header=True,
     infer_schema=True,
@@ -47,7 +46,12 @@ assert data_asset
 
 assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 
-my_batch_request = data_asset.build_batch_request({"year": "2019", "month": "03"})
+my_batch_definition = data_asset.add_batch_definition_monthly(
+    name="Monthly Taxi Data", regex=batching_regex
+)
+my_batch_request = my_batch_definition.build_batch_request(
+    {"year": "2019", "month": "03"}
+)
 batch = data_asset.get_batch(my_batch_request)
 assert set(batch.columns()) == {
     "vendor_id",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
@@ -49,10 +49,7 @@ assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 my_batch_definition = data_asset.add_batch_definition_monthly(
     name="Monthly Taxi Data", regex=batching_regex
 )
-my_batch_request = my_batch_definition.build_batch_request(
-    {"year": "2019", "month": "03"}
-)
-batch = data_asset.get_batch(my_batch_request)
+batch = my_batch_definition.get_batch(batch_parameters={"year": "2019", "month": "03"})
 assert set(batch.columns()) == {
     "vendor_id",
     "pickup_datetime",

--- a/tasks.py
+++ b/tasks.py
@@ -879,15 +879,14 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         requirement_files=(
             "reqs/requirements-dev-test.txt",
             "reqs/requirements-dev-spark.txt",
-            # The GCS datasources list objects with the Python client before Spark reads
-            # them, and neither the test nor the spark requirements pull it in.
-            "reqs/requirements-dev-gcs.txt",
         ),
         services=("spark",),
-        # --gcs as well as --spark: the GCS fixtures that also need Spark are reachable
-        # only from a leg that requests both. docs-creds-needed requests --gcs without
-        # --spark, so without this they are skipped everywhere and the gap is silent.
-        extra_pytest_args=("--gcs", "--spark", "--docs-tests"),
+        # No --gcs here, so the two fixtures needing both GCS and Spark stay skipped.
+        # Spark reads GCS over gs:// URIs, which requires the GCS Hadoop connector on the
+        # JVM classpath; without it the read fails with UnsupportedFileSystemException.
+        # Supplying that jar is CI infrastructure work, not a Python requirement. See
+        # tests/integration/test_definitions/gcs/README.md.
+        extra_pytest_args=("--spark", "--docs-tests"),
     ),
     "gcs_deps": TestDependencies(("reqs/requirements-dev-gcs.txt",)),
     "gx-redshift": TestDependencies(

--- a/tasks.py
+++ b/tasks.py
@@ -878,7 +878,10 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
             "reqs/requirements-dev-spark.txt",
         ),
         services=("spark",),
-        extra_pytest_args=("--spark", "--docs-tests"),
+        # --gcs as well as --spark: the GCS fixtures that also need Spark are reachable
+        # only from a leg that requests both. docs-creds-needed requests --gcs without
+        # --spark, so without this they are skipped everywhere and the gap is silent.
+        extra_pytest_args=("--gcs", "--spark", "--docs-tests"),
     ),
     "gcs_deps": TestDependencies(("reqs/requirements-dev-gcs.txt",)),
     "gx-redshift": TestDependencies(

--- a/tasks.py
+++ b/tasks.py
@@ -854,6 +854,9 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
             "reqs/requirements-dev-azure.txt",
             "reqs/requirements-dev-bigquery.txt",
             "reqs/requirements-dev-cloud.txt",
+            # Explicit rather than inherited from the bigquery requirements, so that GCS
+            # coverage here does not quietly depend on BigQuery staying installed.
+            "reqs/requirements-dev-gcs.txt",
             "reqs/requirements-dev-redshift.txt",
             "reqs/requirements-dev-snowflake.txt",
             "reqs/requirements-dev-sql-server.txt",
@@ -876,6 +879,9 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         requirement_files=(
             "reqs/requirements-dev-test.txt",
             "reqs/requirements-dev-spark.txt",
+            # The GCS datasources list objects with the Python client before Spark reads
+            # them, and neither the test nor the spark requirements pull it in.
+            "reqs/requirements-dev-gcs.txt",
         ),
         services=("spark",),
         # --gcs as well as --spark: the GCS fixtures that also need Spark are reachable

--- a/tasks.py
+++ b/tasks.py
@@ -862,11 +862,12 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         ),
         services=("mssql", "trino"),
         extra_pytest_args=(
-            # TEMPORARY (CI transition): the S3, GCS, Azure Blob, BigQuery, Redshift, and
+            # TEMPORARY (CI transition): the S3, Azure Blob, BigQuery, Redshift, and
             # Snowflake backends are unavailable while their CI infrastructure is torn down.
             # Requesting any of them makes test collection eagerly connect to a dead backend
-            # and abort the whole session, so only the still-available Trino backend is
-            # requested here. Restore the cloud/warehouse flags once the infra is back.
+            # and abort the whole session, so only the available backends are requested here.
+            # Restore the remaining cloud/warehouse flags once the infra is back.
+            "--gcs",
             "--trino",
             "--docs-tests",
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,6 +238,11 @@ def pytest_addoption(parser):
         help="If set, execute tests against bigquery",
     )
     parser.addoption(
+        "--gcs",
+        action="store_true",
+        help="If set, execute tests against Google Cloud Storage",
+    )
+    parser.addoption(
         "--aws",
         action="store_true",
         help="If set, execute tests against AWS resources like S3, RedShift and Athena",

--- a/tests/integration/test_definitions/gcs/README.md
+++ b/tests/integration/test_definitions/gcs/README.md
@@ -12,3 +12,19 @@ variable. The bucket is expected to contain the taxi sample data at
 The variable is required — the test scripts fail immediately if it is not set — so that a
 missing or misconfigured bucket name is reported directly instead of surfacing as an
 object-not-found error.
+
+Credentials come from Application Default Credentials, so `GOOGLE_APPLICATION_CREDENTIALS`
+must point at a service account key that can read the bucket. Use an absolute path: the
+docs snippet runner chdirs into a temp directory before executing each script, and ADC
+resolves the path when the client is constructed.
+
+## Running them
+
+The tests are gated behind `--gcs`:
+
+```bash
+pytest -v --docs-tests --gcs -k "gcs" tests/integration/test_script_runner.py
+```
+
+Watch for skips rather than failures — a skip means the flag or a gate is still wrong, and
+a green run of zero tests is the failure mode worth guarding against.

--- a/tests/integration/test_definitions/gcs/README.md
+++ b/tests/integration/test_definitions/gcs/README.md
@@ -28,3 +28,23 @@ pytest -v --docs-tests --gcs -k "gcs" tests/integration/test_script_runner.py
 
 Watch for skips rather than failures — a skip means the flag or a gate is still wrong, and
 a green run of zero tests is the failure mode worth guarding against.
+
+## What does not run yet: Spark
+
+Two fixtures need both GCS and Spark — `create_a_data_source_filesystem_gcs_spark` and
+`create_a_data_asset_filesystem_gcs_directory_asset` — plus the Spark half of
+`how_to_connect_to_data_on_gcs_using_spark`. They are deliberately left skipped: the
+`docs-creds-needed` leg requests `--gcs` without `--spark`, and `docs-spark` requests
+`--spark` without `--gcs`, so no leg requests both.
+
+The blocker is not the pytest flags. Spark reads GCS through `gs://` URIs, which Hadoop
+resolves only when the GCS connector is on the JVM classpath. Without it the read fails:
+
+```
+org.apache.hadoop.fs.UnsupportedFileSystemException: No FileSystem for scheme "gs"
+```
+
+The connector is a jar that must be present when the JVM starts, so no Python requirement
+can supply it — it needs `PYSPARK_SUBMIT_ARGS` or a pre-staged jar in the workflow, and
+Hadoop config for `fs.gs.impl` and service account auth. Adding `--gcs` to `docs-spark`
+before that exists only converts a skip into a failure.

--- a/tests/integration/test_script_runner.py
+++ b/tests/integration/test_script_runner.py
@@ -548,13 +548,13 @@ def _check_for_skipped_tests(  # noqa: C901, PLR0912 # FIXME CoP
     dependencies = integration_test_fixture.backend_dependencies
     if not dependencies:
         return
-    # TEMPORARY: Tests backed by cloud object stores (S3, GCS, Azure Blob) are
-    # unconditionally skipped during the CI transition. Remove this block to re-enable.
+    # TEMPORARY: Tests backed by S3 and Azure Blob are unconditionally skipped during the
+    # CI transition -- neither has a bucket or a live credential to run against. Remove
+    # this block once that infrastructure is restored.
     elif any(
         dependency
         in (
             BackendDependencies.AWS,
-            BackendDependencies.GCS,
             BackendDependencies.AZURE,
         )
         for dependency in dependencies
@@ -577,8 +577,7 @@ def _check_for_skipped_tests(  # noqa: C901, PLR0912 # FIXME CoP
     ):
         # TODO : Investigate whether this test should be handled by azure-pipelines-cloud-db-integration.yml  # noqa: E501 # FIXME CoP
         pytest.skip("Skipping bigquery tests")
-    elif BackendDependencies.GCS in dependencies and not pytest_args.bigquery:
-        # TODO : Investigate whether this test should be handled by azure-pipelines-cloud-db-integration.yml  # noqa: E501 # FIXME CoP
+    elif BackendDependencies.GCS in dependencies and not pytest_args.gcs:
         pytest.skip("Skipping GCS tests")
     elif BackendDependencies.AWS in dependencies and not pytest_args.aws:
         pytest.skip("Skipping AWS tests")


### PR DESCRIPTION
## Summary

Un-skips the GCS docs snippet fixtures and gates them on a new `--gcs` pytest flag, which `docs-creds-needed` now requests.

Two independent gates each made these fixtures unreachable, so both had to go:

- **The unconditional cloud-object-store skip.** `_check_for_skipped_tests` skipped anything backed by S3, GCS, or Azure Blob outright. S3 and Azure Blob stay in that block — neither has storage or a live credential yet — but GCS now has both, so the blanket gate no longer applies to it.
- **The `--bigquery` gate.** GCS was gated on `--bigquery`, which made GCS coverage silently conditional on BigQuery's health. It now has its own `--gcs` flag, which is inert for `build_test_backends_list` and so cannot abort collection the way the credential-validating flags can.

Two further fixes fell out of actually running them:

- **`docs-creds-needed` now declares `requirements-dev-gcs.txt` explicitly.** It was getting `google-cloud-storage` transitively from the BigQuery requirements — the same GCS-on-BigQuery coupling this PR removes at the flag level, still present one layer down.
- **The Spark GCS guide is migrated to the current asset API.** It passed `batching_regex` into `add_csv_asset` and called `build_batch_request` on the asset, both of which predate batch definitions, so the asset now rejects `batching_regex` as an extra field. The pandas guide beside it was migrated when that API changed; this one was not, and nothing noticed because the fixture had never run. It has been shipping instructions that raise.

## Why

The GCS docs snippets are user-facing documentation that has not been executed in CI for the duration of the CI transition. The bucket (#12056), the credentials (#12057), and the datasource-level tests (#12058) are all restored; this reconnects the docs snippets to them.

## User impact

The Spark-on-GCS guide no longer documents an API call that raises. Everything else is test and CI wiring.

## How to review

All pandas GCS fixtures pass. The bucket needs exactly three objects under `data/taxi_yellow_tripdata_samples/` — `yellow_tripdata_sample_2019-01/02/03.csv` — because `partitioned_on_datetime.py` asserts an exact batch count of 3.

**The Spark GCS fixtures remain skipped, deliberately.** Requesting `--gcs` from `docs-spark` gets them past their Python-side gates and straight into:

```
org.apache.hadoop.fs.UnsupportedFileSystemException: No FileSystem for scheme "gs"
```

Spark resolves `gs://` only with the GCS Hadoop connector on the JVM classpath. That jar must exist when the JVM starts, so no requirements file can supply it — it needs `PYSPARK_SUBMIT_ARGS` or a pre-staged jar plus `fs.gs.impl` and service-account Hadoop config. Until that exists, requesting the flag converts a skip into a failure and buys nothing. The gap is documented in `tests/integration/test_definitions/gcs/README.md` and beside the flags in `tasks.py`, rather than being a silent consequence of which leg requests what.

Worth a close look:

- The `--gcs` flag is genuinely inert for `build_test_backends_list` — the concern is a flag that aborts collection rather than skipping.
- S3 and Azure Blob are still skipped unconditionally; only GCS was removed from that tuple.
- Watch for *skips* rather than failures on the pandas side. A green run of zero tests is the failure mode worth guarding against.