### PR TITLE
[BUGFIX] pass usedforsecurity=False on non-security md5 calls for FIPS hosts

### DIFF
--- a/great_expectations/core/id_dict.py
+++ b/great_expectations/core/id_dict.py
@@ -29,7 +29,11 @@ class IDDict(dict):
             return f"{key}={self[key]!s}"
 
         _id_dict = convert_to_json_serializable(data={k: self[k] for k in id_keys})
-        return hashlib.md5(json.dumps(_id_dict, sort_keys=True).encode("utf-8")).hexdigest()
+        # not used for security: this is a stable id/cache key, not a cryptographic digest.
+        # usedforsecurity=False lets this run on hosts with FIPS-mode OpenSSL.
+        return hashlib.md5(
+            json.dumps(_id_dict, sort_keys=True).encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
 
     @override
     def __hash__(self) -> int:  # type: ignore[override] # FIXME CoP

--- a/great_expectations/execution_engine/pandas_execution_engine.py
+++ b/great_expectations/execution_engine/pandas_execution_engine.py
@@ -731,4 +731,6 @@ def hash_pandas_dataframe(df):
         # In case of facing unhashable objects (like dict), use pickle
         obj = pickle.dumps(df, pickle.HIGHEST_PROTOCOL)
 
-    return hashlib.md5(obj).hexdigest()
+    # not used for security: this is a batch fingerprint, not a cryptographic digest.
+    # usedforsecurity=False lets this run on hosts with FIPS-mode OpenSSL.
+    return hashlib.md5(obj, usedforsecurity=False).hexdigest()

--- a/great_expectations/execution_engine/partition_and_sample/pandas_data_partitioner.py
+++ b/great_expectations/execution_engine/partition_and_sample/pandas_data_partitioner.py
@@ -238,8 +238,10 @@ class PandasDataPartitioner(DataPartitioner):
                 )
             )
         matching_rows = df[column_name].map(
+            # not used for security: this is hash partitioning, not a cryptographic digest.
+            # usedforsecurity=False lets this run on hosts with FIPS-mode OpenSSL.
             lambda x: (
-                hash_method(str(x).encode()).hexdigest()[-1 * hash_digits :]
+                hash_method(str(x).encode(), usedforsecurity=False).hexdigest()[-1 * hash_digits :]
                 == batch_identifiers["hash_value"]
             )
         )

--- a/great_expectations/execution_engine/partition_and_sample/pandas_data_sampler.py
+++ b/great_expectations/execution_engine/partition_and_sample/pandas_data_sampler.py
@@ -160,6 +160,11 @@ class PandasDataSampler(DataSampler):
             )
 
         matches: pd.Series = df[column_name].map(
-            lambda x: hash_func(str(x).encode()).hexdigest()[-1 * hash_digits :] == hash_value
+            # not used for security: this is hash sampling, not a cryptographic digest.
+            # usedforsecurity=False lets this run on hosts with FIPS-mode OpenSSL.
+            lambda x: hash_func(str(x).encode(), usedforsecurity=False).hexdigest()[
+                -1 * hash_digits :
+            ]
+            == hash_value
         )
         return df[matches]

--- a/great_expectations/execution_engine/partition_and_sample/sparkdf_data_partitioner.py
+++ b/great_expectations/execution_engine/partition_and_sample/sparkdf_data_partitioner.py
@@ -289,7 +289,11 @@ class SparkDataPartitioner(DataPartitioner):
 
         def _encrypt_value(to_encode):
             hash_func = getattr(hashlib, hash_function_name)
-            hashed_value = hash_func(to_encode.encode()).hexdigest()[-1 * hash_digits :]
+            # not used for security: this is hash partitioning, not a cryptographic digest.
+            # usedforsecurity=False lets this run on hosts with FIPS-mode OpenSSL.
+            hashed_value = hash_func(to_encode.encode(), usedforsecurity=False).hexdigest()[
+                -1 * hash_digits :
+            ]
             return hashed_value
 
         encrypt_udf = F.udf(_encrypt_value, pyspark.types.StringType())

