### PR TITLE
[DOCS] Teach users to install, use, and remove the agent skills bundled with GX

### DIFF
--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
@@ -27,7 +27,7 @@ python -m great_expectations skills install
 The command reports what it did at each destination:
 
 ```shell title="Terminal output"
-Great Expectations 1.20.0+35.g5b4e2e966 skills in /path/to/my_project
+Great Expectations 1.21.0 skills in /path/to/my_project
 
 Installed (6)
   .agents/skills/gx-configure-checkpoint
@@ -128,20 +128,20 @@ python -m great_expectations skills list
 ```
 
 ```shell title="Terminal output"
-Great Expectations 1.20.0+35.g5b4e2e966 bundles 3 agent skills.
+Great Expectations 1.21.0 bundles 3 agent skills.
 Installed state in /path/to/my_project:
 
 gx-configure-checkpoint
-  .agents/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
-  .claude/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+  .agents/skills  installed by 1.21.0 (copy)
+  .claude/skills  installed by 1.21.0 (copy)
 
 gx-configure-data-source
-  .agents/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
-  .claude/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+  .agents/skills  installed by 1.21.0 (copy)
+  .claude/skills  installed by 1.21.0 (copy)
 
 gx-configure-expectations
-  .agents/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
-  .claude/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+  .agents/skills  installed by 1.21.0 (copy)
+  .claude/skills  installed by 1.21.0 (copy)
 ```
 
 The command only reports state; it never changes it, and it exits successfully even when skills are missing or out of date.

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
@@ -69,7 +69,7 @@ To link to the skills inside the installed package instead of copying them — s
 
 ### What the install command will and will not overwrite
 
