### PR TITLE
[BUGFIX] Restore the install and test steps to py312-min-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,6 +822,12 @@ jobs:
           cache: "pip"
           cache-dependency-path: reqs/requirements-dev-test.txt
 
+      - name: Install dependencies
+        run: pip install . -c ci/constraints-test/py312-min-install.txt -r reqs/requirements-dev-test.txt
+
+      - name: Run the tests
+        run: invoke ci-tests -m unit --xdist --slowest=10  --timeout=2.0
+
   py313-min-versions:
     needs: [unit-tests, static-analysis, check-actor-permissions]
     env:


### PR DESCRIPTION
## Summary

`py312-min-versions` has had no work in it since [#11426](https://github.com/fivetran/great_expectations/pull/11426) (2025-10-09). That PR added `py313-min-versions` by inserting it directly between `py312`'s `Set up Python` step and `py312`'s `Install dependencies` / `Run the tests` steps — so those two steps became the *new* job's, and `py312-min-versions` was left with only a checkout and an interpreter setup.

Two consequences:

1. **Python 3.12 minimum-version unit tests have not run for ~10 months.** `ci/constraints-test/py312-min-install.txt` (numpy 1.26.0 / pandas <2.2.0 / sqlalchemy 2.0.0) has been unexercised the whole time.
2. **The job now fails on every non-draft PR**, taking `ci-required` with it.

## Why it only started failing now

The empty job still *passed*, because `setup-python`'s post-run cache save skips entirely on a cache hit — and the job kept hitting a pip cache left over from back when it really did install dependencies:

```
Cache hit for: setup-python-Linux-x64-24.04-Ubuntu-python-3.12.13-pip-8ddcfe0f...
```

The runner image then moved Python 3.12.13 → 3.12.14. The version is part of the cache key, so the restore missed, and the post step tried to *save* a directory that nothing in the job had ever created:

```
pip cache is not found
##[error]Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip.
This likely indicates that there are no dependencies to cache.
```

The stale cache had been masking an empty job; the Python patch bump simply removed the mask.

## The fix

Restore the two steps to `py312-min-versions`. This addresses both problems at once: 3.12 minimum-version coverage comes back, and installing dependencies creates the `~/.cache/pip` directory the post step expects.

## Verification

`ci.yml` is triggered by `pull_request_target`, so CI runs the workflow from the **base** branch — this PR's own change to `ci.yml` will not execute on this PR. `py312-min-versions` will therefore still show as failing here, using `develop`'s copy of the job. That is expected, and it is the bug being fixed.

Because CI can't self-verify the change, the restored job was reproduced locally on Python 3.12 with the job's exact commands:

```
pip install . -c ci/constraints-test/py312-min-install.txt -r reqs/requirements-dev-test.txt
invoke ci-tests -m unit --xdist --slowest=10  --timeout=2.0
```

- Install resolves cleanly under the min-version constraints (numpy 1.26.0, pandas 2.1.4, sqlalchemy 2.0.0).
- `4716 passed, 250 skipped, 31 xfailed` — exit 0.

So the 10-month coverage gap did not hide any 3.12 regressions; the job goes green as soon as the workflow is in place.
