### PR TITLE
[BUGFIX] Stop silencing warnings for users with no logging configured

### DIFF
--- a/great_expectations/core/batch_manager.py
+++ b/great_expectations/core/batch_manager.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from great_expectations.execution_engine import ExecutionEngine
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 
 class BatchManager:

--- a/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
+++ b/great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py
@@ -66,7 +66,6 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 EXPECTATION_SHORT_DESCRIPTION = (
     "Expect the Kulback-Leibler (KL) divergence (relative entropy) of the specified column "

--- a/great_expectations/validator/metrics_calculator.py
+++ b/great_expectations/validator/metrics_calculator.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from great_expectations.execution_engine import ExecutionEngine
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 
 _MetricsDict: TypeAlias = Dict[MetricConfigurationID, MetricValue]

--- a/great_expectations/validator/validation_graph.py
+++ b/great_expectations/validator/validation_graph.py
@@ -53,7 +53,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 MAX_METRIC_COMPUTATION_RETRIES: int = 3
 

--- a/great_expectations/validator/validator.py
+++ b/great_expectations/validator/validator.py
@@ -69,7 +69,6 @@ from great_expectations.validator.validation_statistics import (
 )
 
 logger = logging.getLogger(__name__)
-logging.captureWarnings(True)
 
 
 if TYPE_CHECKING:

--- a/tests/test_warnings_not_silenced.py
+++ b/tests/test_warnings_not_silenced.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+
+import pytest
+
+# module level markers
+pytestmark = pytest.mark.unit
+
+
+def test_importing_great_expectations_does_not_silence_warnings():
+    """`import great_expectations` must not globally silence `warnings.warn(...)`
+    for users who have not configured logging themselves.
+
+    Several modules used to call `logging.captureWarnings(True)` at import time.
+    That call is process-global: it redirects `warnings.showwarning` into the
+    `logging` module, and if no handler is configured anywhere in the `logging`
+    hierarchy (the common case for a script/notebook with no logging setup),
+    Python's own `logging.captureWarnings` machinery attaches a `NullHandler` to
+    the `py.warnings` logger, which silently swallows the warning instead of
+    printing it. See GH issue #12067.
+
+    This must be checked via a subprocess (inspecting real stderr output),
+    because `pytest.warns`/`warnings.catch_warnings` install their own
+    `showwarning` hook and would mask the regression.
+    """
+    result = subprocess.run(  # trusted, fixed argv, no shell
+        [
+            sys.executable,
+            "-c",
+            "import great_expectations; import warnings; "
+            "warnings.warn('test warning from ge', UserWarning)",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stderr, (
+        "Expected the UserWarning to be printed to stderr, but stderr was empty. "
+        "This means importing great_expectations silenced warnings for users "
+        "with no logging configured."
+    )
+    assert "test warning from ge" in result.stderr


### PR DESCRIPTION
## Root cause

Five modules call `logging.captureWarnings(True)` unconditionally at **import time** (module top-level):

- `great_expectations/validator/validator.py`
- `great_expectations/validator/validation_graph.py`
- `great_expectations/validator/metrics_calculator.py`
- `great_expectations/core/batch_manager.py`
- `great_expectations/expectations/core/expect_column_kl_divergence_to_be_less_than.py`

`logging.captureWarnings(True)` is process-global — it monkeypatches `warnings.showwarning` for the entire interpreter. Because `import great_expectations` transitively imports all five modules, simply importing the library flips this behavior for the whole process, including code that never touches `great_expectations`.

The silencing itself comes from a well-known CPython `logging` gotcha, not anything `great_expectations` codes explicitly. CPython's replacement `showwarning` does roughly:

```python
logger = getLogger("py.warnings")
if not logger.handlers:
    logger.addHandler(NullHandler())
logger.warning("%s", s)
```

So the first warning emitted after `captureWarnings(True)` causes Python to attach a `NullHandler` to the `py.warnings` logger if nothing else is configured. That satisfies `Logger.callHandlers`'s "was a handler found anywhere in the chain?" check, so the record is silently consumed and `logging.lastResort` (which would otherwise print unhandled WARNING+ records to stderr) never fires. Users who already configure logging themselves aren't affected, since their own handler intercepts the record — only users with zero logging configuration lose their warnings.

## Fix

Removed the five module-level `logging.captureWarnings(True)` calls. The `logger = logging.getLogger(__name__)` lines directly above each were left intact since they're independently used elsewhere in those modules. No replacement logic is needed — removing the calls restores Python's default `warnings` display behavior. Applications that want warnings routed through `logging` can still opt in themselves by calling `logging.captureWarnings(True)`.

## Testing

Added `tests/test_warnings_not_silenced.py`, which spawns a subprocess running `import great_expectations; warnings.warn(...)` and asserts the warning appears on stderr. A subprocess is required (rather than `pytest.warns`/`catch_warnings`) because pytest's own warning-capture fixtures install their own `showwarning` hook and would mask the regression — this mirrors the reproduction steps from the issue.

- Confirmed the test **fails** on `develop` (stderr is empty) and **passes** after the fix (stderr contains the warning).
- Ran the touched-area test slice with no regressions: `tests/validator/test_validation_graph.py`, `tests/validator/test_metrics_calculator.py`, `tests/validator/test_validator.py`, `tests/validator/test_v1_validator.py`, and the KL-divergence expectation integration tests (`tests/integration/data_sources_and_expectations/expectations/test_expect_column_kl_divergence_to_be_less_than.py`, pandas backend) — all passing.
- `ruff check` clean on all changed files.

Fixes #12067