### PR TITLE
[BUGFIX] Quote Spark unexpected index query literals

### DIFF
--- a/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
+++ b/great_expectations/expectations/metrics/map_metric_provider/map_condition_auxilliary_methods.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -51,6 +52,37 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _quote_spark_string_literals(expression: str, metric_value_kwargs: Dict[str, Any]) -> str:
+    """Quote string literals lost by Spark's ``Column`` string representation.
+
+    Spark renders expressions such as ``column.isin(["a"])`` and
+    ``column.rlike("^a$")`` as ``IN (a)`` and ``RLIKE(..., ^a$)``.  That
+    representation is useful for debugging, but is not valid Spark SQL when
+    copied into the generated ``F.expr`` query.  The original expectation
+    values are still available in ``metric_value_kwargs``, so use them to
+    restore the SQL string quoting without changing the executable condition.
+    """
+
+    string_literals: list[str] = []
+    for key in ("value_set", "regex", "regex_list"):
+        value = metric_value_kwargs.get(key)
+        if isinstance(value, str):
+            string_literals.append(value)
+        elif isinstance(value, (list, tuple, set)):
+            string_literals.extend(item for item in value if isinstance(item, str))
+
+    for literal in sorted(set(string_literals), key=len, reverse=True):
+        if not literal or literal[0] in "'\"":
+            continue
+        quoted_literal = "'" + literal.replace("'", "''") + "'"
+        expression = re.sub(
+            rf"(?<!['\"\\w]){re.escape(literal)}(?!['\"\\w])",
+            quoted_literal,
+            expression,
+        )
+    return expression
 
 
 def _pandas_map_condition_unexpected_count(
@@ -864,6 +896,9 @@ def _spark_map_condition_query(
         ")"
     ):
         unexpected_condition_filtered = unexpected_condition_filtered[1:-1]
+    unexpected_condition_filtered = _quote_spark_string_literals(
+        unexpected_condition_filtered, metric_value_kwargs
+    )
     return f"df.filter(F.expr({unexpected_condition_filtered}))"
 
 

--- a/tests/expectations/test_spark_map_condition_query.py
+++ b/tests/expectations/test_spark_map_condition_query.py
@@ -1,0 +1,45 @@
+from great_expectations.expectations.metrics.map_metric_provider.map_condition_auxilliary_methods import (  # noqa: E501
+    _spark_map_condition_query,
+)
+
+
+class _SparkColumn:
+    def __init__(self, expression: str) -> None:
+        self.expression = expression
+
+    def __str__(self) -> str:
+        return f"Column<'{self.expression}'>"
+
+
+def _query(expression: str, **kwargs: object) -> str:
+    return _spark_map_condition_query(
+        cls=None,
+        execution_engine=None,
+        metric_domain_kwargs={},
+        metric_value_kwargs={
+            "result_format": {"result_format": "COMPLETE"},
+            **kwargs,
+        },
+        metrics={"unexpected_condition": (_SparkColumn(expression), None, None)},
+    )
+
+
+def test_spark_unexpected_index_query_quotes_string_value_set() -> None:
+    query = _query(
+        "((in_set_str IS NOT NULL) AND (NOT (in_set_str IN (Val1, Val2))))",
+        value_set=["Val1", "Val2"],
+    )
+
+    assert query == (
+        "df.filter(F.expr((in_set_str IS NOT NULL) AND (NOT (in_set_str IN ('Val1', 'Val2')))))"
+    )
+
+
+def test_spark_unexpected_index_query_quotes_regex() -> None:
+    regex = r"^[a-z]+@[a-z]+\.com$"
+    query = _query(
+        rf"((email IS NOT NULL) AND (NOT RLIKE(email, {regex})))",
+        regex=regex,
+    )
+
+    assert f"RLIKE(email, '{regex}')" in query

--- a/tests/integration/data_sources_and_expectations/test_spark_nested_columns_unexpected_index.py
+++ b/tests/integration/data_sources_and_expectations/test_spark_nested_columns_unexpected_index.py
@@ -89,6 +89,31 @@ def test_spark_unexpected_index_column_names_with_nested_columns(spark_session) 
     assert "c" in ids, f"expected 'c' among unexpected ids, got {unexpected_index_list}"
 
 
+def test_spark_unexpected_index_query_quotes_string_literals(spark_session) -> None:
+    """Generated Spark queries should be executable when values are strings."""
+    context = gx.get_context(mode="ephemeral")
+    spark_df = _make_nested_spark_df(spark_session)
+
+    datasource = context.data_sources.add_spark(name="string_query_spark")
+    asset = datasource.add_dataframe_asset(name="string_query_asset")
+    batch_def = asset.add_batch_definition_whole_dataframe(name="string_query_bd")
+    batch = batch_def.get_batch(batch_parameters={"dataframe": spark_df})
+
+    result = batch.validate(
+        gxe.ExpectColumnValuesToBeInSet(
+            column="Data.evt.retry",
+            value_set=["0", "1"],
+        ),
+        result_format={
+            "result_format": "COMPLETE",
+            "return_unexpected_index_query": True,
+        },
+    )
+
+    query = result["result"]["unexpected_index_query"]
+    assert "IN ('0', '1')" in query
+
+
 def test_spark_unexpected_index_column_names_missing_nested_path_errors(
     spark_session,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #10827 by quoting string literals in Spark `unexpected_index_query` output.

## Changes

- Restore SQL quoting for `value_set`, `regex`, and `regex_list` values.
- Add unit and Spark integration regression tests.

## Validation

- Ruff check and format pass.
- Python compilation pass.
- Pytest unavailable in this environment because test dependencies are not installed.

No RFC needed: this is a targeted bug fix.