--- a/great_expectations/execution_engine/partition_and_sample/sparkdf_data_sampler.py
+++ b/great_expectations/execution_engine/partition_and_sample/sparkdf_data_sampler.py
@@ -165,7 +165,11 @@ class SparkDataSampler(DataSampler):
         def _encrypt_value(to_encode):
             to_encode_str = str(to_encode)
             hash_func = getattr(hashlib, hash_function_name)
-            hashed_value = hash_func(to_encode_str.encode()).hexdigest()[-1 * hash_digits :]
+            # not used for security: this is hash sampling, not a cryptographic digest.
+            # usedforsecurity=False lets this run on hosts with FIPS-mode OpenSSL.
+            hashed_value = hash_func(to_encode_str.encode(), usedforsecurity=False).hexdigest()[
+                -1 * hash_digits :
+            ]
             return hashed_value
 
         encrypt_udf = F.udf(_encrypt_value, pyspark.types.StringType())

--- a/great_expectations/execution_engine/sqlalchemy_execution_engine.py
+++ b/great_expectations/execution_engine/sqlalchemy_execution_engine.py
@@ -385,10 +385,15 @@ class SqlAlchemyExecutionEngine(ExecutionEngine[SQLAColumnClause]):
                 def _add_sqlite_functions(connection):
                     logger.info(f"Adding custom sqlite functions to connection {connection}")
                     connection.create_function("sqrt", 1, math.sqrt)
+                    # not used for security: this is hash partitioning/sampling, not a
+                    # cryptographic digest. usedforsecurity=False lets this run on hosts
+                    # with FIPS-mode OpenSSL.
                     connection.create_function(
                         "md5",
                         2,
-                        lambda x, d: hashlib.md5(str(x).encode("utf-8")).hexdigest()[-1 * d :],
+                        lambda x, d: hashlib.md5(
+                            str(x).encode("utf-8"), usedforsecurity=False
+                        ).hexdigest()[-1 * d :],
                     )
 
                 # Add sqlite functions to any future connections.

--- a/tests/datasource/conftest.py
+++ b/tests/datasource/conftest.py
@@ -1,20 +1,12 @@
-import hashlib
-import math
 import os
 from itertools import product
 
 import pytest
 from moto import mock_glue
 
-from great_expectations.compatibility import sqlalchemy
-from great_expectations.data_context.util import file_relative_path
 from great_expectations.execution_engine.sparkdf_execution_engine import (
     SparkDFExecutionEngine,
 )
-from great_expectations.execution_engine.sqlalchemy_execution_engine import (
-    SqlAlchemyExecutionEngine,
-)
-from great_expectations.self_check.util import get_sqlite_connection_url
 
 
 def create_partitions_for_table(glue_client, database_name: str, table_name: str, partitions: dict):
@@ -110,73 +102,3 @@ def glue_titanic_catalog():
             },
         )
         yield client
