### PR TITLE
[BUGFIX] Give the date-part string cast a length Oracle accepts

### DIFF
--- a/great_expectations/execution_engine/partition_and_sample/sqlalchemy_data_partitioner.py
+++ b/great_expectations/execution_engine/partition_and_sample/sqlalchemy_data_partitioner.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
         SqlAlchemyExecutionEngine,
     )
 
+# Oracle compiles a bare `sa.String` type to `VARCHAR2` with no length, and Oracle's grammar
+# rejects a length-less `VARCHAR2` inside `CAST`. An explicit length avoids that while leaving
+# every other dialect's compiled type unchanged. Any length of at least four characters is
+# semantically sufficient, since the widest date part rendered here is a four-digit year.
+_ORACLE_DATE_PART_CAST_LENGTH = 4000
+
 
 class SqlAlchemyDataPartitioner(DataPartitioner):
     """Methods for partitioning data accessible via SqlAlchemyExecutionEngine.
@@ -62,6 +68,19 @@ class SqlAlchemyDataPartitioner(DataPartitioner):
         if self._dialect == GXSqlDialect.SQL_SERVER:
             return sa.func.datepart(sa.text(date_part), column)
         return sa.func.extract(date_part, column)
+
+    def _cast_date_part_to_string(
+        self, date_part_expression: sqlalchemy.ColumnElement
+    ) -> sqlalchemy.ColumnElement:
+        """Cast an extracted date part to a string type the dialect accepts inside CAST.
+
+        A bare ``sa.String`` compiles to a length-less ``VARCHAR2`` on Oracle, which Oracle's
+        grammar rejects inside ``CAST``. Oracle is given an explicit length; every other
+        dialect keeps the length-less form it already renders.
+        """
+        if self._dialect == GXSqlDialect.ORACLE:
+            return sa.cast(date_part_expression, sa.String(_ORACLE_DATE_PART_CAST_LENGTH))
+        return sa.cast(date_part_expression, sa.String)
 
     DATETIME_PARTITIONER_METHOD_TO_GET_UNIQUE_BATCH_IDENTIFIERS_METHOD_MAPPING: dict = {
         PartitionerMethod.PARTITION_ON_YEAR: "get_data_for_batch_identifiers_year",
@@ -506,17 +525,15 @@ class SqlAlchemyDataPartitioner(DataPartitioner):
             Certain SQLAlchemy-compliant backends (e.g., Amazon Redshift, SQLite) allow only binary operators for "CONCAT".
             """  # noqa: E501 # FIXME CoP
             if self._dialect == GXSqlDialect.SQLITE:
