### PR TITLE
[DOCS] Teach integer batch parameters across the documentation

### DIFF
--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_daily.py
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_daily.py
@@ -20,7 +20,7 @@ batch_definition = file_data_asset.add_batch_definition_daily(
 
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_daily.py - retrieve Batch and verify">
 batch = batch_definition.get_batch(
-    batch_parameters={"year": "2019", "month": "01", "day": "01"}
+    batch_parameters={"year": 2019, "month": 1, "day": 1}
 )
 print(batch.head())
 # </snippet>

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_monthly.py
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_monthly.py
@@ -21,7 +21,7 @@ batch_definition = file_data_asset.add_batch_definition_monthly(
 # </snippet>
 
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_monthly.py - retrieve Batch and verify">
-batch = batch_definition.get_batch(batch_parameters={"year": "2019", "month": "01"})
+batch = batch_definition.get_batch(batch_parameters={"year": 2019, "month": 1})
 print(batch.head())
 # </snippet>
 # </snippet>

--- a/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_yearly.py
+++ b/docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_yearly.py
@@ -19,7 +19,7 @@ batch_definition = file_data_asset.add_batch_definition_yearly(
 # </snippet>
 
 # <snippet name="docs/docusaurus/docs/core/connect_to_data/filesystem_data/_create_a_batch_definition/_examples/_file_partitioned_yearly.py - retrieve Batch and verify">
-batch = batch_definition.get_batch(batch_parameters={"year": "2019"})
+batch = batch_definition.get_batch(batch_parameters={"year": 2019})
 print(batch.head())
 # </snippet>
 # </snippet>

--- a/docs/docusaurus/docs/core/define_expectations/_examples/retrieve_a_batch_of_test_data_from_a_batch_definition.py
+++ b/docs/docusaurus/docs/core/define_expectations/_examples/retrieve_a_batch_of_test_data_from_a_batch_definition.py
@@ -60,20 +60,17 @@ batch = batch_definition.get_batch()
 # These are sample Batch Parameter dictionaries:
 # <snippet name="docs/docusaurus/docs/core/define_expectations/_examples/retrieve_a_batch_of_test_data_from_a_batch_definition.py - sample Batch Parameter dictionaries">
 
-# If you're using File Data Assets, pass values as strings
-yearly_batch_parameters = {"year": "2019"}
-monthly_batch_parameters = {"year": "2019", "month": "01"}
-daily_batch_parameters = {"year": "2019", "month": "01", "day": "01"}
-
-# Otherwise, pass values as integers
-integer_daily_batch_parameters = {"year": 2019, "month": 1, "day": 1}
+# Values for year, month, and day are integers, regardless of Data Asset type
+yearly_batch_parameters = {"year": 2019}
+monthly_batch_parameters = {"year": 2019, "month": 1}
+daily_batch_parameters = {"year": 2019, "month": 1, "day": 1}
 
 # </snippet>
 
 # This code retrieves the Batch from a monthly Batch Definition:
 # <snippet name="docs/docusaurus/docs/core/define_expectations/_examples/retrieve_a_batch_of_test_data_from_a_batch_definition.py - retrieve specific Batch">
 
-batch = batch_definition.get_batch(batch_parameters={"year": "2019", "month": "01"})
+batch = batch_definition.get_batch(batch_parameters={"year": 2019, "month": 1})
 # </snippet>
 
 # <snippet name="docs/docusaurus/docs/core/define_expectations/_examples/retrieve_a_batch_of_test_data_from_a_batch_definition.py - verify populated Batch">

--- a/docs/docusaurus/docs/core/define_expectations/_retrieve_a_batch_of_test_data/_from_a_batch_definition.md
+++ b/docs/docusaurus/docs/core/define_expectations/_retrieve_a_batch_of_test_data/_from_a_batch_definition.md
@@ -64,8 +64,6 @@ Batch Definitions both organize a Data Asset's records into Batches and provide 
    ```python title="Python" name="docs/docusaurus/docs/core/define_expectations/_examples/retrieve_a_batch_of_test_data_from_a_batch_definition.py - sample Batch Parameter dictionaries"
    ```
 
-   Note that the format depends on whether or not you are using a [File Data Asset](/core/connect_to_data/filesystem_data/filesystem_data.md?data_asset=file#create-a-data-asset). 
-
 3. Retrieve a Batch of data.
 
    The Batch Definition's `.get_batch(...)` method is used to retrieve a Batch of Data.  The Batch Parameters provided to this method will determine if the first valid Batch is returned, or a Batch for a specific date is returned.

--- a/docs/docusaurus/docs/core/run_validations/_examples/run_a_validation_definition.py
+++ b/docs/docusaurus/docs/core/run_validations/_examples/run_a_validation_definition.py
@@ -60,8 +60,8 @@ validation_definition = context.validation_definitions.get(validation_definition
 # Accepted keys are determined by the BatchDefinition used to instantiate this ValidationDefinition.
 # <snippet name="docs/docusaurus/docs/core/run_validations/_examples/run_a_validation_definition.py - define batch parameters">
 batch_parameters_dataframe = {"dataframe": df}
-batch_parameters_daily = {"year": "2020", "month": "1", "day": "17"}
-batch_parameters_yearly = {"year": "2019"}
+batch_parameters_daily = {"year": 2020, "month": 1, "day": 17}
+batch_parameters_yearly = {"year": 2019}
 # </snippet>
 
 # Run the Validation Definition

--- a/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/run_a_checkpoint.py
+++ b/docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/run_a_checkpoint.py
@@ -77,7 +77,7 @@ set_up_context_for_example(context)
 
 checkpoint = context.checkpoints.get("my_checkpoint")
 
-batch_parameters = {"month": "01", "year": "2019"}
+batch_parameters = {"month": 1, "year": 2019}
 
 # <snippet name="docs/docusaurus/docs/core/trigger_actions_based_on_results/_examples/run_a_checkpoint.py - define Expectation Parameters">
 expectation_parameters = {

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_pandas.py
@@ -52,7 +52,7 @@ assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 batch_definition = data_asset.add_batch_definition_monthly(
     name="Monthly Taxi Data", regex=batching_regex
 )
-batch_parameters = {"year": "2019", "month": "03"}
+batch_parameters = {"year": 2019, "month": 3}
 batch = batch_definition.get_batch(batch_parameters=batch_parameters)
 
 assert set(batch.columns()) == {

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_azure_blob_storage_using_spark.py
@@ -51,7 +51,7 @@ assert data_asset
 
 assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 
-my_batch_request = data_asset.build_batch_request({"year": "2019", "month": "03"})
+my_batch_request = data_asset.build_batch_request({"year": 2019, "month": 3})
 batch = data_asset.get_batch(my_batch_request)
 assert set(batch.columns()) == {
     "vendor_id",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_pandas.py
@@ -44,7 +44,7 @@ assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 my_batch_definition = data_asset.add_batch_definition_monthly(
     name="Monthly Taxi Data", regex=batching_regex
 )
-batch = my_batch_definition.get_batch(batch_parameters={"year": "2019", "month": "03"})
+batch = my_batch_definition.get_batch(batch_parameters={"year": 2019, "month": 3})
 assert set(batch.columns()) == {
     "vendor_id",
     "pickup_datetime",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_gcs_using_spark.py
@@ -49,7 +49,7 @@ assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 my_batch_definition = data_asset.add_batch_definition_monthly(
     name="Monthly Taxi Data", regex=batching_regex
 )
-batch = my_batch_definition.get_batch(batch_parameters={"year": "2019", "month": "03"})
+batch = my_batch_definition.get_batch(batch_parameters={"year": 2019, "month": 3})
 assert set(batch.columns()) == {
     "vendor_id",
     "pickup_datetime",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_pandas.py
@@ -42,7 +42,7 @@ assert data_asset
 
 assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 
-batch_parameters = {"year": "2019", "month": "03"}
+batch_parameters = {"year": 2019, "month": 3}
 batch = batch_definition.get_batch(batch_parameters=batch_parameters)
 assert set(batch.columns()) == {
     "vendor_id",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_data_on_s3_using_spark.py
@@ -49,7 +49,7 @@ batch_definition = data_asset.add_batch_definition_monthly(
 # </snippet>
 
 
-batch = batch_definition.get_batch(batch_parameters={"year": "2019", "month": "03"})
+batch = batch_definition.get_batch(batch_parameters={"year": 2019, "month": 3})
 assert set(batch.columns()) == {
     "vendor_id",
     "pickup_datetime",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_pandas.py
@@ -53,7 +53,7 @@ assert datasource.get_asset_names() == {"my_taxi_data_asset"}
 my_asset = datasource.get_asset(asset_name)
 assert my_asset
 
-my_batch_request = my_asset.build_batch_request({"year": "2019", "month": "03"})
+my_batch_request = my_asset.build_batch_request({"year": 2019, "month": 3})
 batch = my_asset.get_batch(my_batch_request)
 assert set(batch.columns()) == {
     "vendor_id",

--- a/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py
+++ b/docs/docusaurus/docs/oss/guides/connecting_to_your_data/fluent/filesystem/how_to_connect_to_one_or_more_files_using_spark.py
@@ -57,7 +57,7 @@ my_batch_definition = my_asset.add_batch_definition_monthly(
     name="my_monthly_batch_definition", regex=batching_regex
 )
 my_batch_request = my_batch_definition.build_batch_request(
-    batch_parameters={"year": "2019", "month": "03"}
+    batch_parameters={"year": 2019, "month": 3}
 )
 batch = my_asset.get_batch(my_batch_request)
 assert set(batch.columns()) == {


### PR DESCRIPTION
## Summary

Updates every documentation surface that teaches batch parameters — the runnable examples
registered in the docs-tests gate, the non-registered snippets, and the older filesystem
connection guides — to pass integers for numeric batch parameters uniformly across file,
SQL, and directory sources. The prose telling readers that the accepted type depends on
the asset family is removed, because it no longer does.

## This PR must merge only with the release that ships the integer contract

**Expected 1.21.0. Please do not merge it before that release.**

Published documentation builds from released lines. The contract these pages teach is not
released yet: on the currently shipped version, passing an integer to a file-based batch
parameter raises `InvalidBatchRequestError`, while the string forms these pages currently
teach keep working — with a deprecation warning — throughout the transition window.

Merging ahead of the release would hand readers guidance that fails on the version they
have installed. Published guidance must never precede released behavior.

This branch was forked from the head of the feature branch with `develop` as its base, so
once the feature merges, this diff collapses to a documentation-only change and needs no
rebase and no force-push.

## Scope

Parameter typing only. The older connection guides under `oss/guides/` have aged in other
ways — several still show pre-1.0 call shapes — and those are deliberately left alone
rather than modernized here, so this diff stays reviewable as one mechanical change.

Where a snippet asserts the options it built, the expected value moves with the supplied
value, so each snippet stays internally consistent.

## Verification

- The six examples registered in the docs-tests gate all pass against the feature branch
  this was forked from.
- The non-registered snippet and the eight connection guides were checked by hand for
  internal consistency; parameter values and any dependent assertions were updated
  together.
- `ruff check` and `ruff format --check` clean on every changed Python file.
- The diff is confined to `docs/docusaurus/`; `versioned_docs/` is untouched.