-- **Re-running the install command is always safe.** A skill that is already installed at the version you are running is left byte-for-byte alone and is reported under `Already up to date`.
+- **Re-running the install command is always safe.** A skill that is already installed at the version you are running, in the same form — copied, or linked with `--symlink` — is left byte-for-byte alone and is reported under `Already up to date`. Re-running with the other choice of `--symlink` converts it, and reports it under `Updated`.
 - **A directory that GX did not install is never overwritten.** It is reported under `Failed`, left untouched, and the remaining skills still install. `--force` does not change this: if you want GX to install its skill at that path, move or delete the directory yourself first.
 - **A GX-installed copy that you have edited since is left untouched too, so no edits are lost.** It is reported under `Failed` with an explanation. Re-run the install with `--force` to replace it with the bundled skill — this discards your edits, so save a copy elsewhere first if you want to keep them.
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
@@ -129,3 +129,41 @@ Run 'python -m great_expectations skills install' to bring them up to date.
 ```
 
 `skills list` reads each destination's record of what was installed, not the files themselves, so a GX-installed skill that you have edited locally is reported exactly like an untouched one. The install command is what detects local edits.
+
+## What the skills do
+
+The three skills are three segments of one path: get GX reading your data, describe what you expect of that data, then bundle those checks into something you can run again without an agent involved. Each one ends where the next begins, and each one checks that its own starting point exists before it does anything — so you can work straight through, or come back weeks later and pick up where the last one left off.
+
+You do not run a command to start a skill. Describe what you want — "connect GX to my orders table", "check that no amount is ever negative", "make these checks re-runnable" — and your coding agent selects the matching skill from the ones installed in your project. Agents discover installed skills on their own.
+
+**The skills hand work back to you rather than take it.** Anything that reaches past the work you asked for and touches your machine starts from you: a missing database driver is reported by name along with the command to install it, rather than installed; a project directory is created only after you have agreed to write the session out and named where; a change to your project's configuration that goes beyond what you asked for — repairing a disabled Data Docs site, for instance — is explained first and made only after you say yes; and a file you did not ask for and locate is offered in the conversation instead of written to your disk.
+
+### Connect to your data: `gx-configure-data-source`
+
+This skill takes you from "here is my data" to a verified Batch Definition — a named, saved way of pulling a specific slice of your data, proven to work because the skill read through it. It builds three objects in order: a Data Source holding the connection (a directory, a connection string, or an in-memory handle), a Data Asset naming the collection of data within it (a table, a query, a family of files, a dataframe), and a Batch Definition selecting how much of that Asset a single operation reads — the whole thing, or one time window of it. Credentials go into the configuration as `${VARIABLE_NAME}` references, never as literal values.
+
+**What it needs before it starts:** nothing but your data and a way to reach it. This is the first skill in the path. It works against either a GX project on disk or an in-memory session, and it tells you which one it is working on before it configures anything.
+
+**What it leaves behind:** the Data Source, Data Asset, and Batch Definition, as ordinary GX project artifacts built through the public Python API. Before reporting, the skill retrieves a batch and reads rows through it, because retrieving a batch on its own proves nothing — then tells you what it created, what it reused, and what the read returned. It stops there: it does not invent "smoke test" Expectations to demonstrate that the setup works. If the session is in memory, it offers to write the work out to a real project.
+
+When you want to assert something about that data, this skill hands off the Batch Definition it just verified to the next one.
+
+### Describe what you expect: `gx-configure-expectations`
+
+This skill takes you from "here is what I want to be true about my data" to a saved Expectation Suite that has been run against a real batch, with every check reported individually. Two objects are involved: an Expectation is a single check with typed parameters — one column, one assertion, one set of bounds — and an Expectation Suite is the named, persisted collection of them. The skill matches what you describe in plain language against the Expectation catalog shipped inside the installed package, and builds only what you described. It does not profile your data looking for things worth asserting, and it does not append checks you did not ask for; if something you said is too vague to pin down, it asks you which bound you meant instead of picking one from the data.
+
+**What it needs before it starts:** a working Batch Definition. If your project or session has none, the skill says so and points you at `gx-configure-data-source` rather than improvising data access some other way. If more than one exists, it names them and asks which slice of your data you meant.
+
+**What it leaves behind:** the Suite, saved in your project, with each Expectation written through as it was added, and a report of the validation run — every Expectation shown as passed, failed with the observed numbers, or unable to run with the cause named. Validation results themselves are not filed anywhere by this skill: the Suite is the durable artifact, and the report you were given is the record of that run.
+
+Turning a validated Suite into a check that survives the session is where the last skill picks up — and if you stop here instead, this skill's own job is already finished.
+
+### Make the checks re-runnable: `gx-configure-checkpoint`
+
+This skill takes you from "here is a Suite that already validated my data" to a persisted, re-runnable Checkpoint, verified by actually running it once. Two objects again: a Validation Definition binds one Batch Definition to one Expectation Suite — the specific slice of data, and the specific checks to run against it — and a Checkpoint is the named, persisted grouping of Validation Definitions plus the actions that fire after a run, executed as one operation. The skill asks what should happen after a run before assuming nothing should: a Slack or Teams message, an email, a Data Docs rebuild, or one of the less common actions.
+
+**What it needs before it starts:** at least one Expectation Suite and one working Batch Definition. If either is missing, the skill stops and names the skill that builds it.
+
+**What it leaves behind:** the Checkpoint and its Validation Definitions, saved in your project, plus the results of the one verification run, reported per Validation Definition and then per Expectation within it. You also get a small self-contained script that loads the project by an absolute path and re-runs the Checkpoint by name from outside any agent session — which is the point of the Checkpoint. Wiring that script into an actual cadence, such as a cron entry, an Airflow DAG, or a CI job, is your orchestrator's job rather than the skill's.
+
+That script is where the path ends: from there, your checks run on your schedule, with no agent in the loop.

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
@@ -67,7 +67,45 @@ python -m great_expectations skills install --project-root /path/to/my_project
 
 To link to the skills inside the installed package instead of copying them — so that they follow the package when you upgrade it — pass `--symlink`. Not every platform permits symlinks; where they cannot be created, the skill is reported as failed and installs normally without the option.
 
-### What the install command will and will not overwrite
+## What the skills do
+
+The three skills are three segments of one path: get GX reading your data, describe what you expect of that data, then bundle those checks into something you can run again without an agent involved. Each one ends where the next begins, and each one checks that its own starting point exists before it does anything — so you can work straight through, or come back weeks later and pick up where the last one left off.
+
+You do not run a command to start a skill. Describe what you want — "connect GX to my orders table", "check that no amount is ever negative", "make these checks re-runnable" — and your coding agent selects the matching skill from the ones installed in your project. Agents discover installed skills on their own.
+
+**The skills hand work back to you rather than take it.** Anything that reaches past the work you asked for and touches your machine starts from you: a missing database driver is reported by name along with the command to install it, rather than installed; a project directory is created only after you have agreed to write the session out and named where; a change to your project's configuration that goes beyond what you asked for — repairing a disabled Data Docs site, for instance — is explained first and made only after you say yes; and a file you did not ask for and locate is offered in the conversation instead of written to your disk.
+
+### Connect to your data: `gx-configure-data-source`
+
+This skill takes you from "here is my data" to a verified Batch Definition — a named, saved way of pulling a specific slice of your data, proven to work because the skill read through it. It builds three objects in order: a Data Source holding the connection (a directory, a connection string, or an in-memory handle), a Data Asset naming the collection of data within it (a table, a query, a family of files, a dataframe), and a Batch Definition selecting how much of that Asset a single operation reads — the whole thing, or one time window of it. Credentials go into the configuration as `${VARIABLE_NAME}` references, never as literal values.
+
+**What it needs before it starts:** nothing but your data and a way to reach it. This is the first skill in the path. It works against either a GX project on disk or an in-memory session, and it tells you which one it is working on before it configures anything.
+
+**What it leaves behind:** the Data Source, Data Asset, and Batch Definition, as ordinary GX project artifacts built through the public Python API. Before reporting, the skill retrieves a batch and reads rows through it, because retrieving a batch on its own proves nothing — then tells you what it created, what it reused, and what the read returned. It stops there: it does not invent "smoke test" Expectations to demonstrate that the setup works. If the session is in memory, it offers to write the work out to a real project.
+
+When you want to assert something about that data, this skill hands off the Batch Definition it just verified to the next one.
+
+### Describe what you expect: `gx-configure-expectations`
+
+This skill takes you from "here is what I want to be true about my data" to a saved Expectation Suite that has been run against a real batch, with every check reported individually. Two objects are involved: an Expectation is a single check with typed parameters — one column, one assertion, one set of bounds — and an Expectation Suite is the named, persisted collection of them. The skill matches what you describe in plain language against the Expectation catalog shipped inside the installed package, and builds only what you described. It does not profile your data looking for things worth asserting, and it does not append checks you did not ask for; if something you said is too vague to pin down, it asks you which bound you meant instead of picking one from the data.
+
+**What it needs before it starts:** a working Batch Definition. If your project or session has none, the skill says so and points you at `gx-configure-data-source` rather than improvising data access some other way. If more than one exists, it names them and asks which slice of your data you meant.
+
+**What it leaves behind:** the Suite, saved in your project, with each Expectation written through as it was added, and a report of the validation run — every Expectation shown as passed, failed with the observed numbers, or unable to run with the cause named. Validation results themselves are not filed anywhere by this skill: the Suite is the durable artifact, and the report you were given is the record of that run.
+
+Turning a validated Suite into a check that survives the session is where the last skill picks up — and if you stop here instead, this skill's own job is already finished.
+
+### Make the checks re-runnable: `gx-configure-checkpoint`
+
+This skill takes you from "here is a Suite that already validated my data" to a persisted, re-runnable Checkpoint, verified by actually running it once. Two objects again: a Validation Definition binds one Batch Definition to one Expectation Suite — the specific slice of data, and the specific checks to run against it — and a Checkpoint is the named, persisted grouping of Validation Definitions plus the actions that fire after a run, executed as one operation. The skill asks what should happen after a run before assuming nothing should: a Slack or Teams message, an email, a Data Docs rebuild, or one of the less common actions.
+
+**What it needs before it starts:** at least one Expectation Suite and one working Batch Definition. If either is missing, the skill stops and names the skill that builds it.
+
+**What it leaves behind:** the Checkpoint and its Validation Definitions, saved in your project, plus the results of the one verification run, reported per Validation Definition and then per Expectation within it. You also get a small self-contained script that loads the project by an absolute path and re-runs the Checkpoint by name from outside any agent session — which is the point of the Checkpoint. Wiring that script into an actual cadence, such as a cron entry, an Airflow DAG, or a CI job, is your orchestrator's job rather than the skill's.
+
+That script is where the path ends: from there, your checks run on your schedule, with no agent in the loop.
+
+## What the install command will and will not overwrite
 
 - **Re-running the install command is always safe.** A skill that is already installed at the version you are running, in the same form — copied, or linked with `--symlink` — is left byte-for-byte alone and is reported under `Already up to date`. Re-running with the other choice of `--symlink` converts it, and reports it under `Updated`.
 - **A directory that GX did not install is never overwritten.** It is reported under `Failed`, left untouched, and the remaining skills still install. `--force` does not change this: if you want GX to install its skill at that path, move or delete the directory yourself first.
@@ -129,44 +167,6 @@ Run 'python -m great_expectations skills install' to bring them up to date.
 ```
 
 `skills list` reads each destination's record of what was installed, not the files themselves, so a GX-installed skill that you have edited locally is reported exactly like an untouched one. The install command is what detects local edits.
