### PR TITLE
[MAINTENANCE] Drop the gx-redshift CI marker

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -889,11 +889,6 @@ MARKER_DEPENDENCY_MAP: Final[Mapping[str, TestDependencies]] = {
         extra_pytest_args=("--spark", "--docs-tests"),
     ),
     "gcs_deps": TestDependencies(("reqs/requirements-dev-gcs.txt",)),
-    # Deprecated alias for "redshift". Both now install the same upstream dialect;
-    # kept so existing invocations keep resolving.
-    "gx-redshift": TestDependencies(
-        requirement_files=("reqs/requirements-dev-gx-redshift.txt",),
-    ),
     "sql_server": TestDependencies(
         ("reqs/requirements-dev-sql-server.txt",),
         services=("mssql",),
@@ -959,8 +954,6 @@ def _marker_statement(marker: str) -> str:
         "trino",
     ]:
         return f"'all_backends or {marker}'"
-    elif marker == "gx-redshift":
-        return "'redshift'"
     else:
         return f"'{marker}'"
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -15,9 +15,9 @@ LOGGER: Final = logging.getLogger(__name__)
 PROJECT_ROOT: Final = pathlib.Path(__file__).parent.parent
 PYPROJECT_TOML: Final = PROJECT_ROOT / "pyproject.toml"
 # Markers that are used to launch CI but map to a different marker for tests.
-# eg, gx-redshift should run the redshift test so, while a marker for CI
+# eg, mssql should run the sql_server tests so, while a marker for CI,
 # there should be no tests with this marker.
-NO_TEST_MARKERS: Final = ["gx-redshift", "mssql"]
+NO_TEST_MARKERS: Final = ["mssql"]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Follow-up to #12044, now merged — this branch is rebased onto `develop` and contains a single commit.

### What

Removes the `gx-redshift` CI-launch key:

- `MARKER_DEPENDENCY_MAP["gx-redshift"]` in `tasks.py`
- the `gx-redshift` → `'redshift'` translation in `_marker_statement`
- the resulting `NO_TEST_MARKERS` exemption in `tests/test_markers.py`

### Why

`gx-redshift` was never a pytest marker — it was a CI-launch key that selected the requirements file installing the forked dialect, with a marker-string translation mapping it back to `redshift` so the right tests ran. That is also why it needed an exemption from the check that every dependency-map key is a registered marker.

Now that both requirements files install the same upstream dialect and the lane selects `redshift` directly (#12044), the key selects nothing the canonical marker does not already select.

The deprecated `gx-redshift` **extra** is unaffected — it is built from the requirements file directly by `setup.py` and remains supported, so existing install commands keep working.

### Why this was split from #12044

Workflow definitions come from the base branch. Removing this key while `develop` still selected `gx-redshift` would have installed no Redshift dependencies (the lookup is a silent `.get`) and selected no tests — the lane would have run nothing while appearing to run, and `redshift` is in the CI-results gate's `needs:`.

With #12044 merged, `develop`'s lane now invokes `invoke ci-tests 'redshift'`, which resolves against this branch to marker statement `'redshift'` and dependency entry `reqs/requirements-dev-redshift.txt`. The Redshift lane keeps working continuously across both merges.

### Verification

`tests/test_markers.py`, `tests/test_sql_backend_wiring.py`, `tests/test_packaging.py` — 69 passed, 7 skipped against the rebased base. `ruff check` and `ruff format --check` clean.