### PR TITLE
[MAINTENANCE] Sync SparkDBFSDatasource schema with its deprecation notice

### DIFF
--- a/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
+++ b/great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json
@@ -1,6 +1,6 @@
 {
     "title": "SparkDBFSDatasource",
-    "description": "--Public API--Spark based Datasource for DataBricks File System (DBFS) based data assets.",
+    "description": "--Public API--Spark based Datasource for DataBricks File System (DBFS) based data assets.\n\n.. deprecated:: 1.16.0\n    DBFS is deprecated by Databricks. Use Unity Catalog volumes, external locations, or workspace files with SparkFilesystemDatasource instead.",
     "type": "object",
     "properties": {
         "type": {


### PR DESCRIPTION
## Summary

Regenerates `great_expectations/datasource/fluent/schemas/SparkDBFSDatasource.json` via `invoke schema --sync`. The shipped `description` field was missing the `.. deprecated:: 1.16.0` notice that `SparkDBFSDatasource`'s docstring has carried since that release (added via `@deprecated_method_or_class`), so the JSON schema had drifted from the model for four minor releases.

## Why

The datasource's docstring — and therefore its generated schema description — was updated when the deprecation landed in 1.16.0, but the checked-in schema file was never regenerated. Nothing currently catches this class of drift automatically, so it went unnoticed until a manual `invoke schema --sync` run surfaced it as a spurious diff on unrelated work.

Full `invoke schema --sync` was run to check every registered datasource/asset/expectation schema for drift; this was the only file that actually changed. All SQL-family datasource schemas (postgres, snowflake, bigquery, redshift, sqlite, etc.) currently fail to regenerate at all in this environment due to a pre-existing pydantic serialization bug unrelated to this change, so they could not be checked here.

## User impact

None to running behavior. This is a documentation-only correction to a shipped schema artifact: any consumer reading `SparkDBFSDatasource.json` directly (a schema-driven UI, generated docs, an agent using the datasource catalog) will now see the deprecation notice that the Python API has surfaced since 1.16.0.

## How to review

Single-file, single-line diff — confirm the new `description` matches `SparkDBFSDatasource.__doc__` (see `great_expectations/datasource/fluent/spark_dbfs_datasource.py`) and that no other content in the file changed.