-
-## What the skills do
-
-The three skills are three segments of one path: get GX reading your data, describe what you expect of that data, then bundle those checks into something you can run again without an agent involved. Each one ends where the next begins, and each one checks that its own starting point exists before it does anything — so you can work straight through, or come back weeks later and pick up where the last one left off.
-
-You do not run a command to start a skill. Describe what you want — "connect GX to my orders table", "check that no amount is ever negative", "make these checks re-runnable" — and your coding agent selects the matching skill from the ones installed in your project. Agents discover installed skills on their own.
-
-**The skills hand work back to you rather than take it.** Anything that reaches past the work you asked for and touches your machine starts from you: a missing database driver is reported by name along with the command to install it, rather than installed; a project directory is created only after you have agreed to write the session out and named where; a change to your project's configuration that goes beyond what you asked for — repairing a disabled Data Docs site, for instance — is explained first and made only after you say yes; and a file you did not ask for and locate is offered in the conversation instead of written to your disk.
-
-### Connect to your data: `gx-configure-data-source`
-
-This skill takes you from "here is my data" to a verified Batch Definition — a named, saved way of pulling a specific slice of your data, proven to work because the skill read through it. It builds three objects in order: a Data Source holding the connection (a directory, a connection string, or an in-memory handle), a Data Asset naming the collection of data within it (a table, a query, a family of files, a dataframe), and a Batch Definition selecting how much of that Asset a single operation reads — the whole thing, or one time window of it. Credentials go into the configuration as `${VARIABLE_NAME}` references, never as literal values.
-
-**What it needs before it starts:** nothing but your data and a way to reach it. This is the first skill in the path. It works against either a GX project on disk or an in-memory session, and it tells you which one it is working on before it configures anything.
-
-**What it leaves behind:** the Data Source, Data Asset, and Batch Definition, as ordinary GX project artifacts built through the public Python API. Before reporting, the skill retrieves a batch and reads rows through it, because retrieving a batch on its own proves nothing — then tells you what it created, what it reused, and what the read returned. It stops there: it does not invent "smoke test" Expectations to demonstrate that the setup works. If the session is in memory, it offers to write the work out to a real project.
-
-When you want to assert something about that data, this skill hands off the Batch Definition it just verified to the next one.
-
-### Describe what you expect: `gx-configure-expectations`
-
-This skill takes you from "here is what I want to be true about my data" to a saved Expectation Suite that has been run against a real batch, with every check reported individually. Two objects are involved: an Expectation is a single check with typed parameters — one column, one assertion, one set of bounds — and an Expectation Suite is the named, persisted collection of them. The skill matches what you describe in plain language against the Expectation catalog shipped inside the installed package, and builds only what you described. It does not profile your data looking for things worth asserting, and it does not append checks you did not ask for; if something you said is too vague to pin down, it asks you which bound you meant instead of picking one from the data.
-
-**What it needs before it starts:** a working Batch Definition. If your project or session has none, the skill says so and points you at `gx-configure-data-source` rather than improvising data access some other way. If more than one exists, it names them and asks which slice of your data you meant.
-
-**What it leaves behind:** the Suite, saved in your project, with each Expectation written through as it was added, and a report of the validation run — every Expectation shown as passed, failed with the observed numbers, or unable to run with the cause named. Validation results themselves are not filed anywhere by this skill: the Suite is the durable artifact, and the report you were given is the record of that run.
-
-Turning a validated Suite into a check that survives the session is where the last skill picks up — and if you stop here instead, this skill's own job is already finished.
-
-### Make the checks re-runnable: `gx-configure-checkpoint`
-
-This skill takes you from "here is a Suite that already validated my data" to a persisted, re-runnable Checkpoint, verified by actually running it once. Two objects again: a Validation Definition binds one Batch Definition to one Expectation Suite — the specific slice of data, and the specific checks to run against it — and a Checkpoint is the named, persisted grouping of Validation Definitions plus the actions that fire after a run, executed as one operation. The skill asks what should happen after a run before assuming nothing should: a Slack or Teams message, an email, a Data Docs rebuild, or one of the less common actions.
-
-**What it needs before it starts:** at least one Expectation Suite and one working Batch Definition. If either is missing, the skill stops and names the skill that builds it.
-
-**What it leaves behind:** the Checkpoint and its Validation Definitions, saved in your project, plus the results of the one verification run, reported per Validation Definition and then per Expectation within it. You also get a small self-contained script that loads the project by an absolute path and re-runs the Checkpoint by name from outside any agent session — which is the point of the Checkpoint. Wiring that script into an actual cadence, such as a cron entry, an Airflow DAG, or a CI job, is your orchestrator's job rather than the skill's.
-
-That script is where the path ends: from there, your checks run on your schedule, with no agent in the loop.
 
 ## Keep the skills up to date
 

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
@@ -1,0 +1,131 @@
+---
+title: Install agent skills
+description: Install the agent skills bundled with GX so that your coding agent can set up Data Sources, Expectations, and Checkpoints for you.
+---
+
+import PrereqPythonInstalled from '../_core_components/prerequisites/_python_installation.md';
+import PrereqGxInstalled from '../_core_components/prerequisites/_gx_installation.md';
+
+GX bundles a set of agent skills: packaged guidance that a coding agent reads and follows in order to operate GX through its public Python API. With the skills installed in your project, you can ask your coding agent — in your own words — to connect to your data, describe what you expect of that data, and assemble a Checkpoint you can re-run later. The agent works through the same steps a GX practitioner would, with you in the loop.
+
+The skills are plain text files that ship inside the `great_expectations` package. Installing them copies them into the directories that your coding agent already reads, so there is nothing to configure beyond the install command. The skills work with Claude Code, Codex, and Cursor.
+
+## Prerequisites
+
+- <PrereqPythonInstalled/>.
+- <PrereqGxInstalled/>, version 1.21.0 or newer. Earlier versions do not bundle the skills.
+- One of the supported coding agents: Claude Code, Codex, or Cursor.
+
+## Install the skills
+
+Run the install command from the root of the project you want the skills available in:
+
+```bash title="Terminal input"
+python -m great_expectations skills install
+```
+
+The command reports what it did at each destination:
+
+```shell title="Terminal output"
+Great Expectations 1.20.0+35.g5b4e2e966 skills in /path/to/my_project
+
+Installed (6)
+  .agents/skills/gx-configure-checkpoint
+  .agents/skills/gx-configure-data-source
+  .agents/skills/gx-configure-expectations
+  .claude/skills/gx-configure-checkpoint
+  .claude/skills/gx-configure-data-source
+  .claude/skills/gx-configure-expectations
+```
+
+Destinations are shown relative to your project root. GX installs each skill into two locations, because different agents read different ones:
+
+- `.agents/skills/` is read by Codex and Cursor.
+- `.claude/skills/` is read by Claude Code and Cursor.
+
+Installing into both is the default, so a single run serves all three supported agents.
+
+### Choose where the skills are installed
+
+Pass `--target` to narrow the destinations:
+
+| Value | Installs into | Read by |
+| --- | --- | --- |
+| `agents` | `.agents/skills/` | Codex, Cursor |
+| `claude` | `.claude/skills/` | Claude Code, Cursor |
+| `all` (default) | both of the above | Claude Code, Codex, Cursor |
+
+```bash title="Terminal input"
+python -m great_expectations skills install --target claude
+```
+
+To install into a project other than the current directory, pass `--project-root`:
+
+```bash title="Terminal input"
+python -m great_expectations skills install --project-root /path/to/my_project
+```
+
+To link to the skills inside the installed package instead of copying them — so that they follow the package when you upgrade it — pass `--symlink`. Not every platform permits symlinks; where they cannot be created, the skill is reported as failed and installs normally without the option.
+
+### What the install command will and will not overwrite
+
+- **Re-running the install command is always safe.** A skill that is already installed at the version you are running is left byte-for-byte alone and is reported under `Already up to date`.
+- **A directory that GX did not install is never overwritten.** It is reported under `Failed`, left untouched, and the remaining skills still install. `--force` does not change this: if you want GX to install its skill at that path, move or delete the directory yourself first.
+- **A GX-installed copy that you have edited since is left untouched too, so no edits are lost.** It is reported under `Failed` with an explanation. Re-run the install with `--force` to replace it with the bundled skill — this discards your edits, so save a copy elsewhere first if you want to keep them.
+
+If any destination is refused, the command still installs the others, and it exits with a nonzero status.
+
+:::note What counts as an edit
+
+A GX-installed skill directory counts as edited when anything inside it differs from what was installed — including a file put there by an editor or by your operating system, such as `.DS_Store` — because the whole directory is compared against what was written.
+
+:::
+
+## Verify the installation
+
+To see which skills this package bundles and where each one is installed, run:
+
+```bash title="Terminal input"
+python -m great_expectations skills list
+```
+
+```shell title="Terminal output"
+Great Expectations 1.20.0+35.g5b4e2e966 bundles 3 agent skills.
+Installed state in /path/to/my_project:
+
+gx-configure-checkpoint
+  .agents/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+  .claude/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+
+gx-configure-data-source
+  .agents/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+  .claude/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+
+gx-configure-expectations
+  .agents/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+  .claude/skills  installed by 1.20.0+35.g5b4e2e966 (copy)
+```
+
+The command only reports state; it never changes it, and it exits successfully even when skills are missing or out of date.
+
+Each skill is listed with one line per destination. Those lines read as follows:
+
+| State line | What it means |
+| --- | --- |
+| `not installed` | Nothing is at that destination. Run the install command. |
+| `installed by <version> (copy)` | GX installed the skill there, at that version, by copying the files in. |
+| `installed by <version> (symlink)` | The same, installed with `--symlink`, so the destination links to the skills inside the package. |
+| `installed by <version> (<mode>) -- this package is <version>` | The skill was installed by a different version of GX than the one you are running. Re-run the install command to bring it up to date. |
+| `present, but not installed by Great Expectations (no .gx-skill.json)` | Something that GX does not manage occupies that directory. GX will not overwrite it; move or delete it yourself if you want GX to install its skill there. |
+| `cannot be read: <reason>` | GX could not determine what is at that destination — usually because a directory above it, such as `.claude/skills`, cannot be read. Fix the permissions on that path and run the command again. |
+
+If a destination's record of what was installed is incomplete, its line degrades rather than failing: a missing mode drops the parentheses, and a missing version reads `installed by an unrecorded version`. GX treats an unrecorded version as differing from the version you are running, so such a destination is also reported as out of date by the notice below.
+
+When any destination is out of date, the command adds a notice after the listing:
+
+```shell title="Terminal output"
+Some skills were installed by a different version of Great Expectations.
+Run 'python -m great_expectations skills install' to bring them up to date.
+```
+
+`skills list` reads each destination's record of what was installed, not the files themselves, so a GX-installed skill that you have edited locally is reported exactly like an untouched one. The install command is what detects local edits.

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
@@ -167,3 +167,40 @@ This skill takes you from "here is a Suite that already validated my data" to a 
 **What it leaves behind:** the Checkpoint and its Validation Definitions, saved in your project, plus the results of the one verification run, reported per Validation Definition and then per Expectation within it. You also get a small self-contained script that loads the project by an absolute path and re-runs the Checkpoint by name from outside any agent session — which is the point of the Checkpoint. Wiring that script into an actual cadence, such as a cron entry, an Airflow DAG, or a CI job, is your orchestrator's job rather than the skill's.
 
 That script is where the path ends: from there, your checks run on your schedule, with no agent in the loop.