-
-
-@pytest.fixture
-def test_cases_for_sql_data_connector_sqlite_connection_url(sa):
-    if sa is None:
-        raise ValueError("SQL Database tests require sqlalchemy to be installed.")
-
-    db_file_path: str = file_relative_path(
-        __file__,
-        os.path.join(  # noqa: PTH118 # FIXME CoP
-            "..", "test_sets", "test_cases_for_sql_data_connector.db"
-        ),
-    )
-
-    return get_sqlite_connection_url(db_file_path)
-
-
-@pytest.fixture
-def test_cases_for_sql_data_connector_sqlite_execution_engine(
-    sa, test_cases_for_sql_data_connector_sqlite_connection_url
-):
-    """Provide a sqlite ExecutionEngine for SQL data connector tests.
-
-    The engine and its underlying connections are explicitly closed after use to avoid
-    leaking sqlite3.Connection objects (which surface as ResourceWarning in CI).
-    """
-    if sa is None:
-        raise ValueError("SQL Database tests require sqlalchemy to be installed.")
-
-    engine: sa.engine.Engine = sa.create_engine(
-        test_cases_for_sql_data_connector_sqlite_connection_url,
-        poolclass=sqlalchemy.StaticPool,
-    )
-    _raw_dbapi_con = engine.raw_connection()
-    try:
-        _raw_dbapi_con.create_function("sqrt", 1, math.sqrt)
-        _raw_dbapi_con.create_function(
-            "md5",
-            2,
-            lambda x, d: hashlib.md5(str(x).encode("utf-8"), usedforsecurity=False).hexdigest()[
-                -1 * d :
-            ],
-        )
-    finally:
-        # Ensure the temporary raw DB-API connection is closed to avoid ResourceWarning.
-        try:
-            _raw_dbapi_con.close()
-        except Exception:
-            pass
-
-    # Keep a live connection for static pools, but make sure it is closed on teardown.
-    conn: sa.engine.Connection = engine.connect()
-
-    # Build a SqlAlchemyDataset using that database
-    execution_engine = SqlAlchemyExecutionEngine(
-        name="test_sql_execution_engine",
-        engine=engine,
-    )
-
-    try:
-        yield execution_engine
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
-        try:
-            execution_engine.close()
-        except Exception:
-            pass