-                concat_date_parts = sa.cast(
-                    self._extract_date_part(date_parts[0].value, sa.column(column_name)),
-                    sa.String,
+                concat_date_parts = self._cast_date_part_to_string(
+                    self._extract_date_part(date_parts[0].value, sa.column(column_name))
                 )
 
                 date_part: DatePart
                 for date_part in date_parts[1:]:
                     concat_date_parts = concat_date_parts.concat(
-                        sa.cast(
-                            self._extract_date_part(date_part.value, sa.column(column_name)),
-                            sa.String,
+                        self._cast_date_part_to_string(
+                            self._extract_date_part(date_part.value, sa.column(column_name))
                         )
                     )
 
@@ -524,18 +541,16 @@ class SqlAlchemyDataPartitioner(DataPartitioner):
             else:
                 concat_date_parts = sa.func.concat(
                     "",
-                    sa.cast(
-                        self._extract_date_part(date_parts[0].value, sa.column(column_name)),
-                        sa.String,
+                    self._cast_date_part_to_string(
+                        self._extract_date_part(date_parts[0].value, sa.column(column_name))
                     ),
                 )
 
                 for date_part in date_parts[1:]:
                     concat_date_parts = sa.func.concat(
                         concat_date_parts,
-                        sa.cast(
-                            self._extract_date_part(date_part.value, sa.column(column_name)),
-                            sa.String,
+                        self._cast_date_part_to_string(
+                            self._extract_date_part(date_part.value, sa.column(column_name))
                         ),
                     )
 

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -501,6 +501,7 @@ EXPECTED_PARTITION_QUERY_SQL_BY_DIALECT_AND_DATE_PART_COUNT = {
 }
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "dialect_name,date_part_count",
     sorted(EXPECTED_PARTITION_QUERY_SQL_BY_DIALECT_AND_DATE_PART_COUNT),
@@ -526,6 +527,7 @@ def test_partition_query_rendered_sql_is_pinned_across_dialects_and_date_part_co
     assert actual_query_str == expected_query_str
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("dialect_name", sorted(PARTITION_QUERY_DIALECT_MODULES_BY_NAME))
 def test_partition_query_single_date_part_never_carries_a_string_cast(dialect_name: str):
     """What does this test and why?
@@ -543,6 +545,7 @@ def test_partition_query_single_date_part_never_carries_a_string_cast(dialect_na
     assert "aschar" not in rendered
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("date_part_count", [2, 3])
 def test_partition_query_oracle_multi_date_part_string_cast_carries_a_length(
     date_part_count: int,

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -401,7 +401,13 @@ def _render_partition_query_for_date_parts(dialect_name: str, date_parts: List[D
         dialect=PARTITION_QUERY_DIALECT_MODULES_BY_NAME[dialect_name].dialect(),
         compile_kwargs={"literal_binds": True},
     )
-    return str(compiled).replace("\n", "").replace(" ", "").lower()
+    rendered = str(compiled).replace("\n", "").replace(" ", "").lower()
+    # SQLAlchemy's mssql dialect renders an empty string literal as N'' under SQLAlchemy 1.4
+    # and as '' under SQLAlchemy 2.0 (the national-string prefix on a string literal) when
+    # compiling the CONCAT construct here. That construct is not something this change touches,
+    # so the two forms are normalized to compare equal rather than pinning whichever one the
+    # installed SQLAlchemy version happens to render.
+    return rendered.replace("concat(n''", "concat(''")
 
 
 # Pinned exact renderings, one per (dialect, date-part count). Any change to a cast site, an

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -453,8 +453,8 @@ EXPECTED_PARTITION_QUERY_SQL_BY_DIALECT_AND_DATE_PART_COUNT = {
         "cast(extract(monthfromcolumn_name)assignedinteger)asmonthfromtable_name"
     ),
     ("oracle", 2): (
-        "selectdistinct(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar2)),"
-        "cast(extract(monthfromcolumn_name)asvarchar2)))asconcat_distinct_values,"
+        "selectdistinct(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar2(4000char))),"
+        "cast(extract(monthfromcolumn_name)asvarchar2(4000char))))asconcat_distinct_values,"
         "cast(extract(yearfromcolumn_name)asinteger)asyear,"
         "cast(extract(monthfromcolumn_name)asinteger)asmonthfromtable_name"
     ),
@@ -491,9 +491,9 @@ EXPECTED_PARTITION_QUERY_SQL_BY_DIALECT_AND_DATE_PART_COUNT = {
         "cast(extract(dayfromcolumn_name)assignedinteger)asdayfromtable_name"
     ),
     ("oracle", 3): (
-        "selectdistinct(concat(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar2)),"
-        "cast(extract(monthfromcolumn_name)asvarchar2)),"
-        "cast(extract(dayfromcolumn_name)asvarchar2)))asconcat_distinct_values,"
+        "selectdistinct(concat(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar2(4000char))),"
+        "cast(extract(monthfromcolumn_name)asvarchar2(4000char))),"
+        "cast(extract(dayfromcolumn_name)asvarchar2(4000char))))asconcat_distinct_values,"
         "cast(extract(yearfromcolumn_name)asinteger)asyear,"
         "cast(extract(monthfromcolumn_name)asinteger)asmonth,"
         "cast(extract(dayfromcolumn_name)asinteger)asdayfromtable_name"
@@ -544,23 +544,25 @@ def test_partition_query_single_date_part_never_carries_a_string_cast(dialect_na
 
 
 @pytest.mark.parametrize("date_part_count", [2, 3])
-def test_partition_query_oracle_multi_date_part_string_cast_is_currently_length_less(
+def test_partition_query_oracle_multi_date_part_string_cast_carries_a_length(
     date_part_count: int,
 ):
     """What does this test and why?
 
     Engineering fact this assertion pins: SQLAlchemy's Oracle dialect compiles a bare
-    ``sa.String`` type to ``VARCHAR2`` with no length. A ``CAST(... AS VARCHAR2)`` with no
-    length is rejected by Oracle's grammar once the query actually executes. This assertion
-    records that today's rendering carries that length-less type for every string-cast site in
-    the multi-date-part path; a fix that gives the cast an explicit length is expected to
-    invert it.
+    ``sa.String`` type to ``VARCHAR2`` with no length, and a ``CAST(... AS VARCHAR2)`` with no
+    length is rejected by Oracle's grammar once the query actually executes. Every string-cast
+    site in the multi-date-part path now supplies an explicit length, so every one of them
+    renders a lengthed ``VARCHAR2`` and none renders the length-less form. The assertion is
+    positive and exhaustive by count: a partial migration would leave some sites length-less
+    and change this count without necessarily changing whether the length-less form is present
+    at all.
     """
     rendered = _render_partition_query_for_date_parts(
         "oracle", PARTITION_QUERY_DATE_PARTS_BY_COUNT[date_part_count]
     )
-    assert rendered.count("asvarchar2)") == date_part_count
-    assert "asvarchar2(" not in rendered
+    assert rendered.count("asvarchar2(4000char)") == date_part_count
+    assert "asvarchar2)" not in rendered
 
 
 @pytest.mark.parametrize(

--- a/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
+++ b/tests/execution_engine/partition_and_sample/test_sqlalchemy_execution_engine_partitioning.py
@@ -7,6 +7,12 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+import sqlalchemy
+import sqlalchemy.dialects.mssql as mssql_dialect
+import sqlalchemy.dialects.mysql as mysql_dialect
+import sqlalchemy.dialects.oracle as oracle_dialect
+import sqlalchemy.dialects.postgresql as postgresql_dialect
+import sqlalchemy.dialects.sqlite as sqlite_dialect
 from dateutil.parser import parse
 
 from great_expectations.core.batch_spec import SqlAlchemyDatasourceBatchSpec
@@ -357,6 +363,204 @@ def test_get_partition_query_for_data_for_batch_identifiers_for_partition_on_dat
         .lower()
     )
     assert actual_query_str == expected_query_str.replace("\n", "").replace(" ", "").lower()
+
+
+# The partitioner's own `dialect` argument only changes which branch it builds (e.g. the
+# SQLite-only concatenation form); the SQLAlchemy compile-time dialect below is what actually
+# renders each dialect's SQL text, including its cast target types. Both are set to the same
+# target per case so each rendering below reflects how that dialect is exercised at runtime.
+PARTITION_QUERY_DIALECT_MODULES_BY_NAME = {
+    "sqlite": sqlite_dialect,
+    "postgresql": postgresql_dialect,
+    "mssql": mssql_dialect,
+    "mysql": mysql_dialect,
+    "oracle": oracle_dialect,
+}
+
+PARTITION_QUERY_DATE_PARTS_BY_COUNT = {
+    1: [DatePart.YEAR],
+    2: [DatePart.YEAR, DatePart.MONTH],
+    3: [DatePart.YEAR, DatePart.MONTH, DatePart.DAY],
+}
+
+
+def _render_partition_query_for_date_parts(dialect_name: str, date_parts: List[DatePart]) -> str:
+    """Compile the multi-date-part partition query for one dialect, database-free.
+
+    Compiling (rather than executing) against a bare SQLAlchemy dialect object requires neither
+    a driver nor a live service, so this is safe to run in any environment.
+    """
+    data_partitioner = SqlAlchemyDataPartitioner(dialect=dialect_name)
+    selectable = sqlalchemy.text("table_name")
+    query = data_partitioner.get_partition_query_for_data_for_batch_identifiers_for_partition_on_date_parts(  # noqa: E501 # FIXME CoP
+        selectable=selectable,
+        column_name="column_name",
+        date_parts=date_parts,
+    )
+    compiled = query.compile(
+        dialect=PARTITION_QUERY_DIALECT_MODULES_BY_NAME[dialect_name].dialect(),
+        compile_kwargs={"literal_binds": True},
+    )
+    return str(compiled).replace("\n", "").replace(" ", "").lower()
+
+
+# Pinned exact renderings, one per (dialect, date-part count). Any change to a cast site, an
+# extraction call, or the concatenation shape shows up here as a text mismatch, not merely a
+# type check.
+EXPECTED_PARTITION_QUERY_SQL_BY_DIALECT_AND_DATE_PART_COUNT = {
+    ("sqlite", 1): (
+        "selectdistinct(cast(strftime('%y',column_name)asinteger))asconcat_distinct_values,"
+        "cast(cast(strftime('%y',column_name)asinteger)asinteger)asyearfromtable_name"
+    ),
+    ("postgresql", 1): (
+        "selectdistinct(extract(yearfromcolumn_name))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)asinteger)asyearfromtable_name"
+    ),
+    ("mssql", 1): (
+        "selectdistinct(datepart(year,column_name))asconcat_distinct_values,"
+        "cast(datepart(year,column_name)asinteger)asyearfromtable_name"
+    ),
+    ("mysql", 1): (
+        "selectdistinct(extract(yearfromcolumn_name))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)assignedinteger)asyearfromtable_name"
+    ),
+    ("oracle", 1): (
+        "selectdistinct(extract(yearfromcolumn_name))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)asinteger)asyearfromtable_name"
+    ),
+    ("sqlite", 2): (
+        "selectdistinct(cast(cast(strftime('%y',column_name)asinteger)asvarchar)"
+        "||cast(cast(strftime('%m',column_name)asinteger)asvarchar))asconcat_distinct_values,"
+        "cast(cast(strftime('%y',column_name)asinteger)asinteger)asyear,"
+        "cast(cast(strftime('%m',column_name)asinteger)asinteger)asmonthfromtable_name"
+    ),
+    ("postgresql", 2): (
+        "selectdistinct(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar)),"
+        "cast(extract(monthfromcolumn_name)asvarchar)))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)asinteger)asyear,"
+        "cast(extract(monthfromcolumn_name)asinteger)asmonthfromtable_name"
+    ),
+    ("mssql", 2): (
+        "selectdistinct(concat(concat('',cast(datepart(year,column_name)asvarchar(max))),"
+        "cast(datepart(month,column_name)asvarchar(max))))asconcat_distinct_values,"
+        "cast(datepart(year,column_name)asinteger)asyear,"
+        "cast(datepart(month,column_name)asinteger)asmonthfromtable_name"
+    ),
+    ("mysql", 2): (
+        "selectdistinct(concat(concat('',cast(extract(yearfromcolumn_name)aschar)),"
+        "cast(extract(monthfromcolumn_name)aschar)))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)assignedinteger)asyear,"
+        "cast(extract(monthfromcolumn_name)assignedinteger)asmonthfromtable_name"
+    ),
+    ("oracle", 2): (
+        "selectdistinct(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar2)),"
+        "cast(extract(monthfromcolumn_name)asvarchar2)))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)asinteger)asyear,"
+        "cast(extract(monthfromcolumn_name)asinteger)asmonthfromtable_name"
+    ),
+    ("sqlite", 3): (
+        "selectdistinct(cast(cast(strftime('%y',column_name)asinteger)asvarchar)"
+        "||cast(cast(strftime('%m',column_name)asinteger)asvarchar)"
+        "||cast(cast(strftime('%d',column_name)asinteger)asvarchar))asconcat_distinct_values,"
+        "cast(cast(strftime('%y',column_name)asinteger)asinteger)asyear,"
+        "cast(cast(strftime('%m',column_name)asinteger)asinteger)asmonth,"
+        "cast(cast(strftime('%d',column_name)asinteger)asinteger)asdayfromtable_name"
+    ),
+    ("postgresql", 3): (
+        "selectdistinct(concat(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar)),"
+        "cast(extract(monthfromcolumn_name)asvarchar)),cast(extract(dayfromcolumn_name)asvarchar)"
+        "))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)asinteger)asyear,"
+        "cast(extract(monthfromcolumn_name)asinteger)asmonth,"
+        "cast(extract(dayfromcolumn_name)asinteger)asdayfromtable_name"
+    ),
+    ("mssql", 3): (
+        "selectdistinct(concat(concat(concat('',cast(datepart(year,column_name)asvarchar(max))),"
+        "cast(datepart(month,column_name)asvarchar(max))),"
+        "cast(datepart(day,column_name)asvarchar(max))))asconcat_distinct_values,"
+        "cast(datepart(year,column_name)asinteger)asyear,"
+        "cast(datepart(month,column_name)asinteger)asmonth,"
+        "cast(datepart(day,column_name)asinteger)asdayfromtable_name"
+    ),
+    ("mysql", 3): (
+        "selectdistinct(concat(concat(concat('',cast(extract(yearfromcolumn_name)aschar)),"
+        "cast(extract(monthfromcolumn_name)aschar)),cast(extract(dayfromcolumn_name)aschar)"
+        "))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)assignedinteger)asyear,"
+        "cast(extract(monthfromcolumn_name)assignedinteger)asmonth,"
+        "cast(extract(dayfromcolumn_name)assignedinteger)asdayfromtable_name"
+    ),
+    ("oracle", 3): (
+        "selectdistinct(concat(concat(concat('',cast(extract(yearfromcolumn_name)asvarchar2)),"
+        "cast(extract(monthfromcolumn_name)asvarchar2)),"
+        "cast(extract(dayfromcolumn_name)asvarchar2)))asconcat_distinct_values,"
+        "cast(extract(yearfromcolumn_name)asinteger)asyear,"
+        "cast(extract(monthfromcolumn_name)asinteger)asmonth,"
+        "cast(extract(dayfromcolumn_name)asinteger)asdayfromtable_name"
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "dialect_name,date_part_count",
+    sorted(EXPECTED_PARTITION_QUERY_SQL_BY_DIALECT_AND_DATE_PART_COUNT),
+)
+def test_partition_query_rendered_sql_is_pinned_across_dialects_and_date_part_counts(
+    dialect_name: str, date_part_count: int
+):
+    """What does this test and why?
+
+    get_partition_query_for_data_for_batch_identifiers_for_partition_on_date_parts renders
+    dialect-specific SQL text that is otherwise only exercised end to end against a live
+    database. Pinning its exact compiled text for SQLite, Postgres, SQL Server, MySQL, and
+    Oracle, at one, two, and three date parts, is what lets a later change to any dialect
+    branch, cast site, or concatenation shape be caught here rather than only downstream
+    against a real service.
+    """
+    actual_query_str = _render_partition_query_for_date_parts(
+        dialect_name, PARTITION_QUERY_DATE_PARTS_BY_COUNT[date_part_count]
+    )
+    expected_query_str = EXPECTED_PARTITION_QUERY_SQL_BY_DIALECT_AND_DATE_PART_COUNT[
+        (dialect_name, date_part_count)
+    ]
+    assert actual_query_str == expected_query_str
+
+
+@pytest.mark.parametrize("dialect_name", sorted(PARTITION_QUERY_DIALECT_MODULES_BY_NAME))
+def test_partition_query_single_date_part_never_carries_a_string_cast(dialect_name: str):
+    """What does this test and why?
+
+    The single-date-part path builds no concatenation, so it casts nothing to a string type at
+    all -- only the extracted date part is cast, and that cast is to an integer. This is what
+    makes the single-part path's exemption from the multi-part string-cast defect below an
+    observation about the rendered SQL, rather than an assumption about the code that produced
+    it.
+    """
+    rendered = _render_partition_query_for_date_parts(
+        dialect_name, PARTITION_QUERY_DATE_PARTS_BY_COUNT[1]
+    )
+    assert "asvarchar" not in rendered
+    assert "aschar" not in rendered
+
+
+@pytest.mark.parametrize("date_part_count", [2, 3])
+def test_partition_query_oracle_multi_date_part_string_cast_is_currently_length_less(
+    date_part_count: int,
+):
+    """What does this test and why?
+
+    Engineering fact this assertion pins: SQLAlchemy's Oracle dialect compiles a bare
+    ``sa.String`` type to ``VARCHAR2`` with no length. A ``CAST(... AS VARCHAR2)`` with no
+    length is rejected by Oracle's grammar once the query actually executes. This assertion
+    records that today's rendering carries that length-less type for every string-cast site in
+    the multi-date-part path; a fix that gives the cast an explicit length is expected to
+    invert it.
+    """
+    rendered = _render_partition_query_for_date_parts(
+        "oracle", PARTITION_QUERY_DATE_PARTS_BY_COUNT[date_part_count]
+    )
+    assert rendered.count("asvarchar2)") == date_part_count
+    assert "asvarchar2(" not in rendered
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/data_sources_and_expectations/test_curated_backend_suite.py
+++ b/tests/integration/data_sources_and_expectations/test_curated_backend_suite.py
@@ -19,6 +19,7 @@ test module because they need this module's own published key set — a registry
 integration suite would run the dependency the wrong direction.
 """
 
+from datetime import date
 from typing import FrozenSet, List, cast
 
 import pandas as pd
@@ -26,6 +27,7 @@ import pytest
 
 import great_expectations.expectations as gxe
 from great_expectations.datasource.fluent.interfaces import Batch
+from great_expectations.datasource.fluent.sql_datasource import TableAsset
 from great_expectations.expectations.row_conditions import Column
 from tests.integration.conftest import parameterize_batch_for_data_sources
 from tests.integration.test_utils.data_source_config import (
@@ -45,7 +47,7 @@ from tests.integration.test_utils.data_source_config.tiers import CURATED_SQL_DA
 # removing a case here without updating a backend's declaration is exactly what
 # `test_every_declared_exclusion_key_is_a_published_case_key` below is meant to catch.
 #
-# Eight keys, not eleven test functions: `QUOTED_IDENTIFIERS` is one case covering four assertions
+# Nine keys, not twelve test functions: `QUOTED_IDENTIFIERS` is one case covering four assertions
 # (a spaced, a reserved-word, and a mixed-case column name, plus uniqueness under quoting) because
 # all four exercise the same quoted-identifier code path and a backend excluding one would have no
 # reason to keep the others.
@@ -57,6 +59,7 @@ UNIQUENESS = "uniqueness"
 ROW_CONDITION = "row_condition"
 UNEXPECTED_ROWS_QUERY = "unexpected_rows_query"
 QUOTED_IDENTIFIERS = "quoted_identifiers"
+BATCH_DEFINITION = "batch_definition"
 
 CURATED_CASE_KEYS: FrozenSet[str] = frozenset(
     {
@@ -68,6 +71,7 @@ CURATED_CASE_KEYS: FrozenSet[str] = frozenset(
         ROW_CONDITION,
         UNEXPECTED_ROWS_QUERY,
         QUOTED_IDENTIFIERS,
+        BATCH_DEFINITION,
     }
 )
 
@@ -93,6 +97,37 @@ QUOTED_IDENTIFIER_DATA = pd.DataFrame(
         "user name": ["Alice", "Bob", "Charlie"],
         "select": [10, 20, 30],
         "UserName": ["alice", "bob", "charlie"],
+    }
+)
+
+# Plain `datetime.date` values, not `pd.Timestamp`/`datetime.datetime` ones: some curated
+# backends declare no timestamp override, and one has no native timestamp type at all, so a
+# timestamp-shaped column would fail at data-load time for a reason unrelated to partitioning.
+RECORD_DATE_COL = "record_date"
+LABEL_COL = "label"
+
+OUTSIDE_MONTH = "outside_month"
+MARCH_FIRST = "march_first"
+MARCH_SECOND_A = "march_second_a"
+MARCH_SECOND_B = "march_second_b"
+
+# Values are chosen so a daily and a monthly partition select different, known row sets: the
+# daily partition (2024-03-02) returns a strict subset of the monthly partition (2024-03), and
+# neither equals the full frame, which also carries a row outside the target month entirely.
+BATCH_DEFINITION_DATA = pd.DataFrame(
+    {
+        RECORD_DATE_COL: [
+            date(2023, 6, 15),
+            date(2024, 3, 1),
+            date(2024, 3, 2),
+            date(2024, 3, 2),
+        ],
+        LABEL_COL: [
+            OUTSIDE_MONTH,
+            MARCH_FIRST,
+            MARCH_SECOND_A,
+            MARCH_SECOND_B,
+        ],
     }
 )
 
@@ -225,6 +260,41 @@ def test_mixed_case_column(batch_for_datasource: Batch) -> None:
         )
     )
     assert result.success
+
+
+@parameterize_batch_for_data_sources(
+    data_source_configs=_sources(BATCH_DEFINITION), data=BATCH_DEFINITION_DATA
+)
+def test_daily_and_monthly_batch_definitions(asset_for_datasource: TableAsset) -> None:
+    """Daily and monthly batch definitions must select distinct, known row sets.
+
+    Selecting the same rows regardless of partition granularity would let this assertion pass
+    for the wrong reason, so the daily partition (a single day) is checked against a strict
+    subset of the rows the monthly partition (that day's whole month) returns.
+    """
+    daily_definition = asset_for_datasource.add_batch_definition_daily(
+        "batch_definition_daily", column=RECORD_DATE_COL
+    )
+    daily_batch = daily_definition.get_batch(batch_parameters={"year": 2024, "month": 3, "day": 2})
+    daily_result = daily_batch.validate(
+        gxe.ExpectColumnDistinctValuesToEqualSet(
+            column=LABEL_COL,
+            value_set=[MARCH_SECOND_A, MARCH_SECOND_B],
+        )
+    )
+    assert daily_result.success
+
+    monthly_definition = asset_for_datasource.add_batch_definition_monthly(
+        "batch_definition_monthly", column=RECORD_DATE_COL
+    )
+    monthly_batch = monthly_definition.get_batch(batch_parameters={"year": 2024, "month": 3})
+    monthly_result = monthly_batch.validate(
+        gxe.ExpectColumnDistinctValuesToEqualSet(
+            column=LABEL_COL,
+            value_set=[MARCH_FIRST, MARCH_SECOND_A, MARCH_SECOND_B],
+        )
+    )
+    assert monthly_result.success
 
 
 @pytest.mark.project


### PR DESCRIPTION
## Summary

Daily and monthly `BatchDefinition`s are unusable on Oracle. The multi-date-part partition query casts each extracted date part to a string before concatenating them, and SQLAlchemy compiles a bare string type to `VARCHAR2` with no length on Oracle. Oracle's grammar rejects a length-less `VARCHAR2` inside `CAST` with `ORA-00906`, so batch retrieval fails before the expectation can evaluate. Yearly works, because the single-date-part path carries no string cast at all.

The conversion now renders through one private helper on the partitioner, and all four existing cast sites are migrated onto it — including the branch belonging to the other dialect that needs binary concatenation, so whether every site was migrated is a grep rather than a review judgment. The helper supplies an explicit length only for the dialect that requires one; every other dialect renders exactly as before. The length is a named constant, chosen for headroom rather than computed, since the widest date part rendered here is a four-digit year.

This also adds a curated-suite case covering `add_batch_definition_daily` and `add_batch_definition_monthly`, run by every curated backend. Partitioning previously had no tier coverage on any backend — it was exercised against one backend only, in a legacy module — so a defect in the partition query could reach a release unnoticed.

## Why

The cause was isolated against a live server rather than inferred. A length-less cast fails with `ORA-00906` when no `CONCAT` is present at all; a three-deep nested `CONCAT` succeeds when no cast is present; and supplying a length repairs the exact generated statement. The defect is the cast, not the concatenation.

## User impact

`add_batch_definition_daily` and `add_batch_definition_monthly` now work on Oracle. No other backend's rendered SQL changes — the added length is dialect-gated, and the characterization tests pin every other dialect's rendering byte-for-byte.

## How to review

The characterization test was committed and shown green **before** the fix, so it pins what the change must not disturb rather than what the change produced. Reverting the fix locally fails exactly four assertions — the two Oracle renderings and both parametrizations of the length assertion — while every non-Oracle pin stays green. An unconditional length would instead fail twenty-two assertions across five dialects.

The Oracle assertion counts occurrences rather than testing presence, so converting only some of the four sites is distinguishable from converting all of them.

The new fixture frame uses plain dates rather than timestamps, because not every curated backend has a native timestamp type, and its values are chosen so the daily partition returns a strict subset of the monthly one — the two expected row sets differ, so a retrieval that ignored the requested partition could not satisfy both assertions.