+
+## Keep the skills up to date
+
+Installing copies the skills as they shipped in the version of GX you ran the command from. Upgrading GX does not reach back into your projects, so the copies already there stay as they are until you install again. After you upgrade, re-run the install command from the project root:
+
+```bash title="Terminal input"
+python -m great_expectations skills install
+```
+
+Skills installed by an earlier version are replaced and reported under `Updated`; skills already at the version you are running are reported under `Already up to date`. Both groups can appear in the same run: the re-run brings whatever is behind up to date and leaves the rest alone.
+
+`skills list` is what tells you a project has fallen behind. A destination installed by a different version than the package you are running has `-- this package is <version>` appended to its state line, and the listing ends with a notice naming the install command.
+
+Skills installed with `--symlink` follow the package on their own, but the version recorded at each destination stays the one that installed them, so `skills list` reports them as out of date until you re-run. Pass `--symlink` again when you do: a re-run without it replaces the links with copies.
+
+An upgrade does not replace a GX-installed copy that you have edited yourself. It is refused for the same reason as on a first install — see [What the install command will and will not overwrite](#what-the-install-command-will-and-will-not-overwrite) — and every other skill in the run updates around it.
+
+## Remove the skills
+
+There is no uninstall command. Removing the skills is the manual procedure below: delete the directories the install command created. Each skill's record of what GX installed lives inside that skill's own directory, and the install command writes nothing outside these paths, so there is no other state to clean up.
+
+Run this from your project root:
+
+```bash title="Terminal input"
+rm -rf .agents/skills/gx-configure-data-source \
+  .agents/skills/gx-configure-expectations \
+  .agents/skills/gx-configure-checkpoint \
+  .claude/skills/gx-configure-data-source \
+  .claude/skills/gx-configure-expectations \
+  .claude/skills/gx-configure-checkpoint
+```
+
+If you installed with `--target agents` or `--target claude`, only the three directories under that one location exist, and those are the ones to delete. If you installed with `--symlink`, deleting these directories removes the links only — the skills inside the installed package are untouched.
+
+The `.agents/skills` and `.claude/skills` directories are left in place afterwards, as are `.agents` and `.claude` themselves, holding nothing that GX installed. Removing them is your call rather than part of this procedure: they are shared with anything else your coding agents keep there.
+
+Running `skills list` afterwards reports `not installed` at every destination.

--- a/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
+++ b/docs/docusaurus/docs/core/set_up_a_gx_environment/set_up_a_gx_environment.md
@@ -48,4 +48,12 @@ import OverviewCard from '@site/src/components/OverviewCard';
     icon="/img/expectation_icon.svg" 
   />
 
+  <LinkCard 
+    topIcon 
+    label="Install agent skills"
+    description="Install the agent skills bundled with GX for use with your coding agent."
+    to="/core/set_up_a_gx_environment/install_agent_skills" 
+    icon="/img/expectation_icon.svg" 
+  />
+
 </LinkCardGrid>

--- a/docs/docusaurus/sidebars.js
+++ b/docs/docusaurus/sidebars.js
@@ -41,6 +41,11 @@ module.exports = {
           type: 'doc',
           id: 'core/set_up_a_gx_environment/create_a_data_context',
           label: 'Create a Data Context'
+        },
+        {
+          type: 'doc',
+          id: 'core/set_up_a_gx_environment/install_agent_skills',
+          label: 'Install agent skills'
         }
       ]
     },