--- a/tests/datasource/conftest.py
+++ b/tests/datasource/conftest.py
@@ -147,7 +147,11 @@ def test_cases_for_sql_data_connector_sqlite_execution_engine(
     try:
         _raw_dbapi_con.create_function("sqrt", 1, math.sqrt)
         _raw_dbapi_con.create_function(
-            "md5", 2, lambda x, d: hashlib.md5(str(x).encode("utf-8")).hexdigest()[-1 * d :]
+            "md5",
+            2,
+            lambda x, d: hashlib.md5(str(x).encode("utf-8"), usedforsecurity=False).hexdigest()[
+                -1 * d :
+            ],
         )
     finally:
         # Ensure the temporary raw DB-API connection is closed to avoid ResourceWarning.

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
 import os
 from typing import TYPE_CHECKING, List
 from unittest import mock
@@ -798,3 +799,80 @@ def test_sqlite_partition_and_sample_using_limit(
     for row_date in row_dates:
         assert row_date.month == 1
         assert row_date.year == 2018
+
+
+def _sqlite_md5_udf_reference(value: object, hash_digits: int) -> str:
+    """Reference implementation of the md5 UDF SqlAlchemyExecutionEngine registers on sqlite.
+
+    Recomputed here in Python so the tests below pin the UDF's actual output rather than
+    comparing the database against itself.
+    """
+    return hashlib.md5(str(value).encode("utf-8"), usedforsecurity=False).hexdigest()[
+        -1 * hash_digits :
+    ]
+
+
+@pytest.mark.sqlite
+def test_sqlite_partition_on_hashed_column(sa):
+    """What does this test and why?
+    partition_on_hashed_column has no native sqlite implementation; it depends on the md5
+    UDF that SqlAlchemyExecutionEngine registers on every sqlite connection. Drive that
+    path end to end so a regression in the UDF fails here.
+    """
+    hash_digits: int = 1
+    column_name: str = "id"
+    df: pd.DataFrame = pd.DataFrame({column_name: list(range(20))})
+    engine: SqlAlchemyExecutionEngine = build_sa_execution_engine(df, sa)
+
+    hash_value: str = _sqlite_md5_udf_reference(df[column_name][0], hash_digits)
+    expected_ids: List[int] = [
+        value
+        for value in df[column_name]
+        if _sqlite_md5_udf_reference(value, hash_digits) == hash_value
+    ]
+    # Guard against a vacuous assertion: the partition must be a non-empty, proper subset.
+    assert 0 < len(expected_ids) < len(df)
+
+    batch_spec: SqlAlchemyDatasourceBatchSpec = SqlAlchemyDatasourceBatchSpec(
+        table_name="test",
+        schema_name="main",
+        partitioner_method="partition_on_hashed_column",
+        partitioner_kwargs={"column_name": column_name, "hash_digits": hash_digits},
+        batch_identifiers={column_name: hash_value},
+    )
+    batch_data: SqlAlchemyBatchData = engine.get_batch_data(batch_spec=batch_spec)
+
+    rows: list[sa.RowMapping] = (
+        engine.execute_query(sa.select(sa.text("*")).select_from(batch_data.selectable))
+        .mappings()
+        .fetchall()
+    )
+
+    assert sorted(row[column_name] for row in rows) == sorted(expected_ids)
+
+
+@pytest.mark.sqlite
+def test_sqlite_get_data_for_batch_identifiers_on_hashed_column(sa):
+    """What does this test and why?
+    Introspecting the batch identifiers for a hashed-column partitioner runs the same sqlite
+    md5 UDF, through a different query. The identifiers it yields must be the real digests.
+    """
+    hash_digits: int = 2
+    column_name: str = "id"
+    df: pd.DataFrame = pd.DataFrame({column_name: list(range(20))})
+    engine: SqlAlchemyExecutionEngine = build_sa_execution_engine(df, sa)
+
+    data_partitioner: SqlAlchemyDataPartitioner = SqlAlchemyDataPartitioner(dialect="sqlite")
+    batch_identifiers_list: List[dict] = data_partitioner.get_data_for_batch_identifiers(
+        execution_engine=engine,
+        selectable=sa.table("test", schema="main"),
+        partitioner_method_name="partition_on_hashed_column",
+        partitioner_kwargs={"column_name": column_name, "hash_digits": hash_digits},
+    )
+
+    expected_hash_values: set[str] = {
+        _sqlite_md5_udf_reference(value, hash_digits) for value in df[column_name]
+    }
+    assert {
+        batch_identifiers[column_name] for batch_identifiers in batch_identifiers_list
+    } == expected_hash_values

--- a/tests/integration/fixtures/partition_and_sample_data/partitioner_test_cases_and_fixtures.py
+++ b/tests/integration/fixtures/partition_and_sample_data/partitioner_test_cases_and_fixtures.py
@@ -1,5 +1,4 @@
 import datetime
-import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
@@ -118,10 +117,6 @@ class TaxiTestData:
         column_values: List[Optional[Any]] = self.test_df[self.test_column_name].tolist()
         return column_values
 
-    def get_test_multi_column_values(self) -> List[dict]:
-        multi_column_values: List[dict] = self.test_df[self.test_column_names].to_dict("records")
-        return multi_column_values
-
     def get_unique_sorted_test_column_values(
         self,
         reverse: Optional[bool] = False,
@@ -152,49 +147,6 @@ class TaxiTestData:
 
         return column_values[:limit]
 
-    def get_unique_sorted_test_multi_column_values(
-        self,
-        reverse: Optional[bool] = False,
-        limit: Optional[int] = None,
-    ) -> List[dict]:
-        multi_column_values: List[dict] = self.get_test_multi_column_values()
-        multi_column_values = sorted(
-            multi_column_values,
-            key=lambda element: sum(
-                map(
-                    ord,
-                    hashlib.md5(
-                        str(tuple(zip(element.keys(), element.values(), strict=False))).encode(
-                            "utf-8"
-                        ),
-                        usedforsecurity=False,
-                    ).hexdigest(),
-                )
-            ),
-            reverse=reverse,
-        )
-
-        unique_multi_column_values: List[dict] = []
-
-        hash_codes: List[str] = []
-        hash_code: str
-        dictionary_element: dict
-        for dictionary_element in multi_column_values:
-            hash_code = hashlib.md5(
-                str(
-                    tuple(zip(dictionary_element.keys(), dictionary_element.values(), strict=False))
-                ).encode("utf-8"),
-                usedforsecurity=False,
-            ).hexdigest()
-            if hash_code not in hash_codes:
-                unique_multi_column_values.append(dictionary_element)
-                hash_codes.append(hash_code)
-
-        if limit is None:
-            return unique_multi_column_values
-
-        return unique_multi_column_values[:limit]
-
     def get_divided_integer_test_column_values(self, divisor: int) -> List[Optional[Any]]:
         column_values: List[Optional[Any]] = self.get_test_column_values()
 
@@ -210,26 +162,6 @@ class TaxiTestData:
         column_values = [column_value % mod for column_value in column_values]
 
         return list(set(column_values))
-
-    def get_hashed_test_column_values(self, hash_digits: int) -> List[Optional[Any]]:
-        """
-        hashlib.md5(string).hexdigest()
-        hashlib.md5(str(tuple_).encode("utf-8")).hexdigest()
-        [:num_digits]
-        """
-        column_values: List[Optional[Any]] = self.get_unique_sorted_test_column_values(
-            reverse=False, move_null_to_front=False, limit=None
-        )
-
-        column_value: Any
-        column_values = [
-            hashlib.md5(str(column_value).encode("utf-8"), usedforsecurity=False).hexdigest()[
-                -1 * hash_digits :
-            ]
-            for column_value in column_values
-        ]
-
-        return list(sorted(set(column_values)))
 
 
 @dataclass

--- a/tests/integration/fixtures/partition_and_sample_data/partitioner_test_cases_and_fixtures.py
+++ b/tests/integration/fixtures/partition_and_sample_data/partitioner_test_cases_and_fixtures.py
@@ -166,7 +166,8 @@ class TaxiTestData:
                     hashlib.md5(
                         str(tuple(zip(element.keys(), element.values(), strict=False))).encode(
                             "utf-8"
-                        )
+                        ),
+                        usedforsecurity=False,
                     ).hexdigest(),
                 )
             ),
