### PR TITLE
[FEATURE] Route validated expectations onward into checkpoint orchestration

### DIFF
--- a/ci/checks/check_installed_agent_skills.py
+++ b/ci/checks/check_installed_agent_skills.py
@@ -12,11 +12,11 @@ either way, so nothing in the ordinary import-and-run check catches it.
 This script is meant to run after `pip install .`, against the resulting installed
 package, and checks the properties a user actually depends on:
 
-* both bundled skills resolve the way an installed package resolves them -- through
+* the bundled skills resolve the way an installed package resolves them -- through
   the import system, not by checking that some files happen to exist;
 * both schema catalog indexes are present, and each schema tree ships more than just
   its index;
-* the `skills list` subcommand names both skills;
+* the `skills list` subcommand names every bundled skill;
 * installing from the running package produces content that matches its own
   ownership manifest;
 * every file the source tree bundles for a skill actually made it into the installed
@@ -48,7 +48,9 @@ from great_expectations.agent_skills.installer import (
 #: The skills this package currently bundles, named explicitly rather than merely
 #: counted -- a rename or a dropped skill is then reported by name instead of as an
 #: unexplained count mismatch.
-EXPECTED_SKILLS: Final = frozenset({"gx-configure-data-source", "gx-configure-expectations"})
+EXPECTED_SKILLS: Final = frozenset(
+    {"gx-configure-data-source", "gx-configure-expectations", "gx-configure-checkpoint"}
+)
 
 #: The schema trees the package ships alongside the skills, each carrying its own
 #: catalog index, relative to the installed package root.
@@ -61,7 +63,7 @@ INDEX_NAME: Final = "index.json"
 
 
 def check_bundled_skills_resolve() -> list[Path]:
-    """Both skills must be found the way an installed package is found: through the
+    """The bundled skills must be found the way an installed package is found: through the
     import system, not by checking that some files happen to exist.
 
     ``iter_bundled_skills`` is what every install and list run relies on to locate the
@@ -98,8 +100,8 @@ def check_schema_counts_nonzero(installed_root: Path) -> dict[str, int]:
     return counts
 
 
-def check_skills_list_names_both(project_root: Path) -> str:
-    """The ``skills list`` subcommand must name both skills, run the way a user runs it.
+def check_skills_list_names_all(project_root: Path) -> str:
+    """The ``skills list`` subcommand must name every bundled skill, run the way a user runs it.
 
     Invoked in-process through the same entry point ``python -m great_expectations``
     calls, rather than shelled out to, so the exact code path a user runs is exercised
@@ -187,7 +189,7 @@ def main() -> None:
 
         with tempfile.TemporaryDirectory(prefix="gx-installed-skills-guard-") as scratch:
             project_root = Path(scratch)
-            check_skills_list_names_both(project_root)
+            check_skills_list_names_all(project_root)
             check_installed_digests_match_manifest(project_root)
 
         check_every_bundled_file_shipped(source_skills_root, skills[0].parent)

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/SKILL.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/SKILL.md
@@ -258,8 +258,8 @@ exactly as the data-source and expectations skills do — a checkpoint can
 touch as much data as every validation definition it groups, combined.
 `references/run-and-schedule.md` covers what `batch_parameters` actually
 does across multiple validation definitions, including a real trap when more
-than one of them is dataframe-backed, and the one combination of batch
-definition types that cannot share a single run today.
+than one of them is dataframe-backed, and why numeric window parameters are
+integers on every datasource family.
 
 **Pair each outcome to the validation definition it came from by identity,
 never by position:**
@@ -412,8 +412,9 @@ is the end state. Two things sit outside it:
 - `references/action-catalog.md` — every attachable post-run action, its
   fields, the public-API stability split, and enabling Data Docs.
 - `references/run-and-schedule.md` — `batch_parameters` semantics across
-  multiple validation definitions, the mixed-partitioner-type limitation,
-  the run snippet, and where scheduling guidance stops.
+  multiple validation definitions, integer window parameters and the
+  deprecation of digit strings, the run snippet, and where scheduling
+  guidance stops.
 - `references/robustness.md` — the time-budget wrapper, scope-reduction
   levers, and how to report a failure helpfully.
 - `references/write-out.md` — turning an in-memory session into a real

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/SKILL.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/SKILL.md
@@ -298,7 +298,7 @@ an outcome belongs to.
 ## Step 7 — Confirm persistence, offer write-out
 
 **In a file-backed project, the checkpoint and its validation definitions
-are already saved** — the explicit adds in steps 3 and 5 wrote them.
+are already saved** — the explicit adds in steps 3 and 4 wrote them.
 Confirm this concretely: name the checkpoint, name the validation
 definitions it groups, and say that a fresh session picks it up with
 `context.checkpoints.get("<name>")`.
@@ -364,7 +364,7 @@ existing_checkpoints = {c.name for c in context.checkpoints.all()}
 if CHECKPOINT_NAME in existing_checkpoints:
     checkpoint = context.checkpoints.get(CHECKPOINT_NAME)
 else:
-    checkpoint = context.checkpoints.add(                       # step 5: explicit add
+    checkpoint = context.checkpoints.add(                       # step 4: explicit add
         Checkpoint(
             name=CHECKPOINT_NAME,
             validation_definitions=[validation_definition],

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/SKILL.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/SKILL.md
@@ -1,0 +1,420 @@
+---
+name: gx-configure-checkpoint
+description: Turn a working batch definition and expectation suite into a persisted, re-runnable checkpoint with post-run actions — bind them into a validation definition, group into a named checkpoint, verify it by running it once, and hand off a scheduler-agnostic run snippet. Use when a user wants their checks to survive the session ("make this re-runnable", "schedule this", "notify us when this fails", "update our Data Docs after a run"), or when validation results were printed once and never saved.
+license: Apache-2.0
+---
+
+# Configure a Great Expectations checkpoint
+
+This skill takes a user from "here is a suite that already validated my data"
+to a **persisted, re-runnable checkpoint** — a named, saved grouping of one or
+more validation definitions plus the actions that should fire after a run —
+verified by actually running it once.
+
+Two objects, each built on work an earlier skill already did:
+
+- A **validation definition** binds one batch definition to one expectation
+  suite: the specific slice of data, and the specific checks to run against
+  it.
+- A **checkpoint** is the named, persisted grouping of validation definitions
+  plus the post-run actions to fire — notifications, a Data Docs update — run
+  as one operation.
+
+Everything here goes through Great Expectations' public configuration API and
+produces ordinary project artifacts. Nothing depends on this skill being
+present afterwards — the checkpoint this flow builds runs from a plain Python
+script outside any agent session, which is the point of it.
+
+## The flow
+
+1. **Preflight** — find out which project (or in-memory session) you are
+   operating on, and tell the user. See `references/preflight.md`.
+2. **Check the precondition** — at least one expectation suite and one
+   working batch definition must already exist. If either is missing, hand
+   off and stop.
+3. **Bind** — pair batch definitions and suites into validation definitions.
+4. **Group and add** — collect validation definitions into a named checkpoint
+   with post-run actions, chosen from `references/action-catalog.md`,
+   persisting it explicitly as part of the same step.
+5. **Never rely on the run call to persist it for you** — step 4's explicit
+   add is what makes that safe; see why below.
+6. **Verify** by running once, and report per-validation-definition and
+   per-expectation outcomes.
+7. **Confirm persistence**, and offer write-out when the session is in
+   memory.
+8. **Hand off** a run snippet that re-runs the checkpoint from outside this
+   session — see `references/run-and-schedule.md`.
+
+Steps 2 and 5, and the fetch-first rule below, are where this flow fails
+destructively rather than loudly if skipped or reordered. Do not skip step 6
+either — a checkpoint that was never run is not a verified result.
+
+## Step 1 — Preflight
+
+Follow `references/preflight.md` in full before touching anything. It
+establishes whether you are working against a project on disk or an
+in-memory session, tells you what to announce to the user, and covers the
+environment problems that silently masquerade as "no project found".
+
+The outcome you carry forward is a `context` object and one fact: whether the
+session is file-backed or in memory. Both are fully supported paths, and the
+difference matters again at step 7.
+
+## Step 2 — The precondition: a suite and a working batch definition
+
+A checkpoint has nothing to run without both a batch definition to read data
+through and an expectation suite to check it with. **There is no acceptable
+way to improvise either one here** — do not build a suite from a guess at
+what the data looks like, and do not construct a batch definition by hand.
+
+Enumerate what the session already has:
+
+```python
+def existing_suites_and_batch_definitions(context):
+    suite_names = [suite.name for suite in context.suites.all()]
+    batch_definitions = []
+    for datasource in context.data_sources.all().values():
+        for asset in datasource.assets:
+            for batch_definition in asset.batch_definitions:
+                batch_definitions.append((datasource.name, asset.name, batch_definition.name))
+    return suite_names, batch_definitions
+```
+
+**If either list comes back empty, stop and route:**
+
+- No batch definition → hand off to `gx-configure-data-source`.
+- No expectation suite → hand off to `gx-configure-expectations`.
+- Neither exists → lead with the data source, since a suite is built against
+  a batch and there is nothing to build one against yet.
+
+This is a hard stop, not a suggestion — say plainly what's missing, name the
+skill that builds it, and end this flow. Do not carry on and do not
+improvise a workaround.
+
+If more than one suite or batch definition is available, name them and let
+the user choose which pairs to bind — guessing which check should run
+against which slice of their data is not a decision to make for them.
+
+## Step 3 — Bind: one validation definition per pair
+
+A validation definition needs its suite already persisted in the working
+context. **Building one against a suite the context has never seen raises,**
+not silently loses work the way an unregistered suite does elsewhere in this
+skill family:
+
+```python
+from great_expectations.core import ExpectationSuite, ValidationDefinition
+
+unsaved_suite = ExpectationSuite(name="not_saved_yet")
+# ValidationDefinition(name="x", data=batch_definition, suite=unsaved_suite)
+# ctx.validation_definitions.add(...) on this raises ResourceFreshnessAggregateError:
+# "ExpectationSuite 'not_saved_yet' must be added to the DataContext before it
+# can be updated. Please call `context.suites.add(<SUITE_OBJECT>)`..."
+```
+
+So always fetch the suite (and the batch definition) from the context rather
+than closing over an object from earlier in the conversation that might not
+be the one actually persisted:
+
+```python
+from great_expectations.core import ValidationDefinition
+
+VALIDATION_DEFINITION_NAME = "orders_quality_check"
+
+datasource = context.data_sources.get("warehouse")
+asset = datasource.get_asset("orders")
+batch_definition = asset.get_batch_definition("by_month")
+suite = context.suites.get("orders_quality")
+
+existing = {vd.name for vd in context.validation_definitions.all()}
+if VALIDATION_DEFINITION_NAME in existing:
+    validation_definition = context.validation_definitions.get(VALIDATION_DEFINITION_NAME)
+else:
+    validation_definition = context.validation_definitions.add(
+        ValidationDefinition(
+            name=VALIDATION_DEFINITION_NAME, data=batch_definition, suite=suite
+        )
+    )
+```
+
+Membership is checked through `.all()` rather than a fetch-and-except, the
+same reason `references/write-out.md` uses it for these two object types:
+`validation_definitions.get()` on a miss raises `DataContextError`, which is
+not a `LookupError` — the `except LookupError` idiom from the data-source
+skill does not transfer here. Name it in prose, and never import it.
+
+Repeat this once per (batch definition, suite) pair the user wants bound.
+Reusing an already-bound pair under the same name is safe — the fetch above
+returns it unchanged.
+
+## Step 4 — Group: build the checkpoint, and add it
+
+```python
+from great_expectations.checkpoint import Checkpoint
+from great_expectations.checkpoint.actions import UpdateDataDocsAction
+
+CHECKPOINT_NAME = "orders_checkpoint"
+
+existing_checkpoints = {c.name for c in context.checkpoints.all()}
+if CHECKPOINT_NAME in existing_checkpoints:
+    checkpoint = context.checkpoints.get(CHECKPOINT_NAME)
+else:
+    checkpoint = context.checkpoints.add(
+        Checkpoint(
+            name=CHECKPOINT_NAME,
+            validation_definitions=[validation_definition],
+            actions=[UpdateDataDocsAction(name="update_data_docs")],
+        )
+    )
+```
+
+**This is the explicit add step 5 below is about — the create branch calls
+`context.checkpoints.add(...)` directly, so `checkpoint` is a persisted
+object on both branches before anything runs.** Get the two branches from
+step 3's pattern above if adapting this by hand: fetch on a name that already
+exists, build-and-add on one that doesn't. Never construct a bare
+`Checkpoint(...)` and hold onto it without one of these two calls — that is
+exactly the unpersisted object step 5 exists to warn about.
+
+Ask what should happen after a run — a Slack or Teams message, an email, a
+Data Docs rebuild, one of the less common actions — before assuming none is
+wanted. `references/action-catalog.md` covers every attachable action: its
+fields, which four carry a public-API stability guarantee and which four
+don't, and how to word each one's credential requirements.
+
+**Before attaching a Data Docs update action, check whether the project has a
+site to write to.** File-backed projects and in-memory sessions both carry a
+working default site; `references/action-catalog.md` covers both, and one
+project state that doesn't: `great_expectations.yml` can hold
+`data_docs_sites: null`, under which every site-management call silently
+does nothing — no error, no site, no sign anything went wrong. The reference
+gives the fix, and it edits the user's `great_expectations.yml`, so **ask
+before running it.** Finding `data_docs_sites: null` is not, by itself,
+permission to change it — state what you found and what the fix involves,
+and wait for a yes. If the user declines, name the same fix as the path
+forward and build the checkpoint without the action.
+
+## The fetch-first rule: never `add_or_update` an existing checkpoint or validation definition to change it
+
+`context.checkpoints.add_or_update(...)` and
+`context.validation_definitions.add_or_update(...)` both persist the
+**incoming** object with the stored object's id transplanted onto it — a
+whole-object replacement, not a merge. For a checkpoint, the replacement
+**cascades**: a fresh validation-definition object passed in as part of the
+incoming checkpoint is itself `add_or_update`-ed, and that in turn
+`add_or_update`s its own suite. Verified directly, isolating exactly what
+that cascade does and does not touch:
+
+| | outcome |
+| --- | --- |
+| **Always lost** | the checkpoint's validation-definition membership **and its actions** — replaced wholesale by whatever the incoming object listed |
+| **Conditionally lost** | a bound suite's *contents* — only when a **fresh** suite object is passed under an existing name; upserting with the suite you fetched from the context first leaves it untouched |
+| **Never lost** | validation definitions already in the store — nothing here deletes one; a validation definition dropped from a checkpoint's membership is still fetchable afterward |
+
+Be precise about this when you talk to a user: *"you'll lose this
+checkpoint's action list and which validation definitions it groups"* is
+accurate; *"your other validation definitions will be deleted"* is not, and
+overstating the damage is as much a defect as understating it.
+
+**`get` → mutate → `save` avoids the cascade entirely.** To change an
+existing checkpoint's actions, or which validation definitions it groups,
+fetch it, mutate the field, and save the same object back — never rebuild it
+from scratch and hand it to `add_or_update`:
+
+```python
+checkpoint = context.checkpoints.get(CHECKPOINT_NAME)
+checkpoint.actions = checkpoint.actions + [UpdateDataDocsAction(name="update_data_docs")]
+checkpoint.save()
+```
+
+`add_or_update` is not banned outright — it is the right call the one time a
+user explicitly wants a checkpoint's whole contents replaced, and only after
+you have told them exactly what that discards, per the table above.
+
+## Step 5 — Why step 4 added explicitly, before running
+
+**Never construct a bare `Checkpoint(...)` and hand it straight to `.run()`
+without going through the `context.checkpoints.add(...)` /
+`context.checkpoints.get(...)` branches in step 4, even though it would
+work.** `Checkpoint.run()` auto-persists an unsaved checkpoint whose
+validation definitions and suites are themselves already saved — verified
+directly: a `Checkpoint` object built and run without ever being added to
+the context shows up in `context.checkpoints.all()` immediately afterward,
+with no error and no warning that it happened implicitly. That is exactly
+why step 4 is written to add explicitly rather than left to be discovered as
+unnecessary: skipping it still produces a persisted checkpoint, so nothing
+about the flow fails to teach you that the explicit step was needed.
+Persistence is something step 4 does on purpose, not a side effect of the
+verification run in step 6.
+
+## Step 6 — Verify by one run, and report by identity
+
+```python
+result = checkpoint.run(batch_parameters={"dataframe": df})
+```
+
+Run this inside the duration-tracked wrapper in `references/robustness.md`,
+exactly as the data-source and expectations skills do — a checkpoint can
+touch as much data as every validation definition it groups, combined.
+`references/run-and-schedule.md` covers what `batch_parameters` actually
+does across multiple validation definitions, including a real trap when more
+than one of them is dataframe-backed, and the one combination of batch
+definition types that cannot share a single run today.
+
+**Pair each outcome to the validation definition it came from by identity,
+never by position:**
+
+```python
+for vr_id, vr in result.run_results.items():
+    print(f"validation definition: batch={vr_id.batch_identifier} suite={vr.suite_name}")
+    for each in vr.results:
+        config = each.expectation_config
+        if each.success:
+            print(f"  PASS {config.type} {config.kwargs}")
+        elif not each.result:
+            for _metric_id, info in each.exception_info.items():
+                print(f"  ERROR {config.type} {config.kwargs}: {info['exception_message']}")
+        else:
+            print(f"  FAIL {config.type} {config.kwargs}: {each.result}")
+```
+
+The same infra-vs-data discriminator from the expectations skill applies at
+this level too: `success is False` with an **empty** `result` is a metric
+error — a broken column or query, not a finding about the data — while a
+populated `result` (even one carrying `observed_value: None`, which empty
+tables and all-null columns produce routinely) is a real outcome to report as
+such. `references/robustness.md` has the full rules for translating either
+case into something a user can act on; do not report a metric error as
+"your data failed this check."
+
+Report the overall `result.success`, then each validation definition's own
+outcome, then each expectation within it — not just a total pass/fail count.
+`result.describe()` (the summary method that is `@public_api`) gives the
+same information as a formatted JSON string, useful for a short written
+recap, but it does not label its entries by name — use the loop above, not
+`describe()`, whenever the report needs to say *which* validation definition
+an outcome belongs to.
+
+## Step 7 — Confirm persistence, offer write-out
+
+**In a file-backed project, the checkpoint and its validation definitions
+are already saved** — the explicit adds in steps 3 and 5 wrote them.
+Confirm this concretely: name the checkpoint, name the validation
+definitions it groups, and say that a fresh session picks it up with
+`context.checkpoints.get("<name>")`.
+
+**In an in-memory session, none of it survives the process.** Say this
+plainly, and **offer to write the session out** — data sources through
+checkpoints — to a real project, per `references/write-out.md`. That
+procedure extends past suites to validation definitions and checkpoints,
+re-created in the target project only after everything they reference is
+already there. Offer it; don't do it unprompted, and don't pick the
+location. The offer ends this flow the same way it does in the earlier
+skills: write-out is a separate run, starting only after the user has agreed
+and named a directory — never in the same program as the steps above.
+
+## Step 8 — Hand off the run snippet
+
+The checkpoint is only re-runnable outside this conversation if there is a
+concrete way to re-run it. Give the user a small, self-contained script that
+loads the project by an absolute path and re-runs the checkpoint by name —
+see `references/run-and-schedule.md` for the exact template, why each of its
+choices is deliberate, and the one case (a dataframe-backed validation
+definition) where it doesn't apply as written.
+
+**Offer to save it to a file the user confirms; never write it unasked.**
+Present it in the conversation first. Wiring it into an actual schedule — a
+cron entry, an Airflow DAG, a CI job — is the user's orchestrator's job, not
+this skill's; say that plainly if asked, and hand over the snippet as the
+piece their scheduler needs to call.
+
+## Worked example
+
+A file-backed project already holds a verified `orders` batch definition,
+partitioned monthly, and an `orders_quality` suite built and run earlier by
+the other two skills.
+
+```python
+import great_expectations as gx
+from great_expectations.core import ValidationDefinition
+from great_expectations.checkpoint import Checkpoint
+from great_expectations.checkpoint.actions import UpdateDataDocsAction
+
+context = gx.get_context(cloud_mode=False)                    # step 1
+
+# step 2: both preconditions already exist -- proceed
+datasource = context.data_sources.get("warehouse")
+asset = datasource.get_asset("orders")
+batch_definition = asset.get_batch_definition("by_month")
+suite = context.suites.get("orders_quality")
+
+VALIDATION_DEFINITION_NAME = "orders_quality_check"           # step 3
+existing_vds = {vd.name for vd in context.validation_definitions.all()}
+if VALIDATION_DEFINITION_NAME in existing_vds:
+    validation_definition = context.validation_definitions.get(VALIDATION_DEFINITION_NAME)
+else:
+    validation_definition = context.validation_definitions.add(
+        ValidationDefinition(
+            name=VALIDATION_DEFINITION_NAME, data=batch_definition, suite=suite
+        )
+    )
+
+CHECKPOINT_NAME = "orders_checkpoint"                          # step 4
+existing_checkpoints = {c.name for c in context.checkpoints.all()}
+if CHECKPOINT_NAME in existing_checkpoints:
+    checkpoint = context.checkpoints.get(CHECKPOINT_NAME)
+else:
+    checkpoint = context.checkpoints.add(                       # step 5: explicit add
+        Checkpoint(
+            name=CHECKPOINT_NAME,
+            validation_definitions=[validation_definition],
+            actions=[UpdateDataDocsAction(name="update_data_docs")],
+        )
+    )
+
+result = checkpoint.run(batch_parameters={"year": 2024, "month": 3})  # step 6
+
+for vr_id, vr in result.run_results.items():
+    print(f"{vr_id.batch_identifier} / {vr.suite_name}: success={vr.success}")
+    for each in vr.results:
+        config = each.expectation_config
+        status = "PASS" if each.success else ("ERROR" if not each.result else "FAIL")
+        print(f"  {status} {config.type} {config.kwargs}")
+```
+
+Against a month where one order has no customer, that prints:
+
+```text
+warehouse-orders-year_2024-month_3 / orders_quality: success=False
+  FAIL expect_column_values_to_not_be_null {'batch_id': 'warehouse-orders-year_2024-month_3', 'column': 'customer'}
+```
+
+Report to the user: the checkpoint `orders_checkpoint` is saved, groups one
+validation definition (`orders_quality_check`, over the March 2024 window),
+ran once, and found one failure — a missing customer on one row. Then move
+to step 7's persistence confirmation and step 8's run-snippet handoff.
+
+## Where this flow ends
+
+The persisted, run, reported checkpoint — with its run snippet handed off —
+is the end state. Two things sit outside it:
+
+- **Building the suite or batch definition it groups.** If step 2's
+  precondition fails, that is `gx-configure-expectations` or
+  `gx-configure-data-source`'s work, not something to improvise around.
+- **Wiring the run snippet into an actual cadence.** That's the user's
+  orchestrator's job — see `references/run-and-schedule.md`.
+
+## References
+
+- `references/preflight.md` — establishing and announcing the session
+  context.
+- `references/action-catalog.md` — every attachable post-run action, its
+  fields, the public-API stability split, and enabling Data Docs.
+- `references/run-and-schedule.md` — `batch_parameters` semantics across
+  multiple validation definitions, the mixed-partitioner-type limitation,
+  the run snippet, and where scheduling guidance stops.
+- `references/robustness.md` — the time-budget wrapper, scope-reduction
+  levers, and how to report a failure helpfully.
+- `references/write-out.md` — turning an in-memory session into a real
+  project, extended through validation definitions and checkpoints.

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/references/action-catalog.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/references/action-catalog.md
@@ -1,0 +1,302 @@
+# The post-run action catalog
+
+A checkpoint's `actions` list is what fires after `run()` completes: a
+notification, a Data Docs rebuild, a webhook. This document covers every
+attachable action, its fields, and the mechanics of enabling Data Docs so an
+update action has a site to write to.
+
+## Counting the catalog: eight actions, not the base class
+
+`ValidationAction` is the abstract base every action subclasses. Do not
+attach it — it has no `run()` implementation of its own and exists only to be
+subclassed. `DataDocsAction` is an intermediate base below it — it has
+**two** subclasses, not one: `SlackNotificationAction` and
+`UpdateDataDocsAction` (verified: `DataDocsAction.__subclasses__()` returns
+exactly those two). `DataDocsAction` contributes helper methods for building
+and linking a Data Docs site and defines no field of its own (verified:
+`DataDocsAction.__fields__` holds only the two inherited from
+`ValidationAction`, `type` and `name`). That is why `notify_with` — the
+field for linking Data Docs sites in a notification — is declared directly
+on `SlackNotificationAction` itself, **and independently again** on
+`EmailAction`, a class that does not descend from `DataDocsAction` at all
+(its base is `ValidationAction`). Both actions carry it; neither inherits it
+from the other or from a shared base. `DataDocsAction` is not attachable
+either, for the same reason as `ValidationAction`. Selecting on which classes
+carry their own non-`None` `type` literal is what separates the two bases
+from the eight things a user can actually attach — verified directly against
+the running registry, not assumed from a doc count:
+
+```python
+from great_expectations.checkpoint import actions
+
+def closure(cls):
+    found = set(cls.__subclasses__())
+    for c in list(found):
+        found |= closure(c)
+    return found
+
+attachable = sorted(
+    (c for c in closure(actions.ValidationAction) if c.__fields__["type"].default is not None),
+    key=lambda c: c.__name__,
+)
+print([c.__name__ for c in attachable])  # the eight actions below, and only them
+```
+
+Every action instance also needs its own `name` — a string identifying that
+action within the checkpoint, separate from its `type`. `type` is fixed per
+class; `name` is yours to choose (`name="notify_on_call"`, for example).
+
+## Stability split
+
+Four actions are `@public_api`: stable, documented, safe to build guidance
+around without qualification. Four exist, are registered, and deserialize
+from a stored checkpoint's config exactly like the public ones — but carry no
+public-API stability contract, and were adopted into this skill's guidance
+under a recorded case-by-case escalation rather than by default. State that
+caveat plainly wherever one of the four appears in your own guidance to a
+user: *"this action works today but isn't part of Great Expectations'
+public-API stability guarantee, so its interface is more likely to change
+between releases than the others."*
+
+| Action | `type` | Stability |
+| --- | --- | --- |
+| `SlackNotificationAction` | `slack` | `@public_api` |
+| `MicrosoftTeamsNotificationAction` | `microsoft` | `@public_api` |
+| `EmailAction` | `email` | `@public_api` |
+| `UpdateDataDocsAction` | `update_data_docs` | `@public_api` |
+| `PagerdutyAlertAction` | `pagerduty` | not public API — caveat above |
+| `OpsgenieAlertAction` | `opsgenie` | not public API — caveat above |
+| `SNSNotificationAction` | `sns` | not public API — caveat above |
+| `APINotificationAction` | `api` | not public API — caveat above |
+
+## Fields, per action
+
+**This split matters, and it does not follow the public/caveat line.** The
+three notification actions that take a webhook or address — Slack, Teams,
+Email — accept their credential-bearing fields as `Union[ConfigStr, str]`.
+Pass a `${ENV_VAR}` template exactly as in `gx-configure-data-source`'s
+connection strings and it resolves at use time, the same as everywhere else
+in this skill family: environment variables always, plus the project's
+uncommitted config-variables file in a file-backed project.
+
+**`PagerdutyAlertAction.api_key`/`routing_key`, `OpsgenieAlertAction.api_key`,
+`SNSNotificationAction.sns_topic_arn`, and `APINotificationAction.url` are
+plain `str` fields — verified directly against the live models, not
+`ConfigStr`.** Great Expectations performs no substitution on them. A
+`${ENV_VAR}` template placed in one of these fields is not resolved; it is
+stored and used **literally**, character for character, as if it were the
+real credential. Verified end to end through an actual save/reload: a Slack
+action built with `slack_webhook="${SLACK_WEBHOOK_URL}"` reloads as a
+`ConfigStr` that resolves correctly, while a Pagerduty action built with
+`api_key="${PD_KEY}"` reloads holding the bare string `'${PD_KEY}'` — the
+literal template text, not the secret it names. Two consequences follow, and
+both matter more here than anywhere else in this skill family:
+
+- **The template lands verbatim in the persisted checkpoint config**, since
+  nothing ever substitutes it. Writing `${ENV_VAR}` into one of these five
+  fields does not protect the secret the way it does for a connection string
+  or a Slack webhook — it just writes a string that looks like a template and
+  behaves like nothing.
+- **The action then authenticates with that literal text**, which is never a
+  valid credential, so it fails silently at run time rather than at setup —
+  the checkpoint runs, the action's `run()` fires, and only the destination
+  service's own rejection (an auth failure the checkpoint result does not
+  surface) reveals that nothing was actually sent.
+
+**Neither of this skill's usual answers applies to these five fields, and
+this skill does not write a credential into any of them.** A
+`${ENV_VAR}` template doesn't work — GX never resolves it there, so the
+action just fails to authenticate. The only way to make the field
+functional is to place the real credential in it, and that credential then
+lands in `checkpoints/<name>.json`, a file the project's scaffolded
+`.gitignore` does **not** exclude — verified directly: a fresh file-backed
+project's `.gitignore` holds exactly one line, `uncommitted/`, and
+`checkpoints/` is a tracked sibling directory alongside it, committed by
+default like any other project file. That is the opposite of what this
+skill's standard secret handling exists to guarantee, so there is no gated
+or opt-in version of writing it: **this skill will not place a credential
+in one of these five fields, under any circumstance.**
+
+Tell the user plainly: the action they've asked for needs a field Great
+Expectations offers no template mechanism for, so this skill can't wire it
+without putting the credential in tracked project config — something it
+won't do. If they still want the action, they can add it themselves, outside
+this skill, and accept that trade-off knowingly. Then build the checkpoint
+without it.
+
+Every action below with a `notify_on` field accepts the same six values —
+`"all"`, `"success"`, `"failure"`, `"info"`, `"warning"`, `"critical"` —
+verified directly against the live models, not just the two or three each
+individual docstring happens to mention. Treat the per-action lists below as
+covering the default and the common cases, not the full set.
+
+**`SlackNotificationAction`** — `slack`
+
+- Required: **either** `slack_webhook`, **or** both `slack_token` and
+  `slack_channel`. A checkpoint config carrying `slack_webhook` alongside
+  `slack_token`/`slack_channel` raises at construction time — pick one route
+  and use it exclusively.
+- Optional: `notify_on` (default `"all"`; full set above), `notify_with`
+  (list of Data Docs site names to link in the message; default is all
+  sites), `show_failed_expectations` (default `False`).
+
+```python
+SlackNotificationAction(
+    name="notify_slack",
+    slack_webhook="${SLACK_WEBHOOK_URL}",
+    notify_on="failure",
+)
+```
+
+**`MicrosoftTeamsNotificationAction`** — `microsoft`
+
+- Required: `teams_webhook`.
+- Optional: `notify_on` (default `"all"`).
+
+**`EmailAction`** — `email`
+
+- Required: `smtp_address`, `smtp_port`, `receiver_emails`.
+- Optional: `sender_login`, `sender_password` — both warn-only if absent
+  (GX logs that the server must accept unauthenticated mail; it does not
+  refuse to construct the action), `sender_alias` (defaults to
+  `sender_login`), `use_tls`, `use_ssl`, `notify_on` (default `"all"`),
+  `notify_with`.
+
+**`UpdateDataDocsAction`** — `update_data_docs`
+
+- Required: nothing beyond `name`.
+- Optional: `site_names` — a list of site names to build. **An empty list
+  (the default) means every configured site**, not "no sites" — there is no
+  way to request zero sites from this field; omit the action entirely if
+  that's the goal.
+- See "Enabling Data Docs" below before attaching this to a project that has
+  no site yet.
+
+**`PagerdutyAlertAction`** — `pagerduty` (stability caveat above)
+
+- Required: `api_key`, `routing_key` — **plain `str`, not templatable; see
+  "Fields, per action" above before asking for either one.**
+- Optional: `notify_on` (default `"failure"`), `severity` (`"critical"` /
+  `"error"` / `"warning"` / `"info"`, default `"critical"`).
+
+**`OpsgenieAlertAction`** — `opsgenie` (stability caveat above)
+
+- Required: `api_key` — **plain `str`, not templatable; see "Fields, per
+  action" above.**
+- Optional: `region` (set to `"EU"` for the European region, otherwise leave
+  unset), `priority` (`"P1"`–`"P5"`, default `"P3"`), `notify_on` (default
+  `"failure"`), `tags`.
+
+**`SNSNotificationAction`** — `sns` (stability caveat above)
+
+- Required: `sns_topic_arn` — **plain `str`, not templatable; see "Fields,
+  per action" above.**
+- Optional: `sns_message_subject` (defaults to the checkpoint result's name).
+
+**`APINotificationAction`** — `api` (stability caveat above)
+
+- Required: `url` — **plain `str`, not templatable; see "Fields, per action"
+  above.** Not a credential itself, but the same no-substitution behavior
+  applies to whatever this field holds.
+- No optional fields.
+
+## Missing configuration
+
+If the user asks for an action whose required field you don't have a value
+for, name the exact field and what it is (a webhook URL, an API key, an SMTP
+address), and say how to provide it. For Slack, Teams, and Email, that's the
+environment-variable / uncommitted-config-file split used everywhere else in
+this skill family. **For the five plain-`str` fields covered above, there is
+no way to provide it that this skill will use** — Great Expectations has no
+secret-safe mechanism for those fields, per "Fields, per action" above, so
+the action is left off the checkpoint rather than wired with a credential
+this skill won't write. Do not attach any action with a placeholder value
+and do not guess a plausible one; leave it out of the checkpoint's action
+list until it can be configured safely.
+
+## Enabling Data Docs
+
+`UpdateDataDocsAction` needs a Data Docs site to write to. Check
+`context.config.data_docs_sites` before attaching it — three states follow:
+
+**A site already exists.** File-backed projects scaffold a default
+`local_site` automatically; nothing further to do. Attach the action.
+
+**An ephemeral session.** In-memory sessions carry a working `local_site`
+too, pointed at a directory that only lives for the process's lifetime —
+verified: `context.config.data_docs_sites` on a bare `gx.get_context(mode="ephemeral")`
+already holds a `local_site` entry whose `store_backend.base_directory` is a
+freshly created temp directory, and a checkpoint carrying the action builds
+real HTML there. Attach the action; it works. But announce the output as
+throwaway when you report it — say plainly that the site lives in a
+temporary directory that disappears with the process, and that if durable
+Data Docs matter, write-out (`write-out.md`) is what makes them
+survive.
+
+**`data_docs_sites` is explicitly `null` in a file project's
+`great_expectations.yml`.** This is a trap, not a normal "no site configured"
+state: every one of the four public site-CRUD methods
+(`add_data_docs_site`, `list_data_docs_sites`, `update_data_docs_site`,
+`delete_data_docs_site`) **silently no-ops** against it — no exception, no
+log line, no change to the yml. Verified directly: calling
+`add_data_docs_site(...)` against a context loaded with `data_docs_sites:
+null` returns normally, and the yml still reads `null` afterward. Checking
+only "did the call raise" will tell you it worked when it did nothing.
+
+The state is recoverable. **This requires editing the user's
+`great_expectations.yml`, so ask before doing it — the consent to make that
+edit is not implied by the request to attach a Data Docs action.** State
+plainly what you found (`data_docs_sites` is set to `null`, which silently
+blocks every site-management call) and what fixing it involves, then wait for
+a yes before running any of the three steps. If the user declines, state the
+same fix as the path forward and continue building the checkpoint without the
+Data Docs action.
+
+With consent, the fix is a three-step sequence, each step verified in order —
+skipping the reload in the middle leaves you editing an in-memory copy of a
+context whose live object still has `null` cached:
+
+```python
+import yaml
+from pathlib import Path
+import great_expectations as gx
+
+# 1. Change `data_docs_sites: null` to `data_docs_sites: {}` in the yml.
+#    An empty mapping is a real, different value from null -- it's what lets
+#    the public factory add a site into it a moment later.
+yml_path = Path(context.root_directory) / "great_expectations.yml"
+raw = yaml.safe_load(yml_path.read_text())
+raw["data_docs_sites"] = {}
+yml_path.write_text(yaml.dump(raw, sort_keys=False))
+
+# 2. Reload through a fresh file-mode context with an explicit, absolute
+#    project root -- the in-memory `context` object still has `null` cached
+#    and won't pick up the yml edit on its own. This is the same project
+#    already opened at preflight, not a new directory to ask the user about --
+#    only the yml edit above needed their consent.
+context = gx.get_context(mode="file", project_root_dir="<the project root established at preflight>")
+
+# 3. Add the default site through the public factory. Only now does this
+#    call actually do something -- the no-op trap above is gone because
+#    data_docs_sites is {} rather than null.
+context.add_data_docs_site(
+    site_name="local_site",
+    site_config={
+        "class_name": "SiteBuilder",
+        "store_backend": {
+            "class_name": "TupleFilesystemStoreBackend",
+            "base_directory": "uncommitted/data_docs/local_site/",
+        },
+        "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
+    },
+)
+```
+
+Verified end to end: after these three steps, `data_docs_sites` in the yml
+holds the new site, and a checkpoint carrying `UpdateDataDocsAction` produces
+a real `index.html` under `uncommitted/data_docs/local_site/` on its next
+run. There is an in-session shortcut — assigning
+`context.config.data_docs_sites = {}` directly before calling the public
+factory, skipping the reload — that also works, but it mutates configuration
+state that isn't part of the public API. Don't offer it; the three-step
+version above uses only public surface.

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/references/preflight.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/references/preflight.md
@@ -1,0 +1,146 @@
+# Session preflight
+
+Before configuring anything, establish what you're operating on: a project the
+user already has on disk, or a temporary in-memory session. Do this exactly
+once at the start of the flow, and tell the user the outcome before you do
+anything else.
+
+## Enter with `cloud_mode=False`
+
+Call the context factory like this, not with a bare call:
+
+```python executable
+import great_expectations as gx
+
+context = gx.get_context(cloud_mode=False)
+```
+
+A managed cloud offering that this factory can auto-connect to has been
+retired. If a machine still carries leftover configuration for it (environment
+variables, or a leftover config file), a bare `gx.get_context()` — and
+`cloud_mode=True` — will detect that configuration, try to honor it, and raise
+immediately with an error to that effect. That failure has nothing to do with
+the user's local project or data; it's a stale-environment problem, and it
+would happen before you ever got to look at a local project. Passing
+`cloud_mode=False` explicitly skips that detection and always resolves to a
+local file-backed project if one is found, or an in-memory session otherwise.
+
+**Check for stale cloud configuration yourself before you call it**, because
+`cloud_mode=False` silently discards that configuration rather than reporting
+it — there is no signal in the return value or in normal output that it was
+there. Look for `GX_CLOUD_ACCESS_TOKEN`, `GX_CLOUD_ORGANIZATION_ID`, or
+`GX_CLOUD_BASE_URL` in the environment. If any are set, tell the user plainly:
+those variables were found but ignored, because that offering is no longer
+reachable and today they should either unset them or ignore this message —
+they have no effect on the session you're about to build.
+
+## Interpret what comes back
+
+`gx.get_context(cloud_mode=False)` returns one of two things. Branch on the
+type:
+
+```python executable
+from great_expectations.data_context import FileDataContext
+
+if isinstance(context, FileDataContext):
+    context_root = context.root_directory
+    # tell the user: "Using the existing project's configuration at
+    # <context_root>."
+else:
+    # tell the user: "No project found — working in a temporary, in-memory
+    # session. Nothing here is saved until it's written out to a project
+    # (see write-out.md)."
+    ...
+```
+
+**A discovered project is not optional to announce.** Always state
+`context_root` back to the user before doing anything else, so they know
+exactly which project they're about to modify — this also makes
+`add_or_update_*` updates against that project legible rather than a surprise.
+Name it precisely as the project's *configuration directory*, not "the
+project" on its own — `context_root` is the `gx` subdirectory that holds
+`great_expectations.yml` and the stores, and its **parent** is the project
+directory a user would think of as "the project". That parent is what
+`project_root_dir` means everywhere it's accepted (`preflight.md`'s own
+one-liner below, and `write-out.md`'s `gx.get_context(mode="file",
+project_root_dir=...)`). Never feed `context_root` back in as a
+`project_root_dir` — doing so nests a second `gx` directory inside the first
+(`<project>/gx/gx`) instead of reopening the same project.
+
+**An in-memory (ephemeral) session is not a degraded mode to apologize for.**
+It's a normal, fully supported way to work — state plainly that the session is
+temporary and that everything can be written out to a real project later (see
+`write-out.md`). Do not stop, and do not treat the absence of a project as an
+error condition.
+
+## Never scaffold a project yourself
+
+Standing up a new file-backed project is the user's decision, not something
+to do on their behalf or without being asked. Two things follow from this:
+
+- Never call the file-context constructor without an explicit target
+  directory. Concretely: never call `gx.get_context(mode="file")` with no
+  `project_root_dir` — it does not raise or refuse when a project isn't found
+  at that implicit location; it silently creates one, into the current
+  working directory, with no confirmation. That is not something to do without
+  the user asking for it.
+- If a user wants a new project created rather than an in-memory session, give
+  them the one-liner to run themselves and let them choose the location:
+
+  ```python
+  context = gx.get_context(mode="file", project_root_dir="<path>")
+  ```
+
+  Do not walk them through it interactively or pick the path for them.
+
+`write-out.md` is the one procedure that does call `gx.get_context(mode="file",
+...)`, and it is not an exception to this rule — it is this rule with its
+condition met. What makes that call legitimate is not which document it appears
+in; it is that the user agreed to the write-out and named the directory, in
+their own messages, before it ran. Read the gate at the top of that document
+before running any part of it. If those two things haven't happened yet, the
+call is the same silent side effect it is here, and being inside the write-out
+procedure does not make it something else.
+
+## Never treat "no project" as a stop condition
+
+An in-memory session is a supported, first-class outcome of preflight,
+covered above. Do not stop, refuse, or ask the user to go create a project
+first just because discovery didn't find one — proceed with the ephemeral
+session instead.
+
+## When discovery itself fails
+
+Two failure shapes are worth knowing by name, because neither produces an
+obvious, self-explanatory error, and both are easy to misread as "no project
+found" when they're actually a misconfiguration worth surfacing:
+
+**A stale `GX_HOME` environment variable.** If `GX_HOME` points at a directory
+that either doesn't exist or doesn't contain a project config file, project
+discovery does *not* raise — it silently falls back to the in-memory session,
+exactly as if `GX_HOME` had never been set. If the user believes they have a
+project and you get an in-memory session instead, this is the first thing to
+check. Validate it yourself, since the factory won't:
+
+```python executable
+import os
+from pathlib import Path
+
+gx_home = os.environ.get("GX_HOME")
+if gx_home is not None:
+    gx_home_path = Path(gx_home).expanduser()
+    if not (gx_home_path / "great_expectations.yml").is_file():
+        # tell the user: "GX_HOME is set to <gx_home>, but no project config
+        # was found there. If you expected an existing project to be used,
+        # check the path — otherwise this variable can be ignored/unset."
+        ...
+```
+
+**Stale cloud configuration**, covered above — check for it before calling
+the factory, since the factory itself won't tell you it was there.
+
+In both cases, the same shape of report applies: state what looked
+misconfigured, state which value or file caused it, and give one concrete next
+step (fix the path, unset the variable, or proceed with the in-memory
+session). Never let a silent fallback pass as "everything's fine" when the
+environment suggests the user expected otherwise.

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/references/robustness.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/references/robustness.md
@@ -1,0 +1,348 @@
+# Robustness: time budgets, scope reduction, and reading results correctly
+
+Real data is large, slow, and occasionally broken in ways that don't produce
+clean errors. This document covers three things every data-touching step in
+this skill needs: a time budget that doesn't pretend it can cancel anything,
+concrete levers for cutting a query down to size, and how to read a result
+correctly so an infrastructure failure never gets reported as a data-quality
+finding.
+
+## The advisory time budget is a check-in, not a kill switch
+
+Wrap any potentially slow call — testing a connection, retrieving a batch,
+probing it, running a validation — so you can check in with the user *while
+it is still running*, not only after it returns. A budget measured after the
+call has already completed can't do this — by the time you'd act on it, there
+is nothing left to check in about. Instead, run the call on a worker thread
+and poll it with a timeout, so you get control back at regular intervals
+while the real call is still in flight:
+
+```python executable
+import concurrent.futures
+import time
+
+BUDGET_SECONDS = 60   # let the user adjust this for known-slow sources
+POLL_SECONDS = 5      # how often to check whether the budget has passed
+
+executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+future = executor.submit(batch.head, n_rows=5)  # or test_connection(), get_batch(), validate(), ...
+start = time.monotonic()
+checked_in = False
+succeeded = False
+result = None
+
+while True:
+    # Report state instead of racing an exception: on Python 3.11+,
+    # concurrent.futures.TimeoutError IS the builtin TimeoutError, so if the
+    # wrapped call itself raises a TimeoutError (a driver connect/statement
+    # timeout, for example — see lever 3 below), an `except
+    # concurrent.futures.TimeoutError` branch built on `future.result()`
+    # cannot tell "still running" apart from "finished, with that exact
+    # exception". Since a *finished* future's `.result()` returns instantly,
+    # that ambiguity turns into an unthrottled busy loop with no sleep in it.
+    # `concurrent.futures.wait(...)` sidesteps this entirely — it reports
+    # done/not-done without ever raising the wrapped call's own exception.
+    done, _ = concurrent.futures.wait([future], timeout=POLL_SECONDS)
+    elapsed = time.monotonic() - start
+    if not done:
+        # The real call has NOT returned yet — this branch runs while it is
+        # still executing on the worker thread, which is what makes an
+        # in-flight check-in possible at all.
+        if elapsed > BUDGET_SECONDS and not checked_in:
+            checked_in = True
+            # tell the user, right now, while the call is still running:
+            # "This has been running <elapsed>s, past the <BUDGET_SECONDS>s
+            # budget, and is still going." Then follow the three steps below.
+            ...
+        continue
+    try:
+        result = future.result()
+        succeeded = True
+    except Exception as e:
+        # translate the exception — see "Reporting failures helpfully" below
+        result = None
+    break
+
+if succeeded and checked_in:
+    # tell the user it finished after all, at <elapsed>s, past the budget
+    ...
+```
+
+`succeeded` — not `result is not None` — is what distinguishes "the call
+returned" from "the call failed": some wrapped calls (`test_connection()`,
+for one) return `None` on success, so `result` alone can't tell the two
+apart.
+
+**When the budget is exceeded, do not abandon the operation.** On most data
+platforms, the query is running on the platform's own compute the moment it
+was dispatched — closing the client connection or giving up on waiting does
+not cancel it, and it keeps consuming (and costing) resources on the platform
+regardless of whether anything is still waiting on the result. Killing the
+client side only means losing visibility into a query that is still running
+and still being billed. So the moment the budget check-in above fires:
+
+1. Tell the user the operation is still running and has passed the budget.
+2. State plainly that it will keep running (and, on most platforms, keep
+   costing money) whether or not you keep waiting on it.
+3. Ask whether to keep waiting, or to reduce the scope of data involved and
+   try again — never decide this unilaterally.
+
+**Keep the future alive; never cancel it.** Whatever the user picks, do not
+call `future.cancel()` or `executor.shutdown(cancel_futures=True)` — the call
+already dispatched to the platform's own compute, and cancelling the future
+only makes this process stop watching it; it does not stop the remote work,
+which is the point above about it continuing to run and cost money. If the
+user chooses to keep waiting, stay in the polling loop shown above. If the
+user chooses to reduce scope, stop polling this loop and leave `future` and
+`executor` exactly as they are — still running, unattended — and submit the
+reduced-scope attempt (using the levers below) as a new, separate call. Don't
+block on the abandoned future first.
+
+## Scope-reduction levers, in preference order
+
+The goal each time is to make the specific operation touch less data, not to
+change what the asset represents — an asset stays the durable, logical
+collection of data a project points at; a batch definition is what selects
+how much of it a given operation actually reads.
+
+**1. A narrower batch definition window, via the existing partitioner
+factories.** This is the primary lever, and it should be tried first whenever
+there's a usable date/time or otherwise partitionable column. Add (or reuse) a
+partitioned batch definition, then request a specific window at fetch time:
+
+```python
+# One-time setup: partition by month on a datetime column.
+batch_definition = asset.add_batch_definition_monthly(name="monthly", column="event_time")
+
+# Per-attempt: fetch only one narrow window instead of the whole asset.
+batch = batch_definition.get_batch(batch_parameters={"year": 2024, "month": 3})
+```
+
+The equivalent daily/yearly variants exist too
+(`add_batch_definition_daily`, `add_batch_definition_yearly`), as does a
+directory-scoped daily/monthly/yearly split for file-based assets. Always
+reach these through the asset's own `add_batch_definition_*` methods and
+`batch_parameters` — never by constructing a partitioner object directly.
+
+**2. A row-limiting argument on the read itself, for local file-based
+sources.** Where the underlying reader supports it (for example, a pandas
+CSV asset), pass its native `nrows` option — a hard cap on how many rows get
+read — as a keyword argument when adding the asset:
+
+```python
+asset = pandas_datasource.add_csv_asset(
+    name="my_asset",
+    filepath_or_buffer="/path/to/large_file.csv",
+    nrows=1000,
+)
+```
+
+This helps specifically with large local files rather than remote queries.
+
+**3. A driver-level connection or statement timeout**, for SQL sources. Pass
+driver-specific timeout options through the datasource's `kwargs`, which are
+forwarded straight to engine creation:
+
+```python
+datasource = context.data_sources.add_or_update_postgres(
+    name="my_datasource",
+    connection_string="postgresql+psycopg2://${DB_USER}:${DB_PASSWORD}@host/db",
+    kwargs={"connect_args": {"connect_timeout": 10}},
+)
+```
+
+The exact keys are driver-specific (a `connect_timeout` for one driver may be
+a different name for another) — this caps how long a *connection attempt*
+can hang, not how much data a query returns, so treat it as a complement to
+lever 1, not a substitute.
+
+**4. Last resort: a row limit on a query asset, for exploration only.** If no
+column exists to partition on (no usable date/time or other partitionable
+column), and the goal is just to inspect a sample of the data rather than
+operate on the real batch, a query asset with an explicit `LIMIT` in its SQL
+text is an acceptable stopgap:
+
+```python
+asset = datasource.add_query_asset(
+    name="sample_events",
+    query="SELECT * FROM events LIMIT 1000",
+)
+```
+
+Flag this to the user explicitly as temporary and exploration-only when you
+use it. A query asset's row limit is baked into that one query's text — it
+isn't a general batching mechanism, it doesn't compose with the partitioner
+levers above, and it isn't something to reach for as a default way to make a
+slow asset faster. If a project keeps needing this, the honest answer is that
+the reduction lever it actually needs doesn't exist yet in the partitioner set
+— that's a gap to name to the user, not one to paper over with query-asset
+limits everywhere.
+
+## Reporting failures helpfully
+
+Whenever something in this flow raises, report three things and stop there —
+never a raw traceback: **what failed** (the operation you were attempting),
+**why, as far as it's known** (the clearest available cause), and **one
+concrete next step** the user can take.
+
+Two exception shapes are common enough to call out by name:
+
+- **Connection and configuration failures** (a failed `test_connection()`
+  during `add_or_update_*`, or an import error for an optional driver
+  dependency) already carry an actionable message from Great Expectations
+  itself — relay it close to verbatim, plus one next step (fix the connection
+  string, install the backend's optional dependency group, check the
+  credential). Where that message names a bare package to install — the
+  missing-driver errors say things like `pip install sqlalchemy` — hand over
+  the matching dependency group instead, so what arrives stays matched to the
+  installed Great Expectations: `pip install 'great_expectations[postgresql]'`.
+  Read the group names off the installed distribution rather than recalling
+  them, with
+  `importlib.metadata.metadata("great_expectations").get_all("Provides-Extra")`.
+  Hand the command to the user; running it is their call, not yours.
+- **A missing credential.** If a data operation fails because a referenced
+  `${ENV_VAR}` isn't set, say exactly which variable is missing and how to
+  provide it (set the environment variable, or add it to the project's
+  uncommitted config-variables file if working in a file-backed project).
+  Never hardcode a value or invent a placeholder to work around it.
+- **A bare `KeyError` out of a batch probe.** Retrieving a batch off a broken
+  query or table does not itself fail — see "Why a retrieved batch doesn't
+  prove anything" below — but probing it can raise a plain `KeyError`, not a
+  Great Expectations exception, with no readable message of its own (its text
+  is just an internal cache key). The real underlying cause (the actual
+  database error, including which table or column it choked on) is emitted
+  during metric resolution as a **`WARNING`-level log record on the
+  `great_expectations.validator.metrics_calculator` logger** — not printed to
+  stdout. Attach a handler to that logger before the probe so you capture the
+  record directly, rather than trusting the `KeyError`'s own text or scanning
+  raw console output — this avoids depending on stdout/stderr being
+  visible, or on the *root* logger's own level. It does **not** avoid this
+  logger's own effective level: a handler only sees records the logger lets
+  past its own threshold, so if a host has raised
+  `great_expectations.validator.metrics_calculator` above `WARNING`, force it
+  down to `WARNING` for the duration of the probe and restore it afterward:
+
+  ```python
+  import logging
+  import re
+  import ast
+
+  class _CaptureHandler(logging.Handler):
+      def __init__(self):
+          super().__init__(level=logging.WARNING)
+          self.records: list[str] = []
+
+      def emit(self, record: logging.LogRecord) -> None:
+          self.records.append(record.getMessage())
+
+  def _extract_cause(message: str, ceiling: int = 500) -> str:
+      # The log message is a stringified dict of MetricConfigurationID ->
+      # {"exception_message": ..., "exception_traceback": ..., ...} — often
+      # several thousand characters, wrapping a full traceback with absolute
+      # filesystem paths. Never relay it verbatim (see the no-raw-traceback
+      # rule above). Pull out just the exception_message value(s); if the
+      # shape ever changes and the pattern doesn't match, fall back to a
+      # hard-truncated slice so a ceiling is guaranteed either way.
+      found = re.findall(r"'exception_message': (.+?), 'raised_exception':", message, re.DOTALL)
+      try:
+          # A match is not automatically a valid Python literal: an error text
+          # containing the terminator itself truncates the non-greedy match
+          # mid-literal. Fall through to truncation rather than raising from
+          # inside the error-reporting path.
+          cause = "; ".join(ast.literal_eval(m) for m in found) if found else message
+      except Exception:
+          cause = message
+      if len(cause) > ceiling:
+          cause = cause[:ceiling] + "... (truncated)"
+      return cause
+
+  handler = _CaptureHandler()
+  metrics_logger = logging.getLogger("great_expectations.validator.metrics_calculator")
+  metrics_logger.addHandler(handler)
+  prior_level = metrics_logger.level
+  metrics_logger.setLevel(logging.WARNING)
+  try:
+      head = batch.head(n_rows=5)
+  except KeyError:
+      cause = _extract_cause(handler.records[-1]) if handler.records else "<no warning captured>"
+      # report: the batch could not be read; cause holds the real database error
+      ...
+  finally:
+      metrics_logger.removeHandler(handler)
+      metrics_logger.setLevel(prior_level)
+  ```
+
+  Report to the user that the batch could not be read, relay the extracted
+  cause (a few hundred characters, not the raw log message), and point them
+  at checking the query or table name, and the connection, as the next step.
+- **Resource exhaustion on a large dataset** (a `MemoryError`, or a
+  driver/engine error whose message names memory or disk space). This is not
+  a data-quality finding and not a connection problem — it means the
+  operation tried to hold more of the dataset in memory than the machine
+  running it has. Report plainly that it ran out of resources processing the
+  full dataset, then route straight to the scope-reduction levers above: a
+  narrower batch-definition window (lever 1) is the first thing to try, in
+  the same partitioner-first order used for a slow-but-successful call.
+
+## Why a retrieved batch doesn't prove anything, for SQL query assets
+
+`batch_definition.get_batch()` succeeds and returns a real `Batch` object even
+when the underlying table or query is broken — for a SQL query asset, nothing
+about building the batch touches the database. So retrieving a batch is not,
+by itself, evidence of a working configuration. Always follow it with a cheap,
+duration-tracked probe before declaring success:
+
+```python
+batch = batch_definition.get_batch()
+head = batch.head(n_rows=5)  # this is what actually touches the data
+```
+
+A probe that raises means the configuration doesn't work — report per the
+`KeyError` guidance above. A probe that returns means there's a real, working
+batch definition.
+
+## Distinguishing an infrastructure failure from a real data-quality result
+
+After running an expectation (or a suite) against a batch, `success is False`
+can mean two very different things, and they must be reported differently:
+
+- **The metric itself errored** — a broken column reference, a query that
+  fails, a type mismatch the engine can't evaluate. Great Expectations
+  reports this the same way it reports a real failure — `success: False` —
+  but the result payload is empty. Check `result.result`: an empty dict means
+  nothing was actually evaluated; there is no data-quality finding to report,
+  only a configuration problem to fix. Don't guess at what that problem is —
+  `result.exception_info` names it exactly. On this branch it's a dict with
+  one entry per metric that errored, keyed by the **string repr** of a
+  `MetricConfigurationID` (not a `MetricConfigurationID` instance itself — a
+  keyed lookup with one won't match), and each value is a dict whose
+  `exception_message` key holds the real cause verbatim, e.g.
+  `'Error: The column "nope" in BatchData does not exist.'`. Report that
+  message as the *why*, not a guess. Reached through the normal flow these
+  messages are short and clean, because the batch-definition probe catches a
+  broken table long before validation runs. Apply the same length ceiling
+  used for captured log output anyway: validating against a batch that was
+  never probed can surface an engine-level message carrying a full traceback,
+  and the no-raw-traceback rule holds on every path.
+- **The data genuinely failed the expectation.** The result payload is
+  populated — counts, examples, percentages of the specific values that
+  violated the check.
+
+```python
+result = batch.validate(expectation)
+if not result.success and not result.result:
+    # a metric error: result.exception_info is a dict of
+    # {str(MetricConfigurationID): {"exception_message": ..., ...}}, one entry
+    # per metric that errored — report each exception_message verbatim as the
+    # why, not a data-quality finding. Keys are strings; iterating .items()
+    # works, but a keyed lookup with a MetricConfigurationID instance won't.
+    for metric_id, info in result.exception_info.items():
+        # tell the user: info["exception_message"]
+        ...
+elif not result.success:
+    # a genuine data-quality failure: report result.result's counts/examples
+    ...
+```
+
+Never report an empty-`result` failure to the user as "your data failed this
+check" — it didn't get evaluated at all.

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/references/run-and-schedule.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/references/run-and-schedule.md
@@ -1,0 +1,183 @@
+# Running a checkpoint, and handing it off
+
+This document covers what `checkpoint.run()` actually does with its
+arguments, one real limitation worth knowing before you assemble certain
+checkpoints, and the run snippet this skill's flow ends with.
+
+## Run semantics
+
+```python
+result = checkpoint.run(batch_parameters={"year": 2024, "month": 3})
+```
+
+`batch_parameters` is **one dict, applied to every validation definition in
+the checkpoint** — there is no way to give different validation definitions
+different parameters in a single `run()` call. For a checkpoint whose
+validation definitions all share the same partitioning shape (all monthly by
+the same convention, say), this is exactly what you want: one call, one
+window, every check run against it. It stops being harmless the moment the
+validation definitions don't share that shape — see both cases below.
+
+`checkpoint.run()` also accepts `expectation_parameters`, for expectations
+built with runtime parameters rather than fixed values; this skill's flow
+doesn't build those, so it isn't covered further here.
+
+### The dataframe caveat
+
+A dataframe-backed validation definition needs its dataframe supplied at run
+time, exactly as `get_batch()` does in the data-source skill:
+
+```python
+result = checkpoint.run(batch_parameters={"dataframe": df})
+```
+
+Because `batch_parameters` is shared across every validation definition in
+the checkpoint, **a checkpoint containing two or more dataframe-backed
+validation definitions that need different dataframes cannot be run
+correctly in one call** — whichever dataframe you pass is what every
+dataframe-backed validation definition in the checkpoint receives, silently.
+Verified directly: a checkpoint with one validation definition over an
+`orders` dataframe and another over an unrelated `products` dataframe, run
+with only the `orders` frame supplied, does not raise — the `products`
+validation definition runs against the `orders` data instead, and since that
+frame has none of the columns the `products` suite expects, its results come
+back as metric errors (`success: False`, empty `result`), which reads as a
+configuration problem rather than the parameter mismatch it actually is. If
+a user wants several dataframes checked by one named checkpoint, either keep
+each dataframe-backed validation definition in its own checkpoint, or route
+distinct dataframes through separate runs.
+
+## When two batch definitions want incompatible parameter types
+
+**Today's Great Expectations release cannot drive one time-partitioned
+file-based batch definition and one time-partitioned SQL batch definition
+from the same checkpoint run.** The monthly partitioners on the two families
+disagree about what `batch_parameters` should contain — file-based
+partitioners require strings, SQL partitioners require integers — and
+`checkpoint.run()` has only one `batch_parameters` dict to give both. Whichever
+type you pick, one side either fails loudly or fails in a way that reads as
+missing data rather than a type mismatch. Verified directly, both directions:
+
+- **Integers, aimed at a file-based monthly partitioner:**
+  `InvalidBatchRequestError: All batching_regex matching options must be
+  strings. The value of 'year' is not a string: 2024` — loud and immediate.
+- **Strings, aimed at a SQL monthly partitioner:** `NoAvailableBatchesError:
+  No available batches found.` — this is the dangerous direction. It reads
+  exactly like an empty time window (a normal, non-broken outcome elsewhere
+  in this skill family), not like a parameter type problem, and the data is
+  actually there under the same window with integer parameters.
+
+If a user asks for this combination, **say so before you assemble it** —
+don't build a checkpoint whose validation definitions cross this line and let
+them discover the misleading failure themselves. Two working alternatives:
+
+- **Separate checkpoints, one per source family.** A checkpoint of only
+  file-based validation definitions run with string parameters, and a second
+  checkpoint of only SQL validation definitions run with integer parameters.
+  Both stay fully automatable; wiring two run snippets instead of one is a
+  minor cost for correctness.
+- **A fixed, non-partitioned batch definition on one side.** If one source
+  doesn't actually need month-by-month slicing, a whole-table or
+  whole-dataframe batch definition sidesteps the type mismatch entirely by
+  not taking `batch_parameters` for the window at all.
+
+Per-validation-definition parameters aren't available as a third option —
+`checkpoint.run()`'s one `batch_parameters` dict is the whole surface here,
+for both families, whether or not their types happen to agree.
+
+## Reporting the run
+
+Pair each result to the validation definition it came from **by identity**,
+never by position in a list — `checkpoint.run()` gives no guarantee that
+results come back in the order the validation definitions were added, and
+this skill's own worked example builds a checkpoint where they don't:
+
+```python
+result = checkpoint.run(batch_parameters={"dataframe": df})
+
+for vr_id, vr in result.run_results.items():
+    print(f"validation definition: batch={vr_id.batch_identifier} suite={vr.suite_name}")
+    for each in vr.results:
+        config = each.expectation_config
+        if each.success:
+            print(f"  PASS {config.type} {config.kwargs}")
+        elif not each.result:
+            # metric error -- see SKILL.md step 6
+            for _metric_id, info in each.exception_info.items():
+                print(f"  ERROR {config.type} {config.kwargs}: {info['exception_message']}")
+        else:
+            print(f"  FAIL {config.type} {config.kwargs}: {each.result}")
+```
+
+`result.describe()` (the `@public_api` summary method — its underlying
+`describe_dict()` is not public API and shouldn't be called directly) gives
+the same information as a JSON string and is a good basis for a short written
+summary, but its per-validation-definition entries don't self-identify by
+name — use the loop above when you need to say *which* validation definition
+a given outcome belongs to, and `describe()` when an overall JSON summary is
+what's wanted (as in the run snippet below).
+
+## The run snippet
+
+This is what the flow hands off: a small, self-contained script that
+re-runs the persisted checkpoint from outside any agent session — a cron job,
+a CI step, a scheduler's Python operator, or just a terminal.
+
+```python
+import sys
+import great_expectations as gx
+
+context = gx.get_context(mode="file", project_root_dir="<absolute path to the project>")
+checkpoint = context.checkpoints.get("<checkpoint name>")
+result = checkpoint.run()
+print(result.describe())
+sys.exit(0 if result.success else 1)
+```
+
+Three things about this shape are deliberate, each verified by actually
+running it as a subprocess from a working directory unrelated to the
+project:
+
+- **`project_root_dir` is absolute, not relative.** A snippet invoked by a
+  scheduler runs from whatever working directory the scheduler happens to
+  use, which is very unlikely to be the project directory. A relative path
+  either resolves against the wrong location or, worse, silently scaffolds a
+  *new* project there — the same trap `preflight.md` warns about
+  for `gx.get_context(mode="file")` with no `project_root_dir` at all, just
+  reached a different way.
+- **`mode="file"` is explicit**, for the same reason `preflight.md`'s
+  `cloud_mode=False` is explicit: it skips discovery and any stale
+  `GX_CLOUD_*` environment on the machine actually running the snippet, which
+  is not necessarily the machine this conversation is happening on.
+- **The exit code is derived from `result.success`, not from whether the
+  script raised.** A scheduler (cron, CI, an orchestrator's shell step) reads
+  the process exit code to decide whether the step passed — printing a
+  failure report and then exiting 0 makes every consumer of this snippet
+  believe the checkpoint always passes. Verified directly: exit `0` against a
+  checkpoint that passed, exit `1` against one that didn't, both read
+  directly rather than through anything that would swallow the code.
+
+**For a checkpoint holding a dataframe-backed validation definition, this
+snippet does not apply as written** — there is no dataframe to pass, running
+outside any session that built one. Say this plainly rather than handing over
+a snippet that will fail: a dataframe-backed check is re-run from within a
+session that has the dataframe, not from this kind of standalone script.
+
+### Offering the snippet
+
+Show the snippet in the conversation, filled in with the actual project root
+and checkpoint name. **Offer to save it to a file at a path the user
+confirms — never write it unasked.** This is the same offer-don't-do pattern
+as `write-out.md`: presenting it in chat is not the same as
+putting it on disk, and only the second one is something to ask permission
+for first.
+
+### Where scheduling stops
+
+Wiring this snippet into an actual cadence — a cron entry, an Airflow
+operator, a CI job on a schedule — is the user's orchestrator's job, not
+this skill's. The snippet is deliberately runnable by any of them without
+modification; which one, and how often, is a decision this flow doesn't
+make. If the user asks how to schedule it with a specific tool, say plainly
+that wiring the specific scheduler is outside what this skill covers, and
+that the snippet above is the piece their scheduler needs to call.

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/references/run-and-schedule.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/references/run-and-schedule.md
@@ -16,7 +16,7 @@ different parameters in a single `run()` call. For a checkpoint whose
 validation definitions all share the same partitioning shape (all monthly by
 the same convention, say), this is exactly what you want: one call, one
 window, every check run against it. It stops being harmless the moment the
-validation definitions don't share that shape — see both cases below.
+validation definitions don't share that shape — see the dataframe case below.
 
 `checkpoint.run()` also accepts `expectation_parameters`, for expectations
 built with runtime parameters rather than fixed values; this skill's flow
@@ -47,43 +47,38 @@ a user wants several dataframes checked by one named checkpoint, either keep
 each dataframe-backed validation definition in its own checkpoint, or route
 distinct dataframes through separate runs.
 
-## When two batch definitions want incompatible parameter types
+## Numeric window parameters are integers on every family
 
-**Today's Great Expectations release cannot drive one time-partitioned
-file-based batch definition and one time-partitioned SQL batch definition
-from the same checkpoint run.** The monthly partitioners on the two families
-disagree about what `batch_parameters` should contain — file-based
-partitioners require strings, SQL partitioners require integers — and
-`checkpoint.run()` has only one `batch_parameters` dict to give both. Whichever
-type you pick, one side either fails loudly or fails in a way that reads as
-missing data rather than a type mismatch. Verified directly, both directions:
+**One `batch_parameters` dict of integers drives a checkpoint that mixes a
+time-partitioned file-based batch definition and a time-partitioned SQL batch
+definition.** Both families take the same numeric window parameters, so no
+combination of temporal partitioners has to be split across separate runs —
+the `run()` call at the top of this document is the whole of it.
 
-- **Integers, aimed at a file-based monthly partitioner:**
-  `InvalidBatchRequestError: All batching_regex matching options must be
-  strings. The value of 'year' is not a string: 2024` — loud and immediate.
-- **Strings, aimed at a SQL monthly partitioner:** `NoAvailableBatchesError:
-  No available batches found.` — this is the dangerous direction. It reads
-  exactly like an empty time window (a normal, non-broken outcome elsewhere
-  in this skill family), not like a parameter type problem, and the data is
-  actually there under the same window with integer parameters.
+Emit integers whenever you generate a run snippet, including for file-based
+definitions whose partitioning regex is written against zero-padded text:
+`{"month": 3}` selects `sales_2024-03.csv`. You do not pad the parameter to
+match the filename, and `{"month": 3}` is not a different window from
+`{"month": "03"}`.
 
-If a user asks for this combination, **say so before you assemble it** —
-don't build a checkpoint whose validation definitions cross this line and let
-them discover the misleading failure themselves. Two working alternatives:
+Digit strings are still accepted and still select the same batch, but they now
+emit a `GxDeprecationWarning`:
 
-- **Separate checkpoints, one per source family.** A checkpoint of only
-  file-based validation definitions run with string parameters, and a second
-  checkpoint of only SQL validation definitions run with integer parameters.
-  Both stay fully automatable; wiring two run snippets instead of one is a
-  minor cost for correctness.
-- **A fixed, non-partitioned batch definition on one side.** If one source
-  doesn't actually need month-by-month slicing, a whole-table or
-  whole-dataframe batch definition sidesteps the type mismatch entirely by
-  not taking `batch_parameters` for the window at all.
+> String values for numeric batch parameters are deprecated: month, year.
+> Pass integer values instead; string support is planned for removal in 2.0.
 
-Per-validation-definition parameters aren't available as a third option —
-`checkpoint.run()`'s one `batch_parameters` dict is the whole surface here,
-for both families, whether or not their types happen to agree.
+That warning fires **once per call site, not once per run**, so a scheduled job
+passing strings surfaces it on its first execution and then looks clean while
+still accumulating the removal risk. Existing snippets and older documentation
+commonly use strings — when a user brings you one, convert it to integers
+rather than carrying the strings forward.
+
+Per-validation-definition parameters aren't available: `checkpoint.run()`'s one
+`batch_parameters` dict is the whole surface, applied to every validation
+definition in the checkpoint. That is a real constraint for the dataframe case
+above, where the value genuinely differs per validation definition. It is not
+one for time windows, where every validation definition wants the same window
+anyway.
 
 ## Reporting the run
 

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/references/write-out.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/references/write-out.md
@@ -1,0 +1,410 @@
+# Writing an in-memory session out to a project
+
+An in-memory (ephemeral) session, per `preflight.md`, holds everything only in
+process memory — data sources, assets, batch definitions, and expectation
+suites all disappear when the process ends. This procedure turns that session
+into a real, file-backed project so the work survives and is reusable outside
+this conversation.
+
+Offer this at a natural point — after a data source and batch definition are
+verified working, or after a suite has been built and run — not as an
+unprompted interruption mid-task. Only do it when the user agrees.
+
+## The gate: two things the user has to have said
+
+This procedure creates a project on the user's disk.
+`gx.get_context(mode="file", project_root_dir=...)` **creates** the project at
+that path when one isn't already there. It does not refuse, does not prompt,
+and its return value looks identical either way — there is no signal
+afterwards distinguishing a project it opened from one it just brought into
+existence. Whatever path you pass is where a project appears.
+
+So before the first line of the procedure runs, two things have to be true,
+and both are things the **user said**, not things you concluded:
+
+1. They agreed to write the session out.
+2. They named the directory it should go in.
+
+Neither is satisfied by inference. A request to "add a data source", "set this
+up", or "get this working" is a request about data access — it is not
+agreement to create a project, and it does not name a location. If the session
+is in memory and you are holding one of those requests, the correct end state
+is the in-memory result, reported, with write-out **offered**. An absolute
+path is safest; confirm it back before writing anything.
+
+**If you cannot point to the user's message where they agreed, and the one
+where they named the path, you are not past the gate.** Ask, and end your turn
+there.
+
+### The gate is skipped by construction, not by decision
+
+The way this goes wrong is rarely a considered choice to skip the
+confirmation. It is a script: the configure steps, the probe, and this
+procedure assembled into one program and run in a single step. Batched that
+way there is no moment at which the user could have answered — the gate is not
+declined, it simply never occurs, and the project exists by the time anyone
+reports anything.
+
+**Write-out is its own run, and it begins after a user's reply.** If the call
+below is sitting in the same program as the configure and verify calls, that
+program skips the gate no matter what the surrounding prose says. Split it out.
+
+### Why this is the only place to catch it
+
+A project created without asking cannot be detected later. On the next turn —
+and in every session after it — discovery finds the directory and truthfully
+reports an existing project at that path, exactly as it would report one the
+user made themselves. Nothing marks it, nothing records where it came from,
+and no later step has anything to notice. Nobody downstream is going to catch
+this for you.
+
+## The procedure: public factories, not the built-in migrator
+
+Great Expectations ships a method that converts an in-memory context to a
+file-backed one in place. Do not use it here. It resolves the target directory
+from the current working directory rather than from an explicit path, it has
+a known store-migration ordering issue, and its merge behavior does not
+reliably overwrite objects that already exist at the destination — none of
+which is acceptable when the target directory and the correctness of the
+result both matter. Instead, build the file-backed project explicitly and
+re-create each object in it through the same update-safe public factories used
+everywhere else in this skill. That gives you a small, fully disclosed
+sequence of steps, each independently retryable.
+
+**`add_or_update_<datasource>` replaces the datasource wholesale — it is not
+additive.** Calling it drops every asset and batch definition already
+attached to that datasource, including ones that came from outside this
+session: a prior conversation, a teammate, an earlier write-out. Opening a
+project that already has a datasource with the name you're about to write and
+calling `add_or_update_pandas` (or any `add_or_update_<datasource>` factory)
+under that same name silently destroys every other asset already on it — this
+is true the very first time it's called in this project, not just on a
+repeat. **Check whether the datasource already exists first, and skip adding
+it if it does.** Only call `add_or_update_*` again if you specifically intend
+to replace that datasource's connection configuration, and if so, warn the
+user first that doing so will drop every other asset already attached to it.
+
+Build the file-backed project and re-create each object with the pattern
+below. Wrap each object in its own try rather than the whole procedure in one
+try block, and keep a running record of what succeeded and what didn't. The
+asset step needs the datasource handle, and the batch-definition step needs
+the asset handle — a zero-arg step that doesn't reflect this can't express
+the chain. Have each step **re-fetch its dependency by name** from
+`file_context` instead of closing over a variable from an earlier step: that
+gets you the same handle without needing an earlier step to have succeeded in
+the same function scope, and it makes failures cascade correctly — if the
+datasource step failed, the asset step's own fetch of it fails too, with a
+reason that points back at the real cause instead of a confusing `NameError`.
+The same chain extends further, past the suite step, to validation
+definitions and checkpoints — covered below, once the base pattern is on the
+table.
+
+The datasource step follows the same fetch-first-on-`LookupError` shape as
+the asset and batch-definition steps below it — that's what makes it safe to
+run once, unconditionally, without wiping a datasource that's already there.
+List it exactly once, before any asset step, even when the session created
+several assets on it:
+
+```python executable
+import great_expectations as gx
+
+# 1. Create the project at the location the user named. Past this line a
+#    directory exists on their disk, so do not run it until the gate above is
+#    satisfied: they agreed, and the path below is the one they gave.
+file_context = gx.get_context(mode="file", project_root_dir="<confirmed_path>")
+
+def _add_datasource():
+    try:
+        return file_context.data_sources.get("my_datasource")
+    except LookupError:
+        return file_context.data_sources.add_or_update_pandas(name="my_datasource")
+
+def _add_asset():
+    datasource = file_context.data_sources.get("my_datasource")
+    try:
+        return datasource.get_asset("my_asset")
+    except LookupError:
+        return datasource.add_dataframe_asset(name="my_asset")
+
+def _add_batch_definition():
+    asset = file_context.data_sources.get("my_datasource").get_asset("my_asset")
+    try:
+        return asset.get_batch_definition("my_batch_definition")
+    except LookupError:
+        return asset.add_batch_definition_whole_dataframe(name="my_batch_definition")
+
+def _add_suite():
+    # `suite` here is the same ExpectationSuite object (or an equivalent one)
+    # built against the in-memory context earlier in the flow.
+    return file_context.suites.add_or_update(suite)
+
+steps = [
+    ("data source my_datasource", _add_datasource),
+    ("asset my_asset", _add_asset),
+    ("batch definition my_batch_definition", _add_batch_definition),
+    ("suite my_suite", _add_suite),
+    # ... one entry per object to re-create: repeat the asset and
+    # batch-definition pattern (each its own function, closing over its own
+    # name) for every asset/batch definition created in the session, and the
+    # suite pattern for every suite. List the datasource step only once, even
+    # when the session created several assets on it.
+]
+
+written = []
+failed = []
+for label, step in steps:
+    try:
+        step()
+        written.append(label)
+    except Exception as e:
+        failed.append((label, str(e)))
+```
+
+Note the fetch-first pattern in all three of the datasource, asset, and
+batch-definition steps. `add_or_update_pandas` (and the other
+`add_or_update_<datasource>` factories) and `suites.add_or_update` are
+update-safe on their own — calling either again just replaces that one
+object's own content, which is harmless in isolation — but as just covered,
+`add_or_update_<datasource>` is not safe for what's attached underneath a
+datasource, which is why the datasource step above fetches first too. There
+is no `add_or_update_*` factory at all for a dataframe asset or a batch
+definition — calling `add_dataframe_asset` or
+`add_batch_definition_whole_dataframe` a second time with the same name
+raises instead of updating. Fetching first and only adding on a `LookupError`
+is what actually makes every step in this procedure safe to run again — not
+the presence of `add_or_update_*` in some of the calls.
+
+Report both lists to the user explicitly: what was written successfully, and
+what wasn't, with the reason for each failure. If an earlier step failed, a
+later step that depends on it will fail too — report that as a consequence of
+the earlier failure, not as a second, unrelated problem. Because every step
+fetches first, re-running the whole procedure after fixing the cause of a
+failure is safe — nothing already written gets duplicated, corrupted, or (per
+the warning above) destroyed by running it again.
+
+### Continuing the chain: validation definitions and checkpoints
+
+When the session also bound suites into validation definitions and grouped
+those into a checkpoint, two more steps complete the chain — validation
+definitions after suites, checkpoints last, and neither before the step it
+depends on has actually succeeded. The `steps`/`written`/`failed` loop above
+already ran, over the four entries it had at the time it ran — appending to
+`steps` afterward would define a longer list that nothing goes on to loop
+over again. So this is not an append: it replaces `steps` with the complete,
+six-entry list and runs the loop over it again from scratch, calling
+`_add_datasource` and the rest a second time. That's safe for the same
+reasons re-running the four-step version above is safe: the datasource,
+asset, and batch-definition steps fetch first; the suite step's
+`add_or_update` replaces that one suite's content with the same session
+suite it already wrote, which is a no-op the second time, not a second
+destructive replacement; and the two new steps below fetch first as well. It
+produces the one, complete disclosure covering all six objects, superseding
+the four-object one above:
+
+```python
+from great_expectations.core import ValidationDefinition
+from great_expectations.checkpoint import Checkpoint
+
+# Labels of steps below that left an object already present alone, rather
+# than creating it. Populated as a side effect of the two functions below,
+# then used after the loop to separate "written" from "found".
+found = []
+
+def _add_validation_definition():
+    # Re-fetch both dependencies from file_context — not from the in-memory
+    # session — so the object being built is scoped to the target from the
+    # start. `validation_definitions.add()` on an unpersisted suite is
+    # exactly the ordering failure covered above.
+    target_bd = (
+        file_context.data_sources.get("my_datasource")
+        .get_asset("my_asset")
+        .get_batch_definition("my_batch_definition")
+    )
+    target_suite = file_context.suites.get("my_suite")
+    # Existence is checked through all() rather than get()/except: unlike
+    # LookupError on the earlier steps, a missing validation definition or
+    # checkpoint surfaces as a data-context-level error that isn't part of
+    # the public exception surface, so checking membership first keeps every
+    # branch on add()/get()/all() instead.
+    existing = {v.name for v in file_context.validation_definitions.all()}
+    if "my_validation_definition" in existing:
+        found.append("validation definition my_validation_definition")
+        return file_context.validation_definitions.get("my_validation_definition")
+    return file_context.validation_definitions.add(
+        ValidationDefinition(
+            name="my_validation_definition", data=target_bd, suite=target_suite
+        )
+    )
+
+def _add_checkpoint():
+    # `checkpoint` here is the same Checkpoint object (or an equivalent one)
+    # built against the in-memory context earlier in the flow — the same
+    # convention _add_suite uses for `suite` above.
+    #
+    # Rebuilt from the validation definition this procedure just added to
+    # file_context — never from the session's original checkpoint or its
+    # validation definitions. Carrying those over raises, and not for the
+    # reason it looks like: the freshness check a checkpoint runs on each
+    # validation definition's batch definition does not compare against the
+    # handle's *origin* context. It resolves through the process-global
+    # *active* context — whichever context creation, anywhere in this
+    # process, made a context active most recently. Creating file_context
+    # above made it that context, so every handle the original in-memory
+    # session built now fails, not because it is "from a different context"
+    # in some abstract sense, but because it is not the one context object
+    # currently active (observed: CheckpointRelatedResourcesFreshnessError,
+    # "BatchDefinition '...' has changed since it has last been saved").
+    target_vd = file_context.validation_definitions.get("my_validation_definition")
+    existing = {c.name for c in file_context.checkpoints.all()}
+    if "my_checkpoint" in existing:
+        found.append("checkpoint my_checkpoint")
+        return file_context.checkpoints.get("my_checkpoint")
+    return file_context.checkpoints.add(
+        Checkpoint(
+            name="my_checkpoint",
+            validation_definitions=[target_vd],
+            # Actions carry over unchanged — a plain field on the
+            # Checkpoint being constructed, not something that needs
+            # rebuilding like the validation definitions above.
+            actions=list(checkpoint.actions),
+        )
+    )
+
+steps = [
+    ("data source my_datasource", _add_datasource),
+    ("asset my_asset", _add_asset),
+    ("batch definition my_batch_definition", _add_batch_definition),
+    ("suite my_suite", _add_suite),
+    ("validation definition my_validation_definition", _add_validation_definition),
+    ("checkpoint my_checkpoint", _add_checkpoint),
+    # ... one entry per object to re-create, following the same
+    # repeat-per-object note as the four-step version above: the
+    # validation-definition pattern once per (batch definition, suite) pair
+    # the session bound, added only after its own suite step succeeded, and
+    # the checkpoint pattern once per checkpoint, added only after every
+    # validation definition it groups.
+]
+
+written = []
+failed = []
+for label, step in steps:
+    try:
+        step()
+        written.append(label)
+    except Exception as e:
+        failed.append((label, str(e)))
+
+# A step that found an object already present, rather than creating one, is
+# not "written" by this run. Pull it out of `written` so the disclosure
+# names exactly what changed and what didn't — see below.
+written = [label for label in written if label not in found]
+```
+
+**Report three outcomes now, not two: written, found, and failed.** A
+validation definition or checkpoint name can already be taken by an object
+that has nothing to do with this session — a teammate's checkpoint, an
+earlier write-out, anything already in the target project. The two functions
+above refuse to overwrite it, which is the right call: it matches the
+fetch-first, never-clobber shape of every other step, and an existing
+checkpoint or validation definition under that name is left completely
+alone. But refusing to overwrite and reporting "written" are different
+things — if that were reported as written, the user would be told their
+session's checkpoint landed when the object they will actually load and run
+under that name is someone else's. Report `found` as its own list, distinct
+from both `written` and `failed`: "already present, left as-is" is not a
+failure, but it is not this run's work landing on disk either. If a name
+collision on a validation definition or checkpoint is unwanted, that's a
+naming conflict to resolve with the user, not something this procedure
+resolves by overwriting.
+
+This also reaches a checkpoint that *is* written — `_add_checkpoint` builds
+it from whatever object `file_context.validation_definitions.get(...)`
+returns, without regard to whether that get() came from the create branch or
+the found branch just above it. So if the validation-definition step
+reported `found`, the checkpoint step can still report `written`, and the
+checkpoint just written groups someone else's validation definition, not the
+session's. Report the two together when this happens, and resolve the name
+with the user before anyone runs it — a `written` checkpoint is not
+sufficient evidence that what it groups is the session's own.
+
+Everything else about the disclosure contract carries over unchanged: a
+validation definition that fails because its suite never landed is reported
+as a consequence of the suite step's failure, not a second, unrelated
+problem, and a checkpoint that fails because its validation definition never
+landed is reported the same way.
+
+**Why this order, restated as what actually failed above:** the observed
+`ResourceFreshnessAggregateError` when a suite is not yet persisted, and the
+observed `CheckpointRelatedResourcesFreshnessError` when a checkpoint is
+built from a handle that belongs to a context other than the one currently
+active, are two instances of the same rule — every object this procedure
+adds has to be built from handles fetched from `file_context` after it
+became the active context, never from a handle that belongs to the session
+that started the procedure. Datasources, assets, and batch definitions come
+first because nothing else can reference them without already being real;
+suites come next for the same reason validation definitions need them;
+validation definitions come before checkpoints because a checkpoint's
+`validation_definitions` list is checked the same way.
+
+## Report the written location
+
+When it completes, tell the user the absolute path that was written to, and
+name what landed there (data source names, asset names, batch definition
+names, suite names, validation definition names, and checkpoint names).
+Don't just say "done" — the point of write-out is that the user can go find
+these files. If a validation definition or checkpoint name was already taken
+by an unrelated object and this run left it alone (`found`, not `written`),
+say that too, by name — the object under that name in the project is not the
+one this session built, and the user needs to know that before they run it.
+
+## What "usable without modification" means, and its one exception
+
+For everything this run actually wrote, the result is a standard project
+artifact: a fresh `gx.get_context(mode="file", project_root_dir=...)` against
+that directory loads the same data sources, assets, batch definitions,
+suites, validation definitions, and checkpoints, and
+`batch_definition.get_batch()`, `batch.validate(suite)`, and
+`checkpoint.run()` all work exactly as they did in the original session —
+including firing every action on a rebuilt checkpoint, such as an
+`UpdateDataDocsAction` updating the project's own Data Docs site. This
+promise covers what was written, per the `written`/`found` distinction above
+— an object reported as `found` is someone else's, and running it runs
+whatever that object actually is, not the session's version. That includes a
+`written` checkpoint whose validation definition came back `found`: it runs,
+but against a validation definition that isn't the session's, per the
+disclosure note above — resolve that name with the user before treating the
+run as the session's own. One further exception applies even to what was
+written:
+
+**Dataframe assets carry no data.** An in-memory dataframe (a pandas
+`DataFrame` passed as the asset's data) is never serialized to disk — only the
+asset's *configuration* is written out. After write-out, and in every future
+session, retrieving a batch from a dataframe asset still requires passing the
+dataframe explicitly at call time:
+
+```python executable
+batch = batch_definition.get_batch(batch_parameters={"dataframe": df})
+```
+
+State this to the user when a dataframe asset is part of what got written
+out — it's easy to assume the data went with the config, and it didn't. The
+same caveat reaches any rebuilt checkpoint whose validation definitions run
+against a dataframe asset: `checkpoint.run()` still needs
+`batch_parameters={"dataframe": df}` passed at call time for that
+validation definition, exactly as `get_batch()` does above — write-out
+changes nothing about how that argument reaches it.
+
+## Secrets after write-out: the environment-vs-file split
+
+An in-memory session resolves `${ENV_VAR}`-style substitutions only from
+process environment variables — it has no on-disk uncommitted config file to
+read them from, because it has no disk footprint at all. A file-backed project
+gains a second, additive source: an uncommitted config-variables file that
+lives inside the project directory. Writing a session out to a project does
+not change how any existing `${ENV_VAR}` reference resolves — it still comes
+from the environment, exactly as before — but it does mean the user now has
+the option to move any of those values into the project's uncommitted config
+file for anyone else who works in that project without necessarily sharing
+the same shell environment. Mention this as a follow-up option; do not do it
+for them, and never write a resolved secret value into any file yourself —
+only the `${ENV_VAR}`-style reference belongs in a persisted config.

--- a/great_expectations/.agents/skills/gx-configure-checkpoint/references/write-out.md
+++ b/great_expectations/.agents/skills/gx-configure-checkpoint/references/write-out.md
@@ -220,7 +220,13 @@ def _add_validation_definition():
         .get_asset("my_asset")
         .get_batch_definition("my_batch_definition")
     )
-    target_suite = file_context.suites.get("my_suite")
+    # Fetched by the session suite's own name, not by a literal: unlike the
+    # datasource, asset and batch definition above -- which this procedure
+    # creates under the names written here -- the suite arrives from the
+    # session already named, and a literal that disagrees with it fails the
+    # lookup. The loop below swallows that into `failed`, so the write-out
+    # would finish silently short of a validation definition and a checkpoint.
+    target_suite = file_context.suites.get(suite.name)
     # Existence is checked through all() rather than get()/except: unlike
     # LookupError on the earlier steps, a missing validation definition or
     # checkpoint surfaces as a data-context-level error that isn't part of

--- a/great_expectations/.agents/skills/gx-configure-data-source/references/write-out.md
+++ b/great_expectations/.agents/skills/gx-configure-data-source/references/write-out.md
@@ -95,6 +95,9 @@ gets you the same handle without needing an earlier step to have succeeded in
 the same function scope, and it makes failures cascade correctly — if the
 datasource step failed, the asset step's own fetch of it fails too, with a
 reason that points back at the real cause instead of a confusing `NameError`.
+The same chain extends further, past the suite step, to validation
+definitions and checkpoints — covered below, once the base pattern is on the
+table.
 
 The datasource step follows the same fetch-first-on-`LookupError` shape as
 the asset and batch-definition steps below it — that's what makes it safe to
@@ -179,20 +182,199 @@ fetches first, re-running the whole procedure after fixing the cause of a
 failure is safe — nothing already written gets duplicated, corrupted, or (per
 the warning above) destroyed by running it again.
 
+### Continuing the chain: validation definitions and checkpoints
+
+When the session also bound suites into validation definitions and grouped
+those into a checkpoint, two more steps complete the chain — validation
+definitions after suites, checkpoints last, and neither before the step it
+depends on has actually succeeded. The `steps`/`written`/`failed` loop above
+already ran, over the four entries it had at the time it ran — appending to
+`steps` afterward would define a longer list that nothing goes on to loop
+over again. So this is not an append: it replaces `steps` with the complete,
+six-entry list and runs the loop over it again from scratch, calling
+`_add_datasource` and the rest a second time. That's safe for the same
+reasons re-running the four-step version above is safe: the datasource,
+asset, and batch-definition steps fetch first; the suite step's
+`add_or_update` replaces that one suite's content with the same session
+suite it already wrote, which is a no-op the second time, not a second
+destructive replacement; and the two new steps below fetch first as well. It
+produces the one, complete disclosure covering all six objects, superseding
+the four-object one above:
+
+```python
+from great_expectations.core import ValidationDefinition
+from great_expectations.checkpoint import Checkpoint
+
+# Labels of steps below that left an object already present alone, rather
+# than creating it. Populated as a side effect of the two functions below,
+# then used after the loop to separate "written" from "found".
+found = []
+
+def _add_validation_definition():
+    # Re-fetch both dependencies from file_context — not from the in-memory
+    # session — so the object being built is scoped to the target from the
+    # start. `validation_definitions.add()` on an unpersisted suite is
+    # exactly the ordering failure covered above.
+    target_bd = (
+        file_context.data_sources.get("my_datasource")
+        .get_asset("my_asset")
+        .get_batch_definition("my_batch_definition")
+    )
+    target_suite = file_context.suites.get("my_suite")
+    # Existence is checked through all() rather than get()/except: unlike
+    # LookupError on the earlier steps, a missing validation definition or
+    # checkpoint surfaces as a data-context-level error that isn't part of
+    # the public exception surface, so checking membership first keeps every
+    # branch on add()/get()/all() instead.
+    existing = {v.name for v in file_context.validation_definitions.all()}
+    if "my_validation_definition" in existing:
+        found.append("validation definition my_validation_definition")
+        return file_context.validation_definitions.get("my_validation_definition")
+    return file_context.validation_definitions.add(
+        ValidationDefinition(
+            name="my_validation_definition", data=target_bd, suite=target_suite
+        )
+    )
+
+def _add_checkpoint():
+    # `checkpoint` here is the same Checkpoint object (or an equivalent one)
+    # built against the in-memory context earlier in the flow — the same
+    # convention _add_suite uses for `suite` above.
+    #
+    # Rebuilt from the validation definition this procedure just added to
+    # file_context — never from the session's original checkpoint or its
+    # validation definitions. Carrying those over raises, and not for the
+    # reason it looks like: the freshness check a checkpoint runs on each
+    # validation definition's batch definition does not compare against the
+    # handle's *origin* context. It resolves through the process-global
+    # *active* context — whichever context creation, anywhere in this
+    # process, made a context active most recently. Creating file_context
+    # above made it that context, so every handle the original in-memory
+    # session built now fails, not because it is "from a different context"
+    # in some abstract sense, but because it is not the one context object
+    # currently active (observed: CheckpointRelatedResourcesFreshnessError,
+    # "BatchDefinition '...' has changed since it has last been saved").
+    target_vd = file_context.validation_definitions.get("my_validation_definition")
+    existing = {c.name for c in file_context.checkpoints.all()}
+    if "my_checkpoint" in existing:
+        found.append("checkpoint my_checkpoint")
+        return file_context.checkpoints.get("my_checkpoint")
+    return file_context.checkpoints.add(
+        Checkpoint(
+            name="my_checkpoint",
+            validation_definitions=[target_vd],
+            # Actions carry over unchanged — a plain field on the
+            # Checkpoint being constructed, not something that needs
+            # rebuilding like the validation definitions above.
+            actions=list(checkpoint.actions),
+        )
+    )
+
+steps = [
+    ("data source my_datasource", _add_datasource),
+    ("asset my_asset", _add_asset),
+    ("batch definition my_batch_definition", _add_batch_definition),
+    ("suite my_suite", _add_suite),
+    ("validation definition my_validation_definition", _add_validation_definition),
+    ("checkpoint my_checkpoint", _add_checkpoint),
+    # ... one entry per object to re-create, following the same
+    # repeat-per-object note as the four-step version above: the
+    # validation-definition pattern once per (batch definition, suite) pair
+    # the session bound, added only after its own suite step succeeded, and
+    # the checkpoint pattern once per checkpoint, added only after every
+    # validation definition it groups.
+]
+
+written = []
+failed = []
+for label, step in steps:
+    try:
+        step()
+        written.append(label)
+    except Exception as e:
+        failed.append((label, str(e)))
+
+# A step that found an object already present, rather than creating one, is
+# not "written" by this run. Pull it out of `written` so the disclosure
+# names exactly what changed and what didn't — see below.
+written = [label for label in written if label not in found]
+```
+
+**Report three outcomes now, not two: written, found, and failed.** A
+validation definition or checkpoint name can already be taken by an object
+that has nothing to do with this session — a teammate's checkpoint, an
+earlier write-out, anything already in the target project. The two functions
+above refuse to overwrite it, which is the right call: it matches the
+fetch-first, never-clobber shape of every other step, and an existing
+checkpoint or validation definition under that name is left completely
+alone. But refusing to overwrite and reporting "written" are different
+things — if that were reported as written, the user would be told their
+session's checkpoint landed when the object they will actually load and run
+under that name is someone else's. Report `found` as its own list, distinct
+from both `written` and `failed`: "already present, left as-is" is not a
+failure, but it is not this run's work landing on disk either. If a name
+collision on a validation definition or checkpoint is unwanted, that's a
+naming conflict to resolve with the user, not something this procedure
+resolves by overwriting.
+
+This also reaches a checkpoint that *is* written — `_add_checkpoint` builds
+it from whatever object `file_context.validation_definitions.get(...)`
+returns, without regard to whether that get() came from the create branch or
+the found branch just above it. So if the validation-definition step
+reported `found`, the checkpoint step can still report `written`, and the
+checkpoint just written groups someone else's validation definition, not the
+session's. Report the two together when this happens, and resolve the name
+with the user before anyone runs it — a `written` checkpoint is not
+sufficient evidence that what it groups is the session's own.
+
+Everything else about the disclosure contract carries over unchanged: a
+validation definition that fails because its suite never landed is reported
+as a consequence of the suite step's failure, not a second, unrelated
+problem, and a checkpoint that fails because its validation definition never
+landed is reported the same way.
+
+**Why this order, restated as what actually failed above:** the observed
+`ResourceFreshnessAggregateError` when a suite is not yet persisted, and the
+observed `CheckpointRelatedResourcesFreshnessError` when a checkpoint is
+built from a handle that belongs to a context other than the one currently
+active, are two instances of the same rule — every object this procedure
+adds has to be built from handles fetched from `file_context` after it
+became the active context, never from a handle that belongs to the session
+that started the procedure. Datasources, assets, and batch definitions come
+first because nothing else can reference them without already being real;
+suites come next for the same reason validation definitions need them;
+validation definitions come before checkpoints because a checkpoint's
+`validation_definitions` list is checked the same way.
+
 ## Report the written location
 
 When it completes, tell the user the absolute path that was written to, and
 name what landed there (data source names, asset names, batch definition
-names, suite names). Don't just say "done" — the point of write-out is that
-the user can go find these files.
+names, suite names, validation definition names, and checkpoint names).
+Don't just say "done" — the point of write-out is that the user can go find
+these files. If a validation definition or checkpoint name was already taken
+by an unrelated object and this run left it alone (`found`, not `written`),
+say that too, by name — the object under that name in the project is not the
+one this session built, and the user needs to know that before they run it.
 
 ## What "usable without modification" means, and its one exception
 
-Everything written out this way is a standard project artifact: a fresh
-`gx.get_context(mode="file", project_root_dir=...)` against that directory
-loads the same data sources, assets, batch definitions, and suites, and
-`batch_definition.get_batch()` and `batch.validate(suite)` work exactly as
-they did in the original session — with one exception.
+For everything this run actually wrote, the result is a standard project
+artifact: a fresh `gx.get_context(mode="file", project_root_dir=...)` against
+that directory loads the same data sources, assets, batch definitions,
+suites, validation definitions, and checkpoints, and
+`batch_definition.get_batch()`, `batch.validate(suite)`, and
+`checkpoint.run()` all work exactly as they did in the original session —
+including firing every action on a rebuilt checkpoint, such as an
+`UpdateDataDocsAction` updating the project's own Data Docs site. This
+promise covers what was written, per the `written`/`found` distinction above
+— an object reported as `found` is someone else's, and running it runs
+whatever that object actually is, not the session's version. That includes a
+`written` checkpoint whose validation definition came back `found`: it runs,
+but against a validation definition that isn't the session's, per the
+disclosure note above — resolve that name with the user before treating the
+run as the session's own. One further exception applies even to what was
+written:
 
 **Dataframe assets carry no data.** An in-memory dataframe (a pandas
 `DataFrame` passed as the asset's data) is never serialized to disk — only the
@@ -205,7 +387,12 @@ batch = batch_definition.get_batch(batch_parameters={"dataframe": df})
 ```
 
 State this to the user when a dataframe asset is part of what got written
-out — it's easy to assume the data went with the config, and it didn't.
+out — it's easy to assume the data went with the config, and it didn't. The
+same caveat reaches any rebuilt checkpoint whose validation definitions run
+against a dataframe asset: `checkpoint.run()` still needs
+`batch_parameters={"dataframe": df}` passed at call time for that
+validation definition, exactly as `get_batch()` does above — write-out
+changes nothing about how that argument reaches it.
 
 ## Secrets after write-out: the environment-vs-file split
 

--- a/great_expectations/.agents/skills/gx-configure-data-source/references/write-out.md
+++ b/great_expectations/.agents/skills/gx-configure-data-source/references/write-out.md
@@ -220,7 +220,13 @@ def _add_validation_definition():
         .get_asset("my_asset")
         .get_batch_definition("my_batch_definition")
     )
-    target_suite = file_context.suites.get("my_suite")
+    # Fetched by the session suite's own name, not by a literal: unlike the
+    # datasource, asset and batch definition above -- which this procedure
+    # creates under the names written here -- the suite arrives from the
+    # session already named, and a literal that disagrees with it fails the
+    # lookup. The loop below swallows that into `failed`, so the write-out
+    # would finish silently short of a validation definition and a checkpoint.
+    target_suite = file_context.suites.get(suite.name)
     # Existence is checked through all() rather than get()/except: unlike
     # LookupError on the earlier steps, a missing validation definition or
     # checkpoint surfaces as a data-context-level error that isn't part of

--- a/great_expectations/.agents/skills/gx-configure-expectations/SKILL.md
+++ b/great_expectations/.agents/skills/gx-configure-expectations/SKILL.md
@@ -328,13 +328,14 @@ the suite along with the data source, asset, and batch definition it depends
 on; writing out a suite without them leaves a project that cannot run it.
 Offer it; don't do it unprompted, and don't pick the location.
 
-**The offer ends this flow.** Write-out creates a project on the user's disk,
-so it starts only from their reply — a separate run, after they have agreed
-and named a directory. Reporting the results and then writing them out in the
-same breath means they were never asked; putting the write-out call in the
-same program as the suite and validation calls means the same thing, because
-there was no point in it where an answer could have arrived.
-`references/write-out.md` opens with the gate this depends on.
+**The offer ends this step, not the flow.** Write-out creates a project on
+the user's disk, so it starts only from their reply — a separate run, after
+they have agreed and named a directory. Reporting the results and then
+writing them out in the same breath means they were never asked; putting the
+write-out call in the same program as the suite and validation calls means
+the same thing, because there was no point in it where an answer could have
+arrived. `references/write-out.md` opens with the gate this depends on.
+Written out or not, what comes next is below.
 
 ## Worked example
 
@@ -392,15 +393,24 @@ as *one of four rows has no customer, and one amount is negative (-5.0)*; the
 
 ## Where this flow ends
 
-The saved, run, reported suite is the end state. Three things sit outside it:
+**The saved, run, reported suite is this flow's own end state.** The one
+thing that stays outside it is **rendering results anywhere but this
+conversation** — report what the run found; do not build reporting surfaces
+the user did not ask for. Setting up data access when the precondition fails
+(step 2) and building only what the user described rather than profiling
+(step 3) are already hard rules earlier in this flow, not items this closing
+note needs to repeat.
 
-- **Setting up data access.** If the precondition in step 2 fails, that is
-  the `gx-configure-data-source` skill's work, not something to improvise
-  around.
-- **Proposing expectations from the data.** The user describes; this flow
-  builds. See step 3.
-- **Rendering results anywhere but this conversation.** Report what the run
-  found; do not build reporting surfaces the user did not ask for.
+What no longer ends here: turning a validated suite into a check that
+survives the session. Offer the `gx-configure-checkpoint` skill as the next
+step — it binds the batch definition and suite this flow just built into a
+persisted, re-runnable checkpoint with post-run actions, verified by a run of
+its own. If the user asks for both in one breath, finish this flow, report
+it, and then move on.
+
+Declining the offer is a fine place to stop. Whether or not the user takes
+it, this flow's own job — build what was described, run it, report it, and
+persist or offer to persist it — is already done.
 
 ## References
 

--- a/great_expectations/.agents/skills/gx-configure-expectations/references/write-out.md
+++ b/great_expectations/.agents/skills/gx-configure-expectations/references/write-out.md
@@ -95,6 +95,9 @@ gets you the same handle without needing an earlier step to have succeeded in
 the same function scope, and it makes failures cascade correctly — if the
 datasource step failed, the asset step's own fetch of it fails too, with a
 reason that points back at the real cause instead of a confusing `NameError`.
+The same chain extends further, past the suite step, to validation
+definitions and checkpoints — covered below, once the base pattern is on the
+table.
 
 The datasource step follows the same fetch-first-on-`LookupError` shape as
 the asset and batch-definition steps below it — that's what makes it safe to
@@ -179,20 +182,199 @@ fetches first, re-running the whole procedure after fixing the cause of a
 failure is safe — nothing already written gets duplicated, corrupted, or (per
 the warning above) destroyed by running it again.
 
+### Continuing the chain: validation definitions and checkpoints
+
+When the session also bound suites into validation definitions and grouped
+those into a checkpoint, two more steps complete the chain — validation
+definitions after suites, checkpoints last, and neither before the step it
+depends on has actually succeeded. The `steps`/`written`/`failed` loop above
+already ran, over the four entries it had at the time it ran — appending to
+`steps` afterward would define a longer list that nothing goes on to loop
+over again. So this is not an append: it replaces `steps` with the complete,
+six-entry list and runs the loop over it again from scratch, calling
+`_add_datasource` and the rest a second time. That's safe for the same
+reasons re-running the four-step version above is safe: the datasource,
+asset, and batch-definition steps fetch first; the suite step's
+`add_or_update` replaces that one suite's content with the same session
+suite it already wrote, which is a no-op the second time, not a second
+destructive replacement; and the two new steps below fetch first as well. It
+produces the one, complete disclosure covering all six objects, superseding
+the four-object one above:
+
+```python
+from great_expectations.core import ValidationDefinition
+from great_expectations.checkpoint import Checkpoint
+
+# Labels of steps below that left an object already present alone, rather
+# than creating it. Populated as a side effect of the two functions below,
+# then used after the loop to separate "written" from "found".
+found = []
+
+def _add_validation_definition():
+    # Re-fetch both dependencies from file_context — not from the in-memory
+    # session — so the object being built is scoped to the target from the
+    # start. `validation_definitions.add()` on an unpersisted suite is
+    # exactly the ordering failure covered above.
+    target_bd = (
+        file_context.data_sources.get("my_datasource")
+        .get_asset("my_asset")
+        .get_batch_definition("my_batch_definition")
+    )
+    target_suite = file_context.suites.get("my_suite")
+    # Existence is checked through all() rather than get()/except: unlike
+    # LookupError on the earlier steps, a missing validation definition or
+    # checkpoint surfaces as a data-context-level error that isn't part of
+    # the public exception surface, so checking membership first keeps every
+    # branch on add()/get()/all() instead.
+    existing = {v.name for v in file_context.validation_definitions.all()}
+    if "my_validation_definition" in existing:
+        found.append("validation definition my_validation_definition")
+        return file_context.validation_definitions.get("my_validation_definition")
+    return file_context.validation_definitions.add(
+        ValidationDefinition(
+            name="my_validation_definition", data=target_bd, suite=target_suite
+        )
+    )
+
+def _add_checkpoint():
+    # `checkpoint` here is the same Checkpoint object (or an equivalent one)
+    # built against the in-memory context earlier in the flow — the same
+    # convention _add_suite uses for `suite` above.
+    #
+    # Rebuilt from the validation definition this procedure just added to
+    # file_context — never from the session's original checkpoint or its
+    # validation definitions. Carrying those over raises, and not for the
+    # reason it looks like: the freshness check a checkpoint runs on each
+    # validation definition's batch definition does not compare against the
+    # handle's *origin* context. It resolves through the process-global
+    # *active* context — whichever context creation, anywhere in this
+    # process, made a context active most recently. Creating file_context
+    # above made it that context, so every handle the original in-memory
+    # session built now fails, not because it is "from a different context"
+    # in some abstract sense, but because it is not the one context object
+    # currently active (observed: CheckpointRelatedResourcesFreshnessError,
+    # "BatchDefinition '...' has changed since it has last been saved").
+    target_vd = file_context.validation_definitions.get("my_validation_definition")
+    existing = {c.name for c in file_context.checkpoints.all()}
+    if "my_checkpoint" in existing:
+        found.append("checkpoint my_checkpoint")
+        return file_context.checkpoints.get("my_checkpoint")
+    return file_context.checkpoints.add(
+        Checkpoint(
+            name="my_checkpoint",
+            validation_definitions=[target_vd],
+            # Actions carry over unchanged — a plain field on the
+            # Checkpoint being constructed, not something that needs
+            # rebuilding like the validation definitions above.
+            actions=list(checkpoint.actions),
+        )
+    )
+
+steps = [
+    ("data source my_datasource", _add_datasource),
+    ("asset my_asset", _add_asset),
+    ("batch definition my_batch_definition", _add_batch_definition),
+    ("suite my_suite", _add_suite),
+    ("validation definition my_validation_definition", _add_validation_definition),
+    ("checkpoint my_checkpoint", _add_checkpoint),
+    # ... one entry per object to re-create, following the same
+    # repeat-per-object note as the four-step version above: the
+    # validation-definition pattern once per (batch definition, suite) pair
+    # the session bound, added only after its own suite step succeeded, and
+    # the checkpoint pattern once per checkpoint, added only after every
+    # validation definition it groups.
+]
+
+written = []
+failed = []
+for label, step in steps:
+    try:
+        step()
+        written.append(label)
+    except Exception as e:
+        failed.append((label, str(e)))
+
+# A step that found an object already present, rather than creating one, is
+# not "written" by this run. Pull it out of `written` so the disclosure
+# names exactly what changed and what didn't — see below.
+written = [label for label in written if label not in found]
+```
+
+**Report three outcomes now, not two: written, found, and failed.** A
+validation definition or checkpoint name can already be taken by an object
+that has nothing to do with this session — a teammate's checkpoint, an
+earlier write-out, anything already in the target project. The two functions
+above refuse to overwrite it, which is the right call: it matches the
+fetch-first, never-clobber shape of every other step, and an existing
+checkpoint or validation definition under that name is left completely
+alone. But refusing to overwrite and reporting "written" are different
+things — if that were reported as written, the user would be told their
+session's checkpoint landed when the object they will actually load and run
+under that name is someone else's. Report `found` as its own list, distinct
+from both `written` and `failed`: "already present, left as-is" is not a
+failure, but it is not this run's work landing on disk either. If a name
+collision on a validation definition or checkpoint is unwanted, that's a
+naming conflict to resolve with the user, not something this procedure
+resolves by overwriting.
+
+This also reaches a checkpoint that *is* written — `_add_checkpoint` builds
+it from whatever object `file_context.validation_definitions.get(...)`
+returns, without regard to whether that get() came from the create branch or
+the found branch just above it. So if the validation-definition step
+reported `found`, the checkpoint step can still report `written`, and the
+checkpoint just written groups someone else's validation definition, not the
+session's. Report the two together when this happens, and resolve the name
+with the user before anyone runs it — a `written` checkpoint is not
+sufficient evidence that what it groups is the session's own.
+
+Everything else about the disclosure contract carries over unchanged: a
+validation definition that fails because its suite never landed is reported
+as a consequence of the suite step's failure, not a second, unrelated
+problem, and a checkpoint that fails because its validation definition never
+landed is reported the same way.
+
+**Why this order, restated as what actually failed above:** the observed
+`ResourceFreshnessAggregateError` when a suite is not yet persisted, and the
+observed `CheckpointRelatedResourcesFreshnessError` when a checkpoint is
+built from a handle that belongs to a context other than the one currently
+active, are two instances of the same rule — every object this procedure
+adds has to be built from handles fetched from `file_context` after it
+became the active context, never from a handle that belongs to the session
+that started the procedure. Datasources, assets, and batch definitions come
+first because nothing else can reference them without already being real;
+suites come next for the same reason validation definitions need them;
+validation definitions come before checkpoints because a checkpoint's
+`validation_definitions` list is checked the same way.
+
 ## Report the written location
 
 When it completes, tell the user the absolute path that was written to, and
 name what landed there (data source names, asset names, batch definition
-names, suite names). Don't just say "done" — the point of write-out is that
-the user can go find these files.
+names, suite names, validation definition names, and checkpoint names).
+Don't just say "done" — the point of write-out is that the user can go find
+these files. If a validation definition or checkpoint name was already taken
+by an unrelated object and this run left it alone (`found`, not `written`),
+say that too, by name — the object under that name in the project is not the
+one this session built, and the user needs to know that before they run it.
 
 ## What "usable without modification" means, and its one exception
 
-Everything written out this way is a standard project artifact: a fresh
-`gx.get_context(mode="file", project_root_dir=...)` against that directory
-loads the same data sources, assets, batch definitions, and suites, and
-`batch_definition.get_batch()` and `batch.validate(suite)` work exactly as
-they did in the original session — with one exception.
+For everything this run actually wrote, the result is a standard project
+artifact: a fresh `gx.get_context(mode="file", project_root_dir=...)` against
+that directory loads the same data sources, assets, batch definitions,
+suites, validation definitions, and checkpoints, and
+`batch_definition.get_batch()`, `batch.validate(suite)`, and
+`checkpoint.run()` all work exactly as they did in the original session —
+including firing every action on a rebuilt checkpoint, such as an
+`UpdateDataDocsAction` updating the project's own Data Docs site. This
+promise covers what was written, per the `written`/`found` distinction above
+— an object reported as `found` is someone else's, and running it runs
+whatever that object actually is, not the session's version. That includes a
+`written` checkpoint whose validation definition came back `found`: it runs,
+but against a validation definition that isn't the session's, per the
+disclosure note above — resolve that name with the user before treating the
+run as the session's own. One further exception applies even to what was
+written:
 
 **Dataframe assets carry no data.** An in-memory dataframe (a pandas
 `DataFrame` passed as the asset's data) is never serialized to disk — only the
@@ -205,7 +387,12 @@ batch = batch_definition.get_batch(batch_parameters={"dataframe": df})
 ```
 
 State this to the user when a dataframe asset is part of what got written
-out — it's easy to assume the data went with the config, and it didn't.
+out — it's easy to assume the data went with the config, and it didn't. The
+same caveat reaches any rebuilt checkpoint whose validation definitions run
+against a dataframe asset: `checkpoint.run()` still needs
+`batch_parameters={"dataframe": df}` passed at call time for that
+validation definition, exactly as `get_batch()` does above — write-out
+changes nothing about how that argument reaches it.
 
 ## Secrets after write-out: the environment-vs-file split
 

--- a/great_expectations/.agents/skills/gx-configure-expectations/references/write-out.md
+++ b/great_expectations/.agents/skills/gx-configure-expectations/references/write-out.md
@@ -220,7 +220,13 @@ def _add_validation_definition():
         .get_asset("my_asset")
         .get_batch_definition("my_batch_definition")
     )
-    target_suite = file_context.suites.get("my_suite")
+    # Fetched by the session suite's own name, not by a literal: unlike the
+    # datasource, asset and batch definition above -- which this procedure
+    # creates under the names written here -- the suite arrives from the
+    # session already named, and a literal that disagrees with it fails the
+    # lookup. The loop below swallows that into `failed`, so the write-out
+    # would finish silently short of a validation definition and a checkpoint.
+    target_suite = file_context.suites.get(suite.name)
     # Existence is checked through all() rather than get()/except: unlike
     # LookupError on the earlier steps, a missing validation definition or
     # checkpoint surfaces as a data-context-level error that isn't part of

--- a/great_expectations/__main__.py
+++ b/great_expectations/__main__.py
@@ -52,8 +52,9 @@ _REASON_WIDTH: Final = 88
 
 _SKILLS_DESCRIPTION: Final = (
     "Great Expectations bundles skills that teach a coding agent to configure data "
-    "sources and expectations. Agents look for skills in directories inside your "
-    "project, so the skills have to be installed there before an agent can find them."
+    "sources, expectations, and checkpoint orchestration. Agents look for skills in "
+    "directories inside your project, so the skills have to be installed there before "
+    "an agent can find them."
 )
 
 _INSTALL_DESCRIPTION: Final = (

--- a/tests/agent_skills/test_skill_content.py
+++ b/tests/agent_skills/test_skill_content.py
@@ -30,6 +30,8 @@ import pytest
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from great_expectations.compatibility.pydantic import BaseModel
+
 pytestmark = [pytest.mark.unit]
 
 PROJECT_ROOT: Final = pathlib.Path(__file__).parents[2]
@@ -58,11 +60,29 @@ SKILL_NAME_PATTERN: Final = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
 
 #: Number of skills the package is known to bundle. Guards against a discovery bug
 #: silently reducing every parametrized test below to zero cases.
-MIN_BUNDLED_SKILLS: Final = 2
+MIN_BUNDLED_SKILLS: Final = 3
+
+#: The checkpoint skill's action-catalog reference, checked against the live action
+#: registry below.
+ACTION_CATALOG_SKILL: Final = "gx-configure-checkpoint"
+ACTION_CATALOG_REFERENCE: Final = "action-catalog.md"
 
 FRONTMATTER_PATTERN: Final = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
 CODE_SPAN_PATTERN: Final = re.compile(r"`([^`\n]+)`")
 MARKDOWN_LINK_PATTERN: Final = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+#: A reference-shaped path -- one that already carries the ``references/`` prefix --
+#: found inside a fenced code block. Bare filenames in fenced comments ("per
+#: preflight.md") are deliberately not references (see ``_strip_code_fences``), but a
+#: prefixed path is unambiguously meant as one, fence or not.
+FENCED_REFERENCE_PATTERN: Final = re.compile(r"references/[\w./-]+\.md")
+#: A skill of this bundle's naming family (``gx-configure-*``) named in prose as
+#: inline code, e.g. a hand-off ("route to `gx-configure-checkpoint`"). Scoped to the
+#: family prefix so an unrelated ``gx-``-prefixed token -- a package extra name like
+#: ``gx-redshift`` -- is not mistaken for a skill hand-off.
+SKILL_MENTION_PATTERN: Final = re.compile(r"`(gx-configure-[a-z0-9]+(?:-[a-z0-9]+)*)`")
+#: The action catalog's stability-split table rows, e.g.
+#: ``| `SlackNotificationAction` | `slack` | `@public_api` |``.
+ACTION_TABLE_ROW_PATTERN: Final = re.compile(r"^\| `\w+` \| `(?P<type>\w+)` \|", re.MULTILINE)
 
 
 class SkillContentError(Exception):
@@ -194,12 +214,43 @@ def find_relative_references(document: pathlib.Path) -> set[str]:
     return {candidate for candidate in candidates if _is_relative_document_reference(candidate)}
 
 
+def _code_fence_contents(text: str) -> str:
+    """Return only fenced code block content -- the inverse of ``_strip_code_fences``."""
+    fenced: list[str] = []
+    inside_fence = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            inside_fence = not inside_fence
+            continue
+        if inside_fence:
+            fenced.append(line)
+    return "\n".join(fenced)
+
+
+def find_fenced_references(document: pathlib.Path) -> set[str]:
+    """Return reference-shaped paths mentioned inside fenced code blocks.
+
+    ``_strip_code_fences`` drops fenced content before ``find_relative_references``
+    runs, so a wrong ``references/...`` path sitting inside a code comment resolves
+    against nothing and passes silently -- that gap has already shipped a broken
+    reference once, caught only by reading. This scans fenced content on its own,
+    narrowly, for paths that already carry the ``references/`` prefix.
+    """
+    fenced_text = _code_fence_contents(document.read_text(encoding="utf-8"))
+    return set(FENCED_REFERENCE_PATTERN.findall(fenced_text))
+
+
+def find_all_references(document: pathlib.Path) -> set[str]:
+    """Return every reference a document points at, prose and fenced alike."""
+    return find_relative_references(document) | find_fenced_references(document)
+
+
 def reference_problems(skill_dir: pathlib.Path) -> list[str]:
     """Return every reference in a skill that fails to resolve inside the skill."""
     skill_root = skill_dir.resolve()
     problems: list[str] = []
     for document in sorted(skill_dir.rglob("*.md")):
-        for reference in sorted(find_relative_references(document)):
+        for reference in sorted(find_all_references(document)):
             target = (document.parent / reference.split("#", 1)[0]).resolve()
             try:
                 relative = target.relative_to(skill_root)
@@ -225,7 +276,7 @@ def reference_problems(skill_dir: pathlib.Path) -> list[str]:
 
 
 def count_references(skill_dir: pathlib.Path) -> int:
-    return sum(len(find_relative_references(document)) for document in skill_dir.rglob("*.md"))
+    return sum(len(find_all_references(document)) for document in skill_dir.rglob("*.md"))
 
 
 def shared_reference_problems(skills_root: pathlib.Path) -> list[str]:
@@ -258,6 +309,119 @@ def skills_holding(skills_root: pathlib.Path, shared_name: str) -> list[pathlib.
         for skill_dir in discover_skills(skills_root)
         if (skill_dir / REFERENCE_DIR / shared_name).is_file()
     ]
+
+
+def carriage_problems(skills_root: pathlib.Path) -> list[str]:
+    """Return every bundled skill directory missing one of the shared references.
+
+    ``shared_reference_problems`` above compares copies that exist against the
+    canonical one -- it is a byte-equality check with nothing to say about a skill
+    that ships without a copy at all, because there is nothing there to compare.
+    This is the carriage check that byte-equality alone cannot be: every bundled
+    skill must hold its own copy of every shared reference.
+    """
+    problems: list[str] = []
+    for skill_dir in discover_skills(skills_root):
+        for shared_name in SHARED_REFERENCES:
+            if not (skill_dir / REFERENCE_DIR / shared_name).is_file():
+                problems.append(
+                    f"{skill_dir} is missing {REFERENCE_DIR}/{shared_name}. Every bundled"
+                    f" skill must carry its own copy of {shared_name}; copy it from"
+                    f" {skills_root / CANONICAL_SKILL / REFERENCE_DIR / shared_name}."
+                )
+    return problems
+
+
+def find_skill_mentions(document: pathlib.Path) -> set[str]:
+    """Return skill names of this bundle's naming family mentioned in prose."""
+    text = _strip_code_fences(document.read_text(encoding="utf-8"))
+    return set(SKILL_MENTION_PATTERN.findall(text))
+
+
+def unresolved_skill_mention_problems(
+    skills_root: pathlib.Path, skill_dir: pathlib.Path
+) -> list[str]:
+    """Return every prose-mentioned skill name that does not resolve to a bundled skill.
+
+    Nothing else in this suite checks this: frontmatter, references, and shared-copy
+    checks are all silent about a hand-off that names a skill that does not exist. A
+    stale or misspelled name here passes green and misroutes a real user at runtime.
+    """
+    known_skill_names = {known.name for known in discover_skills(skills_root)}
+    problems: list[str] = []
+    for document in sorted(skill_dir.rglob("*.md")):
+        for mentioned in sorted(find_skill_mentions(document)):
+            if mentioned not in known_skill_names:
+                problems.append(
+                    f"{document}: mentions skill {mentioned!r}, which is not a bundled"
+                    f" skill directory under {skills_root}. Fix the name or add the skill."
+                )
+    return problems
+
+
+def _closure_of_subclasses(cls: type[BaseModel]) -> set[type[BaseModel]]:
+    found: set[type[BaseModel]] = set(cls.__subclasses__())
+    for subclass in list(found):
+        found |= _closure_of_subclasses(subclass)
+    return found
+
+
+def _attachable_types_scoped_to(cls: type[BaseModel], owner_module: str) -> frozenset[str]:
+    """Return the ``type`` default of every subclass of ``cls`` owned by ``owner_module``.
+
+    A class is attachable when it declares its own non-``None`` default for the
+    ``type`` field -- that selects concrete actions and excludes abstract bases, whose
+    ``type`` has no default of its own. Scoping to ``owner_module`` is what keeps a
+    third party's own registration from turning a completeness check red; split out
+    as a pure function of its two inputs so that scoping can be proven against a
+    synthetic hierarchy without touching Great Expectations' real action registry.
+    """
+    attachable = (
+        candidate
+        for candidate in _closure_of_subclasses(cls)
+        if candidate.__module__ == owner_module and candidate.__fields__["type"].default is not None
+    )
+    return frozenset(candidate.__fields__["type"].default for candidate in attachable)
+
+
+def gx_attachable_action_types() -> frozenset[str]:
+    """Return the ``type`` literal of every action Great Expectations itself attaches.
+
+    Mirrors the closure the action-catalog reference documents and verifies against,
+    scoped to classes defined inside Great Expectations' own action module -- a third
+    party registering an action of its own must not turn this assertion red.
+    """
+    from great_expectations.checkpoint import actions as actions_module
+
+    return _attachable_types_scoped_to(actions_module.ValidationAction, actions_module.__name__)
+
+
+def documented_action_types(action_catalog: pathlib.Path) -> frozenset[str]:
+    """Return the ``type`` values documented in the action catalog's stability table."""
+    text = action_catalog.read_text(encoding="utf-8")
+    return frozenset(match.group("type") for match in ACTION_TABLE_ROW_PATTERN.finditer(text))
+
+
+def action_catalog_drift_problems(action_catalog: pathlib.Path) -> list[str]:
+    """Return every mismatch between the documented action catalog and the live registry."""
+    documented = documented_action_types(action_catalog)
+    actual = gx_attachable_action_types()
+    problems: list[str] = []
+    missing = actual - documented
+    if missing:
+        problems.append(
+            f"{action_catalog} does not document action type(s) {sorted(missing)}, which"
+            " Great Expectations registers as attachable. This catalog is meant to cover"
+            " every action Great Expectations offers, not a curated subset -- add a row"
+            " and a field table for each."
+        )
+    extra = documented - actual
+    if extra:
+        problems.append(
+            f"{action_catalog} documents action type(s) {sorted(extra)}, which Great"
+            " Expectations no longer registers as attachable. Remove the stale row(s)."
+        )
+    return problems
 
 
 def entry_document_size_problems(skill_dir: pathlib.Path) -> list[str]:
@@ -360,6 +524,24 @@ def test_shared_reference_is_carried_by_every_skill_that_needs_it(shared_name: s
 
 def test_shared_references_are_byte_identical():
     problems = shared_reference_problems(SKILLS_ROOT)
+    assert not problems, "\n".join(problems)
+
+
+def test_every_bundled_skill_carries_every_shared_reference():
+    problems = carriage_problems(SKILLS_ROOT)
+    assert not problems, "\n".join(problems)
+
+
+@pytest.mark.parametrize("skill_dir", SKILL_DIRS, ids=lambda skill_dir: skill_dir.name)
+def test_skill_mentions_in_prose_resolve_to_bundled_skills(skill_dir: pathlib.Path):
+    problems = unresolved_skill_mention_problems(SKILLS_ROOT, skill_dir)
+    assert not problems, "\n".join(problems)
+
+
+def test_action_catalog_matches_the_live_action_registry():
+    action_catalog = SKILLS_ROOT / ACTION_CATALOG_SKILL / REFERENCE_DIR / ACTION_CATALOG_REFERENCE
+    assert action_catalog.is_file(), f"{action_catalog} does not exist"
+    problems = action_catalog_drift_problems(action_catalog)
     assert not problems, "\n".join(problems)
 
 
@@ -541,3 +723,155 @@ def test_over_budget_entry_document_is_reported(violating_skills: pathlib.Path):
     problems = entry_document_size_problems(skill_dir)
 
     assert [problem for problem in problems if "the budget is" in problem]
+
+
+def test_fenced_reference_that_does_not_exist_is_reported(violating_skills: pathlib.Path):
+    """The extractor used to see only prose references -- a wrong path inside a fenced
+    code comment resolved against nothing and passed silently. This is the mutation
+    proof that fenced content is checked too.
+    """
+    skill_dir = violating_skills / CANONICAL_SKILL
+    entry = skill_dir / ENTRY_DOCUMENT
+    text = entry.read_text(encoding="utf-8")
+    entry.write_text(
+        f"{text}\n```python\n# step 1, per references/does-not-exist-in-a-fence.md\n```\n",
+        encoding="utf-8",
+    )
+
+    problems = reference_problems(skill_dir)
+
+    assert [
+        problem
+        for problem in problems
+        if "does-not-exist-in-a-fence.md" in problem and "does not exist" in problem
+    ]
+
+
+def test_fenced_bare_filename_comment_is_not_treated_as_a_reference(
+    violating_skills: pathlib.Path,
+):
+    """A bare filename in a fenced comment ("per preflight.md") is deliberately not a
+    reference -- only a path already carrying the ``references/`` prefix is. This is
+    the counter-proof that the fenced check does not over-fire on ordinary prose.
+    """
+    skill_dir = violating_skills / CANONICAL_SKILL
+    entry = skill_dir / ENTRY_DOCUMENT
+    text = entry.read_text(encoding="utf-8")
+    entry.write_text(
+        f"{text}\n```python\n# step 1, per preflight.md, not a path\n```\n",
+        encoding="utf-8",
+    )
+
+    references = find_fenced_references(entry)
+
+    assert "preflight.md" not in references
+    assert not [reference for reference in references if "does-not-exist" in reference]
+
+
+@pytest.mark.parametrize("shared_name", SHARED_REFERENCES)
+def test_skill_missing_a_shared_reference_is_reported_by_carriage_check_only(
+    violating_skills: pathlib.Path, shared_name: str
+):
+    """The existing byte-equality check compares copies that exist -- it has nothing
+    to say about a skill that ships without a copy at all. This proves the carriage
+    check catches exactly that gap, and that byte-equality alone does not.
+    """
+    sibling = next(
+        skill_dir
+        for skill_dir in discover_skills(violating_skills)
+        if skill_dir.name != CANONICAL_SKILL
+    )
+    (sibling / REFERENCE_DIR / shared_name).unlink()
+
+    carriage = carriage_problems(violating_skills)
+    byte_equality = shared_reference_problems(violating_skills)
+
+    assert [problem for problem in carriage if str(sibling) in problem and shared_name in problem]
+    assert not [problem for problem in byte_equality if str(sibling) in problem], (
+        "byte-equality alone must not notice a missing copy -- that is exactly the gap"
+        " the carriage check exists to close"
+    )
+
+
+def test_unresolved_skill_mention_is_reported(violating_skills: pathlib.Path):
+    skill_dir = violating_skills / ACTION_CATALOG_SKILL
+    entry = skill_dir / ENTRY_DOCUMENT
+    anchor = "- No batch definition → hand off to `gx-configure-data-source`.\n"
+    text = entry.read_text(encoding="utf-8")
+    assert text.count(anchor) == 1, f"anchor is not unique in {entry}"
+    entry.write_text(
+        text.replace(
+            anchor, "- No batch definition → hand off to `gx-configure-nonexistent`.\n", 1
+        ),
+        encoding="utf-8",
+    )
+
+    problems = unresolved_skill_mention_problems(violating_skills, skill_dir)
+
+    assert [problem for problem in problems if "gx-configure-nonexistent" in problem]
+
+
+def test_action_catalog_missing_a_registered_action_is_reported(violating_skills: pathlib.Path):
+    action_catalog = (
+        violating_skills / ACTION_CATALOG_SKILL / REFERENCE_DIR / ACTION_CATALOG_REFERENCE
+    )
+    text = action_catalog.read_text(encoding="utf-8")
+    anchor = "| `UpdateDataDocsAction` | `update_data_docs` | `@public_api` |\n"
+    assert text.count(anchor) == 1, f"anchor is not unique in {action_catalog}"
+    action_catalog.write_text(text.replace(anchor, "", 1), encoding="utf-8")
+
+    problems = action_catalog_drift_problems(action_catalog)
+
+    assert [
+        problem
+        for problem in problems
+        if "update_data_docs" in problem and "does not document" in problem
+    ]
+
+
+def test_action_catalog_documenting_a_nonexistent_action_is_reported(
+    violating_skills: pathlib.Path,
+):
+    action_catalog = (
+        violating_skills / ACTION_CATALOG_SKILL / REFERENCE_DIR / ACTION_CATALOG_REFERENCE
+    )
+    text = action_catalog.read_text(encoding="utf-8")
+    anchor = "| `SlackNotificationAction` | `slack` | `@public_api` |\n"
+    assert text.count(anchor) == 1, f"anchor is not unique in {action_catalog}"
+    bogus_row = "| `FakeAction` | `fake_action_type` | `@public_api` |\n"
+    action_catalog.write_text(text.replace(anchor, anchor + bogus_row, 1), encoding="utf-8")
+
+    problems = action_catalog_drift_problems(action_catalog)
+
+    assert [
+        problem
+        for problem in problems
+        if "fake_action_type" in problem and "no longer registers" in problem
+    ]
+
+
+def test_action_type_filter_is_scoped_to_the_owning_module():
+    """The action-catalog completeness check must fire for Great Expectations' own
+    action registrations and must not fire for anyone else's. Proven against a
+    synthetic hierarchy -- not Great Expectations' real action registry -- because
+    subclassing the real `ValidationAction` registers the class into Great
+    Expectations' process-wide action registry as a side effect, which would leak a
+    fake action into that registry for the rest of the test session.
+    """
+
+    class Base(BaseModel):
+        type: str
+        name: str
+
+    class OwnedAction(Base):
+        type: str = "owned_action_type"
+
+    class ForeignAction(Base):
+        type: str = "foreign_action_type"
+
+    ForeignAction.__module__ = "some_third_party_package.actions"
+
+    scoped = _attachable_types_scoped_to(Base, __name__)
+
+    assert scoped == frozenset({"owned_action_type"})
+    assert "foreign_action_type" not in scoped

--- a/tests/agent_skills/test_snippets.py
+++ b/tests/agent_skills/test_snippets.py
@@ -43,6 +43,7 @@ import sqlite3
 import subprocess
 import sys
 import textwrap
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Final, Iterator
 
 import pandas as pd
@@ -55,10 +56,8 @@ from great_expectations.core import ExpectationSuite, ValidationDefinition
 from great_expectations.data_context import EphemeralDataContext, FileDataContext
 from great_expectations.datasource.fluent.interfaces import Batch
 from great_expectations.exceptions import ResourceFreshnessAggregateError
-from great_expectations.exceptions.exceptions import (
-    InvalidBatchRequestError,
-    NoAvailableBatchesError,
-)
+from great_expectations.exceptions.exceptions import NoAvailableBatchesError
+from great_expectations.warnings import GxDeprecationWarning
 
 if TYPE_CHECKING:
     from great_expectations.core import ExpectationSuite
@@ -1952,13 +1951,47 @@ def test_null_data_docs_sites_silently_no_ops_and_recovers_only_with_the_documen
     assert reloaded.config.data_docs_sites, "the recovered site is not visible from a fresh load"
 
 
+def documented_deprecation_message(document: pathlib.Path) -> str:
+    """Return the sole block quote in ``document``, unwrapped to a single line.
+
+    Read out of the shipped guidance rather than re-typed here, so a test asserting the
+    runtime's wording is asserting the *same* string the skill shows a user. Re-typing
+    it would let the two drift apart in exactly the case this test exists to catch.
+
+    Requiring exactly one block quote is what makes "the sole block quote" a safe way to
+    name it: a second one added later fails here, loudly, rather than being silently
+    concatenated onto the first into a string that matches nothing.
+    """
+    quotes: list[str] = []
+    inside = False
+    for line in document.read_text(encoding="utf-8").splitlines():
+        if line.startswith(">"):
+            if not inside:
+                quotes.append("")
+                inside = True
+            quotes[-1] = f"{quotes[-1]} {line.lstrip('>').strip()}".strip()
+        else:
+            inside = False
+    assert len(quotes) == 1, (
+        f"{canonical_relative_path(document)} carries {len(quotes)} block quotes;"
+        " this helper names the deprecation message by being the only one"
+    )
+    return quotes[0]
+
+
 @pytest.mark.sqlite
-def test_mixed_temporal_source_batch_parameters_fail_in_the_documented_directions(
+def test_one_integer_window_drives_both_a_sql_and_a_file_based_validation_definition(
     ephemeral_context: EphemeralDataContext, warehouse: SqliteDatasource, tmp_path: pathlib.Path
 ):
-    """A checkpoint spanning a SQL and a file-based monthly partitioner cannot share one
-    ``batch_parameters`` dict -- both failure directions, pinned exactly as observed,
-    and not interchangeable with each other."""
+    """A checkpoint spanning a SQL and a file-based monthly partitioner runs from one
+    ``batch_parameters`` dict of integers -- the two families take the same numeric
+    window parameters, so neither has to be split into a checkpoint of its own.
+
+    Digit strings still select the same batch, so a user's existing snippet keeps
+    working, but they emit the deprecation warning ``run-and-schedule.md`` quotes.
+    The zero-padded filename is deliberate: the file side matches ``2024-03`` as text
+    while the parameter that selects it is the unpadded integer ``3``.
+    """
     sql_batch_definition = warehouse.add_table_asset(
         name="orders", table_name="orders"
     ).add_batch_definition_monthly(name="by_month", column="ordered_at")
@@ -1988,12 +2021,34 @@ def test_mixed_temporal_source_batch_parameters_fail_in_the_documented_direction
         Checkpoint(name="mixed_source_cp", validation_definitions=[sql_vd, file_vd], actions=[])
     )
 
-    # The dangerous direction: strings satisfy the file side but the SQL side reports
-    # what reads exactly like an empty window rather than a type mismatch.
-    with pytest.raises(NoAvailableBatchesError):
-        checkpoint.run(batch_parameters={"year": "2024", "month": "03"})
+    with warnings.catch_warnings(record=True) as integer_run_warnings:
+        warnings.simplefilter("always")
+        integer_result = checkpoint.run(batch_parameters={"year": 2024, "month": 3})
 
-    # The other direction is not interchangeable with the first: integers fail loudly
-    # and immediately on the file side instead.
-    with pytest.raises(InvalidBatchRequestError):
-        checkpoint.run(batch_parameters={"year": 2024, "month": 3})
+    assert integer_result.success is True
+    # Both sides really ran: a checkpoint whose file side silently contributed nothing
+    # would still report success, so the count is what makes this an integration claim.
+    assert len(integer_result.run_results) == 2
+    assert [
+        str(each.message)
+        for each in integer_run_warnings
+        if issubclass(each.category, GxDeprecationWarning)
+    ] == [], "integer batch parameters are the documented form and must not be deprecated"
+
+    with warnings.catch_warnings(record=True) as string_run_warnings:
+        warnings.simplefilter("always")
+        string_result = checkpoint.run(batch_parameters={"year": "2024", "month": "03"})
+
+    # Strings are deprecated, not broken -- they still select the same window on both
+    # sides, which is why the guidance converts them rather than telling users to stop.
+    assert string_result.success is True
+    assert len(string_result.run_results) == 2
+    deprecations = {
+        str(each.message)
+        for each in string_run_warnings
+        if issubclass(each.category, GxDeprecationWarning)
+    }
+    assert deprecations == {documented_deprecation_message(CHECKPOINT_RUN_AND_SCHEDULE)}, (
+        "the warning digit strings actually emit is not the one"
+        f" {canonical_relative_path(CHECKPOINT_RUN_AND_SCHEDULE)} quotes to the user"
+    )

--- a/tests/agent_skills/test_snippets.py
+++ b/tests/agent_skills/test_snippets.py
@@ -40,6 +40,8 @@ import json
 import pathlib
 import re
 import sqlite3
+import subprocess
+import sys
 import textwrap
 from typing import TYPE_CHECKING, Any, Callable, Final, Iterator
 
@@ -47,8 +49,12 @@ import pandas as pd
 import pytest
 
 import great_expectations as gx
+from great_expectations.checkpoint import Checkpoint
+from great_expectations.checkpoint.actions import UpdateDataDocsAction
+from great_expectations.core import ExpectationSuite, ValidationDefinition
 from great_expectations.data_context import EphemeralDataContext, FileDataContext
 from great_expectations.datasource.fluent.interfaces import Batch
+from great_expectations.exceptions import ResourceFreshnessAggregateError
 from great_expectations.exceptions.exceptions import (
     InvalidBatchRequestError,
     NoAvailableBatchesError,
@@ -60,6 +66,7 @@ if TYPE_CHECKING:
         ExpectationSuiteValidationResult,
         ExpectationValidationResult,
     )
+    from great_expectations.data_context.store.store import DataDocsSiteConfigTypedDict
     from great_expectations.datasource.fluent.sqlite_datasource import SqliteDatasource
     from great_expectations.expectations.expectation_configuration import (
         ExpectationConfiguration,
@@ -72,6 +79,36 @@ ENTRY_DOCUMENT: Final = "SKILL.md"
 REFERENCE_DIR: Final = "references"
 CANONICAL_SKILL: Final = "gx-configure-data-source"
 SHARED_REFERENCES: Final = ("preflight.md", "write-out.md", "robustness.md")
+
+#: The checkpoint skill's own entry document and reference, used by the checkpoint-flow
+#: tests below. Not part of ``EXECUTABLE_SEQUENCE`` -- unlike the data-source and
+#: expectations skills, none of the checkpoint entry document's Python blocks carry the
+#: ``executable`` fence tag, so its snippets are located and exec'd individually, the same
+#: way the data-source skill's fetch-first snippet is exercised above.
+CHECKPOINT_SKILL: Final = "gx-configure-checkpoint"
+CHECKPOINT_ENTRY_DOCUMENT: Final = SKILLS_ROOT / CHECKPOINT_SKILL / ENTRY_DOCUMENT
+CHECKPOINT_ACTION_CATALOG: Final = (
+    SKILLS_ROOT / CHECKPOINT_SKILL / REFERENCE_DIR / "action-catalog.md"
+)
+CHECKPOINT_RUN_AND_SCHEDULE: Final = (
+    SKILLS_ROOT / CHECKPOINT_SKILL / REFERENCE_DIR / "run-and-schedule.md"
+)
+#: The checkpoint skill's own copy of the shared write-out reference -- byte-identical to
+#: the canonical copy under ``gx-configure-data-source``, asserted elsewhere. Sourced from
+#: here (rather than the canonical path) because the tests below are about the checkpoint
+#: flow specifically.
+CHECKPOINT_WRITE_OUT: Final = SKILLS_ROOT / CHECKPOINT_SKILL / REFERENCE_DIR / "write-out.md"
+
+#: The names the checkpoint entry document's bind/group snippets hardcode -- reusing them
+#: lets the real snippets run unmodified against a fixture built to match.
+VALIDATION_DEFINITION_NAME: Final = "orders_quality_check"
+CHECKPOINT_NAME: Final = "orders_checkpoint"
+
+#: The placeholder the null-sites recovery snippet in ``action-catalog.md`` carries for the
+#: project root -- distinct from ``CONFIRMED_PATH_PLACEHOLDER``, which belongs to the
+#: write-out procedure, because the two snippets are offered at different points in the
+#: flow and each documents its own placeholder text.
+PROJECT_ROOT_PLACEHOLDER: Final = "<the project root established at preflight>"
 
 FENCE: Final = "```"
 PYTHON: Final = "python"
@@ -1383,3 +1420,612 @@ def test_adding_expectations_to_an_unregistered_suite_persists_nothing(
         "an unregistered suite is now stored anyway; the register-first rule in"
         f" gx-configure-expectations/{ENTRY_DOCUMENT} would no longer be necessary"
     )
+
+
+# ---------------------------------------------------------------------------
+# The checkpoint flow: bind, group, explicit add, verify by running.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def checkpoint_ready(
+    ephemeral_context: EphemeralDataContext, warehouse: SqliteDatasource
+) -> EphemeralDataContext:
+    """A session holding exactly what the checkpoint skill's snippets assume exist.
+
+    The names here -- ``warehouse``/``orders``/``by_month``/``orders_quality`` -- are the
+    ones the checkpoint entry document's bind and group snippets hardcode, so those
+    snippets can be exec'd against this fixture unmodified.
+    """
+    asset = warehouse.add_table_asset(name="orders", table_name="orders")
+    asset.add_batch_definition_monthly(name="by_month", column="ordered_at")
+    suite = ephemeral_context.suites.add(gx.ExpectationSuite(name="orders_quality"))
+    suite.add_expectation(gx.expectations.ExpectColumnValuesToNotBeNull(column="customer"))
+    suite.add_expectation(
+        gx.expectations.ExpectColumnValuesToBeBetween(column="amount", min_value=0, max_value=100)
+    )
+    return ephemeral_context
+
+
+@pytest.mark.sqlite
+def test_the_checkpoint_flow_binds_groups_explicitly_adds_and_verifies_by_running(
+    checkpoint_ready: EphemeralDataContext, capsys: pytest.CaptureFixture[str]
+):
+    """Bind, group, explicit add, run -- the shipped snippets, exec'd in sequence.
+
+    Each step is the real block from the entry document, not a paraphrase: the bind
+    snippet, the group-and-add snippet, and the reporting loop that pairs outcomes to the
+    validation definition and expectation they came from.
+    """
+    context = checkpoint_ready
+
+    bind_snippet = sole_block_containing(
+        CHECKPOINT_ENTRY_DOCUMENT,
+        "existing = {vd.name for vd in context.validation_definitions.all()}",
+    )
+    bind_namespace: dict[str, Any] = {"context": context}
+    exec(compile(bind_snippet.source, bind_snippet.identifier, "exec"), bind_namespace)
+    validation_definition = bind_namespace["validation_definition"]
+    assert validation_definition.name == VALIDATION_DEFINITION_NAME
+
+    group_snippet = sole_block_containing(
+        CHECKPOINT_ENTRY_DOCUMENT,
+        'CHECKPOINT_NAME = "orders_checkpoint"\n\nexisting_checkpoints',
+    )
+    group_namespace: dict[str, Any] = {
+        "context": context,
+        "validation_definition": validation_definition,
+    }
+    exec(compile(group_snippet.source, group_snippet.identifier, "exec"), group_namespace)
+    checkpoint = group_namespace["checkpoint"]
+    assert checkpoint.name == CHECKPOINT_NAME
+
+    # The explicit add in the group step, not the run below, is what persists the
+    # checkpoint -- provable only by checking before the run call executes at all.
+    assert context.checkpoints.get(CHECKPOINT_NAME).name == CHECKPOINT_NAME, (
+        "the checkpoint is not fetchable from the session before it has ever been run;"
+        f" the explicit-add step in {CHECKPOINT_SKILL}/{ENTRY_DOCUMENT} is what persists it"
+    )
+
+    result = checkpoint.run(batch_parameters={"year": 2024, "month": 3})
+    assert len(result.run_results) == 1, "one validation definition should produce one result"
+
+    report_snippet = sole_block_containing(
+        CHECKPOINT_ENTRY_DOCUMENT, "validation definition: batch="
+    )
+    report_namespace: dict[str, Any] = {"result": result}
+    exec(compile(report_snippet.source, report_snippet.identifier, "exec"), report_namespace)
+    printed = capsys.readouterr().out
+
+    (validation_result,) = result.run_results.values()
+    by_type = {configuration_of(each).type: each for each in validation_result.results}
+    assert set(by_type) == {
+        "expect_column_values_to_not_be_null",
+        "expect_column_values_to_be_between",
+    }
+    assert by_type["expect_column_values_to_not_be_null"].success is False
+    assert by_type["expect_column_values_to_be_between"].success is False
+
+    # Printed by the exec'd reporting loop, paired to the expectation it belongs to --
+    # by config, per the same rule the expectations skill's own results carry, never by
+    # position in a list.
+    assert "validation definition: batch=" in printed
+    assert "expect_column_values_to_not_be_null" in printed
+    assert "expect_column_values_to_be_between" in printed
+
+
+@pytest.mark.sqlite
+def test_the_checkpoint_flow_updates_rather_than_duplicates_on_a_repeat_pass(
+    checkpoint_ready: EphemeralDataContext,
+):
+    """A second pass over the bind-and-group snippets fetches, and does not duplicate.
+
+    A validation definition or checkpoint the user describes that already exists under
+    that name is updated in place, never duplicated under a second copy.
+    """
+    context = checkpoint_ready
+    bind_snippet = sole_block_containing(
+        CHECKPOINT_ENTRY_DOCUMENT,
+        "existing = {vd.name for vd in context.validation_definitions.all()}",
+    )
+    group_snippet = sole_block_containing(
+        CHECKPOINT_ENTRY_DOCUMENT,
+        'CHECKPOINT_NAME = "orders_checkpoint"\n\nexisting_checkpoints',
+    )
+
+    for _pass in range(2):
+        bind_namespace: dict[str, Any] = {"context": context}
+        exec(compile(bind_snippet.source, bind_snippet.identifier, "exec"), bind_namespace)
+        group_namespace: dict[str, Any] = {
+            "context": context,
+            "validation_definition": bind_namespace["validation_definition"],
+        }
+        exec(compile(group_snippet.source, group_snippet.identifier, "exec"), group_namespace)
+
+    assert [vd.name for vd in context.validation_definitions.all()] == [VALIDATION_DEFINITION_NAME]
+    assert [c.name for c in context.checkpoints.all()] == [CHECKPOINT_NAME]
+
+
+#: The literal name the write-out reference's own checkpoint-extension block writes
+#: under -- an illustrative example name baked into the shipped text itself, not filled
+#: in by any substitution the runner performs (unlike ``CONFIRMED_PATH_PLACEHOLDER``), so
+#: the round-trip test below looks the written checkpoint up by this exact string.
+WRITE_OUT_CHECKPOINT_NAME: Final = "my_checkpoint"
+
+
+def _exec_write_out_procedure(
+    project_root: pathlib.Path, suite: ExpectationSuite, checkpoint: Checkpoint
+) -> gx.data_context.FileDataContext:
+    """Run the shipped write-out procedure exactly as written, in one namespace.
+
+    The six-step block is not self-contained -- per its own prose, it replaces ``steps``
+    with the complete six-entry list and reuses ``_add_datasource``, ``_add_asset``,
+    ``_add_batch_definition``, and ``_add_suite`` from the four-step block rather than
+    redefining them. So the four-step block has to run first, in the same namespace, for
+    the six-step block's reuse of those names to resolve at all.
+    """
+    four_step_block = sole_block_containing(CHECKPOINT_WRITE_OUT, "def _add_datasource():")
+    six_step_block = sole_block_containing(
+        CHECKPOINT_WRITE_OUT, "def _add_validation_definition():"
+    )
+
+    namespace: dict[str, Any] = {"gx": gx, "suite": suite}
+    source = four_step_block.source.replace(CONFIRMED_PATH_PLACEHOLDER, str(project_root))
+    exec(compile(source, four_step_block.identifier, "exec"), namespace)
+    assert namespace["failed"] == [], f"the four-step write-out block failed: {namespace['failed']}"
+
+    namespace["ValidationDefinition"] = ValidationDefinition
+    namespace["Checkpoint"] = Checkpoint
+    namespace["checkpoint"] = checkpoint
+    exec(compile(six_step_block.source, six_step_block.identifier, "exec"), namespace)
+    assert namespace["failed"] == [], f"the six-step write-out block failed: {namespace['failed']}"
+
+    return namespace["file_context"]
+
+
+@pytest.mark.sqlite
+def test_a_fresh_context_reruns_the_persisted_written_out_checkpoint_unmodified(
+    checkpoint_ready: EphemeralDataContext, tmp_path: pathlib.Path
+):
+    """A checkpoint built and run in an ephemeral session, written out through the real,
+    shipped write-out procedure -- not test-owned glue standing in for it -- and re-run
+    from a fresh file-backed context, produces the same outcome -- including firing its
+    Data Docs update action again -- so the write-out promise reaches checkpoints, not
+    just the objects they group. Exercising the actual document text is what pins the
+    fix to the six-step block's suite lookup (``suites.get(suite.name)``, not the literal
+    placeholder it used to be); test-owned glue reproducing the intended *pattern* would
+    keep passing even if the shipped text regressed.
+
+    The written-out checkpoint validates a dataframe asset -- the write-out block's own
+    illustrative example -- rather than the original session's SQL-backed one; the two
+    are compared by the *type* of outcome each expectation produces, which only requires
+    both datasets to violate the same two expectations, not to be the same data.
+    """
+    context = checkpoint_ready
+    batch_definition = (
+        context.data_sources.get("warehouse").get_asset("orders").get_batch_definition("by_month")
+    )
+    suite = context.suites.get("orders_quality")
+    validation_definition = context.validation_definitions.add(
+        ValidationDefinition(name=VALIDATION_DEFINITION_NAME, data=batch_definition, suite=suite)
+    )
+    checkpoint = context.checkpoints.add(
+        Checkpoint(
+            name=CHECKPOINT_NAME,
+            validation_definitions=[validation_definition],
+            actions=[UpdateDataDocsAction(name="update_data_docs")],
+        )
+    )
+    original = checkpoint.run(batch_parameters={"year": 2024, "month": 3})
+
+    project_root = tmp_path / "checkpoint_write_out"
+    file_context = _exec_write_out_procedure(project_root, suite, checkpoint)
+    assert file_context.checkpoints.get(WRITE_OUT_CHECKPOINT_NAME) is not None
+
+    reloaded_context = gx.get_context(mode="file", project_root_dir=str(project_root))
+    reloaded_checkpoint = reloaded_context.checkpoints.get(WRITE_OUT_CHECKPOINT_NAME)
+    rerun = reloaded_checkpoint.run(batch_parameters={"dataframe": _customers_frame()})
+
+    assert rerun.success == original.success
+    (original_result,) = original.run_results.values()
+    (rerun_result,) = rerun.run_results.values()
+    original_by_type = {
+        configuration_of(each).type: each.success for each in original_result.results
+    }
+    rerun_by_type = {configuration_of(each).type: each.success for each in rerun_result.results}
+    assert (
+        rerun_by_type
+        == original_by_type
+        == {
+            "expect_column_values_to_not_be_null": False,
+            "expect_column_values_to_be_between": False,
+        }
+    )
+
+    data_docs_index = (
+        pathlib.Path(reloaded_context.root_directory)
+        / "uncommitted"
+        / "data_docs"
+        / "local_site"
+        / "index.html"
+    )
+    assert data_docs_index.is_file(), (
+        "the rebuilt checkpoint's UpdateDataDocsAction did not produce Data Docs output on"
+        " a fresh-context re-run"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The run snippet, executed as a subprocess -- exit codes, not just source.
+# ---------------------------------------------------------------------------
+
+
+def _build_file_backed_checkpoint_project(
+    project_root: pathlib.Path, warehouse_path: pathlib.Path, suite_name: str, expectation
+) -> None:
+    """A minimal file-backed project holding one named, persisted, runnable checkpoint."""
+    context = gx.get_context(mode="file", project_root_dir=str(project_root))
+    datasource = context.data_sources.add_or_update_sqlite(
+        name="warehouse", connection_string=f"sqlite:///{warehouse_path}"
+    )
+    batch_definition = datasource.add_table_asset(
+        name="orders", table_name="orders"
+    ).add_batch_definition_monthly(name="by_month", column="ordered_at")
+    suite = context.suites.add(gx.ExpectationSuite(name=suite_name))
+    suite.add_expectation(expectation)
+    validation_definition = context.validation_definitions.add(
+        ValidationDefinition(name=f"{suite_name}_check", data=batch_definition, suite=suite)
+    )
+    context.checkpoints.add(
+        Checkpoint(
+            name=f"{suite_name}_checkpoint",
+            validation_definitions=[validation_definition],
+            actions=[],
+        )
+    )
+
+
+@pytest.mark.sqlite
+def test_the_run_snippet_exits_zero_for_a_passing_checkpoint_and_one_for_a_failing_one(
+    warehouse_path: pathlib.Path, tmp_path: pathlib.Path
+):
+    """The run-snippet's exit code is derived from ``result.success``, read directly.
+
+    Both a passing and a failing checkpoint are built into the same project, and the
+    shipped snippet -- filled in with each checkpoint's name -- is run as a real
+    subprocess from a working directory that is not the project's own, exactly as
+    ``run-and-schedule.md`` says it was verified.
+    """
+    project_root = tmp_path / "project"
+    _build_file_backed_checkpoint_project(
+        project_root,
+        warehouse_path,
+        "passing_suite",
+        gx.expectations.ExpectColumnToExist(column="customer"),
+    )
+    _build_file_backed_checkpoint_project(
+        project_root,
+        warehouse_path,
+        "failing_suite",
+        gx.expectations.ExpectColumnValuesToNotBeNull(column="customer"),
+    )
+
+    snippet = sole_block_containing(
+        CHECKPOINT_RUN_AND_SCHEDULE, "sys.exit(0 if result.success else 1)"
+    )
+
+    unrelated_cwd = tmp_path / "not_the_project"
+    unrelated_cwd.mkdir()
+    expected_exit = {"passing_suite": 0, "failing_suite": 1}
+    for suite_name, exit_code in expected_exit.items():
+        source = (
+            snippet.source.replace(
+                'project_root_dir="<absolute path to the project>"',
+                f"project_root_dir={str(project_root)!r}",
+            )
+            .replace(
+                'checkpoints.get("<checkpoint name>")',
+                f'checkpoints.get("{suite_name}_checkpoint")',
+            )
+            .replace(
+                "checkpoint.run()", 'checkpoint.run(batch_parameters={"year": 2024, "month": 3})'
+            )
+        )
+        script = unrelated_cwd / f"run_{suite_name}.py"
+        script.write_text(source, encoding="utf-8")
+
+        completed = subprocess.run(
+            [sys.executable, str(script)],
+            check=False,
+            cwd=unrelated_cwd,
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == exit_code, (
+            f"{suite_name}: expected exit {exit_code}, got {completed.returncode}."
+            f" stdout={completed.stdout!r} stderr={completed.stderr[-1000:]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Trap regressions: the destructive cascade, the unpersisted suite, ephemeral Data
+# Docs, the null-sites no-op and its recovery, and the mixed temporal-source failure.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.sqlite
+def test_building_a_validation_definition_against_an_unpersisted_suite_raises(
+    checkpoint_ready: EphemeralDataContext,
+):
+    """The persist-before-reference rule step 3 states: fetch, never close over a guess."""
+    context = checkpoint_ready
+    batch_definition = (
+        context.data_sources.get("warehouse").get_asset("orders").get_batch_definition("by_month")
+    )
+    unsaved_suite = gx.ExpectationSuite(name="not_saved_yet")
+
+    with pytest.raises(ResourceFreshnessAggregateError):
+        context.validation_definitions.add(
+            ValidationDefinition(name="x", data=batch_definition, suite=unsaved_suite)
+        )
+
+    # Positive inversion: the identical call against a suite that *was* persisted first
+    # succeeds, so the failure above is about persistence, not about the call shape.
+    saved_suite = context.suites.add(gx.ExpectationSuite(name="was_saved"))
+    persisted = context.validation_definitions.add(
+        ValidationDefinition(name="y", data=batch_definition, suite=saved_suite)
+    )
+    assert persisted.name == "y"
+
+
+@pytest.mark.sqlite
+def test_add_or_update_on_a_checkpoint_cascades_exactly_as_documented(
+    checkpoint_ready: EphemeralDataContext,
+):
+    """The three-row cascade table in ``SKILL.md``, each row isolated and proven --
+    including both directions of the conditionally-lost row's "only when" clause.
+
+    Always lost: the checkpoint's own validation-definition membership and actions.
+    Conditionally lost: a bound suite's contents, only when a fresh suite object under
+    an existing name is what gets passed in -- proven destructive below, and proven safe
+    when the suite is fetched from the context first, which is the whole reason the
+    fetch-first rule in ``SKILL.md`` is given as safe advice. Never lost: validation
+    definitions already in the store.
+    """
+    context = checkpoint_ready
+    batch_definition = (
+        context.data_sources.get("warehouse").get_asset("orders").get_batch_definition("by_month")
+    )
+    kept_suite = context.suites.add(gx.ExpectationSuite(name="kept_suite"))
+    kept_suite.add_expectation(gx.expectations.ExpectColumnToExist(column="customer"))
+    kept_vd = context.validation_definitions.add(
+        ValidationDefinition(name="kept_vd", data=batch_definition, suite=kept_suite)
+    )
+    bound_suite = context.suites.get("orders_quality")
+    bound_vd = context.validation_definitions.add(
+        ValidationDefinition(name="bound_vd", data=batch_definition, suite=bound_suite)
+    )
+    checkpoint = context.checkpoints.add(
+        Checkpoint(
+            name="cascaded",
+            validation_definitions=[kept_vd, bound_vd],
+            actions=[UpdateDataDocsAction(name="update_data_docs")],
+        )
+    )
+    assert [vd.name for vd in checkpoint.validation_definitions] == ["kept_vd", "bound_vd"]
+    assert checkpoint.actions != []
+
+    # Negative control for the "only when" clause, run before the destructive case below
+    # empties "orders_quality" -- otherwise this assertion would hold vacuously, on a
+    # suite that was already empty for an unrelated reason. A *second* stored checkpoint
+    # is upserted here, binding the suite fetched from the context (not a fresh object)
+    # under its existing name; `kept_suite` cannot stand in for this because it was never
+    # in the upserted checkpoint at all, so it only shows unrelated suites survive.
+    context.checkpoints.add(
+        Checkpoint(
+            name="cascaded_fetch_first",
+            validation_definitions=[bound_vd],
+            actions=[UpdateDataDocsAction(name="update_data_docs")],
+        )
+    )
+    fetched_suite_same_name = context.suites.get("orders_quality")
+    fetched_vd_same_name = ValidationDefinition(
+        name="fetched_vd", data=batch_definition, suite=fetched_suite_same_name
+    )
+    context.checkpoints.add_or_update(
+        Checkpoint(
+            name="cascaded_fetch_first",
+            validation_definitions=[fetched_vd_same_name],
+            actions=[],
+        )
+    )
+    assert len(context.suites.get("orders_quality").expectations) == 2, (
+        "upserting with the suite fetched from the context first no longer leaves it"
+        f" untouched; the 'only when' clause in {CHECKPOINT_SKILL}/{ENTRY_DOCUMENT} is"
+        " wrong -- fetch-first is no longer safe advice"
+    )
+    fetch_first_checkpoint = context.checkpoints.get("cascaded_fetch_first")
+    assert [vd.name for vd in fetch_first_checkpoint.validation_definitions] == ["fetched_vd"], (
+        "the fetch-first upsert did not even reach the checkpoint it targeted"
+    )
+
+    fresh_suite_same_name = gx.ExpectationSuite(name="orders_quality")  # no expectations
+    fresh_vd_same_name = ValidationDefinition(
+        name="fresh_vd", data=batch_definition, suite=fresh_suite_same_name
+    )
+    context.checkpoints.add_or_update(
+        Checkpoint(name="cascaded", validation_definitions=[fresh_vd_same_name], actions=[])
+    )
+
+    reloaded_checkpoint = context.checkpoints.get("cascaded")
+    # Always lost.
+    assert [vd.name for vd in reloaded_checkpoint.validation_definitions] == ["fresh_vd"], (
+        "the checkpoint's validation-definition membership survived add_or_update; the"
+        f" cascade table in {CHECKPOINT_SKILL}/{ENTRY_DOCUMENT} says it does not"
+    )
+    assert reloaded_checkpoint.actions == [], (
+        "the checkpoint's actions survived add_or_update; the cascade table in"
+        f" {CHECKPOINT_SKILL}/{ENTRY_DOCUMENT} says they do not"
+    )
+    # Conditionally lost: the fresh suite object wiped the bound suite's contents.
+    assert context.suites.get("orders_quality").expectations == [], (
+        "a fresh suite object passed under an existing name no longer empties it; the"
+        f" cascade table in {CHECKPOINT_SKILL}/{ENTRY_DOCUMENT} says it does"
+    )
+    # Never lost: kept_suite (untouched by the cascade) still carries its expectation,
+    # and both validation definitions -- including the one dropped from membership --
+    # remain independently fetchable from the store.
+    assert len(context.suites.get("kept_suite").expectations) == 1
+    assert context.validation_definitions.get("kept_vd").name == "kept_vd"
+    still_there = context.validation_definitions.get("bound_vd")
+    assert still_there.name == "bound_vd"
+    assert still_there.suite.name == "orders_quality"
+
+
+@pytest.mark.sqlite
+def test_an_ephemeral_run_still_updates_data_docs_at_a_local_file_path(
+    checkpoint_ready: EphemeralDataContext,
+):
+    """An in-memory session's Data Docs action is not a no-op -- it just writes to a
+    directory that dies with the process, which is why the flow announces it as
+    throwaway rather than durable."""
+    context = checkpoint_ready
+    batch_definition = (
+        context.data_sources.get("warehouse").get_asset("orders").get_batch_definition("by_month")
+    )
+    suite = context.suites.get("orders_quality")
+    validation_definition = context.validation_definitions.add(
+        ValidationDefinition(name="ephemeral_docs_vd", data=batch_definition, suite=suite)
+    )
+    checkpoint = context.checkpoints.add(
+        Checkpoint(
+            name="ephemeral_docs_cp",
+            validation_definitions=[validation_definition],
+            actions=[UpdateDataDocsAction(name="update_data_docs")],
+        )
+    )
+
+    sites = context.config.data_docs_sites
+    assert sites is not None and "local_site" in sites, (
+        "an ephemeral session no longer carries a working default Data Docs site; the"
+        f" 'attach it; it works' claim in {CHECKPOINT_SKILL}/references/action-catalog.md"
+        " rests on it doing so"
+    )
+    site_directory = pathlib.Path(sites["local_site"]["store_backend"]["base_directory"])
+    assert site_directory.is_absolute(), "the ephemeral site's directory is not a local path"
+
+    checkpoint.run(batch_parameters={"year": 2024, "month": 3})
+
+    written_pages = list(site_directory.rglob("*.html"))
+    assert written_pages, (
+        "no HTML landed under the ephemeral session's Data Docs directory after a run"
+        " carrying an UpdateDataDocsAction"
+    )
+    assert any(page.name == "index.html" for page in written_pages)
+
+
+@pytest.mark.sqlite
+def test_null_data_docs_sites_silently_no_ops_and_recovers_only_with_the_documented_steps(
+    tmp_path: pathlib.Path,
+):
+    """``data_docs_sites: null`` swallows every site-CRUD call; the recovery snippet
+    from ``action-catalog.md`` is what actually clears it, exec'd end to end."""
+    project_root = tmp_path / "null_sites_project"
+    context = gx.get_context(mode="file", project_root_dir=str(project_root))
+    yml_path = pathlib.Path(context.root_directory) / "great_expectations.yml"
+
+    import yaml
+
+    raw = yaml.safe_load(yml_path.read_text())
+    raw["data_docs_sites"] = None
+    yml_path.write_text(yaml.dump(raw, sort_keys=False))
+
+    context = gx.get_context(mode="file", project_root_dir=str(project_root))
+    assert context.config.data_docs_sites is None
+
+    site_config: DataDocsSiteConfigTypedDict = {
+        "class_name": "SiteBuilder",
+        "store_backend": {
+            "class_name": "TupleFilesystemStoreBackend",
+            "base_directory": "uncommitted/data_docs/local_site/",
+        },
+        "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
+    }
+    context.add_data_docs_site(site_name="local_site", site_config=site_config)  # no exception
+
+    still_null = yaml.safe_load(yml_path.read_text())
+    assert still_null.get("data_docs_sites") is None, (
+        "add_data_docs_site() against a null data_docs_sites entry no longer no-ops"
+        " silently; the trap documented in"
+        f" {CHECKPOINT_SKILL}/references/action-catalog.md no longer reproduces"
+    )
+
+    recovery_snippet = sole_block_containing(CHECKPOINT_ACTION_CATALOG, "data_docs_sites: null` to")
+    source = recovery_snippet.source.replace(PROJECT_ROOT_PLACEHOLDER, str(project_root))
+    assert PROJECT_ROOT_PLACEHOLDER not in source, (
+        "the recovery snippet's placeholder was not filled in"
+    )
+    namespace: dict[str, Any] = {"context": context}
+    exec(compile(source, recovery_snippet.identifier, "exec"), namespace)
+
+    recovered = yaml.safe_load(yml_path.read_text())
+    assert recovered.get("data_docs_sites") == {
+        "local_site": {
+            "class_name": "SiteBuilder",
+            "store_backend": {
+                "class_name": "TupleFilesystemStoreBackend",
+                "base_directory": "uncommitted/data_docs/local_site/",
+            },
+            "site_index_builder": {"class_name": "DefaultSiteIndexBuilder"},
+        }
+    }, "the consent-gated recovery snippet did not clear the null sites entry"
+
+    reloaded = gx.get_context(mode="file", project_root_dir=str(project_root))
+    assert reloaded.config.data_docs_sites, "the recovered site is not visible from a fresh load"
+
+
+@pytest.mark.sqlite
+def test_mixed_temporal_source_batch_parameters_fail_in_the_documented_directions(
+    ephemeral_context: EphemeralDataContext, warehouse: SqliteDatasource, tmp_path: pathlib.Path
+):
+    """A checkpoint spanning a SQL and a file-based monthly partitioner cannot share one
+    ``batch_parameters`` dict -- both failure directions, pinned exactly as observed,
+    and not interchangeable with each other."""
+    sql_batch_definition = warehouse.add_table_asset(
+        name="orders", table_name="orders"
+    ).add_batch_definition_monthly(name="by_month", column="ordered_at")
+
+    files = tmp_path / "sales"
+    files.mkdir()
+    (files / "sales_2024-03.csv").write_text("customer,amount\nalice,1.0\n", encoding="utf-8")
+    file_batch_definition = (
+        ephemeral_context.data_sources.add_or_update_pandas_filesystem(
+            name="sales_files", base_directory=files
+        )
+        .add_csv_asset(name="monthly_sales")
+        .add_batch_definition_monthly(
+            name="by_month", regex=r"sales_(?P<year>\d{4})-(?P<month>\d{2})\.csv"
+        )
+    )
+
+    suite = ephemeral_context.suites.add(gx.ExpectationSuite(name="mixed_source_suite"))
+    suite.add_expectation(gx.expectations.ExpectColumnToExist(column="customer"))
+    sql_vd = ephemeral_context.validation_definitions.add(
+        ValidationDefinition(name="sql_vd", data=sql_batch_definition, suite=suite)
+    )
+    file_vd = ephemeral_context.validation_definitions.add(
+        ValidationDefinition(name="file_vd", data=file_batch_definition, suite=suite)
+    )
+    checkpoint = ephemeral_context.checkpoints.add(
+        Checkpoint(name="mixed_source_cp", validation_definitions=[sql_vd, file_vd], actions=[])
+    )
+
+    # The dangerous direction: strings satisfy the file side but the SQL side reports
+    # what reads exactly like an empty window rather than a type mismatch.
+    with pytest.raises(NoAvailableBatchesError):
+        checkpoint.run(batch_parameters={"year": "2024", "month": "03"})
+
+    # The other direction is not interchangeable with the first: integers fail loudly
+    # and immediately on the file side instead.
+    with pytest.raises(InvalidBatchRequestError):
+        checkpoint.run(batch_parameters={"year": 2024, "month": 3})


### PR DESCRIPTION
## Summary

Extends the bundled agent-skill guidance so a session that has already connected a data source and written expectations can go one step further: binding validations into a checkpoint, adding post-run actions, and running it — with the same version-matched, testable-guidance discipline the earlier skills established.

- Adds a third bundled skill covering checkpoint orchestration: binding data assets and suites into validation definitions, grouping them into a named checkpoint with post-run actions (including the documented plain-string vs. templatable credential-field distinction), and verifying with a single run.
- Routes the expectations skill's flow onward into this new skill once results are computed, rather than treating a saved suite as a terminal state — the honest "results are not persisted" caveat still comes first, and declining the offer remains a valid end state.
- Extends the session write-out procedure through validation definitions and checkpoints, rebuilding checkpoints from freshly-persisted objects rather than carrying over stale handles, and reporting a found-not-written outcome so a user is told when an object they'd expect to create already existed.
- Fixes a write-out step that looked up its target suite by a placeholder literal instead of the session's own suite name — a silent failure that left a project missing its validation definition and checkpoint with no error raised.
- Extends the installed-artifacts guard's exact expected-skill set to cover the new skill — an exact set rather than a floor, so a wheel carrying an unexpected skill fails it too — and drops the exact skill count from its prose and one function name, so the guard's own wording doesn't go stale at the next skill the way it would have this time.
- Adds an executable test suite that runs the checkpoint guidance itself (bind, group, add, run) against a real context, asserts a fresh context re-running the persisted checkpoint behaves identically, executes the documented hand-off run snippet as a subprocess, and pins five previously-undocumented failure modes as regression tests (destructive upsert cascades, ordering failures from referencing unpersisted suites, ephemeral-run Data Docs URLs, a silent no-op under a null sites entry, and cross-family batch parameters).

## Follow-through on #12065

`develop` is merged forward into this branch, which required following #12065 through this skill's guidance rather than just resolving a text conflict.

That change made numeric batch parameters acceptable on every datasource family. It therefore removed the cross-family limitation this skill's run reference documented — that a checkpoint could not drive one time-partitioned file-based batch definition and one time-partitioned SQL batch definition from a single run — and deleted the shared test that pinned it. Left as it was, the guidance would have talked a user out of a combination that now works, and would have told an agent to split one checkpoint into two for no reason.

- The run reference now states what holds instead: one integer dict drives both families, integers are what generated snippets should emit even where the partitioning regex is written against zero-padded text, and digit strings are still accepted but emit a deprecation warning whose removal is planned for 2.0. It also records that the warning fires once per call site rather than once per run — which is what makes a string-passing scheduled job look clean after its first execution while the removal risk keeps accruing.
- The regression test that pinned both old failure directions is replaced by one that pins the behaviour that took their place: a single integer window drives both a SQL and a file-based validation definition to success, and digit strings select the same batches while emitting the warning. The warning's text is read out of the shipped reference rather than re-typed in the test, so guidance and runtime cannot drift apart silently — which is the failure the test exists to catch.
- Two cross-references in the entry document that advertised the removed limitation are updated to point at what the reference now covers.

## Why

Guidance that describes a procedure without anything executing it degrades silently — the moment the underlying API shifts, the guidance is confidently wrong rather than visibly out of date, and nothing catches it. #12065 is exactly that shift, and it is the reason the executable-guidance discipline is worth the cost: the API change landed and the paired test failed, rather than the claim quietly becoming false in shipped prose. Every new procedural claim added here ships with a test that would fail if the claim stopped being true, and the installed-artifacts guard is updated to scale to an arbitrary number of bundled skills instead of re-encoding a specific count that the next skill would immediately go stale.

## Note on CI

The installed-artifacts guard step now executes on this PR, and its result here is a real signal. That was not true when this branch was first opened: the step did not yet exist on `develop`, and under `pull_request_target` the workflow definition is read from the base branch rather than from the PR. #12061 has since merged, so the step is present on the base, and this PR is out of draft.

## Test plan
- [x] `tests/agent_skills/` — 275 passed
- [x] `invoke type-check --ci` and the stub-source pass — clean, no issues in 769 + 15 source files
- [x] `ruff check` and `ruff format --check` — clean
- [x] `invoke marker-coverage` — exit 0, read directly rather than through a pipe
- [x] Each assertion added here mutation-tested — six mutations (doc wording drift, a second block quote, integers/strings swapped in each direction, the file side dropped from the checkpoint, an absent window) each fail the test they target
- [x] Reviewed the merge-base diff against this PR's base branch for unrelated changes, secrets, and internal references
- [ ] CI: unit tests, lint, schema checks, installed-artifacts guard