### PR DESCRIPTION
## What this page teaches

A user browsing the documentation today cannot learn that GX bundles agent skills, how to
get them into a project, or how to get rid of them. This adds one page to the environment
setup section that closes that gap end to end:

- **What the skills are** — plain text files that ship inside the `great_expectations`
  package, which a coding agent reads to operate GX through its public API with the human
  in the loop. Claude Code, Codex, and Cursor are the platforms named.
- **Install and verify** — `python -m great_expectations skills install`, what it writes,
  which platform reads each location, how `--target`, `--project-root`, and `--symlink`
  narrow or change that, and `python -m great_expectations skills list` for reading the
  resulting state back.
- **The overwrite contract, stated as user-facing behavior** — re-running is safe at the
  same version and the same form; a directory GX did not install is never overwritten, with
  or without `--force`; a GX-installed copy you have edited survives unless you pass
  `--force`.
- **The three skills as one path** — data source, then expectations, then checkpoint —
  each with what it does, what it needs before it starts, and what it leaves behind.
- **Upgrade and removal** — re-run the install after upgrading GX; and, because there is no
  uninstall command, the removal procedure written out as the documented six directories to
  delete, rather than left as a silence for the reader to interpret.

Two navigation touches make it reachable: one appended sidebar entry and one card on the
section landing page. Both additive; nothing existing is reordered or restructured.

The diff is documentation only. No package code, no skill content, no test, no packaging,
no snippet registration, no version label, no other documentation page.

---

## Pre-merge re-verification

**Why this list exists.** Almost everything on this page is an assertion about live command
output — flags, directory names, group headings, per-destination state lines, sample blocks
reproduced whole. Published guidance that describes behavior the release does not have is
worse than no guidance, and the only way to know the page is still true is to run it. Every
item below was executed against the implementation branch while the page was authored, and
every item is written to be re-run verbatim.

**Re-run it the way a reader will**: a clean virtualenv with the released wheel installed,
no `PYTHONPATH`, and every probe in a scratch directory — never inside a checkout, because
the install command writes into the current directory.

**Section order here follows the verification procedure, not the page.** The page puts the
three skill descriptions ahead of the overwrite contract and the `skills list` reference,
so a reader reaches what the skills do right after installing; this list keeps its
procedure order, and each section header names the page lines it covers.

### 0. Setup

```bash
pip install "great_expectations==<the release>"
python -c "import great_expectations as gx; print(gx.__file__, gx.__version__)"

export PKG=$(python -c "import great_expectations, pathlib; print(pathlib.Path(great_expectations.__file__).parent / '.agents' / 'skills')")
export REPO=/path/to/the/great_expectations/checkout   # first of the two hand-supplied values
export PAGE=$REPO/docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md

export SCRATCH=$(mktemp -d)
newproj() { d=$SCRATCH/$1; rm -rf "$d"; mkdir -p "$d"; cd "$d"; }
```