@@ -182,7 +183,8 @@ class TaxiTestData:
             hash_code = hashlib.md5(
                 str(
                     tuple(zip(dictionary_element.keys(), dictionary_element.values(), strict=False))
-                ).encode("utf-8")
+                ).encode("utf-8"),
+                usedforsecurity=False,
             ).hexdigest()
             if hash_code not in hash_codes:
                 unique_multi_column_values.append(dictionary_element)
@@ -221,7 +223,9 @@ class TaxiTestData:
 
         column_value: Any
         column_values = [
-            hashlib.md5(str(column_value).encode("utf-8")).hexdigest()[-1 * hash_digits :]
+            hashlib.md5(str(column_value).encode("utf-8"), usedforsecurity=False).hexdigest()[
+                -1 * hash_digits :
+            ]
             for column_value in column_values
         ]
 


### PR DESCRIPTION
Closes #11065.

Josh, thanks for the writeup on this one, the call site inventory and the repro
script saved a ton of time. I ran your script against this branch and section
[2] now matches section [0] exactly: get_batch() returns a Batch and
IDDict.to_id() returns 8aacdb17187e6acf2b175d4aa08d7213, same as before.

This covers every site from your list:

- The three direct hashlib.md5() calls: IDDict.to_id(), the pandas dataframe
  fingerprint in hash_pandas_dataframe(), and the sqlite md5 UDF registered in
  SqlAlchemyExecutionEngine.
- The four modules that resolve the hash function dynamically through
  getattr(hashlib, hash_function_name): pandas and Spark partitioning and
  sampling. The flag goes on the actual call, not the getattr check, since
  getattr never touches OpenSSL on its own.
- The two test-only sites you flagged, so the suite can run on a FIPS host too.

Left the sqlalchemy_data_partitioner.py and sqlalchemy_data_sampler.py
sa.func.md5(...) calls alone as you noted, those run server-side and aren't
affected by the client's OpenSSL config.

No digests changed. IDDict's reference hash still matches, and every existing
test with a hardcoded md5 value passes without edits.