### PR TITLE
[BUGFIX] Stop silencing warnings on import

### DIFF
--- a/great_expectations/core/batch_manager.py
+++ b/great_expectations/core/batch_manager.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from great_expectations.execution_engine import ExecutionEngine
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 
 class BatchManager:

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -66,7 +66,6 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 EXPECTATION_SHORT_DESCRIPTION = (
     "Expect the Kulback-Leibler (KL) divergence (relative entropy) of the specified column "

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from great_expectations.execution_engine import ExecutionEngine
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 
 _MetricsDict: TypeAlias = Dict[MetricConfigurationID, MetricValue]

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -53,7 +53,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 MAX_METRIC_COMPUTATION_RETRIES: int = 3
 

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -69,7 +69,6 @@ from great_expectations.validator.validation_statistics import (
 )
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 
 if TYPE_CHECKING:

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,5 +1,7 @@
 import glob
 import re
+import subprocess
+import sys
 from typing import List, Pattern, Tuple
 
 import pytest
@@ -109,3 +111,29 @@ def test_deprecation_warnings_have_been_removed_after_two_minor_versions(
         raise ValueError(
             f"Found {len(unneeded_deprecation_warnings)} warnings but threshold is {UNNEEDED_DEPRECATION_WARNINGS_THRESHOLD}; please adjust accordingly"  # noqa: E501 # FIXME CoP
         )
+
+
+@pytest.mark.unit
+def test_importing_gx_does_not_silence_warnings():
+    """
+    What does this test do and why?
+
+    Importing great_expectations used to call ``logging.captureWarnings(True)`` at
+    module scope in several modules. With no logging configured (a plain script),
+    that routes every warning into the ``py.warnings`` logger, which ends up with
+    a ``NullHandler`` -- so all warnings, including the library's own deprecations,
+    are silently dropped. Run in a fresh interpreter so a plain ``UserWarning``
+    must still reach stderr after ``import great_expectations``.
+    """
+    code = (
+        "import great_expectations  # noqa: F401\n"
+        "import warnings\n"
+        "warnings.warn('GE_WARNINGS_VISIBLE', UserWarning)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "GE_WARNINGS_VISIBLE" in result.stderr


### PR DESCRIPTION
Fixes #12067.

## What

Importing `great_expectations` called `logging.captureWarnings(True)` at module scope in five modules (`core/batch_manager.py`, `expectations/core/expect_column_kl_divergence_to_be_less_than.py`, `validator/metrics_calculator.py`, `validator/validation_graph.py`, `validator/validator.py`). With no logging configured — the default for a plain script — Python routes every warning into the `py.warnings` logger, which receives a `NullHandler`, so **all** warnings disappear from stderr:

```python
import great_expectations as gx  # noqa
import warnings
warnings.warn("control message", UserWarning)  # 0 bytes on stderr
```

That hides the library's own deprecation warnings from exactly the users a deprecation window exists for.

## How

Remove the five module-level `logging.captureWarnings(True)` side effects so warnings reach stderr via the standard mechanism again. Nothing else changes — `warnings.warn(...)` call sites are untouched, and the modules' own `logger = logging.getLogger(__name__)` lines remain.

## Tests

- New subprocess regression test (`tests/test_deprecation.py::test_importing_gx_does_not_silence_warnings`) runs in a fresh interpreter and asserts a plain `UserWarning` reaches stderr after `import great_expectations`. It fails on `main` and passes with this change.
- `tests/validator` + `tests/core` unit suites: 389 passed; the 21 failures (aws_ssm env, docstring rendering) are identical on unpatched `develop` — no regressions introduced.
- ruff check/format clean on all touched files (the 5 pre-existing `@typing.override` findings in `validator.py` are unchanged).