Expected: the path resolves into site-packages and the version is the release under test,
release-shaped — no `+N.g<sha>` suffix and no `.dirty`.

### 1. The version literals the cut confirms

Every version literal on the page is pre-filled with `1.21.0`, the expected release, ahead
of the cut. The cut confirms them, and edits them only if the release was renumbered.
Everything else should re-run unchanged.

1. **Page line 16 — the version floor.** It currently reads `version 1.21.0 or newer`.
   Replace the number if the release was renumbered. Pass rule: the number equals the
   release that first ships `python -m great_expectations skills install`.
2. **Eight sample-output version strings — page lines 30, 131, 135, 136, 139, 140, 143, 144.**
   These are pre-filled with the expected release number rather than captured from a
   working checkout: a source checkout derives its version from `git describe` (e.g.
   `1.20.0+35.g5b4e2e966`, plus `.dirty` when the tree is modified), which no reader of the
   released wheel will ever see. At the cut, re-capture both sample blocks from the
   released wheel in one run; if anything differs, paste the blocks whole. Do not hand-edit
   individual lines — a partial re-capture re-stales them.

### 2. Install and its default run — page lines 19–46

```bash
newproj A && python -m great_expectations skills install
```

3. Exits `0`; first line matches `Great Expectations <version> skills in <project root>`.
4. Group heading reads `Installed (6)`.
5. **Diff the whole block mechanically, not by eye**, normalizing only the version string
   and the project path. Do not substitute `"$PWD"` — on macOS the command prints the
   `/private`-prefixed real path and the substitution silently misses:

   ```bash
   norm() { sed -e 's/[0-9]*\.[0-9]*\.[0-9]*[0-9A-Za-z.+]*/<V>/g' \
                -e 's#skills in .*#skills in /path/to/my_project#' \
                -e 's#Installed state in .*#Installed state in /path/to/my_project:#'; }

   newproj DIFF && python -m great_expectations skills install | norm > live-install.txt
   sed -n '30,38p' "$PAGE" | norm > page-install.txt
   wc -l page-install.txt live-install.txt     # guard: 9 and 9, never 0 and 0
   diff page-install.txt live-install.txt
   ```

   **Check the line counts before believing the `diff`.** Two empty files diff clean, and a
   mistyped `sed` produces exactly that. Expected: identical. Destination order is
   `.agents` before `.claude`, alphabetical by skill within each.
6. The install writes nothing else: `ls -A` shows only `.agents` and `.claude`; no
   top-level marker file, no project scaffolding.

### 3. Targets and the other flags — page lines 48–68

7. `python -m great_expectations skills install --help` lists
   `--target {agents,claude,all}` with `all` documented as the default, and names the same
   three platforms against the same two directories the page does.
8. `--target agents` in a fresh project: `Installed (3)`, `ls -A` shows `.agents` only.
9. `--target claude` in a fresh project: `Installed (3)`, `ls -A` shows `.claude` only.
10. `--target all` in a fresh project: `Installed (6)`, both directories present.
11. `--project-root` writes elsewhere: run it from a directory that is deliberately not the
    project.

    ```bash
    mkdir -p $SCRATCH/elsewhere $SCRATCH/PR && cd $SCRATCH/elsewhere
    python -m great_expectations skills install --project-root $SCRATCH/PR
    ls -A .            # expected: empty
    ls -A $SCRATCH/PR  # expected: .agents and .claude
    ```
12. `--symlink` links into the installed package:

    ```bash
    newproj SYM && python -m great_expectations skills install --symlink
    ls -l .claude/skills/gx-configure-data-source
    find .agents .claude -type l | wc -l    # expected: 12
    ```

    Expected: `SKILL.md` and `references/` are links whose targets are inside the installed
    package; only `.gx-skill.json` is a real file.
13. The page's sentence about platforms that refuse symlinks is a paraphrase of the shipped
    `--symlink` help text and adds nothing to it. Confirm the help text still says it.
    **This condition is not reproducible on APFS; it is verified against the shipped help
    text only, and the page must not gain explanatory prose about it until someone
    reproduces it.**

### 4. The overwrite contract — page lines 108–120

14. **Re-run at the same version and the same form leaves files untouched** — not merely
    equal in content:

    ```bash
    newproj B && python -m great_expectations skills install
    # BSD/macOS stat; on Linux use: stat -c '%n %Y %s'
    stamp() { find .agents .claude -type f -exec stat -f '%N %m %z' {} \; | sort; }
    stamp > before.stat
    sleep 1 && python -m great_expectations skills install
    stamp | diff before.stat -
    ```

    Expected: `Already up to date (6)`, and no `stat` difference — mtimes unchanged, so the
    files were not even rewritten.
15. **The other choice of `--symlink` converts, at zero version skew.** Install with
    `--symlink`, re-run with `--symlink` (expected: `Already up to date (6)`, symlink count
    stays 12), then re-run without it (expected: `Updated (6)`, symlink count 12 → 0).
16. **A directory GX did not install is never overwritten.**

    ```bash
    newproj FOREIGN
    mkdir -p .claude/skills/gx-configure-data-source
    echo "my own notes" > .claude/skills/gx-configure-data-source/README.md
    python -m great_expectations skills install
    ```

    Expected: `Installed (5)`, `Failed (1)` naming that path with the "does not manage /
    holds no .gx-skill.json manifest" explanation, `README.md` byte-identical, exit `1`.
17. **`--force` does not change that.** Re-run the same project with `--force`. Expected:
    identical refusal, identical reason, `README.md` intact, still exit `1`.
18. **A GX-installed copy you have edited is refused too.**

    ```bash
    newproj EDIT && python -m great_expectations skills install
    printf '\nMY LOCAL NOTE\n' >> .claude/skills/gx-configure-expectations/SKILL.md
    python -m great_expectations skills install
    ```

    Expected: `Failed (1)` with the "has local edits / no longer match the .gx-skill.json
    manifest" explanation, the edit still present, exit `1`.
19. **`--force` replaces it and discards the edit.** Re-run the same project with `--force`.
    Expected: `Updated (1)`, `Already up to date (5)`, `MY LOCAL NOTE` gone, exit `0`.
20. A refused destination does not stop the others, and the run exits nonzero — visible in
    items 16, 17, 18.
