### PR TITLE
[CONTRIB] Fix pandas column-pair validation with non-default indexes

### DIFF
--- a/great_expectations/expectations/metrics/column_pair_map_metrics/column_pair_values_in_set.py
+++ b/great_expectations/expectations/metrics/column_pair_map_metrics/column_pair_values_in_set.py
@@ -55,7 +55,7 @@ class ColumnPairValuesInSet(ColumnPairMapMetricProvider):
 
             results.append((a, b) in value_pairs_set)
 
-        return pd.Series(results)
+        return pd.Series(results, index=temp_df.index)
 
     @column_pair_condition_partial(engine=SqlAlchemyExecutionEngine)
     def _sqlalchemy(cls, column_A, column_B, **kwargs):

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_in_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_in_set.py
@@ -12,6 +12,21 @@ from tests.integration.data_sources_and_expectations.test_canonical_expectations
 
 DATA = pd.DataFrame({"foo": [1, 2, 4], "bar": [1, 1, 1]})
 
+NULL_PAIR_NOT_AT_END = pd.DataFrame(
+    {
+        "currency": ["EUR", None, "EUR"],
+        "country": ["DE", None, "FR"],
+    }
+)
+
+NON_DEFAULT_INDEX = pd.DataFrame(
+    {
+        "currency": ["EUR", "EUR"],
+        "country": ["DE", "FR"],
+    },
+    index=[10, 20],
+)
+
 
 @parameterize_batch_for_data_sources(data_source_configs=ALL_DATA_SOURCES, data=DATA)
 def test_success_complete_results(batch_for_datasource: Batch) -> None:
@@ -44,6 +59,42 @@ def test_success_complete_results(batch_for_datasource: Batch) -> None:
         "unexpected_percent_nonmissing": 33.33333333333333,
         "unexpected_percent_total": 33.33333333333333,
     }
+
+
+def assert_successful_pair_validation(batch_for_datasource: Batch) -> dict:
+    expectation = gxe.ExpectColumnPairValuesToBeInSet(
+        column_A="currency",
+        column_B="country",
+        value_pairs_set=[("EUR", "DE"), ("EUR", "FR")],
+    )
+
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    assert result.success, f"expected a verdict, got exception_info={result.exception_info}"
+    result_dict = result.to_json_dict()["result"]
+    assert type(result_dict) is dict
+    assert result_dict["unexpected_count"] == 0
+    return result_dict
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=JUST_PANDAS_DATA_SOURCES, data=NULL_PAIR_NOT_AT_END
+)
+def test_pandas_ignored_row_in_middle_returns_verdict(batch_for_datasource: Batch) -> None:
+    result_dict = assert_successful_pair_validation(batch_for_datasource)
+
+    assert result_dict["element_count"] == 3
+    assert result_dict["missing_count"] == 1
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=JUST_PANDAS_DATA_SOURCES, data=NON_DEFAULT_INDEX
+)
+def test_pandas_non_default_index_returns_verdict(batch_for_datasource: Batch) -> None:
+    result_dict = assert_successful_pair_validation(batch_for_datasource)
+
+    assert result_dict["element_count"] == 2
+    assert result_dict["missing_count"] == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_in_set.py
+++ b/tests/integration/data_sources_and_expectations/expectations/test_expect_column_pair_values_to_be_in_set.py
@@ -15,7 +15,7 @@ DATA = pd.DataFrame({"foo": [1, 2, 4], "bar": [1, 1, 1]})
 NULL_PAIR_NOT_AT_END = pd.DataFrame(
     {
         "currency": ["EUR", None, "EUR"],
-        "country": ["DE", None, "FR"],
+        "country": ["DE", None, "US"],
     }
 )
 
@@ -81,10 +81,27 @@ def assert_successful_pair_validation(batch_for_datasource: Batch) -> dict:
     data_source_configs=JUST_PANDAS_DATA_SOURCES, data=NULL_PAIR_NOT_AT_END
 )
 def test_pandas_ignored_row_in_middle_returns_verdict(batch_for_datasource: Batch) -> None:
-    result_dict = assert_successful_pair_validation(batch_for_datasource)
+    # The row after the ignored (null) row is a genuine violation of value_pairs_set. If
+    # validation loses the post-filter index alignment (e.g. by rebuilding a plain
+    # pd.Series(results) instead of reindexing to temp_df.index), the violation would be
+    # attributed to the wrong row and this assertion would fail even though
+    # `unexpected_count` still came out correct.
+    expectation = gxe.ExpectColumnPairValuesToBeInSet(
+        column_A="currency",
+        column_B="country",
+        value_pairs_set=[("EUR", "DE"), ("EUR", "FR")],
+    )
+
+    result = batch_for_datasource.validate(expectation, result_format=ResultFormat.COMPLETE)
+
+    assert not result.success, f"expected a verdict, got exception_info={result.exception_info}"
+    result_dict = result.to_json_dict()["result"]
+    assert type(result_dict) is dict
 
     assert result_dict["element_count"] == 3
     assert result_dict["missing_count"] == 1
+    assert result_dict["unexpected_count"] == 1
+    assert result_dict["partial_unexpected_list"] == [["EUR", "US"]]
 
 
 @parameterize_batch_for_data_sources(


### PR DESCRIPTION
## Summary

Fix pandas validation for ExpectColumnPairValuesToBeInSet when the evaluated rows do not use a zero-based consecutive index.

The pandas metric built its boolean result Series without the index from the filtered DataFrame. When null filtering removed a row from the middle, or when the source DataFrame already had a custom index, pandas could not align that result with the original rows and validation returned a MetricResolutionError instead of a verdict.

This change preserves the filtered DataFrame index on the result Series. It also adds integration coverage for both the null-filtering case and a non-default input index.

Closes #12095

No RFC needed: This is a scoped bug fix with no public API or backend changes.

## Testing

- Confirmed the null-row regression test fails with the reported index-alignment error before the fix.
- Confirmed both new pandas regression tests pass after the fix.
- Passed all locally runnable pandas and SQLite cases in the target integration test file: 7 passed.
- Passed the full repository lint command: 1,582 files formatted and all checks passed.
- External database, Spark, and cloud variants require backend drivers or credentials and are left to maintainer CI.

- [x] Description of PR changes above includes a link to an existing GitHub issue
- [x] PR title is prefixed with an accepted prefix
- [x] This change is below the RFC threshold
- [x] Code is linted with invoke lint
- [x] Appropriate tests have been updated; documentation is not affected
- [x] Behavioral integration tests are located in tests/integration/data_sources_and_expectations
- [x] This PR does not adopt or recommend a third-party library or service
