### PR TITLE
[BUGFIX] Mask Azure connection strings regardless of field order (#10587)

### DIFF
--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -4,7 +4,6 @@ import copy
 import inspect
 import logging
 import pathlib
-import re
 import warnings
 from typing import Any, Optional
 from urllib.parse import urlparse
@@ -212,22 +211,41 @@ class PasswordMasker:
 
     @classmethod
     def _obfuscate_azure_blobstore_connection_string(cls, url: str) -> str:
-        # Parse Azure Connection Strings
-        azure_conn_str_re = re.compile(
-            "(DefaultEndpointsProtocol=(http|https));(AccountName=([a-zA-Z0-9]+));(AccountKey=)(.+);(EndpointSuffix=([a-zA-Z\\.]+))"
-        )
-        try:
-            matched: re.Match[str] | None = azure_conn_str_re.match(url)
-            if not matched:
-                raise StoreConfigurationError(  # noqa: TRY003, TRY301 # FIXME CoP
-                    f"The URL for the Azure connection-string, was not configured properly. Please check and try again: {url} "  # noqa: E501 # FIXME CoP
+        # Azure connection strings are an unordered set of ``key=value`` pairs joined by ``;``
+        # (see https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string).
+        # Parse them as such rather than matching a single hard-coded field order, and rebuild the
+        # string preserving the original order so only the ``AccountKey`` value is masked.
+        # Error messages here must never echo the raw input or any field value, since the input
+        # contains the very secret this method exists to hide.
+        pairs: list[tuple[str, str]] = []
+        for segment in url.split(";"):
+            if not segment:
+                # Tolerate a trailing or repeated ``;``.
+                continue
+            key, separator, value = segment.partition("=")
+            if not separator:
+                raise StoreConfigurationError(  # noqa: TRY003 # FIXME CoP
+                    "The Azure connection-string was not configured properly: expected "
+                    "';'-separated 'key=value' pairs. Please check and try again."
                 )
-            res = f"DefaultEndpointsProtocol={matched.group(2)};AccountName={matched.group(4)};AccountKey=***;EndpointSuffix={matched.group(8)}"  # noqa: E501 # FIXME CoP
-            return res
-        except Exception as e:
+            pairs.append((key, value))
+
+        fields = dict(pairs)
+        if fields.get("DefaultEndpointsProtocol") not in ("http", "https"):
             raise StoreConfigurationError(  # noqa: TRY003 # FIXME CoP
-                f"Something went wrong when trying to obfuscate URL for Azure connection-string. Please check your configuration: {e}"  # noqa: E501 # FIXME CoP
+                "The Azure connection-string was not configured properly: "
+                "'DefaultEndpointsProtocol' must be 'http' or 'https'. Please check and try again."
             )
+        if "AccountKey" not in fields:
+            raise StoreConfigurationError(  # noqa: TRY003 # FIXME CoP
+                "The Azure connection-string was not configured properly: "
+                "'AccountKey' is missing. Please check and try again."
+            )
+
+        return ";".join(
+            f"{key}={cls.MASKED_PASSWORD_STRING}" if key == "AccountKey" else f"{key}={value}"
+            for key, value in pairs
+        )
 
     @classmethod
     def _mask_db_url_no_sa(cls, url: str) -> str:

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -302,6 +302,45 @@ def test_sanitize_config_azure_blob_store():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "connection_string,expected",
+    [
+        pytest.param(
+            (
+                "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;"
+                "AccountName=iamname;AccountKey=i_am_account_key"
+            ),
+            (
+                "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;"
+                "AccountName=iamname;AccountKey=***"
+            ),
+            id="fields_reordered",
+        ),
+        pytest.param(
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=i_am_account_key",
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=***",
+            id="endpoint_suffix_omitted",
+        ),
+    ],
+)
+def test_azure_connection_string_masked_regardless_of_field_order(connection_string, expected):
+    assert PasswordMasker.mask_db_url(connection_string) == expected
+
+
+@pytest.mark.unit
+def test_azure_connection_string_account_key_never_appears_in_raised_error():
+    """A masking failure must not put the secret it was masking into the traceback."""
+    account_key = "i_am_account_key"
+    malformed = (
+        f"DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey={account_key};NotAField"
+    )
+    try:
+        PasswordMasker.mask_db_url(malformed)
+    except Exception as e:
+        assert account_key not in str(e)
+
+
+@pytest.mark.unit
 def test_sanitize_config_raises_exception_with_bad_input(
     basic_data_context_config,
 ):


### PR DESCRIPTION
## Summary

Fixes #10587.

`PasswordMasker._obfuscate_azure_blobstore_connection_string` matched Azure connection strings with a regex that hard-codes a single field order — `DefaultEndpointsProtocol;AccountName;AccountKey;EndpointSuffix`. Azure connection strings are an **unordered** set of `key=value` pairs, so:

1. **Any other field order raised `StoreConfigurationError`** instead of masking (e.g. `EndpointSuffix` appearing second). A valid string that omits the optional `EndpointSuffix` failed the same way.
2. **The failure path leaked the secret.** The raised error interpolated the raw input, so the plaintext `AccountKey` landed in the traceback — from the one function whose job is to keep it out of logs. This is reachable from ordinary read-only operations on any Azure-backed store (`DataContextConfig.__repr__()` / `.to_sanitized_json_dict()`, `AbstractDataContext.list_stores()`).

## Fix

Parse the string as an unordered `key=value` bag (split on `;`, then on the first `=`), validate `DefaultEndpointsProtocol` and the presence of `AccountKey`, then rebuild the string **preserving the original field order** with only the `AccountKey` value replaced by `***`. Failure messages are now generic and never echo the input, so no code path can put the account key into a message. Parsing on the first `=` also correctly handles base64 `AccountKey` values that contain `=` padding.

The public signature of `PasswordMasker.mask_db_url` is unchanged, and the SQLAlchemy / `urlparse` paths for non-Azure URLs are untouched.

## Tests

Added unit tests in `tests/data_context/test_data_context_utils.py` (no Azure account or network needed — pure string processing):

- masks correctly when fields are reordered
- masks correctly when the optional `EndpointSuffix` is omitted
- a masking failure never puts the `AccountKey` value into the raised exception

The existing `test_sanitize_config_azure_blob_store` — which asserts that a genuinely malformed string (bad protocol, or no `AccountKey`) still raises `StoreConfigurationError` — continues to pass unchanged.

```
pytest tests/data_context/test_data_context_utils.py -m unit -k azure
```

> Side benefit: because the string is now rebuilt from its parsed segments in order, connection strings containing extra fields (e.g. `BlobEndpoint=`) are preserved rather than silently dropped.

---

No RFC needed: bug fix, below the RFC threshold (not new data-source or execution-engine support).

- [x] Description of PR changes above includes a link to an existing GitHub issue (#10587)
- [x] PR title is prefixed with `[BUGFIX]`
- [x] This change is below the RFC threshold
- [x] Code is linted — `ruff format` + `ruff check` pass on the changed files
- [x] Appropriate tests have been updated
- [x] No behavioral change to a data source, validation mechanic, or Expectation, so no `tests/integration/data_sources_and_expectations` test is required — this is a fix to the `PasswordMasker` URL-masking utility, covered by unit tests