21. The page's note about an editor or OS file counting as an edit is literal, not
    illustrative. Drop a real `.DS_Store` into an installed skill directory and re-run.
    Expected: `Failed (1)` with the local-edits explanation, and the command's own footer
    saying the same thing the page's note says.

### 5. The verification command — page lines 122–169

22. `python -m great_expectations skills list` after a default install: exits `0`, first
    line matches `Great Expectations <version> bundles 3 agent skills.`, second matches
    `Installed state in <project root>:`.
23. **Diff the whole listing block mechanically**, same normalization as item 5:

    ```bash
    python -m great_expectations skills list | norm > live-list.txt
    sed -n '131,144p' "$PAGE" | norm > page-list.txt
    wc -l page-list.txt live-list.txt           # guard: 14 and 14
    diff page-list.txt live-list.txt
    ```

    Expected: identical. Order is alphabetical — checkpoint, data-source, expectations —
    deliberately not the path order the surrounding prose uses, because the page reproduces
    what the command prints.
24. **It reports state and never changes it.** `skills list` in an empty project: every
    destination `not installed`, exit `0`, and `ls -A` shows it created nothing.
25. **Every per-destination state line the page documents, produced live.** Each of these
    is a separate setup:
    - `not installed` — empty project (item 24).
    - `installed by <version> (copy)` — default install.
    - `installed by <version> (symlink)` — install with `--symlink`.
    - `installed by <version> (<mode>) -- this package is <version>` — rewrite `gx_version`
      in two of the six `.gx-skill.json` manifests, then list. **The separator is a literal
      `--`, two hyphens, not an em dash.**
    - `present, but not installed by Great Expectations (no .gx-skill.json)` — the FOREIGN
      project from item 16.
    - `cannot be read: <reason>` — `chmod 000 .claude/skills`, list, then restore. **And
      the negative controls that make the page's wording load-bearing**: `chmod 000` on a
      single skill directory, and on a single `.gx-skill.json`, each produce the
      `present, but not installed` line instead. Only the parent-directory case produces
      `cannot be read:`. Restore permissions afterward.
    - A manifest with `mode` removed drops the parentheses, with no placeholder.
    - A manifest with `gx_version` removed reads `installed by an unrecorded version`, and
      is also counted as out of date by the notice below.
26. **The stale-version notice, both lines, diffed:**

    ```bash
    python -m great_expectations skills list | tail -2 > live-notice.txt
    sed -n '165,166p' "$PAGE" > page-notice.txt
    diff page-notice.txt live-notice.txt
    ```

    Expected: byte-identical, including the command quoted inside it.
27. **`list` does not detect local edits.** Over the EDIT project from item 18, with the
    edit in place: the edited destination is reported exactly like its untouched twin, exit
    `0`. The install command is what surfaces edits, and the page says so.

### 6. The three skill descriptions — page lines 70–106

28. **Confirm the shipped skill content has not moved under the page.** The authoring
    base is `5b4e2e966` — the commit this branch was cut from, which the branch derives on
    its own if you would rather not trust a pasted value:

    ```bash
    export BASE=$(git log --format=%P b902f93b6 | head -1)   # -> 5b4e2e966...
    git diff --name-only "$BASE"..<release tag> -- great_expectations/
    ```

    `<release tag>` is the release identity — the **second and last** value supplied by
    hand, the first being `REPO` in section 0, and the same fact section 0 asks for as
    `<the release>`. Every other `<...>` below describes the *shape* of an output line
    rather than something you type. This is the only value that cannot be filled in before
    the cut.

    Expected: no entries. **If any shipped `SKILL.md` or reference document moved, every
    description in this section must be re-read against the document that moved before it
    is trusted** — including the three narrative claims at page lines 72, 82, and 94,
    which are sourced to those documents rather than to a command. Expect this diff to be
    non-empty: the skill content is still being revised, so this is the section most likely
    to have drifted, and the item exists precisely so that drift is not missed.
29. The three skill names — `gx-configure-data-source`, `gx-configure-expectations`,
    `gx-configure-checkpoint` — appear live as directory names and as listing keys in every
    capture above.
30. `python -m great_expectations skills --help` lists exactly two subcommands, `install`
    and `list`. Neither starts a skill, which is what the page's "you do not run a command
    to start a skill" depends on.
31. The four hand-over clauses on the page each trace to a shipped statement in the skill
    content: a missing driver is named with its install command rather than installed; a
    project directory is created only after the user has agreed and named where; a
    configuration edit beyond what was asked for is explained first and made only on a yes;
    a file the user did not ask for and locate is offered in conversation rather than
    written. **Two of these are narrow and checkpoint-only — the configuration edit and the
    unrequested file. Widening either into a property of all three skills is a defect, not
    a simplification.**
32. The remaining per-skill claims trace to the shipped documents: credentials go in as
    `${VARIABLE_NAME}` references and never as literals; the data source skill does not
    invent smoke-test Expectations; the expectations skill matches against the shipped
    catalog and does not profile data; each of the second and third skills checks its
    precondition and, if it is missing, stops and names the skill that builds it; the
    checkpoint run snippet loads the project by absolute path and re-runs the checkpoint by
    name, with scheduling left to the user's orchestration. The four post-run actions named
    at page line 100 — a Slack or Teams message, an email, a Data Docs rebuild, and "one of
    the less common actions" — are the public-API entries in the shipped checkpoint
    reference's action table; the table carries eight attachable actions in total, which is
    why the page's list is not presented as exhaustive.

### 7. Upgrade — page lines 171–185

33. **Mixed groups in one run.** Age two of six manifests, re-run the install. Expected:
    `Updated (2)` and `Already up to date (4)` in the same run, exit `0`, and a subsequent
    `skills list` clean with no notice.
34. **Symlink installs are still reported out of date after a package upgrade.** Install
    with `--symlink`, age all six manifests, list. Expected: every destination shows
    `installed by <old> (symlink) -- this package is <new>` plus the notice, and
    `find .agents .claude -type l | wc -l` is still 12 — the links are untouched, because
    the recorded version is what `list` reads. This is exactly why the page says to pass
    `--symlink` again on the re-run.
