### PR TITLE
[CONTRIB] Mask Azure connection-string AccountKey regardless of field order

### DIFF
--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -239,9 +239,19 @@ class PasswordMasker:
                 "and valid."
             )
 
+        # Only re-emit the fields this method actually validated above; anything else the
+        # connection string happens to carry (e.g. an embedded SAS token) is dropped rather
+        # than echoed back unmasked.
+        recognized_fields = {
+            "DefaultEndpointsProtocol",
+            "AccountName",
+            "AccountKey",
+            "EndpointSuffix",
+        }
         return ";".join(
             f"{key}={cls.MASKED_PASSWORD_STRING}" if key == "AccountKey" else f"{key}={value}"
             for key, value in fields
+            if key in recognized_fields
         )
 
     @classmethod

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -212,22 +212,37 @@ class PasswordMasker:
 
     @classmethod
     def _obfuscate_azure_blobstore_connection_string(cls, url: str) -> str:
-        # Parse Azure Connection Strings
-        azure_conn_str_re = re.compile(
-            "(DefaultEndpointsProtocol=(http|https));(AccountName=([a-zA-Z0-9]+));(AccountKey=)(.+);(EndpointSuffix=([a-zA-Z\\.]+))"
-        )
-        try:
-            matched: re.Match[str] | None = azure_conn_str_re.match(url)
-            if not matched:
-                raise StoreConfigurationError(  # noqa: TRY003, TRY301 # FIXME CoP
-                    f"The URL for the Azure connection-string, was not configured properly. Please check and try again: {url} "  # noqa: E501 # FIXME CoP
-                )
-            res = f"DefaultEndpointsProtocol={matched.group(2)};AccountName={matched.group(4)};AccountKey=***;EndpointSuffix={matched.group(8)}"  # noqa: E501 # FIXME CoP
-            return res
-        except Exception as e:
-            raise StoreConfigurationError(  # noqa: TRY003 # FIXME CoP
-                f"Something went wrong when trying to obfuscate URL for Azure connection-string. Please check your configuration: {e}"  # noqa: E501 # FIXME CoP
+        # Azure connection strings are an unordered set of `key=value` fields separated by `;`.
+        # Parse them as such (rather than matching a single fixed field order) so that masking
+        # succeeds regardless of field order and with the optional EndpointSuffix omitted.
+        # Field order is preserved in the output. No exception raised here may echo the raw url
+        # or the AccountKey value, since that would defeat the purpose of masking it.
+        fields = [
+            (key, value)
+            for key, sep, value in (segment.partition("=") for segment in url.split(";"))
+            if sep
+        ]
+        field_values = dict(fields)
+
+        if (
+            field_values.get("DefaultEndpointsProtocol") not in ("http", "https")
+            or not field_values.get("AccountKey")
+            or not re.fullmatch(r"[a-zA-Z0-9]+", field_values.get("AccountName", ""))
+            or (
+                "EndpointSuffix" in field_values
+                and not re.fullmatch(r"[a-zA-Z\.]+", field_values["EndpointSuffix"])
             )
+        ):
+            raise StoreConfigurationError(  # noqa: TRY003 # FIXME CoP
+                "The URL for the Azure connection-string was not configured properly. Please "
+                "check that DefaultEndpointsProtocol, AccountName, and AccountKey are present "
+                "and valid."
+            )
+
+        return ";".join(
+            f"{key}={cls.MASKED_PASSWORD_STRING}" if key == "AccountKey" else f"{key}={value}"
+            for key, value in fields
+        )
 
     @classmethod
     def _mask_db_url_no_sa(cls, url: str) -> str:

--- a/great_expectations/data_context/util.py
+++ b/great_expectations/data_context/util.py
@@ -173,6 +173,12 @@ class PasswordMasker:
     # values with these keys will be directly replaced with cls.MASKED_PASSWORD_STRING:
     PASSWORD_KEYS = {"access_token", "password"}
 
+    # Azure blobstore connection-string fields that are known not to carry a credential, and so
+    # may be shown in cleartext. Every other field is masked rather than dropped: the masked
+    # string stays a faithful description of what was configured, while a field we do not
+    # recognize - including one Azure adds later - is never revealed by default.
+    AZURE_SAFE_TO_DISPLAY_FIELDS = {"DefaultEndpointsProtocol", "AccountName", "EndpointSuffix"}
+
     @classmethod
     def mask_db_url(cls, url: str, use_urlparse: bool = False, **kwargs) -> str:
         """
@@ -239,19 +245,16 @@ class PasswordMasker:
                 "and valid."
             )
 
-        # Only re-emit the fields this method actually validated above; anything else the
-        # connection string happens to carry (e.g. an embedded SAS token) is dropped rather
-        # than echoed back unmasked.
-        recognized_fields = {
-            "DefaultEndpointsProtocol",
-            "AccountName",
-            "AccountKey",
-            "EndpointSuffix",
-        }
+        # Emit every field the connection string carried, masking the value of any field not
+        # known to be safe to display. Dropping unrecognized fields instead would make the
+        # masked string describe a connection that was never configured - `BlobEndpoint`, for
+        # one, overrides the endpoint built from protocol/account/suffix, so omitting it points
+        # the output at a different endpoint than the real config uses.
         return ";".join(
-            f"{key}={cls.MASKED_PASSWORD_STRING}" if key == "AccountKey" else f"{key}={value}"
+            f"{key}={value}"
+            if key in cls.AZURE_SAFE_TO_DISPLAY_FIELDS
+            else f"{key}={cls.MASKED_PASSWORD_STRING}"
             for key, value in fields
-            if key in recognized_fields
         )
 
     @classmethod

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -320,6 +320,11 @@ def test_sanitize_config_azure_blob_store():
             "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=***;EndpointSuffix=core.windows.net",
             id="trailing_semicolon",
         ),
+        pytest.param(
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=i_am_account_key;SharedAccessSignature=i_am_a_sas_token",
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=***",
+            id="unrecognized_field_dropped",
+        ),
     ],
 )
 def test_azure_connection_string_masked_regardless_of_field_order(connection_string, expected):
@@ -334,6 +339,27 @@ def test_azure_connection_string_account_key_never_appears_in_raised_error():
     with pytest.raises(StoreConfigurationError) as exc_info:
         PasswordMasker.mask_db_url(malformed)
     assert account_key not in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_azure_connection_string_raises_for_invalid_account_name():
+    """AccountName must be alphanumeric; a hyphen should be rejected."""
+    connection_string = (
+        "DefaultEndpointsProtocol=https;AccountName=iam-name;AccountKey=i_am_account_key"
+    )
+    with pytest.raises(StoreConfigurationError):
+        PasswordMasker.mask_db_url(connection_string)
+
+
+@pytest.mark.unit
+def test_azure_connection_string_raises_for_invalid_endpoint_suffix():
+    """EndpointSuffix must match [a-zA-Z.]+; digits/symbols should be rejected."""
+    connection_string = (
+        "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=i_am_account_key;"
+        "EndpointSuffix=core.windows.net123"
+    )
+    with pytest.raises(StoreConfigurationError):
+        PasswordMasker.mask_db_url(connection_string)
 
 
 @pytest.mark.unit

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -302,6 +302,41 @@ def test_sanitize_config_azure_blob_store():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "connection_string,expected",
+    [
+        pytest.param(
+            "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=iamname;AccountKey=i_am_account_key",
+            "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=iamname;AccountKey=***",
+            id="fields_reordered",
+        ),
+        pytest.param(
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=i_am_account_key",
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=***",
+            id="endpoint_suffix_omitted",
+        ),
+        pytest.param(
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=i_am_account_key;EndpointSuffix=core.windows.net;",
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=***;EndpointSuffix=core.windows.net",
+            id="trailing_semicolon",
+        ),
+    ],
+)
+def test_azure_connection_string_masked_regardless_of_field_order(connection_string, expected):
+    assert PasswordMasker.mask_db_url(connection_string) == expected
+
+
+@pytest.mark.unit
+def test_azure_connection_string_account_key_never_appears_in_raised_error():
+    """A masking failure must not put the secret it was masking into the traceback."""
+    account_key = "i_am_account_key"
+    malformed = f"DefaultEndpointsProtocol=nonsense;AccountName=iamname;AccountKey={account_key}"
+    with pytest.raises(StoreConfigurationError) as exc_info:
+        PasswordMasker.mask_db_url(malformed)
+    assert account_key not in str(exc_info.value)
+
+
+@pytest.mark.unit
 def test_sanitize_config_raises_exception_with_bad_input(
     basic_data_context_config,
 ):

--- a/tests/data_context/test_data_context_utils.py
+++ b/tests/data_context/test_data_context_utils.py
@@ -322,13 +322,74 @@ def test_sanitize_config_azure_blob_store():
         ),
         pytest.param(
             "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=i_am_account_key;SharedAccessSignature=i_am_a_sas_token",
-            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=***",
-            id="unrecognized_field_dropped",
+            "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=***;SharedAccessSignature=***",
+            id="sas_token_masked_not_dropped",
+        ),
+        pytest.param(
+            "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=i_am_account_key;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1",
+            "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=***;BlobEndpoint=***;QueueEndpoint=***",
+            id="emulator_endpoint_fields_masked_not_dropped",
+        ),
+        pytest.param(
+            "DefaultEndpointsProtocol=https;AccountName=iamname;SomeFieldAzureAddedLater=i_am_a_new_secret;AccountKey=i_am_account_key",
+            "DefaultEndpointsProtocol=https;AccountName=iamname;SomeFieldAzureAddedLater=***;AccountKey=***",
+            id="unknown_field_masked_by_default",
         ),
     ],
 )
 def test_azure_connection_string_masked_regardless_of_field_order(connection_string, expected):
     assert PasswordMasker.mask_db_url(connection_string) == expected
+
+
+@pytest.mark.unit
+def test_azure_safe_to_display_fields_is_limited_to_known_non_credentials():
+    """Widening this allowlist reveals a field in cleartext, so it is pinned deliberately.
+
+    Notably absent: AccountKey and SharedAccessSignature are credentials, and the *Endpoint
+    fields can carry a SAS token in their query string.
+    """
+    expected_safe_fields = {"DefaultEndpointsProtocol", "AccountName", "EndpointSuffix"}
+    assert expected_safe_fields == PasswordMasker.AZURE_SAFE_TO_DISPLAY_FIELDS
+
+
+@pytest.mark.unit
+def test_azure_connection_string_masking_drops_no_field():
+    """A masked string that silently omits a field describes a connection nobody configured.
+
+    `BlobEndpoint` overrides the endpoint built from protocol/account/suffix, so dropping it
+    would render output pointing at a different endpoint than the real config uses.
+    """
+    connection_string = (
+        "DefaultEndpointsProtocol=https;AccountName=iamname;AccountKey=i_am_account_key;"
+        "EndpointSuffix=core.windows.net;BlobEndpoint=https://private.example.net/iamname;"
+        "SharedAccessSignature=i_am_a_sas_token"
+    )
+    masked = PasswordMasker.mask_db_url(connection_string)
+
+    def keys(value: str) -> list[str]:
+        return [segment.partition("=")[0] for segment in value.split(";")]
+
+    assert keys(masked) == keys(connection_string)
+
+
+@pytest.mark.unit
+def test_azure_connection_string_masks_every_value_not_safe_to_display():
+    """Fail closed: only the allowlisted fields survive in cleartext, every other value is ***."""
+    unsafe_values = {
+        "AccountKey": "i_am_account_key",
+        "SharedAccessSignature": "i_am_a_sas_token",
+        "BlobEndpoint": "https://private.example.net/iamname",
+        "SomeFieldAzureAddedLater": "i_am_a_new_secret",
+    }
+    connection_string = ";".join(
+        ["DefaultEndpointsProtocol=https", "AccountName=iamname", "EndpointSuffix=core.windows.net"]
+        + [f"{key}={value}" for key, value in unsafe_values.items()]
+    )
+    masked = PasswordMasker.mask_db_url(connection_string)
+
+    for key, value in unsafe_values.items():
+        assert value not in masked, f"{key} value leaked into masked output"
+        assert f"{key}={PasswordMasker.MASKED_PASSWORD_STRING}" in masked
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #10587.

`_obfuscate_azure_blobstore_connection_string` matched one hard-coded field order with a regex, so a connection string with fields in a different order (or without `EndpointSuffix`) failed to mask and raised `StoreConfigurationError` with the raw, unmasked string in the message. This parses the string as key=value pairs instead, keeps the original field order in the output, and never puts the raw url or the account key into an error message.

No RFC needed: bug fix, no public API change.

- [x] Description of PR changes above includes a link to an existing GitHub issue
- [x] PR title is prefixed with [CONTRIB]
- [x] This change is below the RFC threshold
- [x] Code is linted - `ruff check` / `ruff format` clean
- [x] Appropriate tests and docs have been updated