35. **An upgrade updates around an edited copy.** Age all six manifests, edit one installed
    copy, re-run the install. Expected: `Updated (5)`, `Failed (1)`, the edit intact, and
    that destination's recorded version still the old one.

### 8. Removal — page lines 187–206

36. **There is no uninstall command.** `python -m great_expectations skills uninstall` and
    `... skills remove` both exit `2` with `invalid choice`.
37. **The record lives inside each skill's own directory.** `cat` any
    `.gx-skill.json`: `content_sha256`, `gx_version`, `managed_by`, `mode`.
38. **Run the page's removal procedure verbatim** — the six `rm -rf` paths exactly as the
    page words them — against a default install. Expected: all six exist before, none
    after.
39. **`--target`-narrowed installs leave only three directories under the one location**
    (items 8 and 9).
40. **Deleting symlink installs does not touch the package.** Digest the packaged skills
    tree either side of the same six deletions, from **inside** `$PKG` so the hashed paths
    are relative — an absolute-path form embeds the checkout location and yields a value
    nobody else can reproduce:

    ```bash
    pkgdigest() { (cd "$PKG" && find . -type f | LC_ALL=C sort | xargs shasum -a 256 | shasum -a 256 | cut -d' ' -f1); }
    ```

    **The pass rule is BEFORE == AFTER, not any literal digest** — the value is a function
    of the shipped skill content and legitimately differs at every release.
41. **`git -C "$REPO" status --porcelain` is empty.** The expected state is not "clean in
    the abstract": **any line naming a file under `great_expectations/`, a test, or
    packaging is a failure**, because it means a probe wrote into the repository, which is
    what running every probe in a scratch directory exists to prevent.
42. **The directories left behind.** Check per directory with `ls -A`, not with a flat
    `find`. Expected: `.agents`, `.claude`, `.agents/skills`, and `.claude/skills` all
    survive; the two `skills` directories are empty; `.agents` and `.claude` are not,
    because each still holds `skills/`. That is why the page says "holding nothing that GX
    installed" rather than "empty".
43. `skills list` afterward reports `not installed` at all six destinations, exit `0`.

### 9. Navigation and page-level checks

44. The sidebar entry's `id` resolves to a file that exists, and it was appended without
    reordering anything:

    ```bash
    ls docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
    grep -n "install_agent_skills" docs/docusaurus/sidebars.js
    ```
45. The page title, the sidebar label, and the landing card label all read
    `Install agent skills`. Three navigation surfaces disagreeing is a real user-visible
    defect and a cheap one to check.
46. The landing card matches its four siblings in attribute order, icon, and shape, and was
    appended last.
47. **The phrase "GX Agent" appears nowhere on the page.**

    ```bash
    grep -ic "GX Agent" docs/docusaurus/docs/core/set_up_a_gx_environment/install_agent_skills.md
    ```

    Expected: `0`. "GX Agent" is a distinct GX Cloud component, and naming it here — even
    to disambiguate — creates exactly the association this avoids.

### 10. Two link classes no CI job can check — both are manual, both at the cut

48. **The in-page anchor is not validated by the build.** The site sets `onBrokenLinks` and
    `onBrokenMarkdownLinks` to `throw` but never sets `onBrokenAnchors`, which defaults to
    `warn`; and the repository's broken-link checker is commented out in CI.

    ```bash
    grep -n "onBroken" docs/docusaurus/docusaurus.config.js
    grep -n "broken link checker" .github/workflows/ci.yml
    ```

    **Check by hand:** the page's one anchor,
    `#what-the-install-command-will-and-will-not-overwrite`, still matches the slug of the
    `##` heading it points at ("What the install command will and will not overwrite",
    currently page line 108). If either the heading or the link is edited, re-derive the slug
    — lowercase, spaces to hyphens, punctuation dropped — and compare.
49. **The landing card's href is computed at runtime and cannot be statically validated.**
    `LinkCard` renders `VersionedLink`, which passes `to` through the `useVersionedPath`
    hook before handing it to Docusaurus's `Link`, so the build sees a runtime value rather
    than a literal route.

    **Check by hand:** the card's `to` equals
    `/core/set_up_a_gx_environment/install_agent_skills`, matching the page's path under
    `docs/core/`, and the four sibling cards use the same shape. A rendered-site click
    through the section landing page is the only end-to-end proof.

### One thing that is deliberately not on the page

50. Adding a data source to a fresh file-backed project rewrites regions of
    `great_expectations.yml` the user never edited — `config_version: 4` becomes `4.0`, a
    comment is dropped, keys are re-indented, and analytics keys are added. This is
    one-time serializer behavior, reproducible without any agent or skill involved. It is
    recorded as a separate defect to be pursued on its own merits, and is deliberately not
    addressed by this PR, whose diff must stay documentation-only. **It stays off this
    page**: documenting it
    would present a defect as designed behavior, and the prose would go stale the moment it
    is fixed. Confirm at the cut that it is still absent here.

---

## Merge is held

This does not merge with the rest of the work. The documentation site publishes
continuously from `develop`, so for this page **merging is publishing** — there is no step
in between. Publishing it before the release that first ships the skills would document a
command that users cannot run.

**The merge is therefore held to the release that first ships the skills — expected
`1.21.0`, recorded as expected rather than as fact — and it is the maintainer's to make.**
This PR stays a draft until then. The pre-merge list above is the release-window procedure:
re-run it against the released wheel, confirm the two version literals from section 1
(editing them only if the cut renumbered), and only then mark ready and merge.

## Collapsing the displayed diff

Until the implementation work lands, this PR's **displayed** diff shows those commits
alongside the documentation. **It will not collapse on its own.** This repository allows
only squash and rebase merges, so the implementation commits never become ancestors of
`develop` and the merge-base with this branch never advances.

Collapsing it is one explicit step, to be taken after the implementation has landed:

```bash
git checkout m/agent-skills/skills-documentation
git fetch origin
git merge origin/develop        # merge forward; do not rebase
git push
```

Never a rebase of this published branch, and never a force-push.

Meanwhile, audit this PR against `5b4e2e966` — the commit this branch was cut from — rather
than against `develop`:

```bash
git diff --stat 5b4e2e966..m/agent-skills/skills-documentation
```

That shows this branch's own commits, which touch exactly three files: the new page, the
sidebar entry, and the landing card — 219 insertions, 0 deletions.


